### PR TITLE
Technique : optimise la performance du routage 2/X

### DIFF
--- a/app/components/conditions/routing_rules_component/routing_rules_component.html.haml
+++ b/app/components/conditions/routing_rules_component/routing_rules_component.html.haml
@@ -7,7 +7,7 @@
       .flex
         - if @groupe_instructeur.routing_rule.nil?
           %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm aucune règle
-        - elsif @groupe_instructeur.invalid_rule?
+        - elsif @groupe_instructeur.invalid_routing_rule?
           %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm règle invalide
         - elsif @groupe_instructeur.non_unique_rule?
           %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm règle déjà attribuée à #{@groupe_instructeur.groups_with_same_rule}

--- a/app/components/conditions/routing_rules_component/routing_rules_component.html.haml
+++ b/app/components/conditions/routing_rules_component/routing_rules_component.html.haml
@@ -9,7 +9,7 @@
           %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm aucune règle
         - elsif @groupe_instructeur.invalid_routing_rule?
           %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm règle invalide
-        - elsif @groupe_instructeur.non_unique_rule?
+        - elsif @groupe_instructeur.non_unique_routing_rule?
           %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm règle déjà attribuée à #{@groupe_instructeur.groups_with_same_rule}
 
       = render Conditions::ConditionsErrorsComponent.new(conditions: condition_per_row, source_tdcs: @source_tdcs)

--- a/app/components/procedure/card/instructeurs_component/instructeurs_component.html.haml
+++ b/app/components/procedure/card/instructeurs_component/instructeurs_component.html.haml
@@ -1,7 +1,7 @@
 .fr-col-6.fr-col-md-4.fr-col-lg-3
   = link_to admin_procedure_groupe_instructeurs_path(@procedure), id: 'groupe-instructeurs', class: 'fr-tile fr-enlarge-link' do
     .fr-tile__body.flex.column.align-center.justify-between
-      - if @procedure.routing_enabled? && @procedure.groupe_instructeurs.any? { _1.routing_to_configure?}
+      - if @procedure.routing_enabled? && @procedure.groupe_instructeurs.routing_to_configure.any?
         %p.fr-badge.fr-badge--warning À faire
       - elsif @procedure.instructeurs.present?
         %p.fr-badge.fr-badge--success Validé

--- a/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
@@ -41,7 +41,7 @@
                     %p.fr-badge.fr-badge--info.fr-badge--sm.fr-mt-1w inactif
                   - elsif gi.routing_rule.nil?
                     %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-mt-1w aucune règle
-                  - elsif gi.invalid_rule?
+                  - elsif gi.invalid_routing_rule?
                     %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-mt-1w règle invalide
                   - elsif gi.non_unique_rule?
                     %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-mt-1w règle déjà attribuée à #{gi.groups_with_same_rule}

--- a/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
@@ -43,7 +43,7 @@
                     %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-mt-1w aucune règle
                   - elsif gi.invalid_routing_rule?
                     %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-mt-1w règle invalide
-                  - elsif gi.non_unique_rule?
+                  - elsif gi.non_unique_routing_rule?
                     %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-mt-1w règle déjà attribuée à #{gi.groups_with_same_rule}
 
                 %td{ scope: 'col' }

--- a/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
@@ -8,7 +8,7 @@
 
 = render Procedure::GroupesSearchComponent.new(procedure: @procedure,
   query: @query,
-  to_configure_count: @procedure.groupe_instructeurs.filter(&:routing_to_configure?).count,
+  to_configure_count: @procedure.groupe_instructeurs.routing_to_configure.size,
   to_configure_filter: @to_configure_filter)
 
 .flex.justify-between.align-baseline

--- a/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
+++ b/app/components/procedure/revision_changes_component/revision_changes_component.html.haml
@@ -232,7 +232,7 @@
   - if @private_move_changes.present?
     - list.with_item do
       = t(".private.move", count: @private_move_changes.size)
