### PR TITLE
Tech: exclut des CSP un sous domaine crisp qu'on ne doit pas utiliser

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -8,22 +8,22 @@
 
 Rails.application.configure do
   config.content_security_policy do |policy|
-    images_whitelist = ["*.openstreetmap.org", "*.cloud.ovh.net", "*"]
+    images_whitelist = ["*.openstreetmap.org", "*.cloud.ovh.net", "image.crisp.chat", "*"]
     images_whitelist << URI(DS_PROXY_URL).host if DS_PROXY_URL.present?
     images_whitelist << URI(MATOMO_IFRAME_URL).host if MATOMO_IFRAME_URL.present?
     policy.img_src(:self, :data, :blob, *images_whitelist)
 
     # Javascript: allow us, SendInBlue and Matomo.
     # We need unsafe_inline because miniprofiler and us have some inline buttons :(
-    scripts_whitelist = ["*.crisp.chat", "crisp.chat", "cdn.jsdelivr.net", "integration.lasuite.numerique.gouv.fr", "unpkg.com"]
+    scripts_whitelist = ["client.crisp.chat", "cdn.jsdelivr.net", "integration.lasuite.numerique.gouv.fr", "unpkg.com"]
     scripts_whitelist << URI(MATOMO_IFRAME_URL).host if MATOMO_IFRAME_URL.present?
     policy.script_src(:self, :unsafe_eval, :unsafe_inline, :blob, *scripts_whitelist)
 
     # CSS: We have a lot of inline style, and some <style> tags.
     # It's too complicated to be fixed right now (and it wouldn't add value: this is hardcoded in views, so not subject to injections)
-    policy.style_src(:self, :unsafe_inline, "*.crisp.chat", "crisp.chat", "unpkg.com", "cdn.jsdelivr.net")
+    policy.style_src(:self, :unsafe_inline, "client.crisp.chat", "unpkg.com", "cdn.jsdelivr.net")
 
-    connect_whitelist = ["wss://*.crisp.chat", "*.crisp.chat", "integration.lasuite.numerique.gouv.fr", "app.franceconnect.gouv.fr", "openmaptiles.data.gouv.fr", "openmaptiles.geo.data.gouv.fr", "openmaptiles.github.io", "tiles.geo.api.gouv.fr", "data.geopf.fr", "object.data.gouv.fr"]
+    connect_whitelist = ["client.crisp.chat", "wss://client.relay.crisp.chat", "storage.crisp.chat", "integration.lasuite.numerique.gouv.fr", "app.franceconnect.gouv.fr", "openmaptiles.data.gouv.fr", "openmaptiles.geo.data.gouv.fr", "openmaptiles.github.io", "tiles.geo.api.gouv.fr", "data.geopf.fr", "object.data.gouv.fr"]
     connect_whitelist << ENV.fetch('APP_HOST')
     connect_whitelist << ENV.fetch('APP_HOST_LEGACY') if ENV.key?('APP_HOST_LEGACY') && ENV['APP_HOST_LEGACY'] != ENV['APP_HOST']
     connect_whitelist << "*.amazonaws.com" if Rails.configuration.active_storage.service == :amazon
@@ -46,7 +46,7 @@ Rails.application.configure do
 
     # Everything else: allow us
     # Add the error source in the violation notification
-    default_whitelist = ["integration.lasuite.numerique.gouv.fr", "fonts.gstatic.com", "in-automate.sendinblue.com", "player.vimeo.com", "app.franceconnect.gouv.fr", "*.crisp.chat", "crisp.chat", "*.crisp.help", "*.sibautomation.com", "sibautomation.com", "data"]
+    default_whitelist = ["integration.lasuite.numerique.gouv.fr", "fonts.gstatic.com", "in-automate.sendinblue.com", "player.vimeo.com", "app.franceconnect.gouv.fr", "client.crisp.chat", "image.crisp.chat", "storage.crisp.chat", "*.crisp.help", "*.sibautomation.com", "sibautomation.com", "data"]
     default_whitelist += ENV.values_at('SENTRY_DSN_JS', 'SENTRY_DSN_RAILS').compact_blank.map { URI(it).host }.uniq
     default_whitelist << URI(DS_PROXY_URL).host if DS_PROXY_URL.present?
     policy.default_src(:self, :data, :blob, :report_sample, *default_whitelist)


### PR DESCRIPTION
Afin de désactiver le module MagicBrowse on le désactive de la config, et on bloque aussi au cas où le domaine  `wss://stream.relay.crisp.chat ` qu'il utilise en n'autorisant que les hosts exacts nécessaires

Cf emails du 5/6 fév 2026

Config CSP:
https://docs.crisp.chat/guides/others/whitelisting-our-systems/crisp-domain-names/