### PR TITLE
ETQ Usager je peux lire correctement le nom du pays selectionné dans le champ adresse sur desktop

### DIFF
--- a/app/components/editable_champ/address_component/address_component.html.haml
+++ b/app/components/editable_champ/address_component/address_component.html.haml
@@ -1,4 +1,4 @@
-.flex.column
+.flex.column.flex-1
   .fr-fieldset__element
     .fr-input-group.address-ban
       = @form.label :address, t('.address_hint'), for: @champ.focusable_input_id, class: 'fr-hint-text', id: input_label_id(@champ)


### PR DESCRIPTION
AVANT

<img width="1204" height="1202" alt="image" src="https://github.com/user-attachments/assets/a14e2be3-591b-4347-836f-9db82e763a2a" />



APRES

<img width="1202" height="569" alt="image" src="https://github.com/user-attachments/assets/cc5ac839-a70a-45a7-bf5f-e869f1a03d74" />
