### PR TITLE
ETQ Admin mes badges de cartes sont harmonisés

### DIFF
--- a/app/components/procedure/card/labels_component/labels_component.html.haml
+++ b/app/components/procedure/card/labels_component/labels_component.html.haml
@@ -2,14 +2,14 @@
   = link_to  [:admin, @procedure, :labels], class: 'fr-tile fr-enlarge-link' do
     .fr-tile__body.flex.column.align-center.justify-between
       - if @procedure.labels.present?
-        %p.fr-badge.fr-badge--info
+        %p.fr-badge.fr-badge--success
           Configuré
         %div
           .line-count.fr-my-1w
             %p.fr-tag= @procedure.labels.size
       - else
-        %p.fr-badge
-          Non configuré
+        %p.fr-badge--info
+          À configurer
 
       %h3.fr-h6
         = t('.title')

--- a/app/components/types_de_champ_editor/info_referentiel_component/info_referentiel_component.html.haml
+++ b/app/components/types_de_champ_editor/info_referentiel_component/info_referentiel_component.html.haml
@@ -5,7 +5,7 @@
   .flex.fr-mb-2w.cell
     %p.fake-label.fr-text--bold.flex-grow.fr-mb-0 Configuration du champ référentiel
     - if !ready?
-      %p.fr-badge.fr-badge--sm.fr-badge--error À configurer
+      %p.fr-badge.fr-badge--sm.fr-badge--info À configurer
     - else
       %p.fr-badge.fr-badge--sm.fr-badge--success Configuré
 


### PR DESCRIPTION
Il s'agit d'un petit fix en marge d'un autre ticket pour harmoniser les intitulés et les couleurs des badges des tuiles sur l'interface admin.

