### PR TITLE
correctif: ETQ instructeurs, je n'accede qu'aux exports avec les même groupes d'instructeurs que moi

### DIFF
--- a/app/controllers/administrateurs/archives_controller.rb
+++ b/app/controllers/administrateurs/archives_controller.rb
@@ -8,7 +8,7 @@ module Administrateurs
     helper_method :create_archive_url
 
     def index
-      @exports = Export.ante_chronological.by_key(all_groupe_instructeurs.map(&:id))
+      @exports = Export.for_groupe_instructeurs(all_groupe_instructeurs).ante_chronological
       @average_dossier_weight = @procedure.average_dossier_weight
       @count_dossiers_termines_by_month = @procedure
         .dossiers

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -79,7 +79,7 @@ class Export < ApplicationRecord
       time_span_type:,
       statut:,
       include_archived:,
-      key: generate_cache_key(groupe_instructeurs.map(&:id), filtered_columns, sorted_column)
+      key: generate_cache_key(filtered_columns, sorted_column)
     }
 
     recent_export = pending
@@ -102,15 +102,10 @@ class Export < ApplicationRecord
       .distinct
   end
 
-  def self.by_key(groupe_instructeurs_ids)
-    where(key: generate_cache_key(groupe_instructeurs_ids))
-  end
-
-  def self.generate_cache_key(groupe_instructeurs_ids, filtered_columns = [], sorted_column = nil)
+  def self.generate_cache_key(filtered_columns = [], sorted_column = nil)
     columns_key = ([sorted_column] + filtered_columns).compact.map(&:id).sort.join
 
     [
-      groupe_instructeurs_ids.sort.join('-'),
       Digest::MD5.hexdigest(columns_key)
     ].join('--')
   end

--- a/spec/factories/export.rb
+++ b/spec/factories/export.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
       procedure_presentation = export.procedure_presentation
       filters = Array.wrap(procedure_presentation&.filters_for(export.statut))
       sorted_column = procedure_presentation&.sorted_column
-      export.key = Export.generate_cache_key(export.groupe_instructeurs.map(&:id), filters, sorted_column)
+      export.key = Export.generate_cache_key(filters, sorted_column)
       export.user_profile = export.groupe_instructeurs.first&.instructeurs&.first if export.user_profile.nil?
       export.dossiers_count = 10 if !export.pending?
     end

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -63,23 +63,6 @@ RSpec.describe Export, type: :model do
     end
   end
 
-  describe '.by_key groupe_instructeurs' do
-    let!(:procedure) { create(:procedure) }
-    let!(:gi_1) { create(:groupe_instructeur, procedure: procedure, instructeurs: [create(:instructeur)]) }
-    let!(:gi_2) { create(:groupe_instructeur, procedure: procedure, instructeurs: [create(:instructeur)]) }
-    let!(:gi_3) { create(:groupe_instructeur, procedure: procedure, instructeurs: [create(:instructeur)]) }
-
-    context 'when an export is made for one groupe instructeur' do
-      let!(:export) { create(:export, groupe_instructeurs: [gi_1, gi_2]) }
-
-      it do
-        expect(Export.by_key([gi_1.id])).to be_empty
-        expect(Export.by_key([gi_2.id, gi_1.id])).to eq([export])
-        expect(Export.by_key([gi_1.id, gi_2.id, gi_3.id])).to be_empty
-      end
-    end
-  end
-
   describe '.find_or_create_fresh_export' do
     let!(:procedure) { create(:procedure) }
     let(:instructeur) { create(:instructeur) }


### PR DESCRIPTION
crisps: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_0e8fb5e5-542d-4823-a9ff-cfc7eada4746/

Le cas est le suivant :

une demarche ac deux groupes de routage A, B
un dossier dans le groupe A, l'autre dans le groupe B
un instructeur X dans les groupes AB
un instructeur Y dans le groupe B
ETQ instructeur X (dans les deux groupes), je fait une demande d'export. OK
ETQ instructeur Y, (dans le seul groupe B), je trouve l'export de X 
