### PR TITLE
ETQ Adminsitrateur, je peux mettre des conditions sur les colonnes

### DIFF
--- a/app/components/conditions/champs_conditions_component.rb
+++ b/app/components/conditions/champs_conditions_component.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class Conditions::ChampsConditionsComponent < Conditions::ConditionsComponent
-  def initialize(tdc:, upper_tdcs:, procedure_id:)
+  def initialize(tdc:, upper_tdcs:, procedure:)
     @tdc, @condition, @source_tdcs = tdc, tdc.condition, upper_tdcs
-    @procedure_id = procedure_id
+    @procedure = procedure
+    @champ_value_in_condition = procedure.champ_value_in_condition?
   end
 
   private
@@ -29,11 +30,11 @@ class Conditions::ChampsConditionsComponent < Conditions::ConditionsComponent
   end
 
   def add_condition_path
-    add_row_admin_procedure_condition_path(@procedure_id, @tdc.stable_id)
+    add_row_admin_procedure_condition_path(@procedure.id, @tdc.stable_id)
   end
 
   def delete_condition_path(row_index)
-    delete_row_admin_procedure_condition_path(@procedure_id, @tdc.stable_id, row_index: row_index)
+    delete_row_admin_procedure_condition_path(@procedure.id, @tdc.stable_id, row_index: row_index)
   end
 
   def input_id_for(name, row_index)

--- a/app/components/conditions/champs_conditions_component/champs_conditions_component.html.haml
+++ b/app/components/conditions/champs_conditions_component/champs_conditions_component.html.haml
@@ -1,5 +1,5 @@
 .flex.justify-start.section{ id: dom_id(@tdc.stable_self, :condition), data: {turbo_force: :server} }
-  = form_tag admin_procedure_condition_path(@procedure_id, @tdc.stable_id), method: :patch, class: 'form' do
+  = form_tag admin_procedure_condition_path(@procedure.id, @tdc.stable_id), method: :patch, class: 'form' do
     .conditionnel.fr-mt-4v
       .flex
         %p

--- a/app/components/conditions/conditions_component.rb
+++ b/app/components/conditions/conditions_component.rb
@@ -40,48 +40,79 @@ class Conditions::ConditionsComponent < ApplicationComponent
     # - its type has changed : number -> carto
     # - it has been removed
     # - it has been put lower in the form
-    current_target_valid = targets_for_select.map(&:second).include?(targeted_champ.to_json)
+    current_target_valid = sources_by_section
+      .values
+      .flat_map { it.map(&:last) }
+      .include?(targeted_champ)
 
-    selected_target = current_target_valid ? targeted_champ.to_json : empty.to_json
+    selected_target = current_target_valid ? targeted_champ : empty
 
     select_tag(
       input_name_for('targeted_champ'),
-      options_for_select(targets_for_select, selected_target),
+      target_options_html(sources_by_section, selected_target),
       onchange: "this.form.action = this.form.action + '/change_targeted_champ?row_index=#{row_index}'",
       id: input_id_for('targeted_champ', row_index),
       class: { 'fr-select': true, alert: !current_target_valid }
     )
   end
 
-  def targets_for_select
-    empty_target_for_select + available_targets_for_select
+  def target_options_html(sources_by_section, selected_target)
+    options = [option_tag(t('.select'), empty, selected_target)]
+
+    sources_by_section.each do |section, sources|
+      options << content_tag(:option, section.libelle, disabled: true) if section.present?
+      sources.each { |label, source| options << option_tag(label, source, selected_target) }
+    end
+
+    safe_join(options)
+  end
+
+  def option_tag(label, source, selected)
+    content_tag(:option, label, value: source.to_json, selected: source == selected)
   end
 
   def empty_target_for_select
     [[t('.select'), empty.to_json]]
   end
 
-  def available_targets_for_select
-    if column_mode?
-      conditionable_targets_by_tdc
-        .map { |column| [column.label + " (col)", column_value(column).to_json] }
-    else
-      @source_tdcs
-        .filter(&:conditionable?)
-        .map { |tdc| [tdc.libelle, champ_value(tdc.stable_id).to_json] }
-    end
-  end
-
   def column_mode?
     feature_enabled?(:column_conditions) && !@champ_value_in_condition
   end
 
-  def conditionable_targets_by_tdc
-    @conditionable_targets_by_tdc ||= @source_tdcs.to_h do |tdc|
-      tdc.columns(procedure: @procedure)
-        .filter { _1.type != :text }
-        .filter { _1.type != :date }
+  def sources_by_section
+    @sources_by_section ||= index_by_top_section(@source_tdcs)
+      .transform_values { |tdcs| to_sources(tdcs) }
+      .compact_blank
+  end
+
+  def index_by_top_section(tdcs)
+    last_section = nil
+    tdcs.each_with_object(Hash.new { |h, k| h[k] = [] }) do |tdc, h|
+      if tdc.header_section? && tdc.header_section_level_value == 1
+        last_section = tdc
+      else
+        h[last_section] << tdc
+      end
     end
+  end
+
+  def to_sources(tdcs) = column_mode? ? to_column_values(tdcs) : to_champ_values(tdcs)
+
+  SUPPORTED_TYPES = [:integer, :decimal, :enum, :enums, :boolean].freeze
+
+  def to_column_values(tdcs)
+    tdcs
+      .reject(&:repetition?)
+      .flat_map { it.columns(procedure: @procedure) }
+      .filter(&:filterable)
+      .filter { it.type.in?(SUPPORTED_TYPES) }
+      .map { |column| [column.label, column_value(column)] }
+  end
+
+  def to_champ_values(tdcs)
+    tdcs
+      .filter(&:conditionable?)
+      .map { |tdc| [tdc.libelle, champ_value(tdc.stable_id)] }
   end
 
   def operator_tag(operator_name, targeted_champ, row_index)
@@ -219,7 +250,7 @@ class Conditions::ConditionsComponent < ApplicationComponent
   end
 
   def render?
-    @condition.present? || available_targets_for_select.any?
+    @condition.present? || sources_by_section.any?
   end
 
   def input_name_for(name)

--- a/app/components/conditions/conditions_component.rb
+++ b/app/components/conditions/conditions_component.rb
@@ -62,9 +62,26 @@ class Conditions::ConditionsComponent < ApplicationComponent
   end
 
   def available_targets_for_select
-    @source_tdcs
-      .filter(&:conditionable?)
-      .map { |tdc| [tdc.libelle, champ_value(tdc.stable_id).to_json] }
+    if column_mode?
+      conditionable_targets_by_tdc
+        .map { |column| [column.label + " (col)", column_value(column).to_json] }
+    else
+      @source_tdcs
+        .filter(&:conditionable?)
+        .map { |tdc| [tdc.libelle, champ_value(tdc.stable_id).to_json] }
+    end
+  end
+
+  def column_mode?
+    feature_enabled?(:column_conditions) && !@champ_value_in_condition
+  end
+
+  def conditionable_targets_by_tdc
+    @conditionable_targets_by_tdc ||= @source_tdcs.to_h do |tdc|
+      tdc.columns(procedure: @procedure)
+        .filter { _1.type != :text }
+        .filter { _1.type != :date }
+    end
   end
 
   def operator_tag(operator_name, targeted_champ, row_index)

--- a/app/components/conditions/conditions_component.rb
+++ b/app/components/conditions/conditions_component.rb
@@ -103,7 +103,7 @@ class Conditions::ConditionsComponent < ApplicationComponent
   def to_column_values(tdcs)
     tdcs
       .reject(&:repetition?)
-      .flat_map { it.columns(procedure: @procedure) }
+      .flat_map { it.columns(procedure_id: @procedure.id) }
       .filter(&:filterable)
       .filter { it.type.in?(SUPPORTED_TYPES) }
       .map { |column| [column.label, column_value(column)] }

--- a/app/components/conditions/conditions_component.rb
+++ b/app/components/conditions/conditions_component.rb
@@ -96,17 +96,17 @@ class Conditions::ConditionsComponent < ApplicationComponent
     end
   end
 
-  def to_sources(tdcs) = column_mode? ? to_column_values(tdcs) : to_champ_values(tdcs)
+  def to_sources(tdcs) = column_mode? ? to_champ_column_values(tdcs) : to_champ_values(tdcs)
 
   SUPPORTED_TYPES = [:integer, :decimal, :enum, :enums, :boolean].freeze
 
-  def to_column_values(tdcs)
+  def to_champ_column_values(tdcs)
     tdcs
       .reject(&:repetition?)
       .flat_map { it.columns(procedure_id: @procedure.id) }
       .filter(&:filterable)
       .filter { it.type.in?(SUPPORTED_TYPES) }
-      .map { |column| [column.label, column_value(column)] }
+      .map { |column| [column.label, champ_column_value(column)] }
   end
 
   def to_champ_values(tdcs)

--- a/app/components/conditions/ineligibilite_rules_component.rb
+++ b/app/components/conditions/ineligibilite_rules_component.rb
@@ -5,9 +5,12 @@ class Conditions::IneligibiliteRulesComponent < Conditions::ConditionsComponent
 
   def initialize(draft_revision:)
     @draft_revision = draft_revision
-    @published_revision = draft_revision.procedure.published_revision
+    @procedure = draft_revision.procedure
+    @published_revision = @procedure.published_revision
     @condition = draft_revision.ineligibilite_rules
     @source_tdcs = draft_revision.types_de_champ_for(scope: :public)
+    @procedure_id = @procedure.id
+    @champ_value_in_condition = @procedure.champ_value_in_condition?
   end
 
   def pending_changes?

--- a/app/components/conditions/routing_rules_component.rb
+++ b/app/components/conditions/routing_rules_component.rb
@@ -6,8 +6,10 @@ class Conditions::RoutingRulesComponent < Conditions::ConditionsComponent
   def initialize(groupe_instructeur:)
     @groupe_instructeur = groupe_instructeur
     @condition = groupe_instructeur.routing_rule || empty_operator(empty, empty)
-    @procedure_id = groupe_instructeur.procedure_id
-    @source_tdcs = groupe_instructeur.procedure.active_revision.types_de_champ_public
+    @procedure = groupe_instructeur.procedure
+    @procedure_id = @procedure.id
+    @source_tdcs = @procedure.active_revision.types_de_champ_public
+    @champ_value_in_condition = @procedure.champ_value_in_condition?
   end
 
   private

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
@@ -614,7 +614,7 @@
       </div>
     <% end %>
 
-    <%= render(Conditions::ChampsConditionsComponent.new(tdc: type_de_champ, upper_tdcs: @upper_coordinates.map(&:type_de_champ), procedure_id: procedure.id)) %>
+    <%= render(Conditions::ChampsConditionsComponent.new(tdc: type_de_champ, upper_tdcs: @upper_coordinates.map(&:type_de_champ), procedure:)) %>
 
     <div class="flex justify-between section footer">
       <div class="position flex align-center">

--- a/app/controllers/administrateurs/conditions_controller.rb
+++ b/app/controllers/administrateurs/conditions_controller.rb
@@ -51,7 +51,7 @@ module Administrateurs
       Conditions::ChampsConditionsComponent.new(
         tdc: @tdc,
         upper_tdcs: @upper_tdcs,
-        procedure_id: @procedure.id
+        procedure: @procedure
       )
     end
 

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -390,8 +390,12 @@ module Instructeurs
 
       respond_to do |format|
         format.turbo_stream do
-          @to_show, @to_hide = []
           @to_update = [annotation].concat(annotation.prefillable_champs)
+
+          @to_show, @to_hide = @dossier.project_champs_private_all
+            .filter { it.conditional? || it.child? }
+            .partition(&:visible?)
+            .map { champs_to_one_selector(_1 - @to_update) }
 
           render :update_annotations
         end

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -383,8 +383,13 @@ module Users
       champ.validate(:champs_public_value) if champ.done?
       respond_to do |format|
         format.turbo_stream do
-          @to_show, @to_hide = []
           @to_update = [champ].concat(champ.prefillable_champs)
+
+          @to_show, @to_hide = dossier.project_champs_public_all
+            .filter { it.conditional? || it.child? }
+            .partition(&:visible?)
+            .map { champs_to_one_selector(_1 - @to_update) }
+
           render :update, layout: false
         end
       end

--- a/app/models/column.rb
+++ b/app/models/column.rb
@@ -70,7 +70,5 @@ class Column
 
   def self.not_filled_option = [I18n.t('activerecord.attributes.type_de_champ.not_filled'), NOT_FILLED_VALUE]
 
-  private
-
   def column_id = "#{table}/#{column}"
 end

--- a/app/models/columns/champ_column.rb
+++ b/app/models/columns/champ_column.rb
@@ -94,6 +94,8 @@ class Columns::ChampColumn < Column
 
   def champ_column? = true
 
+  def column_id = "type_de_champ/#{stable_id}"
+
   private
 
   def range_for_query(date_range)
@@ -102,8 +104,6 @@ class Columns::ChampColumn < Column
 
     start_date..end_date
   end
-
-  def column_id = "type_de_champ/#{stable_id}"
 
   def string_value(champ) = champ.public_send(column)
 

--- a/app/models/columns/json_path_column.rb
+++ b/app/models/columns/json_path_column.rb
@@ -36,6 +36,8 @@ class Columns::JSONPathColumn < Columns::ChampColumn
     end
   end
 
+  def column_id = "type_de_champ/#{stable_id}-#{jsonpath}"
+
   private
 
   def filtered_ids_for_date_range(dossiers, range)
@@ -88,8 +90,6 @@ class Columns::JSONPathColumn < Columns::ChampColumn
     @jsonpath_for_sql ||= jsonpath.split('.').map { _1.match?(/\A\d/) ? "\"#{_1}\"" : _1 }.join('.')
   end
 
