### PR TITLE
Tech: corrige un test non fiable sur la recherche

### DIFF
--- a/spec/controllers/recherche_controller_spec.rb
+++ b/spec/controllers/recherche_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe RechercheController, type: :controller do
-  let(:procedure) {
+  let_it_be(:procedure) {
     create(:procedure, :published,
                        :for_individual,
                        types_de_champ_public: [{ type: :text }, { type: :text }],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,8 @@
 #
 require 'simplecov' if ENV["CI"] || ENV["COVERAGE"] # see config in .simplecov file
 
+require 'test_prof/recipes/rspec/let_it_be'
+
 require 'rspec/retry'
 
 SECURE_PASSWORD = '{My-$3cure-p4ssWord}'


### PR DESCRIPTION
1. on sépare les setup entre les tests qui bossent sur les ids, et ceux qui bossent sur les valeurs des champs. Ca évite [les interférence](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/22310144299/job/64539688587?pr=12699) du genre le dossier d2 qui contient `paris 75000` remonte lorsque qu'on cherche le dossier1 d'id `75`  (on recherche par prefix)
2. on merge des `it` consécutifs
3. on utilise `let_it_be` de `test-prof` pour ne pas ré instancier la procédure à chaque fois.

Du coup, en plus de tuer un flaky test, on passe de 25s a 10s pour jouer tous les tests.