### PR TITLE
tech: refactor(Referentiel.error): extrait le rendu quand une erreurs d'appel a l'API arrive via un refrentiel

### DIFF
--- a/app/components/referentiels/configuration_error_component.html.haml
+++ b/app/components/referentiels/configuration_error_component.html.haml
@@ -1,0 +1,19 @@
+%div{ class: bordered_container_class_names }
+  %h4 Impossible de contacter le référentiel
+
+  = render Dsfr::AlertComponent.new(title: error_title, state: :error, extra_class_names: 'fr-mb-3w') do |c|
+    - c.with_body do
+      %p L'API n'a pas retournée une réponse valide, veuillez vérifier les paramètres du referentiel :
+      %pre Endpoint: #{test_url}
+
+      - if test_headers.present?
+        %pre Headers: #{test_headers}
+
+      %pre Status: #{JSON.pretty_generate(@referentiel.last_response_status)}
+      %pre Body: #{JSON.pretty_generate(@referentiel.last_response_body)}
+
+%ul.fr-btns-group.fr-btns-group--inline-sm.justify-center.fr-mt-5w
+  %li= link_to "Annuler", champs_admin_procedure_path(@procedure), class: 'fr-btn fr-btn--secondary  fr-mr-3w'
+  %li= link_to "Étape précédente", edit_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel.id), class: 'fr-btn'
+  %li
+    %button.fr-btn{ disabled: true } Étape suivante

--- a/app/components/referentiels/configuration_error_component.rb
+++ b/app/components/referentiels/configuration_error_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Referentiels::ConfigurationErrorComponent < Referentiels::MappingFormBase
+  attr_reader :referentiel_service
+  delegate :test_url, :test_headers, to: :referentiel_service
+  def initialize(**args)
+    super
+    @referentiel_service = ReferentielService.new(referentiel: referentiel)
+  end
+
+  def error_title
+    "¡Ay, caramba! 💣💥"
+  end
+end

--- a/app/components/referentiels/mapping_form_component.rb
+++ b/app/components/referentiels/mapping_form_component.rb
@@ -13,10 +13,6 @@ class Referentiels::MappingFormComponent < Referentiels::MappingFormBase
     JSONPathUtil.hash_to_jsonpath(referentiel.last_response_body)
   end
 
-  def error_title
-    "¡Ay, caramba! 💣💥"
-  end
-
   def back_url
     edit_admin_procedure_referentiel_path(procedure, type_de_champ.stable_id, referentiel.id)
   end

--- a/app/components/referentiels/mapping_form_component/mapping_form_component.html.haml
+++ b/app/components/referentiels/mapping_form_component/mapping_form_component.html.haml
@@ -1,79 +1,57 @@
-- if !@referentiel.ready?
+= form_with(model: @type_de_champ, url: update_mapping_type_de_champ_admin_procedure_referentiel_path(@procedure, @type_de_champ.stable_id, @referentiel)) do |f|
   %div{ class: bordered_container_class_names }
-    %h4 Impossible de contacter le référentiel
+    %section.fr-accordion.fr-mb-3w
+      %h3.fr-accordion__title
+        %button.fr-accordion__btn{ type: :button, "aria-controls" => "last_response", "aria-expanded" => "false" } Afficher la réponse récupérée à partir de la requête configurée
 
-    = render Dsfr::AlertComponent.new(title: error_title, state: :error, extra_class_names: 'fr-mb-3w') do |c|
-      - c.with_body do
-        %p L'API n'a pas retournée une réponse valide, veuillez vérifier les paramètres du referentiel :
-        %pre Endpoint: #{test_url}
+    .fr-collapse#last_response
+      %pre Endpoint: #{test_url}
+      - if test_headers.present?
+        %pre Headers: #{test_headers}
+      %pre Status: #{JSON.pretty_generate(@referentiel.last_response_status)}
+      %pre Body: #{JSON.pretty_generate(@referentiel.last_response_body)}
 
-        - if test_headers.present?
-          %pre Headers: #{test_headers}
+    %section
+      .fr-table.fr-table--bordered
+        .fr-table__wrapper
+          .fr-table__container
+            .fr-table__content
+              %table
+                %caption Complétez le tableau de mapping ci-dessous en fonction des données que vous souhaitez exploiter
+                %thead
+                  %tr
+                    %th.fr-cell--fixed Propriété
+                    %th Exemple de donnée
+                    %th Type de donnée
+                    %th
+                      Utiliser la donnée
+                      %br
+                      pour préremplir
+                      %br
+                      un champ du
+                      %br
+                      formulaire
+                    %th
+                      Libellé de la donnée récupérée
+                      %br
+                      (pour afficher à l'usager et/ou l'instructeur)
+                %tbody
+                  - last_request_keys.sort.each do |jsonpath, example_value|
+                    %tr{ data: { controller: "referentiel-mapping" } }
+                      %td.fr-cell--fixed
+                        %span.hidden{ id: label_check_prefill(jsonpath) }= "Utiliser #{jsonpath} pour préremplir le formulaire"
+                        = jsonpath
+                        = hidden_field_tag attribute_name(jsonpath, "example_value"), example_value
+                      %td.fr-cell--multiline= example_value
+                      %td= cast_tag(jsonpath, example_value)
+                      %td.text-center= prefill_tag(jsonpath)
+                      %td
+                        %div{ data: { "referentiel-mapping-target": "enabledContent" }, class: disabled?(jsonpath) ? 'hidden' : '' }= enabled_libelle_tag(jsonpath)
+                        %div{ data: { "referentiel-mapping-target": "disabledContent" }, class: disabled?(jsonpath) ? '' : 'hidden' }= disabled_libelle_tag(jsonpath)
 
