### PR TITLE
ETQ Admin utilisateur de la fonctionnalité RDV, je ne veux pas d'erreur 500 à l'affichage de mes infos de compte

### DIFF
--- a/app/services/rdv_service.rb
+++ b/app/services/rdv_service.rb
@@ -138,7 +138,8 @@ class RdvService
       error_name: "RdvService#get_account_info failed"
     )
 
-    parsed_body["agent"].with_indifferent_access || {}
+    account_info = parsed_body["agent"] || {}
+    account_info.with_indifferent_access
   end
 
   def refresh_token_if_expired!


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/7050468973/?project=1429550

si `parsed_body["agent"]` est nil, on ne plante pas