### PR TITLE
ETQ instructeur, j'identifie plus facilement que je peux prévisualiser l'attestation (d'acceptation / de refus) lorsque j'accepte / refuse un dossier

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -204,7 +204,7 @@
   z-index: 11;
   list-style: none;
 
-  a {
+  a:not(.fr-notice__link) {
     background-image: none; // remove DSFR underline
   }
 

--- a/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
@@ -3,20 +3,22 @@
     - if title == 'Accepter'
       = text_area :dossier, :motivation, class: 'fr-input', placeholder: placeholder, required: false
       - if dossier.attestation_acceptation_template&.activated?
-        %p.help
-          L’acceptation du dossier envoie automatiquement
-          = link_to 'une attestation', apercu_attestation_instructeur_dossier_path(dossier.procedure, dossier, attestation_kind: AttestationTemplate.kinds.fetch(:acceptation)), target: '_blank', rel: 'noopener', title: "Voir l'attestation qui sera envoyée à l'usager"
-          à l'usager.
+        = render Dsfr::NoticeComponent.new(closable: false, data_attributes: { class: 'fr-my-2w' }) do |c|
+          - c.with_title do
+            L’acceptation du dossier envoie automatiquement une attestation à l’usager
+          - c.with_link do
+            = link_to 'Prévisualiser l’attestation', apercu_attestation_instructeur_dossier_path(dossier.procedure, dossier, attestation_kind: AttestationTemplate.kinds.fetch(:acceptation)), class: 'fr-notice__link', **external_link_attributes, title: "Voir l’attestation qui sera envoyée à l'usager"
 
       = render partial: 'instructeurs/dossiers/unspecified_champs', locals: { unspecified_attestation_champs: dossier.unspecified_attestation_champs(AttestationTemplate.kinds.fetch(:acceptation)) }
 
     - elsif title == 'Refuser'
       = text_area :dossier, :motivation, class: 'fr-input', placeholder: placeholder, required: true
       - if dossier.attestation_refus_template&.activated?
-        %p.help
-          Le refus du dossier envoie automatiquement
-          = link_to 'une attestation', apercu_attestation_instructeur_dossier_path(dossier.procedure, dossier, attestation_kind: AttestationTemplate.kinds.fetch(:refus)),  target: '_blank', rel: 'noopener', title: "Voir l'attestation qui sera envoyée à l'usager"
-          à l'usager.
+        = render Dsfr::NoticeComponent.new(closable: false, data_attributes: { class: 'fr-my-2w' }) do |c|
+          - c.with_title do
+            Le refus du dossier envoie automatiquement une attestation à l’usager
+          - c.with_link do
+            = link_to 'Prévisualiser l’attestation', apercu_attestation_instructeur_dossier_path(dossier.procedure, dossier, attestation_kind: AttestationTemplate.kinds.fetch(:refus)), class: 'fr-notice__link', **external_link_attributes, title: "Voir l’attestation qui sera envoyée à l'usager"
 
       = render partial: 'instructeurs/dossiers/unspecified_champs', locals: { unspecified_attestation_champs: dossier.unspecified_attestation_champs(AttestationTemplate.kinds.fetch(:refus)) }
 


### PR DESCRIPTION
closes #12220 

# AVANT

![Capture d’écran 2025-11-10 à 10 01 22](https://github.com/user-attachments/assets/004d17ca-96ab-4dc6-86f1-ee4ca70c35ce)


# APRÈS

![Capture d’écran 2025-11-10 à 10 00 47](https://github.com/user-attachments/assets/2cef37ec-99ed-4925-ae15-14ebc41d1fe8)

