### PR TITLE
ETQ Utilisateur d'un lecteur d'écran, je veux que les erreurs des champs formattés me soient restitués

### DIFF
--- a/app/components/editable_champ/formatted_component/formatted_component.html.haml
+++ b/app/components/editable_champ/formatted_component/formatted_component.html.haml
@@ -1,1 +1,1 @@
-= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, placeholder: @champ.formatted_advanced? ? @champ.expression_reguliere_exemple_text : nil, required: @champ.required?, aria: { describedby: @champ.describedby_id }))
+= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, placeholder: @champ.formatted_advanced? ? @champ.expression_reguliere_exemple_text : nil, required: @champ.required?, aria: { describedby: "#{@champ.describedby_id} #{@champ.error_id}" }))


### PR DESCRIPTION
Fix l'issue https://github.com/demarches-simplifiees/demarches-simplifiees.fr/issues/12139

# Après
<img width="1408" height="789" alt="" src="https://github.com/user-attachments/assets/74f3c2bf-7f3b-4aab-89fd-a0d23da3ac7d" />

# Avant
<img width="1388" height="883" alt="" src="https://github.com/user-attachments/assets/49daa24d-14ac-45d1-930d-d2c3fe13bcd9" />
