### PR TITLE
fix(webhook.perform): enqueue WebHookJob with current state/updated_at for consistency reason

### DIFF
--- a/app/jobs/web_hook_job.rb
+++ b/app/jobs/web_hook_job.rb
@@ -3,12 +3,12 @@ class WebHookJob < ApplicationJob
 
   TIMEOUT = 10
 
-  def perform(procedure, dossier)
+  def perform(procedure_id, dossier_id, state, updated_at)
     body = {
-      procedure_id: procedure.id,
-      dossier_id: dossier.id,
-      state: dossier.state,
-      updated_at: dossier.updated_at
+      procedure_id: procedure_id,
+      dossier_id: dossier_id,
+      state: state,
+      updated_at: updated_at
     }
 
     Typhoeus.post(procedure.web_hook_url, body: body, timeout: TIMEOUT)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1251,8 +1251,10 @@ class Dossier < ApplicationRecord
   def send_web_hook
     if saved_change_to_state? && !brouillon? && procedure.web_hook_url.present?
       WebHookJob.perform_later(
-        procedure,
-        self
+        procedure.id,
+        self.id,
+        self.state,
+        self.updated_at
       )
     end
   end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -962,7 +962,7 @@ describe Dossier do
 
       expect {
         dossier.passer_en_construction!
-      }.to have_enqueued_job(WebHookJob)
+      }.to have_enqueued_job(WebHookJob).with(dossier.procedure.id, dossier.id, 'en_construction', anything)
 
       expect {
         dossier.update_column(:search_terms, 'bonjour2')
@@ -970,7 +970,7 @@ describe Dossier do
 
       expect {
         dossier.passer_en_instruction!(instructeur: instructeur)
-      }.to have_enqueued_job(WebHookJob)
+      }.to have_enqueued_job(WebHookJob).with(dossier.procedure.id, dossier.id, 'en_instruction', anything)
     end
   end
 


### PR DESCRIPTION
# contexte
ETQ consommateur de webhook, je reçois 2x la même notification

voir crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_bb971d2e-6194-489a-a393-ecda3d2a2106/

# constat 
l'utilisateur en question a changer le status du dossier sur la même seconde. je suppose donc que deux jobs sont partis, avec un delais d'attente, il ont tout les deux emis la notif quand le dossier etait deja en accepte: http://localhost:9002/goto/f79f02fb3008444e7b4c58271d09a3b9