### PR TITLE
ETQ usager, il se peut que je n'ai pas validé mon mail pour recevoir les notifs DS. on previent, ils peuvent demander un nouvel email de verification, et ils peuvent valider

### DIFF
--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -95,5 +95,11 @@
         - elsif is_user_context
           = render 'users/main_navigation'
 
+    - if user_signed_in? && !current_user.email_verified_at?
+      = render Dsfr::NoticeComponent.new(closable: true) do |c|
+        - c.with_title do
+          = t('views.shared.account.email_unverified', application_name: APPLICATION_NAME)
+          = link_to users_resend_confirmation_email_path, method: :post, class: 'fr-notice__link', form: { class: 'inline'} do
+            = t('views.shared.account.cta_email_unverified')
 
     = yield(:notice_info)

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -21,6 +21,8 @@ en:
         already_user: "I already have an account"
         create: 'Create an account'
         signin: 'Sign in'
+        email_unverified: "Your email address is not verified, so you will not receive email notifications from %{application_name}. Please check your inbox and click the verification link. Didn't receive the email?"
+        cta_email_unverified: "Resend verification email"
       messages:
         remove_file: 'Remove file'
       piece_justificative:

--- a/config/locales/views/shared/fr.yml
+++ b/config/locales/views/shared/fr.yml
@@ -21,6 +21,8 @@ fr:
         already_user: 'J’ai déjà un compte'
         create: 'Créer un compte'
         signin: 'Se connecter'
+        email_unverified: "Votre adresse e-mail n'est pas vérifiée, vous ne recevrez donc pas les notifications mail de %{application_name}. Veuillez vérifier votre boîte de réception et cliquer sur le lien de vérification. Vous n'avez pas reçu l'email ?"
+        cta_email_unverified: "Renvoyer l’email de vérification"
       messages:
         remove_file: 'Supprimer le fichier'
         remove_all: "Supprimer tous les fichiers"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -296,6 +296,7 @@ Rails.application.routes.draw do
     get 'activate' => '/users/activate#new'
     patch 'activate' => '/users/activate#create'
     get 'confirm_email/:token' => '/users/activate#confirm_email', as: :confirm_email
+    post 'resend_verification_email', to: '/users/activate#resend_verification_email', as: :resend_confirmation_email
   end
 
   # order matters: we don't want those routes to match /admin/procedures/:id

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -35,6 +35,13 @@ module SystemHelpers
     end
   end
 
+  def click_verification_link_for(email)
+    verification_email = open_email(user.email)
+    verification_link = verification_email.text.match(%r{\s+(\S+\/users\/confirm_email/\S+)\s+})[1]
+
+    visit URI.parse(verification_link).request_uri
+  end
+
   def click_confirmation_link_for(email, in_another_browser: false)
     confirmation_email = open_email(email)
     confirmation_link = confirmation_email.text.match(%r{\s+(\S+\/users\/confirmation\S+)\s+})[1]
@@ -106,9 +113,12 @@ module SystemHelpers
   end
 
   def log_out
+    within(".fr-notice__body") { click_on("Masquer le message") } if page.has_selector?('.fr-notice__body')
     within('.fr-header .fr-container .fr-header__tools .fr-btns-group') do
+      scroll_to(find('button[title="Mon profil"]'), align: :center)
       click_button(title: 'Mon profil')
       expect(page).to have_selector('#account.fr-collapse--expanded', visible: true)
+      scroll_to(find('button[title="Mon profil"]'), align: :center)
       click_on 'Se déconnecter'
     end
     expect(page).to have_current_path(root_path, wait: 30)

--- a/spec/system/sessions/verify_user_email.rb
+++ b/spec/system/sessions/verify_user_email.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe 'Not verified users are warned and able to act on:', js: true do
+  let(:user) { create(:user, email_verified_at: nil) }
+  before { login_as user, scope: :user }
+
+  scenario 'user has not his verified email' do
+    visit root_path
+    expect(page).to have_content("Votre adresse e-mail n'est pas vérifiée")
+
+    perform_enqueued_jobs do
+      click_on 'Renvoyer l’email de vérification'
+    end
+
+    click_verification_link_for(user.email)
+
+    expect(page).not_to have_content("Votre adresse e-mail n'est pas vérifiée")
+    user.reload
+    expect(user.email_verified_at).to be_present
+  end
+end


### PR DESCRIPTION
# Problème

verbatim
> Bonjour
> J'ai plusieurs remontés d'instructeurs en préfectures qui ne reçoivent pas les notifications des dossiers DS alors que leurs paramétrages de notification sont bien faits.
> Est-ce que vous avez déjà eu aussi ce type de remontés ? Quelles sont les paramètres de messagerie ou autre configuration que nos instructeurs devraient vérifier pour bien recevoir les notifications. Est-ce que vous avez une idée d'un test que je pourrais faire avec eux pour isoler une raison possible ?
> En vous remerciant,

En prime, ETQ tech, c'est pénible de gérer ce type de cas au support 

# data

donc j'ai fouinné ds la data

```ruby
# nombre total d'utilisateurs sans email vérifié
User.where(email_verified_at: nil).pluck(:email_verified_at).size
=> 436367
# nombre total d'utilisateur sans email s'etant connecté le mois dernier
User.where(email_verified_at: nil).where(current_sign_in_at: 1.months.ago..).pluck(:email_verified_at).size
=> 1515
# nombre total d'instructeur impacté
User.where(email_verified_at: nil).where(current_sign_in_at: 1.months.ago..).joins(:instructeur).pluck(:email_verified_at).size
=> 1450
```

Si mes souvenirs sont bon, on a +20k instructeurs actif/mois. donc 7.5% des instructeurs impactés

# Solution, sortie du chapeau 🎩 🐰 🚀 

ETQ usager, quand j'arrive sur DS sans mon mail vérifié, j'ai un bandeau **relou** qui m'informe des consequences, et me permet de redander un lien de verification
> <img width="1260" height="538" alt="Capture d’écran 2025-07-22 à 5 14 10 PM" src="https://github.com/user-attachments/assets/d834c117-35a1-4d92-b203-af2bb7a5af3b" />

ETQ usager, j'ai du feedback ap avoir clické sur le lien 
> <img width="1119" height="574" alt="Capture d’écran 2025-07-22 à 4 56 44 PM" src="https://github.com/user-attachments/assets/b6b522c5-5557-4bae-964b-da75c62f671f" />

ETQ usager, j'ai le mail classique
>  <img width="613" height="637" alt="Capture d’écran 2025-07-22 à 5 16 45 PM" src="https://github.com/user-attachments/assets/7a8215c1-14a5-4eef-b0b8-060b2ea51456" />

ETQ usager, je click sur le lien de vérification et 🎉 le message **relou** disparait, et on est tranquil au support, et on peut coder oklm
<img width="1710" height="485" alt="Capture d’écran 2025-07-22 à 4 56 54 PM" src="https://github.com/user-attachments/assets/cce90f7b-b420-4b1e-bc22-c3439c179fe0" />

# TODO

relancer par mail l'administratice inquiete, subject: 
> Comprendre pourquoi certains instructeurs ne reçoivent pas les notifications par mail