-        %pre Status: #{JSON.pretty_generate(@referentiel.last_response_status)}
-        %pre Body: #{JSON.pretty_generate(@referentiel.last_response_body)}
+    .clearfix
 
-  %ul.fr-btns-group.fr-btns-group--inline-sm.justify-center.fr-mt-5w
-    %li= link_to "Annuler", champs_admin_procedure_path(@procedure), class: 'fr-btn fr-btn--secondary  fr-mr-3w'
-    %li= link_to "Étape précédente", back_url, class: 'fr-btn'
-    %li
-      %button.fr-btn{ disabled: true } Étape suivante
-
-- else
-  = form_with(model: @type_de_champ, url: update_mapping_type_de_champ_admin_procedure_referentiel_path(@procedure, @type_de_champ.stable_id, @referentiel)) do |f|
-    %div{ class: bordered_container_class_names }
-      %section.fr-accordion.fr-mb-3w
-        %h3.fr-accordion__title
-          %button.fr-accordion__btn{ type: :button, "aria-controls" => "last_response", "aria-expanded" => "false" } Afficher la réponse récupérée à partir de la requête configurée
-
-      .fr-collapse#last_response
-        %pre Endpoint: #{test_url}
-        - if test_headers.present?
-          %pre Headers: #{test_headers}
-        %pre Status: #{JSON.pretty_generate(@referentiel.last_response_status)}
-        %pre Body: #{JSON.pretty_generate(@referentiel.last_response_body)}
-
-      %section
-        .fr-table.fr-table--bordered
-          .fr-table__wrapper
-            .fr-table__container
-              .fr-table__content
-                %table
-                  %caption Complétez le tableau de mapping ci-dessous en fonction des données que vous souhaitez exploiter
-                  %thead
-                    %tr
-                      %th.fr-cell--fixed Propriété
-                      %th Exemple de donnée
-                      %th Type de donnée
-                      %th
-                        Utiliser la donnée
-                        %br
-                        pour préremplir
-                        %br
-                        un champ du
-                        %br
-                        formulaire
-                      %th
-                        Libellé de la donnée récupérée
-                        %br
-                        (pour afficher à l'usager et/ou l'instructeur)
-                  %tbody
-                    - last_request_keys.sort.each do |jsonpath, example_value|
-                      %tr{ data: { controller: "referentiel-mapping" } }
-                        %td.fr-cell--fixed
-                          %span.hidden{ id: label_check_prefill(jsonpath) }= "Utiliser #{jsonpath} pour préremplir le formulaire"
-                          = jsonpath
-                          = hidden_field_tag attribute_name(jsonpath, "example_value"), example_value
-                        %td.fr-cell--multiline= example_value
-                        %td= cast_tag(jsonpath, example_value)
-                        %td.text-center= prefill_tag(jsonpath)
-                        %td
-                          %div{ data: { "referentiel-mapping-target": "enabledContent" }, class: disabled?(jsonpath) ? 'hidden' : '' }= enabled_libelle_tag(jsonpath)
-                          %div{ data: { "referentiel-mapping-target": "disabledContent" }, class: disabled?(jsonpath) ? '' : 'hidden' }= disabled_libelle_tag(jsonpath)
-
-      .clearfix
-
-    %ul.fr-btns-group.fr-btns-group--inline-sm.flex.justify-center.fr-mt-5w
-      %li= link_to "Annuler", champs_admin_procedure_path(@procedure), class: 'fr-btn fr-btn--secondary fr-mr-3w'
-      %li= link_to "Étape précédente", back_url, class: 'fr-btn fr-btn--secondary'
-      %li= f.submit "Étape suivante", class: "fr-btn"
+  %ul.fr-btns-group.fr-btns-group--inline-sm.flex.justify-center.fr-mt-5w
+    %li= link_to "Annuler", champs_admin_procedure_path(@procedure), class: 'fr-btn fr-btn--secondary fr-mr-3w'
+    %li= link_to "Étape précédente", back_url, class: 'fr-btn fr-btn--secondary'
+    %li= f.submit "Étape suivante", class: "fr-btn"

