### PR TITLE
Fix - ajoute un attribut manquant dans un select permettant la création de notifications :dossier_suppression

### DIFF
--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -427,7 +427,7 @@ class DossierNotification < ApplicationRecord
         .termine_or_en_construction_close_to_expiration
     when :dossier_suppression
       dossiers
-        .select(:id, :hidden_by_administration_at, :hidden_by_expired_at)
+        .select(:id, :hidden_by_administration_at, :hidden_by_expired_at, :hidden_by_user_at)
         .hidden_by_expired
         .or(dossiers.hidden_by_administration.hidden_by_user)
     when :dossier_modifie


### PR DESCRIPTION
Sentry : https://demarches-simplifiees.sentry.io/issues/7113355742/?project=1429550&query=is%3Aunresolved%20notification&referrer=issue-stream

Avant le calcul de display_at, on passe par la méthode dossiers_to_notify, qui notamment fait un select, et pour le cas du badge :dossier_suppression, il nous manque l'attribut hidden_by_user_at.