### PR TITLE
Correctif: ETQ usager je ne vois pas la signature de l'attestation d'acceptation de mon groupe instructeur dans mon attestation de refus 

### DIFF
--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -185,7 +185,7 @@ class AttestationTemplate < ApplicationRecord
   end
 
   def signature_to_render(groupe_instructeur)
-    if groupe_instructeur&.signature&.attached?
+    if groupe_instructeur&.signature&.attached? && kind == AttestationTemplate.kinds.fetch(:acceptation)
       groupe_instructeur.signature
     else
       signature


### PR DESCRIPTION
En avançant sur l'ajout du tampon/signature du groupe instructeur dans les attestations de refus, j'ai repéré ce bug (qui est mergé mais pas encore en prod :-) )
Il y a d'autres erreurs à corriger dans les aperçus des attestations mais c'est moins prioritaire