### PR TITLE
ETQ usager, je n'arrive pas a supprimer un filtre en provenance d'un choix simple avec un referentiel importé contenant des caractères spéciaux #12156 

### DIFF
--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -153,8 +153,10 @@ module Administrateurs
         )
 
         items_to_insert = csv_content.map do |row|
+          normalized_row = row.transform_values { ValueNormalizer.normalize(_1) }
+
           {
-            data: { row: row.transform_keys { Referentiel.header_to_path(_1) } },
+            data: { row: normalized_row.transform_keys { Referentiel.header_to_path(_1) } },
             referentiel_id: referentiel.id
           }
         end

--- a/app/controllers/instructeurs/procedure_presentation_controller.rb
+++ b/app/controllers/instructeurs/procedure_presentation_controller.rb
@@ -49,7 +49,10 @@ module Instructeurs
     private
 
     def filtered_column_from_params
-      FilteredColumnType.new.cast(filter_params.to_h)
+      params_hash = filter_params.to_h.deep_stringify_keys
+      params_hash['filter'] = ValueNormalizer.normalize(params_hash['filter']) if params_hash.key?('filter')
+
+      FilteredColumnType.new.cast(params_hash)
     end
 
     def procedure = @procedure_presentation.procedure

--- a/app/services/value_normalizer.rb
+++ b/app/services/value_normalizer.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class ValueNormalizer
+  # Regex to detect invisible ASCII control characters
+  # that can cause problems in string processing
+  # Matches the following characters:
+  # - \u0000-\u0008: control characters NUL, SOH, STX, ETX, EOT, ENQ, ACK, BEL
+  # - \u000B: VT character (Vertical Tab)
+  # - \u000C: FF character (Form Feed)
+  # - \u000E-\u001F: control characters SO, SI, DLE, DC1, DC2, DC3, DC4, NAK, SYN, ETB, CAN, EM, SUB, ESC, FS, GS, RS, US
+  # - \u007F: DEL character (Delete)
+  CONTROL_CHARS_REGEX = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/.freeze
+
+  class << self
+    def normalize(input)
+      case input
+      when Array
+        input.map { normalize(_1) }
+      when Hash
+        input.transform_values { normalize(_1) }
+      else
+        normalize_string(input)
+      end
+    end
+
+    private
+
+    def normalize_string(str)
+      return str if str.nil?
+
+      coerced = str.to_s
+      coerced = coerced.gsub(/\r\n?/, "\n")
+      coerced.gsub(CONTROL_CHARS_REGEX, "")
+    end
+  end
+end

--- a/app/tasks/maintenance/t20251003normalize_procedure_presentation_filters_task.rb
+++ b/app/tasks/maintenance/t20251003normalize_procedure_presentation_filters_task.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20251003normalizeProcedurePresentationFiltersTask < MaintenanceTasks::Task
+    # Documentation: normalise les valeurs des filtres ProcedurePresentation
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    FILTER_ATTRIBUTES = [
+      :a_suivre_filters,
+      :suivis_filters,
+      :traites_filters,
+      :tous_filters,
+      :supprimes_filters,
+      :supprimes_recemment_filters,
+      :expirant_filters,
+      :archives_filters
+    ].freeze
+
+    def collection
+      ProcedurePresentation.includes(assign_to: :procedure)
+    end
+
+    def process(pp)
+      FILTER_ATTRIBUTES.each do |attribute|
+        begin
+          current_filters = pp.public_send(attribute)
+        rescue ActiveRecord::RecordNotFound
+          next
+        end
+
+        next if current_filters.blank?
+
+        normalized_filters = current_filters.map do |filter|
+          normalized_filter = ValueNormalizer.normalize(filter.filter)
+
+          normalized_filter == filter.filter ? filter : FilteredColumn.new(column: filter.column, filter: normalized_filter)
+        end
+
+        pp.public_send("#{attribute}=", normalized_filters)
+      end
+
+      pp.save!
+    end
+  end
+end

--- a/spec/models/filtered_column_spec.rb
+++ b/spec/models/filtered_column_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 describe FilteredColumn do
+  let(:column) { Column.new(procedure_id: 1, table: 'table', column: 'column', label: 'label') }
+
   describe '#check_filters_max_length' do
-    let(:column) { Column.new(procedure_id: 1, table: 'table', column: 'column', label: 'label') }
     let(:filtered_column) { described_class.new(column:, filter:) }
 
     before { filtered_column.valid? }