-  def column_id = "type_de_champ/#{stable_id}-#{jsonpath}"
-
   def typed_value(champ)
     JsonPath.on(champ.value_json, jsonpath).first
   end
@@ -97,8 +97,6 @@ class Columns::JSONPathColumn < Columns::ChampColumn
   def quote_string(string) = ActiveRecord::Base.connection.quote_string(string)
 
   def sanitize_sql(sql) = ActiveRecord::Base.sanitize_sql(sql)
-
-  private
 
   def targeted_dossiers(dossiers, condition)
     dossiers.with_type_de_champ(stable_id).where(condition)

--- a/app/models/columns/linked_drop_down_column.rb
+++ b/app/models/columns/linked_drop_down_column.rb
@@ -50,9 +50,9 @@ class Columns::LinkedDropDownColumn < Columns::ChampColumn
     end
   end
 
-  private
-
   def column_id = "type_de_champ/#{stable_id}.#{path}"
+
+  private
 
   def typed_value(champ)
     primary_value, secondary_value = unpack_values(champ.value)

--- a/app/models/concerns/columns_concern.rb
+++ b/app/models/concerns/columns_concern.rb
@@ -18,9 +18,7 @@ module ColumnsConcern
         .gsub('departement_code', 'department_code')
         .gsub('naf', 'code_naf')
 
-      h_id[:column_id] = new_column_id
-
-      column = columns.find { _1.h_id == h_id }
+      column = columns.find { _1.h_id == h_id.merge(column_id: new_column_id) }
     end
 
     raise ActiveRecord::RecordNotFound.new("Column: unable to find h_id: #{h_id} or label: #{label} for procedure_id #{id}") if column.nil?

--- a/app/models/logic.rb
+++ b/app/models/logic.rb
@@ -131,7 +131,7 @@ module Logic
 
   def champ_value(stable_id) = Logic::ChampValue.new(stable_id)
 
-  def column_value(column) = Logic::ColumnValue.new(column)
+  def column_value(column) = Logic::ColumnValue.new(column.stable_id, column.column_id)
 
   def empty = Logic::Empty.new
 

