### PR TITLE
ETQ expert, correction du parcours d'inscription depuis le lien dans l'email de la demande d'avis

### DIFF
--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -132,6 +132,7 @@ module Experts
 
     def sign_up
       @email = params[:email]
+      @confirmation_token = params[:confirmation_token]
       @dossier = Avis.includes(:dossier).find(params[:id]).dossier
 
       render

--- a/app/views/experts/avis/sign_up.html.haml
+++ b/app/views/experts/avis/sign_up.html.haml
@@ -2,6 +2,7 @@
   .fr-grid-row.fr-grid-row--center
     .fr-col-lg-6
       = form_for(User.new(email: @email), url: sign_up_expert_avis_path(email: @email), method: :post, html: { class: "fr-py-5w" }) do |f|
+        = f.hidden_field :confirmation_token, value: @confirmation_token
 
         %h1.fr-h2
           = t('views.registrations.new.title', name: Current.application_name)

--- a/spec/system/experts/expert_spec.rb
+++ b/spec/system/experts/expert_spec.rb
@@ -22,7 +22,8 @@ describe 'Inviting an expert:', js: true do
       let(:password) { 'This is an expert password' }
 
       before 'Signing up' do
-        visit sign_up_expert_avis_path(avis.dossier.procedure, avis, email: avis.expert.email)
+        avis.expert.user.invite_expert_and_send_avis!(avis)
+        visit sign_up_expert_avis_path(avis.dossier.procedure, avis, email: avis.expert.email, confirmation_token: avis.expert.user.confirmation_token)
 
         expect(page).to have_field('Adresse électronique', with: avis.expert.email, disabled: true)
         fill_in 'Mot de passe', with: password


### PR DESCRIPTION
Closes #12530

Corrige le passage du token d'accès dans le process d'inscription, et les tests passaient car n'utilisaient pas le token