### PR TITLE
ETQ Usager naviguant à la voix, je veux que le titre du lien de suppression des filtres reprennent l'intitulé visible du lien

### DIFF
--- a/app/components/dossiers/user_filter_component/user_filter_component.en.yml
+++ b/app/components/dossiers/user_filter_component/user_filter_component.en.yml
@@ -5,7 +5,7 @@ en:
     depose_at: Submitted since
   button:
     apply_filters: Apply filters
-    cancel_filters: Cancel
+    cancel_filters_html: 'Reset <span class="visually-hidden">filters</span>'
     select_filters: Select a filter
   tag:
     active_filters:

--- a/app/components/dossiers/user_filter_component/user_filter_component.fr.yml
+++ b/app/components/dossiers/user_filter_component/user_filter_component.fr.yml
@@ -5,7 +5,7 @@ fr:
     depose_at: Déposé depuis le
   button:
     apply_filters: Appliquer les filtres
-    cancel_filters: Annuler
+    cancel_filters_html: 'Réinitialiser <span class="visually-hidden">les filtres</span>'
     select_filters: Sélectionner un filtre
   tag:
     active_filters:

--- a/app/components/dossiers/user_filter_component/user_filter_component.html.haml
+++ b/app/components/dossiers/user_filter_component/user_filter_component.html.haml
@@ -25,7 +25,7 @@
 
               .fr-my-2w
                 = f.submit t('.button.apply_filters'), class: 'fr-btn fr-btn--sm'
-                = link_to t('.button.cancel_filters'), dossiers_path(statut: @statut), class: 'fr-btn fr-btn--sm fr-btn--tertiary-no-outline'
+                = link_to t('.button.cancel_filters_html'), dossiers_path(statut: @statut), class: 'fr-btn fr-btn--sm fr-btn--tertiary-no-outline'
 
   - if @filter.filter_params.present?
     .fr-col-12.text-right

--- a/spec/system/users/list_dossiers_spec.rb
+++ b/spec/system/users/list_dossiers_spec.rb
@@ -112,7 +112,7 @@ describe 'user access to the list of their dossiers', js: true do
       expect(page).to have_select 'Statut', selected: 'Refusé', options: ['Sélectionner un statut', 'Accepté', 'Refusé', 'Classé sans suite']
 
       click_on('Sélectionner un filtre')
-      click_on('Annuler')
+      click_on('Réinitialiser')
 
       click_on('Sélectionner un filtre')
       expect(page).to have_select 'Statut', selected: 'Sélectionner un statut', options: ['Sélectionner un statut', 'Accepté', 'Refusé', 'Classé sans suite']
@@ -123,7 +123,7 @@ describe 'user access to the list of their dossiers', js: true do
       expect(page).to have_select 'Statut', selected: 'Accepté', options: ['Sélectionner un statut', 'Accepté', 'Refusé', 'Classé sans suite']
 
       click_on('Sélectionner un filtre')
-      click_on('Annuler')
+      click_on('Réinitialiser')
       expect(page).to have_text('3 dossiers')
       expect(page).to have_select 'Statut', selected: 'Sélectionner un statut', options: ['Sélectionner un statut', 'Accepté', 'Refusé', 'Classé sans suite']
     end


### PR DESCRIPTION
# Reprise de l'intitulé du lien dans l'attribut `title`
## Après
<img width="299" height="130" alt="" src="https://github.com/user-attachments/assets/9d5f5b54-59b5-4633-977f-a6448330129f" />
<img width="313" height="113" alt="" src="https://github.com/user-attachments/assets/b3b2221f-d6c9-4ea7-be3e-36b43ac5bdc8" />

## Avant
<img width="266" height="104" alt="" src="https://github.com/user-attachments/assets/c111169a-aaa7-46df-8cf3-c0d95aa996e9" />
<img width="290" height="100" alt="" src="https://github.com/user-attachments/assets/40706799-f5e6-4e2e-a92f-1d359ca9c45f" />

# Amélioration de l'intitulé du lien de rénitialisation des filtres
## Après
<img width="1176" height="745" alt="" src="https://github.com/user-attachments/assets/0e837a15-e705-4251-a9c4-f222bf2bfe5c" />

## Avant
<img width="1153" height="690" alt="" src="https://github.com/user-attachments/assets/3e18cb74-7844-4460-9979-49e00ee4c55f" />
