### PR TITLE
[BUG] ETQ Instructeur, s'il n'y a pas de rdv sur le dossier l'onglet rendez-vous du dossier doit être vide

### DIFF
--- a/app/services/rdv_service.rb
+++ b/app/services/rdv_service.rb
@@ -132,6 +132,8 @@ class RdvService
   end
 
   def list_rdvs(rdv_ids)
+    return [] if rdv_ids.blank?
+
     refresh_token_if_expired!
 
     response = Typhoeus.get(

--- a/spec/services/rdv_service_spec.rb
+++ b/spec/services/rdv_service_spec.rb
@@ -149,6 +149,14 @@ describe RdvService do
       expect(subject).to eq([rdv])
     end
 
+    context "when the array is empty" do
+      let(:rdv_ids) { [] }
+
+      it "returns an empty array" do
+        expect(subject).to eq([])
+      end
+    end
+
     context "when the request fails" do
       before do
         stub_request(:get, described_class.list_rdvs_url(rdv_ids))


### PR DESCRIPTION
on ne doit pas appeler l'api RDV, sinon il n'y a pas de filtres et ça renvoie tous les rdvs de l'instructeur 🙈 