### PR TITLE
[Design] Petit ajustement de marge pour rééquilibrer le menu d'aide

### DIFF
--- a/app/components/procedure/service_list_contact_component/service_list_contact_component.html.haml
+++ b/app/components/procedure/service_list_contact_component/service_list_contact_component.html.haml
@@ -38,6 +38,6 @@
     - if service.other_contact_info.present?
       .flex.fr-mb-2v
         %dt.fr-mr-2v
-          %span.fr-icon-information-line.fr-icon--sm{ "aria-hidden": "true" }
+          %span.fr-fi-info-line.fr-icon--sm{ "aria-hidden": "true" }
         %dd
           = service.other_contact_info

--- a/app/views/shared/help/dropdown_items/_service_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_service_item.html.haml
@@ -1,5 +1,6 @@
 %span.fr-icon-question-fill.fr-text-action-high--blue-france{ "aria-hidden": "true" }
 .fr-pl-1w
-  %h1= title
+  %h1.fr-mb-1v
+    = title
   %ul
     = render Procedure::ServiceListContactComponent.new(service: service, dossier: dossier)


### PR DESCRIPTION
Avec l'apparition des nouvelles infos de contact dans la dropdown, il faut rajouter un petite margin au h1 pour que ce soit visuellement équilibré.
On en profite pour changer l'icone d'information pour qu'elle soit un peu plus différenciée.

**APRES**
<img width="594" alt="Capture d’écran 2025-05-14 à 13 34 46" src="https://github.com/user-attachments/assets/df48e99d-67a7-42c9-b75b-2096273b7593" />

**AVANT**
<img width="572" alt="Capture d’écran 2025-05-14 à 13 35 00" src="https://github.com/user-attachments/assets/368176a6-82dd-4b4b-81bb-ddfd8cd6a418" />
