### PR TITLE
ETQ administrateur, la prévisualisation entre attestation, mail, export est confuse

### DIFF
--- a/app/components/preview_dossier_link_component.rb
+++ b/app/components/preview_dossier_link_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class PreviewDossierLinkComponent < ApplicationComponent
+  def initialize(preview_service:, label: I18n.t('preview_dossier.link_label', default: 'Modifier le dossier de prévisualisation'))
+    @preview_service = preview_service
+    @label = label
+  end
+
+  attr_reader :label
+
+  def edit_path
+    @preview_service.edit_path
+  end
+
+  private
+
+  attr_reader :preview_service
+end

--- a/app/components/preview_dossier_link_component/preview_dossier_link_component.html.erb
+++ b/app/components/preview_dossier_link_component/preview_dossier_link_component.html.erb
@@ -1,0 +1,5 @@
+<p class="fr-hint-text">
+  L'aperçu est mis à jour automatiquement après chaque modification.
+  Pour générer un aperçu fidèle avec champs et dates,
+  <%= link_to("remplissez votre dossier via l'aperçu", edit_path, target: "_blank", rel: "noopener noreferrer") %>.
+</>

--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -7,8 +7,8 @@ module Administrateurs
     before_action :preload_revisions, only: [:edit, :update, :create]
 
     def show
-      preview_dossier = @procedure.dossier_for_preview(current_user)
-      attributes = @attestation_template.render_attributes_for(dossier: preview_dossier)
+      preview_service = DossierPreviewService.new(procedure: @procedure, current_user:)
+      attributes = @attestation_template.render_attributes_for(dossier: preview_service.dossier)
 
       @body = attributes.fetch(:body)
       @signature = attributes.fetch(:signature)

--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -7,8 +7,8 @@ module Administrateurs
     before_action :preload_revisions, only: [:edit, :update, :create]
 
     def show
-      preview_service = DossierPreviewService.new(procedure: @procedure, current_user:)
-      attributes = @attestation_template.render_attributes_for(dossier: preview_service.dossier)
+      @preview_service = DossierPreviewService.new(procedure: @procedure, current_user:)
+      attributes = @attestation_template.render_attributes_for(dossier: @preview_service.dossier)
 
       @body = attributes.fetch(:body)
       @signature = attributes.fetch(:signature)
@@ -29,6 +29,8 @@ module Administrateurs
     end
 
     def edit
