### PR TITLE
Correction: les combobox s'affichent correctement même avec une version ancienne de navigateur

### DIFF
--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -1,3 +1,4 @@
+import 'core-js/actual/object/has-own';
 import 'core-js/proposals/relative-indexing-method';
 import Rails from '@rails/ujs';
 import * as ActiveStorage from '@rails/activestorage';


### PR DESCRIPTION
cf : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_08e64666-1850-45b8-9ca3-1d5aff9d21be/

# Description du bug 

Etq instructeur avec une version ancienne de Firefox (91), la multicombobox ne s'affiche pas dans la page Réaffectation et dans la page Demander un avis externe.

# Logs de l'erreur
  
<img width="2818" height="936" alt="Capture d’écran 2026-01-28 à 11 30 19" src="https://github.com/user-attachments/assets/9df5292f-f2e6-46cb-900f-7c01cd0f8b4b" />

# Explication probable
 Les navigateurs anciens (Safari < 15.4, Chrome < 93, Firefox < 92) ne supportent pas la méthode `Object.HasOwn` (ES2022).

# Solution
Ajouter le polyfill Object.hasOwn

