### PR TITLE
[fix] ETQ instructeur on m'affiche correctement les champs manquants pour une attestation

### DIFF
--- a/app/views/instructeurs/dossiers/_unspecified_champs.html.haml
+++ b/app/views/instructeurs/dossiers/_unspecified_champs.html.haml
@@ -4,17 +4,15 @@
     - c.with_body do
       %p
         = t('instructeurs.dossiers.alert_unspecified_attestation_champs')
-        %br
-        -# = link_to t('instructeurs.dossiers.alert_error_annotations_link'), annotations_privees_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]), class: 'fr-link'
 
       - unspecified_annotations_privees, unspecified_champs = unspecified_attestation_champs.partition(&:private?)
 
       - if unspecified_champs.present?
         %p.fr-text--sm.fr-text--bold
           Champs de la demande
-        - unspecified_attestation_champs.each do |unspecified_champ|
+        - unspecified_champs.each do |unspecified_champ|
           .fr-mb-1v
-            %li= unspecified_champ.libelle
+            = unspecified_champ.libelle
 
       - if unspecified_annotations_privees.present?
         %p.fr-text--sm.fr-text--bold


### PR DESCRIPTION
**APRES**

<img width="464" height="383" alt="Capture d’écran 2026-01-13 à 15 00 12" src="https://github.com/user-attachments/assets/d4b3ecf7-7ffb-4ec6-b716-9324e5d8a1e2" />


**AVANT**
<img width="461" height="528" alt="Capture d’écran 2026-01-13 à 15 00 33" src="https://github.com/user-attachments/assets/8d4366ea-a779-49a2-8692-35ecf762553e" />
