### PR TITLE
[Fix] Je peux instruire un dossier sans avoir l'alerte d'annotation privées obligatoire lorsqu'il n'y a pas d'annotations

### DIFF
--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -7,14 +7,14 @@ class Champs::PieceJustificativeChamp < Champ
 
   validates :piece_justificative_file,
     size: { less_than: FILE_MAX_SIZE },
-    if: -> { can_validate? && !type_de_champ.skip_pj_validation }
+    if: -> { validate_champ_value? && !type_de_champ.skip_pj_validation }
 
   validates :piece_justificative_file,
     content_type: AUTHORIZED_CONTENT_TYPES,
-    if: -> { can_validate? && !type_de_champ.skip_content_type_pj_validation }
+    if: -> { validate_champ_value? && !type_de_champ.skip_content_type_pj_validation }
 
   validate :validate_dynamic_piece_justificative_rules,
-    if: -> { can_validate? && piece_justificative_file.attached? }
+    if: -> { validate_champ_value? && piece_justificative_file.attached? }
 
   def main_value_name
     :piece_justificative_file

--- a/spec/components/instructeurs/instruction_menu_component_spec.rb
+++ b/spec/components/instructeurs/instruction_menu_component_spec.rb
@@ -58,7 +58,10 @@ RSpec.describe Instructeurs::InstructionMenuComponent, type: :component do
     let(:types_de_champ_private)  { [{ type: :text, mandatory: true }] }
 
     it 'renders an alert if annotations privees are not valid' do
-      expect(subject).to have_selector('#alert-error-annotation', text: "Les annotations privées n’ont pas été correctement renseignées. Elles sont indispensables à l'instruction du dossier.", visible: true)
+      expect(subject).to have_selector(
+        '#alert-error-annotation:not(.hidden)',
+        text: "Les annotations privées n’ont pas été correctement renseignées. Elles sont indispensables à l'instruction du dossier."
+      )
     end
   end
 end


### PR DESCRIPTION
Remontée Crisp : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_563cd747-223d-479d-8c00-09c188f178ec/

