### PR TITLE
ETQ instructeur, je souhaite que le retour a la ligne, le texte enrichi et l'affichage des liens soient respectés dans les messages d'inéligibilité et de fin de dépôt

### DIFF
--- a/app/components/dossiers/invalid_ineligibilite_rules_component.rb
+++ b/app/components/dossiers/invalid_ineligibilite_rules_component.rb
@@ -21,7 +21,7 @@ class Dossiers::InvalidIneligibiliteRulesComponent < ApplicationComponent
   end
 
   def error_message
-    dossier.revision.ineligibilite_message
+    dossier.revision.ineligibilite_message&.strip
   end
 
   def opened? = @opened

--- a/app/components/dossiers/invalid_ineligibilite_rules_component.rb
+++ b/app/components/dossiers/invalid_ineligibilite_rules_component.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Dossiers::InvalidIneligibiliteRulesComponent < ApplicationComponent
+  include ChampHelper
   delegate :can_passer_en_construction?, to: :dossier
 
   def initialize(dossier:, wrapped: true)

--- a/app/components/dossiers/invalid_ineligibilite_rules_component.rb
+++ b/app/components/dossiers/invalid_ineligibilite_rules_component.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Dossiers::InvalidIneligibiliteRulesComponent < ApplicationComponent
-  include ChampHelper
   delegate :can_passer_en_construction?, to: :dossier
 
   def initialize(dossier:, wrapped: true)

--- a/app/components/dossiers/invalid_ineligibilite_rules_component.rb
+++ b/app/components/dossiers/invalid_ineligibilite_rules_component.rb
@@ -20,7 +20,7 @@ class Dossiers::InvalidIneligibiliteRulesComponent < ApplicationComponent
   end
 
   def error_message
-    dossier.revision.ineligibilite_message&.strip
+    dossier.revision.ineligibilite_message
   end
 
   def opened? = @opened

--- a/app/components/dossiers/invalid_ineligibilite_rules_component/invalid_ineligibilite_rules_component.html.haml
+++ b/app/components/dossiers/invalid_ineligibilite_rules_component/invalid_ineligibilite_rules_component.html.haml
@@ -13,7 +13,7 @@
               %h1#fr-modal-title-modal-1.fr-modal__title
                 %span.fr-icon-arrow-right-line.fr-icon--lg>
                 = t('.modal.title')
-              .fr-text--wrap= format_text_value(error_message.strip)
+              .fr-text--wrap= format_text_value(error_message&.strip)
 
 - if wrapped?
   #ineligibilite_rules_modal

--- a/app/components/dossiers/invalid_ineligibilite_rules_component/invalid_ineligibilite_rules_component.html.haml
+++ b/app/components/dossiers/invalid_ineligibilite_rules_component/invalid_ineligibilite_rules_component.html.haml
@@ -13,7 +13,7 @@
               %h1#fr-modal-title-modal-1.fr-modal__title
                 %span.fr-icon-arrow-right-line.fr-icon--lg>
                 = t('.modal.title')
-              .fr-text--wrap= simple_format(error_message, {}, sanitize: false)
+              .fr-text--wrap= format_text_value(error_message.strip)
 
 - if wrapped?
   #ineligibilite_rules_modal

--- a/app/components/dossiers/invalid_ineligibilite_rules_component/invalid_ineligibilite_rules_component.html.haml
+++ b/app/components/dossiers/invalid_ineligibilite_rules_component/invalid_ineligibilite_rules_component.html.haml
@@ -13,7 +13,7 @@
               %h1#fr-modal-title-modal-1.fr-modal__title
                 %span.fr-icon-arrow-right-line.fr-icon--lg>
                 = t('.modal.title')
-              .fr-text--wrap= format_text_value(error_message&.strip)
+              .fr-text--wrap= format_text_value(error_message)
 
 - if wrapped?
   #ineligibilite_rules_modal

