### PR TITLE
fix(filters): multiple drop down list filter with quote should work

### DIFF
--- a/app/models/columns/champ_column.rb
+++ b/app/models/columns/champ_column.rb
@@ -76,8 +76,9 @@ class Columns::ChampColumn < Column
     if type == :enum
       relation.where(champs: { column => search_terms }).ids
     elsif type == :enums
-      # in a multiple drop down list, the value are stored as '["v1", "v2"]'
-      quoted_search_terms = search_terms.map { %{"#{_1}"} }
+      # in a multiple drop down list, the value are stored as JSON array
+      quoted_search_terms = search_terms.map(&:to_json)
+
       relation.filter_ilike(:champs, column, quoted_search_terms).ids
     else
       relation.filter_ilike(:champs, column, search_terms).ids


### PR DESCRIPTION
Remonté au support https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_61a1d94c-12aa-46c4-a8bb-499db7a21d83/

En DB le champ a cette valeur `"[\"Fromage \\\"blanc\\\"\",\"Fromage\"]"`

L'instructeur cherche :
```ruby
search_terms = ["Fromage \"blanc\""]
```

`search_terms.map { %{"#{_1}"} }` produisait 
```ruby
["\"Fromage \"blanc\"\""]
```
donc ça matchait pas avec le champ en DB
en utlisant `search_terms.map(&:to_json)` on cherche 
```ruby
["\"Fromage \\\"blanc\\\"\""]
``` 
donc ça match.
