### PR TITLE
Fix - sentry: je ne veux pas d'erreur pour des requetes turbo_stream sans params

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -154,7 +154,7 @@ module Users
       respond_to do |format|
         format.html
         format.turbo_stream do
-          @dossier.for_tiers = params[:dossier][:for_tiers]
+          @dossier.for_tiers = params[:dossier][:for_tiers] if params[:dossier].present?
         end
       end
     end


### PR DESCRIPTION
sentry : https://demarches-simplifiees.sentry.io/issues/6167168209/events/latest/?project=1429550&referrer=latest-event