@@ -50,7 +51,6 @@ describe FilteredColumn do
   end
 
   describe '#check_filter_is_not_blank' do
-    let(:column) { Column.new(procedure_id: 1, table: 'table', column: 'column', label: 'label') }
     let(:filtered_column) { described_class.new(column:, filter:) }
 
     before { filtered_column.valid? }

--- a/spec/services/value_normalizer_spec.rb
+++ b/spec/services/value_normalizer_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ValueNormalizer do
+  describe '.normalize' do
+    it 'returns nil when given nil' do
+      expect(described_class.normalize(nil)).to be_nil
+    end
+
+    it 'coerces objects to strings before normalizing' do
+      expect(described_class.normalize(12)).to eq('12')
+    end
+
+    it 'normalizes carriage returns into newlines' do
+      expect(described_class.normalize("foo\r\nbar\rbaz\nqux")).to eq("foo\nbar\nbaz\nqux")
+    end
+
+    it 'removes non printable control characters' do
+      value = "start\u0000mid\u0007end"
+      expect(described_class.normalize(value)).to eq('startmidend')
+    end
+
+    it 'keeps tabulations intact' do
+      expect(described_class.normalize("foo\tbar")).to eq("foo\tbar")
+    end
+
+    it 'maps over arrays recursively' do
+      input = ["foo\r\n", "bar\u0000", ["baz\r"]]
+      expect(described_class.normalize(input)).to eq(["foo\n", 'bar', ["baz\n"]])
+    end
+
+    it 'transforms hash values recursively' do
+      input = { operator: 'match', value: ["foo\r\nbar", nil] }
+      expect(described_class.normalize(input)).to eq({ operator: 'match', value: ["foo\nbar", nil] })
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20251003normalize_procedure_presentation_filters_task_spec.rb
+++ b/spec/tasks/maintenance/t20251003normalize_procedure_presentation_filters_task_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20251003normalizeProcedurePresentationFiltersTask do
+    describe ".collection" do
+      subject(:collection) { described_class.collection }
+
+      let(:procedure) { create(:procedure, :published) }
+      let(:instructeur) { create(:instructeur) }
+      let!(:assign_to) { create(:assign_to, procedure:, instructeur:) }
+      let!(:procedure_presentation) { create(:procedure_presentation, assign_to:) }
+
+      it "returns the procedure presentation" do
+        expect(collection).to include(procedure_presentation)
+      end
+    end
+
+    describe "#process" do
+      subject(:process) { described_class.process(procedure_presentation) }
+
+      let(:procedure) { create(:procedure, :published) }
+      let(:instructeur) { create(:instructeur) }
+      let(:assign_to) { create(:assign_to, procedure:, instructeur:) }
+      let!(:procedure_presentation) { create(:procedure_presentation, assign_to:) }
+      let(:column) { procedure.find_column(label: "Demandeur") }
+
+      context "when filters contain control characters" do
+        before do
+          stored_filter = FilteredColumn.new(
+            column: column,
+            filter: { operator: "match", value: ["Valeur avec retour\r\n"] }
+          )
+          procedure_presentation.update!(tous_filters: [stored_filter])
+        end
+
+        it "normalizes the stored filters" do
+          process
+
+          normalized_filter = procedure_presentation.reload.tous_filters.first
+
+          expect(normalized_filter.filter_value).to eq(["Valeur avec retour\n"])
+          expect(normalized_filter.filter_operator).to eq("match")
+        end
+
+        it "skips already normalized filters" do
+          process
+          expect {
+            described_class.process(procedure_presentation.reload)
+          }.not_to change { procedure_presentation.reload.tous_filters.map(&:filter_value) }
+        end
+      end
+
+      context "when filters are blank" do
+        before { procedure_presentation.update!(tous_filters: []) }
+
+        it "does not persist changes" do
+          expect { process }.not_to change { procedure_presentation.reload.updated_at }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
crisp : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_65c44684-1ace-477f-8993-f94ca2e32521/

# problème

c'était un peu tordu : 

1. ça part des champs référentiel avancé : un import de referentiel CSV contenu des caractères spéciaux : crlf
2. une fois ds le rendu html, le crlf devient un \n. 
3. donc dans le filtre, on fait suivre un \n
4. derriere dans la recherche \n != crlf (\r\n)

# solution

double normalisation :  
1. côté import
2. côté filtre