### PR TITLE
Tech: supprime la conf PRO_CONNECT_GOUV dédiée

### DIFF
--- a/app/services/pro_connect_service.rb
+++ b/app/services/pro_connect_service.rb
@@ -56,11 +56,11 @@ class ProConnectService
   # TODO: remove this block when migration to new domain is done
   def self.conf
     if Current.host.end_with?('demarches.numerique.gouv.fr')
-      h = PRO_CONNECT_GOUV.dup
+      h = PRO_CONNECT.dup
       h[:redirect_uri] = h[:redirect_uri].gsub('demarche.numerique', 'demarches.numerique')
       h
     elsif Current.host.end_with?('demarche.numerique.gouv.fr')
-      h = PRO_CONNECT_GOUV.dup
+      h = PRO_CONNECT.dup
       h[:redirect_uri] = h[:redirect_uri].gsub('demarches.numerique', 'demarche.numerique')
       h
     else

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -41,11 +41,6 @@ RNF_TOKEN=""
 # PRO_CONNECT_BASE_URL=""
 # PRO_CONNECT_REDIRECT=""
 
-# useful when migrating to gouv domain
-# PRO_CONNECT_GOUV_ID=""
-# PRO_CONNECT_GOUV_SECRET=""
-# PRO_CONNECT_GOUV_REDIRECT=""
-
 # Certigna usage
 # CERTIGNA_ENABLED="disabled" # "enabled" by default
 


### PR DESCRIPTION
pro_connect now support multiple callbacks, so we use the same conf for all the domains