### PR TITLE
ETQ Usager je ne veux plus avoir une erreur 406 si j'appuie sur Entrée quand je remplis mon dossier

### DIFF
--- a/app/javascript/controllers/prevent_submit_on_enter_controller.ts
+++ b/app/javascript/controllers/prevent_submit_on_enter_controller.ts
@@ -1,0 +1,9 @@
+import { ApplicationController } from './application_controller';
+
+export class PreventSubmitOnEnterController extends ApplicationController {
+  connect(): void {
+    this.on('submit', (event: Event) => {
+      event.preventDefault();
+    });
+  }
+}

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -6,7 +6,7 @@
 .dossier-edit.fr-container.counter-start-header-section
   = render partial: "shared/dossiers/submit_is_over", locals: { dossier: dossier }
   = render NestedForms::FormOwnerComponent.new
-  = form_for dossier_for_editing, url: brouillon_dossier_url(dossier_for_editing), method: :patch, html: { id: 'dossier-edit-form', class: 'form', multipart: true, novalidate: 'novalidate' } do |f|
+  = form_for dossier_for_editing, url: brouillon_dossier_url(dossier_for_editing), method: :patch, html: { id: 'dossier-edit-form', class: 'form', multipart: true, novalidate: 'novalidate', data: { controller: 'prevent-submit-on-enter' } } do |f|
 
     = render Dossiers::ErrorsFullMessagesComponent.new(dossier: dossier_for_editing)
     %header.mb-6


### PR DESCRIPTION
Pour reproduire le bug : créer une démarche avec un champ texte court, remplir un dossier en brouillon, appuyer sur la touche Entrée pendant l'édition du champ texte court.

<img width="1333" height="680" alt="image" src="https://github.com/user-attachments/assets/cd6dbcfe-cef5-4a03-9a19-b8eb0f7ead75" />

Remarqué avec @colinux :
Ce comportement (submit du form lors du Enter) n'est pas observé lorsqu'il y a plusieurs champs Texte Court dans la démarche, donc il arrive assez rarement en production. 
Spec : https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission

Le fix n'a pas d'incidence sur : la navigation au clavier, le submit du form au clavier depuis le bouton Déposer, la création d'éléement répétable au clavier, le choix d'option d'une liste déroulante au clavier.
