### PR TITLE
Tech: optimiser les performances des tests avec let_it_be (test-prof)

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
 --require rails_helper
---profile

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,8 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # While tests run files are not watched, reloading is not necessary.
-  config.enable_reloading = ENV["DISABLE_SPRING"].blank? # Reloading must be enabled with spring
+  # Enable reloading only when Spring is actively running.
+  config.enable_reloading = defined?(Spring::Application)
 
   # Eager loading loads your entire application. When running a single test locally,
   # this is usually not necessary, and can slow down your test suite. However, it's
@@ -54,15 +55,14 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
-  # Highlight code that triggered database queries in logs.
-  config.active_record.verbose_query_logs = true
+  # Verbose query logs add caller backtraces to every SQL query. Opt-in via VERBOSE_QUERY_LOGS=1.
+  config.active_record.verbose_query_logs = ENV["VERBOSE_QUERY_LOGS"].present?
 
   # https://evilmartians.com/chronicles/the-whop-chop-how-we-cut-a-rails-test-suite-and-ci-time-in-half
-  if ENV["CI"].present?
-    config.active_record.verbose_query_logs = false
-    config.active_record.query_log_tags_enabled = false
-    config.log_level = :fatal
+  config.active_record.query_log_tags_enabled = false
+  config.log_level = ENV["CI"].present? ? :fatal : :warn
 
+  if ENV["CI"].present?
     config.assets.compile = false
   end
 

--- a/spec/lib/tasks/clean_services_spec.rb
+++ b/spec/lib/tasks/clean_services_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'rake'
+TPS::Application.load_tasks if Rake::Task.tasks.empty?
+
 describe 'service tasks' do
   let(:rake_task) { Rake::Task[task] }
   subject { rake_task.invoke }

--- a/spec/lib/tasks/jobs_spec.rb
+++ b/spec/lib/tasks/jobs_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'rake'
+TPS::Application.load_tasks if Rake::Task.tasks.empty?
+
 describe 'jobs' do
   describe 'schedule' do
     subject { Rake::Task['jobs:schedule'].invoke }

--- a/spec/lib/tasks/support_spec.rb
+++ b/spec/lib/tasks/support_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'rake'
+TPS::Application.load_tasks if Rake::Task.tasks.empty?
+
 describe 'support' do
   describe 'remove_ex_team_member' do
     let(:rake_task) { Rake::Task['support:remove_ex_team_member'] }

--- a/spec/models/batch_operation_spec.rb
+++ b/spec/models/batch_operation_spec.rb
@@ -45,9 +45,9 @@ describe BatchOperation, type: :model do
   end
 
   describe '#track_processed_dossier' do
-    let(:instructeur) { create(:instructeur) }
-    let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
-    let(:dossier) { create(:dossier, :accepte, :with_individual, archived: true, procedure: procedure) }
+    let_it_be(:instructeur) { create(:instructeur) }
+    let_it_be(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+    let_it_be(:dossier, reload: true) { create(:dossier, :accepte, :with_individual, archived: true, procedure: procedure) }
     let(:batch_operation) { create(:batch_operation, operation: :archiver, instructeur: instructeur, dossiers: [dossier]) }
 
     it 'unlock the dossier' do
@@ -116,8 +116,8 @@ describe BatchOperation, type: :model do
   end
 
   describe '#dossiers_safe_scope (with archiver)' do
-    let(:instructeur) { create(:instructeur) }
-    let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+    let_it_be(:instructeur) { create(:instructeur) }
+    let_it_be(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
     let(:batch_operation) { create(:batch_operation, operation: :archiver, instructeur: instructeur, dossiers: [dossier]) }
 
     context 'when dossier is valid' do
@@ -153,8 +153,8 @@ describe BatchOperation, type: :model do
   end
 
   describe '#dossiers_safe_scope (with passer_en_instruction)' do
-    let(:instructeur) { create(:instructeur) }
-    let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+    let_it_be(:instructeur) { create(:instructeur) }
+    let_it_be(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
     let(:batch_operation) { create(:batch_operation, operation: :passer_en_instruction, instructeur: instructeur, dossiers: [dossier]) }
 
     context 'when dossier is valid' do
@@ -183,8 +183,8 @@ describe BatchOperation, type: :model do
   end
 
   describe '#dossiers_safe_scope (with accepter)' do
-    let(:instructeur) { create(:instructeur) }
-    let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+    let_it_be(:instructeur) { create(:instructeur) }
+    let_it_be(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
     let(:batch_operation) { create(:batch_operation, operation: :accepter, instructeur: instructeur, dossiers: [dossier]) }
 
     context 'when dossier is valid' do
@@ -213,9 +213,9 @@ describe BatchOperation, type: :model do
   end
 
   describe '#safe_create!' do
-    let(:instructeur) { create(:instructeur) }
-    let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
-    let(:dossier_2) { create(:dossier, :accepte, procedure: procedure) }
+    let_it_be(:instructeur) { create(:instructeur) }
+    let_it_be(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+    let_it_be(:dossier_2) { create(:dossier, :accepte, procedure: procedure) }
     subject { BatchOperation.safe_create!(instructeur: instructeur, operation: :archiver, dossier_ids: [dossier.id, dossier_2.id]) }
 
     context 'success with divergent list of dossier_ids' do

--- a/spec/models/concerns/procedure_clone_concern_spec.rb
+++ b/spec/models/concerns/procedure_clone_concern_spec.rb
@@ -2,7 +2,7 @@
 
 describe ProcedureCloneConcern, type: :model do
   describe 'clone' do
-    let(:service) { create(:service) }
+    let_it_be(:service) { create(:service) }
     let(:procedure) do
       create(:procedure,
         received_mail: received_mail,
@@ -32,10 +32,10 @@ describe ProcedureCloneConcern, type: :model do
     let(:signature) { Rack::Test::UploadedFile.new('spec/fixtures/files/black.png', 'image/png') }
 
     let(:groupe_instructeur_1) { create(:groupe_instructeur, procedure: procedure, label: "groupe_1", contact_information: create(:contact_information)) }
-    let(:instructeur_1) { create(:instructeur) }
-    let(:instructeur_2) { create(:instructeur) }
-    let!(:assign_to_1) { create(:assign_to, procedure: procedure, groupe_instructeur: groupe_instructeur_1, instructeur: instructeur_1) }
-    let!(:assign_to_2) { create(:assign_to, procedure: procedure, groupe_instructeur: groupe_instructeur_1, instructeur: instructeur_2) }
+    let_it_be(:instructeur_1) { create(:instructeur) }
+    let_it_be(:instructeur_2) { create(:instructeur) }
+    let(:assign_to_1) { create(:assign_to, procedure: procedure, groupe_instructeur: groupe_instructeur_1, instructeur: instructeur_1) }
+    let(:assign_to_2) { create(:assign_to, procedure: procedure, groupe_instructeur: groupe_instructeur_1, instructeur: instructeur_2) }
     let(:options) do
       {
         clone_attestation_acceptation_template: true,
@@ -63,6 +63,8 @@ describe ProcedureCloneConcern, type: :model do
     end
 
     describe "should keep groupe instructeurs " do
+      before { assign_to_1; assign_to_2 }
+
       it "should clone groupe instructeurs" do
         expect(subject.groupe_instructeurs.size).to eq(2)
         expect(subject.groupe_instructeurs.size).to eq(procedure.groupe_instructeurs.size)
@@ -140,6 +142,8 @@ describe ProcedureCloneConcern, type: :model do
       let(:stable_id) { 1337 }
       let(:types_de_champ_public) { [{ type: :referentiel, referentiel: referentiel, stable_id: }] }
 
+      before { procedure }
+
       context 'when cloned by the same administrateur' do
         let(:administrateur) { procedure.administrateurs.first }
 
@@ -214,6 +218,8 @@ describe ProcedureCloneConcern, type: :model do
     context 'when the procedure is cloned to another administrateur' do
       let(:administrateur) { create(:administrateur) }
       let(:opendata) { false }
+
+      before { assign_to_1; assign_to_2 }
 
       context 'and the procedure does not have a groupe with the defaut label' do
         before do

--- a/spec/models/dossier_notification_spec.rb
+++ b/spec/models/dossier_notification_spec.rb
@@ -65,13 +65,13 @@ RSpec.describe DossierNotification, type: :model do
     end
 
     context "message notification" do
-      let(:procedure) { create(:procedure) }
-      let(:dossier) { create(:dossier, groupe_instructeur:, procedure:) }
-      let(:instructeur) { create(:instructeur) }
-      let(:other_instructeur) { create(:instructeur) }
-      let!(:instructeur_procedure) { create(:instructeurs_procedure, instructeur:, procedure:, display_message_notifications: 'all') }
-      let!(:other_instructeur_procedure) { create(:instructeurs_procedure, instructeur: other_instructeur, procedure:, display_message_notifications: 'all') }
-      let(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur, other_instructeur]) }
+      let_it_be(:procedure) { create(:procedure) }
+      let_it_be(:instructeur) { create(:instructeur) }
+      let_it_be(:other_instructeur) { create(:instructeur) }
+      let_it_be(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur, other_instructeur]) }
+      let_it_be(:dossier) { create(:dossier, groupe_instructeur:, procedure:) }
+      let_it_be(:instructeur_procedure) { create(:instructeurs_procedure, instructeur:, procedure:, display_message_notifications: 'all') }
+      let_it_be(:other_instructeur_procedure) { create(:instructeurs_procedure, instructeur: other_instructeur, procedure:, display_message_notifications: 'all') }
       let(:notification_type) { :message }
 
       context "when user or expert send a message" do
@@ -99,10 +99,10 @@ RSpec.describe DossierNotification, type: :model do
     end
 
     context "when the instructeur has default notification preferences" do
-      let(:procedure) { create(:procedure) }
-      let(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur], procedure:) }
-      let(:instructeur) { create(:instructeur) }
-      let!(:dossier) { create(:dossier, groupe_instructeur:) }
+      let_it_be(:procedure) { create(:procedure) }
+      let_it_be(:instructeur, reload: true) { create(:instructeur) }
+      let_it_be(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur], procedure:) }
+      let_it_be(:dossier, reload: true) { create(:dossier, groupe_instructeur:) }
       let!(:notification_type) { :dossier_modifie }
 
       context "when the instructeur follow the dossier" do
