### PR TITLE
ETQ Instructeur : fix le calcul du nb de jours pour les notifications dossier_depose

### DIFF
--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -191,7 +191,7 @@ module DossierHelper
       if generic[:generic]
         t("activerecord.attributes.notification.#{type}.generic")
       else
-        t("activerecord.attributes.notification.#{type}.specific", days: (Time.current.to_date - notification.display_at.to_date).to_i)
+        t("activerecord.attributes.notification.#{type}.specific", days: (Time.current.to_date - (notification.display_at - DossierNotification::DELAY_DOSSIER_DEPOSE).to_date).to_i)
       end
     else
       t("activerecord.attributes.notification.#{type}")

--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DossierNotification < ApplicationRecord
+  DELAY_DOSSIER_DEPOSE = 7.days
+
   belongs_to :groupe_instructeur, optional: true
   belongs_to :instructeur, optional: true
   belongs_to :dossier
@@ -32,7 +34,7 @@ class DossierNotification < ApplicationRecord
         notification_type:,
         groupe_instructeur_id: dossier.groupe_instructeur_id
       ) do |notification|
-        notification.display_at = dossier.depose_at + 7.days
+        notification.display_at = dossier.depose_at + DELAY_DOSSIER_DEPOSE
       end
 
     when :dossier_modifie, :attente_correction, :attente_avis, :message_usager, :annotation_instructeur, :avis_externe

--- a/config/locales/models/dossier_notification/fr.yml
+++ b/config/locales/models/dossier_notification/fr.yml
@@ -4,7 +4,7 @@ fr:
       notification:
         dossier_depose:
           generic: Déposé depuis longtemps
-          specific: "Dépose depuis %{days} J."
+          specific: "Déposé depuis %{days} J."
         dossier_modifie: Dossier modifié
         attente_correction: En attente de correction
         attente_avis: En attente d'avis externe

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -266,4 +266,18 @@ RSpec.describe DossierHelper, type: :helper do
       }
     end
   end
+
+  describe ".tags_notification" do
+    subject { tags_notification([notification]) }
+
+    context "with dossier_depose notification" do
+      let(:groupe_instructeur) { create(:groupe_instructeur) }
+      let(:dossier) { create(:dossier, groupe_instructeur:, depose_at: 10.days.ago) }
+      let!(:notification) { create(:dossier_notification, :for_groupe_instructeur, groupe_instructeur:, dossier:, notification_type: :dossier_depose, display_at: (dossier.depose_at + DossierNotification::DELAY_DOSSIER_DEPOSE)) }
+
+      it {
+        expect(subject).to have_text("Déposé depuis 10 J.")
+      }
+    end
+  end
 end


### PR DESCRIPTION
un oubli de retrancher les 7 jours de délai avant affichage de la notif 

![image](https://github.com/user-attachments/assets/cdd791f0-3b5d-4321-9d30-b36282b7546f)
