### PR TITLE
Tech : fix collision de stable id hardcodés causant des flaky tests

### DIFF
--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1984,7 +1984,7 @@ describe Users::DossiersController, type: :controller do
   end
 
   describe '#champ' do
-    let(:stable_id) { 1234 }
+    let(:stable_id) { generate(:stable_id) }
     let(:types_de_champ_public) { [{ type: :text, stable_id: }] }
     let(:procedure) { create(:procedure, types_de_champ_public:) }
     let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:, user:) }

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  sequence(:stable_id) { |n| 100_000 + n }
+
   factory :type_de_champ do
     sequence(:libelle) { |n| "Libelle du champ #{n}" }
     sequence(:description) { |n| "description du champ #{n}" }

--- a/spec/graphql/dossier_spec.rb
+++ b/spec/graphql/dossier_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe Types::DossierType, type: :graphql do
 
   describe 'dossier with conditional champs' do
     include Logic
-    let(:stable_id) { 1234 }
+    let(:stable_id) { generate(:stable_id) }
     let(:condition) { ds_eq(champ_value(stable_id), constant(true)) }
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :checkbox, stable_id: stable_id }, { type: :text, condition: condition }]) }
     let(:dossier) { create(:dossier, :accepte, :with_populated_champs, procedure: procedure) }


### PR DESCRIPTION
les tests levaient une contrainte d'unicité en base sur les champs qui tapent dans le même stable id