### PR TITLE
ETQ Tech: suppression d'un controle de passage par pro connect obligatoire qui faisait planter le login

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,7 +9,6 @@ class Users::SessionsController < Devise::SessionsController
 
   layout 'login', only: [:new, :create]
 
-  before_action :redirect_to_pro_connect_if_mandatory, only: [:create]
   before_action :restore_procedure_context, only: [:new, :create]
   skip_before_action :redirect_if_untrusted, only: [:reset_link_sent]
   # POST /resource/sign_in
@@ -123,15 +122,6 @@ class Users::SessionsController < Devise::SessionsController
   # Pro connect callback
   def logout
     redirect_to root_path, notice: I18n.t('devise.sessions.signed_out')
-  end
-
-  def redirect_to_pro_connect_if_mandatory
-    return if !ProConnectService.enabled?
-
-    return if !ProConnectService.email_domain_is_in_mandatory_list?(user_email_params[:email])
-
-    flash[:alert] = "La connexion des agents passe à présent systématiquement par ProConnect"
-    redirect_to pro_connect_path(force_pro_connect: true)
   end
 
   # calling current_user in a before_action will trigger the warden authentication (devise behavior)


### PR DESCRIPTION
Pendant un moment, on a essayer de forcer les agents qui appartenait à un certain domaine de passer par ProConnect.

La liste des domaines concernées est devenu vide suite au pb qu'on avait avec ProConnect.

J'ai supprimé cette liste mais pas tous les appels ce qui faisait planter l'app lors du login.