### PR TITLE
Tech: instrumente le nb de queries à la db pour chaque requête

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -14,7 +14,9 @@ Rails.application.configure do
         tags: ['request', event.payload[:exception] ? 'exception' : nil].compact,
         process: {
           pid: Process.pid
-        }
+        },
+        db_queries: event.payload[:queries_count],
+        db_queries_cached: event.payload[:cached_queries_count]
       }
 
       hash.merge!(event.payload[:to_log]) if event.payload.key?(:to_log)


### PR DESCRIPTION
Le nb de queries db est déjà instrumenté par rails, il suffit de l'injecter dans lograge qui ne le fait pas (vu que c'est plus trop maintenu)

Ceci permet d'obtenir ce genre de payload : 
```json
{
  "db_queries": 29,
  "db_queries_cached": 4


  #  ...
  "db": 227.4,
  "method": "GET",
  "path": "/dossiers/29/modifier",
  "controller": "Users::DossiersController",
  "duration": 703.38,
  "view": 311.33,
}
```