### PR TITLE
[fix] UI - Le bouton pour prévenir le titulaire de modifications passe en style secondaire 

### DIFF
--- a/app/components/dossiers/edit_footer_component/edit_footer_component.html.haml
+++ b/app/components/dossiers/edit_footer_component/edit_footer_component.html.haml
@@ -15,6 +15,6 @@
 
             - if !owner?
               %li= button_to t('.check_completude'), check_completude_dossier_path(@dossier), class: "fr-btn", method: :post
-              %li= button_to t('.notify_owner_for_changes'), notify_owner_for_changes_dossier_path(@dossier), class: "fr-btn", method: :post, data: { confirm: t('.notify_owner_for_changes_alert')}
+              %li= button_to t('.notify_owner_for_changes'), notify_owner_for_changes_dossier_path(@dossier), class: "fr-btn fr-btn--secondary", method: :post, data: { confirm: t('.notify_owner_for_changes_alert')}
 
       = render partial: "shared/dossiers/submit_is_over", locals: { dossier: @dossier }


### PR DESCRIPTION
<img width="1144" height="451" alt="Capture d’écran 2026-02-19 à 17 32 15" src="https://github.com/user-attachments/assets/600247fd-a3fe-4307-b26d-d273296a7639" />
