### PR TITLE
Fix - sentry : lorsqu'un admin supprime des options primaires d'une liste liée, on réinitialise les valeurs si l'usager modifie

### DIFF
--- a/app/models/champs/linked_drop_down_list_champ.rb
+++ b/app/models/champs/linked_drop_down_list_champ.rb
@@ -29,7 +29,7 @@ class Champs::LinkedDropDownListChamp < Champ
   end
 
   def secondary_value=(value)
-    new_secondary_value = secondary_options[primary_value].include?(value) ? value : ""
+    new_secondary_value = secondary_options[primary_value]&.include?(value) ? value : ""
     pack_value(primary_value, new_secondary_value)
   end
 

--- a/spec/models/champs/linked_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/linked_drop_down_list_champ_spec.rb
@@ -54,6 +54,16 @@ describe Champs::LinkedDropDownListChamp do
       champ.secondary_value = '22'
       expect(champ.value).to eq('["1",""]')
     }
+
+    context "when an administrateur has deleted the primary value" do
+      let(:options) { ["--1--", "11", "0", "--2--", "22", "0"] }
+      let(:value) { '["3", "33"]' }
+
+      it {
+        champ.secondary_value = 'O'
+        expect(champ.value).to eq('["",""]')
+      }
+    end
   end
 
   describe '#to_s' do


### PR DESCRIPTION
sentry : https://demarches-simplifiees.sentry.io/issues/6941193115/events/latest/?project=1429550&query=is%3Aunresolved&referrer=latest-event

Le bug :
- on a un formulaire avec une linked drop down list ;
- un usager renseigne ce champ ;
- l'admin supprime des options primaires du champ que l'usager avait saisi dans son dossier ;
- l'usager revient sur son dossier, et modifie que la valeur secondaire, en ayant toujours la même valeur primaire (celle supprimée) 