### PR TITLE
Tech: auth l'admin avant de récupérer ses tokens dans le controller API tokens

### DIFF
--- a/app/controllers/administrateurs/api_tokens_controller.rb
+++ b/app/controllers/administrateurs/api_tokens_controller.rb
@@ -4,7 +4,6 @@ module Administrateurs
   class APITokensController < AdministrateurController
     include ActionView::RecordIdentifier
 
-    before_action :authenticate_administrateur!
     before_action :set_api_token, only: [:edit, :update, :destroy, :remove_procedure]
 
     def nom


### PR DESCRIPTION
fix 
https://demarches-simplifiees.sentry.io/issues/6501462853/events/2e9e477bdb13497fa76aedcc17f4bf38/

le before_action étant déjà défini dans `AdministrateurController`, le redéfinir ici le reléguait à la fin, après d'autres before_action qui ont besoin de `current_administrateur`

