### PR TITLE
ETQ usager, par d'erreur sur la page tampon demarches.numerique si on n'est pas connecté

### DIFF
--- a/app/views/application/transitoire_redirect.html.erb
+++ b/app/views/application/transitoire_redirect.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:main_navigation) do %>
+  <div></div>
+<% end %>
+
 <div class="fr-container">
   <div
     class="


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/7047441768/?project=1429550&query=is%3Aunresolved&referrer=issue-stream

le layout -> main navigation essaie de récupérer current_user qui n'existe pas forcément. Par chance on peut override facilement la navigation plutôt qu'utiliser le partial 😅 