### PR TITLE
ETQ Usager d'un lecteur d'écran, je veux être informé de l'erreur de saisie d'un mail lorsque j'invite une personne à modifier un dossier

### DIFF
--- a/app/views/invites/_button.html.haml
+++ b/app/views/invites/_button.html.haml
@@ -17,4 +17,4 @@
         = t('views.invites.dropdown.invite_to_edit')
 
   = turbo_frame_tag "dossier-invites-modal", data: { "lazy-modal-target": "frame" } do
-    %dialog.fr-modal#dossier-invites-modal-dialog
+    %dialog.fr-modal#dossier-invites-modal-dialog{ role: "dialog" }

--- a/app/views/invites/_form.html.haml
+++ b/app/views/invites/_form.html.haml
@@ -15,7 +15,7 @@
 
   %fieldset.fr-fieldset
     %legend.fr-fieldset__legend
-      %h3.fr-h6= t('views.invites.form.title')
+      %h2.fr-h6= t('views.invites.form.title')
 
     %p.fr-highlight.fr-text--sm= t('asterisk_html', scope: [:utils])
 

--- a/app/views/invites/_form.html.haml
+++ b/app/views/invites/_form.html.haml
@@ -20,7 +20,7 @@
     %p.fr-highlight.fr-text--sm= t('asterisk_html', scope: [:utils])
 
     - if invite.errors.any?
-      %p.fr-alert.fr-alert--error.fr-alert--sm.fr-mb-3w
+      %p.fr-alert.fr-alert--error.fr-alert--sm.fr-mb-3w{ role: 'alert', tabindex: '-1', data: { controller: 'autofocus' } }
         - invite.errors.full_messages.each do |msg|
           = msg
 

--- a/app/views/invites/_form.html.haml
+++ b/app/views/invites/_form.html.haml
@@ -20,10 +20,9 @@
     %p.fr-highlight.fr-text--sm= t('asterisk_html', scope: [:utils])
 
     - if invite.errors.any?
-      .fr-alert.fr-alert--error.fr-alert--sm.fr-mb-3w{ role: 'alert' }
-        %ul
-          - invite.errors.full_messages.each do |msg|
-            %li= msg
+      %p.fr-alert.fr-alert--error.fr-alert--sm.fr-mb-3w
+        - invite.errors.full_messages.each do |msg|
+          = msg
 
     .fr-fieldset__element
       .fr-input-group

--- a/app/views/invites/_modal.html.haml
+++ b/app/views/invites/_modal.html.haml
@@ -1,4 +1,5 @@
 %dialog.fr-modal#modal-invite{
+  role: "dialog",
   aria: { labelledby: "modal-invite-title" }
 }
   .fr-container--fluid.fr-container-md

--- a/app/views/invites/index.html.haml
+++ b/app/views/invites/index.html.haml
@@ -1,5 +1,6 @@
 = turbo_frame_tag("dossier-invites-modal") do
   %dialog.fr-modal#dossier-invites-modal-dialog{
+    role: "dialog",
     aria: { labelledby: "dossier-invites-modal-title" }
   }
     .fr-container--fluid.fr-container-md

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -359,8 +359,8 @@ en:
         want_to_withdraw_permission: "Would you like to withdraw the permission of %{email}?"
         edit_dossier_html:
           zero: '<p class="fr-my-2w"><em>No user can view and edit this file at this time.</em></p>'
-          one: '<h3 class="fr-h6 fr-mt-2w fr-mb-1w">1 user invited</h3>'
-          other: '<h3 class="fr-h6 fr-mt-2w fr-mb-1w">%{count} users invited</h3>'
+          one: '<h2 class="fr-h6 fr-mt-2w fr-mb-1w">1 user invited</h2>'
+          other: '<h2 class="fr-h6 fr-mt-2w fr-mb-1w">%{count} users invited</h2>'
         submit_dossier_yourself: "Once your file is complete, you'll need to submit it yourself."
     pagination:
       next: Next

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -360,8 +360,8 @@ fr:
         want_to_withdraw_permission: "Souhaitez-vous supprimer l’accès invité de %{email} ?"
         edit_dossier_html:
           zero: '<p class="fr-my-2w"><em>Aucun invité ne peut voir et modifier ce dossier actuellement.</em></p>'
-          one: '<h3 class="fr-h6 fr-mt-2w fr-mb-1w">1 personne invitée</h3>'
-          other: '<h3 class="fr-h6 fr-mt-2w fr-mb-1w">%{count} personnes invitées</h3>'
+          one: '<h2 class="fr-h6 fr-mt-2w fr-mb-1w">1 personne invitée</h2>'
+          other: '<h2 class="fr-h6 fr-mt-2w fr-mb-1w">%{count} personnes invitées</h2>'
         submit_dossier_yourself: "Une fois le dossier complet, vous devrez le déposer vous-même."
     pagination:
       next: Suivant

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -339,9 +339,9 @@ fr:
         resent: 'Renvoyer un email de confirmation'
     invites:
       create:
-        success: "Une invitation a été envoyée à %{email}. Vous pouvez <a href=\"#\" class=\"fr-link fr-text--sm\" aria-controls=\"dossier-invites-modal-dialog\" data-fr-opened=\"false\" data-fr-js-modal-button=\"true\">inviter une autre personne</a>."
+        success: "Une invitation a été envoyée à %{email}. Vous pouvez <button type=\"button\" class=\"fr-link fr-text--sm\" aria-controls=\"dossier-invites-modal-dialog\" data-fr-opened=\"false\">inviter une autre personne</button>."
       destroy:
