### PR TITLE
stats: start helpscout stats at 01-2018

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -165,7 +165,7 @@ class StatsController < ApplicationController
   end
 
   def contact_percentage
-    from = Date.new(2017, 10)
+    from = Date.new(2018, 1)
     to = Date.today.prev_month
 
     Helpscout::UserConversationsAdapter.new(from, to)


### PR DESCRIPTION
Les données avant janvier 2018 ne sont pas très fiables, vu qu'elles sont basées sur un faible nombre de dossiers.

De fait aujourd'hui y'a une grosse variance. Autant virer les 3 premiers points de données.

<img width="511" alt="capture d ecran 2019-01-02 a 16 22 00" src="https://user-images.githubusercontent.com/179923/50598304-a3fce580-0eaa-11e9-8ca4-d6b36711f4b0.png">
