### PR TITLE
ETQ administrateur lorsque je clone une démarche, les tampons d'attestation des groupes instructeurs sont conservés

### DIFF
--- a/app/services/clone_pieces_justificatives_service.rb
+++ b/app/services/clone_pieces_justificatives_service.rb
@@ -17,6 +17,8 @@ class ClonePiecesJustificativesService
     when Etablissement
       clone_one_attachment(original, kopy, :entreprise_attestation_sociale)
       clone_one_attachment(original, kopy, :entreprise_attestation_fiscale)
+    when GroupeInstructeur
+      clone_one_attachment(original, kopy, :signature)
     end
   end
 

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -790,6 +790,13 @@ describe Administrateurs::ProceduresController, type: :controller do
       procedure.groupe_instructeurs.each { |gi| gi.update!(contact_information: create(:contact_information)) }
       procedure.active_revision.update(ineligibilite_rules:, ineligibilite_message:, ineligibilite_enabled:)
 
+      procedure.defaut_groupe_instructeur.signature.attach(
+        io: StringIO.new("signature"),
+        filename: "signature.png",
+        content_type: "image/png",
+        metadata: { virus_scan_result: ActiveStorage::VirusScanner::SAFE }
+      )
+
       response = Typhoeus::Response.new(code: 200, body: 'Hello world')
       Typhoeus.stub(/active_storage\/disk/).and_return(response)
     end
@@ -884,6 +891,7 @@ describe Administrateurs::ProceduresController, type: :controller do
           expect(Procedure.last.labels).not_to be_blank
           expect(Procedure.last.labels.first.procedure_id).to eq(Procedure.last.id)
           expect(Procedure.last.libelle).to eq 'Démarche avec un nouveau nom'
+          expect(Procedure.last.defaut_groupe_instructeur.signature.attached?).to be_truthy
         end
       end
 
@@ -950,6 +958,7 @@ describe Administrateurs::ProceduresController, type: :controller do
           expect(Procedure.last.experts_require_administrateur_invitation).to be_falsey
           expect(Procedure.last.experts).to be_blank
           expect(Procedure.last.labels).to be_blank
+          expect(Procedure.last.defaut_groupe_instructeur.signature.attached?).to be_falsey
         end
       end
     end


### PR DESCRIPTION
On avait repéré qu'il manquait ça en faisant la PR sur l'ajout de l'attestation de refus