### PR TITLE
Tech: dans le clone de démarche, ne clone plus les feature flags activés aléatoirement

### DIFF
--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -132,6 +132,7 @@ module ProcedureCloneConcern
 
     Flipper.features.each do |feature|
       next if feature.enabled? # don't clone features globally enabled
+      next if feature.percentage_of_time_value > 0 # don't clone randomly enabled features
       next unless feature_enabled?(feature.key)
 
       Flipper.enable(feature.key, procedure)


### PR DESCRIPTION
cas du chatbot  le vrai risque étant d'atteindre trop rapidement les 500 entrées qui provoqueraient une erreur

NB: `percentage_of_time_value` est tjs un nombre