### PR TITLE
ETQ Tech, correction du job de fabrication du cache sur github

### DIFF
--- a/.github/workflows/bundle_cache_warming.yml
+++ b/.github/workflows/bundle_cache_warming.yml
@@ -16,6 +16,14 @@ on:
 jobs:
   warm-cache:
     runs-on: ubuntu-22.04
+    services:
+      postgres:
+        image: postgis/postgis:17-3.5
+        env:
+          POSTGRES_USER: tps_test
+          POSTGRES_DB: tps_test
+          POSTGRES_PASSWORD: tps_test
+        ports: ["5432:5432"]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
[apparemment](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/22389559684/job/64807814549) , on a besoin de postgres pour build des assets ...