@@ -124,11 +124,11 @@ RSpec.describe DossierNotification, type: :model do
     end
 
     context "when the instructeur has notification preferences" do
-      let(:procedure) { create(:procedure) }
-      let(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur], procedure:) }
-      let(:instructeur) { create(:instructeur) }
-      let(:dossier) { create(:dossier, groupe_instructeur:, procedure:) }
-      let(:instructeur_procedure) { create(:instructeurs_procedure, instructeur:, procedure:) }
+      let_it_be(:procedure) { create(:procedure) }
+      let_it_be(:instructeur, reload: true) { create(:instructeur) }
+      let_it_be(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur], procedure:) }
+      let_it_be(:dossier, reload: true) { create(:dossier, groupe_instructeur:, procedure:) }
+      let_it_be(:instructeur_procedure, reload: true) { create(:instructeurs_procedure, instructeur:, procedure:) }
       let!(:notification_type) { :dossier_modifie }
 
       context "when the instructeur never wants notifications" do
@@ -176,8 +176,8 @@ RSpec.describe DossierNotification, type: :model do
   describe 'refresh_notifications_instructeur_for_followed_dossier' do
     subject { DossierNotification.refresh_notifications_instructeur_for_followed_dossier(instructeur, dossier_to_notify) }
 
-    let(:dossier_to_notify) { create(:dossier, :en_construction, last_champ_updated_at: Time.zone.now, depose_at: Time.zone.yesterday) }
-    let(:instructeur) { create(:instructeur) }
+    let_it_be(:dossier_to_notify) { create(:dossier, :en_construction, last_champ_updated_at: Time.zone.now, depose_at: Time.zone.yesterday) }
+    let_it_be(:instructeur) { create(:instructeur) }
 
     context 'when the instructeur has default preferences for badge notification' do
       it "create notification" do
@@ -349,9 +349,9 @@ RSpec.describe DossierNotification, type: :model do
     context 'when instructeur unfollow a dossier' do
       subject { DossierNotification.destroy_notifications_instructeur_of_unfollowed_dossier(instructeur, dossier) }
 
-      let(:dossier) { create(:dossier) }
-      let(:instructeur) { create(:instructeur) }
-      let!(:message_notification) { create(:dossier_notification, instructeur:, dossier:, notification_type: :message) }
+      let_it_be(:dossier) { create(:dossier) }
+      let_it_be(:instructeur) { create(:instructeur) }
+      let_it_be(:message_notification) { create(:dossier_notification, instructeur:, dossier:, notification_type: :message) }
 
       context 'when the instructeur has default preferences for badge notification' do
         it 'destroys notification' do
@@ -384,13 +384,13 @@ RSpec.describe DossierNotification, type: :model do
   end
 
   describe '.notifications_for' do
-    let!(:instructeur) { create(:instructeur) }
-    let!(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur]) }
-    let!(:other_groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur]) }
-    let!(:dossier) { create(:dossier, :accepte, groupe_instructeur:) }
-    let!(:other_dossier) { create(:dossier, :en_construction, groupe_instructeur: other_groupe_instructeur) }
-    let!(:notification_instructeur) { create(:dossier_notification, dossier:, instructeur:, notification_type: :dossier_modifie) }
-    let!(:other_notification_instructeur) { create(:dossier_notification, dossier: other_dossier, instructeur:, notification_type: :dossier_modifie) }
+    let_it_be(:instructeur) { create(:instructeur) }
+    let_it_be(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur]) }
+    let_it_be(:other_groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur]) }
+    let_it_be(:dossier) { create(:dossier, :accepte, groupe_instructeur:) }
+    let_it_be(:other_dossier) { create(:dossier, :en_construction, groupe_instructeur: other_groupe_instructeur) }
+    let_it_be(:notification_instructeur) { create(:dossier_notification, dossier:, instructeur:, notification_type: :dossier_modifie) }
+    let_it_be(:other_notification_instructeur) { create(:dossier_notification, dossier: other_dossier, instructeur:, notification_type: :dossier_modifie) }
 
     context 'a given instructeur and one dossier' do
       subject { DossierNotification.notifications_for_instructeur_dossier(instructeur, dossier) }
