### PR TITLE
Include a static image for Carto fields in generated PDF.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,10 @@ gem 'rails'
 gem 'rails-i18n' # Locales par défaut
 gem 'rake-progressbar', require: false
 gem 'react-rails'
+gem 'rgeo' # To render maps as PDF
 gem 'rgeo-geojson'
+gem 'rgeo-proj4'
+gem 'ffi-geos'
 gem 'rqrcode'
 gem 'ruby-saml-idp'
 gem 'sanitize-url'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,8 @@ GEM
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.1.0)
     ffi (1.15.0)
+    ffi-geos (2.2.0)
+      ffi (>= 1.0.0)
     flipper (0.20.3)
     flipper-active_record (0.20.3)
       activerecord (>= 5.0, < 7)
@@ -574,6 +576,8 @@ GEM
     rgeo (2.2.0)
     rgeo-geojson (2.1.1)
       rgeo (>= 1.0.0)
+    rgeo-proj4 (3.0.1)
+      rgeo (~> 2.0)
     rodf (1.1.1)
       builder (>= 3.0)
       dry-inflector (~> 0.1)
@@ -819,6 +823,7 @@ DEPENDENCIES
   discard
   dotenv-rails
   factory_bot
+  ffi-geos
   flipper
   flipper-active_record
   flipper-ui
@@ -866,7 +871,9 @@ DEPENDENCIES
   rails-i18n
   rake-progressbar
   react-rails
+  rgeo
   rgeo-geojson
+  rgeo-proj4
   rqrcode
   rspec-rails
   rubocop

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -1,4 +1,5 @@
 require 'prawn/measurement_extensions'
+require 'open-uri'
 
 def default_margin
   10
@@ -138,7 +139,10 @@ def add_single_champ(pdf, champ)
   when 'Champs::ExplicationChamp'
     format_in_2_lines(pdf, champ.libelle, champ.description)
   when 'Champs::CarteChamp'
-    format_in_2_lines(pdf, champ.libelle, champ.to_feature_collection.to_json)
+    geojson = champ.to_feature_collection.to_json
+    format_in_2_lines(pdf, champ.libelle, geojson)
+    mapbox_url = "https://api.mapbox.com/styles/v1/mapbox/satellite-v9/static/geojson(#{CGI.escape(geojson)})/auto/800x600@2x?access_token=#{MAPBOX_TOKEN}"
+    pdf.image open(mapbox_url), width: 400, position: :center
   when 'Champs::SiretChamp'
     pdf.font 'marianne', style: :bold do
       pdf.text champ.libelle


### PR DESCRIPTION
Fixes #6338

ETQ usager, en essayant d'imprimer un dossier soumis, les champs carte sont remplacés par leur GéoJSON.

Cette PR propose d'ajouter au dump du GeoJSON une inclusion d'image issue de l'API WMS de l'IGN sur laquelle est tracée l'emprise définie.

*À corriger avant test :*
- rendre la récupération des images WMS asynchrone ;
- utiliser le bon style de carte ;
- affiner le positionnement et la dimension de l'image utilisée.