### PR TITLE
ETQ instructeur je vois l'attestation du dossier dans la galerie de pièces jointes

### DIFF
--- a/app/components/attachment/gallery_item_component.rb
+++ b/app/components/attachment/gallery_item_component.rb
@@ -28,6 +28,8 @@ class Attachment::GalleryItemComponent < ApplicationComponent
       'Avis externe (instructeur)'
     in Avis if attachment.name == 'piece_justificative_file'
       'Avis externe (expert)'
+    in Attestation
+      'Attestation de décision'
     else
       if attachment.name == 'justificatif_motivation'
         'Justificatif de décision'

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -620,7 +620,12 @@ module Instructeurs
           &.attachment
           &.id
 
-        champs_attachments_ids + commentaires_attachments_ids + avis_attachments_ids + [justificatif_motivation_id]
+        attestation_id = dossier
+          .attestation
+          &.pdf
+          &.id
+
+        champs_attachments_ids + commentaires_attachments_ids + avis_attachments_ids + [justificatif_motivation_id] + [attestation_id]
       end
 
       @gallery_attachments = ActiveStorage::Attachment

--- a/app/helpers/gallery_helper.rb
+++ b/app/helpers/gallery_helper.rb
@@ -9,6 +9,10 @@ module GalleryHelper
       'Pièce jointe au message'
     in Avis
       'Pièce jointe à l’avis'
+    in Attestation if record.dossier.accepte?
+      'Attestation d’acceptation'
+    in Attestation if record.dossier.refuse?
+      'Attestation de refus'
     else
       if attachment.name == 'justificatif_motivation'
         'Pièce jointe à la décision'

--- a/app/models/concerns/blob_image_processor_concern.rb
+++ b/app/models/concerns/blob_image_processor_concern.rb
@@ -13,7 +13,7 @@ module BlobImageProcessorConcern
     end
 
     def representation_required?
-      from_champ? || from_messagerie? || logo? || from_action_text? || from_avis? || from_justificatif_motivation?
+      from_champ? || from_messagerie? || logo? || from_action_text? || from_avis? || from_justificatif_motivation? || from_attestation?
     end
 
     private
@@ -44,6 +44,10 @@ module BlobImageProcessorConcern
 
     def from_justificatif_motivation?
       attachments.any? { _1.name == 'justificatif_motivation' }
+    end
+
+    def from_attestation?
+      attachments.any? { _1.record.class == Attestation }
     end
   end
 end

--- a/spec/components/attachment/gallery_item_component_spec.rb
+++ b/spec/components/attachment/gallery_item_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Attachment::GalleryItemComponent, type: :component do
   let(:procedure) { create(:procedure, :published, types_de_champ_public:, types_de_champ_private:) }
   let(:types_de_champ_public) { [{ type: :piece_justificative }] }
   let(:types_de_champ_private) { [{ type: :piece_justificative }] }
-  let(:dossier) { create(:dossier, :with_populated_champs, :with_populated_annotations, :en_construction, procedure:) }
+  let(:dossier) { create(:dossier, :with_populated_champs, :with_populated_annotations, :with_attestation_acceptation, :accepte, procedure:) }
   let(:filename) { attachment.blob.filename.to_s }
 
   let(:component) { described_class.new(attachment:) }
@@ -108,6 +108,30 @@ RSpec.describe Attachment::GalleryItemComponent, type: :component do
       expect(subject).to have_text('Justificatif de décision')
       expect(subject).to have_link(filename)
       expect(subject).to have_text('Pièce jointe à la décision')
+    end
+  end
+
+  context "when attachment is from an acceptation attestation" do
+    let(:attestation_pdf) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
+    let(:attachment) { dossier.attestation.pdf }
+
+    it "displays a generic libelle, link, tag and renders title" do
+      expect(subject).to have_text('Attestation d’acceptation')
+      expect(subject).to have_link(filename)
+      expect(subject).to have_text('Attestation de décision')
+    end
+  end
+
+  context "when attachment is from an refus attestation" do
+    let(:attestation_pdf) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
+    let(:attachment) { dossier.attestation.pdf }
+
+    before { dossier.update!(state: :refuse) }
+
+    it "displays a generic libelle, link, tag and renders title" do
+      expect(subject).to have_text('Attestation de refus')
+      expect(subject).to have_link(filename)
+      expect(subject).to have_text('Attestation de décision')
     end
   end
 


### PR DESCRIPTION
On ajoute l'attestation d'acceptation ou de refus dans la galerie de PJs cc @marleneklok j'ai modifié la capture écran : tag générique et champ personnalisé (refus ou acceptation)

<img width="2020" height="1444" alt="Capture d’écran 2025-11-25 à 11 26 09" src="https://github.com/user-attachments/assets/fe6d8116-9d2f-453a-95b1-33190ab6e5d0" />

