### PR TITLE
Etq Admin - fix : corrige le filtre "tags" sur la page de recherche des démarches

### DIFF
--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -40,7 +40,6 @@
     .selected-tag.fr-mb-2w
       - @filter.tags.each do |tag|
         = link_to tag, all_admin_procedures_path(@filter.without(:tags, tag)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
-        - params[:tags].delete(tag)
   - if @filter.template?
     .selected-template.fr-mb-2w
       = link_to "Modèle DS", all_admin_procedures_path(@filter.without(:template)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'


### PR DESCRIPTION
Crisp : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_82e111f5-7054-4346-a23a-5341d5c4550c/

description du bug: sur la page du tableau de bord des démarches, lorsqu'un admin ajoute un filtre thématique (ie les tags sur les procédures), ce filtre se voit réinitialisé si l'admin vient à changer de page.

On avait pas ce bug sur une version plus ancienne de l'app, je suppose qu'il est apparu suite à une mise à jour d'une gem (?), et qu'avant cela on avait besoin de la ligne (que je viens de supprimer) 