### PR TITLE
Correction : ETQ instructeur je retrouve les heures des événements concernant un dossier dans l'export pdf

### DIFF
--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -225,7 +225,7 @@ def add_message(pdf, message)
     sender = @dossier.user_email_for(:display)
   end
 
-  format_in_2_lines(pdf, "#{sender}, #{try_format_date(message.created_at)}",
+  format_in_2_lines(pdf, "#{sender}, #{try_format_datetime(message.created_at, format: :short_with_time)}",
     ActionView::Base.full_sanitizer.sanitize(clean_string_for_pdf(message.body)))
 end
 
@@ -286,19 +286,19 @@ end
 
 def add_etats_dossier(pdf, dossier)
   if dossier.depose_at.present?
-    format_in_2_columns(pdf, "Déposé le", try_format_date(dossier.depose_at))
+    format_in_2_columns(pdf, "Déposé le", try_format_datetime(dossier.depose_at, format: :short_with_time))
   end
 
   if dossier.pending_correction?
-    format_in_2_columns(pdf, "Correction demandée le", try_format_date(dossier.pending_corrections.first.created_at))
+    format_in_2_columns(pdf, "Correction demandée le", try_format_datetime(dossier.pending_corrections.first.created_at, format: :short_with_time))
   end
 
   if dossier.en_instruction_at.present?
-    format_in_2_columns(pdf, "En instruction le", try_format_date(dossier.en_instruction_at))
+    format_in_2_columns(pdf, "En instruction le", try_format_datetime(dossier.en_instruction_at, format: :short_with_time))
   end
 
   if dossier.sva_svr_decision_triggered_at.present?
-    format_in_2_columns(pdf, "Décision #{dossier.procedure.sva_svr_configuration.human_decision} prise le", try_format_date(dossier.sva_svr_decision_triggered_at))
+    format_in_2_columns(pdf, "Décision #{dossier.procedure.sva_svr_configuration.human_decision} prise le", try_format_datetime(dossier.sva_svr_decision_triggered_at, format: :short_with_time))
   elsif dossier.sva_svr_decision_on.present?
     value = if dossier.pending_correction?
       "#{dossier.sva_svr_decision_in_days} jours après la correction"
@@ -310,7 +310,7 @@ def add_etats_dossier(pdf, dossier)
   end
 
   if dossier.processed_at.present?
-    format_in_2_columns(pdf, "Décision le", try_format_date(dossier.processed_at))
+    format_in_2_columns(pdf, "Décision le", try_format_datetime(dossier.processed_at, format: :short_with_time))
   end
 end
 


### PR DESCRIPTION
cf https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_40a1f3ca-157d-4d63-a737-05e5a04f61cf/


# Retour de l'usager

<img width="1175" height="567" alt="retour-usager" src="https://github.com/user-attachments/assets/932e4c23-10fd-45a8-8fa6-c9f4228d3e6d" />

# Correction

<img width="2160" height="658" alt="Capture d’écran 2026-01-27 à 10 59 13" src="https://github.com/user-attachments/assets/561a4f38-cf06-4171-a20a-233932a633e5" />
