### PR TITLE
amélioration : ETQ instructeur, je ne souhaite pas soumettre un filtre vide qui me renvoie une 500

### DIFF
--- a/app/controllers/instructeurs/procedure_presentation_controller.rb
+++ b/app/controllers/instructeurs/procedure_presentation_controller.rb
@@ -7,6 +7,11 @@ module Instructeurs
     def add_filter
       statut = params[:statut]
 
+      if filter_params[:id].blank?
+        flash.alert = I18n.t('views.instructeurs.dossiers.filters.missing_column')
+        return redirect_back_or_to([:instructeur, procedure])
+      end
+
       new_filter = filtered_column_from_params
 
       if new_filter.valid?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -434,6 +434,7 @@ en:
         restore: "Restore"
         filters:
           title: Select a filter
+          missing_column: Please select a column before adding a filter
         select_all: Select all
         batch_operation:
           enabled: "Add file %{dossier_id} to the selection for the bulk operation"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -440,6 +440,7 @@ fr:
         restore_and_extend: "Restaurer et étendre la conservation"
         filters:
           title: Sélectionner un filtre
+          missing_column: Veuillez sélectionner une colonne avant d'ajouter un filtre
         select_all: Tout selectionner
         batch_operation:
           enabled: "Ajouter le dossier %{dossier_id} à la sélection pour un traitement de masse"

--- a/spec/controllers/instructeurs/procedure_presentation_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedure_presentation_controller_spec.rb
@@ -136,6 +136,19 @@ describe Instructeurs::ProcedurePresentationController, type: :controller do
         expect(procedure_presentation.reload.tous_filters).to eq([FilteredColumn.new(column:, filter: { operator: 'in', value: ['Paris', 'Lyon'] })])
       end
     end
+
+    context 'when the column id is missing' do
+      let(:params) { { id: procedure_presentation.id, statut: 'tous', filter: { filter: { operator: 'match', value: ['Paris'] } } } }
+
+      it 'does not add the filter and sets a flash alert' do
+        expect {
+          subject
+        }.not_to change { procedure_presentation.reload.tous_filters }
+
+        expect(response).to redirect_to(instructeur_procedure_url(procedure))
+        expect(flash.alert).to eq(I18n.t('views.instructeurs.dossiers.filters.missing_column'))
+      end
+    end
   end
 
   describe '#remove_filter' do

--- a/spec/system/instructeurs/procedure_filters_spec.rb
+++ b/spec/system/instructeurs/procedure_filters_spec.rb
@@ -102,9 +102,10 @@ describe "procedure filters" do
   scenario "shows an error when trying to add a filter without selecting a column", js: true do
     click_on 'Sélectionner un filtre'
     wait_until { all("#search-filter").size == 1 }
-    expect(page).to have_selector("#filter-component", visible: true)
+
     click_button 'Ajouter le filtre'
-    expect(page).to have_selector("#filter-component", visible: false)
+    expect(page).to have_content("Veuillez sélectionner une colonne avant d'ajouter un filtre")
+    expect(page).not_to have_content('Filtre ajouté avec succès')
   end
 
   describe 'with dropdown' do


### PR DESCRIPTION
sentry : https://demarches-simplifiees.sentry.io/issues/6900463409/?project=1429550&query=invalidtransition&referrer=issue-stream

# probleme

ETQ instructeur, je vais sur la dropdown des filtres. J'en selectionne un. Je le supprime. J'appuis sur Ajouter le filter 💥 500

# solution

Pas de mic mac JS pour bloquer le bouton submit (on a une partie react, une partie stimulus). Donc on laisse quand meme la porte ouverte (je pense que c'est une erreur de manip), par contre on rend une erreur propette  💃 🪩 🕺