### PR TITLE
ETQ usager, j'ai un meilleur message d'erreur si mon numéro RNF n'est pas encore complètement saisi

### DIFF
--- a/app/models/champs/rnf_champ.rb
+++ b/app/models/champs/rnf_champ.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
 class Champs::RNFChamp < Champ
+  RNF_REGEXP = /\A[A-Za-z0-9-]{12,20}\z/i.freeze
+
   store_accessor :data, :title, :email, :phone, :createdAt, :updatedAt, :dissolvedAt, :address
 
+  validates :value, allow_blank: true, format: {
+    with: RNF_REGEXP, message: :invalid_rnf,
+  }, if: :validate_champ_value?
   validates_with ReferentielChampValidator, if: :validate_champ_value?
 
   def rnf_id
@@ -19,6 +24,10 @@ class Champs::RNFChamp < Champ
 
   def uses_external_data?
     true
+  end
+
+  def ready_for_external_call?
+    rnf_id&.match?(RNF_REGEXP)
   end
 
   def code_departement

--- a/config/locales/models/champs/rnf_champ/en.yml
+++ b/config/locales/models/champs/rnf_champ/en.yml
@@ -5,6 +5,7 @@ en:
         champs/rnf_champ:
           attributes:
             value:
+              invalid_rnf: "is not a valid RNF number. Example: 075-FDD-00003-01"
               not_found: "RNF %{rnf} (no foundation found)"
     attributes:
       champs/rnf_champ:

--- a/config/locales/models/champs/rnf_champ/fr.yml
+++ b/config/locales/models/champs/rnf_champ/fr.yml
@@ -5,6 +5,7 @@ fr:
         champs/rnf_champ:
           attributes:
             value:
+              invalid_rnf: "n’est pas un numéro RNF valide. Exemple : 075-FDD-00003-01"
               not_found: "RNF %{rnf} (aucune fondation trouvée)"
     attributes:
       champs/rnf_champ:

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -961,7 +961,7 @@ describe Users::DossiersController, type: :controller do
         let(:types_de_champ_public) { [{ type: :rnf }] }
         let(:champs_public_attributes) do
           {
-            first_champ.public_id => { external_id: 'external_id' },
+            first_champ.public_id => { external_id: '075-FDD-00003-01' },
           }
         end
 

--- a/spec/models/champs/rnf_champ_spec.rb
+++ b/spec/models/champs/rnf_champ_spec.rb
@@ -61,6 +61,63 @@ describe Champs::RNFChamp, type: :model do
     end
   end
 
+  describe 'ready_for_external_call?' do
+    subject { champ.ready_for_external_call? }
+
+    context 'when external_id is a partial input' do
+      let(:external_id) { '075' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when external_id is a valid RNF format' do
+      let(:external_id) { '075-FDD-00003-01' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when external_id is blank' do
+      let(:external_id) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe 'format validation' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champs.find(&:rnf?) }
+
+    before { champ.update_columns(external_id:) }
+
+    context 'when value is too short' do
+      let(:external_id) { 'abc' }
+
+      it 'is invalid' do
+        champ.validate(:champs_public_value)
+        expect(champ.errors.full_messages.join).to include("pas un numéro RNF valide")
+      end
+    end
+
+    context 'when value is a valid RNF' do
+      let(:external_id) { '075-FDD-00003-01' }
+
+      it 'has no format error' do
+        champ.validate(:champs_public_value)
+        expect(champ.errors.full_messages.join).not_to include("pas un numéro RNF valide")
+      end
+    end
+
+    context 'when value is blank' do
+      let(:external_id) { nil }
+
+      it 'has no format error' do
+        champ.validate(:champs_public_value)
+        expect(champ.errors.full_messages.join).not_to include("pas un numéro RNF valide")
+      end
+    end
+  end
+
   describe 'fetch_external_data' do
     let(:url) { RNFService.new.send(:url) }
     let(:status) { 200 }


### PR DESCRIPTION
comme pour le RNA, plutôt que dire "aucune fondation trouvée" et induire en erreur et cramer un call API pour rien on dit simplement que le numéro est invalide

https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_c12b86de-22ff-4fdc-9428-d53442bcc35c/

https://demarches-simplifiees.sentry.io/issues/6153641746/