-        success: "L’autorisation de %{email} vient d’être révoquée. Vous pouvez <a href=\"#\" class=\"fr-link fr-text--sm\" aria-controls=\"dossier-invites-modal-dialog\" data-fr-opened=\"false\" data-fr-js-modal-button=\"true\">inviter une autre personne</a>."
+        success: "L’autorisation de %{email} vient d’être révoquée. Vous pouvez <button type=\"button\" class=\"fr-link fr-text--sm\" aria-controls=\"dossier-invites-modal-dialog\" data-fr-opened=\"false\">inviter une autre personne</button>."
         error: "Vous ne pouvez pas révoquer cette autorisation"
       dropdown:
         invite_to_edit: Inviter une personne à modifier ce dossier

--- a/spec/lib/i18n/invites_locales_spec.rb
+++ b/spec/lib/i18n/invites_locales_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+describe 'invites locales accessibility' do
+  describe 'success messages' do
+    let(:email) { 'test@example.fr' }
+
+    describe 'create success message' do
+      let(:message_fr) { I18n.t('views.invites.create.success', email: email, locale: :fr) }
+      let(:message_en) { I18n.t('views.invites.create.success', email: email, locale: :en) }
+
+      it 'uses a button element (not a link) in French locale for reopening modal' do
+        expect(message_fr).to include('<button')
+        expect(message_fr).not_to include('<a ')
+        expect(message_fr).not_to include('href="#"')
+      end
+
+      it 'uses a button element (not a link) in English locale for reopening modal' do
+        expect(message_en).to include('<button')
+        expect(message_en).not_to include('<a ')
+        expect(message_en).not_to include('href="#"')
+      end
+    end
+
+    describe 'destroy success message' do
+      let(:message_fr) { I18n.t('views.invites.destroy.success', email: email, locale: :fr) }
+      let(:message_en) { I18n.t('views.invites.destroy.success', email: email, locale: :en) }
+
+      it 'uses a button element (not a link) in French locale for reopening modal' do
+        expect(message_fr).to include('<button')
+        expect(message_fr).not_to include('<a ')
+        expect(message_fr).not_to include('href="#"')
+      end
+
+      it 'uses a button element (not a link) in English locale for reopening modal' do
+        expect(message_en).to include('<button')
+        expect(message_en).not_to include('<a ')
+        expect(message_en).not_to include('href="#"')
+      end
+    end
+  end
+end

--- a/spec/views/invites/_button.html.haml_spec.rb
+++ b/spec/views/invites/_button.html.haml_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+describe 'invites/_button', type: :view do
+  let(:dossier) { create(:dossier, :en_construction) }
+
+  subject! { render partial: 'invites/button', locals: { dossier: dossier } }
+
+  describe 'accessibility' do
+    it 'has role="dialog" attribute on the placeholder modal for screen readers' do
+      expect(rendered).to have_selector('dialog#dossier-invites-modal-dialog[role="dialog"]')
+    end
+  end
+end

--- a/spec/views/invites/_modal.html.haml_spec.rb
+++ b/spec/views/invites/_modal.html.haml_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe 'invites/_modal', type: :view do
+  let(:dossier) { create(:dossier, :en_construction) }
+  let(:invite) { dossier.invites.build }
+  let(:invites) { [] }
+
+  before do
+    # Stub the form_wrapper partial since it doesn't exist
+    stub_template 'invites/_form_wrapper.html.haml' => '<div>form content</div>'
+  end
+
+  subject! { render partial: 'invites/modal', locals: { dossier: dossier, invite: invite, invites: invites } }
+
+  describe 'accessibility' do
+    it 'has role="dialog" attribute on the modal for screen readers' do
+      expect(rendered).to have_selector('dialog#modal-invite[role="dialog"]')
+    end
+
+    it 'has aria-labelledby attribute pointing to the modal title' do
+      expect(rendered).to have_selector('dialog#modal-invite[aria-labelledby="modal-invite-title"]')
+    end
+  end
+end

--- a/spec/views/invites/index.html.haml_spec.rb
+++ b/spec/views/invites/index.html.haml_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe 'invites/index', type: :view do
+  let(:dossier) { create(:dossier, :en_construction) }
+
+  before do
+    assign(:dossier, dossier)
+  end
+
+  subject! { render }
+
+  describe 'accessibility' do
+    it 'has role="dialog" attribute on the modal for screen readers' do
+      expect(rendered).to have_selector('dialog#dossier-invites-modal-dialog[role="dialog"]')
+    end
+
+    it 'has aria-labelledby attribute pointing to the modal title' do
+      expect(rendered).to have_selector('dialog#dossier-invites-modal-dialog[aria-labelledby="dossier-invites-modal-title"]')
+    end
+  end
+end


### PR DESCRIPTION
# Correction de la hiérarchie de titres dans la modale
## Après
<img width="1182" height="468" alt="" src="https://github.com/user-attachments/assets/4c2d151d-20f9-43dd-ba3e-c31075063877" />

## Avant
<img width="1186" height="401" alt="" src="https://github.com/user-attachments/assets/594bc7fb-e480-4a8b-befb-22eeb0b5e5c4" />

# Suppression de la liste lorsque l'adresse mail saisie est erronée
## Après
<img width="929" height="619" alt="" src="https://github.com/user-attachments/assets/ed8195d0-a578-4dc8-938a-e00917ccb72a" />

## Avant
<img width="1098" height="660" alt="" src="https://github.com/user-attachments/assets/57e282c8-cfcf-4e57-9dd1-6e87539d21bd" />
