### PR TITLE
ETQ Usager malvoyant, je veux que les bouton de suppression soient suffisamment contrastés en mode sombre

### DIFF
--- a/app/components/editable_champ/repetition_row_component/repetition_row_component.html.haml
+++ b/app/components/editable_champ/repetition_row_component/repetition_row_component.html.haml
@@ -7,5 +7,5 @@
     = render section_component
 
   .flex.row-reverse
-    = render NestedForms::OwnedButtonComponent.new(formaction: champs_repetition_path(@dossier, @type_de_champ.stable_id, row_id:), http_method: :delete, opt: { class: "fr-btn fr-btn--sm fr-btn--tertiary fr-text-action-high--red-marianne utils-repetition-required-destroy-button", title: t(".delete_title", row_number:), "aria-label": t(".delete_label", row_number:)}) do
+    = render NestedForms::OwnedButtonComponent.new(formaction: champs_repetition_path(@dossier, @type_de_champ.stable_id, row_id:), http_method: :delete, opt: { class: "fr-btn fr-btn--sm fr-btn--tertiary fr-icon-delete-bin-line fr-btn--icon-left utils-repetition-required-destroy-button", title: t(".delete_title", row_number:), "aria-label": t(".delete_label", row_number:)}) do
       = t(".delete")


### PR DESCRIPTION
ping @marleneklok 

# Après
<img width="1203" height="425" alt="" src="https://github.com/user-attachments/assets/c667ec0f-8d09-4f88-9fa0-5f5bb5eaa7db" />
<img width="1194" height="426" alt="" src="https://github.com/user-attachments/assets/17388202-e73f-4115-9cb8-46494c9c7d52" />

# Avant
<img width="1201" height="423" alt="" src="https://github.com/user-attachments/assets/2eec4a14-5769-4e94-8536-5f69c086d194" />
<img width="1192" height="424" alt="" src="https://github.com/user-attachments/assets/3881d506-6695-4870-a2e4-6c00fbe838a4" />

_Note_ : Actuellement, le contraste n'est pas assuré sur les boutons survolés en mode sombre.   
[Le problème a été signalé au DSFR](https://github.com/GouvernementFR/dsfr/issues/1324).