### PR TITLE
Tech (perf): cache lookup communes par département

### DIFF
--- a/app/services/api_geo_service.rb
+++ b/app/services/api_geo_service.rb
@@ -88,7 +88,9 @@ class APIGeoService
     def communes(departement_code)
       return [] if departement_code.blank? || departement_code == '99'
 
-      get_from_api_geo("communes-#{departement_code}").sort_by { I18n.transliterate([_1[:name], _1[:postal_code]].join(' ')) }
+      Rails.cache.fetch("api_geo_communes_by_dpt_#{departement_code}", expires_in: 1.week, version: 1) do
+        get_from_api_geo("communes-#{departement_code}").sort_by { I18n.transliterate([_1[:name], _1[:postal_code]].join(' ')) }
+      end
     end
 
     def communes_by_postal_code(postal_code)


### PR DESCRIPTION
contexte: vu des lenteurs sur API sur certaines démarches

Le profilers indiquent que les champs adresse et commune sont couteux aussi à cause des transliterations qu'on fait toujours sur les mêmes objets (mesuré ~ 15% d'amélioration, soit 1 à 2s pour 10 secondes) 

Cette PR introduit le cache communes par département, comme on le fait déjà pour communes par code postal . Cela bénéficiera aussi à l'ensemble du site
