### PR TITLE
Usager : activation de l'attestation de dépôt pour toutes les démarches

### DIFF
--- a/app/models/mails/initiated_mail.rb
+++ b/app/models/mails/initiated_mail.rb
@@ -22,12 +22,10 @@ module Mails
     DOSSIER_STATE = Dossier.states.fetch(:en_construction)
 
     def attachment_for_dossier(dossier)
-      if procedure.feature_enabled?(:procedure_dossier_papertrail)
-        {
-          filename: I18n.t('users.dossiers.show.papertrail.filename'),
-          content: deposit_receipt_for_dossier(dossier)
-        }
-      end
+      {
+        filename: I18n.t('users.dossiers.show.papertrail.filename'),
+        content: deposit_receipt_for_dossier(dossier)
+      }
     end
 
     private

--- a/app/views/users/dossiers/show.html.haml
+++ b/app/views/users/dossiers/show.html.haml
@@ -8,9 +8,7 @@
 
   .container
     = render partial: 'users/dossiers/show/status_overview', locals: { dossier: @dossier }
-
-    - if @dossier.procedure.feature_enabled?(:procedure_dossier_papertrail)
-      = render partial: 'users/dossiers/show/papertrail', locals: { dossier: @dossier }
+    = render partial: 'users/dossiers/show/papertrail', locals: { dossier: @dossier }
 
     - if !@dossier.termine?
       = render partial: 'users/dossiers/show/latest_message', locals: { dossier: @dossier }

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -26,8 +26,7 @@ features = [
   :hide_instructeur_email,
   :procedure_revisions,
   :procedure_routage_api,
-  :procedure_process_expired_dossiers_termine,
-  :procedure_dossier_papertrail
+  :procedure_process_expired_dossiers_termine
 ]
 
 def database_exists?

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -16,15 +16,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     it 'renders the template' do
       expect(mail.subject).to eq('Email subject')
       expect((mail.html_part || mail).body).to include('Your dossier was received')
-    end
-
-    context 'when the deposit receipt feature is enabled' do
-      before { Flipper.enable(:procedure_dossier_papertrail, procedure) }
-      after { Flipper.disable(:procedure_dossier_papertrail, procedure) }
-
-      it 'attaches the deposit receipt' do
-        expect(mail.attachments.first.filename).to eq("attestation-de-depot.pdf")
-      end
+      expect(mail.attachments.first.filename).to eq("attestation-de-depot.pdf")
     end
   end
 

--- a/spec/system/users/dossier_details_spec.rb
+++ b/spec/system/users/dossier_details_spec.rb
@@ -16,14 +16,9 @@ describe 'Dossier details:' do
     expect(page).to have_text(dossier.commentaires.last.body)
   end
 
-  context 'when the deposit receipt feature is enabled' do
-    before { Flipper.enable(:procedure_dossier_papertrail, procedure) }
-    after { Flipper.disable(:procedure_dossier_papertrail, procedure) }
-
-    it 'displays a link to download a deposit receipt' do
-      visit dossier_path(dossier)
-      expect(page).to have_link("Obtenir une attestation de dépôt de dossier", href: %r{dossiers/#{dossier.id}/papertrail.pdf})
-    end
+  scenario 'the user can download a deposit receipt' do
+    visit dossier_path(dossier)
+    expect(page).to have_link("Obtenir une attestation de dépôt de dossier", href: %r{dossiers/#{dossier.id}/papertrail.pdf})
   end
 
   describe "the user can see the mean time they are expected to wait" do


### PR DESCRIPTION
Suppression du feature-flag (sur l'instance de DS, la fonctionnalité était déjà activée pour tout le monde).