### PR TITLE
Fix: les dates d'expiration de tous les dossiers sont actualisées lors d'une modification de la durée de conservation

### DIFF
--- a/app/jobs/reset_expiring_dossiers_job.rb
+++ b/app/jobs/reset_expiring_dossiers_job.rb
@@ -14,8 +14,8 @@ class ResetExpiringDossiersJob < ApplicationJob
                         en_construction_close_to_expiration_notice_sent_at: nil,
                         termine_close_to_expiration_notice_sent_at: nil,
                         hidden_by_expired_at: nil)
-          dossier.update_expired_at
         end
+        dossier.update_expired_at
       end
     end
   end

--- a/spec/jobs/reset_expiring_dossiers_job_spec.rb
+++ b/spec/jobs/reset_expiring_dossiers_job_spec.rb
@@ -10,6 +10,7 @@ describe ResetExpiringDossiersJob do
   let!(:expiring_dossier_en_construction) { create(:dossier, :en_construction, procedure: procedure, en_construction_close_to_expiration_notice_sent_at: duree_conservation_dossiers_dans_ds.months.ago) }
   let!(:expiring_dossier_termine) { create(:dossier, :accepte, procedure: procedure, termine_close_to_expiration_notice_sent_at: duree_conservation_dossiers_dans_ds.months.ago) }
   let!(:automatic_expiring_dossier) { create(:dossier, :accepte, procedure:, termine_close_to_expiration_notice_sent_at: 3.weeks.ago, hidden_by_expired_at: 1.week.ago) }
+  let!(:not_expiring_dossier) { create(:dossier, :accepte, procedure:, processed_at: 1.month.ago) }
 
   describe '.perform_now' do
     it 'resets flags' do
@@ -22,6 +23,7 @@ describe ResetExpiringDossiersJob do
       expect(expiring_dossier_en_construction.expired_at).to be_within(1.hour).of(2.months.from_now)
       expect(expiring_dossier_termine.expired_at).to be_within(1.hour).of(2.months.from_now)
       expect(automatic_expiring_dossier.reload.hidden_by_expired_at).to eq(nil)
+      expect(not_expiring_dossier.reload.expired_at).to be_within(1.hour).of(1.month.from_now)
     end
 
     it 'destroys dossier_expirant notification' do


### PR DESCRIPTION
Crisp :
https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_efb15c78-d5cb-4acd-8b6a-3281462af4f5/

je pensais au début qu'on avait oublié le cas où le super admin modifie la durée de conservation des dossiers lorsque l'on avait fait le refacto sur la date d'expiration.

Mais en fait le problème est : un admin (ou super admin) qui modifie la durée de conservation des dossiers au niveau de la procédure, on recalcule la date d'expiration uniquement pour les dossiers expirants, alors qu'il convient de le faire pour tous.

Après la MEP, il conviendra de refaire tourner la MT qui reset la date d'expiration 