### PR TITLE
Tech: task, nettoyage des options des tdc textarea

### DIFF
--- a/app/tasks/maintenance/clean_text_area_options_task.rb
+++ b/app/tasks/maintenance/clean_text_area_options_task.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class CleanTextAreaOptionsTask < MaintenanceTasks::Task
+    # In the rest of PR 10713
+    # TypeDeChamp options may contain options which are not consistent with the
+    # type_champ (e.g. a ‘textarea’ TypeDeChamp which has a
+    # drop_down_options key/value in its options).
+    # The aim here is to clean up the options so that only those wich are useful
+    # for the type_champ in question, here: "character_limit"
+
+    def collection
+      TypeDeChamp
+        .where(type_champ: 'textarea')
+        .where.not(options: {})
+        .where.not("(SELECT COUNT(*) FROM jsonb_each_text(options)) = 1 AND options ? 'character_limit'")
+    end
+
+    def process(tdc)
+      tdc.update(options: tdc.options.slice(:character_limit))
+    end
+  end
+end

--- a/spec/tasks/maintenance/clean_text_area_options_task_spec.rb
+++ b/spec/tasks/maintenance/clean_text_area_options_task_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe CleanTextAreaOptionsTask do
+    describe '#collection' do
+      subject(:collection) { described_class.collection }
+
+      context 'clean textarea tdc with character_limit' do
+        let(:tdc) {
+          create(:type_de_champ_textarea,
+                  options: {
+                    'character_limit' => '400'
+                  })
+        }
+
+        it do
+          expect(collection).not_to include(tdc)
+        end
+      end
+
+      context 'clean textarea tdc with no character_limit' do
+        let(:tdc) {
+          create(:type_de_champ_textarea,
+                  options: {})
+        }
+
+        it do
+          expect(collection).not_to include(tdc)
+        end
+      end
+
+      context 'taxtarea tdc with bad data options' do
+        let(:tdc) {
+          create(:type_de_champ_textarea,
+                  options: {
+                    'character_limit' => '400',
+                    'key' => 'value'
+                  })
+        }
+
+        it do
+          expect(collection).to include(tdc)
+        end
+      end
+
+      context 'other tdc' do
+        let(:tdc) {
+          create(:type_de_champ_header_section,
+                  options: {
+                    'header_section_level' => '1'
+                  })
+        }
+
+        it do
+          expect(collection).not_to include(tdc)
+        end
+      end
+    end
+
+    describe "#process" do
+      subject(:process) { described_class.process(tdc) }
+
+      context 'bad data in options' do
+        let(:tdc) {
+          create(:type_de_champ_textarea,
+                  options: {
+                    'character_limit' => '400',
+                    'key' => 'value'
+                  })
+        }
+
+        it do
+          subject
+          expect(tdc.reload.options).to eq({ 'character_limit' => '400' })
+        end
+      end
+
+      context 'only bad data in options' do
+        let(:tdc) {
+          create(:type_de_champ_textarea,
+                  options: {
+                    'key' => 'value'
+                  })
+        }
+
+        it do
+          subject
+          expect(tdc.reload.options).to eq({})
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
issue : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/10783

l'obj est donc de nettoyer le bruit dans les options du type_de_champ textarea