### PR TITLE
Tech (migration domaine 4/n): page tampon de redirection demarches.numerique => demarche.numerique

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,6 +48,8 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  before_action :redirect_transitoire_domain
+
   def staging_authenticate
     # france connect sector identifier system does not support basic auth
     return if request.path == france_connect_redirect_uris_path
@@ -321,6 +323,14 @@ class ApplicationController < ActionController::Base
       send_login_token_or_bufferize(current_instructeur)
       signed_email = message_encryptor_service.encrypt_and_sign(current_instructeur.email, purpose: :reset_link, expires_in: 1.hour)
       redirect_to link_sent_path(email: signed_email)
+    end
+  end
+
+  def redirect_transitoire_domain
+    if request.host.include?('demarches.numerique.gouv.fr')
+      gon.redirect_url = "https://#{ENV['APP_HOST']}#{request.fullpath}"
+      Current.application_name = ENV["APPLICATION_NAME"] # set new logo name
+      render 'application/transitoire_redirect', layout: 'application'
     end
   end
 

--- a/app/views/application/transitoire_redirect.html.erb
+++ b/app/views/application/transitoire_redirect.html.erb
@@ -1,0 +1,65 @@
+<div class="fr-container">
+  <div
+    class="
+      fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters
+      fr-grid-row--middle fr-grid-row--center
+    "
+  >
+    <div class="fr-py-0 fr-col-12 fr-col-md-6">
+      <h1>Changement d’adresse</h1>
+
+      <p class="fr-text--lead fr-mb-3w">
+        <strong>demarches-simplifiees.fr</strong> devient
+        <strong>demarche.numerique.gouv.fr</strong>
+      </p>
+
+      <p>
+        alors que vous êtes ici sur demarcheS.numerique.gouv.fr.
+        <br>
+        (vous avez mis un <em>s</em> en trop)
+      </p>
+
+      <p class="fr-text--sm fr-mb-3w">
+        Vous serez automatiquement redirigé(e) vers le nouveau site dans
+        <span id="countdown">30</span> secondes.
+      </p>
+
+      <p class="fr-text--sm fr-mb-3w">
+        <strong>Vos identifiants restent les mêmes :</strong> vous pourrez vous
+        reconnecter avec vos identifiants habituels.
+      </p>
+
+      <p class="fr-text--sm fr-mb-3w">
+        N’oubliez pas de mettre à jour vos favoris le cas échéant pour accéder
+        directement à la nouvelle adresse à l’avenir.
+      </p>
+
+      <a class="fr-btn" href="#" id="redirect-button">
+        Accéder au nouveau site
+      </a>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    const redirectButton = document.getElementById('redirect-button');
+    redirectButton.href = gon.redirectURL;
+
+    const logoLink = document.querySelector(".fr-header__service a");
+    logoLink.href = gon.redirectURL;
+
+    // Countdown
+    let secondsLeft = 30;
+    const countdownElement = document.getElementById('countdown');
+    const interval = setInterval(function () {
+      secondsLeft--;
+      if (secondsLeft > 0) {
+        countdownElement.textContent = secondsLeft;
+      } else {
+        clearInterval(interval);
+        window.location.href = gon.redirectURL;
+      }
+    }, 1000);
+  })();
+</script>


### PR DESCRIPTION
Pour arrêter le traffic sur le domaine abandonné, on met une page pénible pour forcer les personnes habituées à ce domaine à changer leurs habitudes et à mettre à jour d'éventuels favoris.

<img width="877" height="622" alt="Capture d’écran 2025-11-20 à 09 36 23" src="https://github.com/user-attachments/assets/cc248c5c-41c7-4df1-9cd4-b3ee9b5ed654" />