@@ -425,16 +425,16 @@ RSpec.describe DossierNotification, type: :model do
   end
 
   describe '.notifications_sticker_for' do
-    let(:procedure) { create(:procedure) }
-    let(:instructeur) { create(:instructeur) }
-    let(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur]) }
-    let(:other_groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur]) }
-    let(:dossier) { create(:dossier, :accepte, procedure:, groupe_instructeur:) }
-    let(:other_dossier) { create(:dossier, :en_construction, procedure:, groupe_instructeur: other_groupe_instructeur) }
-    let!(:notification_news_instructeur) { create(:dossier_notification, dossier:, instructeur:, notification_type: :dossier_modifie) }
-    let!(:notification_not_news_instructeur) { create(:dossier_notification, dossier:, instructeur:) }
-    let!(:other_notification_news_instructeur) { create(:dossier_notification, dossier: other_dossier, instructeur:, notification_type: :annotation_instructeur) }
-    let!(:other_notification_not_news_instructeur) { create(:dossier_notification, dossier: other_dossier, instructeur:) }
+    let_it_be(:procedure) { create(:procedure) }
+    let_it_be(:instructeur, reload: true) { create(:instructeur) }
+    let_it_be(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur]) }
+    let_it_be(:other_groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur]) }
+    let_it_be(:dossier) { create(:dossier, :accepte, procedure:, groupe_instructeur:) }
+    let_it_be(:other_dossier) { create(:dossier, :en_construction, procedure:, groupe_instructeur: other_groupe_instructeur) }
+    let_it_be(:notification_news_instructeur) { create(:dossier_notification, dossier:, instructeur:, notification_type: :dossier_modifie) }
+    let_it_be(:notification_not_news_instructeur) { create(:dossier_notification, dossier:, instructeur:) }
+    let_it_be(:other_notification_news_instructeur) { create(:dossier_notification, dossier: other_dossier, instructeur:, notification_type: :annotation_instructeur) }
+    let_it_be(:other_notification_not_news_instructeur) { create(:dossier_notification, dossier: other_dossier, instructeur:) }
 
     context 'a given instructeur on one dossier' do
       subject { DossierNotification.notifications_sticker_for_instructeur_dossier(instructeur, dossier) }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -165,12 +165,12 @@ describe Dossier, :group, type: :model do
   end
 
   describe 'brouillon_close_to_expiration' do
-    let(:procedure) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 6) }
-    let!(:young_dossier) { create(:dossier, :en_construction, procedure: procedure) }
-    let!(:expiring_dossier) { create(:dossier, updated_at: 85.days.ago, procedure: procedure) }
-    let!(:expiring_dossier_with_notification) { create(:dossier, updated_at: 85.days.ago, brouillon_close_to_expiration_notice_sent_at: Time.zone.now, procedure: procedure) }
-    let!(:just_expired_dossier) { create(:dossier, updated_at: (6.months + 1.hour + 10.seconds).ago, procedure: procedure) }
-    let!(:long_expired_dossier) { create(:dossier, updated_at: 1.year.ago, procedure: procedure) }
+    let_it_be(:procedure) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 6) }
+    let_it_be(:young_dossier) { create(:dossier, :en_construction, procedure:) }
+    let_it_be(:expiring_dossier, reload: true) { create(:dossier, updated_at: 85.days.ago, procedure:) }
+    let_it_be(:expiring_dossier_with_notification, reload: true) { create(:dossier, updated_at: 85.days.ago, brouillon_close_to_expiration_notice_sent_at: Time.zone.now, procedure:) }
+    let_it_be(:just_expired_dossier) { create(:dossier, updated_at: (6.months + 1.hour + 10.seconds).ago, procedure:) }
+    let_it_be(:long_expired_dossier) { create(:dossier, updated_at: 1.year.ago, procedure:) }
 
     subject { Dossier.brouillon_close_to_expiration }
 
@@ -215,12 +215,12 @@ describe Dossier, :group, type: :model do
   end
 
   describe 'en_construction_close_to_expiration' do
-    let(:procedure) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 6) }
-    let!(:young_dossier) { create(:dossier, procedure: procedure) }
-    let!(:expiring_dossier) { create(:dossier, :en_construction, en_construction_at: 175.days.ago, procedure: procedure) }
-    let!(:expiring_dossier_with_notification) { create(:dossier, :en_construction, en_construction_at: 175.days.ago, en_construction_close_to_expiration_notice_sent_at: Time.zone.now, procedure: procedure) }
-    let!(:just_expired_dossier) { create(:dossier, :en_construction, en_construction_at: (6.months + 1.hour + 10.seconds).ago, procedure: procedure) }
-    let!(:long_expired_dossier) { create(:dossier, :en_construction, en_construction_at: 1.year.ago, procedure: procedure) }
+    let_it_be(:procedure, reload: true) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 6) }
+    let_it_be(:young_dossier) { create(:dossier, procedure:) }
+    let_it_be(:expiring_dossier, reload: true) { create(:dossier, :en_construction, en_construction_at: 175.days.ago, procedure:) }
+    let_it_be(:expiring_dossier_with_notification, reload: true) { create(:dossier, :en_construction, en_construction_at: 175.days.ago, en_construction_close_to_expiration_notice_sent_at: Time.zone.now, procedure:) }
+    let_it_be(:just_expired_dossier) { create(:dossier, :en_construction, en_construction_at: (6.months + 1.hour + 10.seconds).ago, procedure:) }
+    let_it_be(:long_expired_dossier) { create(:dossier, :en_construction, en_construction_at: 1.year.ago, procedure:) }
 
     subject { Dossier.en_construction_close_to_expiration }
 
@@ -276,12 +276,12 @@ describe Dossier, :group, type: :model do
   end
 
   describe 'termine_close_to_expiration' do
-    let(:procedure) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 6, procedure_expires_when_termine_enabled: true) }
-    let!(:young_dossier) { create(:dossier, state: :accepte, procedure: procedure, processed_at: 2.days.ago) }
-    let!(:expiring_dossier) { create(:dossier, state: :accepte, procedure: procedure, processed_at: 175.days.ago) }
-    let!(:expiring_dossier_with_notification) { create(:dossier, state: :accepte, procedure: procedure, processed_at: 175.days.ago, termine_close_to_expiration_notice_sent_at: Time.zone.now) }
-    let!(:just_expired_dossier) { create(:dossier, state: :accepte, procedure: procedure, processed_at: (6.months + 1.hour + 10.seconds).ago) }
-    let!(:long_expired_dossier) { create(:dossier, state: :accepte, procedure: procedure, processed_at: 1.year.ago) }
+    let_it_be(:procedure, reload: true) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 6, procedure_expires_when_termine_enabled: true) }
+    let_it_be(:young_dossier) { create(:dossier, state: :accepte, procedure:, processed_at: 2.days.ago) }
+    let_it_be(:expiring_dossier, reload: true) { create(:dossier, state: :accepte, procedure:, processed_at: 175.days.ago) }
+    let_it_be(:expiring_dossier_with_notification, reload: true) { create(:dossier, state: :accepte, procedure:, processed_at: 175.days.ago, termine_close_to_expiration_notice_sent_at: Time.zone.now) }
+    let_it_be(:just_expired_dossier) { create(:dossier, state: :accepte, procedure:, processed_at: (6.months + 1.hour + 10.seconds).ago) }
+    let_it_be(:long_expired_dossier) { create(:dossier, state: :accepte, procedure:, processed_at: 1.year.ago) }
 
     subject { Dossier.termine_close_to_expiration }
 