--- a/app/models/logic.rb
+++ b/app/models/logic.rb
@@ -12,7 +12,7 @@ module Logic
   def self.class_from_name(name)
     [
       ChampValue,
-      ColumnValue,
+      ChampColumnValue,
       Constant,
       Empty,
       LessThan,
@@ -131,7 +131,7 @@ module Logic
 
   def champ_value(stable_id) = Logic::ChampValue.new(stable_id)
 
-  def column_value(column) = Logic::ColumnValue.new(column.stable_id, column.column_id)
+  def column_value(column) = Logic::ChampColumnValue.new(column.stable_id, column.column_id)
 
   def empty = Logic::Empty.new
 

--- a/app/models/logic.rb
+++ b/app/models/logic.rb
@@ -131,7 +131,7 @@ module Logic
 
   def champ_value(stable_id) = Logic::ChampValue.new(stable_id)
 
-  def column_value(column) = Logic::ChampColumnValue.new(column.stable_id, column.column_id)
+  def champ_column_value(column) = Logic::ChampColumnValue.new(column.stable_id, column.column_id)
 
   def empty = Logic::Empty.new
 

--- a/app/models/logic.rb
+++ b/app/models/logic.rb
@@ -12,6 +12,7 @@ module Logic
   def self.class_from_name(name)
     [
       ChampValue,
+      ColumnValue,
       Constant,
       Empty,
       LessThan,
@@ -129,6 +130,8 @@ module Logic
   def constant(value) = Logic::Constant.new(value)
 
   def champ_value(stable_id) = Logic::ChampValue.new(stable_id)
+
+  def column_value(column) = Logic::ColumnValue.new(column)
 
   def empty = Logic::Empty.new
 

--- a/app/models/logic/binary_operator.rb
+++ b/app/models/logic/binary_operator.rb
@@ -11,6 +11,8 @@ class Logic::BinaryOperator < Logic::Term
     [@left, @right].flat_map(&:sources)
   end
 
+  def terms = [self] + @left.terms + @right.terms
+
   def to_h
     {
       "term" => self.class.name,

--- a/app/models/logic/champ_column_value.rb
+++ b/app/models/logic/champ_column_value.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Logic::ColumnValue < Logic::Term
+class Logic::ChampColumnValue < Logic::Term
   attr_reader :stable_id
 
   def initialize(stable_id, column_id)

--- a/app/models/logic/column_value.rb
+++ b/app/models/logic/column_value.rb
@@ -26,14 +26,16 @@ class Logic::ColumnValue < Logic::Term
     end
   end
 
-  def type(_type_de_champs)
-    return :unmanaged if @champ_column.nil?
+  def type(type_de_champs)
+    return :unmanaged if @champ_column.nil? || targeted_tdc(type_de_champs).nil?
 
-    case @champ_column.type
+    type = targeted_column(type_de_champs).type
+
+    case type
     when :integer, :decimal
       Logic::ChampValue::CHAMP_VALUE_TYPE.fetch(:number)
     else
-      @champ_column.type
+      type
     end
   end
 

--- a/app/models/logic/column_value.rb
+++ b/app/models/logic/column_value.rb
@@ -17,7 +17,13 @@ class Logic::ColumnValue < Logic::Term
     return nil if !targeted_champ.visible?
     return nil if targeted_champ.blank? && !targeted_champ.drop_down_other?
 
-    @champ_column.value(targeted_champ)
+    # if it s a dropdown champ and a dropdown tdc (no cast)
+    # and the dropdown is other, return other
+    if targeted_champ.is_type?(@champ_column.tdc_type) && targeted_champ.drop_down_list? && targeted_champ.other?
+      Champs::DropDownListChamp::OTHER
+    else
+      @champ_column.value(targeted_champ)
+    end
   end
 
   def type(_type_de_champs)

--- a/app/models/logic/column_value.rb
+++ b/app/models/logic/column_value.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class Logic::ColumnValue < Logic::Term
+  delegate :label, :stable_id, to: :@champ_column
+
+  def initialize(champ_column)
+    @champ_column = champ_column
+  end
+
+  def sources = [stable_id]
+
+  def compute(champs)
+    targeted_champ = champs.find { |champ| champ.stable_id == stable_id }
+
+    return nil if targeted_champ.nil?
+    return nil if !targeted_champ.visible?
+    return nil if targeted_champ.blank? && !targeted_champ.drop_down_other?
+
+    @champ_column.value(targeted_champ)
+  end
+
+  def type(_type_de_champs)
+    case @champ_column.type
+    when :integer, :decimal
+      Logic::ChampValue::CHAMP_VALUE_TYPE.fetch(:number)
+    else
+      @champ_column.type
+    end
+  end
+
+  def options(_type_de_champs, _other = nil)
+    @champ_column.options_for_select
+  end
+
+  def errors(type_de_champs)
+    # champ_column.present? but the tdc is below current tdc
+    if !type_de_champs.map(&:stable_id).include?(stable_id)
+      [{ type: :not_available }]
+    else
+      []
+    end
+  end
+
+  def to_h
+    {
+      "term" => self.class.name,
+      "column_id" => @champ_column.h_id,
+    }
+  end
+
+  def self.from_h(h)
+    column = Column.find(h['column_id'].deep_symbolize_keys)
+    self.new(column)
+  end
+
+  def ==(other)
+    self.class == other.class && to_h == other.to_h
+  end
+
+  def to_s(_type_de_champ) = label
+end

--- a/app/models/logic/column_value.rb
+++ b/app/models/logic/column_value.rb
@@ -37,10 +37,10 @@ class Logic::ColumnValue < Logic::Term
     end
   end
 
-  def options(_type_de_champs, _other = nil)
+  def options(type_de_champs, _operator_name = nil)
     return [] if @champ_column.nil?
 
-    @champ_column.options_for_select
+    targeted_column(type_de_champs).options_for_select
   end
 
   def label = @champ_column&.label
@@ -80,4 +80,10 @@ class Logic::ColumnValue < Logic::Term
   end
 
   def to_s(_type_de_champ) = label
+
+  private
+
+  def targeted_tdc(tdcs) = tdcs.find { it.stable_id == stable_id }
+  def targeted_column(tdcs) = targeted_tdc(tdcs).columns(procedure_id:).find { it.h_id == @champ_column.h_id }
+  def procedure_id = @champ_column.h_id[:procedure_id]
 end

--- a/app/models/logic/column_value.rb
+++ b/app/models/logic/column_value.rb
@@ -1,35 +1,38 @@
 # frozen_string_literal: true
 
 class Logic::ColumnValue < Logic::Term
-  def initialize(champ_column, h_id: nil)
-    @champ_column = champ_column
-    @column_h_id = h_id
+  attr_reader :stable_id
+
+  def initialize(stable_id, column_id)
+    @stable_id, @column_id = stable_id, column_id
   end
 
-  def sources = [stable_id].compact
+  def sources = [stable_id]
 
   def compute(champs)
-    return nil if @champ_column.nil?
-
-    targeted_champ = champs.find { |champ| champ.stable_id == stable_id }
+    targeted_champ = champs.find { |it| it.stable_id == stable_id }
 
     return nil if targeted_champ.nil?
     return nil if !targeted_champ.visible?
     return nil if targeted_champ.blank? && !targeted_champ.drop_down_other?
 
+    column = targeted_column([targeted_champ.type_de_champ])
+
     # if it s a dropdown champ and a dropdown tdc (no cast)
     # and the dropdown is other, return other
-    if targeted_champ.is_type?(@champ_column.tdc_type) && targeted_champ.drop_down_list? && targeted_champ.other?
+    if targeted_champ.is_type?(column.tdc_type) && targeted_champ.drop_down_list? && targeted_champ.other?
       Champs::DropDownListChamp::OTHER
     else
-      @champ_column.value(targeted_champ)
+      column.value(targeted_champ)
     end
   end
 
   def type(type_de_champs)
-    return :unmanaged if @champ_column.nil? || targeted_tdc(type_de_champs).nil?
+    column = targeted_column(type_de_champs)
 
-    type = targeted_column(type_de_champs).type
+    return :unmanaged if column.nil?
+
+    type = column.type
 
     case type
     when :integer, :decimal
@@ -40,19 +43,14 @@ class Logic::ColumnValue < Logic::Term
   end
 
   def options(type_de_champs, _operator_name = nil)
-    return [] if @champ_column.nil?
+    return [] if targeted_column(type_de_champs).nil?
 
     targeted_column(type_de_champs).options_for_select
   end
 
-  def label = @champ_column&.label
-  def stable_id = @champ_column&.stable_id
-
   def errors(type_de_champs)
-    return [{ type: :not_available }] if @champ_column.nil?
-
-    # champ_column.present? but the tdc is below current tdc
-    if !type_de_champs.map(&:stable_id).include?(stable_id)
+    # the targeted tdc is below current tdc or has been removed
+    if targeted_column(type_de_champs).nil?
       [{ type: :not_available }]
     else
       []
@@ -62,30 +60,28 @@ class Logic::ColumnValue < Logic::Term
   def to_h
     {
       "term" => self.class.name,
-      "column_id" => @champ_column&.h_id || @column_h_id,
+      "stable_id" => stable_id,
+      "column_id" => @column_id,
     }
   end
 
   def self.from_h(h)
-    h_id = h['column_id'].deep_symbolize_keys
-    column = Column.find(h_id)
-    self.new(column)
-  rescue ActiveRecord::RecordNotFound
-    # the underlying column has been destroyed; keep the reference so the
-    # condition can self-heal if the column reappears, and so errors() can
-    # signal :not_available to the editor
-    self.new(nil, h_id: h_id)
+    self.new(h['stable_id'], h['column_id'])
   end
 
   def ==(other)
     self.class == other.class && to_h == other.to_h
   end
 
-  def to_s(_type_de_champ) = label
+  def to_s(tdcs) = targeted_column(tdcs)&.label
 
   private
 
+  def targeted_column(tdcs)
+    targeted_tdc(tdcs)
+      &.columns(procedure_id: nil) # dirty hack as we do not need procedure_id
+      &.find { it.column_id == @column_id }
+  end
+
   def targeted_tdc(tdcs) = tdcs.find { it.stable_id == stable_id }
-  def targeted_column(tdcs) = targeted_tdc(tdcs).columns(procedure_id:).find { it.h_id == @champ_column.h_id }
-  def procedure_id = @champ_column.h_id[:procedure_id]
 end

--- a/app/models/logic/column_value.rb
+++ b/app/models/logic/column_value.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 class Logic::ColumnValue < Logic::Term
-  delegate :label, :stable_id, to: :@champ_column
-
-  def initialize(champ_column)
+  def initialize(champ_column, h_id: nil)
     @champ_column = champ_column
+    @column_h_id = h_id
   end
 
-  def sources = [stable_id]
+  def sources = [stable_id].compact
 
   def compute(champs)
+    return nil if @champ_column.nil?
+
     targeted_champ = champs.find { |champ| champ.stable_id == stable_id }
 
     return nil if targeted_champ.nil?
@@ -20,6 +21,8 @@ class Logic::ColumnValue < Logic::Term
   end
 
   def type(_type_de_champs)
+    return :unmanaged if @champ_column.nil?
+
     case @champ_column.type
     when :integer, :decimal
       Logic::ChampValue::CHAMP_VALUE_TYPE.fetch(:number)
@@ -29,10 +32,17 @@ class Logic::ColumnValue < Logic::Term
   end
 
   def options(_type_de_champs, _other = nil)
+    return [] if @champ_column.nil?
+
     @champ_column.options_for_select
   end
 
+  def label = @champ_column&.label
+  def stable_id = @champ_column&.stable_id
+
   def errors(type_de_champs)
+    return [{ type: :not_available }] if @champ_column.nil?
+
     # champ_column.present? but the tdc is below current tdc
     if !type_de_champs.map(&:stable_id).include?(stable_id)
       [{ type: :not_available }]
@@ -44,13 +54,19 @@ class Logic::ColumnValue < Logic::Term
   def to_h
     {
       "term" => self.class.name,
-      "column_id" => @champ_column.h_id,
+      "column_id" => @champ_column&.h_id || @column_h_id,
     }
   end
 
   def self.from_h(h)
-    column = Column.find(h['column_id'].deep_symbolize_keys)
+    h_id = h['column_id'].deep_symbolize_keys
+    column = Column.find(h_id)
     self.new(column)
+  rescue ActiveRecord::RecordNotFound
+    # the underlying column has been destroyed; keep the reference so the
+    # condition can self-heal if the column reappears, and so errors() can
+    # signal :not_available to the editor
+    self.new(nil, h_id: h_id)
   end
 
   def ==(other)

--- a/app/models/logic/n_ary_operator.rb
+++ b/app/models/logic/n_ary_operator.rb
@@ -11,6 +11,8 @@ class Logic::NAryOperator < Logic::Term
     @operands.flat_map(&:sources)
   end
 
+  def terms = [self] + @operands.flat_map(&:terms)
+
   def to_h
     {
       "term" => self.class.name,

--- a/app/models/logic/term.rb
+++ b/app/models/logic/term.rb
@@ -12,4 +12,6 @@ class Logic::Term
   def eql?(other)
     hash == other.hash
   end
+
+  def terms = [self]
 end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -606,6 +606,13 @@ class Procedure < ApplicationRecord
     active_revision.revision_types_de_champ_public.filter(&:used_by_routing_rules?).map(&:libelle)
   end
 
+  def champ_value_in_condition?
+    return @champ_value_in_condition if defined?(@champ_value_in_condition)
+
+    @champ_value_in_condition = draft_revision.champ_value_in_condition? ||
+      champ_value_in_routing_rule?
+  end
+
   def dossiers_count
     dossiers.count
   end
@@ -829,6 +836,13 @@ class Procedure < ApplicationRecord
   end
 
   private
+
+  def champ_value_in_routing_rule?
+    groupe_instructeurs
+      .filter_map(&:routing_rule)
+      .flat_map(&:terms)
+      .any? { _1.is_a?(Logic::ChampValue) }
+  end
 
   def stable_ids_used_by_routing_rules
     @stable_ids_used_by_routing_rules ||= groupe_instructeurs.flat_map { _1.routing_rule&.sources }.compact.uniq

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -261,6 +261,14 @@ class ProcedureRevision < ApplicationRecord
     types_de_champ_for(scope: :public).filter(&:conditionable?)
   end
 
+  def champ_value_in_condition?
+    conditions = types_de_champ.filter_map(&:condition) + [ineligibilite_rules].compact
+
+    conditions
+      .flat_map(&:terms)
+      .any? { _1.is_a?(Logic::ChampValue) }
+  end
+
   def apply_llm_rule_suggestion_items(changes)
     # Handle adds first, outside transaction to ensure stable_ids are generated and available
     created = changes.fetch(:add, []).each_with_object({}) do |item, accu|

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -500,11 +500,7 @@ class TypeDeChamp < ApplicationRecord
     elsif pays?
       APIGeoService.country_options
     elsif any_drop_down_list?
-      if drop_down_advanced?
-        Array.wrap(referentiel&.options_for_select)
-      else
-        drop_down_options.uniq.map { [_1, _1] }
-      end
+      options_for_select_with_other
     elsif yes_no?
       Champs::YesNoChamp.options
     elsif checkbox?
@@ -515,11 +511,17 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def options_for_select_with_other
-    if drop_down_other?
-      options_for_select + [[I18n.t('shared.champs.drop_down_list.other'), Champs::DropDownListChamp::OTHER]]
+    options = if drop_down_advanced?
+      Array.wrap(referentiel&.options_for_select)
     else
-      options_for_select
+      drop_down_options.uniq.map { [it, it] }
     end
+
+    if drop_down_other?
+      options << [I18n.t('shared.champs.drop_down_list.other'), Champs::DropDownListChamp::OTHER]
+    end
+
+    options
   end
 
   def drop_down_options_from_text=(text)

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -30,6 +30,12 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBase
     if drop_down_advanced?
       referentiel_columns = if referentiel.present?
         referentiel.headers_with_path.map do |(header, path)|
+          options_for_select = referentiel.options_for_path(path)
+
+          if drop_down_other?
+            options_for_select << [I18n.t('shared.champs.drop_down_list.other'), Champs::DropDownListChamp::OTHER]
+          end
+
           Columns::JSONPathColumn.new(
             procedure_id:,
             stable_id:,
@@ -38,7 +44,7 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBase
             type: :enum,
             jsonpath: "$.referentiel.data.row.#{path}",
             displayable:,
-            options_for_select: referentiel.options_for_path(path),
+            options_for_select:,
             mandatory: mandatory?
           )
         end

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -86,7 +86,7 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
         type: :enum,
         path: :primary,
         displayable: false,
-        options_for_select: primary_options,
+        options_for_select: primary_options.map { [it, it] },
         mandatory: mandatory?
       ),
       Columns::LinkedDropDownColumn.new(
@@ -97,7 +97,7 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
         type: :enum,
         path: :secondary,
         displayable: false,
-        options_for_select: secondary_options.values.flatten.uniq.sort,
+        options_for_select: secondary_options.values.flatten.uniq.sort.map { [it, it] },
         mandatory: mandatory?
       ),
     ]

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -35,6 +35,7 @@ features = [
   :switch_domain,
   :llm_nightly_improve_procedure,
   :ami_notifications,
+  :column_conditions,
 ]
 
 def database_exists?

--- a/spec/components/conditions/champs_conditions_component_spec.rb
+++ b/spec/components/conditions/champs_conditions_component_spec.rb
@@ -3,12 +3,18 @@
 describe Conditions::ChampsConditionsComponent, type: :component do
   include Logic
 
+  let(:procedure) { create(:procedure) }
+
   describe 'render' do
     let(:tdc) { create(:type_de_champ, condition: condition) }
     let(:condition) { nil }
     let(:upper_tdcs) { [] }
+    let(:component) { described_class.new(tdc: tdc, upper_tdcs: upper_tdcs, procedure: procedure) }
 
-    before { render_inline(described_class.new(tdc: tdc, upper_tdcs: upper_tdcs, procedure_id: 123)) }
+    before do
+      allow(component).to receive(:feature_enabled?).with(:column_conditions).and_return(false)
+      render_inline(component)
+    end
 
     context 'when there are no upper tdc' do
       it { expect(page).not_to have_text('Logique conditionnelle') }
@@ -189,7 +195,7 @@ describe Conditions::ChampsConditionsComponent, type: :component do
     let(:tdc) { build(:type_de_champ, condition: condition) }
     let(:condition) { nil }
 
-    subject { described_class.new(tdc: tdc, upper_tdcs: [], procedure_id: 123).send(:rows) }
+    subject { described_class.new(tdc: tdc, upper_tdcs: [], procedure: procedure).send(:rows) }
 
     context 'when there is one condition' do
       let(:condition) { ds_eq(empty, constant(1)) }

--- a/spec/components/conditions/champs_conditions_component_spec.rb
+++ b/spec/components/conditions/champs_conditions_component_spec.rb
@@ -108,7 +108,7 @@ describe Conditions::ChampsConditionsComponent, type: :component do
           create(:procedure, types_de_champ_public: [{ type: upper_tdc_type, libelle: 'col' }])
         end
         let(:upper_tdc) { procedure.draft_revision.types_de_champ.first }
-        let(:target) { column_value(upper_tdc.columns(procedure:).first) }
+        let(:target) { column_value(upper_tdc.columns(procedure_id: procedure.id).first) }
 
         include_examples 'targeted condition rendering'
       end

--- a/spec/components/conditions/champs_conditions_component_spec.rb
+++ b/spec/components/conditions/champs_conditions_component_spec.rb
@@ -6,13 +6,14 @@ describe Conditions::ChampsConditionsComponent, type: :component do
   let(:procedure) { create(:procedure) }
 
   describe 'render' do
-    let(:tdc) { create(:type_de_champ, condition: condition) }
+    let(:tdc) { create(:type_de_champ, condition:) }
     let(:condition) { nil }
     let(:upper_tdcs) { [] }
-    let(:component) { described_class.new(tdc: tdc, upper_tdcs: upper_tdcs, procedure: procedure) }
+    let(:component) { described_class.new(tdc:, upper_tdcs:, procedure:) }
+    let(:column_mode) { false }
 
     before do
-      allow(component).to receive(:feature_enabled?).with(:column_conditions).and_return(false)
+      allow(component).to receive(:feature_enabled?).with(:column_conditions).and_return(column_mode)
       render_inline(component)
     end
 
@@ -40,14 +41,76 @@ describe Conditions::ChampsConditionsComponent, type: :component do
       let(:upper_tdc) { create(:type_de_champ_number) }
       let(:upper_tdcs) { [upper_tdc] }
 
-      context 'and one condition' do
-        let(:condition) { ds_eq(champ_value(upper_tdc.stable_id), constant(1)) }
+      shared_examples 'targeted condition rendering' do
+        let(:upper_tdc_type) { :integer_number }
 
-        it do
-          expect(page).to have_button('cliquer pour désactiver')
-          expect(page).to have_selector('table')
-          expect(page).to have_selector('tbody > tr', count: 1)
+        context 'and one condition' do
+          let(:condition) { ds_eq(target, constant(1)) }
+
+          it do
+            expect(page).to have_button('cliquer pour désactiver')
+            expect(page).to have_selector('table')
+            expect(page).to have_selector('tbody > tr', count: 1)
+          end
         end
+
+        context 'focus one row' do
+          context 'enum' do
+            let(:upper_tdc_type) { :drop_down_list }
+            let(:condition) { empty_operator(target, constant(true)) }
+
+            it do
+              expect(page).to have_select('type_de_champ[condition_form][rows][][operator_name]', with_options: ['Est'])
+              expect(page).to have_select('type_de_champ[condition_form][rows][][value]', options: ['Sélectionner', 'val1', 'val2', 'val3'])
+            end
+          end
+
+          context 'regions' do
+            let(:upper_tdc_type) { :regions }
+            let(:condition) { empty_operator(target, constant(true)) }
+            let(:region_options) { APIGeoService.regions.map { _1[:name] } }
+
+            it do
+              expect(page).to have_select('type_de_champ[condition_form][rows][][operator_name]', with_options: ['Est'])
+              expect(page).to have_select('type_de_champ[condition_form][rows][][value]', options: (['Sélectionner'] + region_options))
+            end
+          end
+        end
+
+        context 'when there are 3 conditions' do
+          let(:condition) do
+            ds_or([
+              ds_eq(target, constant(1)),
+              ds_eq(target, empty),
+              greater_than(target, constant(3)),
+            ])
+          end
+
+          it do
+            expect(page).to have_selector('tbody > tr', count: 3)
+            expect(page).to have_select("type_de_champ_condition_form_top_operator_name", selected: "Ou", options: ['Et', 'Ou'])
+          end
+        end
+      end
+
+      context 'in champ_value mode' do
+        let(:upper_tdc) { create(:"type_de_champ_#{upper_tdc_type}") }
+        let(:target) { champ_value(upper_tdc.stable_id) }
+
+        include_examples 'targeted condition rendering'
+      end
+
+      context 'in column_value mode' do
+        let(:column_mode) { true }
+        # Le upper_tdc doit être attaché à la procedure pour que la
+        # désérialisation de la condition (Column.find) retrouve la colonne.
+        let(:procedure) do
+          create(:procedure, types_de_champ_public: [{ type: upper_tdc_type, libelle: 'col' }])
+        end
+        let(:upper_tdc) { procedure.draft_revision.types_de_champ.first }
+        let(:target) { column_value(upper_tdc.columns(procedure:).first) }
+
+        include_examples 'targeted condition rendering'
       end
 
       context 'focus one row' do
@@ -75,17 +138,6 @@ describe Conditions::ChampsConditionsComponent, type: :component do
           it do
             expect(page).to have_select('type_de_champ[condition_form][rows][][operator_name]', with_options: ['Est', 'N’est pas'])
             expect(page).to have_select('type_de_champ[condition_form][rows][][value]', options: ['Oui', 'Non'])
-          end
-        end
-
-        context 'enum' do
-          let(:drop_down) { create(:type_de_champ_drop_down_list) }
-          let(:upper_tdcs) { [drop_down] }
-          let(:condition) { empty_operator(champ_value(drop_down.stable_id), constant(true)) }
-
-          it do
-            expect(page).to have_select('type_de_champ[condition_form][rows][][operator_name]', with_options: ['Est'])
-            expect(page).to have_select('type_de_champ[condition_form][rows][][value]', options: ['Sélectionner', 'val1', 'val2', 'val3'])
           end
         end
 
@@ -125,18 +177,6 @@ describe Conditions::ChampsConditionsComponent, type: :component do
           end
         end
 
-        context 'regions' do
-          let(:regions) { create(:type_de_champ_regions) }
-          let(:upper_tdcs) { [regions] }
-          let(:condition) { empty_operator(champ_value(regions.stable_id), constant(true)) }
-          let(:region_options) { APIGeoService.regions.map { _1[:name] } }
-
-          it do
-            expect(page).to have_select('type_de_champ[condition_form][rows][][operator_name]', with_options: ['Est'])
-            expect(page).to have_select('type_de_champ[condition_form][rows][][value]', options: (['Sélectionner'] + region_options))
-          end
-        end
-
         context 'pays' do
           let(:pays) { create(:type_de_champ_pays) }
           let(:upper_tdcs) { [pays] }
@@ -168,24 +208,6 @@ describe Conditions::ChampsConditionsComponent, type: :component do
         it do
           expect(page).to have_selector('tbody > tr', count: 2)
           expect(page).to have_select("type_de_champ_condition_form_top_operator_name", selected: "Et", options: ['Et', 'Ou'])
-        end
-      end
-
-      context 'when there are 3 conditions' do
-        let(:upper_tdc) { create(:type_de_champ_number) }
-        let(:upper_tdcs) { [upper_tdc] }
-
-        let(:condition) do
-          ds_or([
-            ds_eq(champ_value(upper_tdc.stable_id), constant(1)),
-            ds_eq(champ_value(upper_tdc.stable_id), empty),
-            greater_than(champ_value(upper_tdc.stable_id), constant(3)),
-          ])
-        end
-
-        it do
-          expect(page).to have_selector('tbody > tr', count: 3)
-          expect(page).to have_select("type_de_champ_condition_form_top_operator_name", selected: "Ou", options: ['Et', 'Ou'])
         end
       end
     end

--- a/spec/components/conditions/champs_conditions_component_spec.rb
+++ b/spec/components/conditions/champs_conditions_component_spec.rb
@@ -108,7 +108,7 @@ describe Conditions::ChampsConditionsComponent, type: :component do
           create(:procedure, types_de_champ_public: [{ type: upper_tdc_type, libelle: 'col' }])
         end
         let(:upper_tdc) { procedure.draft_revision.types_de_champ.first }
-        let(:target) { column_value(upper_tdc.columns(procedure_id: procedure.id).first) }
+        let(:target) { champ_column_value(upper_tdc.columns(procedure_id: procedure.id).first) }
 
         include_examples 'targeted condition rendering'
       end

--- a/spec/components/conditions/ineligibilite_rules_component_spec.rb
+++ b/spec/components/conditions/ineligibilite_rules_component_spec.rb
@@ -5,6 +5,11 @@ describe Conditions::IneligibiliteRulesComponent, type: :component do
   let(:procedure) { create(:procedure) }
   let(:component) { described_class.new(draft_revision: procedure.draft_revision) }
 
+  before do
+    allow_any_instance_of(described_class)
+      .to receive(:feature_enabled?).with(:column_conditions).and_return(false)
+  end
+
   describe 'render' do
     let(:ineligibilite_message) { 'ok' }
     let(:ineligibilite_enabled) { true }

--- a/spec/components/conditions/routing_rules_component_spec.rb
+++ b/spec/components/conditions/routing_rules_component_spec.rb
@@ -3,6 +3,26 @@
 describe Conditions::RoutingRulesComponent, type: :component do
   include Logic
 
+  describe '#sources in column mode' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :integer_number, libelle: 'age' },
+        { type: :repetition, libelle: 'family', children: [{ type: :integer_number, libelle: 'child_age' }] },
+      ])
+    end
+    let(:groupe_instructeur) { procedure.groupe_instructeurs.first }
+    let(:component) { Conditions::RoutingRulesComponent.new(groupe_instructeur:) }
+
+    before { allow(component).to receive(:feature_enabled?).with(:column_conditions).and_return(true) }
+
+    it 'excludes repetition tdcs from condition targets' do
+      libelles = component.send(:sources_by_section).values.flatten(1).map(&:first)
+
+      expect(libelles).to include('age')
+      expect(libelles).not_to include('family')
+    end
+  end
+
   describe 'render' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :drop_down_list, libelle: 'Votre ville', options: ['Paris', 'Lyon', 'Marseille'] }, { type: :integer_number, libelle: 'Un champ nombre entier' }]) }
     let(:groupe_instructeur) { procedure.groupe_instructeurs.first }

