### PR TITLE
ETQ Instructeur : je veux identifier une demande de correction annulée

### DIFF
--- a/app/components/dossiers/message_component.rb
+++ b/app/components/dossiers/message_component.rb
@@ -21,7 +21,15 @@ class Dossiers::MessageComponent < ApplicationComponent
     return if groupe_gestionnaire || commentaire.dossier_correction.nil?
 
     if commentaire.dossier_correction.resolved?
-      helpers.correction_resolved_badge(commentaire.dossier_correction.resolved_by_modification? ? :modified : :not_modified)
+      type = if commentaire.discarded?
+        :discarded
+      elsif commentaire.dossier_correction.resolved_by_modification?
+        :modified
+      else
+        :not_modified
+      end
+
+      helpers.correction_resolved_badge(type)
     else
       helpers.pending_correction_badge(connected_user.is_a?(Instructeur) ? :for_instructeur : :for_user)
     end

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -118,8 +118,8 @@ module DossierHelper
       ))
   end
 
-  def correction_resolved_badge(change, html_class: nil)
-    tag.span(Dossier.human_attribute_name("pending_correction.#{change}"), class: ['fr-badge fr-badge--sm', html_class])
+  def correction_resolved_badge(type, html_class: nil)
+    tag.span(Dossier.human_attribute_name("pending_correction.#{type}"), class: ['fr-badge fr-badge--sm', html_class])
   end
 
   def tags_label(labels)

--- a/config/locales/models/dossier/en.yml
+++ b/config/locales/models/dossier/en.yml
@@ -27,6 +27,7 @@ en:
         for_user: "to be corrected"
         modified: "Modified file"
         not_modified: "File not modified"
+        discarded: "Correction request cancelled"
       traitement:
         state: "State"
       traitement/state:

--- a/config/locales/models/dossier/fr.yml
+++ b/config/locales/models/dossier/fr.yml
@@ -27,6 +27,7 @@ fr:
         for_user: "à corriger"
         modified: "Dossier modifié"
         not_modified: "Dossier non modifié"
+        discarded: "Demande de correction annulée"
       traitement:
         state: "État"
       traitement/state:

--- a/spec/components/dossiers/message_component_spec.rb
+++ b/spec/components/dossiers/message_component_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
       end
 
       context 'when the correction is resolved' do
-        context "when the dossier has not been modified: commentaire discarded or dossier en_instruction" do
+        context "when the dossier has not been modified due to a change en_instruction" do
           let!(:correction) { create(:dossier_correction, commentaire:, dossier:, resolved_at: 1.minute.ago) }
 
           it 'returns a badge non modifié' do
@@ -246,6 +246,19 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
           it 'returns a badge modifié' do
             correction.reload
             expect(subject).to have_text("modifié")
+          end
+        end
+
+        context "when the correction has been discarded by instructeur" do
+          let!(:correction) { create(:dossier_correction, commentaire:, dossier:, resolved_at: nil) }
+
+          before do
+            commentaire.soft_delete!
+          end
+
+          it "returns a badge correction annulée" do
+            correction.reload
+            expect(subject).to have_text("Demande de correction annulée")
           end
         end
       end


### PR DESCRIPTION
Suite de https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/12117

Résultat :
<img width="1158" height="871" alt="Capture d’écran 2025-10-30 à 18 11 23" src="https://github.com/user-attachments/assets/2d05d01f-e65c-40b5-b54a-9420a50f608d" />
