### PR TITLE
ETQ usager, pas de chatbot sur les pages /brouillon et /modifier

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -229,9 +229,18 @@ class ApplicationController < ActionController::Base
     gon.matomo = matomo_config
     gon.sentry = sentry_config
 
-    if administrateur_signed_in? || (user_signed_in? && feature_enabled?(:chatbot))
+    if !chatbot_disabled_page? && (administrateur_signed_in? || (user_signed_in? && feature_enabled?(:chatbot)))
       gon.crisp = crisp_config
     end
+  end
+
+  CHATBOT_DISABLED_PAGES = [
+    ['users/dossiers', 'brouillon'],
+    ['users/dossiers', 'modifier'],
+  ].freeze
+
+  def chatbot_disabled_page?
+    CHATBOT_DISABLED_PAGES.include?([controller_path, action_name])
   end
 
   def current_user_roles

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,7 @@
     <%= vite_client_tag %>
     <%= vite_react_refresh_tag %>
     <%= vite_javascript_tag 'application' %>
-    <% if administrateur_signed_in? || (user_signed_in? && feature_enabled?(:chatbot)) %>
+    <% if user_signed_in? %>
       <%= vite_javascript_tag 'chatbot' %>
     <% end %>
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -324,6 +324,20 @@ describe ApplicationController, type: :controller do
         expect(config[:user][:segments]).to contain_exactly('administrateur', 'instructeur')
       end
     end
+
+    context 'on brouillon page' do
+      before do
+        allow(@controller).to receive(:controller_path).and_return('users/dossiers')
+        allow(@controller).to receive(:action_name).and_return('brouillon')
+        allow(@controller).to receive(:matomo_config)
+        allow(@controller).to receive(:sentry_config)
+      end
+
+      it 'does not setup crisp' do
+        expect(@controller).not_to receive(:crisp_config)
+        @controller.send(:setup_tracking)
+      end
+    end
   end
 
   describe 'chatbot feature flag' do


### PR DESCRIPTION
pour pas distraire l'usager pendant qu'il remplir son form ni interférer avec le bandeau du bas 