--- a/spec/components/conditions/routing_rules_component_spec.rb
+++ b/spec/components/conditions/routing_rules_component_spec.rb
@@ -9,10 +9,12 @@ describe Conditions::RoutingRulesComponent, type: :component do
     let(:drop_down_tdc) { procedure.draft_revision.types_de_champ.first }
     let(:integer_number_tdc) { procedure.draft_revision.types_de_champ.last }
     let(:routing_rule) { ds_eq(champ_value(drop_down_tdc.stable_id), constant('Lyon')) }
+    let(:component) { described_class.new(groupe_instructeur: groupe_instructeur) }
 
     before do
       groupe_instructeur.update(routing_rule: routing_rule)
-      render_inline(described_class.new(groupe_instructeur: groupe_instructeur))
+      allow(component).to receive(:feature_enabled?).with(:column_conditions).and_return(false)
+      render_inline(component)
     end
 
     context 'with one row' do

--- a/spec/components/procedures/one_group_management_component_spec.rb
+++ b/spec/components/procedures/one_group_management_component_spec.rb
@@ -23,6 +23,8 @@ describe Procedure::OneGroupeManagementComponent, type: :component do
         })
         procedure.publish_revision!(procedure.administrateurs.first)
         procedure.reload
+        allow_any_instance_of(Conditions::RoutingRulesComponent)
+          .to receive(:feature_enabled?).with(:column_conditions).and_return(false)
         subject
       end
       it { expect(page).to have_text('aucune règle') }

--- a/spec/components/types_de_champ_editor/champ_component_spec.rb
+++ b/spec/components/types_de_champ_editor/champ_component_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 describe TypesDeChampEditor::ChampComponent, type: :component do
+  before do
+    allow_any_instance_of(Conditions::ChampsConditionsComponent)
+      .to receive(:feature_enabled?).with(:column_conditions).and_return(false)
+  end
+
   describe 'render' do
     let(:component) { described_class.new(coordinate:, upper_coordinates: []) }
     let(:routing_rules_stable_ids) { [] }

--- a/spec/components/types_de_champ_editor/editor_component_spec.rb
+++ b/spec/components/types_de_champ_editor/editor_component_spec.rb
@@ -6,6 +6,11 @@ describe TypesDeChampEditor::EditorComponent, type: :component do
   let(:types_de_champ_private) { [{ type: :repetition, children: [], libelle: 'private' }] }
   let(:types_de_champ_public) { [{ type: :repetition, children: [], libelle: 'public' }] }
 
+  before do
+    allow_any_instance_of(Conditions::ChampsConditionsComponent)
+      .to receive(:feature_enabled?).with(:column_conditions).and_return(false)
+  end
+
   describe 'render' do
     subject { render_inline(described_class.new(revision:, is_annotation:)) }
 

--- a/spec/components/types_de_champ_editor/explication_component_spec.rb
+++ b/spec/components/types_de_champ_editor/explication_component_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 describe TypesDeChampEditor::ChampComponent, type: :component do
+  before do
+    allow_any_instance_of(Conditions::ChampsConditionsComponent)
+      .to receive(:feature_enabled?).with(:column_conditions).and_return(false)
+  end
+
   describe 'render by type' do
     context 'explication' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :explication }]) }

--- a/spec/controllers/administrateurs/conditions_controller_spec.rb
+++ b/spec/controllers/administrateurs/conditions_controller_spec.rb
@@ -167,7 +167,7 @@ describe Administrateurs::ConditionsController, type: :controller do
         draft_tdcs = procedure.draft_revision.types_de_champ
         condition = assigns(:tdc).condition
         expect(condition).to be_a(Logic::Eq)
-        expect(condition.left).to be_a(Logic::ColumnValue)
+        expect(condition.left).to be_a(Logic::ChampColumnValue)
         expect(condition.left.type(draft_tdcs)).to eq(:number)
       end
     end

--- a/spec/controllers/administrateurs/conditions_controller_spec.rb
+++ b/spec/controllers/administrateurs/conditions_controller_spec.rb
@@ -132,26 +132,13 @@ describe Administrateurs::ConditionsController, type: :controller do
     end
 
     describe '#change_targeted_champ on a draft-only referentiel column' do
-      let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :integer_number }]) }
-      let(:referentiel) { create(:csv_referentiel, :with_items) }
-      let(:integer_tdc) { procedure.draft_revision.types_de_champ.first }
-      let!(:dropdown_tdc) do
-        procedure.draft_revision.add_type_de_champ(
-          type_champ: 'drop_down_list',
-          libelle: 'liste csv',
-          drop_down_mode: 'advanced',
-          referentiel_id: referentiel.id,
-          after_stable_id: integer_tdc.stable_id
-        )
-      end
-      let!(:text_tdc) do
-        procedure.draft_revision.add_type_de_champ(
-          type_champ: 'text',
-          libelle: 'commentaire',
-          after_stable_id: dropdown_tdc.stable_id
-        )
-      end
-      let(:dessert_column) { dropdown_tdc.columns(procedure:).first }
+      let(:procedure) { create(:procedure, :published, types_de_champ_public: []) }
+      let(:draft) { procedure.draft_revision }
+
+      let!(:dropdown_tdc) { draft.add_type_de_champ(type_champ: 'integer_number') }
+      let!(:text_tdc) { draft.add_type_de_champ(type_champ: 'text', after_stable_id: dropdown_tdc.stable_id) }
+
+      let(:int_column) { dropdown_tdc.columns(procedure:).first }
 
       before do
         Flipper.enable(:column_conditions)
@@ -165,7 +152,7 @@ describe Administrateurs::ConditionsController, type: :controller do
               condition_form: {
                 rows: [
                   {
-                    targeted_champ: column_value(dessert_column).to_json,
+                    targeted_champ: column_value(int_column).to_json,
                                     operator_name: Logic::EmptyOperator.name,
                                     value: empty.to_json,
                   },
@@ -176,11 +163,12 @@ describe Administrateurs::ConditionsController, type: :controller do
           format: :turbo_stream
       end
 
-      it 'binds the column from the draft so the rendered component sees a typed left operand' do
+      it 'binds the column from the draft revision so the rendered component sees a typed left operand' do
+        draft_tdcs = procedure.draft_revision.types_de_champ
         condition = assigns(:tdc).condition
         expect(condition).to be_a(Logic::Eq)
         expect(condition.left).to be_a(Logic::ColumnValue)
-        expect(condition.left.type([])).to eq(:enum)
+        expect(condition.left.type(draft_tdcs)).to eq(:number)
       end
     end
   end

--- a/spec/controllers/administrateurs/conditions_controller_spec.rb
+++ b/spec/controllers/administrateurs/conditions_controller_spec.rb
@@ -130,6 +130,59 @@ describe Administrateurs::ConditionsController, type: :controller do
         expect(assigns(:upper_tdcs)).to eq([first_tdc, second_tdc])
       end
     end
+
+    describe '#change_targeted_champ on a draft-only referentiel column' do
+      let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :integer_number }]) }
+      let(:referentiel) { create(:csv_referentiel, :with_items) }
+      let(:integer_tdc) { procedure.draft_revision.types_de_champ.first }
+      let!(:dropdown_tdc) do
+        procedure.draft_revision.add_type_de_champ(
+          type_champ: 'drop_down_list',
+          libelle: 'liste csv',
+          drop_down_mode: 'advanced',
+          referentiel_id: referentiel.id,
+          after_stable_id: integer_tdc.stable_id
+        )
+      end
+      let!(:text_tdc) do
+        procedure.draft_revision.add_type_de_champ(
+          type_champ: 'text',
+          libelle: 'commentaire',
+          after_stable_id: dropdown_tdc.stable_id
+        )
+      end
+      let(:dessert_column) { dropdown_tdc.columns(procedure:).first }
+
+      before do
+        Flipper.enable(:column_conditions)
+        sign_in(procedure.administrateurs.first.user)
+        patch :change_targeted_champ,
+          params: {
+            procedure_id: procedure.id,
+            stable_id: text_tdc.stable_id,
+            row_index: 0,
+            type_de_champ: {
+              condition_form: {
+                rows: [
+                  {
+                    targeted_champ: column_value(dessert_column).to_json,
+                                    operator_name: Logic::EmptyOperator.name,
+                                    value: empty.to_json,
+                  },
+                ],
+              },
+            },
+          },
+          format: :turbo_stream
+      end
+
+      it 'binds the column from the draft so the rendered component sees a typed left operand' do
+        condition = assigns(:tdc).condition
+        expect(condition).to be_a(Logic::Eq)
+        expect(condition.left).to be_a(Logic::ColumnValue)
+        expect(condition.left.type([])).to eq(:enum)
+      end
+    end
   end
 
   context 'with a repetiton bloc' do

