### PR TITLE
Configuration : suppression des hooks pré- et post- hook de Puma

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,30 +36,9 @@ if ENV.fetch("RAILS_ENV") == "production"
   # Use the `preload_app!` method when specifying a `workers` number.
   # This directive tells Puma to first boot the application and load code
   # before forking the application. This takes advantage of Copy On Write
-  # process behavior so workers use less memory. If you use this option
-  # you need to make sure to reconnect any threads in the `on_worker_boot`
-  # block.
+  # process behavior so workers use less memory.
   #
   preload_app!
-
-  # If you are preloading your application and using Active Record, it's
-  # recommended that you close any connections to the database before workers
-  # are forked to prevent connection leakage.
-  #
-  before_fork do
-    ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
-  end
-
-  # The code in the `on_worker_boot` will be called if you are using
-  # clustered mode by specifying a number of `workers`. After each worker
-  # process is booted, this block will be run. If you are using the `preload_app!`
-  # option, you will want to use this block to reconnect to any threads
-  # or connections that may have been created at application boot, as Ruby
-  # cannot share connections between processes.
-  #
-  on_worker_boot do
-    ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-  end
 end
 
 # Allow puma to be restarted by `rails restart` command.


### PR DESCRIPTION
This is no longer needed since Rails 5.1.

See https://github.com/rails/rails/pull/31241