+      @preview_service = DossierPreviewService.new(procedure: @procedure, current_user:)
+
       @buttons = [
         [
           ['Gras', 'bold', 'bold'],

--- a/app/controllers/administrateurs/mail_templates_controller.rb
+++ b/app/controllers/administrateurs/mail_templates_controller.rb
@@ -33,19 +33,19 @@ module Administrateurs
         mail_template.rich_body = mail_template.body
 
         @mail_template = mail_template
+        @preview_service = DossierPreviewService.new(procedure: @procedure, current_user:)
         render :edit
       end
     end
 
     def preview
       mail_template = find_mail_template_by_slug(params[:id])
-      dossier = @procedure.active_revision.dossier_for_preview(current_user)
-
-      @dossier = dossier
+      @preview_service = DossierPreviewService.new(procedure: @procedure, current_user:)
+      @dossier = @preview_service.dossier
       @logo_url = @procedure.logo_url
       @service = @procedure.service
-      @rendered_template = sanitize(mail_template.body_for_dossier(dossier), scrubber: Sanitizers::MailScrubber.new)
-      @actions = mail_template.actions_for_dossier(dossier)
+      @rendered_template = sanitize(mail_template.body_for_dossier(@dossier), scrubber: Sanitizers::MailScrubber.new)
+      @actions = mail_template.actions_for_dossier(@dossier)
 
       render(template: 'notification_mailer/send_notification', layout: 'mailers/notifications_layout')
     end

--- a/app/controllers/administrateurs/mail_templates_controller.rb
+++ b/app/controllers/administrateurs/mail_templates_controller.rb
@@ -13,6 +13,7 @@ module Administrateurs
 
     def edit
       @mail_template = find_mail_template_by_slug(params[:id])
+      @preview_service = DossierPreviewService.new(procedure: @procedure, current_user:)
       if !@mail_template.valid?
         flash.now.alert = @mail_template.errors.full_messages
       end

--- a/app/controllers/administrateurs/mail_templates_controller.rb
+++ b/app/controllers/administrateurs/mail_templates_controller.rb
@@ -54,7 +54,16 @@ module Administrateurs
     private
 
     def find_mail_template_by_slug(slug)
-      @procedure.mail_templates.find { |template| template.class.const_get(:SLUG) == slug }
+      mail_template_map = {
+        Mails::InitiatedMail::SLUG => :passer_en_construction_email_template,
+        Mails::ReceivedMail::SLUG => :passer_en_instruction_email_template,
+        Mails::ClosedMail::SLUG => :accepter_email_template,
+        Mails::RefusedMail::SLUG => :refuser_email_template,
+        Mails::WithoutContinuationMail::SLUG => :classer_sans_suite_email_template,
+        Mails::ReInstructedMail::SLUG => :repasser_en_instruction_email_template
+      }
+
+      @procedure.send(mail_template_map.fetch(slug) { raise ActiveRecord::RecordNotFound })
     end
 
     def update_params

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -26,7 +26,9 @@ module Administrateurs
     end
 
     def apercu
-      @dossier = procedure_without_control.draft_revision.dossier_for_preview(current_user).with_champs
+      procedure = procedure_without_control
+      @preview_service = DossierPreviewService.new(procedure:, current_user:)
+      @dossier = @preview_service.dossier
       @tab = apercu_tab
       if @tab == 'dossier'
         @dossier.validate(:champs_public_value)

--- a/app/controllers/instructeurs/export_templates_controller.rb
+++ b/app/controllers/instructeurs/export_templates_controller.rb
@@ -6,6 +6,7 @@ module Instructeurs
     before_action :set_export_template, only: [:edit, :update, :destroy]
     before_action :ensure_legitimate_groupe_instructeur, only: [:create, :update]
     before_action :set_types_de_champ, only: [:new, :edit]
+    before_action :set_preview_service, only: [:new, :create, :edit, :update, :preview]
 
     def new
       @export_template = export_template
@@ -45,7 +46,7 @@ module Instructeurs
     def preview
       export_template = ExportTemplate.new(export_template_params)
 
-      render turbo_stream: turbo_stream.replace('preview', partial: 'preview', locals: { procedure: @procedure, export_template: })
+      render turbo_stream: turbo_stream.replace('preview', partial: 'preview', locals: { procedure: @procedure, export_template:, preview_service: @preview_service })
     end
 
     private
@@ -95,6 +96,10 @@ module Instructeurs
       return if export_template_params[:groupe_instructeur_id].in?(@groupe_instructeurs.map { _1.id.to_s })
 
       redirect_to [:export_templates, :instructeur, @procedure], alert: 'Vous n’avez pas le droit de créer un modèle d’export pour ce groupe'
+    end
+
+    def set_preview_service
+      @preview_service = DossierPreviewService.new(procedure: @procedure, current_user:)
     end
   end
 end

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -349,8 +349,8 @@ module Instructeurs
 
     def apercu
       @procedure = procedure
-      @dossier = procedure.active_revision.dossier_for_preview(current_user)
-      @dossier.with_champs
+      @preview_service = DossierPreviewService.new(procedure:, current_user:)
+      @dossier = @preview_service.dossier
     end
 
     def history

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -79,7 +79,8 @@ class RootController < ApplicationController
       end
     end
 
-    @dossier = procedure.draft_revision.dossier_for_preview(current_user)
+    @preview_service = DossierPreviewService.new(procedure:, current_user:)
+    @dossier = @preview_service.dossier
   end
 
   def suivi

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -746,17 +746,6 @@ class Procedure < ApplicationRecord
     lien_dpo.present? && lien_dpo.match?(/@/)
   end
 
-  def dossier_for_preview(user)
-    # Try to use a preview or a dossier filled by current user
-    dossiers.where(for_procedure_preview: true).or(dossiers.visible_by_administration)
-      .order(Arel.sql("CASE WHEN user_id = #{user.id} THEN 1 ELSE 0 END DESC,
-                       CASE WHEN state = 'accepte' THEN 1 ELSE 0 END DESC,
-                       CASE WHEN state = 'brouillon' THEN 0 ELSE 1 END DESC,
-                       CASE WHEN for_procedure_preview = True THEN 1 ELSE 0 END DESC,
-                       id DESC")) \
-      .first
-  end
-
   def reset_closing_params
     update!(closing_reason: nil, closing_details: nil, replaced_by_procedure_id: nil, closing_notification_brouillon: false, closing_notification_en_cours: false)
   end

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -172,19 +172,6 @@ class ProcedureRevision < ApplicationRecord
     changes
   end
 
-  def dossier_for_preview(user)
-    dossier = Dossier
-      .create_with(autorisation_donnees: true)
-      .find_or_initialize_by(revision: self, user: user, for_procedure_preview: true, state: Dossier.states.fetch(:brouillon))
-
-    if dossier.new_record?
-      dossier.build_default_values
-      dossier.save!
-    end
-
-    dossier
-  end
-
   def types_de_champ_for(scope: nil)
     case scope
     when :public

--- a/app/services/dossier_preview_service.rb
+++ b/app/services/dossier_preview_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class DossierPreviewService
+  include Rails.application.routes.url_helpers
+
+  def initialize(procedure:, current_user:)
+    @procedure = procedure
+    @user = current_user
+  end
+
+  def dossier
+    @dossier ||= fetch_or_build_dossier
+  end
+
+  def edit_path
+    apercu_admin_procedure_path(@procedure)
+  end
+
+  private
+
+  attr_reader :procedure, :user
+
+  def fetch_or_build_dossier
+    dossier = Dossier
+      .create_with(autorisation_donnees: true)
+      .find_or_initialize_by(
+        revision: procedure.active_revision,
+        user: user,
+        for_procedure_preview: true,
+        state: Dossier.states.fetch(:brouillon)
+      )
+
+    if dossier.new_record?
+      dossier.build_default_values
+      dossier.save!
+    end
+
+    dossier.with_champs
+  end
+end

--- a/app/views/administrateurs/attestation_template_v2s/_form.html.haml
+++ b/app/views/administrateurs/attestation_template_v2s/_form.html.haml
@@ -115,11 +115,7 @@
             %h2.fr-h4 Aperçu
             %p= link_to 'Prévisualiser en taille réelle', admin_procedure_attestation_template_v2_path(procedure, format: :pdf, attestation_kind:), class: 'fr-link', target: '_blank', rel: 'noopener'
           %iframe.attestation-preview{ title: "Aperçu", src: admin_procedure_attestation_template_v2_path(procedure, format: :pdf, attestation_kind:), data: { attestation_target: 'preview' } }
-          %p.fr-hint-text
-            L'aperçu est mis à jour automatiquement après chaque modification.
-            Pour générer un aperçu fidèle avec champs et dates,
-            = link_to("créez-vous un dossier", new_dossier_path(procedure_id: procedure, brouillon: true), **external_link_attributes)
-            et acceptez-le : l'aperçu l'utilisera.
+          = render PreviewDossierLinkComponent.new(preview_service: @preview_service)
 
   - if attestation_template.draft?
     - content_for(:sticky_header) do

--- a/app/views/administrateurs/mail_templates/edit.html.haml
+++ b/app/views/administrateurs/mail_templates/edit.html.haml
@@ -23,7 +23,7 @@
       method: :put,
       html: { class: 'form form-ds-fr-white procedure-form__column--form fr-background-alt--blue-france' } do |f|
 
-      %h1.page-title= @mail_template.class.const_get(:DISPLAYED_NAME)
+      %h1.fr-mt-3w.fr-h2= @mail_template.class.const_get(:DISPLAYED_NAME)
       = render partial: 'form', locals: { f: f, tags: @mail_template.tags }
       .procedure-form__actions.sticky--bottom
         .actions-right
@@ -31,10 +31,7 @@
 
     .procedure-form__column--preview
       .procedure-form__preview.sticky--top
-        %h3
-          .procedure-form__preview-title
-            Aperçu
-            .notice
-              Cet aperçu est mis à jour après chaque sauvegarde.
+        %h2.fr-mt-3w.fr-mb-0.fr-h3 Aperçu
+        .notice= render PreviewDossierLinkComponent.new(preview_service: @preview_service)
         .procedure-preview
           = render partial: 'apercu', locals: { procedure: @mail_template.procedure }

--- a/app/views/instructeurs/export_templates/_form.html.haml
+++ b/app/views/instructeurs/export_templates/_form.html.haml
@@ -1,4 +1,4 @@
 - if export_template.tabular?
   = render partial: 'form_tabular', locals: { procedure:, export_template:, groupe_instructeurs: }
 - else
-  = render partial: 'form_zip', locals: { procedure:, export_template:, groupe_instructeurs: }
+  = render partial: 'form_zip', locals: { procedure:, export_template:, groupe_instructeurs:, preview_service: }

--- a/app/views/instructeurs/export_templates/_form_zip.html.haml
+++ b/app/views/instructeurs/export_templates/_form_zip.html.haml
@@ -99,4 +99,4 @@
               %li= f.button "Enregistrer", class: "fr-btn", data: { turbo: 'false' }
 
     .fr-col-12.fr-col-md-4.fr-background-alt--blue-france
-      = render partial: 'preview', locals: { procedure:, export_template: }
+      = render partial: 'preview', locals: { procedure:, export_template:, preview_service: }

--- a/app/views/instructeurs/export_templates/_preview.html.haml
+++ b/app/views/instructeurs/export_templates/_preview.html.haml
@@ -1,7 +1,8 @@
-- dossier = procedure.dossier_for_preview(current_instructeur)
+- dossier = preview_service.dossier
 
 #preview.export-template-preview.fr-p-2w.sticky--top
-  %h2.fr-h4 Aperçu
+  %h2.fr-h4.fr-mb-0 Aperçu
+  = render PreviewDossierLinkComponent.new(preview_service: preview_service)
   - if dossier.nil?
     %p.fr-text--sm
       Pour générer un aperçu fidèle avec tous les champs et les dates,

--- a/app/views/instructeurs/export_templates/new.html.haml
+++ b/app/views/instructeurs/export_templates/new.html.haml
@@ -4,5 +4,4 @@
                       [t('.title')]] }
 .fr-container
   %h1 Nouveau modèle d’export
-
-  = render partial: 'form', locals: { procedure: @procedure, export_template: @export_template, groupe_instructeurs: @groupe_instructeurs }
+  = render partial: 'form', locals: { procedure: @procedure, export_template: @export_template, groupe_instructeurs: @groupe_instructeurs, preview_service: @preview_service }

--- a/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
@@ -41,17 +41,11 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
       render_views
 
       context 'with preview dossier' do
-        let!(:dossier) { create(:dossier, :en_construction, procedure:, for_procedure_preview: true) }
+        let!(:dossier) { DossierPreviewService.new(procedure:, current_user: admin.user).dossier }
 
         it do
           is_expected.to include("Mon titre pour Ma démarche")
           is_expected.to include("n° #{dossier.id}")
-        end
-      end
-
-      context 'without preview dossier' do
-        it do
-          is_expected.to include("Mon titre pour --dossier_procedure_libelle--")
         end
       end
 
@@ -100,7 +94,7 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
       render_views
       let(:format) { :pdf }
       let(:attestation_acceptation_template) { build(:attestation_template, :v2, signature:) }
-      let(:dossier) { create(:dossier, :en_construction, procedure:, for_procedure_preview: true) }
+      let!(:dossier) { DossierPreviewService.new(procedure:, current_user: admin.user).dossier }
 
       before do
         html_content = /Ministère des devs.+Mon titre pour Ma démarche.+n° #{dossier.id}/m

--- a/spec/controllers/administrateurs/mail_templates_controller_spec.rb
+++ b/spec/controllers/administrateurs/mail_templates_controller_spec.rb
@@ -45,6 +45,10 @@ describe Administrateurs::MailTemplatesController, type: :controller do
       expect(response.body).to include(procedure.service.nom)
       expect(response.body).to include(procedure.service.telephone)
     end
+
+    it 'exposes a preview dossier link' do
+      expect(assigns(:preview_service)).to be_a(DossierPreviewService)
+    end
   end
 
   describe 'PATCH update' do

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -40,6 +40,7 @@ describe Administrateurs::ProceduresController, type: :controller do
         expect(response).to have_http_status(:ok)
         expect(procedure.dossiers.visible_by_user).to be_empty
         expect(procedure.dossiers.for_procedure_preview).not_to be_empty
+        expect(assigns(:preview_service)).to be_a(DossierPreviewService)
       end
     end
 

--- a/spec/controllers/instructeurs/export_templates_controller_spec.rb
+++ b/spec/controllers/instructeurs/export_templates_controller_spec.rb
@@ -33,6 +33,7 @@ describe Instructeurs::ExportTemplatesController, type: :controller do
     it do
       subject
       expect(assigns(:export_template)).to be_present
+      expect(assigns(:preview_service)).to be_a(DossierPreviewService)
     end
   end
 
@@ -148,6 +149,7 @@ describe Instructeurs::ExportTemplatesController, type: :controller do
     it 'render edit' do
       subject
       expect(response).to render_template(:edit)
+      expect(assigns(:preview_service)).to be_a(DossierPreviewService)
     end
 
     context "with export_template not accessible by current instructeur" do
@@ -253,7 +255,7 @@ describe Instructeurs::ExportTemplatesController, type: :controller do
       subject { put :preview, params: { procedure_id: procedure.id, id: export_template.id, export_template: export_template_params }, format: :turbo_stream }
 
       it 'works with bigbig procedure' do
-        dossier = create(:dossier, procedure: procedure, for_procedure_preview: true)
+        dossier = DossierPreviewService.new(procedure:, current_user: instructeur.user).dossier
         subject
         expect(response.body).to include "DOSSIER_#{dossier.id}"
         expect(response.body).to include "mon_export_#{dossier.id}.pdf"

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -1165,6 +1165,7 @@ describe Instructeurs::ProceduresController, type: :controller do
       expect(response).to have_http_status(:success)
       expect(response.body).to include("Premier champ")
       expect(response.body).not_to include("Déposer")
+      expect(assigns(:preview_service)).to be_a(DossierPreviewService)
     end
   end
 

--- a/spec/services/dossier_preview_service_spec.rb
+++ b/spec/services/dossier_preview_service_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DossierPreviewService do
+  let(:procedure) { create(:procedure) }
+  let(:user) { create(:user) }
+  let(:service) { described_class.new(procedure:, current_user: user) }
+  describe '#dossier' do
+    it 'creates a preview dossier tied to the draft revision' do
+      expect { service.dossier }.to change { Dossier.where(for_procedure_preview: true).count }.by(1)
+
+      dossier = service.dossier
+
+      expect(dossier).to be_persisted
+      expect(dossier).to be_for_procedure_preview
+      expect(dossier.state).to eq(Dossier.states.fetch(:brouillon))
+      expect(dossier.revision).to eq(procedure.draft_revision)
+      expect(dossier.user).to eq(user)
+      expect(dossier.champs.loaded?).to be(true)
+    end
+
+    it 'reuses an existing preview dossier' do
+      service = described_class.new(procedure:, current_user: user)
+      first_dossier = service.dossier
+
+      expect { service.dossier }.not_to change { Dossier.where(for_procedure_preview: true).count }
+    end
+  end
+
+  describe '#edit_path' do
+    it 'returns the administrateur preview path' do
+      expect(service.edit_path).to eq(Rails.application.routes.url_helpers.apercu_admin_procedure_path(procedure))
+    end
+  end
+end


### PR DESCRIPTION
crisp : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_ce552444-6aa8-4127-9e32-3224fb7e8a79/

# probleme

On avait deux implem pour generer/recuperer un dossier pour de la prévisualisation
On avait aussi une difference, parfois on partait de la draft, parfois de l'active_revision.
Concrètement : 
- sur l'edition d'un modele de mail, ça fonctionnait bien sur les demarches en brouillon. Par contre, pour une démarche publiée, on utilisait la draft pour creer le dossier preview. donc pas d'interpolation possible. 

# solution 
1. on utilise l'active_revision partout. donc si t'es en draft, la preview utilise ca en base pour trouver son dossier, et si t'es sur une demarche publiée, mm combat.
2. un service pour tous les cas. 
3. on explique aux admin que pour peupler la preview, bah il utilise un dossier preview

____ 

## apres

attestations (explication + edition via le lien de d'apercu) : 
> <img width="1296" height="850" alt="Capture d’écran 2025-10-10 à 12 10 51 PM" src="https://github.com/user-attachments/assets/4bd8d31b-a24d-4bec-9987-2adbe36add72" />

mail (explication + edition via le lien de d'apercu) : 
> <img width="1073" height="397" alt="Capture d’écran 2025-10-10 à 12 10 32 PM" src="https://github.com/user-attachments/assets/0ca98efe-ab9a-447d-86a7-8499c0809689" />

modele d'export (explication + edition via le lien de d'apercu) : 
> <img width="1240" height="516" alt="Capture d’écran 2025-10-10 à 12 10 02 PM" src="https://github.com/user-attachments/assets/0655c07d-ca44-495e-9733-8387a834d51d" />

____

## avant
attestations (explication mais il fallait creer un dossier, le soumettre, l'accepter) : 
> <img width="1232" height="830" alt="Capture d’écran 2025-10-10 à 12 13 07 PM" src="https://github.com/user-attachments/assets/b71c4f82-bf3d-487a-aef2-6bbab15c0dc9" />

mail (pas d'explication, et on find_or_build un dossier depuis l'active revision, donc sur une demarche non publiée, ca fonctionnait via l'apercu du dossier, pour une demarche publiée, juste jamais d'interpolation de tag car on rebuildé un dossier sur la version de la demarche en brouillon) : 
> <img width="1083" height="735" alt="Capture d’écran 2025-10-10 à 12 13 12 PM" src="https://github.com/user-attachments/assets/f587abc2-9ec0-494d-b3cb-369d6ad4ce15" />


modele d'export (pas d'explication) : 
> <img width="1242" height="478" alt="Capture d’écran 2025-10-10 à 12 13 29 PM" src="https://github.com/user-attachments/assets/2b3244ad-c079-4167-b8f1-95341663c055" />


