### PR TITLE
Fixe la margin bottom sur les confirmations de lecture

### DIFF
--- a/app/components/dossiers/message_component/message_component.html.haml
+++ b/app/components/dossiers/message_component/message_component.html.haml
@@ -35,7 +35,7 @@
       - if read_by_recipient?
         .flex.align-center
           = dsfr_icon('fr-icon-check-line fr-icon--sm fr-mr-1w')
-          %span.fr-text--xs.fr-text-mention--grey.font-weight-normal= t('.read_label')
+          %span.fr-text--xs.fr-text-mention--grey.font-weight-normal.fr-mb-0= t('.read_label')
       - else
         %span.fr-text--xs.fr-text-mention--grey.font-weight-normal.fr-mb-0= t('.unread_label')
 


### PR DESCRIPTION
Avant : 

<img width="1570" height="287" alt="image" src="https://github.com/user-attachments/assets/3a86106d-6d90-45f7-adc7-92f4969803d7" />

Après : 

<img width="967" height="209" alt="image" src="https://github.com/user-attachments/assets/cd08b2bb-ac0f-41b8-86d8-265241c0e5f8" />
