### PR TITLE
Fixe la restauration des démarches supprimées

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -177,7 +177,7 @@ module Administrateurs
 
     def restore
       procedure = current_administrateur.procedures.with_discarded.discarded.find(params[:id])
-      procedure.restore_procedure
+      procedure.restore_procedure(current_administrateur)
       flash.notice = t('administrateurs.index.restored', procedure_id: procedure.id)
       redirect_to admin_procedures_path
     end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -707,9 +707,12 @@ class Procedure < ApplicationRecord
     end
   end
 
-  def restore_procedure
+  def restore_procedure(author)
     if discarded?
       undiscard
+      self.dossiers.hidden_by_administration.each do |dossier|
+        dossier.restore(author)
+      end
     end
   end
 

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -785,7 +785,11 @@ describe Administrateurs::ProceduresController, type: :controller do
   end
 
   describe 'PUT #restore' do
-    let(:procedure) { create :procedure, :discarded, administrateur: admin }
+    let(:procedure) { create :procedure_with_dossiers, :with_service, :published, administrateur: admin }
+
+    before do
+      procedure.discard_and_keep_track!(admin)
+    end
 
     context 'when the admin wants to restore a procedure' do
       before do
@@ -794,6 +798,7 @@ describe Administrateurs::ProceduresController, type: :controller do
       end
 
       it { expect(procedure.discarded?).to be_falsy }
+      it { expect(procedure.dossiers.first.hidden_by_administration_at).to be_nil }
     end
   end
 end


### PR DESCRIPTION
Met "hidden_by_administration_at" des dossiers liés à la démarche à NIL lors de la restauration