### PR TITLE
Test: fix régression suite à changements accidentels dans fichier fixtures de pays

### DIFF
--- a/spec/fixtures/files/pays_dump.json
+++ b/spec/fixtures/files/pays_dump.json
@@ -604,7 +604,7 @@
   "TERRE-NEUVE",
   "TERRES AUSTRALES FRANCAISES",
   "Terres australes françaises",
-  "Territoire britannique de l’océan Indien",
+  "Territoire britannique de l'océan Indien",
   "TERRITOIRES DU ROYAUME-UNI AUX ANTILLES",
   "Thailand",
   "THAILANDE",


### PR DESCRIPTION
Pour les tests on a besoin d'une liste compatible avec celles des pays au format iso-x