### PR TITLE
ETQ Usager d'un lecteur d'écran, je veux que les titres des blocs répétables soient balisés comme tels dans la page récapitulative de mon dossier

### DIFF
--- a/app/components/dossiers/champs_rows_show_component.rb
+++ b/app/components/dossiers/champs_rows_show_component.rb
@@ -3,9 +3,15 @@
 class Dossiers::ChampsRowsShowComponent < ApplicationComponent
   attr_reader :profile
   attr_reader :seen_at
+  attr_reader :repetition_heading_level
 
-  def initialize(champs:, profile:, seen_at:)
+  def initialize(champs:, profile:, seen_at:, repetition_heading_level: 3)
     @champs, @profile, @seen_at = champs, profile, seen_at
+    @repetition_heading_level = repetition_heading_level.to_i.clamp(3, 6)
+  end
+
+  def repetition_heading_tag
+    "h#{@repetition_heading_level}"
   end
 
   private

--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.haml
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.haml
@@ -3,7 +3,7 @@
     - types_de_champ = champ.dossier.revision.children_of(champ.type_de_champ)
     - champ.row_ids.each.with_index(1) do |row_id, row_number|
       .fr-background-alt--grey.fr-p-2w.fr-my-3w.fr-ml-2w.champ-repetition
-        %p.fr-text--bold= "#{champ.libelle} #{row_number} :"
+        = tag.send(repetition_heading_tag, "#{champ.libelle} #{row_number} :", class: "fr-h6 fr-text--bold")
         = render ViewableChamp::SectionComponent.new(dossier: champ.dossier, types_de_champ:, row_id:, demande_seen_at: seen_at, profile:)
 
   - else

--- a/app/components/viewable_champ/section_component.rb
+++ b/app/components/viewable_champ/section_component.rb
@@ -48,6 +48,12 @@ class ViewableChamp::SectionComponent < ApplicationComponent
     header_section.level == 1
   end
 
+  def repetition_heading_level
+    relative_level = header_section ? header_section.level : 1
+    # there are 2 levels of heading before the repetition heading
+    [relative_level + 2, 6].min
+  end
+
   private
 
   def to_sections(nodes:)

--- a/app/components/viewable_champ/section_component/section_component.html.erb
+++ b/app/components/viewable_champ/section_component/section_component.html.erb
@@ -31,7 +31,7 @@
 
   <div id="<%= section_id %>" data-expand-target="content">
     <% if !champs.empty? %>
-      <%= render Dossiers::ChampsRowsShowComponent.new(champs:, seen_at: @demande_seen_at, profile: @profile) %>
+      <%= render Dossiers::ChampsRowsShowComponent.new(champs:, seen_at: @demande_seen_at, profile: @profile, repetition_heading_level: repetition_heading_level) %>
     <% end %>
 
     <% sections.each do |section| %>

--- a/spec/components/dossiers/champs_rows_show_component_spec.rb
+++ b/spec/components/dossiers/champs_rows_show_component_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Dossiers::ChampsRowsShowComponent, type: :component do
+  let(:procedure) do
+    create(:procedure, :published, types_de_champ_public: [
+      { type: :repetition, libelle: "Titre bloc répétable", children: [{ type: :text, libelle: "Texte court" }] },
+    ])
+  end
+  let(:dossier) { create(:dossier, procedure:, populate_champs: true) }
+  let(:champs) { dossier.project_champs_public }
+
+  before { render_inline(component).to_html }
+
+  describe "repeatable block title heading hierarchy" do
+    context "with default repetition_heading_level (h3)" do
+      let(:component) do
+        described_class.new(champs:, profile: "usager", seen_at: nil, repetition_heading_level: 3)
+      end
+
+      it "renders repeatable block titles as h3 for accessibility" do
+        expect(page).to have_selector("h3.fr-h6.fr-text--bold", text: /Titre bloc répétable 1 :/)
+        expect(page).to have_selector("h3.fr-h6.fr-text--bold", text: /Titre bloc répétable 2 :/)
+      end
+    end
+
+    context "with repetition_heading_level 4" do
+      let(:component) do
+        described_class.new(champs:, profile: "usager", seen_at: nil, repetition_heading_level: 4)
+      end
+
+      it "renders repeatable block titles as h4" do
+        expect(page).to have_selector("h4.fr-h6.fr-text--bold", text: /Titre bloc répétable 1 :/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #12515

### Après
<img width="1077" height="695" alt="image" src="https://github.com/user-attachments/assets/15c3e3c4-20bd-4e86-92ac-85efa7b94e63" />

