### PR TITLE
Fixe la largeur sur le type de champ pièce a joindre

### DIFF
--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -23,7 +23,7 @@
                   %span.fr-icon-lock-fill.fr-icon--sm
                   Aucun type de champ autorisé pour transformer ce champ
 
-          .flex.column.justify-start.flex-grow
+          .flex.column.justify-start.width-66
             .cell
               .flex.align-center
                 = form.label :libelle, "Libellé du champ", class: 'flex-grow', for: dom_id(type_de_champ, :libelle)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -721,7 +721,7 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def pj_limit_formats?
-    options[:pj_limit_formats].present?
+    [true, '1'].include?(options[:pj_limit_formats])
   end
 
   def pj_format_families


### PR DESCRIPTION
- Fixe la largeur du `flex-grow `sur le type de champ pièce à joindre
- Fixe le booléen "limiter à certains formats de fichiers" qui se mettait à `true` lorsqu'on ajoutait une description