### PR TITLE
ETQ administrateur DS, j'aimerais que le formulaire du condtionnel ne soit pas planté si une condition sur un champ dropdown sans option est present

### DIFF
--- a/app/components/conditions/conditions_errors_component.rb
+++ b/app/components/conditions/conditions_errors_component.rb
@@ -62,6 +62,10 @@ class Conditions::ConditionsErrorsComponent < ApplicationComponent
       t("required_include.eq", scope: '.errors')
     in { type: :required_include, operator_name: "Logic::NotEq" }
       t("required_include.not_eq", scope: '.errors')
+    in { type: :empty_options, stable_id: stable_id }
+      targeted_champ = @source_tdcs.find { |tdc| tdc.stable_id == stable_id }
+      t('empty_options', scope: '.errors',
+        libelle: targeted_champ.libelle)
     else
       nil
     end

--- a/app/components/conditions/conditions_errors_component/conditions_errors_component.en.yml
+++ b/app/components/conditions/conditions_errors_component/conditions_errors_component.en.yml
@@ -10,3 +10,4 @@ en:
       eq: "The « is » operator does not apply to multiple dropdown list. Select the « includes » operator."
       not_eq: "The « is not » operator does not apply to multiple dropdown list."
     not_included: "« %{right} » is not included in « %{libelle} »."
+    empty_options: "The field « %{libelle} » has no options to select from."

--- a/app/components/conditions/conditions_errors_component/conditions_errors_component.fr.yml
+++ b/app/components/conditions/conditions_errors_component/conditions_errors_component.fr.yml
@@ -10,3 +10,4 @@ fr:
       eq: "Lʼopérateur « est » ne s'applique pas au choix multiple. Sélectionnez l’opérateur « contient »."
       not_eq: "Lʼopérateur « n’est pas » ne s'applique pas au choix multiple."
     not_included: "« %{right} » ne fait pas partie de « %{libelle} »."
+    empty_options: "Le champ « %{libelle} » n'a aucune option parmi lesquelles choisir."

--- a/app/models/logic.rb
+++ b/app/models/logic.rb
@@ -62,7 +62,11 @@ module Logic
       when :empty
         Empty.new
       when :enum, :enums, :commune_enum, :epci_enum, :departement_enum, :address
-        Constant.new(left.options(type_de_champs).first.second)
+        if left.options(type_de_champs).blank?
+          Empty.new
+        else
+          Constant.new(left.options(type_de_champs).first.second)
+        end
       when :number
         Constant.new(0)
       end

--- a/spec/models/logic_spec.rb
+++ b/spec/models/logic_spec.rb
@@ -71,7 +71,9 @@ describe Logic do
       it 'returns a stable condition and reports the missing value' do
         drop_down.update!(drop_down_options: [])
 
-        expect { subject }.not_to raise_error
+        expect(subject.errors(type_de_champs)).to include(
+          a_hash_including(type: :empty_options, stable_id: drop_down.stable_id)
+        )
       end
     end
   end


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/6330769028/?project=1429550&query=change_targeted_champ&referrer=issue-stream
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_ad51a014-42c3-4c36-b881-a76a7ec4a350/

# probleme
L'editeur de champ était en vrac si on avait un champ conditionné sur une dropdown ayant une liste vide (ce qui peut arriver quand tu veux refaire ta liste)

# solution 
On detecte et remonte le cas d'erreur proprement

**Apres:**

https://github.com/user-attachments/assets/4af973d9-df49-4051-abaa-8b69f57fccd4



**Avant:**

https://github.com/user-attachments/assets/f5209cfc-6ba9-419d-ae2b-0e7413f5845f


