### PR TITLE
ETQ Usager sur Safari : bug sur le champ explication avec un texte complémentaire

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -281,3 +281,8 @@ input[type='radio'] {
 .fr-modal__body {
   scroll-padding-bottom: 130px; /* hauteur des boutons sticky + marge */
 }
+
+// fix https://github.com/demarche-numerique/demarche.numerique.gouv.fr/issues/12648
+.dossier-edit .fr-fieldset {
+  align-items: flex-end;
+}


### PR DESCRIPTION
Fixes #12648