### PR TITLE
ETQ usager, je peux accéder à la démarche si la restriction ProConnect n'est active que pour les admin/instructeurs

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -507,7 +507,7 @@ module Users
 
     def ensure_pro_connect_for_procedure(procedure = dossier.procedure)
       return if procedure.blank?
-      return if procedure.pro_connect_restriction_none?
+      return if !procedure.pro_connect_restriction_all?
       return if logged_in_with_pro_connect?
 
       flash.alert = t('users.dossiers.pro_connect_restriction_required')

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -2096,6 +2096,14 @@ describe Users::DossiersController, type: :controller do
         expect(brouillon).to be_brouillon
       end
     end
+
+    context 'when restriction is admin only and user is not ProConnected' do
+      let(:procedure) { create(:procedure, :for_individual, :published, pro_connect_restriction: :instructeurs) }
+      it 'allows creating a dossier' do
+        post :new, params: { procedure_id: procedure.id }
+        expect(response).to redirect_to(identite_dossier_path(Dossier.last))
+      end
+    end
   end
 
   private


### PR DESCRIPTION
un trou dans la raquette
https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_ce7aad86-a10f-45da-8f23-b2588eadaedd/