### PR TITLE
Accessibilité: ajoute l'attribut title précisant l'ouverture dans un nouvel onglet dans l'auto-formatter de texte

### DIFF
--- a/app/components/simple_format_component.rb
+++ b/app/components/simple_format_component.rb
@@ -28,13 +28,9 @@ class SimpleFormatComponent < ApplicationComponent
       .join("\n\n")   #
     @allow_a = allow_a
     @renderer = Redcarpet::Markdown.new(
-      Redcarpet::BareRenderer.new(link_attributes: external_link_attributes, class_names_map: class_names_map),
+      Redcarpet::BareRenderer.new(class_names_map:),
       REDCARPET_EXTENSIONS.merge(autolink: @allow_a)
     )
-  end
-
-  def external_link_attributes
-    { target: '_blank', rel: 'noopener noreferrer' }
   end
 
   def tags
@@ -46,6 +42,6 @@ class SimpleFormatComponent < ApplicationComponent
   end
 
   def attributes
-    ['target', 'rel', 'href', 'class']
+    ['target', 'rel', 'href', 'class', 'title']
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -142,7 +142,7 @@ module ApplicationHelper
   end
 
   def new_tab_suffix(title)
-    "#{title} — #{I18n.t('utils.new_tab')}"
+    [title, I18n.t('utils.new_tab')].compact.join(' — ')
   end
 
   def download_details(attachment)

--- a/app/lib/redcarpet/bare_renderer.rb
+++ b/app/lib/redcarpet/bare_renderer.rb
@@ -1,6 +1,7 @@
 module Redcarpet
   class BareRenderer < Redcarpet::Render::HTML
     include ActionView::Helpers::TagHelper
+    include ApplicationHelper
 
     # won't use rubocop tag method because it is missing output buffer
     # rubocop:disable Rails/ContentTag
@@ -16,6 +17,17 @@ module Redcarpet
     def paragraph(text)
       content_tag(:p, text, { class: @options[:class_names_map].fetch(:paragraph) {} }, false)
     end
+
+    def link(href, title, content)
+      content_tag(:a, content, { href:, title: new_tab_suffix(title), **external_link_attributes }, false)
+    end
+
+    def autolink(link, link_type)
+      return super unless link_type == :url
+
+      link(link, nil, link)
+    end
+
     # rubocop:enable Rails/ContentTag
   end
 end

--- a/spec/components/simple_format_component_spec.rb
+++ b/spec/components/simple_format_component_spec.rb
@@ -64,6 +64,11 @@ TEXT
     context 'enabled' do
       let(:allow_a) { true }
       it { expect(page).to have_selector("a") }
+      it "inject expected attributes" do
+        link = page.find_link("https://www.demarches-simplifiees.fr").native
+        expect(link[:rel]).to eq("noopener noreferrer")
+        expect(link[:title]).to eq("Nouvel onglet")
+      end
     end
 
     context 'disabled' do


### PR DESCRIPTION
Concerne : la description de la démarche, la messagerie, le champe xplication et quelques autres endroits où les utilisateurs peuvent saisir des urls qu'on convertit en lien.

Closes #8095

 @julieSalha : pour info ce sont juste des urls converties en lien, volontairement sans titre ou ancre personnalisable pour éviter le phishing et faire un lien vers un site frauduleux en prétendant être un lien vers un site fiable (exemple: on ne veut _pas_ pouvoir faire `<a href="http://site-pirate" title="Allez sur le site des impots - Nouvel onglet">site des impots</a>`, ce qui masquerait l'url cible et inspirerait confiance alors qu'il faut se méfier)



![Capture d’écran 2023-03-22 à 12 49 37](https://user-images.githubusercontent.com/150279/226895573-91d52fe3-3033-4af1-8f05-9f4fa3d69a43.png)
