### PR TITLE
Tech: corrige le timeout PG du récapitulatif hebdomadaire instructeur

### DIFF
--- a/app/jobs/cron/weekly_overview_job.rb
+++ b/app/jobs/cron/weekly_overview_job.rb
@@ -7,9 +7,13 @@ class Cron::WeeklyOverviewJob < Cron::CronJob
     # Feature flipped to avoid mails in staging due to unprocessed dossier
     return unless Rails.application.config.ds_weekly_overview
 
-    Instructeur.find_each do |instructeur|
-      # mailer won't send anything if overview if empty
-      InstructeurMailer.last_week_overview(instructeur)&.deliver_later(wait: rand(0..3.hours))
-    end
+    Instructeur
+      .joins(:instructeurs_procedures)
+      .where(instructeurs_procedures: { weekly_email_summary: true })
+      .distinct
+      .find_each do |instructeur|
+        # mailer won't send anything if overview is empty
+        InstructeurMailer.last_week_overview(instructeur)&.deliver_later(wait: rand(0..3.hours))
+      end
   end
 end

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -167,28 +167,25 @@ class Instructeur < ApplicationRecord
   end
 
   def weekly_email_summary_data
-    procedures = self.procedures
+    procedures = Procedure
       .joins(:instructeurs_procedures)
-      .where(instructeurs_procedures: {
-        instructeur: self,
-        weekly_email_summary: true,
-      })
+      .where(instructeurs_procedures: { instructeur: self, weekly_email_summary: true })
       .publiees
-      .includes(dossiers: :groupe_instructeur)
 
-    gi_ids = groupe_instructeurs.ids
+    gi_ids = groupe_instructeur_ids
+    return nil if gi_ids.empty?
 
-    procedure_overviews = procedures.map do |procedure|
-      dossiers = procedure
-        .dossiers
-        .filter { |d| gi_ids.include?(d.groupe_instructeur_id) && d.visible_by_administration? }
+    procedure_overviews = procedures.filter_map do |procedure|
+      dossiers = procedure.dossiers
+        .visible_by_administration
+        .state_en_construction_ou_instruction
+        .for_groupe_instructeur(gi_ids)
 
-      ProcedureOverview.new(procedure, dossiers)
+      overview = ProcedureOverview.new(procedure, dossiers)
+      overview if overview.had_some_activities?
     end
 
-    active_procedure_overviews = procedure_overviews.filter(&:had_some_activities?)
-
-    active_procedure_overviews.empty? ? nil : active_procedure_overviews
+    procedure_overviews.empty? ? nil : procedure_overviews
   end
 
   def create_trusted_device_token

--- a/app/models/procedure_overview.rb
+++ b/app/models/procedure_overview.rb
@@ -12,20 +12,20 @@ class ProcedureOverview
     @start_date = 1.week.ago.beginning_of_week
     @procedure = procedure
 
-    @dossiers_en_instruction = dossiers.filter(&:en_instruction?)
-    @dossiers_en_construction = dossiers.filter(&:en_construction?)
+    dossiers_en_instruction = dossiers.state_en_instruction
+    dossiers_en_construction = dossiers.state_en_construction
 
-    @dossiers_en_instruction_count = @dossiers_en_instruction.count
-    @dossiers_en_construction_count = @dossiers_en_construction.count
+    @dossiers_en_instruction_count = dossiers_en_instruction.count
+    @dossiers_en_construction_count = dossiers_en_construction.count
 
     @old_dossiers_en_instruction =
-      @dossiers_en_instruction.filter { |d| d.en_instruction_at < 1.week.ago }
+      dossiers_en_instruction.where(en_instruction_at: ...1.week.ago).select(:id).to_a
 
     @old_dossiers_en_construction =
-      @dossiers_en_construction.filter { |d| d.depose_at < 1.week.ago }
+      dossiers_en_construction.where(depose_at: ...1.week.ago).select(:id).to_a
 
     @created_dossiers_count =
-      dossiers.count { |d| d.created_at >= @start_date }
+      dossiers.where(created_at: @start_date..).count
   end
 
   def had_some_activities?

