### PR TITLE
Tech: fix erreur sur page toutes les démarches, on ne doit plus passer les params explicitement à la pagination

### DIFF
--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -73,5 +73,5 @@
     .fr-table__footer
       .fr-table__footer--start
       .fr-table__footer--middle
-        = paginate @procedures, params: @filter.params, views_prefix: 'shared'
+        = paginate @procedures, views_prefix: 'shared'
       .fr-table__footer--end.flex-no-grow


### PR DESCRIPTION
Les params sont récupérés automatiquement.

(L'erreur vient plutôt du deprecation warning à ce sujet , warning qui n'est plus compatible avec rails 7.2 et qui provoque une 500, cf https://github.com/kaminari/kaminari/pull/1135 )