### PR TITLE
ETQ usager je peux renseigner ma commune ou adresse même si l'API geo n'est pas joignable

### DIFF
--- a/app/services/api_geo_degraded_service.rb
+++ b/app/services/api_geo_degraded_service.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+class APIGeoDegradedService
+  # Follows API Geo structure
+  CommunesResponse = Data.define(:body, :success?, :code) do
+    def initialize(communes:)
+      mock_response_body = communes.map do |commune|
+        {
+          nom: commune[:name],
+          code: commune[:code],
+          codesPostaux: [commune[:postal_code]],
+          codeDepartement: commune[:departement_code],
+          codeRegion: commune[:region_code],
+          population: nil
+        }
+      end
+
+      super(
+        body: mock_response_body.to_json,
+        success?: true,
+        code: 200
+      )
+    end
+  end
+
+  class << self
+    def fetch_communes_by_name(name, departements_data)
+      communes = search_communes_by_name(name, departements_data)
+      CommunesResponse.new(communes:)
+    end
+
+    def fetch_communes_by_postal_code(postal_code, departements_data)
+      communes = search_communes_by_postal_code(postal_code, departements_data)
+      CommunesResponse.new(communes:)
+    end
+
+    private
+
+    def search_communes_by_name(name, departements_data)
+      normalized_query = normalize_commune_name(name)
+      results = []
+
+      departements_data.each do |departement_code, communes|
+        next if departement_code == '99' # Skip "Etranger"
+
+        matching_communes = communes.filter do |commune|
+          normalized_commune_name = normalize_commune_name(commune[:name])
+          normalized_commune_name.include?(normalized_query)
+        end
+
+        results.concat(matching_communes)
+        break if results.size >= 100 # perf: don't fetch all communes in many results
+      end
+
+      # Sort by relevance and postal code
+      sorted_results = results.sort_by do |commune|
+        normalized_commune_name = normalize_commune_name(commune[:name])
+        pertinence = if normalized_commune_name == normalized_query
+          0 # Correspondance exacte
+        elsif normalized_commune_name.start_with?(normalized_query)
+          1 # Commence par la requête
+        else
+          2 # Contient la requête
+        end
+
+        [pertinence, commune[:postal_code]]
+      end
+
+      sorted_results.first(100)
+    end
+
+    def search_communes_by_postal_code(postal_code, departements_data)
+      results = []
+
+      departements_data.each do |departement_code, communes|
+        next if departement_code == '99' # Skip "Etranger"
+
+        matching_communes = communes.filter do |commune|
+          commune[:postal_code] == postal_code
+        end
+
+        if matching_communes.any?
+          results.concat(matching_communes)
+          break if results.size >= 20
+        end
+      end
+
+      results.first(20)
+    end
+
+    def normalize_commune_name(name)
+      I18n.transliterate(name).downcase.delete("\s\-_")
+    end
+  end
+end

--- a/config/env.example
+++ b/config/env.example
@@ -80,6 +80,10 @@ UNIVERSIGN_USERPWD=""
 API_ADRESSE_URL="https://data.geopf.fr/geocodage"
 API_GEO_URL="https://geo.api.gouv.fr"
 
+# If the Geo API for administrative boundaries is unreachable, set this variable to bypass the API using our local data.
+# This allows the commune champ and the address champ to continue working in manual mode.
+# API_GEO_DEGRADED_MODE="enabled"
+
 # External service: API Education
 API_EDUCATION_URL="https://data.education.gouv.fr/api/records/1.0"
 

--- a/config/initializers/00_env_vars.rb
+++ b/config/initializers/00_env_vars.rb
@@ -15,5 +15,6 @@ if ENV['RAILS_ENV'] != 'test' && File.basename($0) != 'rake'
 end
 
 def ENV.enabled?(name)
-  ENV.fetch("#{name}_ENABLED", "").downcase.in?(["enabled", "yes", "true", "1"])
+  value = ENV["#{name}_ENABLED"] || ENV[name] || ""
+  value.downcase.in?(["enabled", "yes", "true", "1"])
 end

