### PR TITLE
ETQ Tech, corrige un test instable sur la performance de lecture d'un dossier par un instructeur

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -858,7 +858,7 @@ class Procedure < ApplicationRecord
     recent_ids = types_de_champ_scope
       .joins(:revision_types_de_champ)
       .where(revision_types_de_champ: { revision_id: revision_ids, parent_id: parent_ids })
-      .group(:stable_id).select('MAX(types_de_champ.id)')
+      .group(:stable_id).pluck('MAX(types_de_champ.id)')
 
     # fetch the more recent procedure_revision_types_de_champ
     # which includes recents_ids
@@ -867,7 +867,7 @@ class Procedure < ApplicationRecord
       .where(type_de_champ_id: recent_ids)
       .where.not(revision_id: draft_revision_id)
       .group(:type_de_champ_id)
-      .select('MAX(id)')
+      .pluck('MAX(id)')
 
     TypeDeChamp
       .joins(:revision_types_de_champ)

--- a/spec/perf/instructeur_dossier_controller_spec.rb
+++ b/spec/perf/instructeur_dossier_controller_spec.rb
@@ -52,7 +52,7 @@ describe Instructeurs::DossiersController, type: :controller do
           get :show, params: { procedure_id: procedure.id, dossier_id: dossier.id, statut: 'a-suivre' }
         end
 
-        expect(query_count).to be <= 122
+        expect(query_count).to be <= 124
       end
     end
   end


### PR DESCRIPTION
la requête original pour récupérer tous les types de champs publiés d'une démarche ressemble à ca : 

```sql
SELECT 
  "types_de_champ".* 
FROM 
  "types_de_champ" 
  INNER JOIN "procedure_revision_types_de_champ" "revision_types_de_champ" ON "revision_types_de_champ"."type_de_champ_id" = "types_de_champ"."id" 
WHERE 
  "revision_types_de_champ"."id" IN (
    SELECT 
      MAX(id) 
    FROM 
      "procedure_revision_types_de_champ" 
    WHERE 
      "procedure_revision_types_de_champ"."type_de_champ_id" IN (
        SELECT 
          MAX(types_de_champ.id) 
        FROM 
          "types_de_champ" 
          INNER JOIN "procedure_revision_types_de_champ" "revision_types_de_champ" ON "revision_types_de_champ"."type_de_champ_id" = "types_de_champ"."id" 
        WHERE 
          "types_de_champ"."type_champ" NOT IN ('header_section', 'explication') 
          AND "revision_types_de_champ"."revision_id" = 11 
          AND "revision_types_de_champ"."parent_id" IS NULL 
        GROUP BY 
          "types_de_champ"."stable_id"
      ) 
      AND "procedure_revision_types_de_champ"."revision_id" != 12 
    GROUP BY 
      "procedure_revision_types_de_champ"."type_de_champ_id"
  ) 
ORDER BY 
  "types_de_champ"."private" ASC, 
  "position" ASC, 
  "revision_types_de_champ"."revision_id" DESC
```

C'est beau, c'est compliqué ... mais des fois, je ne sais pas pourquoi, ca plante sur les db de la ci.

J'ai simplifié en émettant 2 sous requêtes pour alléger la grosse requête ... et ça marche sur les tests (100 runs).

Par ailleurs, un point ou je me questionne, c'est qu'on cache l'intégralité de la relation sur du redis au lieu de seulement stocker les ids. Ca implique un plus gros traffic vers redis mais une requête en moins en base. Je ne sais pas ce qui est préférable.