### PR TITLE
ETQ Super Administrateur, je peux débloquer un usager

### DIFF
--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -102,6 +102,21 @@ module Manager
       redirect_to emails_manager_user_path(@user)
     end
 
+    def reactivate
+      user = User.find(params[:id])
+
+      if user.blocked_at.nil?
+        flash[:notice] = "Ce compte n'est pas bloqué."
+      else
+        user.update!(blocked_at: nil, blocked_reason: nil)
+        UserMailer.account_reactivated(user).deliver_later
+        logger.info("L'utilisateur #{user.id} a été réactivé par #{current_super_admin.id}")
+        flash[:notice] = "Le compte de l'utilisateur #{user.email} a été réactivé."
+      end
+
+      redirect_to manager_user_path(user)
+    end
+
     private
 
     def targeted_email

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -119,6 +119,13 @@ class UserMailer < ApplicationMailer
     mail(to: user.email, subject: @subject, content: @content, procedure: @procedure)
   end
 
+  def account_reactivated(user)
+    @user = user
+    @subject = "Votre compte a été réactivé"
+
+    mail(to: user.email, subject: @subject)
+  end
+
   def self.critical_email?(action_name)
     [
       'france_connect_merge_confirmation',

--- a/app/views/manager/users/show.html.erb
+++ b/app/views/manager/users/show.html.erb
@@ -38,6 +38,15 @@
         class: "button") %>
     <% end %>
 
+    <% if user.blocked_at %>
+      <%= button_to(
+        "Réactiver le compte",
+        reactivate_manager_user_path(page.resource),
+        method: :put,
+        class: "button",
+        data: { turbo_confirm: "Confirmez-vous la réactivation du compte de #{user.email} ?" }) %>
+    <% end %>
+
     <%= link_to(
       "Modifier",
       edit_manager_user_path(page.resource),

--- a/app/views/user_mailer/account_reactivated.html.haml
+++ b/app/views/user_mailer/account_reactivated.html.haml
@@ -1,0 +1,20 @@
+- content_for(:title, @subject)
+
+%p
+  Bonjour,
+
+%p
+  Votre compte #{APPLICATION_NAME} associé à l'adresse
+  %strong= @user.email
+  a été réactivé par un administrateur.
+
+%p
+  Vous pouvez désormais vous connecter à nouveau en cliquant sur le bouton ci-dessous.
+
+= round_button('Se connecter', new_user_session_url, :primary)
+= vertical_margin(6)
+
+%p
+  Si vous avez des questions, veuillez contacter le support.
+
+= render partial: "layouts/mailers/signature"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
       put 'enable_feature', on: :member
       get 'emails', on: :member
       put 'unblock_email'
+      put 'reactivate', on: :member
     end
 
     resources :experts, only: [:index, :show]

--- a/spec/controllers/manager/users_controller_spec.rb
+++ b/spec/controllers/manager/users_controller_spec.rb
@@ -16,6 +16,14 @@ describe Manager::UsersController, type: :controller do
     end
 
     it { expect(response.body).to include(user.email) }
+
+    context 'when user is blocked' do
+      let(:user) { create(:user, blocked_at: Time.zone.now) }
+
+      it 'displays the reactivate button' do
+        expect(response.body).to include("Réactiver le compte")
+      end
+    end
   end
 
   describe '#update' do
@@ -71,6 +79,47 @@ describe Manager::UsersController, type: :controller do
       subject
 
       expect(User.find_by(id: user.id)).to be_nil
+    end
+  end
+
+  describe '#reactivate' do
+    subject { put :reactivate, params: { id: user.id } }
+
+    context 'when user is blocked' do
+      let(:user) { create(:user, blocked_at: Time.zone.now, blocked_reason: "Activité suspecte") }
+
+      it 'clears blocked_at and blocked_reason' do
+        subject
+        user.reload
+
+        expect(user.blocked_at).to be_nil
+        expect(user.blocked_reason).to be_nil
+      end
+
+      it 'enqueues a reactivation email to the user' do
+        expect { subject }.to have_enqueued_mail(UserMailer, :account_reactivated).with(user)
+      end
+
+      it 'redirects to user show page with confirmation flash' do
+        subject
+
+        expect(flash[:notice]).to include("réactivé")
+        expect(response).to redirect_to(manager_user_path(user))
+      end
+    end
+
+    context 'when user is not blocked' do
+      let(:user) { create(:user, blocked_at: nil) }
+
+      it 'does not enqueue a reactivation email' do
+        expect { subject }.not_to have_enqueued_mail(UserMailer, :account_reactivated)
+      end
+
+      it 'sets an informational flash message' do
+        subject
+
+        expect(flash[:notice]).to include("n'est pas bloqué")
+      end
     end
   end
 end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -43,6 +43,10 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.notify_after_closing(user, "Cette démarche est close")
   end
 
+  def account_reactivated
+    UserMailer.account_reactivated(user)
+  end
+
   private
 
   def user

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -196,4 +196,14 @@ RSpec.describe UserMailer, type: :mailer do
 
     it { expect(subject['BYPASS_UNVERIFIED_MAIL_PROTECTION']).to be_present }
   end
+
+  describe '.account_reactivated' do
+    subject { described_class.account_reactivated(user) }
+
+    it 'sends reactivation notification to user with login link' do
+      expect(subject.to).to eq([user.email])
+      expect(subject.body).to include(user.email)
+      expect(subject.body).to have_link('Se connecter', href: new_user_session_url)
+    end
+  end
 end


### PR DESCRIPTION
Super admins can now unblock users directly from the Manager UI. When a user is blocked (blocked_at is set), a "Réactiver le compte" button appears on their show page. Reactivation clears blocked_at and blocked_reason, sends a notification email, and logs the action.