### PR TITLE
correctif ETQ instructeur, j'aimerais visualiser les etablissements d'un dossier dans le cas d'un bad data

### DIFF
--- a/app/tasks/maintenance/t20251112backfill_champ_siret_external_state_with_etablissement_but_no_value_or_external_id_task.rb
+++ b/app/tasks/maintenance/t20251112backfill_champ_siret_external_state_with_etablissement_but_no_value_or_external_id_task.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20251112backfillChampSiretExternalStateWithEtablissementButNoValueOrExternalIdTask < MaintenanceTasks::Task
+    # Documentation: cette tâche modifie les données pour…
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    # Uncomment only if this task MUST run imperatively on its first deployment.
+    # If possible, leave commented for manual execution later.
+    # run_on_first_deploy
+
+    def collection
+      Champs::SiretChamp.in_batches
+    end
+
+    def process(batch)
+      Champs::SiretChamp
+        .includes(:etablissement)
+        .where(
+          id: batch.ids,
+          value: nil,
+          external_id: nil,
+          external_state: :fetched
+        )
+        .find_each do |champ|
+          champ.update_columns(
+            value: champ.etablissement.siret,
+            external_id: champ.etablissement.siret
+          )
+        end
+    end
+
+    def count
+      # noop
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20251112backfill_champ_siret_external_state_with_etablissement_but_no_value_or_external_id_task_spec.rb
+++ b/spec/tasks/maintenance/t20251112backfill_champ_siret_external_state_with_etablissement_but_no_value_or_external_id_task_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20251112backfillChampSiretExternalStateWithEtablissementButNoValueOrExternalIdTask do
+    describe "#process" do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
+      let(:etablissement) { create(:etablissement, siret: "44011762001530") }
+      let(:dossier) { create(:dossier, :with_populated_champs, procedure:, etablissement:) }
+      let(:champ) { dossier.project_champs_public.first }
+
+      subject(:process) { described_class.process(Champs::SiretChamp.all) }
+
+      before do
+        champ.update_columns(etablissement_id: etablissement.id, value: nil, external_id: nil, external_state: :fetched)
+      end
+
+      context 'when champ has an etablissement' do
+        it 'backfills the value and external_id with etablissement siret' do
+          expect { subject }.to change { champ.reload.value }.from(nil).to(etablissement.siret)
+          expect(champ.external_id).to eq(etablissement.siret)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_63721902-dc36-4486-a9fa-07051b22e215/

PS:
j'avais une autre option, plus performante mais j'ai trouvé ça bcp moins lisible : 

```ruby
def process(batch)
      # Use raw SQL with UPDATE ... FROM to reference joined table safely
      ids = batch.ids
      fetched_state = Champs::SiretChamp.external_states[:fetched]
      conn = ApplicationRecord.connection

      sql = <<~SQL
        UPDATE champs
        SET value = etablissements.siret,
            external_id = etablissements.siret
        FROM etablissements
        WHERE champs.etablissement_id = etablissements.id
          AND champs.id = ANY(ARRAY[#{ids.join(',')}])
          AND champs.value IS NULL
          AND champs.external_id IS NULL
          AND champs.external_state = #{conn.quote(fetched_state)}
          AND champs.type = #{conn.quote('Champs::SiretChamp')}
      SQL

      conn.execute(sql)
    end
```