### PR TITLE
ETQ Usager d'un lecteur d'écran, je veux que la hiérarchie de titre soit cohérente dans la page de formulaire

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -34,20 +34,20 @@
     margin-top: 1.5rem;
   }
 
-  .section-2 {
+  .section-3 {
     margin-bottom: 1.5rem;
     padding-top: 2rem;
     border-top: 2px solid var(--border-default-grey);
   }
 
-  .section-3 {
+  .section-4 {
     margin-bottom: 1.5rem;
   }
 
-  .section-4,
   .section-5,
   .section-6,
-  .section-7 {
+  .section-7,
+  .section-8 {
     margin-bottom: 1.25rem;
   }
 

--- a/app/components/editable_champ/header_section_component.rb
+++ b/app/components/editable_champ/header_section_component.rb
@@ -22,6 +22,11 @@ class EditableChamp::HeaderSectionComponent < ApplicationComponent
     class_names(
       {
         "section-#{level}": true,
+        # Accessibility:
+        # A hidden <h2> ("Formulaire") is injected above the form to fix
+        # the document heading structure. We decrement the DSFR visual
+        # heading level so the UI appearance remains unchanged.
+        "fr-h#{level - 1}": true,
         'header-section': @champ.dossier.auto_numbering_section_headers_for?(@champ.type_de_champ),
         'hidden': !@champ.visible?,
       }.merge(@html_class)

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -30,6 +30,7 @@
               %p.fr-pb-0= t('views.shared.dossiers.edit.invite_notice').html_safe
 
 
+    %h2.fr-sr-only Formulaire
     %fieldset.fr-fieldset= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.types_de_champ_public)
 
     = render Dossiers::PendingCorrectionCheckboxComponent.new(dossier:)


### PR DESCRIPTION
suite à la PR d'access : #12654
- Il manquait un h2 pour garder la bonne hiérarchie dans la page formulaire
- ajout de classes CSS pour retrouver le style des titres des sections comme avant (ils étaient tous descendus d'un cran)
