### PR TITLE
Tech: essai de résoudre l'instabilité des tests lents de la ci en changeant de runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
 
   unit_tests_slow_or_deps:
     name: (slow, dep) unit tests
-    runs-on: ubuntu-22.04
+    runs-on: warp-ubuntu-2204-x64-2x
     timeout-minutes: 20
     env:
       RUBY_YJIT_ENABLE: "1"


### PR DESCRIPTION
Essai de résoudre ce pb: 
- https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/21396815316/job/61597125857
- https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/21393079103/job/61584556992

```
 1) Instructeurs::DossiersController with a demarche with 100 conditional champs show 
     Failure/Error: all_revisions_types_de_champ.flat_map { _1.columns(procedure: self) }
     
     ActiveRecord::QueryCanceled:
       PG::QueryCanceled: ERROR:  canceling statement due to statement timeout
     # ./app/models/concerns/columns_concern.rb:237:in 'Enumerable#flat_map'
     # ./app/models/concerns/columns_concern.rb:237:in 'Procedure#types_de_champ_columns'
     # ./app/models/concerns/columns_concern.rb:41:in 'Procedure#columns'
     # ./app/models/concerns/columns_concern.rb:12:in 'Procedure#find_column'
     # ./app/models/column.rb:52:in 'Column.find'
     # ./app/types/column_type.rb:20:in 'ColumnType#cast'
     # ./app/types/filtered_column_type.rb:16:in 'FilteredColumnType#cast'
     # ./app/types/filtered_column_type.rb:23:in 'FilteredColumnType#deserialize'
     # ./app/models/instructeur.rb:118:in 'Instructeur#procedure_presentation_for_procedure_id'
     # ./app/controllers/concerns/instructeur_concern.rb:8:in 'Instructeurs::DossiersController#retrieve_procedure_presentation'
     # ./app/controllers/application_controller.rb:430:in 'ApplicationController#switch_locale'
     # ./spec/perf/instructeur_dossier_controller_spec.rb:52:in 'block (5 levels) in <top (required)>'
     # ./spec/perf/instructeur_dossier_controller_spec.rb:51:in 'block (4 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # PG::QueryCanceled:
     #   ERROR:  canceling statement due to statement timeout
     #   ./app/models/concerns/columns_concern.rb:237:in 'Enumerable#flat_map'
```

`columns_concern` appelle `all_revisions_types_de_champ` mais un test en local sur cette methode par les 10 procedures qui ont le plus de révision ne prend pas de temps


Annexe:

query pour avoir les démarches avec le plus de révision : 
```sql
select procedure_id, count(id) as toto from procedure_revisions group by procedure_id order by toto desc limit 10;
```
