### PR TITLE
Tech: active le debug de reactionview en dev seulement à la demande par une variable d'env

### DIFF
--- a/config/initializers/reactionview.rb
+++ b/config/initializers/reactionview.rb
@@ -4,6 +4,6 @@ ReActionView.configure do |config|
   # Intercept .html.erb templates and process them with `Herb::Engine` for enhanced features
   # config.intercept_erb = true
 
-  # Enable debug mode in development (adds debug attributes to HTML)
-  config.debug_mode = Rails.env.development?
+  # Enable debug mode in development (adds debug elements and attributes to HTML, may break design).
+  config.debug_mode = Rails.env.development? && ENV["REACTIONVIEW_DEBUG"].present?
 end


### PR DESCRIPTION
Motivation: le debug modifie le DOM, ce qui peut changer le design perçu et peut laisser croire à un pb de notre markup alors que ça vient du debug.

https://mattermost.incubateur.net/betagouv/pl/8mw1echnxfniurkcryxfa391zo