@@ -830,11 +830,11 @@ describe Dossier, :group, type: :model do
     end
 
     context "when the groupe instructeur change" do
-      let(:procedure) { create(:procedure) }
-      let(:instructeur) { create(:instructeur) }
-      let(:new_instructeur) { create(:instructeur) }
-      let(:previous_groupe_instructeur) { create(:groupe_instructeur, procedure:, instructeurs: [instructeur]) }
-      let(:dossier) { create(:dossier, :en_construction, groupe_instructeur: previous_groupe_instructeur, procedure:) }
+      let_it_be(:procedure) { create(:procedure) }
+      let_it_be(:instructeur) { create(:instructeur) }
+      let_it_be(:new_instructeur) { create(:instructeur) }
+      let_it_be(:previous_groupe_instructeur) { create(:groupe_instructeur, procedure:, instructeurs: [instructeur]) }
+      let_it_be(:dossier, reload: true) { create(:dossier, :en_construction, groupe_instructeur: previous_groupe_instructeur, procedure:) }
 
       context "when an instructeur of the previous groupe is not is the new groupe" do
         let(:new_groupe_instructeur) { create(:groupe_instructeur, procedure:, instructeurs: [new_instructeur]) }
@@ -2831,8 +2831,8 @@ describe Dossier, :group, type: :model do
   end
 
   describe '#update_champs_timestamps' do
-    let(:procedure) { create(:procedure, types_de_champ_public: [{}, { type: :piece_justificative }, { type: :titre_identite }]) }
-    let(:dossier) { create(:dossier, procedure:, brouillon_close_to_expiration_notice_sent_at: 10.days.ago) }
+    let_it_be(:procedure) { create(:procedure, types_de_champ_public: [{}, { type: :piece_justificative }, { type: :titre_identite }]) }
+    let_it_be(:dossier, reload: true) { create(:dossier, procedure:, brouillon_close_to_expiration_notice_sent_at: 10.days.ago) }
     let(:changed_champs) { dossier.champs.filter(&:text?) }
 
     subject { -> { dossier.update_champs_timestamps(changed_champs, Champ::USER_BUFFER_STREAM) } }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Dossier, type: :model do
+describe Dossier, :group, type: :model do
   include ActionView::Helpers::SanitizeHelper
 
   let(:user) { create(:user) }
@@ -40,14 +40,14 @@ describe Dossier, type: :model do
     end
 
     describe 'by_statut' do
-      let(:procedure) { create(:procedure) }
-      let(:dossier_en_construction) { create(:dossier, :en_construction, procedure:) }
-      let(:dossier_en_instruction) { create(:dossier, :en_instruction, procedure:) }
-      let(:dossier_accepte) { create(:dossier, :accepte, procedure:) }
-      let(:dossier_refuse) { create(:dossier, :refuse, procedure:) }
-      let(:dossier_accepte_archive) { create(:dossier, :accepte, :archived, procedure:) }
-      let(:dossier_accepte_deleted) { create(:dossier, :accepte, :hidden_by_administration, procedure:) }
-      let(:dossier_accepte_archive_deleted) { create(:dossier, :accepte, :archived, :hidden_by_administration, procedure:) }
+      let_it_be(:procedure) { create(:procedure) }
+      let_it_be(:dossier_en_construction) { create(:dossier, :en_construction, procedure:) }
+      let_it_be(:dossier_en_instruction) { create(:dossier, :en_instruction, procedure:) }
+      let_it_be(:dossier_accepte) { create(:dossier, :accepte, procedure:) }
+      let_it_be(:dossier_refuse) { create(:dossier, :refuse, procedure:) }
+      let_it_be(:dossier_accepte_archive) { create(:dossier, :accepte, :archived, procedure:) }
+      let_it_be(:dossier_accepte_deleted) { create(:dossier, :accepte, :hidden_by_administration, procedure:) }
+      let_it_be(:dossier_accepte_archive_deleted) { create(:dossier, :accepte, :archived, :hidden_by_administration, procedure:) }
 
       let!(:dossiers) { [dossier_en_construction, dossier_en_instruction, dossier_accepte, dossier_refuse] }
 
@@ -565,13 +565,13 @@ describe Dossier, type: :model do
   end
 
   describe '#avis_for' do
-    let!(:instructeur) { create(:instructeur) }
-    let!(:procedure) { create(:procedure, :published, instructeurs: [instructeur]) }
-    let!(:dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction)) }
-    let!(:experts_procedure) { create(:experts_procedure, expert: expert_1, procedure: procedure) }
-    let!(:experts_procedure_2) { create(:experts_procedure, expert: expert_2, procedure: procedure) }
-    let!(:expert_1) { create(:expert) }
-    let!(:expert_2) { create(:expert) }
+    let_it_be(:instructeur) { create(:instructeur) }
+    let_it_be(:expert_1) { create(:expert) }
+    let_it_be(:expert_2) { create(:expert) }
+    let_it_be(:procedure) { create(:procedure, :published, instructeurs: [instructeur]) }
+    let_it_be(:dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction)) }
+    let_it_be(:experts_procedure) { create(:experts_procedure, expert: expert_1, procedure: procedure) }
+    let_it_be(:experts_procedure_2) { create(:experts_procedure, expert: expert_2, procedure: procedure) }
 
     context 'when there is a public advice asked from the dossiers instructeur' do
       let!(:avis) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure, confidentiel: false) }
@@ -802,10 +802,10 @@ describe Dossier, type: :model do
   end
 
   describe '.ordered_for_export' do
-    let(:procedure) { create(:procedure) }
-    let!(:dossier2) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_construction), depose_at: Time.zone.parse('03/01/2010')) }
-    let!(:dossier3) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_instruction), depose_at: Time.zone.parse('01/01/2010')) }
-    let!(:dossier4) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_instruction), archived: true, depose_at: Time.zone.parse('02/01/2010')) }
+    let_it_be(:procedure) { create(:procedure) }
+    let_it_be(:dossier2) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_construction), depose_at: Time.zone.parse('03/01/2010')) }
+    let_it_be(:dossier3) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_instruction), depose_at: Time.zone.parse('01/01/2010')) }
+    let_it_be(:dossier4) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_instruction), archived: true, depose_at: Time.zone.parse('02/01/2010')) }
 
     subject { procedure.dossiers.ordered_for_export }
 
@@ -1361,7 +1361,7 @@ describe Dossier, type: :model do
   end
 
   describe "#can_transition_to_en_construction?" do
-    let(:procedure) { create(:procedure, :published) }
+    let_it_be(:procedure) { create(:procedure, :published) }
     let(:dossier) { create(:dossier, state: state, procedure: procedure) }
 
     subject { dossier.can_transition_to_en_construction? }
@@ -2444,15 +2444,15 @@ describe Dossier, type: :model do
   end
 
   describe "with_notifiable_procedure" do
