### PR TITLE
Ajoute un raccourci pour copier un siret dans la vue instructeur

### DIFF
--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -27,7 +27,8 @@
           %td= raison_sociale_or_name(etablissement)
         %tr
           %td.libelle SIRET :
-          %td= pretty_siret(etablissement.siret)
+          %td #{pretty_siret(etablissement.siret)} #{ render Dsfr::CopyButtonComponent.new(text: etablissement.siret, title: "Copier le siret dans le presse-papier", success: "Le siret a été copié dans le presse-papier") }
+
 
         - unless local_assigns[:short_identity]
           - if etablissement.siret != etablissement.entreprise.siret_siege_social


### PR DESCRIPTION
pour un siret dans la partie identification

![Screenshot 2023-03-20 at 17-36-45 Demande · Dossier nº 413624 (NOTRE TRANSPORTS) · demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/226410381-3aa4aa8e-47ae-4830-8aeb-d19ff6dd3c2c.png)

pour un siret dans un champ

![Screenshot 2023-03-20 at 17-44-59 Demande · Dossier nº 4745807 (LE LOUARN LE LOUARN SMAIL_MARINE _) · demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/226410375-1bdcdaf7-5c53-48fd-ae3b-c65e9f4c7374.png)


Le rendu est pas top (saut de ligne), mais je vois pas trop de quick flx.