### PR TITLE
Tech: n'essaie pas de cacher une réponse typhoeus s'il y a une directive `cache-control: public` sans max-age

### DIFF
--- a/app/lib/typhoeus/cache/successful_requests_rails_cache.rb
+++ b/app/lib/typhoeus/cache/successful_requests_rails_cache.rb
@@ -3,7 +3,7 @@
 module Typhoeus
   module Cache
     # Cache successful Typhoeus requests in the Rails cache that are cacheable
-    # according to their Cache-Control headers (only public + max-age >= 0).
+    # according to their Cache-Control headers (only public + max-age > 0).
     #
     # Usage:
     #   Typhoeus.config.cache = Typhoeus::Cache::SuccessfulRequestsRailsCache.new
@@ -45,7 +45,9 @@ module Typhoeus
           @expires_in = CacheInfo.expires_in(directives)
         end
 
-        def cacheable? = @cacheable
+        def cacheable?
+          @cacheable && @expires_in > 0
+        end
 
         private
 

--- a/spec/lib/typhoeus/cache/successful_requests_rails_cache_spec.rb
+++ b/spec/lib/typhoeus/cache/successful_requests_rails_cache_spec.rb
@@ -124,8 +124,13 @@ describe Typhoeus::Cache::SuccessfulRequestsRailsCache, lib: true do
     end
 
     describe '#cacheable?' do
-      it 'returns true when public directive is present' do
+      it 'returns false when public directive is present but no max-age' do
         cache_info = described_class.new('public')
+        expect(cache_info.cacheable?).to be false
+      end
+
+      it 'returns true when public directive and max-age > 0 are present' do
+        cache_info = described_class.new('public, max-age=60')
         expect(cache_info.cacheable?).to be true
       end
 


### PR DESCRIPTION
ça plante car on considère que max-age = 0 qui n'est pas un TTL valide.

la reco est de considérer qu'on ne doit pas faire de cache plutot que mettre une valeur par défaut

Fix https://demarches-simplifiees.sentry.io/issues/7229735053

