### PR TITLE
ETQ Usager, je suis toujours averti, mm avec les streams, que les invités ne peuvent pas déposer de modification

### DIFF
--- a/app/views/invites/_form.html.haml
+++ b/app/views/invites/_form.html.haml
@@ -8,9 +8,8 @@
           %small
             = link_to t('views.invites.form.withdraw_permission'), invite_path(invite), data: { turbo_method: :delete, turbo_confirm: t('views.invites.form.want_to_withdraw_permission', email: invite.email) }, class: "fr-btn fr-btn--sm fr-btn--tertiary-no-outline", id: "dossier-invite-delete-#{index}", "aria-labelledby": "dossier-invite-delete-#{index} dossier-invite-#{index}"
 
-    - if dossier.brouillon?
-      .fr-alert.fr-alert--info.fr-mb-4w
-        %p= t('views.invites.form.submit_dossier_yourself')
+    .fr-alert.fr-alert--info.fr-mb-4w
+      %p= t('views.invites.form.submit_dossier_yourself')
 
   %hr.fr-hr
 


### PR DESCRIPTION
On parle ici de l'avertissement que seul les propriétaires du dosisers peuvent soumettre des modifications (pas les invités).

<img width="1200" height="796" alt="Screenshot 2025-10-10 at 10-10-26 Votre dossier · Dossier 24577099 (une bien belle procédure) · demarches-simplifiees fr" src="https://github.com/user-attachments/assets/85335c5c-3d8a-4995-9ab8-bf75f8508c90" />

on retire ici le `if brouillon` car l'information est toujours vrai et que cette action est disponible uniquement si l'utilisateur courant est le propriétaire du dossier `current_user.owns?(dossier)`  (`app/views/users/dossiers/show/_header.html.haml:17`)