### PR TITLE
ETQ instructeur, ne crash pas des exports à cause du formatage en datetime

### DIFF
--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -336,6 +336,7 @@ module TagsSubstitutionConcern
   # i18n-tasks-use t('time.formats.human')
   # i18n-tasks-use t('time.formats.long')
   # i18n-tasks-use t('time.formats.short_datetime')
+  # i18n-tasks-use t('time.formats.dashed')
   def format_date(date)
     if date.present?
       format = defined?(self.class::FORMAT_DATE) ? self.class::FORMAT_DATE : :short_date

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -839,6 +839,7 @@ en:
       human: "%A %-d %B at %Hh%M"
       short_datetime: "%b %d %Y %I:%M %p"
       short_date: "%d/%m/%Y"
+      dashed: "%Y-%m-%d"
   date:
     formats:
       short_date: "%d/%m/%Y"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -850,6 +850,7 @@ fr:
       human: "%A %-d %B à %Hh%M"
       short_datetime: "Le %d/%m/%Y %H:%M"
       short_date: "%d/%m/%Y"
+      dashed: "%Y-%m-%d"
   datetime:
     formats:
       long: "%d %B %y %H:%M"


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/7078211582/
on a aussi bien des données de type `date` que `datetime` qui peuvent passer ici 