### PR TITLE
[Fix #2575] Chaque admin est automatiquement affecté à ses démarches

### DIFF
--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -71,6 +71,10 @@ class Admin::ProceduresController < AdminController
       render 'new'
     else
       flash.notice = 'Démarche enregistrée.'
+      gestionnaire = Gestionnaire.find_by(email: current_administrateur.email)
+      if gestionnaire
+        gestionnaire.assign_to_procedure(@procedure)
+      end
       redirect_to admin_procedure_types_de_champ_path(procedure_id: @procedure.id)
     end
   end

--- a/app/views/admin/instructeurs/show.html.haml
+++ b/app/views/admin/instructeurs/show.html.haml
@@ -18,9 +18,6 @@
                 %br
                 %br
                 = f.submit 'Valider', class: 'btn btn-info', style: 'float: left;', id: 'add-gestionnaire-email'
-        %br
-        .alert.alert-info
-          Astuce : ajoutez votre adresse email pour tester la partie instructeur.
       .col-xs-6
         %h3.text-success Affectés
         = smart_listing_render :instructeurs_assign

--- a/spec/controllers/admin/procedures_controller_spec.rb
+++ b/spec/controllers/admin/procedures_controller_spec.rb
@@ -197,6 +197,19 @@ describe Admin::ProceduresController, type: :controller do
 
         it { expect(flash[:notice]).to be_present }
       end
+
+      context 'when procedure is correctly saved' do
+        let!(:gestionnaire) { create(:gestionnaire, email: admin.email) }
+
+        before do
+          post :create, params: { procedure: procedure_params }
+        end
+
+        describe "admin can also instruct the procedure as a gestionnaire" do
+          subject { Procedure.last }
+          it { expect(subject.gestionnaires).to include(gestionnaire) }
+        end
+      end
     end
 
     context 'when many attributs are not valid' do


### PR DESCRIPTION
Comme m'a indiqué @kemenaran je pioche dans le backlog trello recemment maj. 
Je me base sur la tache trello de @chaibax posté mardi dernier: Chaque admin est automatiquement affecté à ses démarches
Elle référence l'issue #2575 mais avec le renommage, de la tache dans github,  je ne sais pas si cela plaira à tout le monde. A vous de voir.  
En tout cas, voici un argumentaire
- beaucoup de personnes ne savent pas qu'il faut affecter les instructeurs, n'arrivent pas à publier leurs démarches
- en tant qu'administrateur, on a besoin par défaut d'aller dans les démarches pour pouvoir voir ce qui s'y passe, controller, etc...
Bref je comprends qu'on puisse vouloir affecter par défaut le créateur de la démarche en tant qu'instructeur, cela facilite les points précédents. 

J'ai ajouté l'affectation, supprimé l'astuce qui ne sert plus, ajouté un test. 
L'affectation ne se fait que si le gestionnaire est loggé, pour ne pas casser tous les tests et les laisser indépendants du gestionnaire.