--- a/app/components/dossiers/invalid_ineligibilite_rules_component/invalid_ineligibilite_rules_component.html.haml
+++ b/app/components/dossiers/invalid_ineligibilite_rules_component/invalid_ineligibilite_rules_component.html.haml
@@ -13,7 +13,7 @@
               %h1#fr-modal-title-modal-1.fr-modal__title
                 %span.fr-icon-arrow-right-line.fr-icon--lg>
                 = t('.modal.title')
-              .fr-text--wrap= format_text_value(error_message)
+              .fr-text--wrap= render SimpleFormatComponent.new(error_message)
 
 - if wrapped?
   #ineligibilite_rules_modal

--- a/app/components/dossiers/invalid_ineligibilite_rules_component/invalid_ineligibilite_rules_component.html.haml
+++ b/app/components/dossiers/invalid_ineligibilite_rules_component/invalid_ineligibilite_rules_component.html.haml
@@ -13,7 +13,7 @@
               %h1#fr-modal-title-modal-1.fr-modal__title
                 %span.fr-icon-arrow-right-line.fr-icon--lg>
                 = t('.modal.title')
-              %p= error_message
+              .fr-text--wrap= simple_format(error_message, {}, sanitize: false)
 
 - if wrapped?
   #ineligibilite_rules_modal

--- a/app/models/dossier_submitted_message.rb
+++ b/app/models/dossier_submitted_message.rb
@@ -2,4 +2,6 @@
 
 class DossierSubmittedMessage < ApplicationRecord
   has_many :revisions, class_name: 'ProcedureRevision', inverse_of: :dossier_submitted_message, dependent: :nullify
+
+  normalizes :message_on_submit_by_usager, with: -> message { message&.strip }
 end

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -37,6 +37,8 @@ class ProcedureRevision < ApplicationRecord
 
   serialize :ineligibilite_rules, coder: LogicSerializer
 
+  normalizes :ineligibilite_message, with: -> message { message&.strip }
+
   def add_type_de_champ(params)
     parent_stable_id = params.delete(:parent_stable_id)
     parent_coordinate, _ = coordinate_and_tdc(parent_stable_id)

--- a/app/views/administrateurs/dossier_submitted_messages/_informations.html.haml
+++ b/app/views/administrateurs/dossier_submitted_messages/_informations.html.haml
@@ -1,4 +1,4 @@
 .fr-input-group
   = f.label :message_on_submit_by_usager do
     Message affiché après l'envoi du dossier
-  = f.text_area :message_on_submit_by_usager, placeholder: "Merci, votre dossier sera traité dans les plus brefs délais", class: 'fr-input'
+  = f.text_area :message_on_submit_by_usager, placeholder: "Merci, votre dossier sera traité dans les plus brefs délais", class: 'fr-input', data: { controller: 'autoresize' }, rows: 5

--- a/app/views/users/dossiers/_merci.html.haml
+++ b/app/views/users/dossiers/_merci.html.haml
@@ -18,7 +18,7 @@
             = t('views.users.dossiers.merci.dossier_edit_l3')
           %strong= t('views.users.dossiers.merci.dossier_edit_l4')
         - if procedure.active_dossier_submitted_message
-          .fr-m-2.fr-text--wrap= render SimpleFormatComponent.new(procedure.active_dossier_submitted_message.message_on_submit_by_usager&.strip)
+          .fr-m-2.fr-text--wrap= render SimpleFormatComponent.new(procedure.active_dossier_submitted_message.message_on_submit_by_usager)
     %p.justify-center.flex.fr-mb-5w.fr-mt-2w
       = render(partial: 'users/dossiers/show/download_dossier', locals: { dossier: dossier })
       = link_to t('views.users.dossiers.merci.acces_dossier'), dossier ? dossier_path(dossier) : "#dossier" , class: 'fr-btn fr-mx-2w'

--- a/app/views/users/dossiers/_merci.html.haml
+++ b/app/views/users/dossiers/_merci.html.haml
@@ -18,7 +18,7 @@
             = t('views.users.dossiers.merci.dossier_edit_l3')
           %strong= t('views.users.dossiers.merci.dossier_edit_l4')
         - if procedure.active_dossier_submitted_message
