### PR TITLE
Tech: augmente le temps alloué à l'analyse de RIB

### DIFF
--- a/app/services/ocr_service.rb
+++ b/app/services/ocr_service.rb
@@ -10,7 +10,7 @@ class OCRService
     json = { "url": blob_url, "hint": { "type": "rib" } }
     headers = { 'X-Remote-File': blob_url } # needed for logging
 
-    handle_api_result(API::Client.new.call(url:, method: :post, headers:, json:))
+    handle_api_result(API::Client.new.call(url:, method: :post, headers:, json:, timeout: 31))
   end
 
   private


### PR DESCRIPTION
Sur un échantillon de 486 ribs dont l'analyse a timeouté à 10s, on peut en sauver 379 (~80%) si augmente le temps de traitement a 30s.

Attention, ca peut commencer a encombrer la queue default (mais l'UI attend qd mm un retour, alors j'ai pas envie de mettre le job en `low`)

Parallèlement, je fais [une modification à la taupe](https://github.com/demarche-numerique/la_taupe/pull/51) pour qu'il renvoie un `504` s'il ne trouve pas de résultat en un timeout configurable (disons 30s) pour commencer.

raf : 
- [ ] catcher le 504 avec le message `analysis timeout`, et le stocker sans envoyer a sentry.

Du coup, je modifie ici le timeout a 31s, comme ca, on ne remontera à priori plus d'erreur de timeout dans sentry

## Data:
RIB analysé `champ_ids.count ==> 7208`
RIB avec une erreur à l'analyse : `err_champ_ids.count ==> 1409` , ratio : ~ 20%

Sur ces erreurs, 86% proviennent de timeout.
Donc avec le changement on devrait arriver a un ratio autour de 5% avec une erreur.

## Annexes:

Les requetes qu'il faut :
```ruby
tdc_stable_ids = TypeDeChamp.where(nature: 'RIB').pluck(:stable_id)
champ_ids = Champ.where(stable_id: tdc_stable_ids).where.not(external_state: 'idle').ids
err_champ_ids = Champ.where(id: champ_ids).where.not(fetch_external_data_exceptions: []).ids
timeout_ids, other_ids = Champ.where(id: err_champ_ids).pluck(:id, :fetch_external_data_exceptions).map { |id, ex| [id, ex.first.reason] }.partition { |_, r| r.match? /Timeout/  }
```