### PR TITLE
[a11y] Amélioration de l'accessibilité pour les longs filtres avec un label tronqué

### DIFF
--- a/app/components/instructeurs/column_filter_value_component.rb
+++ b/app/components/instructeurs/column_filter_value_component.rb
@@ -29,12 +29,12 @@ class Instructeurs::ColumnFilterValueComponent < ApplicationComponent
   end
 
   def render_label
-    content_tag(
-      :span,
-      label_text,
-      title: label_title,
-      aria: label_title ? { label: label } : {}
-    )
+    return content_tag(:span, label) if !truncated_label?
+
+    safe_join([
+      content_tag(:span, label_text, title: label, aria: { hidden: true }),
+      content_tag(:span, label, class: 'fr-sr-only'),
+    ])
   end
 
   def value
@@ -135,7 +135,7 @@ class Instructeurs::ColumnFilterValueComponent < ApplicationComponent
     label.truncate(MAX_LABEL_LENGTH)
   end
 
-  def label_title
-    label if label.length > MAX_LABEL_LENGTH
+  def truncated_label?
+    label.length > MAX_LABEL_LENGTH
   end
 end

--- a/spec/components/instructeurs/column_filter_value_component_spec.rb
+++ b/spec/components/instructeurs/column_filter_value_component_spec.rb
@@ -117,11 +117,16 @@ describe Instructeurs::ColumnFilterValueComponent, type: :component do
       )
     end
 
-    it 'truncates the label, adds a title attribute and aria-label' do
-      expect(page).to have_text(long_label.truncate(50))
-      expect(page).to have_selector('[title]', visible: true)
-      expect(page.find('[title]')[:title]).to eq(long_label)
-      expect(page.find('[aria-label]')[:'aria-label']).to eq(long_label)
+    it 'renders a truncated visible label and a sr-only full label' do
+      expect(page).to have_selector(
+        'span[aria-hidden="true"][title]',
+        text: long_label.truncate(50)
+      )
+      expect(page.find('span[aria-hidden="true"]')[:title]).to eq(long_label)
+      expect(page).to have_selector(
+        'span.fr-sr-only',
+        text: long_label
+      )
     end
   end
 
@@ -137,10 +142,12 @@ describe Instructeurs::ColumnFilterValueComponent, type: :component do
       )
     end
 
-    it 'does not add a title or aria-label attribute' do
-      expect(page).to have_selector('label.fr-label', text: 'label court')
-      expect(page).not_to have_selector('label.fr-label[title]')
-      expect(page).not_to have_selector('label.fr-label[aria-label]')
+    it 'renders only one visible span without sr-only or title' do
+      expect(page).to have_selector('span', text: 'label court')
+
+      expect(page).not_to have_selector('span.fr-sr-only')
+      expect(page).not_to have_selector('span[aria-hidden]')
+      expect(page).not_to have_selector('span[title]')
     end
   end
 end


### PR DESCRIPTION
Suite de la PR https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/12561