-    let(:test_procedure) { create(:procedure) }
-    let(:published_procedure) { create(:procedure, :published) }
-    let(:closed_procedure) { create(:procedure, :closed) }
-    let(:unpublished_procedure) { create(:procedure, :unpublished) }
+    let_it_be(:test_procedure) { create(:procedure) }
+    let_it_be(:published_procedure) { create(:procedure, :published) }
+    let_it_be(:closed_procedure) { create(:procedure, :closed) }
+    let_it_be(:unpublished_procedure) { create(:procedure, :unpublished) }
 
-    let!(:dossier_on_test_procedure) { create(:dossier, procedure: test_procedure) }
-    let!(:dossier_on_published_procedure) { create(:dossier, procedure: published_procedure) }
-    let!(:dossier_on_closed_procedure) { create(:dossier, procedure: closed_procedure) }
-    let!(:dossier_on_unpublished_procedure) { create(:dossier, procedure: unpublished_procedure) }
+    let_it_be(:dossier_on_test_procedure) { create(:dossier, procedure: test_procedure) }
+    let_it_be(:dossier_on_published_procedure) { create(:dossier, procedure: published_procedure) }
+    let_it_be(:dossier_on_closed_procedure) { create(:dossier, procedure: closed_procedure) }
+    let_it_be(:dossier_on_unpublished_procedure) { create(:dossier, procedure: unpublished_procedure) }
 
     let(:notify_on_closed) { false }
     let(:dossiers) { Dossier.with_notifiable_procedure(notify_on_closed: notify_on_closed) }

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
 describe Instructeur, type: :model do
-  let(:admin) { create :administrateur }
-  let(:procedure) { create :procedure, :published, administrateur: admin }
-  let(:procedure_2) { create :procedure, :published, administrateur: admin }
-  let(:procedure_3) { create :procedure, :published, administrateur: admin }
-  let(:instructeur) { create :instructeur, administrateurs: [admin] }
-  let(:procedure_assign) { assign(procedure) }
+  let_it_be(:admin) { create :administrateur }
+  let_it_be(:procedure) { create :procedure, :published, administrateur: admin }
+  let_it_be(:procedure_2) { create :procedure, :published, administrateur: admin }
+  let_it_be(:procedure_3) { create :procedure, :published, administrateur: admin }
+  let_it_be(:instructeur, reload: true) { create :instructeur, administrateurs: [admin] }
+  let_it_be(:procedure_assign) { assign(procedure) }
 
-  before do
-    procedure_assign
+  before_all do
     assign(procedure_2)
-    procedure_3
   end
 
   describe 'associations' do
@@ -301,7 +299,7 @@ describe Instructeur, type: :model do
   end
 
   describe '#daily_email_summary_data' do
-    let(:instructeur) { create(:instructeur) }
+    let_it_be(:instructeur) { create(:instructeur) }
     let!(:groupe_instructeur) { create(:groupe_instructeur, procedure:, instructeurs: [instructeur]) }
     let(:procedure) { create(:procedure, :published) }
     let!(:instructeur_procedure) { create(:instructeurs_procedure, instructeur:, procedure:, daily_email_summary: true) }
@@ -444,12 +442,12 @@ describe Instructeur, type: :model do
   end
 
   describe "#dossiers_count_summary" do
-    let(:instructeur_2) { create(:instructeur) }
-    let(:instructeur_3) { create(:instructeur) }
-    let(:procedure) { create(:procedure, instructeurs: [instructeur_2, instructeur_3], procedure_expires_when_termine_enabled: true) }
-    let(:gi_1) { procedure.defaut_groupe_instructeur }
-    let(:gi_2) { create(:groupe_instructeur, label: '2', procedure: procedure) }
-    let(:gi_3) { create(:groupe_instructeur, label: '3', procedure: procedure) }
+    let_it_be(:instructeur_2, reload: true) { create(:instructeur) }
+    let_it_be(:instructeur_3) { create(:instructeur) }
+    let_it_be(:procedure, reload: true) { create(:procedure, instructeurs: [instructeur_2, instructeur_3], procedure_expires_when_termine_enabled: true) }
+    let_it_be(:gi_1) { procedure.defaut_groupe_instructeur }
+    let_it_be(:gi_2) { create(:groupe_instructeur, label: '2', procedure: procedure) }
+    let_it_be(:gi_3) { create(:groupe_instructeur, label: '3', procedure: procedure) }
 
     subject do
       instructeur_2.dossiers_count_summary([gi_1.id, gi_2.id])
@@ -641,8 +639,8 @@ describe Instructeur, type: :model do
   end
 
   describe '#merge' do
-    let(:old_instructeur) { create(:instructeur) }
-    let(:new_instructeur) { create(:instructeur) }
+    let_it_be(:old_instructeur, reload: true) { create(:instructeur) }
+    let_it_be(:new_instructeur, reload: true) { create(:instructeur) }
 
     subject { new_instructeur.merge(old_instructeur) }
 

--- a/spec/models/prefill_champs_spec.rb
+++ b/spec/models/prefill_champs_spec.rb
@@ -64,84 +64,61 @@ RSpec.describe PrefillChamps do
       end
     end
 
-    shared_examples "a champ public value that is authorized" do |type_de_champ_type, value|
-      context "when the type de champ is authorized (#{type_de_champ_type})" do
-        let(:types_de_champ_public) { [{ type: type_de_champ_type }.merge(additional_tdc_opts)] }
+    context "when the public type de champ is authorized" do
+      let_it_be(:procedure) do
+        ref = create(:api_referentiel, :exact_match)
+        create(:procedure, :published, types_de_champ_public: [
+          { type: :text }, { type: :textarea }, { type: :decimal_number },
+          { type: :integer_number }, { type: :email }, { type: :phone },
+          { type: :iban }, { type: :civilite }, { type: :pays },
+          { type: :regions }, { type: :date }, { type: :datetime },
+          { type: :yes_no }, { type: :checkbox }, { type: :drop_down_list },
+          { type: :departements }, { type: :communes }, { type: :address },
+          { type: :multiple_drop_down_list }, { type: :dossier_link },
+          { type: :epci }, { type: :siret },
+          { type: :referentiel, referentiel: ref }
+        ])
+      end
+      let_it_be(:dossier, reload: true) { create(:dossier, :brouillon, procedure:) }
+      let_it_be(:linked_dossier) { create(:dossier, :en_construction, procedure:) }
 
