### PR TITLE
ETQ Instructeur - fix : je veux être informé de la suppression du compte usager sur le tableau de suivi

### DIFF
--- a/app/components/instructeurs/cell_component.rb
+++ b/app/components/instructeurs/cell_component.rb
@@ -75,7 +75,7 @@ class Instructeurs::CellComponent < ApplicationComponent
   end
 
   def email_and_tiers(dossier)
-    email = dossier&.user&.email
+    email = dossier&.user&.email || dossier.user_email_for(:display)
 
     if dossier.for_tiers
       prenom, nom = dossier&.individual&.prenom, dossier&.individual&.nom

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -114,8 +114,7 @@
                             - if dossier.hidden_by_administration_at.present?
                               %span
                                 = render Instructeurs::CellComponent.new(dossier:, column:)
-                                - if dossier.hidden_by_user_at.present?
-                                  = "- #{t("views.instructeurs.dossiers.deleted_reason.#{dossier.hidden_by_reason}")}"
+                                = "- #{t("views.instructeurs.dossiers.deleted_reason.#{dossier.hidden_by_reason}")}" if dossier.hidden_by_user_at.present?
                             - else
                               %a{ href: path }
                                 = render Instructeurs::CellComponent.new(dossier:, column:)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -422,6 +422,10 @@ en:
           rendez_vous: Appointment
         archived_dossier: "This file will be kept for an additional month"
         delete_dossier: "Move file to trash"
+        deleted_reason:
+          user_request: File deleted by the user
+          expired: The file is expired
+          user_removed: The user has deleted his/her account
         acts_on_behalf: "acts for"
         deleted_by_administration: "File deleted by administration"
         restore: "Restore"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -428,8 +428,9 @@ fr:
         archived_dossier: "Le dossier sera conservé 1 mois supplémentaire"
         delete_dossier: "Mettre à la corbeille"
         deleted_reason:
-          user_request: supprimé par l’usager
-          expired: a expiré
+          user_request: Dossier supprimé par l’usager
+          expired: Le dossier a expiré
+          user_removed: L’usager a supprimé son compte
         acts_on_behalf: "agit pour"
         deleted_by_administration: "Dossier supprimé par l’administration"
         restore: "Restaurer"


### PR DESCRIPTION
Correction d'un bug sur une traduction manquante, en reprenant le principe actuelle de la vue détaillée du dossier.
Avant:
<img width="1836" height="55" alt="Capture d’écran 2025-09-02 à 14 28 56" src="https://github.com/user-attachments/assets/a2745b89-92e4-43f6-9512-ca92d5c1216c" />

Après:
<img width="1836" height="55" alt="Capture d’écran 2025-09-02 à 14 28 22" src="https://github.com/user-attachments/assets/c65ed74d-26db-4847-971c-f6bedf90edca" />
