### PR TITLE
ETQ Usager, je veux que la longueurs des selects soient uniformes

### DIFF
--- a/app/assets/stylesheets/02_utils.scss
+++ b/app/assets/stylesheets/02_utils.scss
@@ -123,12 +123,6 @@
 // sizing
 .width-100 {
   width: 100%;
-
-  @media (max-width: $two-columns-breakpoint) {
-    &-mobile {
-      width: 100%;
-    }
-  }
 }
 
 .width-33 {

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -378,6 +378,16 @@
         }
       }
     }
+
+    select {
+      @media (max-width: $two-columns-breakpoint) {
+        width: 100%;
+      }
+
+      @media (min-width: $two-columns-breakpoint) {
+      }
+      width: 33.33%;
+    }
   }
 
   input[type='checkbox'],

--- a/app/components/editable_champ/epci_component/epci_component.html.haml
+++ b/app/components/editable_champ/epci_component/epci_component.html.haml
@@ -1,11 +1,11 @@
 .fr-fieldset__element
   = @form.label :code_departement, for: @champ.code_departement_input_id, class: 'fr-label' do
     - "Le département de l’EPCI"
-  = @form.select :code_departement, departement_options, departement_select_options, required: @champ.required?, id: @champ.code_departement_input_id, class: "width-33-desktop width-100-mobile fr-select"
+  = @form.select :code_departement, departement_options, departement_select_options, required: @champ.required?, id: @champ.code_departement_input_id, class: "fr-select"
 
 - if @champ.departement?
   .fr-fieldset__element
     .fr-select-group
       = @form.label :value, for: @champ.epci_input_id, class: 'fr-label' do
         - "EPCI"
-      = @form.select :value, epci_options, epci_select_options, required: @champ.required?, id: @champ.epci_input_id, class: "width-33-desktop width-100-mobile fr-select"
+      = @form.select :value, epci_options, epci_select_options, required: @champ.required?, id: @champ.epci_input_id, class: "fr-select"

--- a/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
@@ -5,14 +5,13 @@
     = @form.select :primary_value, @champ.primary_options, {}, required: @champ.required?, class: 'fr-select fr-mb-3v', id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }
 
 - if @champ.has_secondary_options_for_primary?
-  .secondary
-    .fr-fieldset__element
-      .fr-select-group
-        = @form.label :secondary_value, for: "#{@champ.input_id}-secondary", class: 'fr-label' do
-          - sanitize(secondary_label)
-        - if @champ.drop_down_secondary_description.present?
-          .notice{ id: "#{@champ.describedby_id}-secondary" }
-            = render SimpleFormatComponent.new(@champ.drop_down_secondary_description, allow_a: true)
-        = @form.select :secondary_value, @champ.secondary_options[@champ.primary_value], {}, required: @champ.required?, class: 'fr-select', id: "#{@champ.input_id}-secondary", aria: { describedby: "#{@champ.describedby_id}-secondary" }
+  .fr-fieldset__element
+    .fr-select-group
+      = @form.label :secondary_value, for: "#{@champ.input_id}-secondary", class: 'fr-label' do
+        - sanitize(secondary_label)
+      - if @champ.drop_down_secondary_description.present?
+        .notice{ id: "#{@champ.describedby_id}-secondary" }
+          = render SimpleFormatComponent.new(@champ.drop_down_secondary_description, allow_a: true)
+      = @form.select :secondary_value, @champ.secondary_options[@champ.primary_value], {}, required: @champ.required?, class: 'fr-select', id: "#{@champ.input_id}-secondary", aria: { describedby: "#{@champ.describedby_id}-secondary" }
 - else
   = @form.hidden_field :secondary_value, value: ''

--- a/app/components/editable_champ/pays_component/pays_component.html.haml
+++ b/app/components/editable_champ/pays_component/pays_component.html.haml
@@ -1,1 +1,1 @@
-= @form.select :value, options, select_options, required: @champ.required?, id: @champ.input_id, autocomplete: @champ.dossier.for_tiers? ? "off" : "country-name", aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, class: "width-33-desktop width-100-mobile fr-select"
+= @form.select :value, options, select_options, required: @champ.required?, id: @champ.input_id, autocomplete: @champ.dossier.for_tiers? ? "off" : "country-name", aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, class: "fr-select"

--- a/app/components/editable_champ/regions_component/regions_component.html.haml
+++ b/app/components/editable_champ/regions_component/regions_component.html.haml
@@ -1,1 +1,1 @@
-= @form.select :value, options, select_options, required: @champ.required?, id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, class: "width-33-desktop width-100-mobile fr-select"
+= @form.select :value, options, select_options, required: @champ.required?, id: @champ.input_id, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, class: "fr-select"


### PR DESCRIPTION
# Uniformisation de la longueur des `select`
__Après__
<img width="1197" alt="" src="https://github.com/user-attachments/assets/68c891f5-3960-4a90-ac88-3343082b6bb3" />
<img width="1241" alt="" src="https://github.com/user-attachments/assets/5f5f207e-d107-496f-9b3e-edc5f4235726" />


__Avant__
<img width="1234" alt="" src="https://github.com/user-attachments/assets/03066444-7fc2-4d9c-b017-baf8b464566d" />
<img width="1231" alt="" src="https://github.com/user-attachments/assets/78812dfd-d363-4fb0-80f2-0317a52d6b45" />