-        let(:additional_tdc_opts) do
-          case type_de_champ_type
-          when :referentiel
-            { referentiel: create(:api_referentiel, :exact_match) }
-          else
-            {}
-          end
-        end
-
-        let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
-        let(:champ) { find_champ_by_stable_id(dossier, type_de_champ.stable_id) }
-        let(:champ_value) { value == 'linked_dossier_id' ? linked_dossier.id : value }
-
-        let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => champ_value } }
-
-        it "builds an array of hash matching the given params", :slow do
-          expect(prefill_champs_array).to match([{ id: champ.id }.merge(attributes(champ, champ_value))])
+      [
+        [:text, "value"],
+        [:textarea, "value"],
+        [:decimal_number, "3.14"],
+        [:integer_number, "42"],
+        [:email, "value"],
+        [:phone, "value"],
+        [:iban, "value"],
+        [:civilite, "M."],
+        [:pays, "FR"],
+        [:regions, "03"],
+        [:date, "2022-12-22"],
+        [:datetime, "2022-12-22T10:30"],
+        [:yes_no, "true"],
+        [:yes_no, "false"],
+        [:checkbox, "true"],
+        [:checkbox, "false"],
+        [:drop_down_list, "value"],
+        [:departements, "03"],
+        [:communes, ['01540', '01457']],
+        [:address, "20 avenue de Ségur 75007 Paris"],
+        [:multiple_drop_down_list, ["val1", "val2"]],
+        [:dossier_link, :linked_dossier_id],
+        [:epci, ['01', '200042935']],
+        [:siret, "13002526500013"],
+        [:referentiel, "13002526500013"]
+      ].each do |type, value|
+        it "builds correct prefill for #{type} (#{value})", :slow do
+          tdc = procedure.published_revision.types_de_champ_public.find { _1.type_champ == type.to_s }
+          champ = find_champ_by_stable_id(dossier, tdc.stable_id)
+          champ_value = value == :linked_dossier_id ? linked_dossier.id : value
+          params = { "champ_#{tdc.to_typed_id_for_query}" => champ_value }
+          result = described_class.new(dossier, params).to_a
+          expect(result).to match([{ id: champ.id }.merge(attributes(champ, champ_value))])
         end
       end
     end
-
-    shared_examples "a champ private value that is authorized" do |type_de_champ_type, value|
-      context "when the type de champ is authorized (#{type_de_champ_type})" do
-        let(:types_de_champ_private) { [{ type: type_de_champ_type }] }
-        let(:type_de_champ) { procedure.published_revision.types_de_champ_private.first }
-        let(:champ) { find_champ_by_stable_id(dossier, type_de_champ.stable_id) }
-        let(:champ_value) { value == 'linked_dossier_id' ? linked_dossier.id : value }
-
-        let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => champ_value } }
-
-        it "builds an array of hash matching the given params", :slow do
-          expect(prefill_champs_array).to match([{ id: champ.id }.merge(attributes(champ, champ_value))])
-        end
-      end
-    end
-
-    shared_examples "a champ public value that is unauthorized" do |type_de_champ_type, value|
-      let(:types_de_champ_public) { [{ type: type_de_champ_type }] }
-      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
-
-      let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => value } }
-
-      context "when the type de champ is unauthorized (#{type_de_champ_type})" do
-        it "filters out the param" do
-          expect(prefill_champs_array).to match([])
-        end
-      end
-    end
-
-    it_behaves_like "a champ public value that is authorized", :text, "value"
-    it_behaves_like "a champ public value that is authorized", :textarea, "value"
-    it_behaves_like "a champ public value that is authorized", :decimal_number, "3.14"
-    it_behaves_like "a champ public value that is authorized", :integer_number, "42"
-    it_behaves_like "a champ public value that is authorized", :email, "value"
-    it_behaves_like "a champ public value that is authorized", :phone, "value"
-    it_behaves_like "a champ public value that is authorized", :iban, "value"
-    it_behaves_like "a champ public value that is authorized", :civilite, "M."
-    it_behaves_like "a champ public value that is authorized", :pays, "FR"
-    it_behaves_like "a champ public value that is authorized", :regions, "03"
-    it_behaves_like "a champ public value that is authorized", :date, "2022-12-22"
-    it_behaves_like "a champ public value that is authorized", :datetime, "2022-12-22T10:30"
-    it_behaves_like "a champ public value that is authorized", :yes_no, "true"
-    it_behaves_like "a champ public value that is authorized", :yes_no, "false"
-    it_behaves_like "a champ public value that is authorized", :checkbox, "true"
-    it_behaves_like "a champ public value that is authorized", :checkbox, "false"
-    it_behaves_like "a champ public value that is authorized", :drop_down_list, "value"
-    it_behaves_like "a champ public value that is authorized", :departements, "03"
-    it_behaves_like "a champ public value that is authorized", :communes, ['01540', '01457']
-    it_behaves_like "a champ public value that is authorized", :address, "20 avenue de Ségur 75007 Paris"
-    it_behaves_like "a champ public value that is authorized", :multiple_drop_down_list, ["val1", "val2"]
-    it_behaves_like "a champ public value that is authorized", :dossier_link, 'linked_dossier_id'
-    it_behaves_like "a champ public value that is authorized", :epci, ['01', '200042935']
-    it_behaves_like "a champ public value that is authorized", :siret, "13002526500013"
-    it_behaves_like "a champ public value that is authorized", :referentiel, "13002526500013"
 
     context "when the public type de champ is authorized (repetition)" do
       let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :text }] }] }
@@ -158,31 +135,59 @@ RSpec.describe PrefillChamps do
       end
     end
 
-    it_behaves_like "a champ private value that is authorized", :text, "value"
-    it_behaves_like "a champ private value that is authorized", :textarea, "value"
-    it_behaves_like "a champ private value that is authorized", :decimal_number, "3.14"
-    it_behaves_like "a champ private value that is authorized", :integer_number, "42"
-    it_behaves_like "a champ private value that is authorized", :email, "value"
-    it_behaves_like "a champ private value that is authorized", :phone, "value"
-    it_behaves_like "a champ private value that is authorized", :iban, "value"
-    it_behaves_like "a champ private value that is authorized", :civilite, "M."
-    it_behaves_like "a champ private value that is authorized", :pays, "FR"
-    it_behaves_like "a champ private value that is authorized", :regions, "93"
-    it_behaves_like "a champ private value that is authorized", :date, "2022-12-22"
-    it_behaves_like "a champ private value that is authorized", :datetime, "2022-12-22T10:30"
-    it_behaves_like "a champ private value that is authorized", :yes_no, "true"
-    it_behaves_like "a champ private value that is authorized", :yes_no, "false"
-    it_behaves_like "a champ private value that is authorized", :checkbox, "true"
-    it_behaves_like "a champ private value that is authorized", :checkbox, "false"
-    it_behaves_like "a champ private value that is authorized", :drop_down_list, "value"
-    it_behaves_like "a champ private value that is authorized", :regions, "93"
-    it_behaves_like "a champ private value that is authorized", :siret, "13002526500013"
-    it_behaves_like "a champ private value that is authorized", :departements, "03"
-    it_behaves_like "a champ private value that is authorized", :communes, ['01540', '01457']
-    it_behaves_like "a champ private value that is authorized", :address, "20 avenue de Ségur 75007 Paris"
-    it_behaves_like "a champ private value that is authorized", :multiple_drop_down_list, ["val1", "val2"]
-    it_behaves_like "a champ private value that is authorized", :dossier_link, 'linked_dossier_id'
-    it_behaves_like "a champ private value that is authorized", :epci, ['01', '200042935']
+    context "when the private type de champ is authorized" do
+      let_it_be(:procedure) do
+        create(:procedure, :published, types_de_champ_private: [
+          { type: :text }, { type: :textarea }, { type: :decimal_number },
+          { type: :integer_number }, { type: :email }, { type: :phone },
+          { type: :iban }, { type: :civilite }, { type: :pays },
+          { type: :regions }, { type: :date }, { type: :datetime },
+          { type: :yes_no }, { type: :checkbox }, { type: :drop_down_list },
+          { type: :departements }, { type: :communes }, { type: :address },
+          { type: :multiple_drop_down_list }, { type: :dossier_link },
+          { type: :epci }, { type: :siret }
+        ])
+      end
+      let_it_be(:dossier, reload: true) { create(:dossier, :brouillon, procedure:) }
+      let_it_be(:linked_dossier) { create(:dossier, :en_construction, procedure:) }
+
+      [
+        [:text, "value"],
+        [:textarea, "value"],
+        [:decimal_number, "3.14"],
+        [:integer_number, "42"],
+        [:email, "value"],
+        [:phone, "value"],
+        [:iban, "value"],
+        [:civilite, "M."],
+        [:pays, "FR"],
+        [:regions, "93"],
+        [:date, "2022-12-22"],
+        [:datetime, "2022-12-22T10:30"],
+        [:yes_no, "true"],
+        [:yes_no, "false"],
+        [:checkbox, "true"],
+        [:checkbox, "false"],
+        [:drop_down_list, "value"],
+        [:regions, "93"],
+        [:siret, "13002526500013"],
+        [:departements, "03"],
+        [:communes, ['01540', '01457']],
+        [:address, "20 avenue de Ségur 75007 Paris"],
+        [:multiple_drop_down_list, ["val1", "val2"]],
+        [:dossier_link, :linked_dossier_id],
+        [:epci, ['01', '200042935']]
+      ].each do |type, value|
+        it "builds correct prefill for #{type} (#{value})", :slow do
+          tdc = procedure.published_revision.types_de_champ_private.find { _1.type_champ == type.to_s }
+          champ = find_champ_by_stable_id(dossier, tdc.stable_id)
+          champ_value = value == :linked_dossier_id ? linked_dossier.id : value
+          params = { "champ_#{tdc.to_typed_id_for_query}" => champ_value }
+          result = described_class.new(dossier, params).to_a
+          expect(result).to match([{ id: champ.id }.merge(attributes(champ, champ_value))])
+        end
+      end
+    end
 
     context "when the private type de champ is authorized (repetition)" do
       let(:types_de_champ_private) { [{ type: :repetition, children: [{ type: :text }] }] }
