### PR TITLE
ETQ admin, ne détruit pas l'attestation v1 en allant sur la page pour préparer une v2

### DIFF
--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -130,7 +130,7 @@ module Administrateurs
 
     def build_default_attestation
       state = should_edit_draft? ? :draft : :published
-      @procedure.build_attestation_template(version: 2, json_body: AttestationTemplate::TIPTAP_BODY_DEFAULT, activated: true, state:)
+      @procedure.attestation_templates.build(version: 2, json_body: AttestationTemplate::TIPTAP_BODY_DEFAULT, activated: true, state:)
     end
 
     def should_edit_draft? = !@procedure.brouillon?

--- a/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
@@ -140,6 +140,7 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
         subject
         expect(assigns(:attestation_template).version).to eq(2)
         expect(assigns(:attestation_template)).to be_draft
+        expect(attestation_template.reload).to be_present
       end
     end
 


### PR DESCRIPTION
la relation `Procedure#attestation_template` étant unitaire (`has_one`), rails supprimait l'existante lorsqu'on en build une nouvelle.