### PR TITLE
Tech: fix N+1 à la génération du PDF dans le contexte exports

### DIFF
--- a/app/models/dossier_preloader.rb
+++ b/app/models/dossier_preloader.rb
@@ -19,7 +19,7 @@ class DossierPreloader
 
   def in_batches_with_block(&block)
     @dossiers.in_batches(of: adaptive_batch_size(@dossiers)) do |batch|
-      data = Dossier.where(id: batch.ids).includes(:individual, :traitement, :etablissement, user: :france_connect_informations, avis: :expert, commentaires: [:instructeur, :expert])
+      data = Dossier.where(id: batch.ids).includes(:individual, :traitement, :etablissement, :pending_corrections, user: :france_connect_informations, avis: :expert, commentaires: [:instructeur, :expert])
 
       dossiers = data.to_a
       load_dossiers(dossiers)

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -290,7 +290,7 @@ def add_etats_dossier(pdf, dossier)
   end
 
   if dossier.pending_correction?
-    format_in_2_columns(pdf, "Correction demandée le", try_format_date(dossier.pending_correction.created_at))
+    format_in_2_columns(pdf, "Correction demandée le", try_format_date(dossier.pending_corrections.first.created_at))
   end
 
   if dossier.en_instruction_at.present?

--- a/spec/perf/export_spec.rb
+++ b/spec/perf/export_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+describe 'Export performance' do
+  let(:instructeur) { create(:instructeur) }
+  let(:types_de_champ_public) do
+    [
+      { type: :text, libelle: 'Nom' },
+      { type: :textarea, libelle: 'Description' },
+      { type: :integer_number, libelle: 'Nombre' },
+      { type: :date, libelle: 'Date' },
+      { type: :piece_justificative, libelle: 'Justificatif' },
+    ]
+  end
+  let(:types_de_champ_private) do
+    [
+      { type: :text, libelle: 'Note interne' },
+    ]
+  end
+  let(:procedure) { create(:procedure, :published, :for_individual, types_de_champ_public:, types_de_champ_private:, instructeurs: [instructeur]) }
+  let(:expert) { create(:expert) }
+  let(:experts_procedure) { create(:experts_procedure, expert:, procedure:) }
+
+  def create_dossier_with_associations(state)
+    dossier = create(:dossier, state, :with_individual, :with_populated_champs, procedure:)
+
+    create(:traitement, dossier:, state:)
+
+    create(:commentaire, dossier:, instructeur:)
+    create(:commentaire, dossier:, expert:)
+    create(:commentaire, dossier:)
+
+    create(:avis, dossier:, claimant: instructeur, experts_procedure:)
+
+    commentaire_correction = create(:commentaire, dossier:, instructeur:)
+    create(:dossier_correction, dossier:, commentaire: commentaire_correction)
+
+    dossier
+  end
+
+  describe 'generate_dossiers_export' do
+    let!(:dossiers) do
+      # Mix of states to test all code paths including pending_correction?
+      dossiers = []
+      5.times { dossiers << create_dossier_with_associations(:en_construction) }
+      5.times { dossiers << create_dossier_with_associations(:en_instruction) }
+      5.times { dossiers << create_dossier_with_associations(:accepte) }
+      dossiers
+    end
+    let(:pj_service) { PiecesJustificativesService.new(user_profile: instructeur, export_template: nil) }
+
+    it 'does not have N+1 queries', :slow do
+      all_dossiers = Dossier.where(id: dossiers.map(&:id))
+
+      query_count = 0
+
+      ActiveSupport::Notifications.subscribed(lambda { |*_args| query_count += 1 }, "sql.active_record") do
+        DossierPreloader.new(all_dossiers).in_batches_with_block do |loaded|
+          pj_service.generate_dossiers_export(loaded)
+        end
+      end
+
+      expect(query_count).to be <= 35
+    end
+  end
+end


### PR DESCRIPTION
- commentaires: réutilise l'association préloadée
- dossier corrections , on a besoin de l'association dans le preloader

Il y en a d'autres, pour plus tard