### PR TITLE
Je veux que que le bouton de suppression d'un tag ait une étiquette visible sans CSS

### DIFF
--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -234,15 +234,18 @@ export function MultiComboBox(maybeProps: MultiComboBoxProps) {
             <Tag
               key={item.value}
               id={item.value}
-              textValue={`Retirer ${item.label}`}
+              textValue={`Supprimer ${item.label}`}
               className="fr-tag fr-tag--sm fr-tag--dismiss"
             >
               {item.label}
               <Button
+                aria-labelledby=""
                 aria-label=""
                 slot="remove"
                 className="fr-tag--dismiss"
-              ></Button>
+              >
+                <span className="sr-only">Supprimer {item.label}</span>
+              </Button>
             </Tag>
           ))}
         </TagList>


### PR DESCRIPTION
# Après
<img width="325" height="57" alt="" src="https://github.com/user-attachments/assets/f2168ddb-4ed3-49f6-97d2-e73b3d3586d7" />
  
<img width="1009" height="406" alt="" src="https://github.com/user-attachments/assets/d3006505-7736-4f46-bbe7-7bf190c37e2d" />

# Avant
<img width="202" height="50" alt="" src="https://github.com/user-attachments/assets/6f42cd74-ac5c-41fb-b039-cc7d94362b34" />
  
<img width="1015" height="274" alt="" src="https://github.com/user-attachments/assets/f15c88f6-caa7-4713-9b65-4891b9420565" />