### PR TITLE
Tech: configure toutes nos adresses d'émission d'email auto

### DIFF
--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -16,7 +16,7 @@ class Commentaire < ApplicationRecord
   normalizes :body, with: NORMALIZES_NON_PRINTABLE_PROC
 
   FILE_MAX_SIZE = 20.megabytes
-  SYSTEM_EMAILS = ["demarche.numerique.gouv.fr", "demarches.numerique.gouv.fr", CONTACT_EMAIL, OLD_CONTACT_EMAIL]
+  SYSTEM_EMAILS = [CONTACT_EMAIL, OLD_CONTACT_EMAIL.split(",")].flatten
 
   validates :piece_jointe,
     content_type: AUTHORIZED_CONTENT_TYPES,

--- a/config/initializers/contacts.rb
+++ b/config/initializers/contacts.rb
@@ -6,6 +6,8 @@ if !defined?(CONTACT_EMAIL)
   NO_REPLY_EMAIL = ENV.fetch("NO_REPLY_EMAIL", "Démarche Numérique <ne-pas-repondre@demarche.numerique.gouv.fr>")
   CONTACT_PHONE = ENV.fetch("CONTACT_PHONE", "01 76 42 02 87")
 
-  OLD_CONTACT_EMAIL = ENV.fetch("OLD_CONTACT_EMAIL", "contact@tps.apientreprise.fr")
+  # rubocop:disable DS/ApplicationName
+  OLD_CONTACT_EMAIL = ENV.fetch("OLD_CONTACT_EMAIL", "contact@tps.apientreprise.fr,contact@demarches-simplifiees.fr,contact@demarches.numerique.gouv.fr")
   CONTACT_ADDRESS = ENV.fetch("CONTACT_ADDRESS", "Incubateur de Services Numériques / beta.gouv.fr\nServices du Premier Ministre, 20 avenue de Ségur, 75007 Paris")
+  # rubocop:enable DS/ApplicationName
 end


### PR DESCRIPTION
on se sert de ces constantes:
- soit en clause `where(email:)` (donc exact match)
- soit avec un `email.include?` 

ça pourrait surement être re-harmonisé