### PR TITLE
ETQ tech je veux une maintenance task de création de variants plus rapide

### DIFF
--- a/app/jobs/backfill_variants_for_dossier_job.rb
+++ b/app/jobs/backfill_variants_for_dossier_job.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class BackfillVariantsForDossierJob < ApplicationJob
+  queue_as :low
+
+  retry_on StandardError, wait: 1.minute, attempts: 3
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(dossier_id, file_type)
+    dossier = Dossier.find(dossier_id)
+
+    champ_ids = Champ
+      .where(dossier_id: dossier)
+      .where(type: ["Champs::PieceJustificativeChamp", "Champs::TitreIdentiteChamp"])
+      .ids
+
+    return if champ_ids.empty?
+
+    attachments = ActiveStorage::Attachment
+      .includes(:blob)
+      .where(record_id: champ_ids)
+
+    attachments.each do |attachment|
+      process_attachment(attachment, file_type)
+    end
+  end
+
+  private
+
+  def process_attachment(attachment, file_type)
+    return if !attachment.representable? || !attachment.representation_required?
+    return if skip_attachment?(attachment, file_type)
+
+    if attachment.variable?
+      variant = attachment.variant(resize_to_limit: [400, 400])
+      variant.processed if variant.key.nil?
+
+      if attachment.blob.content_type.in?(RARE_IMAGE_TYPES)
+        large_variant = attachment.variant(resize_to_limit: [2000, 2000])
+        large_variant.processed if large_variant.key.nil?
+      end
+    elsif attachment.previewable?
+      preview = attachment.preview(resize_to_limit: [400, 400])
+      preview.processed if preview.image.blank?
+    end
+  rescue MiniMagick::Error, ActiveStorage::Error, EOFError, Excon::Error => e
+    Rails.logger.warn "BackfillVariantsForDossierJob: failed to process attachment #{attachment.id}: #{e.message}"
+  end
+
+  def skip_attachment?(attachment, file_type)
+    content_type = attachment.blob.content_type
+    case file_type
+    when "image"
+      !content_type.in?(AUTHORIZED_IMAGE_TYPES)
+    when "pdf"
+      !content_type.in?(AUTHORIZED_PDF_TYPES)
+    else
+      false
+    end
+  end
+end

--- a/app/tasks/maintenance/backfill_variants_for_pj_task.rb
+++ b/app/tasks/maintenance/backfill_variants_for_pj_task.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class BackfillVariantsForPjTask < MaintenanceTasks::Task
+    # Enqueues jobs to generate thumbnails for files (images and/or PDFs)
+    # for dossiers submitted between two dates.
+    #
+    # Unlike CreateVariantsForPjOfLatestDossiersTask which processes synchronously,
+    # this task enqueues jobs for each dossier.
+    #
+    # This task should be performed cautiously, using a limited number of files,
+    # preferably at night and on weekends.
+
+    attribute :start_text, :string
+    validates :start_text, presence: true
+
+    attribute :end_text, :string
+    validates :end_text, presence: true
+
+    attribute :file_type, :string
+    validates :file_type, inclusion: { in: ['image', 'pdf', ''] }
+
+    def collection
+      start_date = DateTime.parse(start_text)
+      end_date = DateTime.parse(end_text)
+
+      Dossier
+        .state_en_construction_ou_instruction
+        .where(depose_at: start_date..end_date)
+    end
+
+    def process(dossier)
+      BackfillVariantsForDossierJob.perform_later(dossier.id, file_type)
+    end
+  end
+end

--- a/spec/jobs/backfill_variants_for_dossier_job_spec.rb
+++ b/spec/jobs/backfill_variants_for_dossier_job_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe BackfillVariantsForDossierJob, type: :job do
+  let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
+  let(:dossier) { create(:dossier, :en_construction, procedure:) }
+
+  describe '#perform' do
+    context 'when dossier exists' do
+      it 'does not raise an error' do
+        expect { described_class.perform_now(dossier.id, '') }.not_to raise_error
+      end
+    end
+
+    context 'when dossier does not exist' do
+      it 'discards the job without error' do
+        expect { described_class.perform_now(nil, '') }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#skip_attachment?' do
+    let(:job) { described_class.new }
+    let(:champ) { dossier.champs.first }
+    let(:attachment) { champ.piece_justificative_file.first }
+
+    before do
+      champ.piece_justificative_file.attach(
+        io: StringIO.new('test'),
+        filename: 'test.jpg',
+        content_type: 'image/jpeg'
+      )
+    end
+
+    it 'skips image when file_type is pdf' do
+      expect(job.send(:skip_attachment?, attachment, 'pdf')).to be true
+    end
+
+    it 'does not skip image when file_type is image' do
+      expect(job.send(:skip_attachment?, attachment, 'image')).to be false
+    end
+
+    it 'does not skip image when file_type is empty' do
+      expect(job.send(:skip_attachment?, attachment, '')).to be false
+    end
+  end
+end

--- a/spec/tasks/maintenance/backfill_variants_for_pj_task_spec.rb
+++ b/spec/tasks/maintenance/backfill_variants_for_pj_task_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe Maintenance::BackfillVariantsForPjTask do
+  describe '#process' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
+    let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:, depose_at: 1.day.ago) }
+
+    subject(:task) do
+      described_class.new.tap do |task|
+        task.start_text = 2.days.ago.to_s
+        task.end_text = Time.current.to_s
+        task.file_type = 'pdf'
+      end
+    end
+
+    it 'enqueues a BackfillVariantsForDossierJob for each dossier' do
+      expect {
+        task.process(dossier)
+      }.to have_enqueued_job(BackfillVariantsForDossierJob).with(dossier.id, 'pdf')
+    end
+  end
+
+  describe '#collection' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
+
+    let!(:dossier_in_range) { create(:dossier, :en_construction, procedure:, depose_at: 1.day.ago) }
+    let!(:dossier_out_of_range) { create(:dossier, :en_construction, procedure:, depose_at: 10.days.ago) }
+    let!(:dossier_brouillon) { create(:dossier, :brouillon, procedure:, depose_at: 1.day.ago) }
+
+    subject(:task) do
+      described_class.new.tap do |task|
+        task.start_text = 2.days.ago.to_s
+        task.end_text = Time.current.to_s
+        task.file_type = ''
+      end
+    end
+
+    it 'returns only dossiers in construction or instruction within date range' do
+      expect(task.collection).to include(dossier_in_range)
+      expect(task.collection).not_to include(dossier_out_of_range)
+      expect(task.collection).not_to include(dossier_brouillon)
+    end
+  end
+end


### PR DESCRIPTION
- Actuellement, la MT qu'on utilise pour créer des variants d'image suite à un échec du process standard (CreateVariantsForPjOfLatestDossiersTask) fonctionne de façon séquentielle, un dossier après l'autre. Pour rattraper les dossiers déposés pendant une journée (~4000) ça prend ~12 h
- Je tente une autre approche : lancer un job par dossier sur la queue default. L'idée étant de lancer cette task la nuit et le week-end pour ne pas concurrencer les jobs en journée