### PR TITLE
Tech: nettoyage des données de cadre juridique moins agressif

### DIFF
--- a/app/tasks/maintenance/t20251210_clean_cadre_juridique_task.rb
+++ b/app/tasks/maintenance/t20251210_clean_cadre_juridique_task.rb
@@ -6,9 +6,9 @@ module Maintenance
   # Les données legacy légitimes (numéros de décret, références légales) sont préservées
   class T20251210CleanCadreJuridiqueTask < MaintenanceTasks::Task
     PATTERNS = [
-      /<[a-z]/i,                           # Balises HTML (<a>, etc.)
-      /&#\d+;/,                            # Entités HTML encodées (&#60; = <)
-      /&#x[0-9a-f]+;/i,                    # Entités HTML hex (&#x3c; = <)
+      /<.+>/i, # Balises HTML (<a>, etc.)
+      /&#60;/,                             # Entités HTML encodées (&#60; = <)
+      /&#x3c;;/i,                          # Entités HTML hex (&#x3c; = <)
       /\Ajavascript:/i,                    # Schéma javascript:
       /\Adata:/i,                          # Schéma data:
       /\Avbscript:/i,                      # Schéma vbscript:


### PR DESCRIPTION
Contexte https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/12437

on a quelques démarches avec du texte valable qui contient des `&#…` par exemple qui ne sont pas des `<script>`. On ne va finalement pas les cleaner pour ne pas provoquer d'erreur de validation sur ces démarches.