### PR TITLE
amelioration: ETQ usager, le mail de compte deja existant est plus clair

### DIFF
--- a/app/views/user_mailer/new_account_warning.html.haml
+++ b/app/views/user_mailer/new_account_warning.html.haml
@@ -14,19 +14,23 @@
     Si vous souhaitez remplir la démarche
     = surround '« ', ' »,' do
       %i= @procedure.libelle
-    cliquez sur le bouton ci-dessous.
+    cliquez sur le bouton ci-dessous, puis connectez-vous à votre compte.
 
   = round_button("Commencer la démarche « #{@procedure.libelle.truncate(60)} »", commencer_sign_in_url(path: @procedure.path), :primary)
   = vertical_margin(16)
-  = round_button('J’ai oublié mon mot de passe', new_password_url(@user), :secondary)
+  = round_button('Demander un nouveau mot de passe', new_password_url(@user), :secondary)
 
 - else
   %p
-    Vous n’avez rien à faire. Si vous avez oublié votre mot de passe, cliquez sur le bouton ci-dessous.
-  = round_button('J’ai oublié mon mot de passe', new_password_url(@user), :secondary)
+    Rendez-vous sur le site #{APPLICATION_NAME} pour vous connecter à votre compte.
+    = round_button('Se connecter', new_user_session_url, :primary)
+
+  %p
+    Vous avez oublié votre mot de passe ?
+    = round_button('Demander un nouveau mot de passe', new_password_url(@user), :secondary)
 
 = vertical_margin(6)
 %p
-  Si vous n’êtes pas à l'origine de cette demande, vous pouvez ignorer ce mail.
+  Si vous n’êtes pas à l'origine de cette demande, vous pouvez ignorer cet email.
 
 = render partial: "layouts/mailers/signature"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UserMailer, type: :mailer do
     it 'sends email to the correct user with expected body content and link' do
       expect(subject.to).to eq([user.email])
       expect(subject.body).to include(user.email)
-      expect(subject.body).to have_link('J’ai oublié mon mot de passe')
+      expect(subject.body).to have_link('Demander un nouveau mot de passe')
     end
 
     context 'when a procedure is provided' do


### PR DESCRIPTION
crisp : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_66050b46-648b-4142-8821-7dfc7bb52c28/

apres:
<img width="614" height="834" alt="Capture d’écran 2025-12-19 à 4 26 39 PM" src="https://github.com/user-attachments/assets/83a8060d-9de5-42ba-9078-faec4a234c79" />


avant:
<img width="608" height="727" alt="Capture d’écran 2025-12-19 à 2 58 38 PM" src="https://github.com/user-attachments/assets/2fed0abd-bb81-427e-8127-b293448f1887" />
