### PR TITLE
ETQ administrateur, l’action "Clore" est de nouveau proposée dans le menu d’actions d’une démarche publiée en page Liste

### DIFF
--- a/app/views/administrateurs/procedures/_procedures_list.html.haml
+++ b/app/views/administrateurs/procedures/_procedures_list.html.haml
@@ -108,3 +108,10 @@
                 %span.icon.unarchive
                 .dropdown-description
                   %h4= t('administrateurs.dropdown_actions.restore')
+
+          - if procedure.locked? && !procedure.close?
+            - menu.with_item do
+              = link_to admin_procedure_close_path(procedure.id), role: 'menuitem' do
+                = dsfr_icon('fr-icon-calendar-close-fill')
+                .dropdown-description
+                  %h4= t('administrateurs.dropdown_actions.to_close')


### PR DESCRIPTION
closes #12448 

<img width="1254" height="500" alt="Capture d’écran 2026-01-05 à 16 48 51" src="https://github.com/user-attachments/assets/df2bd95b-defc-4a16-ae6e-619404449c6e" />