@@ -199,30 +204,51 @@ RSpec.describe PrefillChamps do
       end
     end
 
-    it_behaves_like "a champ public value that is unauthorized", :decimal_number, "non decimal string"
-    it_behaves_like "a champ public value that is unauthorized", :integer_number, "non integer string"
-    it_behaves_like "a champ public value that is unauthorized", :number, "value"
-    it_behaves_like "a champ public value that is unauthorized", :dossier_link, "value"
-    it_behaves_like "a champ public value that is unauthorized", :titre_identite, "value"
-    it_behaves_like "a champ public value that is unauthorized", :civilite, "value"
-    it_behaves_like "a champ public value that is unauthorized", :date, "value"
-    # Does not care because it's going to be normalized anyway
-    # it_behaves_like "a champ public value that is unauthorized", :datetime, "value"
-    # it_behaves_like "a champ public value that is unauthorized", :datetime, "12-22-2022T10:30"
-    it_behaves_like "a champ public value that is unauthorized", :linked_drop_down_list, "value"
-    it_behaves_like "a champ public value that is unauthorized", :header_section, "value"
-    it_behaves_like "a champ public value that is unauthorized", :explication, "value"
-    it_behaves_like "a champ public value that is unauthorized", :piece_justificative, "value"
-    it_behaves_like "a champ public value that is unauthorized", :cnaf, "value"
-    it_behaves_like "a champ public value that is unauthorized", :dgfip, "value"
-    it_behaves_like "a champ public value that is unauthorized", :pole_emploi, "value"
-    it_behaves_like "a champ public value that is unauthorized", :mesri, "value"
-    it_behaves_like "a champ public value that is unauthorized", :carte, "value"
-    it_behaves_like "a champ public value that is unauthorized", :pays, "value"
-    it_behaves_like "a champ public value that is unauthorized", :regions, "value"
-    it_behaves_like "a champ public value that is unauthorized", :departements, "value"
-    it_behaves_like "a champ public value that is unauthorized", :communes, "value"
-    it_behaves_like "a champ public value that is unauthorized", :multiple_drop_down_list, ["value"]
+    context "when the public type de champ is unauthorized" do
+      let_it_be(:procedure) do
+        create(:procedure, :published, types_de_champ_public: [
+          { type: :decimal_number }, { type: :integer_number }, { type: :number },
+          { type: :dossier_link }, { type: :titre_identite }, { type: :civilite },
+          { type: :date }, { type: :linked_drop_down_list }, { type: :header_section },
+          { type: :explication }, { type: :piece_justificative }, { type: :cnaf },
+          { type: :dgfip }, { type: :pole_emploi }, { type: :mesri },
+          { type: :carte }, { type: :pays }, { type: :regions },
+          { type: :departements }, { type: :communes }, { type: :multiple_drop_down_list }
+        ])
+      end
+      let_it_be(:dossier, reload: true) { create(:dossier, :brouillon, procedure:) }
+
+      [
+        [:decimal_number, "non decimal string"],
+        [:integer_number, "non integer string"],
+        [:number, "value"],
+        [:dossier_link, "value"],
+        [:titre_identite, "value"],
+        [:civilite, "value"],
+        [:date, "value"],
+        [:linked_drop_down_list, "value"],
+        [:header_section, "value"],
+        [:explication, "value"],
+        [:piece_justificative, "value"],
+        [:cnaf, "value"],
+        [:dgfip, "value"],
+        [:pole_emploi, "value"],
+        [:mesri, "value"],
+        [:carte, "value"],
+        [:pays, "value"],
+        [:regions, "value"],
+        [:departements, "value"],
+        [:communes, "value"],
+        [:multiple_drop_down_list, ["value"]]
+      ].each do |type, value|
+        it "filters out unauthorized #{type}" do
+          tdc = procedure.published_revision.types_de_champ_public.find { _1.type_champ == type.to_s }
+          params = { "champ_#{tdc.to_typed_id_for_query}" => value }
+          result = described_class.new(dossier, params).to_a
+          expect(result).to match([])
+        end
+      end
+    end
 
     context "when the public type de champ is unauthorized because of wrong value format (repetition)" do
       let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :text }] }] }

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -936,8 +936,8 @@ describe Procedure do
   end
 
   describe "#publish_revision!" do
-    let(:administrateur) { create(:administrateur) }
-    let(:procedure) { create(:procedure, :published, administrateurs: [administrateur]) }
+    let_it_be(:administrateur) { create(:administrateur) }
+    let_it_be(:procedure, reload: true) { create(:procedure, :published, administrateurs: [administrateur]) }
     let(:tdc_attributes) { { type_champ: :number, libelle: 'libelle 1' } }
     let(:publication_date) { Time.zone.local(2021, 1, 1, 12, 00, 00) }
 
@@ -1607,18 +1607,11 @@ describe Procedure do
 
   describe 'extend_conservation_for_dossiers' do
     let(:duree_conservation_dossiers_dans_ds) { 2 }
