### PR TITLE
ETQ admin, corrige l'affichage des démarches modèles après le passage à demarche.numerique

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,8 +3,6 @@
 module ApplicationHelper
   APP_HOST = ENV['APP_HOST']
   APP_HOST_LEGACY = ENV['APP_HOST_LEGACY']
-  REGEXP_REPLACE_TRAILING_EXTENSION = /(\.\w+)+$/.freeze
-  REGEXP_REPLACE_WORD_SEPARATOR = /[\s_-]+/.freeze
 
   def app_host_legacy?(request)
     return false if APP_HOST_LEGACY.blank?
@@ -165,8 +163,9 @@ module ApplicationHelper
   end
 
   def acronymize(str)
-    str.gsub(REGEXP_REPLACE_TRAILING_EXTENSION, '')
-      .split(REGEXP_REPLACE_WORD_SEPARATOR)
+    str.gsub(/\.(?:gouv\.fr|\w+)$/, '')
+      .split(/[\s_.-]+/)
+      .reject(&:empty?)
       .map { |word| word[0].upcase }
       .join
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -143,24 +143,9 @@ describe ApplicationHelper do
       expect(helper.acronymize('Application Name')).to eq('AN')
       expect(helper.acronymize('Hello World')).to eq('HW')
       expect(helper.acronymize('Demarches Simplifiees')).to eq('DS')
-    end
-
-    it 'handles single word input' do
-      expect(helper.acronymize('Word')).to eq('W')
-    end
-
-    it 'returns an empty string for empty input' do
-      expect(helper.acronymize('')).to eq('')
-    end
-
-    it 'handles strings with extensions' do
-      expect(helper.acronymize('file_name.txt')).to eq('FN')
-      expect(helper.acronymize('example.pdf')).to eq('E')
-    end
-
-    it 'handles strings with various word separators' do
-      expect(helper.acronymize('multi-word_string')).to eq('MWS')
-      expect(helper.acronymize('another_example-test')).to eq('AET')
+      expect(helper.acronymize('demarche.numerique.gouv.fr')).to eq('DN')
+      expect(helper.acronymize('demarches-simplifiees.fr')).to eq('DS')
+      expect(helper.acronymize('demarches.adullact.org')).to eq('DA')
     end
   end
 end


### PR DESCRIPTION
notre méthode d'acronymisation renvoyait `D` comme acronyme `demarche.numerique.gouv.fr`, on le corrige pour afficher `DN`

## apres
<img width="423" height="125" alt="Capture d’écran 2025-12-08 à 14 38 07" src="https://github.com/user-attachments/assets/bded664b-98d6-44d2-8082-4ab9da6c9829" />

## avant
<img width="326" height="85" alt="Capture d’écran 2025-12-08 à 14 39 09" src="https://github.com/user-attachments/assets/b18f6fb5-30a3-439e-8254-15b37d4c142a" />
