### PR TITLE
Tech: contourne timeout dans la maintenance task de migration de DOM du champ pays

### DIFF
--- a/app/tasks/maintenance/t20251023_migrate_champs_pays_after_api_geo_update_task.rb
+++ b/app/tasks/maintenance/t20251023_migrate_champs_pays_after_api_geo_update_task.rb
@@ -41,7 +41,7 @@ module Maintenance
     }.freeze
 
     def collection
-      Champs::PaysChamp.where(value: COUNTRY_VALUE_MAPPING.keys)
+      Champs::PaysChamp.select(:id, :value, :external_id)
     end
 
     def process(champ)
@@ -55,7 +55,9 @@ module Maintenance
     end
 
     def count
-      # NOOP too long
+      with_statement_timeout("15min") do
+        collection.count(:id)
+      end
     end
   end
 end


### PR DESCRIPTION
C'est la clause where qui provoque le timeout, donc on l'enlève et c'est filtré ensuite dans le process. En contrepartie je rétablis le count pour avoir la visibilité sur les 5M de champs.

(cf #12248)