### PR TITLE
ETQ Instructeur si mon jeton de connexion est expiré je peux demander à me faire renvoyer un jeton par email

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -30,7 +30,7 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def reset_link_sent
-    instructeur = instructeur_from_signed_email(params[:email])
+    instructeur = instructeur_from_signed_email(params[:signed_email])
 
     if instructeur.nil?
       redirect_to new_user_session_path, alert: t('devise.failure.unauthenticated')

--- a/app/views/users/sessions/link_sent.html.haml
+++ b/app/views/users/sessions/link_sent.html.haml
@@ -18,7 +18,7 @@
     %p.fr-text--sm.fr-text-mention--grey.fr-mb-1w
       = t('views.confirmation.new.email_missing')
 
-    = button_to instructeurs_reset_link_sent_path(email: @signed_email), class: 'fr-btn fr-btn--secondary', method: 'POST' do
+    = button_to instructeurs_reset_link_sent_path(signed_email: @signed_email), class: 'fr-btn fr-btn--secondary', method: 'POST' do
       = t('views.confirmation.new.resent')
 
     %p.fr-text--sm.fr-text-mention--grey.fr-mt-3w

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -351,7 +351,7 @@ describe Users::SessionsController, type: :controller do
       let(:signed_email) do
         controller.message_encryptor_service.encrypt_and_sign(instructeur.email, purpose: :reset_link)
       end
-      let(:params) { { email: signed_email } }
+      let(:params) { { signed_email: } }
 
       before do
         allow(controller).to receive(:signed_email_for_instructeur)


### PR DESCRIPTION
Sentry : https://demarches-simplifiees.sentry.io/issues/6912577971/events/?project=1429550&query=is%3Aunresolved&referrer=issue-stream

Lorsqu'un lien de connexion sécurisé expiré est utilisé, l’utilisateur n’est pas connecté et est redirigé vers la page /lien-envoye. S’il clique ensuite sur "Renvoyer un email de confirmation", l’action `Users::SessionsController#reset_link_sent` est appelée sans current_instructeur et ça fait des chocapics (`undefined method 'young_login_token?' for nil`).

<img width="722" height="623" alt="Capture d’écran 2025-11-13 à 18 55 16" src="https://github.com/user-attachments/assets/4414e21c-b13a-49f7-ac49-30e306d58d54" />
