### PR TITLE
ETQ Instructeur - fix: export zip personnalité d'une procédure routée

### DIFF
--- a/app/views/instructeurs/export_templates/_form_zip.html.haml
+++ b/app/views/instructeurs/export_templates/_form_zip.html.haml
@@ -21,7 +21,7 @@
             = f.check_box :shared
             = f.label :shared, "Partager avec tous les autres groupes instructeurs", class: 'fr-label'
         - else
-          = f.hidden_field :groupe_instructeur_id, value: procedure.defaut_groupe_instructeur.id
+          = f.hidden_field :groupe_instructeur_id
 
         .fr-input-group{ data: { controller: 'tiptap', 'tiptap-attributes-value': { spellcheck: false }.to_json } }
           = f.label '[dossier_folder][template]', class: "fr-label" do


### PR DESCRIPTION
HS: https://secure.helpscout.net/conversation/3025008596/2220649?viewId=8314348

Suite de ce correctif : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11910

On a un faux blocage lorsque le current_instructeur est dans un seul groupe de routage sans que ce soit le groupe par défaut de la procédure : en envoyant en params l'id du groupe par défaut, la méthode ExportTemplatesController#ensure_legitimate_groupe_instructeur en faisait une exclusion dans le cas donc où l'instructeur est dans un groupe de routage qui ne correspond pas au groupe par défaut.