--- a/spec/controllers/administrateurs/conditions_controller_spec.rb
+++ b/spec/controllers/administrateurs/conditions_controller_spec.rb
@@ -152,7 +152,7 @@ describe Administrateurs::ConditionsController, type: :controller do
               condition_form: {
                 rows: [
                   {
-                    targeted_champ: column_value(int_column).to_json,
+                    targeted_champ: champ_column_value(int_column).to_json,
                                     operator_name: Logic::EmptyOperator.name,
                                     value: empty.to_json,
                   },

--- a/spec/controllers/administrateurs/conditions_controller_spec.rb
+++ b/spec/controllers/administrateurs/conditions_controller_spec.rb
@@ -138,7 +138,7 @@ describe Administrateurs::ConditionsController, type: :controller do
       let!(:dropdown_tdc) { draft.add_type_de_champ(type_champ: 'integer_number') }
       let!(:text_tdc) { draft.add_type_de_champ(type_champ: 'text', after_stable_id: dropdown_tdc.stable_id) }
 
-      let(:int_column) { dropdown_tdc.columns(procedure:).first }
+      let(:int_column) { dropdown_tdc.columns(procedure_id: procedure.id).first }
 
       before do
         Flipper.enable(:column_conditions)

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -1631,6 +1631,44 @@ describe Instructeurs::DossiersController, type: :controller do
     end
   end
 
+  describe "#annotation" do
+    include Logic
+
+    let(:referentiel) { create(:api_referentiel, :exact_match, :with_exact_match_response) }
+    let(:async_stable_id) { 10 }
+    let(:checkbox_stable_id) { 20 }
+    let(:explication_stable_id) { 30 }
+    let(:condition) { ds_eq(champ_value(checkbox_stable_id), constant(true)) }
+    let(:types_de_champ_private) do
+      [
+        { type: :referentiel, referentiel:, stable_id: async_stable_id },
+        { type: :checkbox, stable_id: checkbox_stable_id },
+        { type: :explication, stable_id: explication_stable_id, condition: },
+      ]
+    end
+    let(:procedure) { create(:procedure, :published, types_de_champ_private:, instructeurs:) }
+    let(:dossier) { create(:dossier, :en_construction, :with_populated_annotations, procedure:) }
+
+    subject do
+      get :annotation, params: { procedure_id: procedure.id, dossier_id: dossier.id, stable_id: async_stable_id, row_id: nil }, format: :turbo_stream
+    end
+
+    context 'when a conditional annotation exists alongside the polled annotation' do
+      before do
+        dossier.champs.find(&:referentiel?).update_columns(external_id: 'kthxbye', value: 'OK', data: {})
+        dossier.champs.find { _1.stable_id == checkbox_stable_id }.update_columns(value: 'true')
+      end
+
+      it 'recomputes visibility of conditional annotations after polling' do
+        subject
+
+        explication_annotation = assigns(:dossier).project_champs_private_all
+          .find { _1.type_de_champ.stable_id == explication_stable_id }
+        expect(assigns(:to_show)).to include("##{explication_annotation.input_group_id}")
+      end
+    end
+  end
+
   describe "#annotations_privees" do
     context "when annotation_instructeur notifications exist" do
       let!(:other_instructeur) { create(:instructeur) }

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -2418,6 +2418,36 @@ describe Users::DossiersController, type: :controller do
           expect(response).not_to include('Trop de demandes. Nous réessayons pour vous.')
         end
       end
+
+      context 'when a conditional champ exists alongside the polled champ' do
+        include Logic
+
+        let(:async_stable_id) { 10 }
+        let(:checkbox_stable_id) { 20 }
+        let(:explication_stable_id) { 30 }
+        let(:condition) { ds_eq(champ_value(checkbox_stable_id), constant(true)) }
+        let(:types_de_champ_public) do
+          [
+            { type: :referentiel, referentiel:, stable_id: async_stable_id },
+            { type: :checkbox, stable_id: checkbox_stable_id },
+            { type: :explication, stable_id: explication_stable_id, condition: },
+          ]
+        end
+        let(:stable_id) { async_stable_id }
+
+        before do
+          dossier.champs.find(&:referentiel?).update_columns(external_id: 'kthxbye', value: 'OK', data: {})
+          dossier.champs.find { _1.stable_id == checkbox_stable_id }.update_columns(value: 'true')
+        end
+
+        it 'recomputes visibility of conditional champs after polling' do
+          subject
+
+          explication_champ = assigns(:dossier).project_champs_public_all
+            .find { _1.type_de_champ.stable_id == explication_stable_id }
+          expect(assigns(:to_show)).to include("##{explication_champ.input_group_id}")
+        end
+      end
     end
   end
 

--- a/spec/models/columns/linked_drop_down_column_spec.rb
+++ b/spec/models/columns/linked_drop_down_column_spec.rb
@@ -104,6 +104,26 @@ describe Columns::LinkedDropDownColumn do
     end
   end
 
+  describe '#options_for_select' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :linked_drop_down_list, libelle: 'linked', drop_down_options: ['--section 1--', 'option A', 'option B', '--section 2--', 'option C'] },
+      ])
+    end
+
+    it 'normalizes the primary options as [label, value] pairs' do
+      column = procedure.find_column(label: 'linked (Primaire)')
+
+      expect(column.options_for_select).to eq([['section 1', 'section 1'], ['section 2', 'section 2']])
+    end
+
+    it 'normalizes the secondary options as [label, value] pairs' do
+      column = procedure.find_column(label: 'linked (Secondaire)')
+
+      expect(column.options_for_select).to eq([['option A', 'option A'], ['option B', 'option B'], ['option C', 'option C']])
+    end
+  end
+
   describe 'unpack_values' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :linked_drop_down_list, libelle: 'linked' }]) }
     let(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }

--- a/spec/models/concerns/columns_concern_spec.rb
+++ b/spec/models/concerns/columns_concern_spec.rb
@@ -59,6 +59,26 @@ describe ColumnsConcern do
         expect(procedure.find_column(h_id:)).to eq(code_naf_column)
       end
     end
+
+    xcontext 'when the column lives only in the draft revision' do
+      let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :integer_number }]) }
+      let(:referentiel) { create(:csv_referentiel, :with_items) }
+      let(:integer_tdc) { procedure.draft_revision.types_de_champ.first }
+      let(:draft_tdc) do
+        procedure.draft_revision.add_type_de_champ(
+          type_champ: 'drop_down_list',
+          libelle: 'liste csv',
+          drop_down_mode: 'advanced',
+          referentiel_id: referentiel.id,
+          after_stable_id: integer_tdc.stable_id
+        )
+      end
+      let(:draft_column) { draft_tdc.columns(procedure:).first }
+
+      it 'falls back to the draft revision columns' do
+        expect(procedure.find_column(h_id: draft_column.h_id)).to eq(draft_column)
+      end
+    end
   end
 
   describe "#columns" do

--- a/spec/models/concerns/columns_concern_spec.rb
+++ b/spec/models/concerns/columns_concern_spec.rb
@@ -73,7 +73,7 @@ describe ColumnsConcern do
           after_stable_id: integer_tdc.stable_id
         )
       end
-      let(:draft_column) { draft_tdc.columns(procedure:).first }
+      let(:draft_column) { draft_tdc.columns(procedure_id: procedure.id).first }
 
       it 'falls back to the draft revision columns' do
         expect(procedure.find_column(h_id: draft_column.h_id)).to eq(draft_column)

--- a/spec/models/logic/champ_column_value_spec.rb
+++ b/spec/models/logic/champ_column_value_spec.rb
@@ -5,7 +5,7 @@ describe Logic::ChampColumnValue do
 
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :yes_no, libelle: 'yes' }]) }
   let(:column) { procedure.find_column(label: 'yes') }
-  let(:column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
+  let(:champ_column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
 
   describe '#compute' do
     let(:dossier) { create(:dossier, procedure:) }
@@ -13,28 +13,28 @@ describe Logic::ChampColumnValue do
 
     before { champ.update(value: 'true') }
 
-    it { expect(column_value.compute([champ])).to be(true) }
+    it { expect(champ_column_value.compute([champ])).to be(true) }
 
     context 'when the targeted champ is not visible' do
       before { allow(champ).to receive(:visible?).and_return(false) }
 
-      it { expect(column_value.compute([champ])).to be_nil }
+      it { expect(champ_column_value.compute([champ])).to be_nil }
     end
 
     context 'when the targeted champ is blank' do
       before { champ.update(value: nil) }
 
-      it { expect(column_value.compute([champ])).to be_nil }
+      it { expect(champ_column_value.compute([champ])).to be_nil }
     end
 
     context 'when the targeted champ is missing from the list' do
-      it { expect(column_value.compute([])).to be_nil }
+      it { expect(champ_column_value.compute([])).to be_nil }
     end
   end
 
   # stable_id is needed when computing error (Eq.errors)
   describe '#stable_id' do
-    it { expect(column_value.stable_id).to eq(column.stable_id) }
+    it { expect(champ_column_value.stable_id).to eq(column.stable_id) }
   end
 
   # Preserves parity with Logic::ChampValue: a condition on a drop_down_list with
@@ -47,14 +47,14 @@ describe Logic::ChampColumnValue do
       ])
     end
     let(:column) { procedure.find_column(label: 'menu') }
-    let(:column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
+    let(:champ_column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
     let(:dossier) { create(:dossier, procedure:) }
     let(:champ) { dossier.champs.first }
 
     context "when the user picked 'other' without typing a value" do
       before { champ.update!(value: Champs::DropDownListChamp::OTHER) }
 
-      it { expect(column_value.compute([champ])).to eq(Champs::DropDownListChamp::OTHER) }
+      it { expect(champ_column_value.compute([champ])).to eq(Champs::DropDownListChamp::OTHER) }
     end
 
     context "when the user picked 'other' and typed a custom value" do
@@ -63,18 +63,18 @@ describe Logic::ChampColumnValue do
         champ.update!(value_other: 'ma valeur')
       end
 
-      it { expect(column_value.compute([champ])).to eq(Champs::DropDownListChamp::OTHER) }
+      it { expect(champ_column_value.compute([champ])).to eq(Champs::DropDownListChamp::OTHER) }
     end
   end
 
   describe '#sources' do
-    it { expect(column_value.sources).to eq([column.stable_id]) }
+    it { expect(champ_column_value.sources).to eq([column.stable_id]) }
   end
 
   describe '#errors' do
     it do
-      expect(column_value.errors(procedure.active_revision.types_de_champ)).to eq([])
-      expect(column_value.errors([])).to eq([{ type: :not_available }])
+      expect(champ_column_value.errors(procedure.active_revision.types_de_champ)).to eq([])
+      expect(champ_column_value.errors([])).to eq([{ type: :not_available }])
     end
   end
 
@@ -134,7 +134,7 @@ describe Logic::ChampColumnValue do
       let(:drop_down_options) { ['--1--', 'A', '--2--', 'B'] }
       let(:linked_drop_down_stable_id) { procedure.active_revision.types_de_champ.first.stable_id }
       let(:column) { procedure.find_column(label: 'linked (Secondaire)') }
-      let(:column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
+      let(:champ_column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
 
       before do
         procedure.draft_revision
@@ -142,27 +142,27 @@ describe Logic::ChampColumnValue do
       end
 
       it 'are based on the tdc given as arg' do
-        expect(column_value.options(draft_tdcs).map(&:first)).to eq(['A', 'C'])
+        expect(champ_column_value.options(draft_tdcs).map(&:first)).to eq(['A', 'C'])
       end
     end
   end
 
   describe '#to_s' do
-    it { expect(column_value.to_s(procedure.active_revision.types_de_champ)).to eq(column.label) }
+    it { expect(champ_column_value.to_s(procedure.active_revision.types_de_champ)).to eq(column.label) }
   end
 
   describe 'serialization round-trip' do
     it 'rebuilds an equal ChampColumnValue from to_h' do
-      rebuilt = Logic::ChampColumnValue.from_h(column_value.to_h)
+      rebuilt = Logic::ChampColumnValue.from_h(champ_column_value.to_h)
 
-      expect(rebuilt).to eq(column_value)
-      expect(rebuilt.sources).to eq(column_value.sources)
+      expect(rebuilt).to eq(champ_column_value)
+      expect(rebuilt.sources).to eq(champ_column_value.sources)
     end
 
     it 'rebuilds an equal ChampColumnValue from to_json (Logic.from_json)' do
-      rebuilt = Logic.from_json(column_value.to_json)
+      rebuilt = Logic.from_json(champ_column_value.to_json)
 
-      expect(rebuilt).to eq(column_value)
+      expect(rebuilt).to eq(champ_column_value)
     end
   end
 
@@ -178,14 +178,14 @@ describe Logic::ChampColumnValue do
       column = procedure.find_column(label: 'yes')
       other = Logic::ChampColumnValue.new(column.stable_id, column.column_id)
 
-      expect(column_value).to eq(other)
+      expect(champ_column_value).to eq(other)
     end
 
     it 'is not equal to a ChampColumnValue pointing to another column' do
       column = procedure.find_column(label: 'n')
       other = Logic::ChampColumnValue.new(column.stable_id, column.column_id)
 
-      expect(column_value).not_to eq(other)
+      expect(champ_column_value).not_to eq(other)
     end
   end
 

--- a/spec/models/logic/column_value_spec.rb
+++ b/spec/models/logic/column_value_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-describe Logic::ColumnValue do
+describe Logic::ChampColumnValue do
   include Logic
 
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :yes_no, libelle: 'yes' }]) }
   let(:column) { procedure.find_column(label: 'yes') }
-  let(:column_value) { Logic::ColumnValue.new(column.stable_id, column.column_id) }
+  let(:column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
 
   describe '#compute' do
     let(:dossier) { create(:dossier, procedure:) }
@@ -47,7 +47,7 @@ describe Logic::ColumnValue do
       ])
     end
     let(:column) { procedure.find_column(label: 'menu') }
-    let(:column_value) { Logic::ColumnValue.new(column.stable_id, column.column_id) }
+    let(:column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
     let(:dossier) { create(:dossier, procedure:) }
     let(:champ) { dossier.champs.first }
 
@@ -82,7 +82,7 @@ describe Logic::ColumnValue do
     let(:draft_tdcs) { procedure.draft_revision.types_de_champ }
     let(:column) { draft_tdcs.first.columns(procedure_id: procedure.id).first }
 
-    subject { Logic::ColumnValue.new(column.stable_id, column.column_id).type(draft_tdcs) }
+    subject { Logic::ChampColumnValue.new(column.stable_id, column.column_id).type(draft_tdcs) }
 
     context 'integer column' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :integer_number, libelle: 'n' }]) }
