### PR TITLE
ETQ instructeur, je peux utiliser les filtres de dates pour les données présentes dans value_json

### DIFF
--- a/app/models/columns/json_path_column.rb
+++ b/app/models/columns/json_path_column.rb
@@ -20,7 +20,37 @@ class Columns::JSONPathColumn < Columns::ChampColumn
   end
 
   def filtered_ids(dossiers, filter)
-    filtered_ids_for_values(dossiers, filter[:value])
+    case filter
+    in { operator: 'before', value: [end_date, *_] }
+      filtered_ids_for_date_range(dossiers, ..end_date&.then { Time.zone.parse(_1) }&.beginning_of_day)
+    in { operator: 'after', value: [start_date, *_] }
+      filtered_ids_for_date_range(dossiers, (start_date&.then { Time.zone.parse(_1) }&.end_of_day..))
+    in { operator: 'this_week' }
+      filtered_ids_for_date_range(dossiers, Time.current.all_week)
+    in { operator: 'this_month' }
+      filtered_ids_for_date_range(dossiers, Time.current.all_month)
+    in { operator: 'this_year' }
+      filtered_ids_for_date_range(dossiers, Time.current.all_year)
+    else
+      filtered_ids_for_values(dossiers, filter[:value])
+    end
+  end
+
+  private
+
+  def filtered_ids_for_date_range(dossiers, range)
+    return dossiers.ids if range.begin.nil? && range.end.nil?
+
+    start_date = range.begin&.to_date&.iso8601
+    end_date = range.end&.to_date&.iso8601
+
+    parts = []
+    parts << %(@ >= "#{start_date}") if start_date
+    parts << %(@ <= "#{end_date}") if end_date
+
+    condition = sanitize_sql(%{champs.value_json @? '#{jsonpath} ? (#{parts.join(' && ')})'})
+
+    dossiers.with_type_de_champ(stable_id).where(condition).ids
   end
 
   def filtered_ids_for_values(dossiers, search_terms)
@@ -44,8 +74,6 @@ class Columns::JSONPathColumn < Columns::ChampColumn
       raise
     end
   end
-
-  private
 
   def column_id = "type_de_champ/#{stable_id}-#{jsonpath}"
 

--- a/spec/models/columns/json_path_column_spec.rb
+++ b/spec/models/columns/json_path_column_spec.rb
@@ -57,6 +57,66 @@ describe Columns::JSONPathColumn do
       end
     end
 
+    context 'with date range' do
+      let(:jsonpath) { '$.issue_date' }
+      let(:column) { described_class.new(procedure_id: procedure.id, label: 'label', stable_id:, tdc_type:, jsonpath:, type: :date, displayable: true, mandatory: true) }
+      let(:dossier_in_range)  { create(:dossier, procedure:) }
+      let(:dossier_out_range) { create(:dossier, procedure:) }
+
+      context 'bounded on both sides (this_year)' do
+        before do
+          dossier_in_range.champs.first.update(value_json: { issue_date: Date.current.iso8601 })
+          dossier_out_range.champs.first.update(value_json: { issue_date: 5.years.ago.to_date.iso8601 })
+        end
+
+        subject { column.filtered_ids(Dossier.all, { operator: 'this_year' }) }
+
+        it do
+          is_expected.to include(dossier_in_range.id)
+          is_expected.not_to include(dossier_out_range.id)
+        end
+      end
+
+      context 'bounded only on the right (before operator)' do
+        before do
+          dossier_in_range.champs.first.update(value_json: { issue_date: '2020-06-15' })
+          dossier_out_range.champs.first.update(value_json: { issue_date: '2022-06-15' })
+        end
+
+        subject { column.filtered_ids(Dossier.all, { operator: 'before', value: ['2021-01-01'] }) }
+
+        it do
+          is_expected.to include(dossier_in_range.id)
+          is_expected.not_to include(dossier_out_range.id)
+        end
+      end
+
+      context 'bounded only on the left (after operator)' do
+        before do
+          dossier_in_range.champs.first.update(value_json: { issue_date: '2022-06-15' })
+          dossier_out_range.champs.first.update(value_json: { issue_date: '2020-06-15' })
+        end
+
+        subject { column.filtered_ids(Dossier.all, { operator: 'after', value: ['2021-01-01'] }) }
+
+        it do
+          is_expected.to include(dossier_in_range.id)
+          is_expected.not_to include(dossier_out_range.id)
+        end
+      end
+
+      context 'nil..nil range' do
+        before do
+          dossier_in_range.champs.first.update(value_json: { issue_date: '2022-06-15' })
+          dossier_out_range.champs.first.update(value_json: { issue_date: '2020-06-15' })
+        end
+
+        subject { column.filtered_ids(Dossier.all, { operator: 'after', value: [nil] }) }
+
+        it { is_expected.to include(dossier_in_range.id, dossier_out_range.id) }
+      end
+    end
+
     context 'with blank filter values' do
       let(:jsonpath) { '$.postal_code' }
       let(:dossier1) { create(:dossier, procedure:) }


### PR DESCRIPTION
C'est particulièrement utile pour les données provenant de service tiers comme Api Particulier ou Document IA. Par exemple, avec ce mécanisme, on peut filtrer les dossiers ayant des justificatif de domicile récent.

Pour que ca marche, la donnée doit être sérialisée au format iso8601 (yyyy-mm-dd)