### PR TITLE
Instructeur : corrige la présence de démarches supprimées dans la liste des démarches

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -8,6 +8,7 @@ module Instructeurs
     def index
       @procedures = current_instructeur
         .procedures
+        .kept
         .with_attached_logo
         .includes(:defaut_groupe_instructeur)
         .order(closed_at: :desc, unpublished_at: :desc, published_at: :desc, created_at: :desc)

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -99,10 +99,12 @@ describe Instructeurs::ProceduresController, type: :controller do
         let(:procedure_draft) { create(:procedure) }
         let(:procedure_published) { create(:procedure, :published) }
         let(:procedure_closed) { create(:procedure, :closed) }
+        let(:procedure_draft_discarded) { create(:procedure, :discarded) }
+        let(:procedure_closed_discarded) { create(:procedure, :discarded) }
         let(:procedure_not_assigned) { create(:procedure) }
 
         before do
-          [procedure_draft, procedure_published, procedure_closed].each do |p|
+          [procedure_draft, procedure_published, procedure_closed, procedure_draft_discarded, procedure_closed_discarded].each do |p|
             instructeur.groupe_instructeurs << p.defaut_groupe_instructeur
           end
           subject
@@ -110,7 +112,7 @@ describe Instructeurs::ProceduresController, type: :controller do
 
         it 'assigns procedures visible to the instructeur' do
           expect(assigns(:procedures)).to include(procedure_draft, procedure_published, procedure_closed)
-          expect(assigns(:procedures)).not_to include(procedure_not_assigned)
+          expect(assigns(:procedures)).not_to include(procedure_draft_discarded, procedure_closed_discarded, procedure_not_assigned)
         end
       end
 


### PR DESCRIPTION
Sur `/procedures` en tant qu'Instructeur, les démarches supprimées sont visibles (HS #37312).

C'est parce qu'on ne met pas explicitement le scope `kept` pour éviter les démarches `discarded`. En théorie on a le default_scope – mais là on fait la requête via AssignsTo -> GroupeInstructeur -> Procedure, et GroupeInstructeur.procedure demande explicitement à avoir les démarches supprimées (normal).

Donc les default_scope, saylemal, et ici on doit le spécifier explicitement.