### PR TITLE
Amelioration: ETQ consommateur d'API, je peux maj une annotation de type dossier link

### DIFF
--- a/app/graphql/mutations/dossier_modifier_annotation.rb
+++ b/app/graphql/mutations/dossier_modifier_annotation.rb
@@ -70,6 +70,8 @@ module Mutations
         TypeDeChamp.type_champs.fetch(:decimal_number)
       when :drop_down_list
         TypeDeChamp.type_champs.fetch(:drop_down_list)
+      when :dossier_link
+        TypeDeChamp.type_champs.fetch(:dossier_link)
       end
     end
   end

--- a/app/graphql/mutations/dossier_modifier_annotations.rb
+++ b/app/graphql/mutations/dossier_modifier_annotations.rb
@@ -17,6 +17,7 @@ module Mutations
       argument :decimal_number, Float, "Modifier la valeur d’un champ nombre décimal", required: false
       argument :drop_down_list, String, "Modifier la sélection d’un champ choix simple", required: false
       argument :multiple_drop_down_list, [String], "Modifier la sélection d’un champ choix multiple", required: false
+      argument :dossier_link, String, "Modifier la valeur d'un champ lien vers un dossier", required: false
       argument :repetition, Int, "Ajouter des repetitions à un champ répétable", required: false
     end
 
@@ -105,6 +106,7 @@ module Mutations
         TypeDeChamp.type_champs.fetch(:decimal_number),
         TypeDeChamp.type_champs.fetch(:drop_down_list),
         TypeDeChamp.type_champs.fetch(:multiple_drop_down_list),
+        TypeDeChamp.type_champs.fetch(:dossier_link),
         TypeDeChamp.type_champs.fetch(:repetition),
       ]
     end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -199,6 +199,11 @@ input AnnotationValueInput @oneOf {
   decimalNumber: Float
 
   """
+  Modifier la valeur d'un champ lien vers un dossier
+  """
+  dossierLink: String
+
+  """
   Modifier la sélection d’un champ choix simple
   """
   dropDownList: String

--- a/spec/graphql/annotation_spec.rb
+++ b/spec/graphql/annotation_spec.rb
@@ -273,6 +273,34 @@ RSpec.describe Mutations::DossierModifierAnnotations, type: :graphql do
       end
     end
 
+    context 'with dossier_link annotation and invalid dossier id' do
+      let(:types_de_champ_private) { [{ type: :dossier_link }] }
+      let(:dossier_link_annotation) { champs_private.find(&:dossier_link?) }
+      let(:annotations) { [{ id: dossier_link_annotation.to_typed_id, value: { dossierLink: '999999' } }] }
+
+      it 'returns error' do
+        expect(data).to eq(dossierModifierAnnotations: {
+          annotations: [],
+          errors: [{ message: "Le dossier n’existe pas" }],
+        })
+      end
+    end
+
+    context 'with dossier_link annotation and valid dossier id' do
+      let(:types_de_champ_private) { [{ type: :dossier_link }] }
+      let(:linked_dossier) { create(:dossier, :en_construction, procedure: procedure) }
+      let(:dossier_link_annotation) { champs_private.find(&:dossier_link?) }
+      let(:annotations) { [{ id: dossier_link_annotation.to_typed_id, value: { dossierLink: linked_dossier.id.to_s } }] }
+
+      it 'update annotation' do
+        expect(data).to eq(dossierModifierAnnotations: {
+          annotations: [{ id: dossier_link_annotation.to_typed_id }],
+          errors: nil,
+        })
+        expect(dossier_link_annotation.reload.value).to eq(linked_dossier.id.to_s)
+      end
+    end
+
     context 'with multiple annotations' do
       let(:types_de_champ_private) do
         [


### PR DESCRIPTION
bon c'est une demande via startup ds info, [unique](https://mattermost.incubateur.net/betagouv/pl/gu5bie7sf3dddjat894h3zqghh ) je sais. Mais... ça coutait vraiment pas cher (qq token claude, et une relecture, decouverte du nouveau systeme d'annotation) et j'ai l'impression qu'on tend a couvrir de plus en plus de prefill/dossierModifierAnnotation