### PR TITLE
ETQ Tech, je ne veux pas que l'install de playwright soit le goulet d'étranglement dans le workflow de tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
         uses: ./.github/actions/ci-setup-bun-node
 
       - name: Setup playwright
-        run: bun playwright install chromium
+        run: bun playwright install --only-shell chromium
 
       - name: Download or pre-compile assets
         uses: ./.github/actions/ci-setup-assets


### PR DESCRIPTION
Dans [cet exemple](https://github.com/demarches-simplifiees/demarches-simplifiees.fr/actions/runs/18194201627/job/51796120920) , un test système est beaucoup plus long que les autres (7m30). C'est du à l'installation de playwright (3m). 

- on installe que la version shell de chromium (-170Mo)