### PR TITLE
fix(rebase): fix repetition champ rebase

### DIFF
--- a/app/models/concerns/dossier_rebase_concern.rb
+++ b/app/models/concerns/dossier_rebase_concern.rb
@@ -64,7 +64,7 @@ module DossierRebaseConcern
   def add_new_champs_for_revision(published_type_de_champ)
     if published_type_de_champ.parent
       find_champs_by_stable_id(published_type_de_champ.parent.stable_id).each do |champ_repetition|
-        champ_repetition.rows.size.times do |row|
+        champ_repetition.champs.map(&:row).uniq.each do |row|
           champ = published_type_de_champ.champ.build(row: row)
           champ_repetition.champs << champ
         end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1497,6 +1497,7 @@ describe Dossier do
 
       datetime_champ.update(value: Date.today.to_s)
       text_champ.update(value: 'bonjour')
+      repetition_champ.add_row(repetition_champ.champs.last.row + 2)
     end
 
     it "updates the brouillon champs with the latest revision changes" do
@@ -1505,8 +1506,9 @@ describe Dossier do
 
       expect(dossier.revision).to eq(procedure.published_revision)
       expect(dossier.champs.size).to eq(4)
-      expect(repetition_champ.rows.size).to eq(1)
+      expect(repetition_champ.rows.size).to eq(2)
       expect(repetition_champ.rows[0].size).to eq(1)
+      expect(repetition_champ.rows[1].size).to eq(1)
 
       procedure.publish_revision!
       perform_enqueued_jobs
@@ -1520,8 +1522,9 @@ describe Dossier do
       expect(rebased_text_champ.type_de_champ_id).not_to eq(text_champ.type_de_champ_id)
       expect(rebased_datetime_champ.type_champ).to eq(TypeDeChamp.type_champs.fetch(:date))
       expect(rebased_datetime_champ.value).to be_nil
-      expect(rebased_repetition_champ.rows.size).to eq(1)
+      expect(rebased_repetition_champ.rows.size).to eq(2)
       expect(rebased_repetition_champ.rows[0].size).to eq(2)
+      expect(rebased_repetition_champ.rows[1].size).to eq(2)
       expect(rebased_text_champ.rebased_at).not_to be_nil
       expect(rebased_datetime_champ.rebased_at).not_to be_nil
     end


### PR DESCRIPTION
Les `row` sont une séquence, mais qui peut avoir des "trous" (en cas de suppression de répétition). On ne peut pas se baser sur l'index.