### PR TITLE
Tech: supprime un ancien callback agent_connect maintenant obsolète

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,8 +208,6 @@ Rails.application.routes.draw do
   get 'pro_connect' => 'pro_connect#index'
   get 'pro_connect/login' => 'pro_connect#login'
   get 'pro_connect/callback' => 'pro_connect#callback'
-  # to be migrated
-  get 'agent_connect/callback' => 'pro_connect#callback'
 
   namespace :champs do
     post ':dossier_id/:stable_id/repetition', to: 'repetition#add', as: :repetition


### PR DESCRIPTION
tous les callbacks utilisent maintenant le préfixe `pro_connect`