### PR TITLE
Tech: active le cache pour un test dont les queries sont normalement cachées en prod

### DIFF
--- a/spec/perf/instructeur_dossier_controller_spec.rb
+++ b/spec/perf/instructeur_dossier_controller_spec.rb
@@ -5,7 +5,7 @@ describe Instructeurs::DossiersController, type: :controller do
   let(:user) { instructeur.user }
   before { sign_in(user) }
 
-  context 'with a demarche with 100 conditional champs' do
+  context 'with a demarche with 100 conditional champs', caching: true do
     include Logic
 
     let(:nb_champ) { 100 }


### PR DESCRIPTION
Ce test timeout souvent car il joue une grosse requête pour 100 champs car en test le cache est inactif par défaut, alors qu'on cache les résultats en prod. On active le cache pour mieux simuler al prod, et réduire les chances de timeout.


```
1) Instructeurs::DossiersController with a demarche with 100 conditional champs show 
     Failure/Error: all_revisions_types_de_champ.flat_map { _1.columns(procedure: self) }
     
     ActiveRecord::QueryCanceled:
       PG::QueryCanceled: ERROR:  canceling statement due to statement timeout
     # ./app/models/concerns/columns_concern.rb:237:in 'Enumerable#flat_map'
     # ./app/models/concerns/columns_concern.rb:237:in 'Procedure#types_de_champ_columns'
     # ./app/models/concerns/columns_concern.rb:41:in 'Procedure#columns'
     # ./app/models/concerns/columns_concern.rb:12:in 'Procedure#find_column'
     # ./app/models/column.rb:52:in 'Column.find'
     # ./app/types/column_type.rb:20:in 'ColumnType#cast'
     # ./app/types/filtered_column_type.rb:16:in 'FilteredColumnType#cast'
     # ./app/types/filtered_column_type.rb:23:in 'FilteredColumnType#deserialize'
     # ./app/models/instructeur.rb:118:in 'Instructeur#procedure_presentation_for_procedure_id'
     # ./app/controllers/concerns/instructeur_concern.rb:8:in 'Instructeurs::DossiersController#retrieve_procedure_presentation'
     # ./app/controllers/application_controller.rb:437:in 'ApplicationController#switch_locale'
     # ./spec/perf/instructeur_dossier_controller_spec.rb:52:in 'block (5 levels) in <top (required)>'
     # ./spec/perf/instructeur_dossier_controller_spec.rb:51:in 'block (4 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # PG::QueryCanceled:
     #   ERROR:  canceling statement due to statement timeout
     #   ./app/models/concerns/columns_concern.rb:237:in 'Enumerable#flat_map'
```