### PR TITLE
ETQ usager sans dossier, je peux savoir comment trouver une démarche

### DIFF
--- a/app/views/users/dossiers/_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_dossiers_list.html.haml
@@ -94,7 +94,7 @@
 
 
 - else
-  - if filter.present?
+  - if filter.present? && filter.filter_params_count > 0
     .blank-tab
       %h2.empty-text= t('views.users.dossiers.dossiers_list.no_result_title')
       %p.empty-text-details
@@ -114,3 +114,5 @@
       %h2.empty-text= t('views.users.dossiers.dossiers_list.no_result_title')
       %p.empty-text-details
         = t('views.users.dossiers.dossiers_list.no_result_text_html', app_base: APPLICATION_BASE_URL)
+      %p
+        = link_to t("root.landing.how_to_find_procedure"), t("links.common.faq.comment_trouver_ma_demarche_url"), class: "fr-btn fr-btn--lg fr-mr-1w fr-mb-2w", **external_link_attributes


### PR DESCRIPTION
close #9823 

Avec cette PR, lorsqu'un utilisateur se connecte via France Connect et qu'il n'a aucun dossier, un lien lui est fourni pour savoir comment trouver sa démarche

![2023-12-08-144737_832x451_scrot](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/assets/1111966/48f27e54-e6aa-4f57-b06f-62c70247c7a3)