--- a/app/components/referentiels/stepper_component.rb
+++ b/app/components/referentiels/stepper_component.rb
@@ -15,7 +15,7 @@ class Referentiels::StepperComponent < ViewComponent::Base
   end
 
   def step_title
-    if step_component == Referentiels::NewFormComponent
+    if step_component.in?([Referentiels::NewFormComponent, Referentiels::ConfigurationErrorComponent])
       "Requête"
     elsif step_component == Referentiels::MappingFormComponent
       "Réponse et mapping"
@@ -35,7 +35,7 @@ class Referentiels::StepperComponent < ViewComponent::Base
   end
 
   def current_step
-    return 1 if step_component == Referentiels::NewFormComponent
+    return 1 if step_component.in?([Referentiels::NewFormComponent, Referentiels::ConfigurationErrorComponent])
 
     case [step_component, referentiel.mode]
     when [Referentiels::MappingFormComponent, 'exact_match']

--- a/app/controllers/administrateurs/referentiels_controller.rb
+++ b/app/controllers/administrateurs/referentiels_controller.rb
@@ -5,10 +5,14 @@ module Administrateurs
     before_action :retrieve_procedure
     before_action :retrieve_type_de_champ
     before_action :retrieve_referentiel, except: [:new, :create]
+    before_action :reachable_referentiel?, only: [:mapping_type_de_champ]
     layout 'empty_layout'
 
     def new
       @referentiel = @type_de_champ.build_referentiel(build_or_clone_by_id_params)
+    end
+
+    def configuration_error
     end
 
     def edit
@@ -25,8 +29,6 @@ module Administrateurs
     end
 
     def mapping_type_de_champ
-      @service = ReferentielService.new(referentiel: @referentiel)
-      @service.validate_referentiel
     end
 
     def update_mapping_type_de_champ
@@ -46,6 +48,12 @@ module Administrateurs
     end
 
     private
+
+    def reachable_referentiel?
+      if !ReferentielService.new(referentiel: @referentiel).validate_referentiel
+        redirect_to configuration_error_admin_procedure_referentiel_path(@procedure, @type_de_champ.stable_id, @referentiel), flash: { alert: "Le référentiel n'est pas accessible" }
+      end
+    end
 
     def handle_referentiel_save(referentiel)
       if referentiel.configured? && referentiel.save && params[:commit].present?

--- a/app/views/administrateurs/referentiels/configuration_error.html.haml
+++ b/app/views/administrateurs/referentiels/configuration_error.html.haml
@@ -1,0 +1,1 @@
+= render Referentiels::StepperComponent.new(referentiel: @referentiel, type_de_champ: @type_de_champ, procedure: @procedure, step_component: Referentiels::ConfigurationErrorComponent)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -783,6 +783,7 @@ Rails.application.routes.draw do
 
       resources :referentiels, only: [:new, :create, :edit, :update], path: ':stable_id', constraints: { stable_id: /\d+/ } do
         member do
+          get :configuration_error
           get :mapping_type_de_champ
           patch :update_mapping_type_de_champ
           patch :update_prefill_and_display_type_de_champ

--- a/spec/components/referentiels/configuration_error_component_spec.rb
+++ b/spec/components/referentiels/configuration_error_component_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe Referentiels::ConfigurationErrorComponent, type: :component do
+  let(:component) { described_class.new(referentiel:, type_de_champ:, procedure:) }
+  let(:procedure) { create(:procedure, types_de_champ_public:) }
+  let(:types_de_champ_public) { [{ type: :referentiel, referentiel: }] }
+  let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+  let(:referentiel) { create(:api_referentiel, :configured) }
+  before do
+    render_inline(component)
+  end
+  context 'when referentiel is not ready' do
+    it 'render error' do
+      expect(page).to have_text(component.error_title)
+      expect(page).to have_selector("button.fr-btn[disabled]")
+    end
+  end
+end

--- a/spec/components/referentiels/mapping_form_component_spec.rb
+++ b/spec/components/referentiels/mapping_form_component_spec.rb
@@ -17,13 +17,6 @@ RSpec.describe Referentiels::MappingFormComponent, type: :component do
       render_inline(component)
     end
 
-    context 'when referentiel is not ready' do
-      it 'render error' do
-        expect(page).to have_text(component.error_title)
-        expect(page).to have_selector("button.fr-btn[disabled]")
-      end
-    end
-
     context 'when referentiel is properly configured' do
       let(:referentiel) { create(:api_referentiel, :with_last_response, :configured, :exact_match) }
 


### PR DESCRIPTION
progress: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11161
juste une PR de refactoring pour alléger la pr d'autocomplete
on wrap l'erreur dans la vue d'une page, que se soit pr la configuration d'un referentiel avance en exact match ou autocomplete (qui n'ont pas les memes etapes)