### PR TITLE
amélioration: ETQ usager, les champs referentiel configurable ont des comboxbox pouvant atteindre jusqu'a 1k element (aligné ac la limit du back)

### DIFF
--- a/app/components/editable_champ/referentiel_component.rb
+++ b/app/components/editable_champ/referentiel_component.rb
@@ -16,6 +16,7 @@ class EditableChamp::ReferentielComponent < EditableChamp::EditableChampBaseComp
       placeholder: t('views.components.remote_combobox'),
       selected_key: @champ.selected_key,
       items: @champ.selected_items,
+      limit: ReferentielAutocompleteRenderService::MAX_RENDERED_OBJECTS,
       loader: data_sources_data_source_referentiel_path(referentiel_id: referentiel.id),
       minimum_input_length: DataSources::ReferentielController::MIN_QUERY_LENGTH,
       use_post: true,


### PR DESCRIPTION
verbatim : 
>  Actuellement 10 propositions sont soumises. Dans le cadre de notre DS, j'ai déjà dupliqué les API en fonction de la région pour éviter le nombre élevé de propositions mais cela ne suffit pas. Est-il possible d'en visualiser une vingtaine ?