### PR TITLE
ETQ Usager malvoyant, je veux que la prise de focus des tags cliquables soit visible

### DIFF
--- a/app/assets/stylesheets/combobox.scss
+++ b/app/assets/stylesheets/combobox.scss
@@ -20,6 +20,10 @@
     gap: 0.3rem;
     margin-bottom: 0.5rem;
   }
+  .fr-tag--dismiss button:focus {
+    outline: 1px solid currentColor;
+    outline-offset: -2px;
+  }
 }
 
 .fr-ds-combobox__menu {


### PR DESCRIPTION
# Après
<img width="457" height="144" alt="" src="https://github.com/user-attachments/assets/2c067821-28a1-4cc8-a276-4ca3943ec0a0" />

# Avant
<img width="434" height="151" alt="" src="https://github.com/user-attachments/assets/529bca8c-bc9a-4854-bec7-3297c9f1e0ef" />

