### PR TITLE
ETQ Tech, nouvel essai pour tenter de corriger un test system de surlignage dans tiptap

### DIFF
--- a/spec/system/administrateurs/dossier_submitted_message_spec.rb
+++ b/spec/system/administrateurs/dossier_submitted_message_spec.rb
@@ -11,13 +11,12 @@ describe 'As an administateur i can setup a DossierSubmittedMessage', js: true d
     editor = find('.tiptap-editor')
     editor.click
 
-    # Type text that will be bold
     editor.send_keys('Texte super important')
     editor.send_keys(*Array.new(15, [:shift, :left])) # Select "super important"
     click_on 'Gras'
 
     within('#tiptap-preview .tiptap-content') do
-      expect(find("strong").text).to eq("super important")
+      expect(page).to have_css("strong", text: "super important")
     end
 
     # Link modal


### PR DESCRIPTION
Ca continue à [foirer](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/22447870585/job/65007481967) malgré le dernier change qui consistait à envoyer en une fois les 15 évènements claviers pour surligner du texte.

~~Du coup, je fais une boucle avec 3 essais.~~ ca marche pas non plus.

Du coup, on utilise plutot un matcher capybara qui va attendre que le surlignage soit bon, en espérant que c'était un pb de timing et pas de commandes clavier perdues.