### PR TITLE
Tech: accélération de la page avis/index

### DIFF
--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -18,8 +18,7 @@ module Experts
     def index
       avis = current_expert.avis
         .not_revoked
-        .includes(:dossier)
-        .includes(procedure: { logo_attachment: :blob })
+        .includes(:dossier, :procedure)
         .not_hidden_by_administration
       @avis_by_procedure = avis.to_a.group_by(&:procedure)
     end


### PR DESCRIPTION
La page index des avis prenait du temps à cause d'un includes des logos des procédures qui provoquait un left join sur cette grosse table.

Corrélation [skylight](https://www.skylight.io/app/applications/zAvWTaqO0mu1/recent/6h/endpoints/Experts::AvisController%23index?responseType=html)

Or le logo n'est plus affiché depuis 512fa0d301d0e48197684bd061472a0f779fdc45 .

On retire l'`includes`, on passe sur mon poste de 800ms -> 100ms.

(je comprends pas très bien pourquoi ce join met autant de temps sachant qu'il est interrogé par sa clé primaire indexée)