### PR TITLE
Tech: correction de l'appel en mode dégradé de l'api entreprise avec des sirets avec des espaces

### DIFF
--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -38,7 +38,7 @@ class Champs::SiretChamp < Champ
   rescue APIEntreprise::API::Error => error
     if APIEntrepriseService.service_unavailable_error?(error, target: :insee)
       update!(
-        etablissement: APIEntrepriseService.create_etablissement_as_degraded_mode(self, external_id, dossier.user&.id)
+        etablissement: APIEntrepriseService.create_etablissement_as_degraded_mode(self, external_id.delete(" "), dossier.user&.id)
       )
       Failure(retryable: true, reason: error, code: 503)
     else


### PR DESCRIPTION
devrait corriger ce [sentry](https://demarches-simplifiees.sentry.io/issues/6988425884/?environment=production&project=1429550&query=is%3Aunresolved&referrer=issue-stream)

Ce problème devrait être temporaire car une fois passé à la nouvelle architecture complètement, cad une fois le `def external_id` nettoyé, le external_id devrait automatiquement formaté par le `normalizes`