### PR TITLE
fix(ProcedureArchiveService.zip_root_folder): should take archive instance otherwise when we generate many archive for the same procedure, errors may occures

### DIFF
--- a/spec/services/procedure_archive_service_spec.rb
+++ b/spec/services/procedure_archive_service_spec.rb
@@ -55,11 +55,11 @@ describe ProcedureArchiveService do
           files = ZipTricks::FileReader.read_zip_structure(io: f)
 
           structure = [
-            "procedure-#{procedure.id}/",
-            "procedure-#{procedure.id}/dossier-#{dossier.id}/",
-            "procedure-#{procedure.id}/dossier-#{dossier.id}/pieces_justificatives/",
-            "procedure-#{procedure.id}/dossier-#{dossier.id}/pieces_justificatives/attestation-dossier--05-03-2021-00-00-#{dossier.attestation.pdf.id % 10000}.pdf",
-            "procedure-#{procedure.id}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf"
+            "procedure-#{procedure.id}-#{archive.id}/",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/pieces_justificatives/",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/pieces_justificatives/attestation-dossier--05-03-2021-00-00-#{dossier.attestation.pdf.id % 10000}.pdf",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf"
           ]
           expect(files.map(&:filename)).to match_array(structure)
         end
@@ -75,11 +75,11 @@ describe ProcedureArchiveService do
         archive.file.open do |f|
           files = ZipTricks::FileReader.read_zip_structure(io: f)
           structure = [
-            "procedure-#{procedure.id}/",
-            "procedure-#{procedure.id}/dossier-#{dossier.id}/",
-            "procedure-#{procedure.id}/dossier-#{dossier.id}/pieces_justificatives/",
-            "procedure-#{procedure.id}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf",
-            "procedure-#{procedure.id}/LISEZMOI.txt"
+            "procedure-#{procedure.id}-#{archive.id}/",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/pieces_justificatives/",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf",
+            "procedure-#{procedure.id}-#{archive.id}/LISEZMOI.txt"
           ]
           expect(files.map(&:filename)).to match_array(structure)
         end
@@ -122,16 +122,16 @@ describe ProcedureArchiveService do
           archive.file.open do |f|
             zip_entries = ZipTricks::FileReader.read_zip_structure(io: f)
             structure = [
-              "procedure-#{procedure.id}/",
-              "procedure-#{procedure.id}/dossier-#{dossier.id}/",
-              "procedure-#{procedure.id}/dossier-#{dossier.id}/export-dossier-05-03-2020-00-00-1.pdf",
-              "procedure-#{procedure.id}/dossier-#{dossier.id}/pieces_justificatives/",
-              "procedure-#{procedure.id}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf",
-              "procedure-#{procedure.id}/LISEZMOI.txt"
+              "procedure-#{procedure.id}-#{archive.id}/",
+              "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/",
+              "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/export-dossier-05-03-2020-00-00-1.pdf",
+              "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/pieces_justificatives/",
+              "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2021-00-00-#{dossier.id}.pdf",
+              "procedure-#{procedure.id}-#{archive.id}/LISEZMOI.txt"
             ]
             expect(zip_entries.map(&:filename)).to match_array(structure)
             zip_entries.map do |entry|
-              next unless entry.filename == "procedure-#{procedure.id}/LISEZMOI.txt"
+              next unless entry.filename == "procedure-#{procedure.id}-#{archive.id}/LISEZMOI.txt"
               extracted_content = ""
               extractor = entry.extractor_from(f)
               extracted_content << extractor.extract(1024 * 1024) until extractor.eof?
