### PR TITLE
Correction : ETQ administrateur j'ai les bonnes informations pour ajouter des instructeurs par import csv

### DIFF
--- a/app/components/procedure/import_component/import_component.en.yml
+++ b/app/components/procedure/import_component/import_component.en.yml
@@ -6,9 +6,9 @@ en:
     file_size_limit: "File size limit : %{max_file_size}."
     groupes:
       title: Bulk Import / Export
-      notice_1_html: For the import, your csv file must have <strong>2 columns (Group, Email)</strong> (see file model below). The file size must be less than %{csv_max_size}.
+      notice_1_html: "For the import, your csv file must have 2 columns : <strong>Email</strong> and <strong>Groupe</strong>. The file size must be less than %{csv_max_size} (see model below)."
       notice_2_html: The import does not overwrite existing groups and instructors. It only allows you to <strong>add them</strong>.
     instructeurs:
       title: Adding instructors with file import
-      notice_1_html: For the import, your csv file must have <strong>1 column (Email)</strong> listing the email addresses of the instructors (see file model below). The file size must be less than %{csv_max_size}.
+      notice_1_html: For the import, your csv file must have <strong>1 column :Email</strong> listing the email addresses of the instructors. The file size must be less than %{csv_max_size} (see model below).
       notice_2_html: The import does not overwrite existing instructors. It only allows you to <strong>add them</strong>.

--- a/app/components/procedure/import_component/import_component.fr.yml
+++ b/app/components/procedure/import_component/import_component.fr.yml
@@ -7,7 +7,7 @@ fr:
     file_size_limit: "Taille maximale : %{max_file_size}."
     groupes:
       title: Ajout de groupes / instructeurs avec import de fichier
-      notice_1_html: Pour l’import, votre fichier csv doit comporter <strong>2 colonnes (Groupe, Adresse électronique)</strong> (voir modèle de fichier ci-dessous). Le poids du fichier doit être inférieur à %{csv_max_size}.
+      notice_1_html: "Pour l’import, votre fichier csv doit comporter 2 colonnes : <strong>Email</strong> et <strong>Groupe</strong>. Le poids du fichier doit être inférieur à %{csv_max_size} (voir modèle ci-dessous)."
       notice_2_html: L’import n’écrase pas les groupes et instructeurs existants. Il permet uniquement <strong>d’en ajouter</strong>.
       notice_3_html: Une fois votre import effectué, vous devrez ensuite <strong>configurer les règles de routage</strong> pour chacun des groupes ajoutés.
       notification_alert_html: Même si votre démarche est encore en test / non publiée, tous les instructeurs que vous ajouterez à la démarche <strong>seront notifiés par email</strong>.
@@ -15,5 +15,5 @@ fr:
 
     instructeurs:
       title: Ajout d’instructeurs avec import de fichier
-      notice_1_html: Pour l’import, votre fichier csv doit comporter <strong>1 seule colonne (Adresse électronique)</strong> listant les adresses électroniques des instructeurs (voir modèle de fichier ci-dessous). Le poids du fichier doit être inférieur à %{csv_max_size}.
+      notice_1_html: "Pour l’import, votre fichier csv doit comporter <strong>1 seule colonne : Email</strong> listant les adresses électroniques des instructeurs. Le poids du fichier doit être inférieur à %{csv_max_size} (voir modèle ci-dessous)."
       notice_2_html: L’import n’écrase pas les instructeurs existants. Il permet uniquement <strong>d’en ajouter</strong>.


### PR DESCRIPTION
ETQ admin, dans la page des groupes instructeurs, on a remplacé à tort "email" par "adresse électronique". Et ça donnait une indication erronée pour l'import d'instructeurs par fichier csv