### PR TITLE
Tech: ignore les gems dans les stacktraces de sentry pour avoir une vision app only/full trace

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -11,6 +11,8 @@ Sentry.init do |config|
   config.environment = ENV['SENTRY_CURRENT_ENV'] || Rails.env
   config.enabled_environments = ['production', ENV['SENTRY_CURRENT_ENV'].presence].compact
   config.breadcrumbs_logger = [:active_support_logger]
+  config.app_dirs_pattern = %r{#{Regexp.escape(Rails.root.to_s)}/(app|bin|config|db|lib)/}
+
   config.traces_sampler = lambda do |sampling_context|
     # if this is the continuation of a trace, just use that decision (rate controlled by the caller)
     unless sampling_context[:parent_sampled].nil?


### PR DESCRIPTION
Notre process de déploiement n'installe pas les gems dans le répertoire par défaut de bundle, mais dans /vendor ce qui fait qu'elles sont au même niveau que notre code, et sentry ne sait pas faire la distinction tout seul. Alors on l'aide en lui disant qu'est-ce qui fait partie de notre app.