### PR TITLE
correctif: ETQ instructeur en provenance de demarches.numerique.gouv.fr j'aimerais pouvoir utiliser le lien de connexion sécurisé

### DIFF
--- a/app/mailers/concerns/mailer_defaults_configurable_concern.rb
+++ b/app/mailers/concerns/mailer_defaults_configurable_concern.rb
@@ -27,11 +27,15 @@ module MailerDefaultsConfigurableConcern
     before_action :set_currents_for_legacy
     after_action -> { self.class.reset_original_defaults }
 
-    def configure_defaults_for_user(user)
+    def configure_defaults_for_user(user, forced_domain = nil)
       return if !user.is_a?(User) # not for super-admins
 
       if user.preferred_domain_demarches_numerique_gouv_fr?
         set_currents_for_demarches_numerique_gouv_fr
+      elsif forced_domain == ApplicationHelper::APP_HOST
+        set_currents_for_demarches_numerique_gouv_fr
+      elsif forced_domain == ApplicationHelper::APP_HOST_LEGACY
+        set_currents_for_legacy
       else
         set_currents_for_legacy
       end

--- a/app/mailers/instructeur_mailer.rb
+++ b/app/mailers/instructeur_mailer.rb
@@ -35,14 +35,14 @@ class InstructeurMailer < ApplicationMailer
     mail(to: recipient.email, subject: subject)
   end
 
-  def send_login_token(instructeur, login_token)
+  def send_login_token(instructeur, login_token, host = nil)
     @instructeur = instructeur
     @login_token = login_token
     subject = "Connexion sécurisée à #{Current.application_name}"
 
     bypass_unverified_mail_protection!
 
-    configure_defaults_for_user(instructeur.user)
+    configure_defaults_for_user(instructeur.user, host)
     mail(to: instructeur.email, subject: subject)
   end
 

--- a/app/models/concerns/trusted_device_concern.rb
+++ b/app/models/concerns/trusted_device_concern.rb
@@ -26,7 +26,7 @@ module TrustedDeviceConcern
   def send_login_token_or_bufferize(instructeur)
     if !instructeur.young_login_token?
       token = instructeur.create_trusted_device_token
-      InstructeurMailer.send_login_token(instructeur, token).deliver_later
+      InstructeurMailer.send_login_token(instructeur, token, Current.host).deliver_later
       true
     else
       false

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -349,7 +349,7 @@ describe Users::SessionsController, type: :controller do
 
     context 'when the instructeur is signed without trust_device_token' do
       it 'send InstructeurMailer.send_login_token' do
-        expect(InstructeurMailer).to receive(:send_login_token).with(instructeur, anything).and_return(double(deliver_later: true))
+        expect(InstructeurMailer).to receive(:send_login_token).with(instructeur, anything, anything).and_return(double(deliver_later: true))
         expect { subject }.to change { instructeur.trusted_device_tokens.count }.by(1)
       end
     end
@@ -368,7 +368,7 @@ describe Users::SessionsController, type: :controller do
         travel_to 15.minutes.from_now
       end
       it 'send InstructeurMailer.send_login_token' do
-        expect(InstructeurMailer).to receive(:send_login_token).with(instructeur, anything).and_return(double(deliver_later: true))
+        expect(InstructeurMailer).to receive(:send_login_token).with(instructeur, anything, anything).and_return(double(deliver_later: true))
         expect { subject }.to change { instructeur.trusted_device_tokens.count }.by(1)
       end
     end

--- a/spec/mailers/instructeur_mailer_spec.rb
+++ b/spec/mailers/instructeur_mailer_spec.rb
@@ -40,6 +40,29 @@ RSpec.describe InstructeurMailer, type: :mailer do
         expect { subject.deliver_later }.to have_enqueued_job.on_queue(Rails.application.config.action_mailer.deliver_later_queue_name)
       end
     end
+
+    context 'without given host' do
+      let(:host) { ApplicationHelper::APP_HOST }
+
+      subject { described_class.send_login_token(user, token) }
+
+      it { expect(subject.body).to include(ApplicationHelper::APP_HOST_LEGACY) }
+    end
+
+    context 'with given host as APP_HOST' do
+      let(:host) { ApplicationHelper::APP_HOST }
+
+      subject { described_class.send_login_token(user, token, host) }
+
+      it { expect(subject.body).to include("demarches.numerique.gouv.fr") }
+    end
+    context 'with given host as APP_HOST_LEGACY' do
+      let(:host) { ApplicationHelper::APP_HOST_LEGACY }
+
+      subject { described_class.send_login_token(user, token, host) }
+
+      it { expect(subject.body).to include(host) }
+    end
   end
 
   describe '#trusted_device_token_renewal' do


### PR DESCRIPTION
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_2654fe11-aea3-40ba-b606-3bda8c32a2e8/

# problème

on perd l'host sur le lien de connexion sécurisé (depuis demarches.numerique.gouv.fr, mon lien de connexion sécurisé pointe sur demarches-simplifiees.fr), nos instructeurs se retrouvent donc dans une sorte de boucle infinie sur demarches.numerique.gouv.fr)

# solution 

pour le moment on fwd le domaine dans la stack d'envoie d'email

# a discuter : 

et si ? et si ? on serrait le `users.preferred_domain` after_sign in ? j'aimerais refacto les "callbacks" entre device/oidc pour les centraliser dans un seul endroit. Ca touche des trucs flacky de l'app : 
- `users.verified_email_at` (qui a pu planter a différents moments car on l'avait oublié)
- lier les nouveaux comptes aux invitations précédement envoyées (pareil, ça a pu planter à differents moments)
- `users.loged_in_with_france_connect` p-e faudrait revoir ça non ?