### PR TITLE
ETQ usager, je n'ai pas de rupture dans mon parcours de création de dossier pré-rempli si je passe par une connexion pro-connect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :multiple_devise_profile_connect?, :instructeur_signed_in?, :current_instructeur, :current_expert, :expert_signed_in?,
     :administrateur_signed_in?, :current_administrateur, :current_account, :localization_enabled?, :set_locale, :current_expert_not_instructeur?,
-    :gestionnaire_signed_in?, :current_gestionnaire
+    :gestionnaire_signed_in?, :current_gestionnaire, :extra_query_params
 
   before_action do
     Current.request_id = request.uuid

--- a/app/controllers/devise/store_location_extension.rb
+++ b/app/controllers/devise/store_location_extension.rb
@@ -3,6 +3,10 @@
 module Devise
   # Useful helpers additions to Devise::Controllers::StoreLocation
   module StoreLocationExtension
+    def extra_query_params
+      params.permit(:prefill_token, :test).to_h
+    end
+
     # A variant of `stored_location_key_for` which doesn't delete the stored path.
     def get_stored_location_for(resource_or_scope)
       location = stored_location_for(resource_or_scope)

--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -14,6 +14,7 @@ module Users
       @revision = params[:test] ? @procedure.draft_revision : @procedure.active_revision
 
       if params[:prefill_token].present? || commencer_page_is_reloaded?
+        store_user_location!(@procedure)
         retrieve_prefilled_dossier(params[:prefill_token] || session[:prefill_token])
       elsif prefill_params_present?
         build_prefilled_dossier
@@ -99,10 +100,6 @@ module Users
     end
 
     private
-
-    def extra_query_params
-      params.slice(:prefill_token, :test).to_unsafe_h.compact
-    end
 
     def commencer_page_is_reloaded?
       session[:prefill_token].present? && session[:prefill_params_digest] == PrefillChamps.digest(params)

--- a/app/views/layouts/procedure_context.html.herb
+++ b/app/views/layouts/procedure_context.html.herb
@@ -21,7 +21,7 @@
 <% end %>
 
 <% if procedure.present? %>
-  <% content_for(:pro_connect_path, commencer_pro_connect_path(procedure.path)) %>
+  <% content_for(:pro_connect_path, commencer_pro_connect_path(procedure.path, **extra_query_params)) %>
 <% end %>
 
 <%= render template: 'layouts/application' %>

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -93,6 +93,10 @@ describe Users::CommencerController, type: :controller do
       subject { get :commencer, params: { path: path, prefill_token: dossier.prefill_token } }
 
       shared_examples 'a prefilled brouillon dossier retriever' do
+        it 'stores the prefill token in session' do
+          expect { subject }.to change { controller.stored_location_for(:user) }.to(commencer_path(dossier.procedure.path, prefill_token: dossier.prefill_token))
+        end
+
         context 'when the dossier is a prefilled brouillon and the prefill token is present' do
           it 'retrieves the dossier' do
             subject
@@ -126,6 +130,14 @@ describe Users::CommencerController, type: :controller do
         let(:user) { nil }
 
         it_behaves_like 'a prefilled brouillon dossier retriever'
+
+        context 'when rendered view' do
+          render_views
+          it 'includes the prefill token in Pro Connect link' do
+            subject
+            expect(response.body).to have_link('Agent', href: commencer_pro_connect_path(dossier.procedure.path, prefill_token: dossier.prefill_token))
+          end
+        end
       end
 
       context 'when the user is authenticated' do

--- a/spec/views/layouts/procedure_context.html.haml_spec.rb
+++ b/spec/views/layouts/procedure_context.html.haml_spec.rb
@@ -8,6 +8,7 @@ describe 'layouts/procedure_context', type: :view do
     allow(view).to receive(:instructeur_signed_in?).and_return(false)
     allow(view).to receive(:administrateur_signed_in?).and_return(false)
     allow(view).to receive(:localization_enabled?).and_return(false)
+    allow(view).to receive(:extra_query_params).and_return({})
   end
 
   subject do


### PR DESCRIPTION
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_de168dd6-34c5-43ad-a31b-51fedddead40/
fix: https://github.com/orgs/demarches-simplifiees/projects/1/views/1?pane=issue&itemId=126326331&issue=demarches-simplifiees%7Cdemarches-simplifiees.fr%7C12006
# probleme

ETQ usager essayer de prefill un dossier. si je passe par une connexion pro connect. Je perds mon prefill token

# solution 

shameless plug de déglingo 😎 . on repart d'un joli commit : https://github.com/demarches-simplifiees/demarches-simplifiees.fr/commit/8817c6361e7e8b66970211ecacbf471a6b5f2a4e – pr stocker l'url du dossier a prefiller et donc retomber dessus ap la connexion ? 😊 