### PR TITLE
ETQ Tech, je veux que les tests automatiques bénéficient d'un cache

### DIFF
--- a/.github/workflows/bundle_cache_warming.yml
+++ b/.github/workflows/bundle_cache_warming.yml
@@ -1,0 +1,28 @@
+name: Warm bundle cache
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - Gemfile.lock
+      - .ruby-version
+      - package.json
+      - vite.config.ts
+      - app/javascript/**
+      - app/assets/**
+      - patches/**
+
+jobs:
+  warm-cache:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Ruby and bundle cache
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup assets cache
+        uses: ./.github/actions/ci-setup-assets


### PR DESCRIPTION
actuellement, a chaque fois que fois que l'on ouvre une pr, la ci semble ne pas utiliser de cache pour les deps ruby ou les deps js (exemple [ici](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/22354539336/job/64690341510?pr=12705))

D'apres [la doc](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache), une branche n'a accès qu'à son cache et aux caches des branches dont elle dépend, ici main.

Or, y a plus de cache sur main depuis qu'on ne build plus main.

Pour corriger, on propose un workflow ultra simple qui ne fait que construire les caches lors des merges sur main et uniquement lorsqu'il y a besoin