### PR TITLE
ETQ Usager, je ne veux pas pouvoir déposer n'importe quel type de fichier sur un champ PJ

### DIFF
--- a/app/components/attachment/edit_component.rb
+++ b/app/components/attachment/edit_component.rb
@@ -228,7 +228,7 @@ class Attachment::EditComponent < ApplicationComponent
   end
 
   def accept_from_type_de_champ
-    return nil if champ.blank?
+    return nil if !champ&.respond_to?(:type_de_champ)
 
     if champ.titre_identite_nature?
       return ['.jpg', '.jpeg', '.png'].join(', ')

--- a/spec/components/attachment/edit_component_spec.rb
+++ b/spec/components/attachment/edit_component_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Attachment::EditComponent, type: :component do
     let(:types_de_champ_public) { [{ type: :piece_justificative, nature: 'TITRE_IDENTITE' }] }
     let(:attachment) { nil }
 
+    before { champ.piece_justificative_file.purge }
+
     it 'sets accept to jpg/jpeg/png only' do
       expect(subject).to have_selector("input[accept*='.jpg']")
       expect(subject).to have_selector("input[accept*='.jpeg']")


### PR DESCRIPTION
Il y avait déjà un test qui testait ce qu'on attendait, mais comme dans les tests le champ PJ était initialisé avec un attachment on n'avait jamais le cas où `champ.blank? == true` qui se produit en prod