### PR TITLE
Fix: affiche également un placeholder pour le champ annuaire education

### DIFF
--- a/app/components/editable_champ/annuaire_education_component.rb
+++ b/app/components/editable_champ/annuaire_education_component.rb
@@ -9,6 +9,7 @@ class EditableChamp::AnnuaireEducationComponent < EditableChamp::EditableChampBa
     react_input_opts(id: @champ.focusable_input_id,
       class: "fr-mt-1w",
       name: @form.field_name(:external_id),
+      placeholder: t('views.components.remote_combobox'),
       selected_key: @champ.external_id,
       items: @champ.selected_items,
       loader: 'https://data.education.gouv.fr/api/records/1.0/search?dataset=fr-en-annuaire-education&rows=5',


### PR DESCRIPTION
Issue : https://github.com/demarche-numerique/demarche.numerique.gouv.fr/issues/10188

Complément pour le champ annuaire education de la PR : https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/11863

Maintenant:
<img width="1378" height="124" alt="Capture d’écran 2026-02-19 à 11 25 51" src="https://github.com/user-attachments/assets/e8d0e478-bb1a-4602-bf54-37d3612d2a18" />
