### PR TITLE
ETQ Tech je veux moins d'erreurs lors des appels à l'api Adresse

### DIFF
--- a/app/components/editable_champ/address_component.rb
+++ b/app/components/editable_champ/address_component.rb
@@ -19,7 +19,7 @@ class EditableChamp::AddressComponent < EditableChamp::EditableChampBaseComponen
       selected_key: @champ.selected_key,
       items: @champ.selected_items,
       loader: data_sources_data_source_adresse_path,
-      minimum_input_length: 2,
+      minimum_input_length: 3,
       translations: {
         search_error:,
       },

--- a/spec/controllers/data_sources/adresse_controller_spec.rb
+++ b/spec/controllers/data_sources/adresse_controller_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe DataSources::AdresseController, type: :controller do
+  describe "#clean_query" do
+    subject(:clean_query) { controller.send(:clean_query, input) }
+
+    context "when the query is valid but needs formatting" do
+      let(:input) { "   123    rue  de   Paris   " }
+
+      it "strips, collapses spaces, and returns the sanitized query" do
+        expect(clean_query).to eq("123 rue de Paris")
+      end
+    end
+
+    context "when the query starts with non alphanumeric characters" do
+      let(:input) { "###Rue de la Paix" }
+
+      it "removes the leading characters before returning" do
+        expect(clean_query).to eq("Rue de la Paix")
+      end
+    end
+
+    context "when the sanitized query is shorter than 3 characters" do
+      let(:input) { "  a " }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the sanitized query exceeds 200 characters" do
+      let(:input) { "a" * 201 }
+
+      it "returns the first 200 characters" do
+        expect(clean_query).to eq("a" * 200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Depuis qu'on track les erreurs sur l'api adresse on rempli bien le sentry : https://demarches-simplifiees.sentry.io/issues/6963102135/

une erreur renvoyée souvent par l'api : `{"code":400,"message":"Failed parsing query","detail":["q: must contain between 3 and 200 chars and start with a number or a letter"]}`

Cette PR vérifie que la query envoyée à l'api respecte ces règles, si possible la nettoie, sinon l'appel n'est pas fait.
