### PR TITLE
Tech: pas d'erreur sentry lorsque des bots ou autres balancent une locale invalide

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -122,7 +122,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale(locale)
-    if locale && locale.to_sym.in?(I18n.available_locales)
+    return if !locale.respond_to?(:to_sym)
+
+    if locale.to_sym.in?(I18n.available_locales)
       cookies[:locale] = { value: locale, secure: Rails.env.production?, httponly: true }
       if user_signed_in?
         current_user.update(locale: locale)


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/6972063625/events/8d438311676c4246a85785d56e6f016d/
Typiquement envoi d'un array de locale[] en post ou get à la place d'un string