### PR TITLE
Correction : dans la galerie de pièces jointes, les fichiers utilisés pour les vignettes de prévisualisation des pdf sont les miniatures et non les images en grande taille

### DIFF
--- a/app/components/attachment/thumbnail_component.rb
+++ b/app/components/attachment/thumbnail_component.rb
@@ -8,7 +8,7 @@ class Attachment::ThumbnailComponent < ApplicationComponent
 
   def initialize(attachment:, small: false, top_classes: '')
     @attachment, @small, @top_classes = attachment, small, top_classes
-    @thumbnail_url = representation_url_for(attachment)
+    @thumbnail_url = variant_url_for(attachment)
   end
 
   def size_class = small ? 'thumbnail-100' : 'thumbnail-200'

--- a/app/helpers/gallery_helper.rb
+++ b/app/helpers/gallery_helper.rb
@@ -28,13 +28,13 @@ module GalleryHelper
     blob.variable? && blob.content_type.in?(AUTHORIZED_IMAGE_TYPES)
   end
 
-  def representation_url_for(attachment)
-    return variant_url_for(attachment) if displayable_image?(attachment.blob)
+  def variant_url_for(attachment)
+    return image_variant_url_for(attachment) if displayable_image?(attachment.blob)
 
-    preview_url_for(attachment) if displayable_pdf?(attachment.blob)
+    pdf_preview_variant_url_for(attachment) if displayable_pdf?(attachment.blob)
   end
 
-  def preview_url_for(attachment)
+  def pdf_preview_variant_url_for(attachment)
     preview_image = attachment.blob.preview_image
     return unless preview_image.attached?
 
@@ -43,7 +43,7 @@ module GalleryHelper
   rescue StandardError
   end
 
-  def variant_url_for(attachment)
+  def image_variant_url_for(attachment)
     variant = attachment.variant(resize_to_limit: [400, 400])
     variant.key.present? ? variant.processed.url : nil
   rescue StandardError

--- a/spec/helpers/gallery_helper_spec.rb
+++ b/spec/helpers/gallery_helper_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe GalleryHelper, type: :helper do
     champ_pj.piece_justificative_file.attachments.first
   end
 
-  describe ".variant_url_for" do
-    subject { variant_url_for(attachment) }
+  describe ".image_variant_url_for" do
+    subject { image_variant_url_for(attachment) }
 
     context "when image attachment has a variant" do
       let(:file) { fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png') }
@@ -47,8 +47,8 @@ RSpec.describe GalleryHelper, type: :helper do
     end
   end
 
-  describe ".preview_url_for" do
-    subject { preview_url_for(attachment) }
+  describe ".pdf_preview_variant_url_for" do
+    subject { pdf_preview_variant_url_for(attachment) }
 
     context "when pdf attachment has a preview with variant" do
       let(:file) { fixture_file_upload('spec/fixtures/files/RIB.pdf', 'application/pdf') }
@@ -84,8 +84,8 @@ RSpec.describe GalleryHelper, type: :helper do
     end
   end
 
-  describe ".representation_url_for" do
-    subject { representation_url_for(attachment) }
+  describe ".variant_url_for" do
+    subject { variant_url_for(attachment) }
 
     context "when attachment is an image with no variant" do
       let(:file) { fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png') }


### PR DESCRIPTION
**Ce que fait la PR**
Actuellement dans les vignettes de la galerie de pjs, pour les pdfs, on affiche la grande version de l'image et non la petite. C'est corrigé dans le 1er commit. Et dans le 2e, c'est du renommage autour des notions de variant et de représentation.

**Le contexte**
- Quand un usager uploade une image dans un dossier, cela crée 2 blobs : 
  - Le blob de l'image dont l'attachment a un record_type: "champ" 
  - Le blob de la miniature de l'image dont l'attachment a un record_type: "ActiveStorage::VariantRecord"

- Quand un usager uploade un pdf dans un dossier, cela crée 3 blobs : 
  - le blob du pdf, dont l'attachment a un record_type: "champ"
  - le blob de l'image de preview dont l'attachment a un record_type: "ActiveStorage::Blob"
  - le blob de l'image miniature de la preview dont l'attachment a un record_type: "ActiveStorage::VariantRecord"

Il y avait une confusion autour de la notion de représentation. Dans Active Storage une représentation englobe les deux façons de générer une image à partir d'un blob : un variant à partir d'une image, ou une preview à partir d'un pdf ou d'une vidéo. Et on confondait la preview de la pdf avec la miniature de la preview de pdf

**Résumé**
Dans notre cas, une représentation peut être :
- une miniature d'image (variant)
- une prévisualisation de pdf (preview_image)
- une miniature de prévisualisation de pdf (variant)

