### PR TITLE
ETQ Usager d'un lecteur d'écran, je veux que la synthèse des dossiers soit correctement structurée

### DIFF
--- a/app/views/instructeurs/procedures/synthese.html.erb
+++ b/app/views/instructeurs/procedures/synthese.html.erb
@@ -1,14 +1,12 @@
 <turbo-frame id="synthese-content">
-  <p>
+  <dl class="fr-badges-group">
     <% @counters.all_dossiers_counts.each do |tab_key, dossier_count| %>
       <% if dossier_count.positive? %>
-        <span class="fr-badge">
-          <span class="flex column align-center">
-            <span class="fr-cell--numeric"><%= number_with_html_delimiter(dossier_count) %></span>
-            <%= i18n_tab_from_status(tab_key) %>
-          </span>
-        </span>
+        <div class="fr-badge flex column">
+          <dt class="fr-cell--numeric"><%= number_with_html_delimiter(dossier_count) %></dt>
+          <dd><%= i18n_tab_from_status(tab_key) %></dd>
+        </div>
       <% end %>
     <% end %>
-  </p>
+  </dl>
 </turbo-frame>


### PR DESCRIPTION
Remplacement de la structure en `<span>` par une liste de description.

# Après
<img width="694" height="257" alt="" src="https://github.com/user-attachments/assets/09891068-be25-4af3-8c96-449adf7f9476" />
<img width="345" height="290" alt="" src="https://github.com/user-attachments/assets/5850e5cd-db00-415a-985b-956e26f5c636" />


# Avant
<img width="820" height="245" alt="" src="https://github.com/user-attachments/assets/fce85508-47f4-49c4-a9c9-e89ac3cefefe" />
<img width="340" height="271" alt="" src="https://github.com/user-attachments/assets/ef1d76c8-8b33-4b2f-a0f4-463520cf5cd9" />

