### PR TITLE
ETQ utilisateur de l'api, je ne veux pas que ça plante si un champ entier contient une valeur supérieur à max int 

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -3522,7 +3522,7 @@ type IntegerColumn implements Column {
   La valeur de la colonne sous forme texte.
   """
   stringValue: String
-  value: Int
+  value: BigInt
 }
 
 type IntegerNumberChamp implements Champ {

--- a/app/graphql/types/columns/integer_column_type.rb
+++ b/app/graphql/types/columns/integer_column_type.rb
@@ -4,7 +4,7 @@ module Types::Columns
   class IntegerColumnType < Types::BaseObject
     implements Types::ColumnType
 
-    field :value, Int, null: true, extras: [:parent]
+    field :value, GraphQL::Types::BigInt, null: true, extras: [:parent]
 
     def value(parent:)
       object.value(parent)

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -169,7 +169,7 @@ describe API::V2::GraphqlController do
           expect(columns.size).to eq(17)
 
           expect(columns[0]).to include(label: "label text", value: 'text')
-          expect(columns[1]).to include(label: "label integer_number", value: 42)
+          expect(columns[1]).to include(label: "label integer_number", value: "42")
           expect(columns[2]).to include(label: "label decimal_number", value: 42.1)
           expect(columns[3]).to include(label: "label checkbox", value: true)
           expect(columns[4][:value].first).to include(__typename: "File", filename: "toto.txt", contentType: "text/plain")

--- a/spec/graphql/dossier_spec.rb
+++ b/spec/graphql/dossier_spec.rb
@@ -313,6 +313,33 @@ RSpec.describe Types::DossierType, type: :graphql do
     }
   end
 
+  describe 'dossier with large integer in columns' do
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ libelle: 'Montant', type: :integer_number }]) }
+    let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure: procedure) }
+    let(:query) { DOSSIER_WITH_INTEGER_COLUMNS_QUERY }
+    let(:variables) { { number: dossier.id } }
+    let(:large_integer) { 3400936534933 }
+
+    before do
+      integer_champ = dossier.project_champs_public.first
+      integer_champ.update(value: large_integer.to_s)
+    end
+
+    it 'handles large integers in columns without error' do
+      expect(errors).to be_nil
+      expect(data[:dossier][:champs].first).not_to be_nil
+
+      # Verify the large integer is returned correctly in the columns field
+      integer_champ = data[:dossier][:champs].first
+      expect(integer_champ[:columns]).not_to be_empty
+
+      integer_column = integer_champ[:columns].find { |col| col[:__typename] == 'IntegerColumn' }
+      expect(integer_column).not_to be_nil
+      # BigInt values are returned as strings to avoid precision loss in JavaScript
+      expect(integer_column[:value]).to eq(large_integer.to_s)
+    end
+  end
+
   describe 'dossier with titre identite filled' do
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :titre_identite }]) }
     let(:dossier) { create(:dossier, :accepte, :with_populated_champs, procedure: procedure) }
@@ -596,6 +623,23 @@ RSpec.describe Types::DossierType, type: :graphql do
         ... on RepetitionChamp {
           rows {
             champs { id }
+          }
+        }
+      }
+    }
+  }
+  GRAPHQL
+
+  DOSSIER_WITH_INTEGER_COLUMNS_QUERY = <<-GRAPHQL
+  query($number: Int!) {
+    dossier(number: $number) {
+      champs {
+        id
+        columns {
+          __typename
+          label
+          ... on IntegerColumn {
+            value
           }
         }
       }


### PR DESCRIPTION
Remonté au support : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_f5bda121-ff9e-42e6-89bc-458c9bb4efcc/

et sur sentry : https://demarches-simplifiees.sentry.io/issues/6994352995/?project=1429550