-  - if @previous_revision.procedure.routing_enabled? && @previous_revision.procedure.groupe_instructeurs.any?(&:invalid_rule?)
+  - if @previous_revision.procedure.routing_enabled? && @previous_revision.procedure.groupe_instructeurs.invalid_routing_rule.any?
     - list.with_item do
       .fr-alert.fr-alert--warning.fr-mt-1v
         = t(".invalid_routing_rules_alert")

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -448,7 +448,7 @@ module Administrateurs
       end
 
       if params[:filter] == '1'
-        groupes = Kaminari.paginate_array(groupes.filter(&:routing_to_configure?))
+        groupes = Kaminari.paginate_array(groupes.routing_to_configure)
       end
 
       groupes

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -103,6 +103,10 @@ class GroupeInstructeur < ApplicationRecord
     !valid_routing_rule?
   end
 
+  def non_unique_routing_rule?
+    !unique_routing_rule?
+  end
+
   def valid_rule?
     return false if routing_rule.nil?
     if [And, Or].include?(routing_rule.class)
@@ -114,11 +118,6 @@ class GroupeInstructeur < ApplicationRecord
 
   def valid_rule_line?(rule)
     !rule.is_a?(EmptyOperator) && routing_rule_matches_tdc?(rule)
-  end
-
-  def non_unique_rule?
-    return false if invalid_routing_rule?
-    routing_rule.in?(other_groupe_instructeurs.map(&:routing_rule))
   end
 
   def groups_with_same_rule

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -35,6 +35,7 @@ class GroupeInstructeur < ApplicationRecord
   scope :for_dossiers, -> (dossiers) { joins(:dossiers).where(dossiers: dossiers).distinct(:id) }
   scope :routing_to_configure, -> { invalid_routing_rule.or(non_unique_routing_rule) }
   scope :invalid_routing_rule, -> { where(valid_routing_rule: false) }
+  scope :valid_routing_rule, -> { where(valid_routing_rule: true) }
   scope :non_unique_routing_rule, -> { where(unique_routing_rule: false) }
 
   def add(instructeur)
@@ -98,8 +99,8 @@ class GroupeInstructeur < ApplicationRecord
     update!(valid_routing_rule: valid_rule?)
   end
 
-  def invalid_rule?
-    !valid_rule?
+  def invalid_routing_rule?
+    !valid_routing_rule?
   end
 
   def valid_rule?
@@ -116,7 +117,7 @@ class GroupeInstructeur < ApplicationRecord
   end
 
   def non_unique_rule?
-    return false if invalid_rule?
+    return false if invalid_routing_rule?
     routing_rule.in?(other_groupe_instructeurs.map(&:routing_rule))
   end
 

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -33,6 +33,9 @@ class GroupeInstructeur < ApplicationRecord
   scope :active, -> { where(closed: false) }
   scope :closed, -> { where(closed: true) }
   scope :for_dossiers, -> (dossiers) { joins(:dossiers).where(dossiers: dossiers).distinct(:id) }
+  scope :routing_to_configure, -> { invalid_routing_rule.or(non_unique_routing_rule) }
+  scope :invalid_routing_rule, -> { where(valid_routing_rule: false) }
+  scope :non_unique_routing_rule, -> { where(unique_routing_rule: false) }
 
   def add(instructeur)
     return if instructeur.nil?
@@ -93,10 +96,6 @@ class GroupeInstructeur < ApplicationRecord
 
   def update_rule_validity_status
     update!(valid_routing_rule: valid_rule?)
-  end
-
-  def routing_to_configure?
-    invalid_rule? || non_unique_rule?
   end
 
   def invalid_rule?

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -93,6 +93,7 @@ class GroupeInstructeur < ApplicationRecord
   def update_rule_statuses
     update_rule_validity_status
     procedure.update_all_groupes_rule_unicity_status
+    reload
   end
 
   def update_rule_validity_status
@@ -121,16 +122,16 @@ class GroupeInstructeur < ApplicationRecord
   end
 
   def groups_with_same_rule
