### PR TITLE
correctif: ETQ usager, le dossier recupéré est annoncé par la synthèse vocale

### DIFF
--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -17,6 +17,7 @@ module Dsfr
       siret_support_status? ||
       rna_support_statut? ||
       referentiel_support_statut? ||
+      dossier_link_support_statut? ||
       prefilled? ||
       pjs_statut?
     end
@@ -37,6 +38,10 @@ module Dsfr
       @champ.RIB? && !@champ.idle?
     end
 
+    def dossier_link_support_statut?
+      type_de_champ.dossier_link? && @champ.value.present?
+    end
+
     def statut_message
       case @champ.type_de_champ.type_champ
       when TypeDeChamp.type_champs[:siret]
@@ -52,6 +57,11 @@ module Dsfr
         end
       when TypeDeChamp.type_champs[:rna]
         { state: :info, text: t(".rna.data_fetched", title: @champ.title, address: @champ.full_address) }
+      when TypeDeChamp.type_champs[:dossier_link]
+        dossier = Dossier.visible_by_administration.find_by(id: @champ.value)
+        if dossier.present?
+          { state: :info, text: dossier.text_summary }
+        end
       when TypeDeChamp.type_champs[:referentiel]
         if @champ.pending?
           { state: :info, text: t(".referentiel.fetching") }

--- a/app/components/editable_champ/dossier_link_component.rb
+++ b/app/components/editable_champ/dossier_link_component.rb
@@ -3,9 +3,5 @@
 class EditableChamp::DossierLinkComponent < EditableChamp::EditableChampBaseComponent
   def dsfr_input_classname
     'fr-input'
-    end
-
-  def dossier
-    @dossier ||= @champ.blank? ? nil : Dossier.visible_by_administration.find_by(id: @champ.to_s)
   end
 end

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
@@ -1,4 +1,1 @@
-= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, inputmode: :numeric, min: 1, pattern: "[0-9]{1,12}", autocomplete: 'off', required: @champ.required?, class: "#{@champ.blank? ? '' : 'small-margin'}"))
-
-- if !@champ.blank? && !dossier.blank?
-  .fr-info-text.fr-mb-4w= sanitize(dossier.text_summary)
+= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id}" }, inputmode: :numeric, min: 1, pattern: "[0-9]{1,12}", autocomplete: 'off', required: @champ.required?, class: "width-33-desktop"))

--- a/spec/components/input_status_message_component_spec.rb
+++ b/spec/components/input_status_message_component_spec.rb
@@ -41,6 +41,21 @@ RSpec.describe Dsfr::InputStatusMessageComponent, type: :component do
       end
     end
 
+    context 'with dossier_link champs' do
+      let(:types_de_champ_public) { [{ type: :dossier_link }] }
+      let(:linked_dossier) { create(:dossier, :en_construction) }
+
+      before do
+        champ.update(value: linked_dossier.id.to_s)
+      end
+
+      context "when a dossier is found" do
+        it "renders the dossier information" do
+          expect(subject).to have_css(".fr-message--info", text: /Dossier/)
+        end
+      end
+    end
+
     context 'with referentiel champs' do
       let(:referentiel) { create(:api_referentiel, :exact_match) }
       let(:types_de_champ_public) { [{ type: :referentiel, referentiel: }] }


### PR DESCRIPTION
fix: https://github.com/orgs/demarche-numerique/projects/1/views/1?pane=issue&itemId=131183116&issue=demarche-numerique%7Cdemarche.numerique.gouv.fr%7C12127

https://github.com/user-attachments/assets/bb207e39-89fb-4412-b1c6-697d8ca24d2f

# TODO
- [x] Valider ac @inseo une fois en prod, ou demo local fonction des dispo