### PR TITLE
ETQ Usager, je veux que la couleur du lien d'une alerte soit de la même couleur que le texte

### DIFF
--- a/app/assets/stylesheets/new_alert.scss
+++ b/app/assets/stylesheets/new_alert.scss
@@ -1,5 +1,4 @@
 .alert {
-  padding: 15px;
   &:before {
     margin-right: 3px;
   }

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -17,7 +17,7 @@
         <% sticky = defined?(sticky) ? sticky : false %>
         <% fixed = defined?(fixed) ? fixed : false %>
         <div
-          class="alert <%= flash_class(key, sticky: sticky, fixed: fixed) %>"
+          class="alert <%= flash_class(key, sticky: sticky, fixed: fixed) %> fr-p-2w"
           role="<%= flash_role(key) %>"
         >
           <% if value.class == Array %>


### PR DESCRIPTION
Corrige un bogue introduit par https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/12263 😞 

# Après
<img width="652" height="71" alt="" src="https://github.com/user-attachments/assets/faca4f55-0c70-4001-9775-05115c724dd9" />
<img width="622" height="71" alt="" src="https://github.com/user-attachments/assets/855bb72c-8321-4cc4-a8e0-adcf72a0dc6c" />
<img width="600" height="74" alt="" src="https://github.com/user-attachments/assets/2c33e4e2-3f2f-4072-9ca9-a965ddad302a" />
<img width="594" height="73" alt="" src="https://github.com/user-attachments/assets/e2deb8c7-84f5-4500-95b7-c4fc74013cd2" />

# Avant
<img width="1019" height="124" alt="" src="https://github.com/user-attachments/assets/0758997c-086d-4d86-85e0-e7224705fd6a" />