@@ -134,7 +134,7 @@ describe Logic::ColumnValue do
       let(:drop_down_options) { ['--1--', 'A', '--2--', 'B'] }
       let(:linked_drop_down_stable_id) { procedure.active_revision.types_de_champ.first.stable_id }
       let(:column) { procedure.find_column(label: 'linked (Secondaire)') }
-      let(:column_value) { Logic::ColumnValue.new(column.stable_id, column.column_id) }
+      let(:column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
 
       before do
         procedure.draft_revision
@@ -152,14 +152,14 @@ describe Logic::ColumnValue do
   end
 
   describe 'serialization round-trip' do
-    it 'rebuilds an equal ColumnValue from to_h' do
-      rebuilt = Logic::ColumnValue.from_h(column_value.to_h)
+    it 'rebuilds an equal ChampColumnValue from to_h' do
+      rebuilt = Logic::ChampColumnValue.from_h(column_value.to_h)
 
       expect(rebuilt).to eq(column_value)
       expect(rebuilt.sources).to eq(column_value.sources)
     end
 
-    it 'rebuilds an equal ColumnValue from to_json (Logic.from_json)' do
+    it 'rebuilds an equal ChampColumnValue from to_json (Logic.from_json)' do
       rebuilt = Logic.from_json(column_value.to_json)
 
       expect(rebuilt).to eq(column_value)
@@ -174,16 +174,16 @@ describe Logic::ColumnValue do
       ])
     end
 
-    it 'is equal to another ColumnValue pointing to the same column' do
+    it 'is equal to another ChampColumnValue pointing to the same column' do
       column = procedure.find_column(label: 'yes')
-      other = Logic::ColumnValue.new(column.stable_id, column.column_id)
+      other = Logic::ChampColumnValue.new(column.stable_id, column.column_id)
 
       expect(column_value).to eq(other)
     end
 
-    it 'is not equal to a ColumnValue pointing to another column' do
+    it 'is not equal to a ChampColumnValue pointing to another column' do
       column = procedure.find_column(label: 'n')
-      other = Logic::ColumnValue.new(column.stable_id, column.column_id)
+      other = Logic::ChampColumnValue.new(column.stable_id, column.column_id)
 
       expect(column_value).not_to eq(other)
     end
@@ -191,7 +191,7 @@ describe Logic::ColumnValue do
 
   describe 'when the underlying column has disappeared' do
     let(:h_id) { { procedure_id: 999_999, column_id: "type_de_champ/123" } }
-    let(:broken) { Logic::ColumnValue.from_h({ "term" => "Logic::ColumnValue", "column_id" => h_id, "stable_id" => 1234 }) }
+    let(:broken) { Logic::ChampColumnValue.from_h({ "term" => "Logic::ChampColumnValue", "column_id" => h_id, "stable_id" => 1234 }) }
 
     it 'does not raise on from_h' do
       expect { broken }.not_to raise_error
@@ -211,11 +211,11 @@ describe Logic::ColumnValue do
     end
 
     it 'to_h preserves the original h_id (no nesting / no wrapping leak)' do
-      expect(broken.to_h).to eq({ "term" => "Logic::ColumnValue", "column_id" => h_id, 'stable_id' => 1234 })
+      expect(broken.to_h).to eq({ "term" => "Logic::ChampColumnValue", "column_id" => h_id, 'stable_id' => 1234 })
     end
 
     it 'survives multiple save/reload cycles without growing nested wrappers' do
-      twice_round_tripped = Logic::ColumnValue.from_h(broken.to_h)
+      twice_round_tripped = Logic::ChampColumnValue.from_h(broken.to_h)
 
       expect(twice_round_tripped.to_h).to eq(broken.to_h)
     end

--- a/spec/models/logic/column_value_spec.rb
+++ b/spec/models/logic/column_value_spec.rb
@@ -74,7 +74,8 @@ describe Logic::ColumnValue do
   end
 
   describe '#type' do
-    subject { Logic::ColumnValue.new(procedure.find_column(label:)).type([]) }
+    let(:draft_tdcs) { procedure.draft_revision.types_de_champ }
+    subject { Logic::ColumnValue.new(procedure.find_column(label:)).type(draft_tdcs) }
 
     context 'integer column' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :integer_number, libelle: 'n' }]) }
@@ -97,10 +98,22 @@ describe Logic::ColumnValue do
     end
 
     context 'drop_down_list column' do
-      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :drop_down_list, libelle: 'menu' }]) }
+      let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :drop_down_list, libelle: 'menu' }]) }
       let(:label) { 'menu' }
 
       it { is_expected.to eq(:enum) }
+
+      context 'when a tdc has changed between revision' do
+        let(:stable_id) { procedure.active_revision.types_de_champ.first.stable_id }
+
+        before do
+          procedure.draft_revision
+            .find_and_ensure_exclusive_use(stable_id)
+            .update(type_champ: 'multiple_drop_down_list')
+        end
+
+        it { is_expected.to eq(:enums) }
+      end
     end
   end
 

--- a/spec/models/logic/column_value_spec.rb
+++ b/spec/models/logic/column_value_spec.rb
@@ -105,19 +105,25 @@ describe Logic::ColumnValue do
   end
 
   describe '#options' do
-    context 'when options_for_select is a list of [label, value] pairs' do
-      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :drop_down_list, libelle: 'menu' }]) }
-      let(:column) { procedure.find_column(label: 'menu') }
-
-      it 'returns them as-is' do
-        expect(column_value.options([])).to match_array([["val1", "val1"], ["val2", "val2"], ["val3", "val3"]])
+    describe 'when there are different revision' do
+      let(:procedure) { create(:procedure, :published, types_de_champ_public: [linked_drop_down]) }
+      let(:draft_tdcs) { procedure.draft_revision.types_de_champ }
+      let(:linked_drop_down) do
+        { type: :linked_drop_down_list, libelle: 'linked', drop_down_options: }
       end
-    end
+      let(:drop_down_options) { ['--1--', 'A', '--2--', 'B'] }
+      let(:linked_drop_down_stable_id) { procedure.active_revision.types_de_champ.first.stable_id }
+      let(:column) { procedure.find_column(label: 'linked (Secondaire)') }
+      let(:column_value) { Logic::ColumnValue.new(column) }
 
-    context 'when options_for_select is empty' do
-      before { column.options_for_select = [] }
+      before do
+        procedure.draft_revision
+          .find_and_ensure_exclusive_use(linked_drop_down_stable_id).update(drop_down_options: ['--1--', 'A', '--2--', 'C'])
+      end
 
-      it { expect(column_value.options([])).to eq([]) }
+      it 'are based on the tdc given as arg' do
+        expect(column_value.options(draft_tdcs).map(&:first)).to eq(['A', 'C'])
+      end
     end
   end
 

--- a/spec/models/logic/column_value_spec.rb
+++ b/spec/models/logic/column_value_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+describe Logic::ColumnValue do
+  include Logic
+
+  let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :yes_no, libelle: 'yes' }]) }
+  let(:column) { procedure.find_column(label: 'yes') }
+  let(:column_value) { Logic::ColumnValue.new(column) }
+
+  describe '#compute' do
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champs.first }
+
+    before { champ.update(value: 'true') }
+
+    it { expect(column_value.compute([champ])).to be(true) }
+
+    context 'when the targeted champ is not visible' do
+      before { allow(champ).to receive(:visible?).and_return(false) }
+
+      it { expect(column_value.compute([champ])).to be_nil }
+    end
+
+    context 'when the targeted champ is blank' do
+      before { champ.update(value: nil) }
+
+      it { expect(column_value.compute([champ])).to be_nil }
+    end
+
+    context 'when the targeted champ is missing from the list' do
+      it { expect(column_value.compute([])).to be_nil }
+    end
+  end
+
+  # Preserves parity with Logic::ChampValue: a condition on a drop_down_list with
+  # "other" enabled compares against the OTHER sentinel, not the human label
+  # surfaced by ChampColumn#value in the dashboard.
+  describe '#compute with a drop_down_list with other enabled' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :drop_down_list, libelle: 'menu', drop_down_other: true },
+      ])
+    end
+    let(:column) { procedure.find_column(label: 'menu') }
+    let(:column_value) { Logic::ColumnValue.new(column) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champs.first }
+
+    context "when the user picked 'other' without typing a value" do
+      before { champ.update!(value: Champs::DropDownListChamp::OTHER) }
+
+      it { expect(column_value.compute([champ])).to eq(Champs::DropDownListChamp::OTHER) }
+    end
+
+    context "when the user picked 'other' and typed a custom value" do
+      before do
+        champ.update!(value: Champs::DropDownListChamp::OTHER)
+        champ.update!(value_other: 'ma valeur')
+      end
+
+      it { expect(column_value.compute([champ])).to eq(Champs::DropDownListChamp::OTHER) }
+    end
+  end
+
+  describe '#sources' do
+    it { expect(column_value.sources).to eq([column.stable_id]) }
+  end
+
+  describe '#errors' do
+    it do
+      expect(column_value.errors(procedure.active_revision.types_de_champ)).to eq([])
+      expect(column_value.errors([])).to eq([{ type: :not_available }])
+    end
+  end
+
+  describe '#type' do
+    subject { Logic::ColumnValue.new(procedure.find_column(label:)).type([]) }
+
+    context 'integer column' do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :integer_number, libelle: 'n' }]) }
+      let(:label) { 'n' }
+
+      it { is_expected.to eq(:number) }
+    end
+
+    context 'decimal column' do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :decimal_number, libelle: 'd' }]) }
+      let(:label) { 'd' }
+
+      it { is_expected.to eq(:number) }
+    end
+
+    context 'yes_no column' do
+      let(:label) { 'yes' }
+
+      it { is_expected.to eq(:boolean) }
+    end
+
+    context 'drop_down_list column' do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :drop_down_list, libelle: 'menu' }]) }
+      let(:label) { 'menu' }
+
+      it { is_expected.to eq(:enum) }
+    end
+  end
+
+  describe '#options' do
+    context 'when options_for_select is a list of [label, value] pairs' do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :drop_down_list, libelle: 'menu' }]) }
+      let(:column) { procedure.find_column(label: 'menu') }
+
+      it 'returns them as-is' do
+        expect(column_value.options([])).to match_array([["val1", "val1"], ["val2", "val2"], ["val3", "val3"]])
+      end
+    end
+
+    context 'when options_for_select is empty' do
+      before { column.options_for_select = [] }
+
+      it { expect(column_value.options([])).to eq([]) }
+    end
+  end
+
+  describe '#to_s' do
+    it { expect(column_value.to_s(procedure.active_revision.types_de_champ)).to eq(column.label) }
+  end
+
+  describe 'serialization round-trip' do
+    it 'rebuilds an equal ColumnValue from to_h' do
+      rebuilt = Logic::ColumnValue.from_h(column_value.to_h)
+
+      expect(rebuilt).to eq(column_value)
+      expect(rebuilt.sources).to eq(column_value.sources)
+    end
+
+    it 'rebuilds an equal ColumnValue from to_json (Logic.from_json)' do
+      rebuilt = Logic.from_json(column_value.to_json)
+
+      expect(rebuilt).to eq(column_value)
+    end
+  end
+
+  describe '#==' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :yes_no, libelle: 'yes' },
+        { type: :integer_number, libelle: 'n' },
+      ])
+    end
+
+    it 'is equal to another ColumnValue pointing to the same column' do
+      other = Logic::ColumnValue.new(procedure.find_column(label: 'yes'))
+
+      expect(column_value).to eq(other)
+    end
+
+    it 'is not equal to a ColumnValue pointing to another column' do
+      other = Logic::ColumnValue.new(procedure.find_column(label: 'n'))
+
+      expect(column_value).not_to eq(other)
+    end
+
+    it 'is not equal to a ChampValue, even with the same stable_id' do
+      expect(column_value).not_to eq(Logic::ChampValue.new(column.stable_id))
+    end
+  end
+end

--- a/spec/models/logic/column_value_spec.rb
+++ b/spec/models/logic/column_value_spec.rb
@@ -5,7 +5,7 @@ describe Logic::ColumnValue do
 
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :yes_no, libelle: 'yes' }]) }
   let(:column) { procedure.find_column(label: 'yes') }
-  let(:column_value) { Logic::ColumnValue.new(column) }
+  let(:column_value) { Logic::ColumnValue.new(column.stable_id, column.column_id) }
 
   describe '#compute' do
     let(:dossier) { create(:dossier, procedure:) }
@@ -32,6 +32,11 @@ describe Logic::ColumnValue do
     end
   end
 
+  # stable_id is needed when computing error (Eq.errors)
+  describe '#stable_id' do
+    it { expect(column_value.stable_id).to eq(column.stable_id) }
+  end
+
   # Preserves parity with Logic::ChampValue: a condition on a drop_down_list with
   # "other" enabled compares against the OTHER sentinel, not the human label
   # surfaced by ChampColumn#value in the dashboard.
@@ -42,7 +47,7 @@ describe Logic::ColumnValue do
       ])
     end
     let(:column) { procedure.find_column(label: 'menu') }
-    let(:column_value) { Logic::ColumnValue.new(column) }
+    let(:column_value) { Logic::ColumnValue.new(column.stable_id, column.column_id) }
     let(:dossier) { create(:dossier, procedure:) }
     let(:champ) { dossier.champs.first }
 
@@ -75,7 +80,9 @@ describe Logic::ColumnValue do
 
   describe '#type' do
     let(:draft_tdcs) { procedure.draft_revision.types_de_champ }
-    subject { Logic::ColumnValue.new(procedure.find_column(label:)).type(draft_tdcs) }
+    let(:column) { draft_tdcs.first.columns(procedure_id: procedure.id).first }
+
+    subject { Logic::ColumnValue.new(column.stable_id, column.column_id).type(draft_tdcs) }
 
     context 'integer column' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :integer_number, libelle: 'n' }]) }