-    return if routing_rule.nil?
+    return if routing_rule.nil? || unique_routing_rule?
+
     other_groupe_instructeurs
-      .filter { _1.routing_rule.present? }
-      .filter { _1.routing_rule == routing_rule }
-      .map(&:label)
+      .where(routing_rule: routing_rule)
+      .pluck(:label)
       .join(', ')
   end
 
   def other_groupe_instructeurs
-    procedure.groupe_instructeurs - [self]
+    procedure.groupe_instructeurs.where.not(id:)
   end
 
   def humanized_routing_rule

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -589,7 +589,7 @@ class Procedure < ApplicationRecord
   end
 
   def groupe_instructeurs_but_defaut
-    groupe_instructeurs - [defaut_groupe_instructeur]
+    groupe_instructeurs.where.not(id: defaut_groupe_instructeur_id)
   end
 
   def routing_champs

--- a/app/models/routing_engine.rb
+++ b/app/models/routing_engine.rb
@@ -4,7 +4,7 @@ module RoutingEngine
   def self.compute(dossier, assignment_mode: DossierAssignment.modes.fetch(:auto))
     return if dossier.forced_groupe_instructeur
 
-    matching_groupe = dossier.procedure.groupe_instructeurs.active.reject(&:invalid_rule?).find do |gi|
+    matching_groupe = dossier.procedure.groupe_instructeurs.active.valid_routing_rule.find do |gi|
       gi.routing_rule&.compute(dossier.filled_champs)
     end
 

--- a/app/views/administrateurs/groupe_instructeurs/_routing_alert_sticky_header.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/_routing_alert_sticky_header.html.haml
@@ -3,8 +3,8 @@
     .flex.justify-between.align-center.fr-text-default--warning
       %span
         = dsfr_icon("fr-icon-warning-fill fr-mr-1v")
-        - if @procedure.groupe_instructeurs.any?(&:invalid_rule?)
+        - if @procedure.groupe_instructeurs.invalid_routing_rule.any?
           = t('.routing_alert_with_invalid_rules_html', count: @procedure.dossiers.state_en_construction_ou_instruction.count)
         - else
           = t('.routing_alert_html', count: @procedure.dossiers.state_en_construction_ou_instruction.count)
-      = button_to t('.bulk_route'), bulk_route_admin_procedure_groupe_instructeurs_path(@procedure), class: 'fr-btn no-wrap', disabled: @procedure.groupe_instructeurs.any?(&:invalid_rule?), data: { disable_with: "Routage en cours…", confirm: t('.bulk_routing_confirm') }
+      = button_to t('.bulk_route'), bulk_route_admin_procedure_groupe_instructeurs_path(@procedure), class: 'fr-btn no-wrap', disabled: @procedure.groupe_instructeurs.invalid_routing_rule.any?, data: { disable_with: "Routage en cours…", confirm: t('.bulk_routing_confirm') }

--- a/spec/components/conditions/routing_rules_component_spec.rb
+++ b/spec/components/conditions/routing_rules_component_spec.rb
@@ -12,7 +12,8 @@ describe Conditions::RoutingRulesComponent, type: :component do
 
     before do
       groupe_instructeur.update(routing_rule: routing_rule)
-      render_inline(described_class.new(groupe_instructeur: groupe_instructeur))
+      procedure.update_all_groupes_rule_statuses
+      render_inline(described_class.new(groupe_instructeur: groupe_instructeur.reload))
     end
 
     context 'with one row' do

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -963,6 +963,21 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         expect(procedure3.routing_enabled).to be_truthy
         expect(procedure3.routing_alert).to be_truthy
       end