-    let(:procedure) { create(:procedure, duree_conservation_dossiers_dans_ds:) }
-    let(:expiring_dossier_brouillon) { create(:dossier, :brouillon, procedure: procedure, brouillon_close_to_expiration_notice_sent_at: duree_conservation_dossiers_dans_ds.months.ago) }
-    let(:expiring_dossier_en_construction) { create(:dossier, :en_construction, procedure: procedure, en_construction_close_to_expiration_notice_sent_at: duree_conservation_dossiers_dans_ds.months.ago) }
-    let(:expiring_dossier_en_termine) { create(:dossier, :accepte, procedure: procedure, termine_close_to_expiration_notice_sent_at: duree_conservation_dossiers_dans_ds.months.ago) }
-    let(:not_expiring_dossie) { create(:dossier, :accepte, procedure: procedure, created_at: duree_conservation_dossiers_dans_ds.months.ago) }
-    before do
-      procedure
-      expiring_dossier_brouillon
-      expiring_dossier_en_construction
-      expiring_dossier_en_termine
-      not_expiring_dossie
-    end
+    let_it_be(:procedure, reload: true) { create(:procedure, duree_conservation_dossiers_dans_ds: 2) }
+    let_it_be(:expiring_dossier_brouillon) { create(:dossier, :brouillon, procedure: procedure, brouillon_close_to_expiration_notice_sent_at: 2.months.ago) }
+    let_it_be(:expiring_dossier_en_construction) { create(:dossier, :en_construction, procedure: procedure, en_construction_close_to_expiration_notice_sent_at: 2.months.ago) }
+    let_it_be(:expiring_dossier_en_termine) { create(:dossier, :accepte, procedure: procedure, termine_close_to_expiration_notice_sent_at: 2.months.ago) }
+    let_it_be(:not_expiring_dossie) { create(:dossier, :accepte, procedure: procedure, created_at: 2.months.ago) }
 
     context 'when duree_conservation_dossiers_dans_ds does not changes' do
       it 'does not enqueues any job' do
@@ -1643,7 +1636,7 @@ describe Procedure do
   end
 
   describe "#attestation_template" do
-    let(:procedure) { create(:procedure) }
+    let_it_be(:procedure, reload: true) { create(:procedure) }
     subject { procedure.reload }
 
     context "when there is a v2 draft and a v1" do
@@ -1689,9 +1682,9 @@ describe Procedure do
   end
 
   describe "#parsed_latest_zone_labels" do
-    let!(:draft_procedure) { create(:procedure) }
-    let!(:published_procedure) { create(:procedure_with_dossiers, :published, dossiers_count: 2) }
-    let!(:closed_procedure) { create(:procedure, :closed) }
+    let_it_be(:draft_procedure) { create(:procedure) }
+    let_it_be(:published_procedure) { create(:procedure_with_dossiers, :published, dossiers_count: 2) }
+    let_it_be(:closed_procedure) { create(:procedure, :closed) }
     let!(:procedure_detail_draft) { ProcedureDetail.new(id: draft_procedure.id, latest_zone_labels: '{ "zone1", "zone2" }') }
     let!(:procedure_detail_published) { ProcedureDetail.new(id: published_procedure.id, latest_zone_labels: '{ "zone3", "zone4" }') }
     let!(:procedure_detail_closed) { ProcedureDetail.new(id: closed_procedure.id, latest_zone_labels: '{ "zone5", "zone6" }') }
@@ -1813,18 +1806,18 @@ describe Procedure do
   describe 'routing rule statuses management' do
     include Logic
 
-    let(:admin) { create :administrateur }
-    let(:procedure) { create(:procedure, :published, routing_enabled: true, administrateur: admin) }
-    let(:stable_id) { procedure.published_revision.types_de_champ_public.last.stable_id }
-
-    before do
-      procedure.draft_revision.add_type_de_champ(
+    let_it_be(:admin) { create :administrateur }
+    let_it_be(:procedure, reload: true) do
+      p = create(:procedure, :published, routing_enabled: true, administrateur: admin)
+      p.draft_revision.add_type_de_champ(
         type_champ: :drop_down_list,
         libelle: 'Ville',
         drop_down_options: ['Paris', 'Lyon', 'Marseille']
       )
-      procedure.publish_revision!(admin)
+      p.publish_revision!(admin)
+      p
     end
+    let_it_be(:stable_id) { procedure.published_revision.types_de_champ_public.last.stable_id }
 
     describe '#update_all_groupes_rule_validity_status' do
       let!(:gi_valid) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,9 +45,6 @@ end
 
 ActiveJob::Base.queue_adapter = :test
 
-TPS::Application.load_tasks
-Rake.application.options.trace = false
-
 RSpec.configure do |config|
   # Since rspec 3.8.0, bisect uses fork to improve bisection speed.
   # This however fails as soon as we're running feature tests (which uses many processes).
@@ -82,8 +79,6 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
 
   config.before(:each) do
-    Rake.verbose false
-
     Typhoeus::Expectation.clear
 
     ActionMailer::Base.deliveries.clear

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -7,5 +7,3 @@ RSpec.configure do |config|
     clear_enqueued_jobs
   end
 end
-
-ActiveJob::Base.queue_adapter = :test

--- a/spec/support/test_prof.rb
+++ b/spec/support/test_prof.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'test_prof/recipes/rspec/let_it_be'
+require 'test_prof/recipes/rspec/before_all'

--- a/spec/support/test_prof.rb
+++ b/spec/support/test_prof.rb
@@ -2,3 +2,7 @@
 
 require 'test_prof/recipes/rspec/let_it_be'
 require 'test_prof/recipes/rspec/before_all'
+
+TestProf::BeforeAll.configure do |config|
+  config.setup_fixtures = true
+end

--- a/spec/support/warden.rb
+++ b/spec/support/warden.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-include Warden::Test::Helpers
-
 RSpec.configure do |config|
-  config.before(:all) do
+  config.include Warden::Test::Helpers
+
+  config.before(:suite) do
     Warden.test_mode!
   end
 end


### PR DESCRIPTION
## Summary

- Configure test-prof et `let_it_be` pour réutiliser les objets factory entre les exemples RSpec, réduisant les créations redondantes en base de données
- Convertir `let` / `let!` en `let_it_be` dans les specs modèles les plus lourdes : `dossier_spec`, `procedure_spec`, `instructeur_spec`, `prefill_champs_spec`, `batch_operation_spec`, `dossier_notification_spec`, `procedure_clone_concern_spec`
- Nettoyer la configuration des specs : centraliser le support test-prof, simplifier `rails_helper.rb` et les fichiers de support

## Détails

Les factories Rails sont souvent le goulot d'étranglement principal dans l'exécution des tests. `let_it_be` (de la gem test-prof) permet de créer les données partagées une seule fois par contexte au lieu de les recréer pour chaque exemple, tout en garantissant l'isolation grâce aux options `reload: true` quand nécessaire.

Fichiers modifiés (16) sur 9 commits atomiques, chacun ciblant un fichier ou un aspect spécifique.

## Test plan

- [ ] Vérifier que la CI passe (tous les tests doivent rester verts)
- [ ] Vérifier qu'il n'y a pas de régression sur les tests modifiés avec `--bisect` en cas d'échec intermittent

🤖 Generated with [Claude Code](https://claude.com/claude-code)