### PR TITLE
ETQ Usager, je veux un message d'erreur pertinent si je dépose mon dossier et que le champ SIRET met du temps à répondre

### DIFF
--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -10,8 +10,6 @@ class Champs::ReferentielChamp < Champ
 
   before_save :clear_previous_result, if: -> { external_id_changed? }
 
-  validates_with ReferentielChampValidator, if: :validate_champ_value?
-
   def fetch_external_data
     ReferentielService.new(referentiel:).call(external_id).fmap do |data|
       {

--- a/app/models/champs/rnf_champ.rb
+++ b/app/models/champs/rnf_champ.rb
@@ -8,8 +8,6 @@ class Champs::RNFChamp < Champ
   validates :value, allow_blank: true, format: {
     with: RNF_REGEXP, message: :invalid_rnf,
   }, if: :validate_champ_value?
-  validates_with ReferentielChampValidator, if: :validate_champ_value?
-
   def rnf_id
     external_id&.gsub(/[[:space:]]/, '')
   end

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -19,6 +19,7 @@ module ChampExternalDataConcern
 
   included do
     include AASM
+    validates_with ExternalDataChampValidator, if: :validate_external_data_response?
 
     attribute :fetch_external_data_exceptions, :external_data_exception, array: true
 
@@ -70,6 +71,10 @@ module ChampExternalDataConcern
     def uses_external_data? = false
 
     private
+
+    def validate_external_data_response?
+      uses_external_data? && validate_champ_value?
+    end
 
     def ready_for_external_call? = external_id.present?
 

--- a/app/validators/external_data_champ_validator.rb
+++ b/app/validators/external_data_champ_validator.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-class ReferentielChampValidator < ActiveModel::Validator
-  # case required, delegated to check_mandatory_and_visible_champs_public
+class ExternalDataChampValidator < ActiveModel::Validator
+  # Required checks are delegated to check_mandatory_and_visible_champs_public.
   def validate(record)
-    if record.pending? # user filled the field, but background job is still running / pending
+    if record.pending?
+      # User filled the field, but background job is still running.
       record.errors.add(:value, :api_response_pending)
-    elsif record.external_error? # user filled the field, but background job failed
+    elsif record.external_error?
+      # User filled the field, but background job failed.
       record.errors.add(:value, error_key_for_api_response_code(record))
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -703,7 +703,7 @@ en:
         not_a_phone: 'is invalid. Enter a valid phone number. Example: 0612345678'
         url: 'is not a valid link'
         invalid_email_format: 'is invalid. Enter a valid email. Example: address@mail.com'
-        api_response_pending: 'Pending response...'
+        api_response_pending: 'Pending response... Please try again in a few moments.'
         api_response_error: 'Not found.'
         code_429: 'Too many requests. We are retrying for you.'
         code_500: 'Server error. We are retrying for you.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -710,7 +710,7 @@ fr:
         inclusion: "n’est pas inclus(e) dans la liste"
         url: 'n’est pas un lien valide'
         invalid_email_format: 'est invalide. Saisissez une adresse électronique valide. Exemple : adresse@mail.com'
-        api_response_pending: 'En attente de réponse...'
+        api_response_pending: 'En attente de réponse... Réessayez dans quelques instants.'
         api_response_error: 'Aucun résultat ne correspond à votre recherche.'
         code_429: 'Trop de demandes. Nous réessayons pour vous.'
         code_500: 'Erreur du serveur. Nous réessayons pour vous.'

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -40,6 +40,33 @@ describe Champs::SiretChamp do
 
       it { is_expected.to be_valid }
     end
+
+    context 'when external fetch is pending' do
+      let(:external_id) { "12345678901245" }
+
+      before { champ.update_columns(external_state: 'waiting_for_job') }
+
+      it 'adds a pending error on value' do
+        expect(subject.errors[:value]).to include(I18n.t('activerecord.errors.messages.api_response_pending'))
+      end
+    end
+
+    context 'when external fetch failed' do
+      let(:external_id) { "12345678901245" }
+      let(:exception) { ExternalDataException.new(reason: 'Not retryable', code: 404) }
+
+      before do
+        champ.update_columns(
+          external_state: 'external_error',
+          fetch_external_data_exceptions: [exception]
+        )
+      end
+
+      it 'adds the external error on value only' do
+        expect(subject.errors[:value]).to include(I18n.t('activerecord.errors.messages.code_404'))
+        expect(subject.errors[:external_id]).to be_empty
+      end
+    end
   end
 
   describe '.fetch_external_data' do

--- a/spec/system/api_particulier/api_particulier_spec.rb
+++ b/spec/system/api_particulier/api_particulier_spec.rb
@@ -288,7 +288,9 @@ describe 'fetch API Particulier Data', js: true do
         fill_in 'Le code postal', with: code_postal
         wait_until { cnaf_champ.reload.external_id.present? }
 
-        perform_enqueued_jobs
+        perform_enqueued_jobs do
+          wait_until { cnaf_champ.reload.fetched? }
+        end
         click_on 'Déposer le dossier'
 
         expect(page).to have_current_path(merci_dossier_path(Dossier.last))
@@ -478,7 +480,9 @@ describe 'fetch API Particulier Data', js: true do
         fill_in "La référence d’avis d’imposition", with: reference_avis
         wait_until { dgfip_champ.reload.external_id.present? }
 
-        perform_enqueued_jobs
+        perform_enqueued_jobs do
+          wait_until { dgfip_champ.reload.fetched? }
+        end
         click_on 'Déposer le dossier'
 
         expect(page).to have_current_path(merci_dossier_path(Dossier.last))


### PR DESCRIPTION
Remonté par @kvkq 

### Avant : 
<img width="712" height="458" alt="image" src="https://github.com/user-attachments/assets/b3ff7979-1520-4965-9fd6-7f47975e0f18" />

### Après :
<img width="779" height="335" alt="image" src="https://github.com/user-attachments/assets/f7df5294-1a4e-492a-a417-0e8bfbc924c7" />

On réutilise le `ReferentielChampValidator` pour qu'il s'applique à tous les champs avec `uses_external_data? == true`