### PR TITLE
Correctif : plus d'ids des procédures pouvant être ordonnées dans l'url order_positions_instructeur_procedures

### DIFF
--- a/app/views/instructeurs/procedures/index.html.haml
+++ b/app/views/instructeurs/procedures/index.html.haml
@@ -40,7 +40,7 @@
       %h2.fr-h6.fr-m-0
         = page_entries_info collection
       - if (@statut == "en-cours" && @all_procedures_en_cours.size > 1)
-        = link_to "Personnaliser l'ordre", order_positions_instructeur_procedures_path(collection_ids: @all_procedures_en_cours.map(&:id)), class: 'fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-left fr-icon-settings-5-line'
+        = link_to "Personnaliser l'ordre", order_positions_instructeur_procedures_path, class: 'fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-left fr-icon-settings-5-line'
     %ul.procedure-list.fr-pl-0
       = render partial: 'instructeurs/procedures/list',
         collection: collection,


### PR DESCRIPTION
Ceci peut causer des pb pour les instructeurs qui ont beaucoup de démarches --> on recalcule donc coté serveur la liste d'ids des procédures pouvant être ordonnées