### PR TITLE
correctif: ETQ usager/instructeurs, je souhaite que la mise en page du copier/coller de la valeur d'un champ ne soit pas en vracs ac les types de champ nombre

### DIFF
--- a/app/javascript/controllers/clipboard2_controller.ts
+++ b/app/javascript/controllers/clipboard2_controller.ts
@@ -82,10 +82,19 @@ export class Clipboard2Controller extends Controller {
       return;
     }
 
-    const lastChild = wrapper.lastElementChild;
+    // lastElementChild only returns HTMLElements (skipping TextNode).
+    // But numbers champs have a <span>separator</span> in between groups of 3 digits ie:
+    //  <textNode text="1"><span class="delimiter"/><textNode text="000">
+    // So we use childNodes to get the actual last node (which can be a TextNode).
+    // Then we insert after that node
+    const lastChild = wrapper.childNodes[wrapper.childNodes.length - 1] as
+      | Node
+      | undefined;
 
-    if (lastChild && lastChild.tagName !== 'BR') {
+    if (lastChild instanceof HTMLElement && lastChild.tagName !== 'BR') {
       lastChild.appendChild(button);
+    } else if (lastChild instanceof Text && lastChild.parentNode) {
+      lastChild.parentNode.insertBefore(button, lastChild.nextSibling);
     } else {
       wrapper.appendChild(button);
     }


### PR DESCRIPTION
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_c2dad961-c70e-4c67-b575-2c8fd3e35980/

apres:
<img width="674" height="148" alt="Capture d’écran 2025-10-28 à 4 35 35 PM" src="https://github.com/user-attachments/assets/b6f5b6e1-7f30-4435-8577-eb9427da5be8" />

avant:
<img width="676" height="192" alt="Capture d’écran 2025-10-28 à 4 35 59 PM" src="https://github.com/user-attachments/assets/3bd01e35-4666-40f9-9dd1-9fef3dfc9e0b" />