@@ -127,7 +134,7 @@ describe Logic::ColumnValue do
       let(:drop_down_options) { ['--1--', 'A', '--2--', 'B'] }
       let(:linked_drop_down_stable_id) { procedure.active_revision.types_de_champ.first.stable_id }
       let(:column) { procedure.find_column(label: 'linked (Secondaire)') }
-      let(:column_value) { Logic::ColumnValue.new(column) }
+      let(:column_value) { Logic::ColumnValue.new(column.stable_id, column.column_id) }
 
       before do
         procedure.draft_revision
@@ -168,25 +175,23 @@ describe Logic::ColumnValue do
     end
 
     it 'is equal to another ColumnValue pointing to the same column' do
-      other = Logic::ColumnValue.new(procedure.find_column(label: 'yes'))
+      column = procedure.find_column(label: 'yes')
+      other = Logic::ColumnValue.new(column.stable_id, column.column_id)
 
       expect(column_value).to eq(other)
     end
 
     it 'is not equal to a ColumnValue pointing to another column' do
-      other = Logic::ColumnValue.new(procedure.find_column(label: 'n'))
+      column = procedure.find_column(label: 'n')
+      other = Logic::ColumnValue.new(column.stable_id, column.column_id)
 
       expect(column_value).not_to eq(other)
-    end
-
-    it 'is not equal to a ChampValue, even with the same stable_id' do
-      expect(column_value).not_to eq(Logic::ChampValue.new(column.stable_id))
     end
   end
 
   describe 'when the underlying column has disappeared' do
     let(:h_id) { { procedure_id: 999_999, column_id: "type_de_champ/123" } }
-    let(:broken) { Logic::ColumnValue.from_h({ "term" => "Logic::ColumnValue", "column_id" => h_id }) }
+    let(:broken) { Logic::ColumnValue.from_h({ "term" => "Logic::ColumnValue", "column_id" => h_id, "stable_id" => 1234 }) }
 
     it 'does not raise on from_h' do
       expect { broken }.not_to raise_error
@@ -196,7 +201,7 @@ describe Logic::ColumnValue do
       expect(broken.compute([])).to be_nil
       expect(broken.type([])).to eq(:unmanaged)
       expect(broken.options([])).to eq([])
-      expect(broken.sources).to eq([])
+      expect(broken.sources).to eq([1234])
       expect(broken.to_s([])).to be_nil
     end
 
@@ -206,19 +211,13 @@ describe Logic::ColumnValue do
     end
 
     it 'to_h preserves the original h_id (no nesting / no wrapping leak)' do
-      expect(broken.to_h).to eq({ "term" => "Logic::ColumnValue", "column_id" => h_id })
+      expect(broken.to_h).to eq({ "term" => "Logic::ColumnValue", "column_id" => h_id, 'stable_id' => 1234 })
     end
 
     it 'survives multiple save/reload cycles without growing nested wrappers' do
       twice_round_tripped = Logic::ColumnValue.from_h(broken.to_h)
 
       expect(twice_round_tripped.to_h).to eq(broken.to_h)
-    end
-
-    it 'two broken ColumnValues with the same h_id are equal' do
-      other = Logic::ColumnValue.from_h({ "term" => "Logic::ColumnValue", "column_id" => h_id })
-
-      expect(broken).to eq(other)
     end
   end
 end

--- a/spec/models/logic/column_value_spec.rb
+++ b/spec/models/logic/column_value_spec.rb
@@ -164,4 +164,42 @@ describe Logic::ColumnValue do
       expect(column_value).not_to eq(Logic::ChampValue.new(column.stable_id))
     end
   end
+
+  describe 'when the underlying column has disappeared' do
+    let(:h_id) { { procedure_id: 999_999, column_id: "type_de_champ/123" } }
+    let(:broken) { Logic::ColumnValue.from_h({ "term" => "Logic::ColumnValue", "column_id" => h_id }) }
+
+    it 'does not raise on from_h' do
+      expect { broken }.not_to raise_error
+    end
+
+    it do
+      expect(broken.compute([])).to be_nil
+      expect(broken.type([])).to eq(:unmanaged)
+      expect(broken.options([])).to eq([])
+      expect(broken.sources).to eq([])
+      expect(broken.to_s([])).to be_nil
+    end
+
+    it 'errors always returns :not_available, regardless of the tdcs passed' do
+      expect(broken.errors([])).to eq([{ type: :not_available }])
+      expect(broken.errors(procedure.active_revision.types_de_champ)).to eq([{ type: :not_available }])
+    end
+
+    it 'to_h preserves the original h_id (no nesting / no wrapping leak)' do
+      expect(broken.to_h).to eq({ "term" => "Logic::ColumnValue", "column_id" => h_id })
+    end
+
+    it 'survives multiple save/reload cycles without growing nested wrappers' do
+      twice_round_tripped = Logic::ColumnValue.from_h(broken.to_h)
+
+      expect(twice_round_tripped.to_h).to eq(broken.to_h)
+    end
+
+    it 'two broken ColumnValues with the same h_id are equal' do
+      other = Logic::ColumnValue.from_h({ "term" => "Logic::ColumnValue", "column_id" => h_id })
+
+      expect(broken).to eq(other)
+    end
+  end
 end

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -966,6 +966,60 @@ describe ProcedureRevision do
     end
   end
 
+  describe '#champ_value_in_condition?' do
+    include Logic
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :yes_no, libelle: 'gate' },
+        { type: :integer_number, libelle: 'value' },
+      ])
+    end
+    let(:gate_tdc) { draft.types_de_champ_public.first }
+    let(:value_tdc) { draft.types_de_champ_public.second }
+    let(:gate_column) { procedure.find_column(label: 'gate') }
+
+    subject { procedure.reload.draft_revision.champ_value_in_condition? }
+
+    context 'when no tdc has a condition' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'when a tdc condition uses a champ_value' do
+      before { value_tdc.update!(condition: ds_eq(champ_value(gate_tdc.stable_id), constant(true))) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when a tdc condition uses only a column_value' do
+      before { value_tdc.update!(condition: ds_eq(column_value(gate_column), constant(true))) }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when a champ_value is nested deep inside an And' do
+      before do
+        value_tdc.update!(condition: ds_and([
+          ds_eq(column_value(gate_column), constant(true)),
+          ds_eq(champ_value(gate_tdc.stable_id), constant(true)),
+        ]))
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when ineligibilite_rules use a champ_value' do
+      before { draft.update!(ineligibilite_rules: ds_eq(champ_value(gate_tdc.stable_id), constant(true))) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when ineligibilite_rules use only a column_value' do
+      before { draft.update!(ineligibilite_rules: ds_eq(column_value(gate_column), constant(true))) }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
   describe 'children_of' do
     context 'with a simple tdc' do
       let(:procedure) { create(:procedure, :with_type_de_champ) }

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -990,8 +990,8 @@ describe ProcedureRevision do
       it { is_expected.to be(true) }
     end
 
-    context 'when a tdc condition uses only a column_value' do
-      before { value_tdc.update!(condition: ds_eq(column_value(gate_column), constant(true))) }
+    context 'when a tdc condition uses only a champ_column_value' do
+      before { value_tdc.update!(condition: ds_eq(champ_column_value(gate_column), constant(true))) }
 
       it { is_expected.to be(false) }
     end
@@ -999,7 +999,7 @@ describe ProcedureRevision do
     context 'when a champ_value is nested deep inside an And' do
       before do
         value_tdc.update!(condition: ds_and([
-          ds_eq(column_value(gate_column), constant(true)),
+          ds_eq(champ_column_value(gate_column), constant(true)),
           ds_eq(champ_value(gate_tdc.stable_id), constant(true)),
         ]))
       end
@@ -1013,8 +1013,8 @@ describe ProcedureRevision do
       it { is_expected.to be(true) }
     end
 
-    context 'when ineligibilite_rules use only a column_value' do
-      before { draft.update!(ineligibilite_rules: ds_eq(column_value(gate_column), constant(true))) }
+    context 'when ineligibilite_rules use only a champ_column_value' do
+      before { draft.update!(ineligibilite_rules: ds_eq(champ_column_value(gate_column), constant(true))) }
 
       it { is_expected.to be(false) }
     end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -2017,6 +2017,67 @@ describe Procedure do
     end
   end
 
+  describe '#champ_value_in_condition?' do
+    include Logic
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :yes_no, libelle: 'gate' },
+        { type: :integer_number, libelle: 'value' },
+      ])
+    end
+    let(:revision) { procedure.draft_revision }
+    let(:gate_tdc) { revision.types_de_champ_public.first }
+    let(:value_tdc) { revision.types_de_champ_public.second }
+    let(:gate_column) { procedure.find_column(label: 'gate') }
+
+    subject { procedure.reload.champ_value_in_condition? }
+
+    context 'with no conditions anywhere' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'when a draft_revision tdc condition uses a champ_value' do
+      before { value_tdc.update!(condition: ds_eq(champ_value(gate_tdc.stable_id), constant(true))) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when ineligibilite_rules uses a champ_value' do
+      before { revision.update!(ineligibilite_rules: ds_eq(champ_value(gate_tdc.stable_id), constant(true))) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when a routing_rule uses a champ_value' do
+      before do
+        create(:groupe_instructeur, procedure:, routing_rule: ds_eq(champ_value(gate_tdc.stable_id), constant(true)))
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when a champ_value is nested deep inside ineligibilite_rules' do
+      before do
+        revision.update!(ineligibilite_rules: ds_and([
+          ds_eq(column_value(gate_column), constant(true)),
+          ds_eq(champ_value(gate_tdc.stable_id), constant(true)),
+        ]))
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when only column_values are used everywhere' do
+      before do
+        value_tdc.update!(condition: ds_eq(column_value(gate_column), constant(true)))
+        revision.update!(ineligibilite_rules: ds_eq(column_value(gate_column), constant(true)))
+        create(:groupe_instructeur, procedure:, routing_rule: ds_eq(column_value(gate_column), constant(true)))
+      end
+
+      it { is_expected.to be(false) }
+    end
+  end
+
   describe '#used_by_referentiel_urls?' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text, stable_id: 100 }, { type: :referentiel, stable_id: 200 }]) }
     let(:text_tdc) { procedure.draft_revision.types_de_champ.find { _1.stable_id == 100 } }

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -2059,7 +2059,7 @@ describe Procedure do
     context 'when a champ_value is nested deep inside ineligibilite_rules' do
       before do
         revision.update!(ineligibilite_rules: ds_and([
-          ds_eq(column_value(gate_column), constant(true)),
+          ds_eq(champ_column_value(gate_column), constant(true)),
           ds_eq(champ_value(gate_tdc.stable_id), constant(true)),
         ]))
       end
@@ -2069,9 +2069,9 @@ describe Procedure do
 
     context 'when only column_values are used everywhere' do
       before do
-        value_tdc.update!(condition: ds_eq(column_value(gate_column), constant(true)))
-        revision.update!(ineligibilite_rules: ds_eq(column_value(gate_column), constant(true)))
-        create(:groupe_instructeur, procedure:, routing_rule: ds_eq(column_value(gate_column), constant(true)))
+        value_tdc.update!(condition: ds_eq(champ_column_value(gate_column), constant(true)))
+        revision.update!(ineligibilite_rules: ds_eq(champ_column_value(gate_column), constant(true)))
+        create(:groupe_instructeur, procedure:, routing_rule: ds_eq(champ_column_value(gate_column), constant(true)))
       end
 
       it { is_expected.to be(false) }

--- a/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
@@ -47,5 +47,31 @@ describe TypesDeChamp::DropDownListTypeDeChamp do
         expect(subject.first.label).to eq(dropdown_list_tdc.libelle)
       end
     end
+
+    context 'other true and referentiel off' do
+      let(:types_de_champ_public) { [{ type: :drop_down_list, drop_down_options: ['1', '2'], drop_down_other: true }] }
+      let(:column) { dropdown_list_tdc.columns(procedure:).first }
+      let(:column_value) { Logic::ColumnValue.new(column) }
+
+      it 'exposes other as a choice in the enum' do
+        option_labels = column.options_for_select.map(&:first)
+
+        expect(option_labels).to eq(['1', '2', 'Entrer une autre option'])
+      end
+
+      describe 'when a champ has a other value' do
+        let(:dossier) { create(:dossier, procedure:) }
+        let(:champ) { dossier.project_champs.first }
+
+        it 'matches other' do
+          champ.value = '__other__'
+          champ.value_other = 'something'
+
+          expect(champ.value).to eq('something')
+          expect(column.value(champ)).to eq('something')
+          expect(column_value.compute([champ])).to eq('__other__')
+        end
+      end
+    end
   end
 end

--- a/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
@@ -6,6 +6,8 @@ describe TypesDeChamp::DropDownListTypeDeChamp do
     let(:types_de_champ_public) { [{ type: :drop_down_list, referentiel:, drop_down_mode: }] }
     let(:referentiel) { create(:csv_referentiel, :with_items) }
     let(:dropdown_list_tdc) { procedure.active_revision.types_de_champ.first }
+    let(:column) { dropdown_list_tdc.columns(procedure_id: procedure.id).first }
+
     subject { dropdown_list_tdc.columns(procedure_id: procedure.id) }
 
     context 'when drop_down_mode is advanced (referentiel)' do

--- a/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
@@ -62,7 +62,7 @@ describe TypesDeChamp::DropDownListTypeDeChamp do
 
     context 'other true and referentiel off' do
       let(:types_de_champ_public) { [{ type: :drop_down_list, drop_down_options: ['1', '2'], drop_down_other: true }] }
