### PR TITLE
Perf: modification de procedure_path pour une meilleur utilisation de l'index unique sur path

### DIFF
--- a/app/models/procedure_path.rb
+++ b/app/models/procedure_path.rb
@@ -5,7 +5,9 @@ class ProcedurePath < ApplicationRecord
 
   before_destroy :ensure_one_path, :ensure_is_customized
 
-  validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: { case_sensitive: false }
+  normalizes :path, with: -> path { path.strip.downcase }
+
+  validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: true
 
   def ensure_one_path
     return if procedure.procedure_paths.count > 1 || destroyed_by_association


### PR DESCRIPTION
Sur mon ordi, la vue admin d'une procédure provoque 2 requêtes sql sur les procedure_paths qui prennent 200ms.

<img width="1932" height="804" alt="Screenshot 2025-10-08 at 19-46-50 _admin_procedures_121457 (1375 2 ms) - Profiling Results" src="https://github.com/user-attachments/assets/6160bb28-c11e-4af4-8954-3920c77a37be" />

Cela est du à un controle de la validité de la procédure qui déclenche un controle de la validité de ces procédures path qui utilise `validates :path, ..., uniqueness: { case_sensitive: false }` .

Le `case_sensitive: false` empêche rails de se reposer sur l'index unique existant sur path et provoque un full scan de la table avec un `LOWER`

On corrige en normalisant la valeur `path` en minuscule. Les requêtes ne sont plus émises :tada:.

TODO
- [x] vérifier qu'il n'existe pas de path avec des majuscules en prod (il n'y en a pas sur ma base et je ne suis pas sur que ça pose problème, mais c'est pour être sûr).