--- a/spec/services/api_geo_degraded_service_spec.rb
+++ b/spec/services/api_geo_degraded_service_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+describe APIGeoDegradedService do
+  let(:departements_data) do
+    APIGeoService.departements.each_with_object({}) do |departement, data|
+      next if departement[:code] == '99'
+      data[departement[:code]] = APIGeoService.send(:get_from_api_geo, "communes-#{departement[:code]}")
+    end
+  end
+
+  describe '.fetch_communes_by_name' do
+    it 'boost exact match and sort by postal code' do
+      response = APIGeoDegradedService.fetch_communes_by_name('Paris', departements_data)
+
+      expect(response.success?).to be true
+      expect(response.code).to eq(200)
+
+      body = JSON.parse(response.body)
+      expect(body).to be_an(Array)
+      expect(body.first['nom']).to eq('Paris')
+      expect(body.first['code']).to eq('75056')
+      expect(body.first['codesPostaux']).to eq(['75001'])
+    end
+
+    it 'handle spaces and dash in query' do
+      response = APIGeoDegradedService.fetch_communes_by_name('bouc bel a', departements_data)
+
+      body = JSON.parse(response.body)
+      expect(body).to be_an(Array)
+      expect(body.first['nom']).to eq('Bouc-Bel-Air')
+    end
+  end
+
+  describe '.fetch_communes_by_postal_code' do
+    it 'find a commune by postal code' do
+      response = APIGeoDegradedService.fetch_communes_by_postal_code('07470', departements_data)
+
+      expect(response.success?).to be true
+      body = JSON.parse(response.body)
+
+      expect(body).to be_an(Array)
+      expect(body.first['nom']).to eq('Coucouron')
+      expect(body.first['codesPostaux']).to include('07470')
+    end
+  end
+
+  describe 'Response data structure' do
+    it 'returns same response as API geo' do
+      response = APIGeoDegradedService.fetch_communes_by_name('Paris', departements_data)
+      body = JSON.parse(response.body)
+      commune = body.first
+
+      expect(commune['nom']).to eq("Paris")
+      expect(commune['code']).to eq("75056")
+      expect(commune['codesPostaux']).to eq(["75001"])
+      expect(commune['codeDepartement']).to eq("75")
+      expect(commune['codeRegion']).to eq("11")
+      expect(commune).to have_key('population')
+    end
+  end
+end

--- a/spec/services/api_geo_service_spec.rb
+++ b/spec/services/api_geo_service_spec.rb
@@ -155,4 +155,23 @@ describe APIGeoService do
       it { is_expected.to eq('Paris') }
     end
   end
+
+  describe 'degraded mode' do
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('API_GEO_DEGRADED_MODE').and_return('enabled')
+    end
+
+    it 'returns commune results without calling API' do
+      expect(Typhoeus).not_to receive(:get)
+
+      response = APIGeoService.commune_by_name_or_postal_code('stras')
+      results = JSON.parse(response.body)
+      expect(results[0]["nom"]).to eq("Strasbourg")
+
+      response = APIGeoService.commune_by_name_or_postal_code('41000')
+      results = JSON.parse(response.body)
+      expect(results[0]["nom"]).to eq("Blois")
+    end
+  end
 end


### PR DESCRIPTION
Dans l'optique d'être plus résilient face aux incidents des API tierces, avec la variable `API_GEO_DEGRADED_MODE=enabled` on active un mode dégradé, qui pour la recherche par commune/code postal :

- n'appelle plus l'API
- utilise nos data locales pour générer des suggestions et construire un objet comme s'il s'agissait d'une réponse de l'API
- continue de passer dans le service habituel pour les traitements spécifiques de Paris etc…

Ceci permet de continuer de faire marcher le champ commune, et le champ adresse en mode saisie manuelle (qui utilise le champ commune), au prix de : 
- un algo de recherche un peu moins performant (pas de boost par population, mais d'après mes essais ça reste très convenable)
- pas de gros pb de perf a priori
- des données non validées par la BAN, mais on continue de remonter des infos comme le code postal et insee de la commune.
- il faut informer l'usager que l'adresse n'est pas dispo et passer par la suggestion (PR de @mmagn à venir)


https://github.com/user-attachments/assets/010a6461-7b8f-4ac8-ac46-596b0fb3936d


<img width="901" height="314" alt="Capture d’écran 2025-10-14 à 14 45 13" src="https://github.com/user-attachments/assets/2559fe83-5145-49ef-9943-402028b38bfe" />
<img width="924" height="342" alt="Capture d’écran 2025-10-14 à 14 43 59" src="https://github.com/user-attachments/assets/11513e83-e0c7-4c02-a087-ce09b2c9f5da" />
