### PR TITLE
ETQ admin, petite correction visuelle sur le toggle opendata

### DIFF
--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -75,13 +75,7 @@
           %p= t(:opendata_notice_html, scope: [:administrateurs, :informations])
 
     .fr-fieldset__element
-      .fr-input-group
-        = f.label :opendata, t(:opendata, scope: [:administrateurs, :informations]), class: 'fr-label'
-        %label.toggle-switch
-          = f.check_box :opendata, class: 'toggle-switch-checkbox'
-          %span.toggle-switch-control.round
-          %span.toggle-switch-label.on Oui
-          %span.toggle-switch-label.off Non
+      = render Dsfr::ToggleComponent.new(form: f, target: :opendata, title: t(:opendata, scope: [:administrateurs, :informations]), extra_class_names: nil)
 
   .fr-fieldset__element
     .fr-input-group


### PR DESCRIPTION
https://mattermost.incubateur.net/betagouv/pl/ny553nnr37f4ubtebmtqatxssh

introduit par #12145 suite à la suppression de la classe `form` pour faire marcher un autre toggle

<img width="711" height="149" alt="Capture d’écran 2025-10-21 à 15 02 53" src="https://github.com/user-attachments/assets/9fec1c6b-47e5-43bb-84f0-453588de7182" />
