### PR TITLE
ETQ instructeur, je vois des compteurs de dossiers sur les onglets "à archiver" et "corbeille"

### DIFF
--- a/app/components/instructeurs/procedure_counters_component.rb
+++ b/app/components/instructeurs/procedure_counters_component.rb
@@ -34,6 +34,14 @@ class Instructeurs::ProcedureCountersComponent < ApplicationComponent
     formatted_count(:dossiers_expirant_count_per_procedure)
   end
 
+  def archives_count
+    formatted_count(:dossiers_archives_count_per_procedure)
+  end
+
+  def supprimes_count
+    formatted_count(:dossiers_supprimes_count_per_procedure)
+  end
+
   def notifications?
     current_instructeur.feature_enabled?(:notification) &&
       @notifications_counts_per_procedure[procedure.id]&.any?

--- a/app/components/instructeurs/procedure_counters_component/procedure_counters_component.html.erb
+++ b/app/components/instructeurs/procedure_counters_component/procedure_counters_component.html.erb
@@ -16,8 +16,16 @@
 
 <% if procedure.procedure_expires_when_termine_enabled? %>
   <%= turbo_stream.update "procedure-#{procedure.id}-expirant-count" do %>
-    <%= expirant_count %>
+    (<%= expirant_count %>)
   <% end %>
+<% end %>
+
+<%= turbo_stream.update "procedure-#{procedure.id}-archives-count" do %>
+  (<%= archives_count %>)
+<% end %>
+
+<%= turbo_stream.update "procedure-#{procedure.id}-supprimes-count" do %>
+  (<%= supprimes_count %>)
 <% end %>
 
 <%- each_statut_having_notification do |statut| %>

--- a/app/components/instructeurs/procedure_summary_component/procedure_summary_component.html.erb
+++ b/app/components/instructeurs/procedure_summary_component/procedure_summary_component.html.erb
@@ -185,13 +185,14 @@
       <li class="fr-btn fr-btn--tertiary-no-outline flex justify-center fr-enlarge-link fr-my-1w">
         <%= link_to(instructeur_procedure_path(p, statut: 'expirant')) do %>
           <div class="center fr-text--bold">
-            <span id="procedure-<%= p.id %>-expirant-count">
-              <%= placeholder_span %>
-            </span>
+            <span class="fr-icon-timer-line fr-icon--sm"></span>
           </div>
 
           <div class="center fr-text--sm">
             <%= t('instructeurs.dossiers.labels.close_to_expiration') %>
+            <span id="procedure-<%= p.id %>-expirant-count">
+              <%= placeholder_span %>
+            </span>
           </div>
         <% end %>
       </li>
@@ -205,6 +206,9 @@
 
         <div class="center fr-text--sm">
           <%= t('instructeurs.dossiers.labels.to_archive') %>
+          <span id="procedure-<%= p.id %>-archives-count">
+            <%= placeholder_span %>
+          </span>
         </div>
       <% end %>
     </li>
@@ -217,6 +221,9 @@
 
         <div class="center fr-text--sm">
           <%= t('instructeurs.dossiers.labels.trash') %>
+          <span id="procedure-<%= p.id %>-supprimes-count">
+            <%= placeholder_span %>
+          </span>
         </div>
       <% end %>
     </li>

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -22,13 +22,14 @@ module TabsHelper
     end
   end
 
-  def tab_item(label, url, active: false, badge: nil, notification: false, html_class: nil)
+  def tab_item(label, url, active: false, badge: nil, notification: false, small_counter: nil, html_class: nil)
     render partial: 'shared/tab_item', locals: {
       label: label,
       url: url,
       active: active,
       badge: badge,
       notification: notification,
+      small_counter: small_counter,
       html_class: html_class,
     }
   end

--- a/app/services/instructeurs_procedures_counters_service.rb
+++ b/app/services/instructeurs_procedures_counters_service.rb
@@ -7,6 +7,8 @@ class InstructeursProceduresCountersService
     :dossiers_a_suivre_count_per_procedure,
     :dossiers_termines_count_per_procedure,
     :dossiers_expirant_count_per_procedure,
+    :dossiers_archives_count_per_procedure,
+    :dossiers_supprimes_count_per_procedure,
     :followed_dossiers_count_per_procedure,
     :all_dossiers_counts
   )
@@ -34,6 +36,8 @@ class InstructeursProceduresCountersService
     dossiers_a_suivre_count_per_procedure = dossiers.by_statut('a-suivre').count
     dossiers_termines_count_per_procedure = dossiers.by_statut('traites').count
     dossiers_expirant_count_per_procedure = dossiers.by_statut('expirant').count
+    dossiers_archives_count_per_procedure = dossiers.by_statut('archives').count
+    dossiers_supprimes_count_per_procedure = dossiers.by_statut('supprimes').count
 
     followed_dossiers_count_per_procedure = instructeur.followed_dossiers
       .joins(:groupe_instructeur)
@@ -58,6 +62,8 @@ class InstructeursProceduresCountersService
       dossiers_a_suivre_count_per_procedure:,
       dossiers_termines_count_per_procedure:,
       dossiers_expirant_count_per_procedure:,
+      dossiers_archives_count_per_procedure:,
+      dossiers_supprimes_count_per_procedure:,
       followed_dossiers_count_per_procedure:,
       all_dossiers_counts:
     )

