### PR TITLE
Perf: optimise le procedure_revision_preloader

### DIFF
--- a/app/models/procedure_revision_preloader.rb
+++ b/app/models/procedure_revision_preloader.rb
@@ -7,7 +7,7 @@ class ProcedureRevisionPreloader
 
   def all
     revisions = @revisions.to_a
-    load_revisions(revisions)
+    load_procedure_revision_types_de_champ(revisions)
   end
 
   def self.load_one(revision)
@@ -16,15 +16,12 @@ class ProcedureRevisionPreloader
 
   private
 
-  def load_revisions(revisions)
-    load_procedure_revision_types_de_champ(revisions)
-  end
-
   def load_procedure_revision_types_de_champ(revisions)
     revisions_by_id = revisions.index_by(&:id)
+
     coordinates_by_revision_id = ProcedureRevisionTypeDeChamp
       .where(revision_id: revisions.map(&:id))
-      .includes(type_de_champ: { notice_explicative_attachment: :blob, piece_justificative_template_attachment: :blob })
+      .preload(type_de_champ: { notice_explicative_attachment: :blob, piece_justificative_template_attachment: :blob })
       .order(:position, :id)
       .to_a
       .group_by(&:revision_id)

--- a/lib/tasks/benchmarks.rake
+++ b/lib/tasks/benchmarks.rake
@@ -135,6 +135,48 @@ namespace :benchmarks do
     end
   end
 
+  desc 'Benchmark ProcedureRevisionPreloader.load_one'
+  task procedure_revision_preloader: :environment do
+    revision_ids = ProcedureRevision.order('RANDOM()').limit(100).pluck(:id)
+    all_revisions = ProcedureRevision.where(id: revision_ids).includes(:procedure)
+
+    Benchmark.bm do |x|
+      x.report("load_one (#{all_revisions.count} revisions) without includes") do
+        all_revisions.each do |revision|
+          ProcedureRevisionPreloader.load_one(revision)
+        end
+      end
+
+      x.report("load_one (#{all_revisions.count} revisions) with includes (old way)") do
+        all_revisions.each do |revision|
+          revisions = [revision]
+
+          revisions_by_id = revisions.index_by(&:id)
+
+          coordinates_by_revision_id = ProcedureRevisionTypeDeChamp
+            .where(revision_id: revisions.map(&:id))
+            .includes(type_de_champ: { notice_explicative_attachment: :blob, piece_justificative_template_attachment: :blob })
+            .order(:position, :id)
+            .to_a
+            .group_by(&:revision_id)
+
+          coordinates_by_revision_id.each_pair do |revision_id, coordinates|
+            revision = revisions_by_id[revision_id]
+
+            coordinates.each do |coordinate|
+              coordinate.association(:revision).target = revision
+              coordinate.association(:procedure).target = revision.procedure
+            end
+          end
+
+          revisions_by_id.each_pair do |revision_id, revision|
+            revision.association(:revision_types_de_champ).target = coordinates_by_revision_id[revision_id] || []
+          end
+        end
+      end
+    end
+  end
+
   desc "Inspect possible memory leaks"
   task inspect_memory_leak: :environment do
     10.times do


### PR DESCRIPTION
avant :
- ProcedureRevisionPreloader chargeait les `piece_justificative_template` et les `notice_explicatives` par un `include` ce qui aboutissait à une requête sql comprenant 2 inner joins sur la table ActiveRecord qui était flagué lente sur un explain en local (voir [ici](https://explain.dalibo.com/plan/h01a2h6h333e588c) )

après :
- on évite les inner join en procédant à une requete supplémentaire et un chargement manuelle des attachments

sur un benchmark de 100 procédure revision on obtient : 

```
                                                      user     system      total            real
load_one (100 revisions) without includes         1.698969   0.064930   1.763899 (  2.228575)
load_one (100 revisions) with includes (old way)  1.168968   0.033439   1.202407 ( 34.580515)
```

la différence au niveau du temps réellement passé `real` pourrait s'expliquer par de l'io (les inner joins)

Sur l ´éditeur de champ pour une procédure comprenant tous les champs on passe de `2.3s` à `1s`