### PR TITLE
Correctif : applique le bon style au composant dsfr Bandeau d'information importante

### DIFF
--- a/app/components/dsfr/notice_component.rb
+++ b/app/components/dsfr/notice_component.rb
@@ -15,7 +15,8 @@ class Dsfr::NoticeComponent < ApplicationComponent
   end
 
   def options
-    data_attributes.merge(class: "fr-notice fr-notice--#{@state}").merge(notice_data_attributes)
+    attrs = notice_data_attributes
+    attrs.merge(class: class_names(attrs[:class], "fr-notice", "fr-notice--#{@state}"))
   end
 
   def closable?


### PR DESCRIPTION
Il y a eu une petite régression qui faisait qu'on écrasait les classes `fr-notice` `fr-notice-[state]`

### Avant

<img width="1956" height="524" alt="Capture d’écran 2025-08-28 à 17 51 23" src="https://github.com/user-attachments/assets/034e936c-2fea-47e5-951a-814104a1cab9" />


### Après

<img width="1956" height="524" alt="Capture d’écran 2025-08-28 à 17 50 43" src="https://github.com/user-attachments/assets/54dd07f7-7b88-4118-8b25-04c286bc937c" />
