### PR TITLE
[BUG] ETQ qu'instructeur, je ne vois pas les actions de l'utilisateur invité pour vérifier la complétude du dossier

### DIFF
--- a/app/components/dossiers/edit_footer_component.rb
+++ b/app/components/dossiers/edit_footer_component.rb
@@ -14,6 +14,10 @@ class Dossiers::EditFooterComponent < ApplicationComponent
     controller.current_user.owns?(@dossier)
   end
 
+  def show_for_user?
+    controller.is_a?(Users::DossiersController)
+  end
+
   def annotation?
     @annotation.present?
   end

--- a/app/components/dossiers/edit_footer_component/edit_footer_component.html.haml
+++ b/app/components/dossiers/edit_footer_component/edit_footer_component.html.haml
@@ -2,19 +2,20 @@
   .send-dossier-actions-bar
     = render Dossiers::AutosaveFooterComponent.new(dossier: @dossier, annotation: annotation?, owner: owner?)
 
-    - if can_submit? && owner?
-      - if !can_passer_en_construction?
-        = link_to t('.submit_disabled'), "#", disabled_submit_button_options
-      = button_to submit_button_label, submit_button_path, submit_button_options
+    - if show_for_user?
+      - if can_submit? && owner?
+        - if !can_passer_en_construction?
+          = link_to t('.submit_disabled'), "#", disabled_submit_button_options
+        = button_to submit_button_label, submit_button_path, submit_button_options
 
+      - if !owner?
+        = button_to t('.check_completude'), check_completude_dossier_path(@dossier), class: "fr-btn", method: :post
+
+  - if show_for_user?
     - if !owner?
-      = button_to t('.check_completude'), check_completude_dossier_path(@dossier), class: "fr-btn", method: :post
+      .fr-pb-2w.invite-cannot-submit
+        = render ::Dsfr::AlertComponent.new(state: :info, title: nil, size: :sm, heading_level: :p, extra_class_names: 'fr-mt-1w') do |c|
+          - c.with_body do
+            %p.fr-pb-0= t('.invite_notice').html_safe
 
-  - if !owner?
-    .fr-pb-2w.invite-cannot-submit
-      = render ::Dsfr::AlertComponent.new(state: :info, title: nil, size: :sm, heading_level: :p, extra_class_names:' fr-mt-1w') do |c|
-        - c.with_body do
-          %p.fr-pb-0= t('.invite_notice').html_safe
-
-  - if !annotation?
     = render partial: "shared/dossiers/submit_is_over", locals: { dossier: @dossier }

--- a/spec/components/dossiers/edit_footer_component_spec.rb
+++ b/spec/components/dossiers/edit_footer_component_spec.rb
@@ -2,17 +2,21 @@
 
 RSpec.describe Dossiers::EditFooterComponent, type: :component do
   let(:annotation) { false }
-  let(:component) { Dossiers::EditFooterComponent.new(dossier:, annotation:) }
+  let(:component) { described_class.new(dossier:, annotation:) }
 
   subject { render_inline(component).to_html }
 
-  before { allow(component).to receive(:owner?).and_return(true) }
+  before do
+    allow(component).to receive(:owner?).and_return(true)
+    allow(component).to receive(:show_for_user?).and_return(true)
+  end
 
   context 'when brouillon' do
     let(:dossier) { create(:dossier, :brouillon) }
 
     context 'when dossier can be submitted' do
       before { allow(component).to receive(:can_passer_en_construction?).and_return(true) }
+
       it 'renders submit button without disabled' do
         expect(subject).to have_selector('button', text: 'Déposer le dossier')
       end
@@ -20,9 +24,19 @@ RSpec.describe Dossiers::EditFooterComponent, type: :component do
 
     context 'when dossier can not be submitted' do
       before { allow(component).to receive(:can_passer_en_construction?).and_return(false) }
+
       it 'renders submit button with disabled' do
         expect(subject).to have_selector('a', text: 'Pourquoi je ne peux pas déposer mon dossier ?')
         expect(subject).to have_selector('button[disabled]', text: 'Déposer le dossier')
+      end
+    end
+
+    context 'when rendered in instructeur context' do
+      before { allow(component).to receive(:show_for_user?).and_return(false) }
+
+      it 'does not render user actions' do
+        expect(subject).not_to include('Déposer le dossier')
+        expect(subject).not_to include('Vérifier la complétude')
       end
     end
   end


### PR DESCRIPTION
Bug introduit dans la PR de verification de la complétude d'un dossier par un invité :
https://github.com/demarches-simplifiees/demarches-simplifiees.fr/pull/11873

On n'etait pas assez strict sur le contexte user/ instructeur

<img width="1080" height="697" alt="Capture d’écran 2025-12-23 à 17 52 49" src="https://github.com/user-attachments/assets/92398774-3b16-4a3b-91fd-d3685bd394fa" />
<img width="1273" height="673" alt="Capture d’écran 2025-12-23 à 17 53 04" src="https://github.com/user-attachments/assets/91d37db4-a89a-4146-aa4c-d31316293fca" />