--- a/app/views/instructeurs/procedures/_tabs.html.haml
+++ b/app/views/instructeurs/procedures/_tabs.html.haml
@@ -27,14 +27,17 @@
       = tab_item(i18n_tab_from_status('expirant'),
         instructeur_procedure_path(procedure, statut: 'expirant'),
         active: statut == 'expirant',
-        badge: number_with_html_delimiter(expirant_count))
+        small_counter: number_with_html_delimiter(expirant_count),
+        html_class: 'fr-icon-timer-line fr-tabs__tab--icon-left')
 
     = tab_item(i18n_tab_from_status('archives'),
       instructeur_procedure_path(procedure, statut: 'archives'),
       active: statut == 'archives',
+      small_counter: number_with_html_delimiter(archives_count),
       html_class: 'fr-icon-folder-2-line fr-tabs__tab--icon-left')
 
     = tab_item(i18n_tab_from_status('supprimes'),
       instructeur_procedure_path(procedure, statut: 'supprimes'),
       active: statut == 'supprimes',
+      small_counter: number_with_html_delimiter(supprimes_count),
       html_class: 'fr-icon-delete-line fr-tabs__tab--icon-left')

--- a/app/views/shared/_tab_item.html.haml
+++ b/app/views/shared/_tab_item.html.haml
@@ -4,3 +4,5 @@
     - if badge.present?
       %span.fr-badge.fr-badge--blue-ecume.fr-mr-1w= badge
     = label
+    - if small_counter.present?
+      %span.fr-text--sm.fr-text--regular.fr-ml-1v= "(#{small_counter})"

--- a/spec/services/instructeur_procedures_counters_service_spec.rb
+++ b/spec/services/instructeur_procedures_counters_service_spec.rb
@@ -55,11 +55,15 @@ describe InstructeursProceduresCountersService do
           expect(subject.followed_dossiers_count_per_procedure[procedure.id]).to eq(nil)
           expect(subject.dossiers_termines_count_per_procedure[procedure.id]).to eq(2)
           expect(subject.dossiers_expirant_count_per_procedure[procedure.id]).to eq(2)
+          expect(subject.dossiers_archives_count_per_procedure[procedure.id]).to eq(1)
+          expect(subject.dossiers_supprimes_count_per_procedure[procedure.id]).to eq(2)
 
           expect(subject.dossiers_count_per_procedure[procedure2.id]).to eq(3)
           expect(subject.dossiers_a_suivre_count_per_procedure[procedure2.id]).to eq(nil)
           expect(subject.followed_dossiers_count_per_procedure[procedure2.id]).to eq(1)
           expect(subject.dossiers_termines_count_per_procedure[procedure2.id]).to eq(1)
+          expect(subject.dossiers_archives_count_per_procedure[procedure2.id]).to eq(nil)
+          expect(subject.dossiers_supprimes_count_per_procedure[procedure2.id]).to eq(nil)
 
           expect(subject.dossiers_count_per_procedure[procedure3.id]).to eq(2)
 
@@ -68,6 +72,8 @@ describe InstructeursProceduresCountersService do
           expect(subject.all_dossiers_counts['traites']).to eq(2 + 1 + 1 + 1)
           expect(subject.all_dossiers_counts['tous']).to eq(5 + 3 + 2 + 1)
           expect(subject.all_dossiers_counts['expirant']).to eq(2 + 0)
+          expect(subject.all_dossiers_counts['archives']).to eq(nil)
+          expect(subject.all_dossiers_counts['supprimes']).to eq(nil)
         end
       end
 

--- a/spec/views/instructeur/procedures/synthese.html.erb_spec.rb
+++ b/spec/views/instructeur/procedures/synthese.html.erb_spec.rb
@@ -8,6 +8,8 @@ describe 'instructeurs/procedures/synthese', type: :view do
       dossiers_a_suivre_count_per_procedure: {},
       dossiers_termines_count_per_procedure: {},
       dossiers_expirant_count_per_procedure: {},
+      dossiers_archives_count_per_procedure: {},
+      dossiers_supprimes_count_per_procedure: {},
       followed_dossiers_count_per_procedure: {},
       groupes_instructeurs_ids: [12]
     )


### PR DESCRIPTION
closes #12616 

Les compteurs sont de retour pour les onglets supprimés et archivés - mais dans un format plus petit que les autre compteurs. Et on uniformise pour l'onglet expirants.

**APRES**
<img width="1355" height="317" alt="Capture d’écran 2026-02-10 à 15 15 39" src="https://github.com/user-attachments/assets/28bc1a0b-ed3b-4b52-ab67-29d4a2a815e3" />
<img width="1245" height="218" alt="Capture d’écran 2026-02-10 à 15 17 25" src="https://github.com/user-attachments/assets/dc5976db-2546-4c2b-83df-d37a082dd2a5" />

**AVANT**
<img width="1358" height="319" alt="Capture d’écran 2026-02-10 à 15 16 04" src="https://github.com/user-attachments/assets/3a2745b2-68a5-4de9-a9f0-37c00fbb46f3" />
<img width="1245" height="222" alt="Capture d’écran 2026-02-10 à 15 17 42" src="https://github.com/user-attachments/assets/6cd38fc4-73f0-40c0-81b1-8ac1d9d69c0c" />
