### PR TITLE
[bug] ETQ instructeur, si je supprime un message avec une PJ, la PJ disparait immédiatement

### DIFF
--- a/app/components/dossiers/message_component.rb
+++ b/app/components/dossiers/message_component.rb
@@ -132,4 +132,10 @@ class Dossiers::MessageComponent < ApplicationComponent
       false
     end
   end
+
+  def show_attachments?
+    return false if commentaire.discarded?
+
+    commentaire.piece_jointe.attached?
+  end
 end

--- a/app/components/dossiers/message_component/message_component.html.haml
+++ b/app/components/dossiers/message_component/message_component.html.haml
@@ -23,7 +23,7 @@
     = button_to delete_url, method: :delete,  class: 'fr-btn fr-btn--sm fr-btn--tertiary fr-icon-delete-line fr-btn--icon-left fr-text-default--warning fr-mb-1w', form: { data: { turbo: true, turbo_confirm: t('.confirm') } } do
       = delete_button_text
 
-  - if groupe_gestionnaire.nil? && commentaire.piece_jointe.attached?
+  - if groupe_gestionnaire.nil? && show_attachments?
     .fr-mt-2w
       - commentaire.piece_jointe.each do |attachment|
         = render Attachment::ShowComponent.new(attachment: attachment, new_tab: true)

--- a/spec/components/dossiers/message_component_spec.rb
+++ b/spec/components/dossiers/message_component_spec.rb
@@ -64,6 +64,33 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
       it { is_expected.not_to have_selector('img[src="demarches-simplifiees.fr"]') }
     end
 
+    context 'attachments visibility' do
+      let(:rib_path) { 'spec/fixtures/files/RIB.pdf' }
+
+      before do
+        commentaire.piece_jointe.attach(
+          io: File.open(rib_path),
+          filename: 'RIB.pdf',
+          content_type: 'application/pdf',
+          metadata: { virus_scan_result: ActiveStorage::VirusScanner::SAFE }
+        )
+      end
+
+      context 'when commentaire is not discarded' do
+        it 'displays the attachment' do
+          is_expected.to include('RIB.pdf')
+        end
+      end
+
+      context 'when commentaire is discarded' do
+        before { commentaire.discard! }
+
+        it 'does not display the attachment' do
+          is_expected.not_to include('RIB.pdf')
+        end
+      end
+    end
+
     context 'with a seen_at after commentaire created_at' do
       let(:seen_at) { commentaire.created_at + 1.hour  }
 


### PR DESCRIPTION
Suite à un retour au support, une instructrice a supprimé un message mais la PJ s'affichait encore.
Le turbo ne fonctionnait pas car la suppression de la PJ se fait en asynchrone.

Maintenant l'affichage de la PJ disparait instantanément en même temps que le message tout en gardant la purge en asynchrone.
<img width="777" height="275" alt="Capture d’écran 2025-12-17 à 15 51 49" src="https://github.com/user-attachments/assets/afddc14c-5401-46db-9450-dd5c640d63d9" />
<img width="753" height="160" alt="Capture d’écran 2025-12-17 à 15 51 59" src="https://github.com/user-attachments/assets/376eb6a4-b438-4b60-b522-ef32f8c11e9c" />
