### PR TITLE
ETQ Instructeur je ne veux plus d'erreur sur les filtres sur les liste déroulantes liées

### DIFF
--- a/app/models/columns/linked_drop_down_column.rb
+++ b/app/models/columns/linked_drop_down_column.rb
@@ -25,7 +25,7 @@ class Columns::LinkedDropDownColumn < Columns::ChampColumn
   def filtered_ids_for_values(dossiers, search_terms)
     relation = dossiers.with_type_de_champ(@stable_id)
 
-    search_terms = search_terms.compact.reject(&:empty?)
+    search_terms = Array(search_terms).compact.reject(&:empty?)
 
     case path
     when :value
@@ -33,7 +33,7 @@ class Columns::LinkedDropDownColumn < Columns::ChampColumn
         # when looking for "section 1 / option A",
         # the value must contain both "section 1" and "option A"
         primary, *secondary = search_term.split(%r{[[:space:]]*/[[:space:]]*})
-        safe_terms = [primary, *secondary].map { "%#{safe_like(_1)}%" }
+        safe_terms = [primary, *secondary].compact.reject(&:empty?).map { "%#{safe_like(_1)}%" }
 
         relation.where("champs.value ILIKE ALL (ARRAY[?])", safe_terms).ids
       end.uniq

--- a/spec/models/columns/linked_drop_down_column_spec.rb
+++ b/spec/models/columns/linked_drop_down_column_spec.rb
@@ -16,6 +16,20 @@ describe Columns::LinkedDropDownColumn do
       it { expect { subject }.not_to raise_error }
     end
 
+    context "when filter value is nil" do
+      let(:column) { procedure.find_column(label: 'linked') }
+      let(:search_terms) { nil }
+
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context "when filter value is missing" do
+      let(:column) { procedure.find_column(label: 'linked') }
+      subject { column.filtered_ids(Dossier.all, { operator: 'match' }) }
+
+      it { expect { subject }.not_to raise_error }
+    end
+
     context 'when path is :value' do
       let(:column) { procedure.find_column(label: 'linked') }
 
@@ -37,6 +51,11 @@ describe Columns::LinkedDropDownColumn do
         let(:search_terms) { ['section 1  /  option A'] }
 
         it { is_expected.to match_array([kept_dossier.id]) }
+      end
+      describe 'when value is malformed' do
+        let(:search_terms) { ['section 1  /'] }
+
+        it { expect { subject }.not_to raise_error }
       end
 
       describe 'when looking for the aggregated value or a common value' do


### PR DESCRIPTION
Corrige https://demarches-simplifiees.sentry.io/issues/7003343135

Si la valeur du filtre était `"a /"` quand on `split("/")` on se retrouve avec `nil` en `secondary` et ça fait boum