### PR TITLE
ETQ Instructeur, lorsque je recois le jeton de connexion par mail, je peux utiliser l'ancien site

### DIFF
--- a/app/views/instructeur_mailer/send_login_token.html.haml
+++ b/app/views/instructeur_mailer/send_login_token.html.haml
@@ -1,9 +1,20 @@
+-# haml-lint:disable ApplicationNameLinter
+- demarche_link = sign_in_by_link_url(@instructeur.id, jeton: @login_token, host: 'demarche.numerique.gouv.fr')
+- ds_link = sign_in_by_link_url(@instructeur.id, jeton: @login_token, host: 'www.demarches-simplifiees.fr')
+
 %p
   Bonjour,
 
 %p
   Veuillez cliquer sur le lien sécurisé suivant pour vous connecter à  #{Current.application_name} : 
-  = link_to(sign_in_by_link_url(@instructeur.id, jeton: @login_token), sign_in_by_link_url(@instructeur.id, jeton: @login_token))
+  - if ENV['APP_HOST'] == 'demarche.numerique.gouv.fr'
+    = link_to(demarche_link, demarche_link)
+
+    %p
+      En cas de difficulté, essayez l'ancienne adresse : 
+      = link_to(ds_link, ds_link)
+  - else
+    = link_to(sign_in_by_link_url(@instructeur.id, jeton: @login_token), sign_in_by_link_url(@instructeur.id, jeton: @login_token))
 
 %p
   Ce lien est
@@ -12,3 +23,4 @@
   %b plusieurs fois.
 
 = render partial: "layouts/mailers/signature"
+-# haml-lint:enable ApplicationNameLinter


### PR DESCRIPTION
avant
<img width="600" height="420" alt="Screenshot 2025-11-19 at 16-44-23 Mailer Preview for instructeur_mailer#send_login_token" src="https://github.com/user-attachments/assets/bc8e4f54-4ba5-4585-aad8-1ccb2952bcf8" />

apres

<img width="600" height="442" alt="Screenshot 2025-11-19 at 16-52-22 Mailer Preview for instructeur_mailer#send_login_token" src="https://github.com/user-attachments/assets/0515a210-f21e-4ed6-af50-38bd5b08dba3" />

on a les noms des applications qui ne collent pas encore, mais cela dépend `Current.application_name` qui est géré par ailleurs.
