### PR TITLE
ETQ instructeur je vois le bas des fichiers pdf dans la galerie de pièces jointes

### DIFF
--- a/app/assets/stylesheets/gallery.scss
+++ b/app/assets/stylesheets/gallery.scss
@@ -20,6 +20,7 @@
 .lg-has-iframe {
   width: 80% !important;
   margin-top: 50px;
+  height: calc(100% - 50px) !important;
 }
 
 .lg-icon {


### PR DESCRIPTION
**AVANT**

<img width="3420" height="120" alt="Capture d’écran 2026-02-13 à 15 10 13" src="https://github.com/user-attachments/assets/36e53d4d-a312-4e88-b174-3daa614c9ef5" />

**APRÈS**

<img width="3420" height="250" alt="Capture d’écran 2026-02-13 à 15 09 31" src="https://github.com/user-attachments/assets/88b531cc-8613-426e-bbc7-57c44269f446" />
