### PR TITLE
fix(smtp): Allow specifying SSL settings

### DIFF
--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -206,7 +206,8 @@ SMTP_HOST=""
 SMTP_PORT=""
 SMTP_USER=""
 SMTP_PASS=""
-SMTP_TLS=""
+SMTP_STARTTLS="enabled" # Use any non-blank value to enable starttls
+SMTP_TLS=""             # Use any non-blank value to enable TLS
 SMTP_AUTHENTICATION="plain"
 
 # Sendmail

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,8 +105,8 @@ Rails.application.configure do
       user_name:            ENV.fetch("SMTP_USER"),
       password:             ENV.fetch("SMTP_PASS"),
       authentication:       ENV.fetch("SMTP_AUTHENTICATION"),
-      enable_starttls_auto: ENV.fetch("SMTP_TLS").present?,
-      ssl:                  ENV.fetch("SMTP_SSL").present?
+      enable_starttls_auto: ENV.fetch("SMTP_STARTTLS", "enabled").present?,
+      tls:                  ENV.fetch("SMTP_TLS", "").present?
     }
   elsif ENV['SENDMAIL_ENABLED'] == 'enabled'
     config.action_mailer.delivery_method = :sendmail

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,7 +105,8 @@ Rails.application.configure do
       user_name:            ENV.fetch("SMTP_USER"),
       password:             ENV.fetch("SMTP_PASS"),
       authentication:       ENV.fetch("SMTP_AUTHENTICATION"),
-      enable_starttls_auto: ENV.fetch("SMTP_TLS").present?
+      enable_starttls_auto: ENV.fetch("SMTP_TLS").present?,
+      ssl:                  ENV.fetch("SMTP_SSL").present?
     }
   elsif ENV['SENDMAIL_ENABLED'] == 'enabled'
     config.action_mailer.delivery_method = :sendmail


### PR DESCRIPTION
Pour les serveurs mails utilisant TLS mais pas starttls il faut l'activer à la main