### PR TITLE
Fix: corrige l'affichage des labels sur la page de personnalisation de l'ordre

### DIFF
--- a/app/assets/stylesheets/sticky.scss
+++ b/app/assets/stylesheets/sticky.scss
@@ -1,14 +1,22 @@
 @import 'constants';
 
+.sticky-footer,
 .fixed-footer {
   border-top: 2px solid var(--border-plain-blue-france);
-  position: fixed;
   bottom: 0;
   left: 0;
   right: 0;
   padding-top: $default-padding;
   background-color: var(--background-default-grey);
   z-index: 2;
+}
+
+.fixed-footer {
+  position: fixed;
+}
+
+.sticky-footer {
+  position: sticky;
 }
 
 @media (max-width: 62em) {
@@ -23,7 +31,8 @@
   }
 }
 
-[data-fr-theme='dark'] .fixed-footer {
+[data-fr-theme='dark'] .fixed-footer,
+[data-fr-theme='dark'] .sticky-footer {
   background-color: var(--background-action-low-blue-france);
 }
 

--- a/app/views/administrateurs/labels/order_positions.html.haml
+++ b/app/views/administrateurs/labels/order_positions.html.haml
@@ -1,4 +1,4 @@
-.fr-container.fr-mt-6w.fr-mb-15w
+.fr-container.fr-mt-6w.fr-mb-6w
   = link_to " Liste des labels", admin_procedure_labels_path, class: 'fr-link fr-icon-arrow-left-line fr-link--icon--left fr-icon--sm'
   %h3.fr-my-3w
     Personnaliser l’ordre des #{@labels.size} labels
@@ -14,7 +14,7 @@
             = tag_label(label.name, label.color)
           = hidden_field_tag "ordered_label_ids[]", label.id
 
-.fixed-footer.fr-py-1w
+.sticky-footer.fr-py-1w
   .fr-btns-group.fr-btns-group--center.fr-btns-group--inline.fr-btns-group--inline-lg
     = link_to "Annuler", admin_procedure_labels_path, class: 'fr-btn fr-btn--secondary fr-my-1w'
     %button.fr-btn.fr-my-1w{ type: "submit", form: 'order-admin-procedure-labels-form' } Valider


### PR DESCRIPTION
Bug d'interface remonté par @marleneklok :
<img width="1012" height="870" alt="image" src="https://github.com/user-attachments/assets/6416c591-f66d-4508-ac1e-2f085690c85e" />

Dans certains cas le footer venait masquer les derniers labels de la liste. On passe donc ici le footer de fixed à sticky.