### PR TITLE
ETQ admin, instructeur, expert,améliore la redirection depuis ds.fr vers demarche.numerique si je suis déjà connecté

### DIFF
--- a/app/components/switch_domain_banner_component.rb
+++ b/app/components/switch_domain_banner_component.rb
@@ -23,6 +23,12 @@ class SwitchDomainBannerComponent < ApplicationComponent
   end
 
   def new_host_url
+    stored_location = helpers.get_stored_location_for(:user)
+
+    # don't work on any controller
+    # user was not signed on ds.fr,  ut may be signed on demarche.numerique.gouv
+    return "//#{ApplicationHelper::APP_HOST}#{stored_location}" if stored_location.present?
+
     helpers.url_for(url_options)
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -168,24 +168,28 @@ class ApplicationController < ActionController::Base
 
   def authenticate_instructeur!
     if !instructeur_signed_in?
+      store_location_for(:user, request.fullpath)
       redirect_to new_user_session_path
     end
   end
 
   def authenticate_expert!
     if !expert_signed_in?
+      store_location_for(:user, request.fullpath)
       redirect_to new_user_session_path
     end
   end
 
   def authenticate_instructeur_or_expert!
     if !instructeur_signed_in? && !expert_signed_in?
+      store_location_for(:user, request.fullpath)
       redirect_to new_user_session_path
     end
   end
 
   def authenticate_administrateur!
     if !administrateur_signed_in?
+      store_location_for(:user, request.fullpath)
       redirect_to new_user_session_path
     end
   end

--- a/app/controllers/devise/store_location_extension.rb
+++ b/app/controllers/devise/store_location_extension.rb
@@ -19,6 +19,8 @@ module Devise
         location
       end
 
+      helper_method :get_stored_location_for
+
       # Delete the url stored in the session for the given scope.
       def clear_stored_location_for(resource_or_scope)
         session_key = send(:stored_location_key_for, resource_or_scope)

--- a/spec/components/switch_domain_banner_component_spec.rb
+++ b/spec/components/switch_domain_banner_component_spec.rb
@@ -55,5 +55,17 @@ RSpec.describe SwitchDomainBannerComponent, type: :component do
       expect(rendered.to_html).not_to include("window.location")
       expect(rendered.to_html).to include("Suivez ce lien")
     end
+
+    context "when a stored location exists" do
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:get_stored_location_for)
+          .with(:user).and_return("/procedures/123/dossiers")
+      end
+
+      it "uses the stored location in the redirect URL" do
+        expect(rendered.to_html).to have_link("demarche.numerique.gouv.fr",
+          href: "//demarche.numerique.gouv.fr/procedures/123/dossiers")
+      end
+    end
   end
 end


### PR DESCRIPTION
Amélioration pour le cas où:
- on n'est pas connecté sur ds.fr (ce qui commence par rediriger sur page de connexion)
- on est deja connecté sur demarche.numerique


Cette PR:
- redirige directement vers la bonne page ce qui ne casse plus les liens 
- n'affiche plus "vous êtes déjà connectés" (car on redirigeait vers la page de signin)