### PR TITLE
Correctif : ETQ Usager/Admin, le formulaire pdf ne doit pas afficher de case à cocher sans valeur définie au saut de page

### DIFF
--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -44,19 +44,14 @@ def format_with_checkbox(pdf, option, offset = 0)
   label = option.is_a?(String) ? option : option.first
   value = option.is_a?(String) ? option : option.last
 
-  # Skip empty options to avoid orphaned checkboxes
-  return if label.blank?
-
   if value == Champs::DropDownListChamp::OTHER
     label += " : "
   end
 
   pdf.font 'marianne', size: 9 do
-    # Simple page break check: ensure at least 40 points for checkbox + text + header spacing
+    # Ensure enough space for checkbox + text to avoid orphaned checkboxes at page breaks
     if pdf.cursor < (pdf.bounds.bottom + 40)
       pdf.start_new_page
-      # Move cursor down to avoid header overlap on new pages
-      pdf.move_down(25)
     end
 
     pdf.stroke_rectangle [0 + offset, pdf.cursor], 10, 10


### PR DESCRIPTION
Lorsque le formulaire contient un ou plusieurs champs choix simple/multiples, ceux-ci sont masqués dans la génération du formulaire pdf au moment du saut de page. Il en résulte une case à cochée isolée et donc un item manquant.

Exemple : 
Ici un champ choix simple faisant remonter les communes du 94 dans l'ordre alphabétique, 
La commune de Fresnes n'est pas affichée, seule une case à cocher apparaît.
<img width="925" height="857" alt="Image" src="https://github.com/user-attachments/assets/8eec3b8e-fd8d-4973-94fe-2f57eacb9f57" />

Aperçu après correction : 
<img width="1019" height="848" alt="image" src="https://github.com/user-attachments/assets/c7ad8dce-a544-4384-8fca-87734e36e8d5" />