+
+      it 'assigns the admin instructeur to all new groups' do
+        groups = procedure3.groupe_instructeurs.where(label: ['Paris', 'Lyon', 'Marseille'])
+        expect(groups.map(&:instructeurs)).to all(include(admin.instructeur))
+      end
+
+      it 'creates exactly one AssignTo per new group' do
+        paris_groupe = procedure3.groupe_instructeurs.find_by(label: 'Paris')
+        lyon_groupe = procedure3.groupe_instructeurs.find_by(label: 'Lyon')
+        marseille_groupe = procedure3.groupe_instructeurs.find_by(label: 'Marseille')
+
+        expect(AssignTo.where(groupe_instructeur: paris_groupe, instructeur: admin.instructeur).count).to eq(1)
+        expect(AssignTo.where(groupe_instructeur: lyon_groupe, instructeur: admin.instructeur).count).to eq(1)
+        expect(AssignTo.where(groupe_instructeur: marseille_groupe, instructeur: admin.instructeur).count).to eq(1)
+      end
     end
 
     context 'with a departements type de champ' do

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -67,6 +67,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
 
       before do
         gi_1_1.update(routing_rule: ds_eq(champ_value(drop_down_tdc.stable_id), constant('Deuxième choix')))
+        procedure.update_all_groupes_rule_statuses
         get :show, params: { procedure_id: procedure.id, id: gi_1_1.id }
       end
 

--- a/spec/jobs/bulk_route_job_spec.rb
+++ b/spec/jobs/bulk_route_job_spec.rb
@@ -26,6 +26,7 @@ describe BulkRouteJob, type: :job do
     end
 
     before do
+      procedure.update_all_groupes_rule_statuses
       dossier1.champs.first.update(value: 'Paris')
       dossier2.champs.first.update(value: 'Lyon')
       dossier3.champs.first.update(value: 'Marseille')

--- a/spec/models/groupe_instructeur_spec.rb
+++ b/spec/models/groupe_instructeur_spec.rb
@@ -268,6 +268,16 @@ describe GroupeInstructeur, type: :model do
           .to change { gi.reload.unique_routing_rule }.from(false).to(true)
       end
     end
+
+    describe '#groups_with_same_rule' do
+      let(:routing_rule) { ds_eq(champ_value(1), constant('A')) }
+      let!(:gi1) { create(:groupe_instructeur, procedure:, routing_rule:) }
+      let!(:gi2) { create(:groupe_instructeur, procedure:, routing_rule:) }
+
+      it 'finds groups with same rule' do
+        expect(gi1.groups_with_same_rule).to include(gi2.label)
+      end
+    end
   end
 
   private

--- a/spec/models/routing_engine_spec.rb
+++ b/spec/models/routing_engine_spec.rb
@@ -9,6 +9,7 @@ describe RoutingEngine, type: :model do
     let(:gi_2) { procedure.groupe_instructeurs.create(label: 'a second group') }
 
     subject do
+      procedure.update_all_groupes_rule_statuses
       RoutingEngine.compute(dossier)
       dossier.groupe_instructeur
     end
@@ -244,7 +245,7 @@ describe RoutingEngine, type: :model do
         procedure_id = procedure.id
         tdc_stable_id = drop_down_tdc.stable_id
 
-        groupe_data = Array.new(4999).map do |i|
+        groupe_data = Array.new(4999).map.with_index do |_, i|
           commune_name = "Commune_#{format('%04d', i + 2)}"
           {
             label: commune_name,

--- a/spec/tasks/maintenance/t20250522_re_route_procedure_task_spec.rb
+++ b/spec/tasks/maintenance/t20250522_re_route_procedure_task_spec.rb
@@ -24,7 +24,7 @@ module Maintenance
         rule_operator = :ds_eq
 
         create_groups_from_territorial_tdc(tdc_options, tdc.stable_id, rule_operator, admin)
-
+        procedure.update_all_groupes_rule_statuses
         dossier1.reload
         dossier2.reload
       end


### PR DESCRIPTION
Deuxième étape de l'optimisation de la performance du routage (cf https://github.com/demarche-numerique/demarche.numerique.gouv.fr/issues/12419), suite de la PR #12388

- Utilise les valeurs des champs `valid_routing_rule` et `unique_routing_rule` de la table `groupe_instructeurs` pour optimiser les performances
- Optimise des requêtes lors du routage des dossiers et de la configuration du routage