### PR TITLE
ETQ Admin, si mon jeton api entreprise est expiré, la page de ma démarche doit m'afficher un lien correct pour le changer

### DIFF
--- a/app/components/procedure/api_entreprise_token_expiration_alert_component.rb
+++ b/app/components/procedure/api_entreprise_token_expiration_alert_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Procedure::APIEntrepriseTokenExpirationAlertComponent < ApplicationComponent
+  def initialize(procedure:)
+    @procedure = procedure
+  end
+
+  def render?
+    @procedure.api_entreprise_token.expired_or_expires_soon?
+  end
+
+  private
+
+  attr_reader :procedure
+end

--- a/app/components/procedure/api_entreprise_token_expiration_alert_component/api_entreprise_token_expiration_alert_component.en.yml
+++ b/app/components/procedure/api_entreprise_token_expiration_alert_component/api_entreprise_token_expiration_alert_component.en.yml
@@ -1,0 +1,3 @@
+---
+en:
+  technical_issues: 'Issues are affecting the proper functioning of the process'

--- a/app/components/procedure/api_entreprise_token_expiration_alert_component/api_entreprise_token_expiration_alert_component.fr.yml
+++ b/app/components/procedure/api_entreprise_token_expiration_alert_component/api_entreprise_token_expiration_alert_component.fr.yml
@@ -1,0 +1,3 @@
+---
+fr:
+  technical_issues: Des problèmes impactent le bon fonctionnement de la démarche

--- a/app/components/procedure/api_entreprise_token_expiration_alert_component/api_entreprise_token_expiration_alert_component.html.erb
+++ b/app/components/procedure/api_entreprise_token_expiration_alert_component/api_entreprise_token_expiration_alert_component.html.erb
@@ -1,0 +1,11 @@
+<%= render Dsfr::AlertComponent.new(state: :error, title: t(".technical_issues"), extra_class_names: 'fr-mb-2w') do |c| %>
+  <% c.with_body do %>
+    <ul class="fr-mb-0">
+      <li>
+        Le
+        <%= link_to "Jeton API Entreprise", admin_procedure_jetons_path(procedure), class: 'error-anchor' %>
+        est expiré ou va expirer prochainement
+      </li>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -41,14 +41,7 @@
         = link_to 'Clore', admin_procedure_close_path(procedure_id: @procedure.id), class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-calendar-close-fill', id: "close-procedure-link"
 
 .fr-container
-  - if @procedure.api_entreprise_token.expired_or_expires_soon?
-    = render Dsfr::AlertComponent.new(state: :error, title: t(:technical_issues, scope: [:administrateurs, :procedures]), extra_class_names: 'fr-mb-2w') do |c|
-      - c.with_body do
-        %ul.fr-mb-0
-          %li
-            Le
-            = link_to "Jeton API Entreprise", jeton_admin_procedure_path(@procedure), class: 'error-anchor'
-            est expiré ou va expirer prochainement
+  = render Procedure::APIEntrepriseTokenExpirationAlertComponent.new(procedure: @procedure)
 
   - if @procedure.draft_changed?
     = render Dsfr::CalloutComponent.new(title: t(:has_changes, scope: [:administrateurs, :revision_changes]), icon: "fr-fi-information-line") do |c|

--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -72,7 +72,6 @@ en:
         dpd_part_4: How to do ? You can either send him the link to the procedure on test stage by email, or name him "administrator". In any case, publish your approach only after having had his opinion.
         back_to_procedure: 'Cancel and return to the procedure page'
         submit: Publish
-      technical_issues: "Issues are affecting the proper functioning of the process"
       check_path:
         path_not_available:
           owner: This URL is identical to another of your published procedures. If you publish this procedure, the URL will no longer point to the old procedure.

--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -72,7 +72,6 @@ fr:
         dpd_part_4: Comment faire ? Vous pouvez soit lui communiquer par email le lien vers la démarche en test, ou bien le nommer « administrateur ». Dans tous les cas, ne publiez votre démarche qu’après avoir eu son avis.
         back_to_procedure: 'Annuler et revenir à la page de la démarche'
         submit: Publier
-      technical_issues: Des problèmes impactent le bon fonctionnement de la démarche
       check_path:
         path_not_available:
           owner: Cette url est identique à celle d’une autre de vos démarches publiées. Si vous publiez cette démarche, le lien ne pointera plus sur l'ancienne démarche.

--- a/spec/components/procedure/api_entreprise_token_expiration_alert_component_spec.rb
+++ b/spec/components/procedure/api_entreprise_token_expiration_alert_component_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Procedure::APIEntrepriseTokenExpirationAlertComponent, type: :component do
+  subject { render_inline(described_class.new(procedure:)) }
+
+  let(:procedure) { create(:procedure, api_entreprise_token:) }
+  let(:url_helpers) { Rails.application.routes.url_helpers }
+
+  context "when token is expired or expires soon" do
+    let(:api_entreprise_token) { JWT.encode({ exp: 2.days.from_now.to_i }, nil, "none") }
+
+    it "renders the alert" do
+      expect(subject).to have_css('.fr-alert--error')
+      expect(subject).to have_text('Des problèmes impactent le bon fonctionnement de la démarche')
+      expect(subject).to have_text('Le')
+      expect(subject).to have_text('est expiré ou va expirer prochainement')
+    end
+
+    it "renders the link to jetons path" do
+      expect(subject).to have_link('Jeton API Entreprise', href: url_helpers.admin_procedure_jetons_path(procedure), class: 'error-anchor')
+    end
+  end
+
+  context "when token expires in a long time" do
+    let(:api_entreprise_token) { JWT.encode({ exp: 2.months.from_now.to_i }, nil, "none") }
+
+    it "does not render" do
+      expect(subject.to_html).to be_empty
+    end
+  end
+
+  context "when there is no token" do
+    let(:api_entreprise_token) { nil }
+
+    before do
+      allow_any_instance_of(APIEntrepriseToken).to receive(:expired_or_expires_soon?).and_return(false)
+    end
+
+    it "does not render" do
+      expect(subject.to_html).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Il y avait eu un changement dans les routes et `jeton_admin_procedure_path` n'existait plus.
J'en profite pour en faire un composant testé.