### PR TITLE
Nettoyage : déplacement de la classe ActiveJobLogSubscriber en dehors des initializers

### DIFF
--- a/app/lib/active_job/application_log_subscriber.rb
+++ b/app/lib/active_job/application_log_subscriber.rb
@@ -1,7 +1,7 @@
 require 'active_job/logging'
 require 'logstash-event'
 
-class ActiveJobLogSubscriber < ::ActiveJob::LogSubscriber
+class ActiveJob::ApplicationLogSubscriber < ::ActiveJob::LogSubscriber
   def enqueue(event)
     process_event(event, 'enqueue')
   end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,5 +1,3 @@
-require_relative './active_job_log_subscriber'
-
 Rails.application.configure do
   config.lograge.formatter = Lograge::Formatters::Logstash.new
   config.lograge.base_controller_class = ['ActionController::Base', 'Manager::ApplicationController']
@@ -33,6 +31,6 @@ Rails.application.configure do
   config.lograge.logger = ActiveSupport::Logger.new(Rails.root.join('log', "logstash_#{Rails.env}.log"))
 
   if config.lograge.enabled
-    ActiveJobLogSubscriber.attach_to(:active_job)
+    ActiveJob::ApplicationLogSubscriber.attach_to(:active_job)
   end
 end


### PR DESCRIPTION
This is a class of its own, it doesn't need to be in the initializers.