### PR TITLE
ETQ Admin je peux supprimer une signature de groupe instructeur

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -54,6 +54,7 @@ class AttachmentsController < ApplicationController
     return if admin_changing_its_attestation_template?
     return if admin_changing_its_type_de_champ?
     return if expert_changing_its_avis?
+    return if admin_changing_its_groupe_instructeur?
 
     head :not_found
   end
@@ -82,6 +83,10 @@ class AttachmentsController < ApplicationController
     type_de_champ? && current_user.administrateur? && current_administrateur.in?(record.revisions.first.procedure.administrateurs)
   end
 
+  def admin_changing_its_groupe_instructeur?
+    groupe_instructeur? && current_user.administrateur? && current_administrateur.in?(record.procedure.administrateurs)
+  end
+
   def expert_changing_its_avis?
     avis? && current_expert == record.expert
   end
@@ -92,6 +97,7 @@ class AttachmentsController < ApplicationController
   def avis? = record.is_a?(Avis)
   def attestation_template? = record.is_a?(AttestationTemplate)
   def type_de_champ? = record.is_a?(TypeDeChamp)
+  def groupe_instructeur? = record.is_a?(GroupeInstructeur)
 
   def champ
     @champ ||= if champ?

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -134,6 +134,26 @@ describe AttachmentsController, type: :controller do
             expect(type_de_champ.reload.notice_explicative.attached?).to be(false)
           end
         end
+
+        context 'can remove a groupe instructeur signature' do
+          let(:procedure) { create(:procedure) }
+          let(:groupe_instructeur) { procedure.groupe_instructeurs.first }
+          let(:attachment) { groupe_instructeur.signature.attachments.first }
+          let(:signed_id) { attachment.blob.signed_id }
+
+          before do
+            groupe_instructeur.signature.attach(
+              io: Rails.root.join('spec/fixtures/files/black.png').open,
+              filename: 'signature.png',
+              content_type: 'image/png'
+            )
+          end
+
+          it do
+            is_expected.to have_http_status(200)
+            expect(groupe_instructeur.reload.signature.attached?).to be(false)
+          end
+        end
       end
 
       context 'when the administrateur does not own the procedure' do


### PR DESCRIPTION
bug remonté au support

https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_9639ab00-205d-4fdf-a8a8-57523f82d680/