@@ -158,15 +158,15 @@ describe ProcedureArchiveService do
         archive.file.open do |f|
           files = ZipTricks::FileReader.read_zip_structure(io: f)
           structure = [
-            "procedure-#{procedure.id}/",
-            "procedure-#{procedure.id}/dossier-#{dossier.id}/",
-            "procedure-#{procedure.id}/dossier-#{dossier.id}/pieces_justificatives/",
-            "procedure-#{procedure.id}/dossier-#{dossier.id}/pieces_justificatives/attestation-dossier--05-03-2020-00-00-#{dossier.attestation.pdf.id % 10000}.pdf",
-            "procedure-#{procedure.id}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2020-00-00-#{dossier.id}.pdf",
-            "procedure-#{procedure.id}/dossier-#{dossier_2020.id}/",
-            "procedure-#{procedure.id}/dossier-#{dossier_2020.id}/export-#{dossier_2020.id}-05-03-2020-00-00-#{dossier_2020.id}.pdf",
-            "procedure-#{procedure.id}/dossier-#{dossier_2020.id}/pieces_justificatives/",
-            "procedure-#{procedure.id}/dossier-#{dossier_2020.id}/pieces_justificatives/attestation-dossier--05-03-2020-00-00-#{dossier_2020.attestation.pdf.id % 10000}.pdf"
+            "procedure-#{procedure.id}-#{archive.id}/",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/pieces_justificatives/",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/pieces_justificatives/attestation-dossier--05-03-2020-00-00-#{dossier.attestation.pdf.id % 10000}.pdf",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier.id}/export-#{dossier.id}-05-03-2020-00-00-#{dossier.id}.pdf",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier_2020.id}/",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier_2020.id}/export-#{dossier_2020.id}-05-03-2020-00-00-#{dossier_2020.id}.pdf",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier_2020.id}/pieces_justificatives/",
+            "procedure-#{procedure.id}-#{archive.id}/dossier-#{dossier_2020.id}/pieces_justificatives/attestation-dossier--05-03-2020-00-00-#{dossier_2020.attestation.pdf.id % 10000}.pdf"
           ]
           expect(files.map(&:filename)).to match_array(structure)
         end
@@ -176,29 +176,30 @@ describe ProcedureArchiveService do
   end
 
   describe '#download_and_zip' do
+    let(:archive) { build(:archive, id: '3') }
     it 'create a tmpdir while block is running' do
       previous_dir_list = Dir.entries(ProcedureArchiveService::ARCHIVE_CREATION_DIR)
 
-      service.send(:download_and_zip, []) do |_zip_file|
+      service.send(:download_and_zip, archive, []) do |_zip_file|
         new_dir_list = Dir.entries(ProcedureArchiveService::ARCHIVE_CREATION_DIR)
         expect(previous_dir_list).not_to eq(new_dir_list)
       end
     end
 
     it 'cleans up its tmpdir after block execution' do
-      expect { service.send(:download_and_zip, []) { |zip_file| } }
+      expect { service.send(:download_and_zip, archive, []) { |zip_file| } }
         .not_to change { Dir.entries(ProcedureArchiveService::ARCHIVE_CREATION_DIR) }
     end
 
     it 'creates a zip with zip utility' do
-      expected_zip_path = File.join(ProcedureArchiveService::ARCHIVE_CREATION_DIR, "#{service.send(:zip_root_folder)}.zip")
+      expected_zip_path = File.join(ProcedureArchiveService::ARCHIVE_CREATION_DIR, "#{service.send(:zip_root_folder, archive)}.zip")
       expect(service).to receive(:system).with('zip', '-0', '-r', expected_zip_path, an_instance_of(String))
-      service.send(:download_and_zip, []) { |zip_path| }
+      service.send(:download_and_zip, archive, []) { |zip_path| }
     end
 
     it 'cleans up its generated zip' do
-      expected_zip_path = File.join(ProcedureArchiveService::ARCHIVE_CREATION_DIR, "#{service.send(:zip_root_folder)}.zip")
-      service.send(:download_and_zip, []) do |_zip_path|
+      expected_zip_path = File.join(ProcedureArchiveService::ARCHIVE_CREATION_DIR, "#{service.send(:zip_root_folder, archive)}.zip")
+      service.send(:download_and_zip, archive, []) do |_zip_path|
         expect(File.exist?(expected_zip_path)).to be_truthy
       end
       expect(File.exist?(expected_zip_path)).to be_falsey


### PR DESCRIPTION
## Problème 

Lorsqu'on génére une archive pour une procédure, celle ci a toujours le même nom (`procedure-{procedure.id}.zip`). 

En testant la fonction sur le pass culture, j'ai lancé 4/5 archives en parallel (pour le moment le worker de delayed job a su en prendre 4 en parallel) ; mais on pourrait se retrouver a ecraser/re-ecrire un fichier procedure-id.zip en cours de route. on veut pas ça, donc on suffixe le nom de l'archive par l'id de l'archive