-          .fr-m-2.fr-text--wrap= format_text_value(procedure.active_dossier_submitted_message.message_on_submit_by_usager.strip)
+          .fr-m-2.fr-text--wrap= render SimpleFormatComponent.new(procedure.active_dossier_submitted_message.message_on_submit_by_usager&.strip)
     %p.justify-center.flex.fr-mb-5w.fr-mt-2w
       = render(partial: 'users/dossiers/show/download_dossier', locals: { dossier: dossier })
       = link_to t('views.users.dossiers.merci.acces_dossier'), dossier ? dossier_path(dossier) : "#dossier" , class: 'fr-btn fr-mx-2w'

--- a/app/views/users/dossiers/_merci.html.haml
+++ b/app/views/users/dossiers/_merci.html.haml
@@ -18,7 +18,7 @@
             = t('views.users.dossiers.merci.dossier_edit_l3')
           %strong= t('views.users.dossiers.merci.dossier_edit_l4')
         - if procedure.active_dossier_submitted_message
-          %p.fr-m-2= procedure.active_dossier_submitted_message.message_on_submit_by_usager
+          .fr-m-2.fr-text--wrap= simple_format(procedure.active_dossier_submitted_message.message_on_submit_by_usager.strip, {}, sanitize: false)
     %p.justify-center.flex.fr-mb-5w.fr-mt-2w
       = render(partial: 'users/dossiers/show/download_dossier', locals: { dossier: dossier })
       = link_to t('views.users.dossiers.merci.acces_dossier'), dossier ? dossier_path(dossier) : "#dossier" , class: 'fr-btn fr-mx-2w'

--- a/app/views/users/dossiers/_merci.html.haml
+++ b/app/views/users/dossiers/_merci.html.haml
@@ -18,7 +18,7 @@
             = t('views.users.dossiers.merci.dossier_edit_l3')
           %strong= t('views.users.dossiers.merci.dossier_edit_l4')
         - if procedure.active_dossier_submitted_message
-          .fr-m-2.fr-text--wrap= simple_format(procedure.active_dossier_submitted_message.message_on_submit_by_usager.strip, {}, sanitize: false)
+          .fr-m-2.fr-text--wrap= format_text_value(procedure.active_dossier_submitted_message.message_on_submit_by_usager.strip)
     %p.justify-center.flex.fr-mb-5w.fr-mt-2w
       = render(partial: 'users/dossiers/show/download_dossier', locals: { dossier: dossier })
       = link_to t('views.users.dossiers.merci.acces_dossier'), dossier ? dossier_path(dossier) : "#dossier" , class: 'fr-btn fr-mx-2w'


### PR DESCRIPTION

> # Message d'inéligibilité
> Exemple pour le respect des sauts de ligne, format "gras", et format "lien" :
> 
> _Configuration ADMIN_
> 
> ![Image](https://github.com/user-attachments/assets/18ea8761-1f7a-4f6a-826b-516a8805be1e)
> 
> _Rendu USAGER_AVANT
> 
> ![Image](https://github.com/user-attachments/assets/f16981ef-89b0-42a1-a905-9f3023ae8a15)
> 
> _Rendu USAGER_APRES
> 
> ![Image](https://github.com/user-attachments/assets/ec01e07f-4e34-459a-80bf-8e87f41c0073)

> # Page de fin de dépôt
> 
> 
> _Configuration ADMIN + aperçu du rendu USAGER_AVANT
> 
> ![Image](https://github.com/user-attachments/assets/4a907d1b-c240-4e36-ae17-e1ae425b12d8)
> 
> _Configuration ADMIN + aperçu du rendu USAGER_APRES
> 
> ![Image](https://github.com/user-attachments/assets/a42b6ee2-886a-48c6-9bfc-b7829ab5ff5d)



