### PR TITLE
ETQ Administrateur, le libelle par défaut du type de champ dossier lié est correct

### DIFF
--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -281,7 +281,7 @@ class TypeDeChamp < ApplicationRecord
 
     I18n.t(type_champ,
       scope: [:activerecord, :attributes, :type_de_champ, :default_libelle],
-      default: I18n.t(type_champ, scope: [:activerecord, :attributes, :type_de_champ, :type_champs]))
+      default: I18n.t(type_champ, scope: [:activerecord, :attributes, :type_de_champ, :type_champs]), app_name: APPLICATION_NAME)
   end
 
   def safe_referentiel_mapping

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -343,7 +343,7 @@ describe TypeDeChamp do
     context "when the type champ is changed" do
       before { type_de_champ.update(type_champ: :dossier_link) }
 
-      it { expect(type_de_champ.libelle).to eq("Numéro de dossier déposé sur %{app_name}") }
+      it { expect(type_de_champ.libelle).to eq("Numéro de dossier déposé sur demarche.numerique.gouv.fr") }
 
       context "when the libelle is customized" do
         let(:libelle) { "Customized libelle" }


### PR DESCRIPTION
Avant
<img width="2400" height="790" alt="Screenshot 2026-03-02 at 17-35-16 demarche numerique gouv fr" src="https://github.com/user-attachments/assets/ebf9341e-ddda-45e4-b726-1e9586722c2b" />

Après
<img width="2400" height="654" alt="Screenshot 2026-03-02 at 17-36-57 demarche numerique gouv fr" src="https://github.com/user-attachments/assets/2d77c5be-868e-4c21-a1b5-9ea055b0c665" />
