### PR TITLE
ETQ Admin, je ne veux pas de redirection infinie sur le lien de ma démarche

### DIFF
--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -152,7 +152,7 @@ module Users
     def procedure_not_found
       procedure = Procedure.find_with_path(params[:path]).first
 
-      if procedure&.replaced_by_procedure
+      if procedure&.replaced_by_procedure && procedure.replaced_by_procedure != procedure
         redirect_to commencer_path(procedure.replaced_by_procedure.path, **extra_query_params)
         return
       elsif procedure&.close?

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -102,6 +102,17 @@ describe Users::CommencerController, type: :controller do
       end
     end
 
+    context 'when procedure has a replaced_by_procedure pointing to itself (circular reference that should not be allowed in a next fix)' do
+      let(:path) { published_procedure.path }
+
+      it 'does not create an infinite redirect loop and redirects to closing_details instead' do
+        published_procedure.update!(replaced_by_procedure_id: published_procedure.id)
+        published_procedure.close!
+        expect(subject).to redirect_to(closing_details_path(published_procedure.path))
+        expect(subject.status).to eq(302)
+      end
+    end
+
     context 'when a dossier has been prefilled by POST before' do
       let(:dossier) { create(:dossier, :brouillon, :prefilled, user: user) }
       let(:path) { dossier.procedure.path }


### PR DESCRIPTION
cas au support : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_c885ff78-4d6e-4e09-b5b2-2b92ce733156/

il s'agit d'une démarche fermée qui est replacée par elle même.

cette PR corrige la redirection infinie, une prochaine PR pour empêcher ce cas de se produire.