### PR TITLE
Perf: accélère l'analyse des ribs en plaçant leur analyse d'image en `default`

### DIFF
--- a/app/jobs/image_processor_job.rb
+++ b/app/jobs/image_processor_job.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 
 class ImageProcessorJob < ApplicationJob
-  queue_as :low # thumbnails and watermarks. Execution depends of virus scanner which is more urgent
+  queue_as do
+    blob = self.arguments.first
+    maybe_champ = blob&.attachments&.first&.record
+
+    if rib?(maybe_champ)
+      :default # UI is waiting
+    else
+      :low # thumbnails and watermarks. Execution depends of virus scanner which is more urgent
+    end
+  end
 
   class FileNotScannedYetError < StandardError
   end


### PR DESCRIPTION
Je ne suis pas sur.

D'un coté ça va accélérer le traitement de ces pjs (actuellement 40 min d'attente). D'un autre, c'est un job lent ( > 2s) donc ca va  retarder  toute la file critical ... mais y en a pas beaucoup...

On pourrait sinon extraire l'analyse dans un job à part, mais ça ne serait intéressant que si on fait sauter l'analyse anti virus.