### PR TITLE
ETQ Instructeur/Administrateur, lorsque j'essaye de me connecter avec FC, on m'encourage à utiliser ProConnect

### DIFF
--- a/app/controllers/france_connect_controller.rb
+++ b/app/controllers/france_connect_controller.rb
@@ -235,7 +235,7 @@ class FranceConnectController < ApplicationController
 
   def destroy_fci_and_redirect_to_login(fci)
     fci.destroy
-    redirect_to new_user_session_path, alert: t('errors.messages.france_connect.forbidden_html', reset_link: new_user_password_path)
+    redirect_to pro_connect_path, alert: t('errors.messages.france_connect.forbidden_html', app_name: APPLICATION_NAME)
   end
 
   def connect_france_connect(user)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -820,7 +820,7 @@ en:
         not_found: "We haven't found an establishment corresponding to this SIRET number."
       france_connect:
         connexion: "Error trying to connect to France Connect."
-        forbidden_html: "Only citizen can use FranceConnect. As an instructor or administrator, you should <a href='%{reset_link}'>reset your password</a>."
+        forbidden_html: "Only citizen can use FranceConnect. As an instructor or administrator, please identify yourself with ProConnect or log in with your %{app_name} account."
         internal_error: "Error trying to connect to France Connect. Please try another way to connect."
       missing_range_rules: The minimum and maximum values ​​must be specified.
       invalid_range_rules: The minimum value must be less than the maximum value.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -827,7 +827,7 @@ fr:
         email_domain_not_allowed: "Votre domaine d’email n’est pas autorisé à utiliser ProConnect sur cette plateforme."
       france_connect:
         connexion: "Une erreur est survenue lors de la connexion avec FranceConnect. Veuillez réessayer."
-        forbidden_html: "Seul-e-s les usagers peuvent se connecter via France Connect. En tant qu’instructeur ou administrateur, nous vous invitons à <a href='%{reset_link}'>réininitialiser votre mot de passe</a>."
+        forbidden_html: "Seul-e-s les usagers peuvent se connecter via France Connect. En tant qu’instructeur ou administrateur, veuillez vous identifier avec ProConnect ou vous connecter avec votre compte %{app_name}."
         internal_error: "Une erreur est survenue lors de la connexion avec FranceConnect. Veuillez essayer un autre mode de connexion."
       siret:
         network_error: 'Désolé, la récupération des informations SIRET est temporairement indisponible. Veuillez réessayer dans quelques instants.'

--- a/spec/controllers/france_connect_controller_spec.rb
+++ b/spec/controllers/france_connect_controller_spec.rb
@@ -142,7 +142,7 @@ describe FranceConnectController, type: :controller do
           before { subject }
 
           it do
-            expect(response).to redirect_to(new_user_session_path)
+            expect(response).to redirect_to(pro_connect_path)
             expect(flash[:alert]).to be_present
           end
         end
@@ -172,8 +172,8 @@ describe FranceConnectController, type: :controller do
             it 'redirects to the login path' do
               expect { subject }.not_to change { User.count }
 
-              expect(response).to redirect_to(new_user_session_path)
-              expect(flash[:alert]).to eq(I18n.t('errors.messages.france_connect.forbidden_html', reset_link: new_user_password_path))
+              expect(response).to redirect_to(pro_connect_path)
+              expect(flash[:alert]).to eq(I18n.t('errors.messages.france_connect.forbidden_html', app_name: APPLICATION_NAME))
             end
           end
         end
@@ -502,8 +502,8 @@ describe FranceConnectController, type: :controller do
           subject
           expect(FranceConnectInformation.exists?(fci.id)).to be_falsey
           expect(controller.current_user).to be_nil
-          expect(response).to redirect_to(new_user_session_path)
-          expect(flash[:alert]).to eq(I18n.t('errors.messages.france_connect.forbidden_html', reset_link: new_user_password_path))
+          expect(response).to redirect_to(pro_connect_path)
+          expect(flash[:alert]).to eq(I18n.t('errors.messages.france_connect.forbidden_html', app_name: APPLICATION_NAME))
         end
       end
     end


### PR DESCRIPTION
Close #12619 
<img width="3042" height="1822" alt="Screenshot 2026-02-05 at 17-45-23 Se connecter avec ProConnect · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/e823c0e8-b2ef-480f-abe2-9792145f39ef" />
