### PR TITLE
Correction : ETQ instructeur je n'ai pas d'export pdf du dossier si je l'ai décoché du modèle d'export

### DIFF
--- a/app/models/export_template.rb
+++ b/app/models/export_template.rb
@@ -59,7 +59,7 @@ class ExportTemplate < ApplicationRecord
   end
 
   def attachment_path(dossier, attachment, index: 0, row_index: nil, champ: nil)
-    file_path = if attachment.name == 'pdf_export_for_instructeur'
+    file_path = if attachment.name == 'pdf_export_for_instructeur' && export_pdf.enabled?
       export_pdf.path(dossier, attachment:)
     elsif attachment.record_type == 'Attestation' && attestation&.enabled?
       attestation.path(dossier, attachment:)

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -31,6 +31,7 @@ class PiecesJustificativesService
 
   def generate_dossiers_export(dossiers) # TODO: renommer generate_dossier_export sans s
     return [] if dossiers.empty?
+    return [] if @export_template && !@export_template.export_pdf.enabled?
 
     pdfs = []
 

--- a/spec/models/export_template_spec.rb
+++ b/spec/models/export_template_spec.rb
@@ -47,6 +47,16 @@ describe ExportTemplate do
       it 'gives absolute filename for export of specific dossier' do
         expect(export_template.attachment_path(dossier, attachment)).to eq("DOSSIER-#{dossier.id}/mon_export-#{dossier.id}.pdf")
       end
+
+      context 'when export pdf is disabled' do
+        let(:export_template) do
+          build(:export_template, groupe_instructeur:, dossier_folder: ExportItem.default(prefix: "DOSSIER"), export_pdf: ExportItem.default(prefix: "mon_export", enabled: false))
+        end
+
+        it 'returns nil' do
+          expect(export_template.attachment_path(dossier, attachment)).to be_nil
+        end
+      end
     end
 
     context 'for pj' do

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -489,6 +489,14 @@ describe PiecesJustificativesService do
       it 'gives custom name to export pdf file' do
         expect(subject.first.second).to eq "DOSSIER-#{dossier.id}/export-#{dossier.id}.pdf"
       end
+
+      context 'when export pdf is disabled' do
+        let(:export_template) { create(:export_template, groupe_instructeur:, export_pdf: ExportItem.default(prefix: 'export', enabled: false)) }
+
+        it 'does not export pdf' do
+          expect(subject).to be_empty
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Suite a un retour au support : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_560862f4-6c1b-42fd-aff6-e35dfc799ef8/