### PR TITLE
ETQ Instructeur, dans les filtres quand je clique sur un radio button, il se selectionne bien.

### DIFF
--- a/app/components/dsfr/radio_button_list_component.rb
+++ b/app/components/dsfr/radio_button_list_component.rb
@@ -23,4 +23,10 @@ class Dsfr::RadioButtonListComponent < ApplicationComponent
       yield(*button.values_at(:label, :value, :hint, :tooltip), **button.merge!(index:).except(:label, :value, :hint, :tooltip))
     end
   end
+
+  def label_options(button_options)
+    {
+      for: button_options[:id],
+    }.compact
+  end
 end

--- a/app/components/dsfr/radio_button_list_component/radio_button_list_component.html.haml
+++ b/app/components/dsfr/radio_button_list_component/radio_button_list_component.html.haml
@@ -5,7 +5,7 @@
     .fr-fieldset__element{ class: ("fr-fieldset__element--inline" if @inline) }
       .fr-radio-group
         = @form.radio_button @target, value, **button_options.except(:index)
-        = @form.label @target, value: value, class: 'fr-label' do
+        = @form.label @target, value: value, class: 'fr-label', **label_options(button_options) do
           - capture do
             = label
 

--- a/app/components/instructeurs/column_filter_value_component.rb
+++ b/app/components/instructeurs/column_filter_value_component.rb
@@ -53,7 +53,15 @@ class Instructeurs::ColumnFilterValueComponent < ApplicationComponent
   end
 
   def radio_button_options
-    column_filter_options.map { |opt_label, opt_value| { label: opt_label, value: opt_value, checked: opt_value.to_s.in?(value), data: { turbo_force: :server } } }
+    column_filter_options.map.with_index do |(opt_label, opt_value)|
+      {
+        label: opt_label,
+        value: opt_value,
+        checked: opt_value.to_s.in?(value),
+        id: input_id(value: opt_value),
+        data: { turbo_force: :server },
+      }
+    end
   end
 
   def date_filter_options
@@ -94,8 +102,8 @@ class Instructeurs::ColumnFilterValueComponent < ApplicationComponent
     }
   end
 
-  def input_id
-    "value_#{filtered_column&.id&.parameterize}"
+  def input_id(value: nil)
+    ["value", filtered_column&.id&.parameterize, value].compact.join('_')
   end
 
   private

--- a/spec/components/instructeurs/column_filter_value_component_spec.rb
+++ b/spec/components/instructeurs/column_filter_value_component_spec.rb
@@ -47,8 +47,8 @@ describe Instructeurs::ColumnFilterValueComponent, type: :component do
       let(:mandatory) { true }
       it do
         expect(page).to have_selector('input[name="filter[filter][value][]"][type="radio"]', count: 2)
-        expect(page).to have_selector('label[for="filter[filter][value][]_true"]', text: 'oui')
-        expect(page).to have_selector('label[for="filter[filter][value][]_false"]', text: 'non')
+        expect(page).to have_selector('label[for="value_filter-operator-match-value-value_true"]', text: 'oui')
+        expect(page).to have_selector('label[for="value_filter-operator-match-value-value_false"]', text: 'non')
       end
     end
 
@@ -57,9 +57,9 @@ describe Instructeurs::ColumnFilterValueComponent, type: :component do
 
       it do
         expect(page).to have_selector('input[name="filter[filter][value][]"][type="radio"]', count: 3)
-        expect(page).to have_selector('label[for="filter[filter][value][]_true"]', text: 'oui')
-        expect(page).to have_selector('label[for="filter[filter][value][]_false"]', text: 'non')
-        expect(page).to have_selector('label[for="filter[filter][value][]_nil"]', text: 'Non renseigné')
+        expect(page).to have_selector('label[for="value_filter-operator-match-value-value_true"]', text: 'oui')
+        expect(page).to have_selector('label[for="value_filter-operator-match-value-value_false"]', text: 'non')
+        expect(page).to have_selector('label[for="value_filter-operator-match-value-value_nil"]', text: 'Non renseigné')
       end
     end
   end
@@ -72,8 +72,8 @@ describe Instructeurs::ColumnFilterValueComponent, type: :component do
 
       it do
         expect(page).to have_selector('input[name="filter[filter][value][]"][type="radio"]', count: 2)
-        expect(page).to have_selector('label[for="filter[filter][value][]_true"]', text: 'coché')
-        expect(page).to have_selector('label[for="filter[filter][value][]_false"]', text: 'non coché')
+        expect(page).to have_selector('label[for="value_filter-operator-match-value-value_true"]', text: 'coché')
+        expect(page).to have_selector('label[for="value_filter-operator-match-value-value_false"]', text: 'non coché')
       end
     end
 
@@ -82,8 +82,8 @@ describe Instructeurs::ColumnFilterValueComponent, type: :component do
 
       it do
         expect(page).to have_selector('input[name="filter[filter][value][]"][type="radio"]', count: 2)
-        expect(page).to have_selector('label[for="filter[filter][value][]_true"]', text: 'coché')
-        expect(page).to have_selector('label[for="filter[filter][value][]_false"]', text: 'non coché')
+        expect(page).to have_selector('label[for="value_filter-operator-match-value-value_true"]', text: 'coché')
+        expect(page).to have_selector('label[for="value_filter-operator-match-value-value_false"]', text: 'non coché')
       end
     end
   end


### PR DESCRIPTION
Correction : les ID des boutons radio n'étaient pas uniques lorsque plusieurs filtres radio étaient affichés, empêchant leur sélection correcte.