### PR TITLE
[fix] ETQ instructeur je veux voir l'alerte d'erreur pour les annotations privées que lorsque j'instruis le dossier

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -24,6 +24,17 @@ class Dossier < ApplicationRecord
     sans_suite:      'sans_suite',
   }
 
+  INSTRUCTION_ACTIONS = [
+    :accepter,
+    :refuser,
+    :classer_sans_suite,
+  ].freeze
+
+  def self.instruction_action?(action)
+    return false if action.blank?
+    INSTRUCTION_ACTIONS.include?(action.to_sym)
+  end
+
   EN_CONSTRUCTION_OU_INSTRUCTION = [states.fetch(:en_construction), states.fetch(:en_instruction)]
   TERMINE = [states.fetch(:accepte), states.fetch(:refuse), states.fetch(:sans_suite)]
   INSTRUCTION_COMMENCEE = TERMINE + [states.fetch(:en_instruction)]

--- a/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_button_motivation.html.haml
@@ -31,13 +31,14 @@
     .hidden.js_delete_motivation{ id: "delete_motivation_import_#{popup_class}" }
       %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0.fr-mt-1w{ type: 'button', onclick: "DS.deleteJustificatif('#{popup_class}');" } Supprimer le  justificatif
 
-    #alert-error-annotation{ class: dossier.any_annotations_privees_with_errors? ? '' : 'hidden' }
-      = render Dsfr::AlertComponent.new(state: :warning, title: nil, size: :sm, extra_class_names: 'fr-mt-2w') do |c|
-        - c.with_body do
-          %p
-            = t('instructeurs.dossiers.alert_error_annotations')
-            %br
-            = link_to t('instructeurs.dossiers.alert_error_annotations_link'), annotations_privees_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]), class: 'fr-link'
+    - if Dossier.instruction_action?(process_action)
+      #alert-error-annotation{ class: dossier.any_annotations_privees_with_errors? ? '' : 'hidden' }
+        = render Dsfr::AlertComponent.new(state: :warning, title: nil, size: :sm, extra_class_names: 'fr-mt-2w') do |c|
+          - c.with_body do
+            %p
+              = t('instructeurs.dossiers.alert_error_annotations')
+              %br
+              = link_to t('instructeurs.dossiers.alert_error_annotations_link'), annotations_privees_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]), class: 'fr-link'
 
     .fr-btns-group.fr-btns-group--sm.fr-mt-2w
       = button_tag "Annuler", type: :reset, class: 'fr-btn fr-btn--secondary', onclick: 'DS.motivationCancel();'

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -76,6 +76,16 @@ describe Dossier, type: :model do
       end
     end
 
+    describe '.instruction_action?' do
+      it 'is true when its an instruction action' do
+        expect(described_class.instruction_action?('accepter')).to be(true)
+        expect(described_class.instruction_action?('refuser')).to be(true)
+        expect(described_class.instruction_action?('classer_sans_suite')).to be(true)
+        expect(described_class.instruction_action?('passer_en_instruction')).to be(false)
+        expect(described_class.instruction_action?(nil)).to be(false)
+      end
+    end
+
     describe '.brouillon_expired' do
       let(:interval_between_first_and_second_expiration) { Dossier::MONTHS_AFTER_EXPIRATION.months + Dossier::DAYS_AFTER_EXPIRATION.days }
 


### PR DESCRIPTION
Suite à la mise en prod des annotations obligatoires, il restait un petit bug d'affichage : l'alerte en cas d'annotations privées non remplies s'affichait dans la popup de "demande de correction". 


BUG D'AFFICHAGE : 
<img width="512" height="571" alt="Capture d’écran 2026-01-21 à 11 28 03" src="https://github.com/user-attachments/assets/8bbae773-5322-4841-8a15-68caf8ab6282" />
