### PR TITLE
Tech: permet l'utilisation de pro connect sur demarche et demarches.numerique.gouv.fr

### DIFF
--- a/app/services/pro_connect_service.rb
+++ b/app/services/pro_connect_service.rb
@@ -55,8 +55,14 @@ class ProConnectService
 
   # TODO: remove this block when migration to new domain is done
   def self.conf
-    if Current.host.end_with?('.gouv.fr')
-      PRO_CONNECT_GOUV
+    if Current.host.end_with?('demarches.numerique.gouv.fr')
+      h = PRO_CONNECT_GOUV.dup
+      h[:redirect_uri] = h[:redirect_uri].gsub('demarche.numerique', 'demarches.numerique')
+      h
+    elsif Current.host.end_with?('demarche.numerique.gouv.fr')
+      h = PRO_CONNECT_GOUV.dup
+      h[:redirect_uri] = h[:redirect_uri].gsub('demarches.numerique', 'demarche.numerique')
+      h
     else
       PRO_CONNECT
     end


### PR DESCRIPTION
si y a un s, on s 'assure que le redirect comporte un s
si y en a pas, pareil