### PR TITLE
ETQ Tech, je ne veux plus d'erreurs imagemagick dans sentry si le mimetype n'est pas autorisé par la policy

### DIFF
--- a/app/jobs/image_processor_job.rb
+++ b/app/jobs/image_processor_job.rb
@@ -50,11 +50,15 @@ class ImageProcessorJob < ApplicationJob
     add_ocr_data(blob)
     auto_rotate(blob) if ["image/jpeg", "image/jpg"].include?(blob.content_type)
     uninterlace(blob) if blob.content_type == "image/png"
-    create_representations(blob) if blob.representation_required?
+    create_representations(blob) if blob.representation_required? && mime_type_authorized_by_policy?(blob)
     add_watermark(blob) if blob.watermark_pending?
   end
 
   private
+
+  def mime_type_authorized_by_policy?(blob)
+    blob.content_type.in?(AUTHORIZED_CONTENT_TYPES_IN_POLICY_XML)
+  end
 
   def auto_rotate(blob)
     blob.open do |file|

--- a/config/initializers/authorized_content_types.rb
+++ b/config/initializers/authorized_content_types.rb
@@ -138,3 +138,13 @@ FORMAT_FAMILY_EXAMPLES = {
   video: '.mp4, .mov, .avi, .wmv',
   archive: '.zip, .rar, .7z, .gz',
 }.freeze
+
+# look for policy.xml in ImageMagick-7/policy.xml
+AUTHORIZED_CONTENT_TYPES_IN_POLICY_XML = [
+  'image/jpeg',
+  'image/jpg',
+  'image/bmp',
+  'image/png',
+  'image/tiff',
+  'image/webp',
+].freeze


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/6896750023/events/6e056fabf90342c6a790fcdc5311731b/?project=1429550

TLDR;

On a un fichier policy.xml qui autorise imagemagick à traiter seulement certains types de fichiers.
Si le mimetype ne fait pas partie de cette liste, pas la peine d'appeler `create_representations`.