--- a/spec/jobs/cron/weekly_overview_job_spec.rb
+++ b/spec/jobs/cron/weekly_overview_job_spec.rb
@@ -3,7 +3,8 @@
 RSpec.describe Cron::WeeklyOverviewJob, type: :job do
   describe 'perform' do
     let!(:instructeur) { create(:instructeur) }
-    let(:overview) { double('overview') }
+    let!(:procedure) { create(:procedure, :published) }
+    let!(:instructeurs_procedure) { create(:instructeurs_procedure, instructeur:, procedure:, weekly_email_summary: true) }
 
     context 'if the feature is enabled' do
       before do
@@ -43,12 +44,14 @@ RSpec.describe Cron::WeeklyOverviewJob, type: :job do
     end
 
     context 'if the feature is disabled' do
+      let(:mailer_double) { double('mailer', deliver_later: true) }
+
       before do
-        allow(Instructeur).to receive(:find_each)
+        allow(InstructeurMailer).to receive(:last_week_overview).and_return(mailer_double)
         Cron::WeeklyOverviewJob.new.perform
       end
 
-      it { expect(Instructeur).not_to receive(:find_each) }
+      it { expect(InstructeurMailer).not_to have_received(:last_week_overview) }
     end
   end
 end


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/7200183131/

## TLDR
instructeurs pour qui ça timeout : 160795,  166317, 30903, 166159, 30811, 166455, … car on load parfois + de 100K dossiers (*tous* les dossiers des démarches) dans une query complexe (même l'explain timeout) alors que l'activité ne concerne qu'une petite partie d'entre eux (ceux en construction, ou autre).

Un refacto permet d'éviter la requête complexe et de ne plus charger tous les dossiers en réutilisant des scopes plus ciblés , au prix de 5 requêtes mais "faciles" (sur count ou ids de dossiers avec scope ciblés ; ces N+1 sont limités car par démarche et un instructeur n'a qu'au plus quelques démarches).

Maintenant pour ces instructeurs la méthode `weekly_email_summary_data` est < 1 seconde

## Problème

Le job `Cron::WeeklyOverviewJob` (lancé chaque lundi à 04:05) provoque des timeouts PostgreSQL en production via `Instructeur#weekly_email_summary_data`.

Deux causes combinées :

1. **DISTINCT sur ~70 colonnes** : `self.procedures` passe par les associations `groupe_instructeurs`/`assign_tos` (qui produisent des doublons), puis ajoute `.joins(:instructeurs_procedures)`. Le `-> { distinct }` de l'association force un `SELECT DISTINCT procedures.*` sur toutes les colonnes — très coûteux.

2. **Chargement de TOUS les dossiers en mémoire** : `.includes(dossiers: :groupe_instructeur)` charge potentiellement 100k+ dossiers par procédure, puis les filtre en Ruby avec `.filter`.

3. **Itération sur TOUS les instructeurs** : le job parcourait tous les instructeurs, même ceux n'ayant pas activé le récap hebdomadaire.

## Solution

### `Instructeur#weekly_email_summary_data`
- Remplace `self.procedures.joins(...)` par `Procedure.joins(:instructeurs_procedures)` → plus besoin de DISTINCT (l'index unique sur `(instructeur_id, procedure_id)` garantit l'unicité)
- Supprime `.includes(dossiers:)` (plus de chargement massif)
- Utilise les scopes SQL existants (`visible_by_administration`, `for_groupe_instructeur`, `state_en_construction_ou_instruction`) au lieu du filtrage Ruby

### `ProcedureOverview`
- Utilise les scopes ActiveRecord (`.state_en_instruction`, `.state_en_construction`, `.where(...)`) au lieu de `.filter` sur des tableaux Ruby
- Produit 5 petites requêtes indexées par procédure (3 COUNT + 2 SELECT) au lieu de charger tous les dossiers

### `WeeklyOverviewJob`
- Restreint l'itération aux seuls instructeurs ayant `weekly_email_summary: true` (le DISTINCT ici ne porte que sur `instructeurs.id`, un entier — pas coûteux)

## Impact performance

**Avant** : 1 requête massive avec DISTINCT sur 70 colonnes + eager-load de TOUS les dossiers + filtrage Ruby
**Après** : 1 requête simple sans DISTINCT + 5 petites requêtes indexées par procédure
