### PR TITLE
tech: refactor(Referentiel.response): extract un composant qui rend la reponse d'une API pour un champ referentiel API

### DIFF
--- a/app/components/referentiels/mapping_form_component.rb
+++ b/app/components/referentiels/mapping_form_component.rb
@@ -2,12 +2,6 @@
 
 class Referentiels::MappingFormComponent < Referentiels::MappingFormBase
   TYPES = [:string, :decimal_number, :integer_number, :boolean, :date, :datetime, :array].index_by(&:itself).freeze
-  attr_reader :referentiel_service
-  delegate :test_url, :test_headers, to: :referentiel_service
-  def initialize(**args)
-    super
-    @referentiel_service = ReferentielService.new(referentiel: referentiel)
-  end
 
   def last_request_keys
     JSONPathUtil.hash_to_jsonpath(referentiel.last_response_body)

--- a/app/components/referentiels/mapping_form_component/mapping_form_component.html.haml
+++ b/app/components/referentiels/mapping_form_component/mapping_form_component.html.haml
@@ -1,15 +1,6 @@
 = form_with(model: @type_de_champ, url: update_mapping_type_de_champ_admin_procedure_referentiel_path(@procedure, @type_de_champ.stable_id, @referentiel)) do |f|
   %div{ class: bordered_container_class_names }
-    %section.fr-accordion.fr-mb-3w
-      %h3.fr-accordion__title
-        %button.fr-accordion__btn{ type: :button, "aria-controls" => "last_response", "aria-expanded" => "false" } Afficher la réponse récupérée à partir de la requête configurée
-
-    .fr-collapse#last_response
-      %pre Endpoint: #{test_url}
-      - if test_headers.present?
-        %pre Headers: #{test_headers}
-      %pre Status: #{JSON.pretty_generate(@referentiel.last_response_status)}
-      %pre Body: #{JSON.pretty_generate(@referentiel.last_response_body)}
+    = render Referentiels::ResponseRendererComponent.new(referentiel:)
 
     %section
       .fr-table.fr-table--bordered

--- a/app/components/referentiels/response_renderer_component.html.haml
+++ b/app/components/referentiels/response_renderer_component.html.haml
@@ -1,0 +1,10 @@
+%section.fr-accordion.fr-mb-3w
+  %h3.fr-accordion__title
+    %button.fr-accordion__btn{ type: :button, "aria-controls" => "last_response", "aria-expanded" => "false" } Afficher la réponse récupérée à partir de la requête configurée
+
+.fr-collapse#last_response
+  %pre Endpoint: #{test_url}
+  - if test_headers.present?
+    %pre Headers: #{test_headers}
+  %pre Status: #{JSON.pretty_generate(referentiel.last_response_status)}
+  %pre Body: #{JSON.pretty_generate(referentiel.last_response_body)}

--- a/app/components/referentiels/response_renderer_component.rb
+++ b/app/components/referentiels/response_renderer_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Referentiels::ResponseRendererComponent < ViewComponent::Base
+  attr_reader :referentiel, :referentiel_service
+  delegate :test_url, :test_headers, to: :referentiel_service
+
+  def initialize(referentiel:)
+    @referentiel = referentiel
+    @referentiel_service = ReferentielService.new(referentiel: referentiel)
+  end
+end


### PR DESCRIPTION
progress: https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/11161
juste une PR de refactoring pour alléger la pr d'autocomplete
ce composant sera ré-utiliser sur la vue de configuration de l'autocomplete (quels champs afficher ds la combox ?)