### PR TITLE
ETQ usager, ma connexion FranceConnect préremplit l'information du mandataire, pas de bénéficaire

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -156,7 +156,7 @@ module Users
       respond_to do |format|
         format.html
         format.turbo_stream do
-          @dossier.for_tiers = params[:dossier][:for_tiers] if params[:dossier].present?
+          @dossier.assign_for_tiers(params.dig(:dossier, :for_tiers) == 'true')
         end
       end
     end
@@ -165,6 +165,8 @@ module Users
       @dossier = dossier
       @no_description = true
       email = dossier_params.dig('individual_attributes', 'email')
+
+      @dossier.assign_for_tiers(dossier_params[:for_tiers] == 'true')
 
       if @dossier.update(dossier_params) && @dossier.individual.valid?
         # verify for_tiers email

--- a/app/models/concerns/dossier_france_connect_prefill_concern.rb
+++ b/app/models/concerns/dossier_france_connect_prefill_concern.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module DossierFranceConnectPrefillConcern
+  extend ActiveSupport::Concern
+
+  def assign_for_tiers(will_be_for_tiers)
+    self.for_tiers = will_be_for_tiers
+
+    return unless france_connected_with_one_identity?
+
+    if will_be_for_tiers
+      prefill_mandataire_from_france_connect
+      reset_individual_for_tiers
+    else
+      prefill_individual_from_france_connect
+    end
+  end
+
+  private
+
+  def prefill_mandataire_from_france_connect
+    fc_info = user.france_connect_informations.first
+    self.mandataire_first_name = fc_info.given_name
+    self.mandataire_last_name = fc_info.family_name
+  end
+
+  def reset_individual_for_tiers
+    individual.assign_attributes(
+      nom: nil,
+      prenom: nil,
+      gender: nil,
+      birthdate: nil
+    )
+  end
+
+  def prefill_individual_from_france_connect
+    fc_info = user.france_connect_informations.first
+    individual.assign_attributes(
+      nom: fc_info.family_name,
+      prenom: fc_info.given_name,
+      gender: fc_info.gender == 'female' ? Individual::GENDER_FEMALE : Individual::GENDER_MALE
+    )
+  end
+end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -5,6 +5,7 @@ class Dossier < ApplicationRecord
 
   include DossierCloneConcern
   include DossierCorrectableConcern
+  include DossierFranceConnectPrefillConcern
   include DossierPendingResponseConcern
   include DossierFilteringConcern
   include DossierPrefillableConcern


### PR DESCRIPTION
Ceci prépare [le verrouillage des informations d'identité quand on passe par FC](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/12622) pour fournir d'authentification de la création du dossier  à l'instruction.

Le seul cas identifié qui pourrait gêner c'est avec Aidant Connect, c'est à dire lorsqu'un tiers se connecte à FC avec le compte de la personne. Cela dit leur parcours pourrait être que l'aidant connect ne passe plus par le FC du bénéficiaire, mais avec son compte, et qu'il remplisse simplement le form bénéficiaire.

En fonction des retours on pourra aussi étudier de modifier malgré tout l'identité, sauf que l'instructeur ne verra plus l'information de connexion FC 


Note: cela ne gère pas les cas où un user a plusieurs FC informations: on avait précédemment décidé que dans cette situation il ne fallait pas faire de pré-remplissage , et dans l'optique de verrouiller l'identité FC, on ne pourrait pas en choisir une arbitrairement.