### PR TITLE
ETQ administrateur, je souhaite que les pdfs ne levent pas d'erreur de font

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ gem 'openid_connect'
 gem 'parsby'
 gem 'pg'
 gem 'phonelib'
+gem 'prawn', '2.4.0' # remove after: https://github.com/prawnpdf/prawn/issues/1346
 gem 'prawn-rails' # PDF Generation
 gem 'premailer-rails'
 gem 'puma' # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark-ips (2.14.0)
-    bigdecimal (3.1.8)
+    bigdecimal (3.1.9)
     bindata (2.5.0)
     bindex (0.8.1)
     bootsnap (1.18.4)
@@ -488,16 +488,15 @@ GEM
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
-    pdf-core (0.10.0)
+    pdf-core (0.9.0)
     pg (1.5.9)
     phonelib (0.10.1)
     playwright-ruby-client (1.46.0)
       concurrent-ruby (>= 1.1.6)
       mime-types (>= 3.0)
-    prawn (2.5.0)
-      matrix (~> 0.4)
-      pdf-core (~> 0.10.0)
-      ttfunk (~> 1.8)
+    prawn (2.4.0)
+      pdf-core (~> 0.9.0)
+      ttfunk (~> 1.7)
     prawn-rails (1.5.0)
       actionview (>= 3.1.0)
       activesupport (>= 3.1.0)
@@ -968,6 +967,7 @@ DEPENDENCIES
   parsby
   pg
   phonelib
+  prawn (= 2.4.0)
   prawn-rails
   premailer-rails
   puma


### PR DESCRIPTION
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_3eab7b74-cd1f-4ef8-81aa-da3d3621bf53/

# prob

les pdf levent des erreurs sur la font Marianne

# solution

en creusant, il semblerait que prawn 2.5.0 requiert pdfunk 1.8.x, cf: https://github.com/prawnpdf/prawn/issues/1346
donc on force la version de pdfunk en attendant 