### PR TITLE
Correction : ETQ usager, lorsque j'ajoute un fichier à un dossier en construction, le bouton "Déposer mes modifications" apparait instantanément

### DIFF
--- a/app/components/dossiers/edit_footer_component.rb
+++ b/app/components/dossiers/edit_footer_component.rb
@@ -15,7 +15,7 @@ class Dossiers::EditFooterComponent < ApplicationComponent
   end
 
   def show_for_user?
-    controller.is_a?(Users::DossiersController)
+    !annotation?
   end
 
   def annotation?

--- a/spec/controllers/champs/piece_justificative_controller_spec.rb
+++ b/spec/controllers/champs/piece_justificative_controller_spec.rb
@@ -69,6 +69,17 @@ describe Champs::PieceJustificativeController, type: :controller do
       end
     end
 
+    context 'when the champ is public and the dossier is en_construction' do
+      let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
+      let!(:dossier) { create(:dossier, :en_construction, user: user, procedure: procedure) }
+      let!(:champ) { dossier.project_champs_public.first }
+
+      it 'renders the footer with submit button' do
+        subject
+        expect(response.body).to include('Déposer les modifications')
+      end
+    end
+
     context 'when the file is invalid' do
       let(:file) { fixture_file_upload('spec/fixtures/files/invalid_file_format.json', 'bad/bad') }
 


### PR DESCRIPTION
Il fallait recharger la page pour que le bouton apparaisse