### PR TITLE
Fix typo: 'best cast scenario' → 'best case scenario'

### DIFF
--- a/app/components/procedure/estimated_delay_component/estimated_delay_component.en.yml
+++ b/app/components/procedure/estimated_delay_component/estimated_delay_component.en.yml
@@ -1,6 +1,6 @@
 ---
 en:
-  explanation: "Based on %{percentile}% during the last %{nb_recent_dossiers} days, the instruction time is :"
-  fast_html: "<strong>In the best cast scenario</strong> : <strong>%{estimation}</strong>."
-  mean_html: "If your file <strong>requires minor adjustments</strong>, the instruction time is  <strong>%{estimation}</strong>."
-  slow_html: "If you file <strong>is missing some information</strong> which requires a lot of exchanges with the administration, the instruction time is around <strong>%{estimation}</strong>."
+  explanation: 'Based on %{percentile}% during the last %{nb_recent_dossiers} days, the instruction time is :'
+  fast_html: '<strong>In the best case scenario</strong> : <strong>%{estimation}</strong>.'
+  mean_html: 'If your file <strong>requires minor adjustments</strong>, the instruction time is  <strong>%{estimation}</strong>.'
+  slow_html: 'If you file <strong>is missing some information</strong> which requires a lot of exchanges with the administration, the instruction time is around <strong>%{estimation}</strong>.'


### PR DESCRIPTION
## Description
Fixed a typo in the English translation file for the estimated delay component.

## Changes
- Changed "best cast scenario" to "best case scenario" in `estimated_delay_component.en.yml`

## Type of Change
- [x] Bug fix (typo correction)
- [x] Non-breaking change