-      let(:column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
+      let(:champ_column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
 
       it 'exposes other as a choice in the enum' do
         option_labels = column.options_for_select.map(&:first)
@@ -80,7 +80,7 @@ describe TypesDeChamp::DropDownListTypeDeChamp do
 
           expect(champ.value).to eq('something')
           expect(column.value(champ)).to eq('something')
-          expect(column_value.compute([champ])).to eq('__other__')
+          expect(champ_column_value.compute([champ])).to eq('__other__')
         end
       end
     end

--- a/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
@@ -35,6 +35,16 @@ describe TypesDeChamp::DropDownListTypeDeChamp do
 
         it { expect(calorie_column.options_for_select).to eq([["100", "100"], ["170", "170"]]) }
       end
+
+      context 'with other on' do
+        let(:types_de_champ_public) { [{ type: :drop_down_list, referentiel:, drop_down_mode: 'advanced', drop_down_other: true }] }
+
+        it 'exposes other as a choice in the enum' do
+          option_labels = column.options_for_select.map(&:first)
+
+          expect(option_labels).to eq(['fromage', 'dessert', 'fruit', 'Entrer une autre option'])
+        end
+      end
     end
 
     context 'when drop_down_mode is simple' do
@@ -50,7 +60,6 @@ describe TypesDeChamp::DropDownListTypeDeChamp do
 
     context 'other true and referentiel off' do
       let(:types_de_champ_public) { [{ type: :drop_down_list, drop_down_options: ['1', '2'], drop_down_other: true }] }
-      let(:column) { dropdown_list_tdc.columns(procedure:).first }
       let(:column_value) { Logic::ColumnValue.new(column) }
 
       it 'exposes other as a choice in the enum' do

--- a/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
@@ -62,7 +62,7 @@ describe TypesDeChamp::DropDownListTypeDeChamp do
 
     context 'other true and referentiel off' do
       let(:types_de_champ_public) { [{ type: :drop_down_list, drop_down_options: ['1', '2'], drop_down_other: true }] }
-      let(:column_value) { Logic::ColumnValue.new(column.stable_id, column.column_id) }
+      let(:column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
 
       it 'exposes other as a choice in the enum' do
         option_labels = column.options_for_select.map(&:first)

--- a/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
@@ -62,7 +62,7 @@ describe TypesDeChamp::DropDownListTypeDeChamp do
 
     context 'other true and referentiel off' do
       let(:types_de_champ_public) { [{ type: :drop_down_list, drop_down_options: ['1', '2'], drop_down_other: true }] }
-      let(:column_value) { Logic::ColumnValue.new(column) }
+      let(:column_value) { Logic::ColumnValue.new(column.stable_id, column.column_id) }
 
       it 'exposes other as a choice in the enum' do
         option_labels = column.options_for_select.map(&:first)

--- a/spec/system/administrateurs/condition_spec.rb
+++ b/spec/system/administrateurs/condition_spec.rb
@@ -148,7 +148,7 @@ describe 'As an administrateur I can edit types de champ condition', js: true do
     before { Flipper.enable(:column_conditions) }
     after { Flipper.disable(:column_conditions) }
 
-    let(:target_value) { column_value(first_tdc.columns(procedure_id:).first) }
+    let(:target_value) { champ_column_value(first_tdc.columns(procedure_id:).first) }
 
     include_examples 'condition editor'
   end

--- a/spec/system/administrateurs/condition_spec.rb
+++ b/spec/system/administrateurs/condition_spec.rb
@@ -11,6 +11,7 @@ describe 'As an administrateur I can edit types de champ condition', js: true do
              { type: :text, libelle: 'nom du parent' },
            ])
   end
+  let(:procedure_id) { procedure.id }
 
   let(:first_tdc) { procedure.draft_revision.types_de_champ.first }
   let(:second_tdc) { procedure.draft_revision.types_de_champ.second }
@@ -147,7 +148,7 @@ describe 'As an administrateur I can edit types de champ condition', js: true do
     before { Flipper.enable(:column_conditions) }
     after { Flipper.disable(:column_conditions) }
 
-    let(:target_value) { column_value(first_tdc.columns(procedure:).first) }
+    let(:target_value) { column_value(first_tdc.columns(procedure_id:).first) }
 
     include_examples 'condition editor'
   end

--- a/spec/system/administrateurs/condition_spec.rb
+++ b/spec/system/administrateurs/condition_spec.rb
@@ -20,118 +20,135 @@ describe 'As an administrateur I can edit types de champ condition', js: true do
     visit champs_admin_procedure_path(procedure)
   end
 
-  scenario 'add/remove/add condition' do
-    within '.type-de-champ:nth-child(2)' do
-      click_on 'cliquer pour activer'
-      find('button[title="Supprimer la ligne"]').click
-      click_on 'cliquer pour activer'
-    end
-  end
-
-  scenario "adding a new condition" do
-    within '.type-de-champ:nth-child(2)' do
-      click_on 'cliquer pour activer'
-
-      within '.condition-table tbody tr:nth-child(1)' do
-        expect(page).to have_select('type_de_champ[condition_form][rows][][targeted_champ]', options: ['Sélectionner', 'age'])
-
-        within('.target') { select('age') }
-        within('.operator') { select('Supérieur ou égal à') }
-        within('.value') { fill_in with: 18 }
-      end
-    end
-
-    expected_condition = greater_than_eq(champ_value(first_tdc.stable_id), constant(18))
-    wait_until { second_tdc.reload.condition == expected_condition }
-  end
-
-  scenario "the first type de champ is removed" do
-    within '.type-de-champ:nth-child(1)' do
-      accept_alert do
-        click_on 'Supprimer'
-      end
-    end
-
-    # the condition table is deleted
-    expect(page).to have_no_content('Logique conditionnelle')
-  end
-
-  context 'with a preexisting condition' do
-    before do
-      second_tdc.update(condition: greater_than_eq(champ_value(first_tdc.stable_id), constant(18)))
-
-      page.refresh
-    end
-
-    scenario "removing all conditions" do
+  shared_examples 'condition editor' do
+    scenario 'add/remove/add condition' do
       within '.type-de-champ:nth-child(2)' do
-        accept_alert do
-          click_on 'cliquer pour désactiver'
-        end
-
-        # the condition table is deleted
-        expect(page).to have_no_table
+        click_on 'cliquer pour activer'
+        find('button[title="Supprimer la ligne"]').click
+        click_on 'cliquer pour activer'
       end
     end
 
-    scenario "removing a condition" do
+    scenario "adding a new condition" do
       within '.type-de-champ:nth-child(2)' do
+        click_on 'cliquer pour activer'
+
         within '.condition-table tbody tr:nth-child(1)' do
-          within('.delete-column') { click_on 'Supprimer la ligne' }
-        end
+          expect(page).to have_select('type_de_champ[condition_form][rows][][targeted_champ]', options: ['Sélectionner', 'age'])
 
-        # the condition table is deleted
-        expect(page).to have_no_table
-      end
-    end
-
-    scenario "adding a second row" do
-      within '.type-de-champ:nth-child(2)' do
-        click_on 'Ajouter une condition'
-
-        # the condition table has 2 rows
-        within '.condition-table tbody' do
-          expect(page).to have_selector('tr', count: 2)
+          within('.target') { select('age') }
+          within('.operator') { select('Supérieur ou égal à') }
+          within('.value') { fill_in with: 18 }
         end
       end
+
+      expected_condition = greater_than_eq(target_value, constant(18))
+      wait_until { second_tdc.reload.condition == expected_condition }
     end
 
-    scenario "changing target champ to a not managed type" do
-      expect(page).to have_no_selector('.errors-summary')
-
+    scenario "the first type de champ is removed" do
       within '.type-de-champ:nth-child(1)' do
-        select('Départements', from: 'Type de champ')
+        accept_alert do
+          click_on 'Supprimer'
+        end
       end
 
-      within '.type-de-champ:nth-child(2)' do
-        expect(page).to have_selector('.errors-summary')
-      end
+      # the condition table is deleted
+      expect(page).to have_no_content('Logique conditionnelle')
     end
 
-    scenario "moving a target champ below the condition" do
-      expect(page).to have_no_selector('.errors-summary')
+    context 'with a preexisting condition' do
+      before do
+        second_tdc.update(condition: greater_than_eq(target_value, constant(18)))
 
-      within '.type-de-champ:nth-child(1)' do
-        click_on 'Déplacer le champ vers le bas'
+        page.refresh
       end
 
-      # the now first champ has an error
-      within '.type-de-champ:nth-child(1)' do
-        expect(page).to have_selector('.errors-summary')
+      scenario "removing all conditions" do
+        within '.type-de-champ:nth-child(2)' do
+          accept_alert do
+            click_on 'cliquer pour désactiver'
+          end
+
+          # the condition table is deleted
+          expect(page).to have_no_table
+        end
+      end
+
+      scenario "removing a condition" do
+        within '.type-de-champ:nth-child(2)' do
+          within '.condition-table tbody tr:nth-child(1)' do
+            within('.delete-column') { click_on 'Supprimer la ligne' }
+          end
+
+          # the condition table is deleted
+          expect(page).to have_no_table
+        end
+      end
+
+      scenario "adding a second row" do
+        within '.type-de-champ:nth-child(2)' do
+          click_on 'Ajouter une condition'
+
+          # the condition table has 2 rows
+          within '.condition-table tbody' do
+            expect(page).to have_selector('tr', count: 2)
+          end
+        end
+      end
+
+      scenario "changing target champ to a not managed type" do
+        expect(page).to have_no_selector('.errors-summary')
+
+        within '.type-de-champ:nth-child(1)' do
+          select('Départements', from: 'Type de champ')
+        end
+
+        within '.type-de-champ:nth-child(2)' do
+          expect(page).to have_selector('.errors-summary')
+        end
+      end
+
+      scenario "moving a target champ below the condition" do
+        expect(page).to have_no_selector('.errors-summary')
+
+        within '.type-de-champ:nth-child(1)' do
+          click_on 'Déplacer le champ vers le bas'
+        end
+
+        # the now first champ has an error
+        within '.type-de-champ:nth-child(1)' do
+          expect(page).to have_selector('.errors-summary')
+        end
+      end
+
+      scenario "moving the condition champ above the target" do
+        expect(page).to have_no_selector('.errors-summary')
+
+        within '.type-de-champ:nth-child(2)' do
+          click_on 'Déplacer le champ vers le haut'
+        end
+
+        # the now first champ has an error
+        within '.type-de-champ:nth-child(1)' do
+          expect(page).to have_selector('.errors-summary')
+        end
       end
     end
+  end
 
-    scenario "moving the condition champ above the target" do
-      expect(page).to have_no_selector('.errors-summary')
+  context 'in champ_value mode' do
+    let(:target_value) { champ_value(first_tdc.stable_id) }
 
-      within '.type-de-champ:nth-child(2)' do
-        click_on 'Déplacer le champ vers le haut'
-      end
+    include_examples 'condition editor'
+  end
 
-      # the now first champ has an error
-      within '.type-de-champ:nth-child(1)' do
-        expect(page).to have_selector('.errors-summary')
-      end
-    end
+  context 'in column_value mode' do
+    before { Flipper.enable(:column_conditions) }
+    after { Flipper.disable(:column_conditions) }
+
+    let(:target_value) { column_value(first_tdc.columns(procedure:).first) }
+
+    include_examples 'condition editor'
   end
 end


### PR DESCRIPTION
Au lieu de conditionner simplement sur la valeur principale d'un champ, on permet de conditionner sur ses colonnes (compatible), comme ce qui est possible d'afficher sur le tableau de bord.

**Concrètement, ca rajoute quoi ?**

pour les champs conditionnels, le routage et l'inéligibilité :

|colonne|type de condition|
|-|-|
|civilite|M. / Mme|
|epci|département et région|
|champ siret|département et région|
|champ rna|département et région|
|champ rnf|département et région|
|menu déroulant lié| premier et second choix|
|quotient familial|nombre| 
|champ simple référentiel| toutes les colonnes en enumeration|

**Pour l'affichage ?**

En accord avec l'UX, pour l'instant on garde les différents colonnes aux mm niveaux, on rajoute le nom des sections de premier niveau en séparateur

<img width="1232" height="556" alt="Screenshot From 2026-05-13 17-47-39" src="https://github.com/user-attachments/assets/dbdd8632-1b37-4a4b-aeb5-39644bb482c1" />

**UNE DÉMO, UNE DÉMO !**

https://github.com/user-attachments/assets/17b58caa-e1b7-45a6-9cb6-d564a623f17c

**Et pour le déploiement ?**

la fonctionnalité est pour l'instant uniquement accessible sous feature_flag `column_conditions` et uniquement s'il n'y a pas d'anciennes conditions utilisées pour l'affichage des champs / le routage / inéligibilité.

Dans un second temps, une migration convertira automatiquement les anciennes conditions vers le nouveau système pour que tout le monde puisse en profiter.

**les étapes suivantes :**
- :exclamation: :point_right: **column everyting** :point_left: :exclamation: 
  - champ référentiel expose plus de colonnes avec des types compatibles, et permettre aux admins de les typer
  - repasser sur les colonnes des api entreprise et voir si on ne peut en passer certains en enum ou number
  - rajouter des colonnes adresse sur le justificatif de domicile
  - france connecté / pro connecté
- rajouter des opérateurs pour de nouveau type (en particulier les dates)

**ce qui demanderait un refacto plus gros**
- c'est vraiment bizarre ce `procedure_id` dans l'id des columns. ca nous oblige a faire un truc chelou au clonage, je me demande si c'est vraiment nécessaire