### PR TITLE
Tech: refactorer les concerns pour utiliser les patterns idiomatiques d'ActiveSupport::Concern

### DIFF
--- a/app/controllers/concerns/csv_parsing_concern.rb
+++ b/app/controllers/concerns/csv_parsing_concern.rb
@@ -10,40 +10,38 @@ module CsvParsingConcern
     "application/vnd.ms-excel",
   ]
 
-  included do
-    private
+  private
 
-    def csv_file?
-      CSV_ACCEPTED_CONTENT_TYPES.include?(referentiel_file.content_type) ||
-        CSV_ACCEPTED_CONTENT_TYPES.include?(marcel_content_type)
-    end
+  def csv_file?
+    CSV_ACCEPTED_CONTENT_TYPES.include?(referentiel_file.content_type) ||
+      CSV_ACCEPTED_CONTENT_TYPES.include?(marcel_content_type)
+  end
 
-    def parse_csv(file, strings_as_keys: true, keep_original_headers: false, convert_values_to_numeric: false)
-      raw_content = file.read
+  def parse_csv(file, strings_as_keys: true, keep_original_headers: false, convert_values_to_numeric: false)
+    raw_content = file.read
 
-      utf8_content = ensure_utf8(raw_content)
+    utf8_content = ensure_utf8(raw_content)
 
-      Tempfile.create(['referentiel', '.csv'], encoding: 'UTF-8') do |tempfile|
-        tempfile.write(utf8_content)
-        tempfile.rewind
+    Tempfile.create(['referentiel', '.csv'], encoding: 'UTF-8') do |tempfile|
+      tempfile.write(utf8_content)
+      tempfile.rewind
 
-        begin
-          SmarterCSV.process(
-            tempfile.path,
-            strings_as_keys:,
-            keep_original_headers:,
-            convert_values_to_numeric:
-          )
-        rescue *[CSV::MalformedCSVError, SmarterCSV::NoColSepDetected, ArgumentError]
-          []
-        end
+      begin
+        SmarterCSV.process(
+          tempfile.path,
+          strings_as_keys:,
+          keep_original_headers:,
+          convert_values_to_numeric:
+        )
+      rescue *[CSV::MalformedCSVError, SmarterCSV::NoColSepDetected, ArgumentError]
+        []
       end
     end
+  end
 
-    def ensure_utf8(content)
-      detection = CharlockHolmes::EncodingDetector.detect(content)
-      source_encoding = detection[:encoding] || 'Windows-1252'
-      CharlockHolmes::Converter.convert(content, source_encoding, 'UTF-8')
-    end
+  def ensure_utf8(content)
+    detection = CharlockHolmes::EncodingDetector.detect(content)
+    source_encoding = detection[:encoding] || 'Windows-1252'
+    CharlockHolmes::Converter.convert(content, source_encoding, 'UTF-8')
   end
 end

--- a/app/controllers/concerns/france_connect_concern.rb
+++ b/app/controllers/concerns/france_connect_concern.rb
@@ -3,24 +3,22 @@
 module FranceConnectConcern
   extend ActiveSupport::Concern
 
-  included do
-    def logged_in_with_france_connect?
-      cookies.encrypted[FranceConnectController::ID_TOKEN_COOKIE_NAME].present?
-    end
+  def logged_in_with_france_connect?
+    cookies.encrypted[FranceConnectController::ID_TOKEN_COOKIE_NAME].present?
+  end
 
-    def france_connect_logout_url(callback:)
-      id_token = cookies.encrypted[FranceConnectController::ID_TOKEN_COOKIE_NAME]
-      state = cookies.encrypted[FranceConnectController::STATE_COOKIE_NAME]
+  def france_connect_logout_url(callback:)
+    id_token = cookies.encrypted[FranceConnectController::ID_TOKEN_COOKIE_NAME]
+    state = cookies.encrypted[FranceConnectController::STATE_COOKIE_NAME]
 
-      cookies.delete(FranceConnectController::ID_TOKEN_COOKIE_NAME)
-      cookies.delete(FranceConnectController::STATE_COOKIE_NAME)
+    cookies.delete(FranceConnectController::ID_TOKEN_COOKIE_NAME)
+    cookies.delete(FranceConnectController::STATE_COOKIE_NAME)
 
-      FranceConnectService.logout_url(id_token:, state:, callback:)
-    end
+    FranceConnectService.logout_url(id_token:, state:, callback:)
+  end
 
-    def delete_france_connect_cookies
-      cookies.delete(FranceConnectController::ID_TOKEN_COOKIE_NAME)
-      cookies.delete(FranceConnectController::STATE_COOKIE_NAME)
-    end
+  def delete_france_connect_cookies
+    cookies.delete(FranceConnectController::ID_TOKEN_COOKIE_NAME)
+    cookies.delete(FranceConnectController::STATE_COOKIE_NAME)
   end
 end

--- a/app/controllers/concerns/gc_tracking_concern.rb
+++ b/app/controllers/concerns/gc_tracking_concern.rb
@@ -5,23 +5,23 @@ module GcTrackingConcern
 
   included do
     around_action :track_gc_stat, if: :track_gc?
+  end
 
-    def track_gc_stat
-      before = GC.stat
-      yield
-      after = GC.stat
+  def track_gc_stat
+    before = GC.stat
+    yield
+    after = GC.stat
 
-      begin
-        @query_info ||= {}
-        @query_info[:gc_stat_count] = after[:count] - before[:count] # number of gc
-        @query_info[:gc_stat_heap_available_slots] = after[:heap_available_slots] - before[:heap_available_slots]
-      rescue => e
-        Sentry.capture_exception(e)
-      end
+    begin
+      @query_info ||= {}
+      @query_info[:gc_stat_count] = after[:count] - before[:count] # number of gc
+      @query_info[:gc_stat_heap_available_slots] = after[:heap_available_slots] - before[:heap_available_slots]
+    rescue => e
+      Sentry.capture_exception(e)
     end
+  end
 
-    def track_gc?
-      ENV['TRACK_GC_ENABLED'] == 'enabled'
-    end
+  def track_gc?
+    ENV['TRACK_GC_ENABLED'] == 'enabled'
   end
 end

--- a/app/controllers/concerns/groupe_instructeurs_signature_concern.rb
+++ b/app/controllers/concerns/groupe_instructeurs_signature_concern.rb
@@ -3,61 +3,59 @@
 module GroupeInstructeursSignatureConcern
   extend ActiveSupport::Concern
 
-  included do
-    def add_signature
-      @procedure = procedure
-      @groupe_instructeur = groupe_instructeur
-      @instructeurs = paginated_instructeurs
+  def add_signature
+    @procedure = procedure
+    @groupe_instructeur = groupe_instructeur
+    @instructeurs = paginated_instructeurs
 
-      signature_file = params[:groupe_instructeur][:signature]
+    signature_file = params[:groupe_instructeur][:signature]
 
-      if params[:groupe_instructeur].nil? || signature_file.blank?
-        if respond_to?(:available_instructeur_emails)
-          @available_instructeur_emails = available_instructeur_emails
-        end
+    if params[:groupe_instructeur].nil? || signature_file.blank?
+      if respond_to?(:available_instructeur_emails)
+        @available_instructeur_emails = available_instructeur_emails
+      end
 
-        flash[:alert] = "Aucun fichier joint pour le tampon de l’attestation"
-        render :show
+      flash[:alert] = "Aucun fichier joint pour le tampon de l'attestation"
+      render :show
+    else
+      if @groupe_instructeur.signature.attach(signature_file)
+        handle_redirect :success
       else
-        if @groupe_instructeur.signature.attach(signature_file)
-          handle_redirect :success
-        else
-          handle_redirect :alert
-        end
+        handle_redirect :alert
       end
     end
+  end
 
-    def preview_attestation_acceptation
-      attestation_acceptation_template = procedure.attestation_acceptation_template || procedure.build_attestation_acceptation_template
-      @attestation = attestation_acceptation_template.render_attributes_for({ groupe_instructeur: groupe_instructeur })
+  def preview_attestation_acceptation
+    attestation_acceptation_template = procedure.attestation_acceptation_template || procedure.build_attestation_acceptation_template
+    @attestation = attestation_acceptation_template.render_attributes_for({ groupe_instructeur: groupe_instructeur })
 
-      render 'administrateurs/attestation_templates/show', formats: [:pdf]
+    render 'administrateurs/attestation_templates/show', formats: [:pdf]
+  end
+
+  private
+
+  def handle_redirect(status)
+    redirect, preview = if self.class.module_parent_name == "Administrateurs"
+      [
+        :admin_procedure_groupe_instructeur_path,
+        :preview_attestation_acceptation_admin_procedure_groupe_instructeur_path,
+      ]
+    else
+      [
+        :instructeur_groupe_path,
+        :preview_attestation_acceptation_instructeur_groupe_path,
+      ]
     end
 
-    private
+    redirect_path = method(redirect).call(@procedure, @groupe_instructeur)
+    preview_path = method(preview).call(@procedure, @groupe_instructeur)
 
-    def handle_redirect(status)
-      redirect, preview = if self.class.module_parent_name == "Administrateurs"
-        [
-          :admin_procedure_groupe_instructeur_path,
-          :preview_attestation_acceptation_admin_procedure_groupe_instructeur_path,
-        ]
-      else
-        [
-          :instructeur_groupe_path,
-          :preview_attestation_acceptation_instructeur_groupe_path,
-        ]
-      end
-
-      redirect_path = method(redirect).call(@procedure, @groupe_instructeur)
-      preview_path = method(preview).call(@procedure, @groupe_instructeur)
-
-      case status
-      when :success
-        redirect_to redirect_path, notice: "Le tampon de l’attestation a bien été ajouté. #{helpers.link_to("Prévisualiser l’attestation", preview_path)}"
-      when :alert
-        redirect_to redirect_path, alert: "Une erreur a empêché l’ajout du tampon. Réessayez dans quelques instants."
-      end
+    case status
+    when :success
+      redirect_to redirect_path, notice: "Le tampon de l'attestation a bien été ajouté. #{helpers.link_to("Prévisualiser l'attestation", preview_path)}"
+    when :alert
+      redirect_to redirect_path, alert: "Une erreur a empêché l'ajout du tampon. Réessayez dans quelques instants."
     end
   end
 end

--- a/app/controllers/concerns/instructeur_concern.rb
+++ b/app/controllers/concerns/instructeur_concern.rb
@@ -3,22 +3,20 @@
 module InstructeurConcern
   extend ActiveSupport::Concern
 
-  included do
-    def retrieve_procedure_presentation
-      @procedure_presentation ||= current_instructeur.procedure_presentation_for_procedure_id(params[:procedure_id])
-    end
+  def retrieve_procedure_presentation
+    @procedure_presentation ||= current_instructeur.procedure_presentation_for_procedure_id(params[:procedure_id])
+  end
 
-    def set_notifications
-      @notifications_sticker = DossierNotification.notifications_sticker_for_instructeur_dossier(current_instructeur, dossier)
-      @notifications = DossierNotification.notifications_for_instructeur_dossier(current_instructeur, dossier)
-    end
+  def set_notifications
+    @notifications_sticker = DossierNotification.notifications_sticker_for_instructeur_dossier(current_instructeur, dossier)
+    @notifications = DossierNotification.notifications_for_instructeur_dossier(current_instructeur, dossier)
+  end
 
-    def destroy_notification(notification_type)
-      DossierNotification.destroy_notification_by_dossier_and_type_and_instructeur(
-        dossier,
-        notification_type,
-        current_instructeur
-      )
-    end
+  def destroy_notification(notification_type)
+    DossierNotification.destroy_notification_by_dossier_and_type_and_instructeur(
+      dossier,
+      notification_type,
+      current_instructeur
+    )
   end
 end

--- a/app/controllers/concerns/instructeur_email_notification_concern.rb
+++ b/app/controllers/concerns/instructeur_email_notification_concern.rb
@@ -3,30 +3,28 @@
 module InstructeurEmailNotificationConcern
   extend ActiveSupport::Concern
 
-  included do
-    def notify_instructeurs(groupe, added_instructeurs, current_user)
-      known_instructeurs, new_instructeurs = added_instructeurs.partition { |instructeur| instructeur.user.email_verified_at }
+  def notify_instructeurs(groupe, added_instructeurs, current_user)
+    known_instructeurs, new_instructeurs = added_instructeurs.partition { |instructeur| instructeur.user.email_verified_at }
 
-      new_instructeurs.filter(&:should_receive_email_activation?).each { GroupeInstructeurMailer.confirm_and_notify_added_instructeur(_1, groupe, current_user.email).deliver_later }
+    new_instructeurs.filter(&:should_receive_email_activation?).each { GroupeInstructeurMailer.confirm_and_notify_added_instructeur(_1, groupe, current_user.email).deliver_later }
 
-      if known_instructeurs.present?
-        GroupeInstructeurMailer
-          .notify_added_instructeurs(groupe, known_instructeurs, current_user.email)
-          .deliver_later
-      end
+    if known_instructeurs.present?
+      GroupeInstructeurMailer
+        .notify_added_instructeurs(groupe, known_instructeurs, current_user.email)
+        .deliver_later
     end
+  end
 
-    def notify_instructeur_added_in_many_groupes(instructeur, groupes)
-      if instructeur.user.email_verified_at
+  def notify_instructeur_added_in_many_groupes(instructeur, groupes)
+    if instructeur.user.email_verified_at
+      GroupeInstructeurMailer
+        .notify_added_instructeur_in_many_groupes(instructeur, groupes, current_administrateur.email)
+        .deliver_later
+    else
+      if instructeur.should_receive_email_activation?
         GroupeInstructeurMailer
-          .notify_added_instructeur_in_many_groupes(instructeur, groupes, current_administrateur.email)
+          .confirm_and_notify_added_instructeur_in_many_groupes(instructeur, groupes, current_administrateur.email)
           .deliver_later
-      else
-        if instructeur.should_receive_email_activation?
-          GroupeInstructeurMailer
-            .confirm_and_notify_added_instructeur_in_many_groupes(instructeur, groupes, current_administrateur.email)
-            .deliver_later
-        end
       end
     end
   end

--- a/app/controllers/concerns/instructeur_procedure_concern.rb
+++ b/app/controllers/concerns/instructeur_procedure_concern.rb
@@ -3,33 +3,31 @@
 module InstructeurProcedureConcern
   extend ActiveSupport::Concern
 
-  included do
-    private
+  private
 
-    def ensure_instructeur_procedures_for(procedures)
-      current_instructeur_procedures = current_instructeur.instructeurs_procedures.where(procedure_id: procedures.map(&:id))
-      top_position = current_instructeur_procedures.map(&:position).max.to_i
-      missing_instructeur_procedures = procedures.sort_by(&:published_at).filter_map do |procedure|
-        if !procedure.id.in?(current_instructeur_procedures.map(&:procedure_id))
-          { instructeur_id: current_instructeur.id, procedure_id: procedure.id, position: top_position += 1, last_revision_seen_id: procedure.published_revision_id }
-        end
+  def ensure_instructeur_procedures_for(procedures)
+    current_instructeur_procedures = current_instructeur.instructeurs_procedures.where(procedure_id: procedures.map(&:id))
+    top_position = current_instructeur_procedures.map(&:position).max.to_i
+    missing_instructeur_procedures = procedures.sort_by(&:published_at).filter_map do |procedure|
+      if !procedure.id.in?(current_instructeur_procedures.map(&:procedure_id))
+        { instructeur_id: current_instructeur.id, procedure_id: procedure.id, position: top_position += 1, last_revision_seen_id: procedure.published_revision_id }
       end
-      InstructeursProcedure.insert_all(missing_instructeur_procedures) if missing_instructeur_procedures.size.positive?
+    end
+    InstructeursProcedure.insert_all(missing_instructeur_procedures) if missing_instructeur_procedures.size.positive?
+  end
+
+  def find_or_create_instructeur_procedure(procedure)
+    instructeur_procedure = InstructeursProcedure.find_or_initialize_by(
+      instructeur: current_instructeur,
+      procedure: procedure
+    )
+
+    if instructeur_procedure.new_record?
+      instructeur_procedure.last_revision_seen_id = procedure.published_revision_id
+      instructeur_procedure.position = current_instructeur.instructeurs_procedures.map(&:position).max.to_i + 1
+      instructeur_procedure.save!
     end
 
-    def find_or_create_instructeur_procedure(procedure)
-      instructeur_procedure = InstructeursProcedure.find_or_initialize_by(
-        instructeur: current_instructeur,
-        procedure: procedure
-      )
-
-      if instructeur_procedure.new_record?
-        instructeur_procedure.last_revision_seen_id = procedure.published_revision_id
-        instructeur_procedure.position = current_instructeur.instructeurs_procedures.map(&:position).max.to_i + 1
-        instructeur_procedure.save!
-      end
-
-      instructeur_procedure
-    end
+    instructeur_procedure
   end
 end

--- a/app/controllers/concerns/lockable_concern.rb
+++ b/app/controllers/concerns/lockable_concern.rb
@@ -3,16 +3,14 @@
 module LockableConcern
   extend ActiveSupport::Concern
 
-  included do
-    def lock_action(key)
-      lock = Kredis.flag(key)
-      head :locked and return if lock.marked?
+  def lock_action(key)
+    lock = Kredis.flag(key)
+    head :locked and return if lock.marked?
 
-      lock.mark(expires_in: 10.seconds)
+    lock.mark(expires_in: 10.seconds)
 
-      yield
+    yield
 
-      lock.remove
-    end
+    lock.remove
   end
 end

--- a/app/controllers/concerns/nav_bar_profile_concern.rb
+++ b/app/controllers/concerns/nav_bar_profile_concern.rb
@@ -3,52 +3,50 @@
 module NavBarProfileConcern
   extend ActiveSupport::Concern
 
-  included do
-    # Override this method on controller basis for more precise context or custom logic
-    def nav_bar_profile
-    end
+  # Override this method on controller basis for more precise context or custom logic
+  def nav_bar_profile
+  end
 
-    def fallback_nav_bar_profile
-      return :guest if current_user.blank?
+  def fallback_nav_bar_profile
+    return :guest if current_user.blank?
 
-      nav_bar_profile_from_referrer || default_nav_bar_profile_for_user
-    end
+    nav_bar_profile_from_referrer || default_nav_bar_profile_for_user
+  end
 
-    private
+  private
 
-    def nav_bar_user_or_guest
-      # when instanciating manually the controller (see below),
-      # we don't have request and current_user would fail
-      request && current_user ? :user : :guest
-    end
+  def nav_bar_user_or_guest
+    # when instanciating manually the controller (see below),
+    # we don't have request and current_user would fail
+    request && current_user ? :user : :guest
+  end
 
-    # Shared controllers (search, errors, release notes…) don't have specific context
-    # Simple attempt to try to re-use the profile from the previous page
-    # so user does'not feel lost.
-    def nav_bar_profile_from_referrer
-      # detect context from referer, simple (no detection when refreshing the page)
-      params = Rails.application.routes.recognize_path(request&.referer)
+  # Shared controllers (search, errors, release notes…) don't have specific context
+  # Simple attempt to try to re-use the profile from the previous page
+  # so user does'not feel lost.
+  def nav_bar_profile_from_referrer
+    # detect context from referer, simple (no detection when refreshing the page)
+    params = Rails.application.routes.recognize_path(request&.referer)
 
-      controller_class = "#{params[:controller].camelize}Controller".safe_constantize
-      return if controller_class.nil?
+    controller_class = "#{params[:controller].camelize}Controller".safe_constantize
+    return if controller_class.nil?
 
-      controller_instance = controller_class.new
-      controller_instance.try(:nav_bar_profile)
-    rescue StandardError => e # we don't want broken logic in nav bar profile to fail the request
-      Sentry.capture_exception(e)
+    controller_instance = controller_class.new
+    controller_instance.try(:nav_bar_profile)
+  rescue StandardError => e # we don't want broken logic in nav bar profile to fail the request
+    Sentry.capture_exception(e)
 
-      nil
-    end
+    nil
+  end
 
-    # Fallback for shared controllers from user account
-    # to the more relevant profile.
-    def default_nav_bar_profile_for_user
-      return :gestionnaire if current_user.gestionnaire?
-      return :administrateur if current_user.administrateur?
-      return :instructeur if current_user.instructeur?
-      return :expert if current_user.expert?
+  # Fallback for shared controllers from user account
+  # to the more relevant profile.
+  def default_nav_bar_profile_for_user
+    return :gestionnaire if current_user.gestionnaire?
+    return :administrateur if current_user.administrateur?
+    return :instructeur if current_user.instructeur?
+    return :expert if current_user.expert?
 
-      :user
-    end
+    :user
   end
 end

--- a/app/controllers/concerns/pro_connect_session_concern.rb
+++ b/app/controllers/concerns/pro_connect_session_concern.rb
@@ -7,23 +7,23 @@ module ProConnectSessionConcern
 
   included do
     helper_method :logged_in_with_pro_connect?
+  end
 
-    def set_pro_connect_session_info_cookie(user_id, mfa: false)
-      value = { user_id:, mfa: }.to_json
-      cookies.encrypted[SESSION_INFO_COOKIE_NAME] = { value:, secure: Rails.env.production?, httponly: true }
-    end
+  def set_pro_connect_session_info_cookie(user_id, mfa: false)
+    value = { user_id:, mfa: }.to_json
+    cookies.encrypted[SESSION_INFO_COOKIE_NAME] = { value:, secure: Rails.env.production?, httponly: true }
+  end
 
-    def logged_in_with_pro_connect?
-      pro_connect_session.present?
-    end
+  def logged_in_with_pro_connect?
+    pro_connect_session.present?
+  end
 
-    def pro_connect_mfa?
-      pro_connect_session['mfa'] == true
-    end
+  def pro_connect_mfa?
+    pro_connect_session['mfa'] == true
+  end
 
-    def delete_pro_connect_session_info_cookie
-      cookies.delete SESSION_INFO_COOKIE_NAME
-    end
+  def delete_pro_connect_session_info_cookie
+    cookies.delete SESSION_INFO_COOKIE_NAME
   end
 
   private

--- a/app/controllers/concerns/simpliscore_concern.rb
+++ b/app/controllers/concerns/simpliscore_concern.rb
@@ -5,124 +5,124 @@ module SimpliscoreConcern
 
   included do
     before_action :ensure_simpliscore_enabled, only: [:simplify, :accept_simplification, :enqueue_simplify, :poll_simplify]
+  end
 
-    def enqueue_simplify
-      if llm_rule_suggestion_scope.where(rule:).exists?(state: [:queued, :running])
-        redirect_to simplify_admin_procedure_types_de_champ_path(@procedure, rule:), notice: 'Une recherche est déjà en cours pour cette règle.'
-      else
-        LLM::ImproveProcedureJob.perform_now(@procedure, rule, action: action_name, user_id: current_administrateur.user.id) # nothing async, the job re-enqueues a GenerateRuleSuggestionJob
-        redirect_to simplify_admin_procedure_types_de_champ_path(@procedure, rule:), notice: 'La recherche a été lancée. Vous serez prévenu(e) lorsque les suggestions seront prêtes.'
-      end
+  def enqueue_simplify
+    if llm_rule_suggestion_scope.where(rule:).exists?(state: [:queued, :running])
+      redirect_to simplify_admin_procedure_types_de_champ_path(@procedure, rule:), notice: 'Une recherche est déjà en cours pour cette règle.'
+    else
+      LLM::ImproveProcedureJob.perform_now(@procedure, rule, action: action_name, user_id: current_administrateur.user.id) # nothing async, the job re-enqueues a GenerateRuleSuggestionJob
+      redirect_to simplify_admin_procedure_types_de_champ_path(@procedure, rule:), notice: 'La recherche a été lancée. Vous serez prévenu(e) lorsque les suggestions seront prêtes.'
     end
+  end
 
-    def simplify
-      tunnel = LLM::TunnelFinder.new(draft.id)
-      last_completed = tunnel.last_completed_step
-      tunnel_complete = tunnel.final_step.present?
+  def simplify
+    tunnel = LLM::TunnelFinder.new(draft.id)
+    last_completed = tunnel.last_completed_step
+    tunnel_complete = tunnel.final_step.present?
 
-      if !tunnel_complete && last_completed
-        requested_rule_index = LLM::Rule::SEQUENCE.index(rule)
-        last_completed_index = LLM::Rule::SEQUENCE.index(last_completed.rule)
+    if !tunnel_complete && last_completed
+      requested_rule_index = LLM::Rule::SEQUENCE.index(rule)
+      last_completed_index = LLM::Rule::SEQUENCE.index(last_completed.rule)
 
-        if requested_rule_index && last_completed_index && requested_rule_index <= last_completed_index
-          next_rule = LLM::Rule.next_rule(last_completed.rule)
-          if next_rule
-            redirect_to simplify_admin_procedure_types_de_champ_path(@procedure, rule: next_rule) and return
-          end
-        end
-      end
-
-      @llm_rule_suggestion = llm_rule_suggestion_scope
-        .where(rule:, schema_hash: current_schema_hash)
-        .includes(:llm_rule_suggestion_items)
-        .order(created_at: :desc)
-        .first
-
-      @llm_rule_suggestion ||= draft.llm_rule_suggestions.build(rule:, schema_hash: current_schema_hash)
-    end
-
-    def poll_simplify
-      @llm_rule_suggestion = llm_rule_suggestion_scope
-        .where(rule: rule)
-        .order(created_at: :desc)
-        .first
-
-      if @llm_rule_suggestion&.state&.in?(['completed', 'failed'])
-        render turbo_stream: turbo_stream.refresh
-      else
-        head :no_content
-      end
-    end
-
-    def accept_simplification
-      @llm_rule_suggestion = llm_rule_suggestion_scope
-        .completed
-        .where(schema_hash: current_schema_hash)
-        .includes(:llm_rule_suggestion_items)
-        .find_by(id: params[:llm_suggestion_rule_id])
-
-      if @llm_rule_suggestion.nil?
-        redirect_to(simplify_index_admin_procedure_types_de_champ_path(@procedure), alert: "Suggestion non trouvée")
-        # elsif @llm_rule_suggestion.schema_hash != current_schema_hash
-        # redirect_to(simplify_admin_procedure_types_de_champ_path(@procedure, rule:), alert: "Le formulaire a évolué depuis la génération de cette suggestion. Veuillez relancer une nouvelle analyse.")
-      else
-        ActiveRecord::Base.transaction do
-          if @llm_rule_suggestion.llm_rule_suggestion_items.empty?
-            @llm_rule_suggestion.skipped!
-          else
-            @llm_rule_suggestion.assign_attributes(suggestion_items_attributes)
-            @llm_rule_suggestion.save!
-            @procedure.draft_revision.apply_llm_rule_suggestion_items(@llm_rule_suggestion.changes_to_apply)
-            @llm_rule_suggestion.accepted!
-          end
-        end
-
-        next_rule = LLM::Rule.next_rule(@llm_rule_suggestion.rule)
-
+      if requested_rule_index && last_completed_index && requested_rule_index <= last_completed_index
+        next_rule = LLM::Rule.next_rule(last_completed.rule)
         if next_rule
-          redirect_to simplify_admin_procedure_types_de_champ_path(@procedure, rule: next_rule), notice: "Parfait, continuons"
-        else
-          redirect_to simplify_admin_procedure_types_de_champ_path(@procedure, rule: LLM::Rule::SEQUENCE.last), notice: "Toutes les suggestions ont été examinées"
+          redirect_to simplify_admin_procedure_types_de_champ_path(@procedure, rule: next_rule) and return
         end
       end
     end
 
-    private
+    @llm_rule_suggestion = llm_rule_suggestion_scope
+      .where(rule:, schema_hash: current_schema_hash)
+      .includes(:llm_rule_suggestion_items)
+      .order(created_at: :desc)
+      .first
 
-    def ensure_simpliscore_enabled
-      return if @procedure.feature_enabled?(:llm_nightly_improve_procedure)
+    @llm_rule_suggestion ||= draft.llm_rule_suggestions.build(rule:, schema_hash: current_schema_hash)
+  end
 
-      redirect_to admin_procedure_path(@procedure), alert: "Les appels aux modèles de langage ne sont pas activés pour cette procédure."
+  def poll_simplify
+    @llm_rule_suggestion = llm_rule_suggestion_scope
+      .where(rule: rule)
+      .order(created_at: :desc)
+      .first
+
+    if @llm_rule_suggestion&.state&.in?(['completed', 'failed'])
+      render turbo_stream: turbo_stream.refresh
+    else
+      head :no_content
     end
+  end
 
-    def rule
-      params[:rule]
-    end
+  def accept_simplification
+    @llm_rule_suggestion = llm_rule_suggestion_scope
+      .completed
+      .where(schema_hash: current_schema_hash)
+      .includes(:llm_rule_suggestion_items)
+      .find_by(id: params[:llm_suggestion_rule_id])
 
-    def tunnel_started_at
-      @tunnel_started_at ||= first_rule_suggestion&.created_at
-    end
-
-    def llm_rule_suggestion_scope
-      scope = LLMRuleSuggestion.where(procedure_revision_id: draft.id)
-
-      if tunnel_started_at
-        scope = scope.where(created_at: tunnel_started_at..)
+    if @llm_rule_suggestion.nil?
+      redirect_to(simplify_index_admin_procedure_types_de_champ_path(@procedure), alert: "Suggestion non trouvée")
+      # elsif @llm_rule_suggestion.schema_hash != current_schema_hash
+      # redirect_to(simplify_admin_procedure_types_de_champ_path(@procedure, rule:), alert: "Le formulaire a évolué depuis la génération de cette suggestion. Veuillez relancer une nouvelle analyse.")
+    else
+      ActiveRecord::Base.transaction do
+        if @llm_rule_suggestion.llm_rule_suggestion_items.empty?
+          @llm_rule_suggestion.skipped!
+        else
+          @llm_rule_suggestion.assign_attributes(suggestion_items_attributes)
+          @llm_rule_suggestion.save!
+          @procedure.draft_revision.apply_llm_rule_suggestion_items(@llm_rule_suggestion.changes_to_apply)
+          @llm_rule_suggestion.accepted!
+        end
       end
-      scope
-    end
 
-    def current_schema_hash
-      @current_schema_hash ||= Digest::SHA256.hexdigest(draft.schema_to_llm.to_json)
-    end
+      next_rule = LLM::Rule.next_rule(@llm_rule_suggestion.rule)
 
-    def first_rule_suggestion
-      @first_rule_suggestion ||= LLM::TunnelFinder.new(draft.id).first_step
+      if next_rule
+        redirect_to simplify_admin_procedure_types_de_champ_path(@procedure, rule: next_rule), notice: "Parfait, continuons"
+      else
+        redirect_to simplify_admin_procedure_types_de_champ_path(@procedure, rule: LLM::Rule::SEQUENCE.last), notice: "Toutes les suggestions ont été examinées"
+      end
     end
+  end
 
-    def suggestion_items_attributes
-      params.require(:llm_rule_suggestion)
-        .permit(llm_rule_suggestion_items_attributes: [:id, :verify_status])
+  private
+
+  def ensure_simpliscore_enabled
+    return if @procedure.feature_enabled?(:llm_nightly_improve_procedure)
+
+    redirect_to admin_procedure_path(@procedure), alert: "Les appels aux modèles de langage ne sont pas activés pour cette procédure."
+  end
+
+  def rule
+    params[:rule]
+  end
+
+  def tunnel_started_at
+    @tunnel_started_at ||= first_rule_suggestion&.created_at
+  end
+
+  def llm_rule_suggestion_scope
+    scope = LLMRuleSuggestion.where(procedure_revision_id: draft.id)
+
+    if tunnel_started_at
+      scope = scope.where(created_at: tunnel_started_at..)
     end
+    scope
+  end
+
+  def current_schema_hash
+    @current_schema_hash ||= Digest::SHA256.hexdigest(draft.schema_to_llm.to_json)
+  end
+
+  def first_rule_suggestion
+    @first_rule_suggestion ||= LLM::TunnelFinder.new(draft.id).first_step
+  end
+
+  def suggestion_items_attributes
+    params.require(:llm_rule_suggestion)
+      .permit(llm_rule_suggestion_items_attributes: [:id, :verify_status])
   end
 end

--- a/app/mailers/concerns/mailer_monitoring_concern.rb
+++ b/app/mailers/concerns/mailer_monitoring_concern.rb
@@ -4,7 +4,7 @@ module MailerMonitoringConcern
   extend ActiveSupport::Concern
 
   included do
-    # Don’t retry to send a message if the server rejects the recipient address
+    # Don't retry to send a message if the server rejects the recipient address
     rescue_from Net::SMTPSyntaxError do |_exception|
       message.perform_deliveries = false
     end
@@ -14,9 +14,9 @@ module MailerMonitoringConcern
         message.perform_deliveries = false
       end
     end
+  end
 
-    def log_delivery_error(exception)
-      EmailEvent.create_from_message!(message, status: "dispatch_error")
-    end
+  def log_delivery_error(exception)
+    EmailEvent.create_from_message!(message, status: "dispatch_error")
   end
 end

--- a/app/mailers/concerns/priority_delivery_concern.rb
+++ b/app/mailers/concerns/priority_delivery_concern.rb
@@ -2,36 +2,39 @@
 
 module PriorityDeliveryConcern
   extend ActiveSupport::Concern
+
   included do
     self.delivery_job = PriorizedMailDeliveryJob
 
     before_action :set_critical_header, if: :critical_email?
     before_action :set_forced_delivery_method_header, if: :should_force_delivery?
+  end
 
-    def self.critical_email?(action_name)
+  class_methods do
+    def critical_email?(action_name)
       raise NotImplementedError
     end
+  end
 
-    def critical_email?
-      self.class.critical_email?(action_name)
-    end
+  def critical_email?
+    self.class.critical_email?(action_name)
+  end
 
-    def bypass_unverified_mail_protection!
-      headers[BalancerDeliveryMethod::BYPASS_UNVERIFIED_MAIL_PROTECTION] = true
-    end
+  def bypass_unverified_mail_protection!
+    headers[BalancerDeliveryMethod::BYPASS_UNVERIFIED_MAIL_PROTECTION] = true
+  end
 
-    private
+  private
 
-    def set_critical_header
-      headers[BalancerDeliveryMethod::CRITICAL_HEADER] = true
-    end
+  def set_critical_header
+    headers[BalancerDeliveryMethod::CRITICAL_HEADER] = true
+  end
 
-    def should_force_delivery?
-      SafeMailer.forced_delivery_method.present? && critical_email?
-    end
+  def should_force_delivery?
+    SafeMailer.forced_delivery_method.present? && critical_email?
+  end
 
-    def set_forced_delivery_method_header
-      headers[BalancerDeliveryMethod::FORCE_DELIVERY_METHOD_HEADER] = SafeMailer.forced_delivery_method
-    end
+  def set_forced_delivery_method_header
+    headers[BalancerDeliveryMethod::FORCE_DELIVERY_METHOD_HEADER] = SafeMailer.forced_delivery_method
   end
 end

--- a/app/models/concerns/addressable_column_concern.rb
+++ b/app/models/concerns/addressable_column_concern.rb
@@ -3,26 +3,24 @@
 module AddressableColumnConcern
   extend ActiveSupport::Concern
 
-  included do
-    def addressable_columns(procedure:, displayable: true, prefix: nil)
-      [
-        ["Code postal (5 chiffres)", '$.postal_code', :text, []],
-        ["Commune", '$.city_name', :text, []],
-        ["Département", '$.department_code', :enum, APIGeoService.departement_options],
-        ["Région", '$.region_name', :enum, APIGeoService.region_options],
-      ].map do |(label, jsonpath, type, options_for_select)|
-        Columns::JSONPathColumn.new(
-          procedure_id: procedure.id,
-          stable_id:,
-          tdc_type: type_champ,
-          label: "#{libelle_with_prefix(prefix)} – #{label}",
-          jsonpath:,
-          displayable:,
-          options_for_select:,
-          type:,
-          mandatory: mandatory?
-        )
-      end
+  def addressable_columns(procedure:, displayable: true, prefix: nil)
+    [
+      ["Code postal (5 chiffres)", '$.postal_code', :text, []],
+      ["Commune", '$.city_name', :text, []],
+      ["Département", '$.department_code', :enum, APIGeoService.departement_options],
+      ["Région", '$.region_name', :enum, APIGeoService.region_options],
+    ].map do |(label, jsonpath, type, options_for_select)|
+      Columns::JSONPathColumn.new(
+        procedure_id: procedure.id,
+        stable_id:,
+        tdc_type: type_champ,
+        label: "#{libelle_with_prefix(prefix)} – #{label}",
+        jsonpath:,
+        displayable:,
+        options_for_select:,
+        type:,
+        mandatory: mandatory?
+      )
     end
   end
 end

--- a/app/models/concerns/api_entreprise_token_concern.rb
+++ b/app/models/concerns/api_entreprise_token_concern.rb
@@ -5,15 +5,15 @@ module APIEntrepriseTokenConcern
 
   included do
     validates_associated :api_entreprise_token
+  end
 
-    def api_entreprise_token
-      t = self[:api_entreprise_token].presence || ENV['API_ENTREPRISE_KEY']
+  def api_entreprise_token
+    t = self[:api_entreprise_token].presence || ENV['API_ENTREPRISE_KEY']
 
-      APIEntrepriseToken.new(t)
-    end
+    APIEntrepriseToken.new(t)
+  end
 
-    def specific_api_entreprise_token?
-      self[:api_entreprise_token].present?
-    end
+  def specific_api_entreprise_token?
+    self[:api_entreprise_token].present?
   end
 end

--- a/app/models/concerns/blob_image_processor_concern.rb
+++ b/app/models/concerns/blob_image_processor_concern.rb
@@ -3,63 +3,57 @@
 module BlobImageProcessorConcern
   extend ActiveSupport::Concern
 
-  included do
-    def watermark_pending?
-      watermark_required? && !watermark_done?
+  def watermark_pending?
+    watermark_required? && !watermark_done?
+  end
+
+  def watermark_done?
+    watermarked_at.present?
+  end
+
+  def representation_required?
+    from_champ? || from_messagerie? || logo? || from_action_text? || from_avis? || from_justificatif_motivation? || from_attestation?
+  end
+
+  private
+
+  def from_champ?
+    attachments.any? { _1.record.class == Champs::TitreIdentiteChamp || _1.record.class == Champs::PieceJustificativeChamp }
+  end
+
+  def from_messagerie?
+    attachments.any? { _1.record.class == Commentaire }
+  end
+
+  def logo?
+    attachments.any? { _1.name == 'logo' }
+  end
+
+  def from_action_text?
+    attachments.any? { _1.record.class == ActionText::RichText }
+  end
+
+  def from_avis?
+    attachments.any? { _1.record.class == Avis }
+  end
+
+  def from_justificatif_motivation?
+    attachments.any? { _1.name == 'justificatif_motivation' }
+  end
+
+  def watermark_required?
+    attachments.any? do |attachment|
+      record = attachment.record
+      next true if record.is_a?(Champs::TitreIdentiteChamp)
+      next if !record.is_a?(Champs::PieceJustificativeChamp)
+
+      # dossier's preloaded revision to avoid N+1 queries
+      type_de_champ = record.dossier.revision.types_de_champ.find { _1.stable_id == record.stable_id }
+      type_de_champ&.titre_identite_nature?
     end
+  end
 
-    def watermark_done?
-      watermarked_at.present?
-    end
-
-    def representation_required?
-      from_champ? || from_messagerie? || logo? || from_action_text? || from_avis? || from_justificatif_motivation? || from_attestation?
-    end
-
-    private
-
-    def from_champ?
-      attachments.any? { _1.record.class == Champs::TitreIdentiteChamp || _1.record.class == Champs::PieceJustificativeChamp }
-    end
-
-    def from_messagerie?
-      attachments.any? { _1.record.class == Commentaire }
-    end
-
-    def logo?
-      attachments.any? { _1.name == 'logo' }
-    end
-
-    def from_action_text?
-      attachments.any? { _1.record.class == ActionText::RichText }
-    end
-
-    def from_avis?
-      attachments.any? { _1.record.class == Avis }
-    end
-
-    def from_justificatif_motivation?
-      attachments.any? { _1.name == 'justificatif_motivation' }
-    end
-
-    def watermark_required?
-      attachments.any? do |attachment|
-        record = attachment.record
-        next true if record.is_a?(Champs::TitreIdentiteChamp)
-        next if !record.is_a?(Champs::PieceJustificativeChamp)
-
-        # dossier's preloaded revision to avoid N+1 queries
-        type_de_champ = record.dossier.revision.types_de_champ.find { _1.stable_id == record.stable_id }
-        type_de_champ&.titre_identite_nature?
-      end
-    end
-
-    def from_justificatif_motivation?
-      attachments.any? { _1.name == 'justificatif_motivation' }
-    end
-
-    def from_attestation?
-      attachments.any? { _1.record.class == Attestation }
-    end
+  def from_attestation?
+    attachments.any? { _1.record.class == Attestation }
   end
 end

--- a/app/models/concerns/blob_signed_id_concern.rb
+++ b/app/models/concerns/blob_signed_id_concern.rb
@@ -3,12 +3,10 @@
 module BlobSignedIdConcern
   extend ActiveSupport::Concern
 
-  included do
-    # We override signed_id to add `expires_in` option to generated hash.
-    # This is a measure to ensure that we never under any circumstance
-    # expose permanent attachment url
-    def signed_id(**options)
-      ActiveStorage.verifier.generate(id, **options, purpose: :blob_id, expires_in: Rails.application.config.active_storage.service_urls_expire_in)
-    end
+  # We override signed_id to add `expires_in` option to generated hash.
+  # This is a measure to ensure that we never under any circumstance
+  # expose permanent attachment url
+  def signed_id(**options)
+    ActiveStorage.verifier.generate(id, **options, purpose: :blob_id, expires_in: Rails.application.config.active_storage.service_urls_expire_in)
   end
 end

--- a/app/models/concerns/champ_conditional_concern.rb
+++ b/app/models/concerns/champ_conditional_concern.rb
@@ -3,67 +3,65 @@
 module ChampConditionalConcern
   extend ActiveSupport::Concern
 
-  included do
-    def conditional?
-      type_de_champ.read_attribute_before_type_cast('condition').present?
+  def conditional?
+    type_de_champ.read_attribute_before_type_cast('condition').present?
+  end
+
+  def dependent_conditions?
+    dossier.revision.dependent_conditions(type_de_champ).any?
+  end
+
+  def visible?
+    # Huge gain perf for cascade conditions
+    return @visible if instance_variable_defined? :@visible
+
+    return false if parent_hidden?
+
+    @visible = if conditional?
+      type_de_champ.condition.compute(champs_for_condition)
+    else
+      true
     end
+  end
 
-    def dependent_conditions?
-      dossier.revision.dependent_conditions(type_de_champ).any?
+  def submitted_filled?
+    return false if dossier.submitted_revision_id.blank?
+    return false if dossier.submitted_revision_id == dossier.revision_id
+
+    !type_de_champ.champ_blank?(self)
+  end
+
+  def reset_visible # recompute after a dossier update
+    remove_instance_variable :@visible if instance_variable_defined? :@visible
+    remove_instance_variable :@champs_for_condition if instance_variable_defined? :@champs_for_condition
+  end
+
+  private
+
+  def champs_for_condition
+    if row_id.nil?
+      Array(filled_champs_by_row_id[nil])
+    else
+      Array(filled_champs_by_row_id[row_id]) + Array(filled_champs_by_row_id[nil])
     end
+  end
 
-    def visible?
-      # Huge gain perf for cascade conditions
-      return @visible if instance_variable_defined? :@visible
+  def filled_champs_by_row_id
+    @filled_champs_by_row_id ||= dossier.filled_champs.group_by(&:row_id)
+  end
 
-      return false if parent_hidden?
+  def parent_hidden?
+    # if there is no row_id, it always has been a root champ
+    return false if !child?
 
-      @visible = if conditional?
-        type_de_champ.condition.compute(champs_for_condition)
-      else
-        true
-      end
-    end
+    # otherwise maybe the champ has been moved outside a repetition
+    parent_tdc = dossier.revision.parent_of(type_de_champ)
 
-    def submitted_filled?
-      return false if dossier.submitted_revision_id.blank?
-      return false if dossier.submitted_revision_id == dossier.revision_id
+    return false if parent_tdc.nil?
 
-      !type_de_champ.champ_blank?(self)
-    end
+    parent = dossier.project_champs
+      .find { it.type_de_champ == parent_tdc }
 
-    def reset_visible # recompute after a dossier update
-      remove_instance_variable :@visible if instance_variable_defined? :@visible
-      remove_instance_variable :@champs_for_condition if instance_variable_defined? :@champs_for_condition
-    end
-
-    private
-
-    def champs_for_condition
-      if row_id.nil?
-        Array(filled_champs_by_row_id[nil])
-      else
-        Array(filled_champs_by_row_id[row_id]) + Array(filled_champs_by_row_id[nil])
-      end
-    end
-
-    def filled_champs_by_row_id
-      @filled_champs_by_row_id ||= dossier.filled_champs.group_by(&:row_id)
-    end
-
-    def parent_hidden?
-      # if there is no row_id, it always has been a root champ
-      return false if !child?
-
-      # otherwise maybe the champ has been moved outside a repetition
-      parent_tdc = dossier.revision.parent_of(type_de_champ)
-
-      return false if parent_tdc.nil?
-
-      parent = dossier.project_champs
-        .find { it.type_de_champ == parent_tdc }
-
-      !parent.visible?
-    end
+    !parent.visible?
   end
 end

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -62,64 +62,64 @@ module ChampExternalDataConcern
         transitions from: [:idle, :waiting_for_job, :fetching, :fetched, :external_error], to: :idle
       end
     end
+  end
 
-    def pending? = waiting_for_job? || fetching?
-    def done? = fetched? || external_error?
+  def pending? = waiting_for_job? || fetching?
+  def done? = fetched? || external_error?
 
-    def has_async_external_data? = false
+  def has_async_external_data? = false
 
-    def external_data_needed_for_validation? = has_async_external_data?
+  def external_data_needed_for_validation? = has_async_external_data?
 
-    private
+  private
 
-    def ready_for_external_call? = external_id.present?
+  def ready_for_external_call? = external_id.present?
 
-    def fetch_external_data_later(wait: nil)
-      ChampFetchExternalDataJob.set(wait:).perform_later(self, external_id)
-    end
+  def fetch_external_data_later(wait: nil)
+    ChampFetchExternalDataJob.set(wait:).perform_later(self, external_id)
+  end
 
-    # it should only be called after fetch! event callback
-    def fetch_and_handle_result
-      fetch_external_data.then { handle_result(it) }
-    end
+  # it should only be called after fetch! event callback
+  def fetch_and_handle_result
+    fetch_external_data.then { handle_result(it) }
+  end
 
-    def fetch_external_data
-      raise NotImplemented.new(:fetch_external_data)
-    end
+  def fetch_external_data
+    raise NotImplemented.new(:fetch_external_data)
+  end
 
-    def handle_result(result)
-      if result.is_a?(Dry::Monads::Result)
-        case result
-        in Success(hash)
-          update_external_data!(hash)
-          external_data_fetched!
-        in Failure(retryable: true, reason:, code:)
-          save_external_exception(reason, code)
-          retry!
-          raise RetryableFetchError.new(reason)
-        in Failure(retryable: false, reason:, code:)
-          save_external_exception(reason, code)
-          Sentry.capture_exception(reason) if code != 404
-          external_data_error!
-        end
-      elsif result.present?
-        update_external_data!(data: result)
+  def handle_result(result)
+    if result.is_a?(Dry::Monads::Result)
+      case result
+      in Success(hash)
+        update_external_data!(hash)
         external_data_fetched!
+      in Failure(retryable: true, reason:, code:)
+        save_external_exception(reason, code)
+        retry!
+        raise RetryableFetchError.new(reason)
+      in Failure(retryable: false, reason:, code:)
+        save_external_exception(reason, code)
+        Sentry.capture_exception(reason) if code != 404
+        external_data_error!
       end
+    elsif result.present?
+      update_external_data!(data: result)
+      external_data_fetched!
     end
+  end
 
-    def update_external_data!(hash)
-      update!(hash.merge(fetch_external_data_exceptions: []))
-    end
+  def update_external_data!(hash)
+    update!(hash.merge(fetch_external_data_exceptions: []))
+  end
 
-    def save_external_exception(exception, code)
-      exceptions = fetch_external_data_exceptions || []
-      exceptions << ExternalDataException.new(reason: exception.inspect, code:)
-      update_columns(fetch_external_data_exceptions: exceptions)
-    end
+  def save_external_exception(exception, code)
+    exceptions = fetch_external_data_exceptions || []
+    exceptions << ExternalDataException.new(reason: exception.inspect, code:)
+    update_columns(fetch_external_data_exceptions: exceptions)
+  end
 
-    def after_reset_external_data(opts = {})
-      update(opts.merge(data: nil, value_json: nil, fetch_external_data_exceptions: []))
-    end
+  def after_reset_external_data(opts = {})
+    update(opts.merge(data: nil, value_json: nil, fetch_external_data_exceptions: []))
   end
 end

--- a/app/models/concerns/champ_validate_concern.rb
+++ b/app/models/concerns/champ_validate_concern.rb
@@ -5,32 +5,32 @@ module ChampValidateConcern
 
   included do
     validates_with ExternalDataChampValidator, if: :validate_external_data_response?
+  end
 
-    private
+  private
 
-    def should_validate_in_current_context?
-      case validation_context
-      when :champs_public_value
-        public? && is_validation_relevant? && visible?
-      when :champs_private_value
-        private? && is_validation_relevant? && visible?
-      when :prefill
-        true
-      else
-        false
-      end
+  def should_validate_in_current_context?
+    case validation_context
+    when :champs_public_value
+      public? && is_validation_relevant? && visible?
+    when :champs_private_value
+      private? && is_validation_relevant? && visible?
+    when :prefill
+      true
+    else
+      false
     end
+  end
 
-    def is_validation_relevant?
-      in_dossier_stream? && in_dossier_revision? && is_same_type_as_revision? && !in_discarded_row?
-    end
+  def is_validation_relevant?
+    in_dossier_stream? && in_dossier_revision? && is_same_type_as_revision? && !in_discarded_row?
+  end
 
-    def in_dossier_stream?
-      dossier.stream == stream
-    end
+  def in_dossier_stream?
+    dossier.stream == stream
+  end
 
-    def validate_external_data_response?
-      should_validate_in_current_context? && has_async_external_data? && external_data_needed_for_validation?
-    end
+  def validate_external_data_response?
+    should_validate_in_current_context? && has_async_external_data? && external_data_needed_for_validation?
   end
 end

--- a/app/models/concerns/columns_concern.rb
+++ b/app/models/concerns/columns_concern.rb
@@ -3,240 +3,238 @@
 module ColumnsConcern
   extend ActiveSupport::Concern
 
-  included do
-    # we cannot use column.id ( == { procedure_id, column_id }.to_json)
-    # as the order of the keys is not guaranteed
-    # instead, we are using h_id == { procedure_id:, column_id: }
-    # another way to find a column is to look for its label
-    def find_column(h_id: nil, label: nil)
-      column = columns.find { _1.h_id == h_id } if h_id.present?
-      column = columns.find { _1.label == label } if label.present?
+  # we cannot use column.id ( == { procedure_id, column_id }.to_json)
+  # as the order of the keys is not guaranteed
+  # instead, we are using h_id == { procedure_id:, column_id: }
+  # another way to find a column is to look for its label
+  def find_column(h_id: nil, label: nil)
+    column = columns.find { _1.h_id == h_id } if h_id.present?
+    column = columns.find { _1.label == label } if label.present?
 
-      # TODO: to remove after linked_drop_down column column_id migration
-      if column.nil? && h_id.is_a?(Hash) && h_id[:column_id].present?
-        new_column_id = h_id[:column_id]
-          .gsub('->', '.')
-          .gsub('departement_code', 'department_code')
-          .gsub('naf', 'code_naf')
+    # TODO: to remove after linked_drop_down column column_id migration
+    if column.nil? && h_id.is_a?(Hash) && h_id[:column_id].present?
+      new_column_id = h_id[:column_id]
+        .gsub('->', '.')
+        .gsub('departement_code', 'department_code')
+        .gsub('naf', 'code_naf')
 
-        h_id[:column_id] = new_column_id
+      h_id[:column_id] = new_column_id
 
-        column = columns.find { _1.h_id == h_id }
-      end
-
-      raise ActiveRecord::RecordNotFound.new("Column: unable to find h_id: #{h_id} or label: #{label} for procedure_id #{id}") if column.nil?
-
-      column
+      column = columns.find { _1.h_id == h_id }
     end
 
-    def columns
-      Current.procedure_columns ||= {}
+    raise ActiveRecord::RecordNotFound.new("Column: unable to find h_id: #{h_id} or label: #{label} for procedure_id #{id}") if column.nil?
 
-      Current.procedure_columns[id] ||= begin
-        columns = dossier_columns
-        columns.concat(standard_columns)
-        columns.concat(individual_columns) if for_individual
-        columns.concat(moral_columns) if !for_individual
-        columns.concat(procedure_chorus_columns) if chorusable? && chorus_configuration.complete?
-        columns.concat(types_de_champ_columns)
-      end
-    end
+    column
+  end
 
-    def usager_columns_for_export
-      columns = [dossier_id_column, user_email_for_display_column, user_france_connected_column]
+  def columns
+    Current.procedure_columns ||= {}
+
+    Current.procedure_columns[id] ||= begin
+      columns = dossier_columns
+      columns.concat(standard_columns)
       columns.concat(individual_columns) if for_individual
       columns.concat(moral_columns) if !for_individual
       columns.concat(procedure_chorus_columns) if chorusable? && chorus_configuration.complete?
-
-      # ensure the columns exist in main list
-      # otherwise, they will be found by the find_column method
-      columns.filter { _1.id.in?(self.columns.map(&:id)) }
+      columns.concat(types_de_champ_columns)
     end
-
-    def dossier_columns_for_export
-      columns = [dossier_state_column, dossier_archived_column]
-      columns.concat(dossier_dates_columns)
-      columns.concat([dossier_motivation_column])
-      columns.concat(sva_svr_columns(for_export: true)) if sva_svr_enabled?
-      columns.concat([dossier_accuse_lecture_agreement_at_column]) if accuse_lecture?
-      columns.concat([groupe_instructeurs_id_column, followers_instructeurs_email_column])
-      columns.concat([dossier_labels_column])
-
-      # ensure the columns exist in main list
-      # otherwise, they will be found by the find_column method
-      columns.filter { _1.id.in?(self.columns.map(&:id)) }
-    end
-
-    def dossier_id_column = dossier_col(table: 'self', column: 'id', type: :integer)
-
-    def dossier_state_column
-      options_for_select = I18n.t('instructeurs.dossiers.filterable_state').map(&:to_a).map(&:reverse)
-
-      dossier_col(table: 'self', column: 'state', type: :enum, options_for_select:, displayable: false)
-    end
-
-    def notifications_column = dossier_col(table: 'notifications', column: 'notifications', label: "notifications", filterable: false, displayable: false)
-
-    def dossier_notifications_column
-      options_for_select = I18n.t('instructeurs.dossiers.filterable_notification').map(&:to_a).map(&:reverse)
-
-      dossier_col(table: 'dossier_notifications', column: 'notification_type', type: :enum, options_for_select:, displayable: false)
-    end
-
-    def sva_svr_columns(for_export: false)
-      scope = [:activerecord, :attributes, :procedure_presentation, :fields, :self]
-
-      columns = [
-        dossier_col(table: 'self', column: 'sva_svr_decision_on', type: :date,
-                  label: I18n.t("#{sva_svr_decision}_decision_on", scope:, type: sva_svr_configuration.human_decision)),
-      ]
-      if !for_export
-        columns << dossier_col(table: 'self', column: 'sva_svr_decision_before', type: :date, displayable: false,
-                      label: I18n.t("#{sva_svr_decision}_decision_before", scope:))
-      end
-      columns
-    end
-
-    def default_sorted_column
-      SortedColumn.new(column: notifications_column, order: 'desc')
-    end
-
-    def default_displayed_columns = [email_column]
-
-    def dossier_filterable_columns
-      dossier_columns
-        .concat([dossier_labels_column])
-        .concat([dossier_notifications_column])
-        .filter(&:filterable)
-    end
-
-    def instructeurs_filterable_columns
-      Array([groupe_instructeurs_id_column, followers_instructeurs_email_column]).filter(&:filterable)
-    end
-
-    def usager_filterable_columns
-      columns = []
-      if for_individual?
-        columns.concat(individual_columns)
-      else
-        columns.concat(moral_columns)
-      end
-      columns.concat([email_column])
-      columns.filter(&:filterable)
-    end
-
-    def form_filterable_columns
-      all_revisions_types_de_champ.public_only.flat_map { _1.columns(procedure: self) }.filter(&:filterable)
-    end
-
-    def annotation_privees_filterable_columns
-      all_revisions_types_de_champ.private_only.flat_map { _1.columns(procedure: self) }.filter(&:filterable)
-    end
-
-    private
-
-    def groupe_instructeurs_id_column = dossier_col(table: 'groupe_instructeur', column: 'id', type: :enum)
-
-    def followers_instructeurs_email_column = dossier_col(table: 'followers_instructeurs', column: 'email')
-
-    def dossier_archived_column = dossier_col(table: 'self', column: 'archived', type: :boolean, displayable: false, filterable: false);
-
-    def dossier_motivation_column = dossier_col(table: 'self', column: 'motivation', type: :text, displayable: false, filterable: false);
-
-    def user_email_for_display_column = dossier_col(table: 'self', column: 'user_email_for_display', filterable: false, displayable: false)
-
-    def user_france_connected_column = dossier_col(table: 'self', column: 'user_from_france_connect?', type: :boolean, filterable: false, displayable: false)
-
-    def dossier_labels_column = dossier_col(table: 'dossier_labels', column: 'label_id', type: :enum, options_for_select: labels.map { [_1.name, _1.id] })
-
-    def traitements_email_column = dossier_col(table: 'traitements', column: 'instructeur_email', filterable: true, displayable: false)
-
-    def procedure_chorus_columns
-      ['domaine_fonctionnel', 'referentiel_prog', 'centre_de_cout']
-        .map { |column| dossier_col(table: 'procedure', column:, displayable: false, filterable: false) }
-    end
-
-    def dossier_non_displayable_dates_columns
-      ['updated_since', 'depose_since', 'en_construction_since', 'en_instruction_since', 'processed_since']
-        .map { |column| dossier_col(table: 'self', column:, type: :date, displayable: false, filterable: false) }
-    end
-
-    def dossier_dates_columns
-      ['created_at', 'updated_at', 'last_champ_updated_at', 'depose_at', 'en_construction_at', 'en_instruction_at', 'processed_at', 'expired_at']
-        .map { |column| dossier_col(table: 'self', column:, type: :datetime) }
-    end
-
-    def dossier_accuse_lecture_agreement_at_column = dossier_col(table: 'self', column: 'accuse_lecture_agreement_at', type: :date, filterable: false)
-
-    def email_column
-      dossier_col(table: 'user', column: 'email')
-    end
-
-    def dossier_columns
-      columns = [dossier_id_column, notifications_column]
-      columns.concat([dossier_state_column])
-      columns.concat([dossier_archived_column])
-      columns.concat(dossier_dates_columns)
-      columns.concat([dossier_motivation_column])
-      columns.concat([dossier_accuse_lecture_agreement_at_column]) if accuse_lecture?
-      columns.concat(sva_svr_columns(for_export: false)) if sva_svr_enabled?
-      columns.concat(dossier_non_displayable_dates_columns)
-      columns.concat([Columns::ReadAgreementColumn.new(procedure_id: id)]) if accuse_lecture?
-      columns
-    end
-
-    def standard_columns
-      [
-        email_column,
-        user_email_for_display_column,
-        followers_instructeurs_email_column,
-        groupe_instructeurs_id_column,
-        dossier_col(table: 'avis', column: 'question_answer', filterable: false),
-        user_france_connected_column,
-        dossier_labels_column,
-        dossier_notifications_column,
-        traitements_email_column,
-      ]
-    end
-
-    def individual_columns
-      @individual_columns = []
-
-      @individual_columns << dossier_col(
-        table: 'individual',
-        column: 'gender',
-        type: :enum,
-        options_for_select: [
-          [Individual::GENDER_FEMALE, Individual::GENDER_FEMALE],
-          [Individual::GENDER_MALE, Individual::GENDER_MALE],
-        ]
-      ) unless self.no_gender?
-
-      @individual_columns
-        .concat ['nom', 'prenom'].map { |column| dossier_col(table: 'individual', column:) }
-        .concat ['mandataire_last_name', 'mandataire_first_name'].map { |column| dossier_col(table: 'self', column:) }
-        .concat ['for_tiers'].map { |column| dossier_col(table: 'self', column:, type: :boolean, options_for_select: Champs::YesNoChamp.options) }
-    end
-
-    def moral_columns
-      siret_column = dossier_col(table: 'etablissement', column: :siret)
-
-      etablissements = Etablissement::DISPLAYABLE_COLUMNS.map do |(column, attributes)|
-        dossier_col(table: 'etablissement', column:, type: attributes[:type], filterable: attributes.fetch(:filterable, true))
-      end
-
-      others = %w[code_postal].map { |column| dossier_col(table: 'etablissement', column:) }
-
-      for_export = Etablissement::EXPORTABLE_ETABLISSEMENT_COLUMNS.map { |(column, attributes)| dossier_col(table: 'etablissement', column:, type: attributes[:type]) }
-      for_export += Etablissement::EXPORTABLE_ASSOCIATION_COLUMNS.map { |(column, attributes)| dossier_col(table: 'etablissement', column:, type: attributes[:type]) }
-
-      [siret_column, etablissements, others, for_export].flatten
-    end
-
-    def types_de_champ_columns
-      all_revisions_types_de_champ.flat_map { _1.columns(procedure: self) }
-    end
-
-    def dossier_col(**args) = Columns::DossierColumn.new(**(args.merge(procedure_id: id)))
   end
+
+  def usager_columns_for_export
+    columns = [dossier_id_column, user_email_for_display_column, user_france_connected_column]
+    columns.concat(individual_columns) if for_individual
+    columns.concat(moral_columns) if !for_individual
+    columns.concat(procedure_chorus_columns) if chorusable? && chorus_configuration.complete?
+
+    # ensure the columns exist in main list
+    # otherwise, they will be found by the find_column method
+    columns.filter { _1.id.in?(self.columns.map(&:id)) }
+  end
+
+  def dossier_columns_for_export
+    columns = [dossier_state_column, dossier_archived_column]
+    columns.concat(dossier_dates_columns)
+    columns.concat([dossier_motivation_column])
+    columns.concat(sva_svr_columns(for_export: true)) if sva_svr_enabled?
+    columns.concat([dossier_accuse_lecture_agreement_at_column]) if accuse_lecture?
+    columns.concat([groupe_instructeurs_id_column, followers_instructeurs_email_column])
+    columns.concat([dossier_labels_column])
+
+    # ensure the columns exist in main list
+    # otherwise, they will be found by the find_column method
+    columns.filter { _1.id.in?(self.columns.map(&:id)) }
+  end
+
+  def dossier_id_column = dossier_col(table: 'self', column: 'id', type: :integer)
+
+  def dossier_state_column
+    options_for_select = I18n.t('instructeurs.dossiers.filterable_state').map(&:to_a).map(&:reverse)
+
+    dossier_col(table: 'self', column: 'state', type: :enum, options_for_select:, displayable: false)
+  end
+
+  def notifications_column = dossier_col(table: 'notifications', column: 'notifications', label: "notifications", filterable: false, displayable: false)
+
+  def dossier_notifications_column
+    options_for_select = I18n.t('instructeurs.dossiers.filterable_notification').map(&:to_a).map(&:reverse)
+
+    dossier_col(table: 'dossier_notifications', column: 'notification_type', type: :enum, options_for_select:, displayable: false)
+  end
+
+  def sva_svr_columns(for_export: false)
+    scope = [:activerecord, :attributes, :procedure_presentation, :fields, :self]
+
+    columns = [
+      dossier_col(table: 'self', column: 'sva_svr_decision_on', type: :date,
+                label: I18n.t("#{sva_svr_decision}_decision_on", scope:, type: sva_svr_configuration.human_decision)),
+    ]
+    if !for_export
+      columns << dossier_col(table: 'self', column: 'sva_svr_decision_before', type: :date, displayable: false,
+                    label: I18n.t("#{sva_svr_decision}_decision_before", scope:))
+    end
+    columns
+  end
+
+  def default_sorted_column
+    SortedColumn.new(column: notifications_column, order: 'desc')
+  end
+
+  def default_displayed_columns = [email_column]
+
+  def dossier_filterable_columns
+    dossier_columns
+      .concat([dossier_labels_column])
+      .concat([dossier_notifications_column])
+      .filter(&:filterable)
+  end
+
+  def instructeurs_filterable_columns
+    Array([groupe_instructeurs_id_column, followers_instructeurs_email_column]).filter(&:filterable)
+  end
+
+  def usager_filterable_columns
+    columns = []
+    if for_individual?
+      columns.concat(individual_columns)
+    else
+      columns.concat(moral_columns)
+    end
+    columns.concat([email_column])
+    columns.filter(&:filterable)
+  end
+
+  def form_filterable_columns
+    all_revisions_types_de_champ.public_only.flat_map { _1.columns(procedure: self) }.filter(&:filterable)
+  end
+
+  def annotation_privees_filterable_columns
+    all_revisions_types_de_champ.private_only.flat_map { _1.columns(procedure: self) }.filter(&:filterable)
+  end
+
+  private
+
+  def groupe_instructeurs_id_column = dossier_col(table: 'groupe_instructeur', column: 'id', type: :enum)
+
+  def followers_instructeurs_email_column = dossier_col(table: 'followers_instructeurs', column: 'email')
+
+  def dossier_archived_column = dossier_col(table: 'self', column: 'archived', type: :boolean, displayable: false, filterable: false);
+
+  def dossier_motivation_column = dossier_col(table: 'self', column: 'motivation', type: :text, displayable: false, filterable: false);
+
+  def user_email_for_display_column = dossier_col(table: 'self', column: 'user_email_for_display', filterable: false, displayable: false)
+
+  def user_france_connected_column = dossier_col(table: 'self', column: 'user_from_france_connect?', type: :boolean, filterable: false, displayable: false)
+
+  def dossier_labels_column = dossier_col(table: 'dossier_labels', column: 'label_id', type: :enum, options_for_select: labels.map { [_1.name, _1.id] })
+
+  def traitements_email_column = dossier_col(table: 'traitements', column: 'instructeur_email', filterable: true, displayable: false)
+
+  def procedure_chorus_columns
+    ['domaine_fonctionnel', 'referentiel_prog', 'centre_de_cout']
+      .map { |column| dossier_col(table: 'procedure', column:, displayable: false, filterable: false) }
+  end
+
+  def dossier_non_displayable_dates_columns
+    ['updated_since', 'depose_since', 'en_construction_since', 'en_instruction_since', 'processed_since']
+      .map { |column| dossier_col(table: 'self', column:, type: :date, displayable: false, filterable: false) }
+  end
+
+  def dossier_dates_columns
+    ['created_at', 'updated_at', 'last_champ_updated_at', 'depose_at', 'en_construction_at', 'en_instruction_at', 'processed_at', 'expired_at']
+      .map { |column| dossier_col(table: 'self', column:, type: :datetime) }
+  end
+
+  def dossier_accuse_lecture_agreement_at_column = dossier_col(table: 'self', column: 'accuse_lecture_agreement_at', type: :date, filterable: false)
+
+  def email_column
+    dossier_col(table: 'user', column: 'email')
+  end
+
+  def dossier_columns
+    columns = [dossier_id_column, notifications_column]
+    columns.concat([dossier_state_column])
+    columns.concat([dossier_archived_column])
+    columns.concat(dossier_dates_columns)
+    columns.concat([dossier_motivation_column])
+    columns.concat([dossier_accuse_lecture_agreement_at_column]) if accuse_lecture?
+    columns.concat(sva_svr_columns(for_export: false)) if sva_svr_enabled?
+    columns.concat(dossier_non_displayable_dates_columns)
+    columns.concat([Columns::ReadAgreementColumn.new(procedure_id: id)]) if accuse_lecture?
+    columns
+  end
+
+  def standard_columns
+    [
+      email_column,
+      user_email_for_display_column,
+      followers_instructeurs_email_column,
+      groupe_instructeurs_id_column,
+      dossier_col(table: 'avis', column: 'question_answer', filterable: false),
+      user_france_connected_column,
+      dossier_labels_column,
+      dossier_notifications_column,
+      traitements_email_column,
+    ]
+  end
+
+  def individual_columns
+    @individual_columns = []
+
+    @individual_columns << dossier_col(
+      table: 'individual',
+      column: 'gender',
+      type: :enum,
+      options_for_select: [
+        [Individual::GENDER_FEMALE, Individual::GENDER_FEMALE],
+        [Individual::GENDER_MALE, Individual::GENDER_MALE],
+      ]
+    ) unless self.no_gender?
+
+    @individual_columns
+      .concat ['nom', 'prenom'].map { |column| dossier_col(table: 'individual', column:) }
+      .concat ['mandataire_last_name', 'mandataire_first_name'].map { |column| dossier_col(table: 'self', column:) }
+      .concat ['for_tiers'].map { |column| dossier_col(table: 'self', column:, type: :boolean, options_for_select: Champs::YesNoChamp.options) }
+  end
+
+  def moral_columns
+    siret_column = dossier_col(table: 'etablissement', column: :siret)
+
+    etablissements = Etablissement::DISPLAYABLE_COLUMNS.map do |(column, attributes)|
+      dossier_col(table: 'etablissement', column:, type: attributes[:type], filterable: attributes.fetch(:filterable, true))
+    end
+
+    others = %w[code_postal].map { |column| dossier_col(table: 'etablissement', column:) }
+
+    for_export = Etablissement::EXPORTABLE_ETABLISSEMENT_COLUMNS.map { |(column, attributes)| dossier_col(table: 'etablissement', column:, type: attributes[:type]) }
+    for_export += Etablissement::EXPORTABLE_ASSOCIATION_COLUMNS.map { |(column, attributes)| dossier_col(table: 'etablissement', column:, type: attributes[:type]) }
+
+    [siret_column, etablissements, others, for_export].flatten
+  end
+
+  def types_de_champ_columns
+    all_revisions_types_de_champ.flat_map { _1.columns(procedure: self) }
+  end
+
+  def dossier_col(**args) = Columns::DossierColumn.new(**(args.merge(procedure_id: id)))
 end

--- a/app/models/concerns/domain_migratable_concern.rb
+++ b/app/models/concerns/domain_migratable_concern.rb
@@ -7,14 +7,14 @@ module DomainMigratableConcern
     enum :preferred_domain, { demarche_numerique_gouv_fr: 0, demarches_simplifiees_fr: 1 }, prefix: true
 
     validates :preferred_domain, inclusion: { in: User.preferred_domains.keys, allow_nil: true }
+  end
 
-    def update_preferred_domain(host)
-      case host
-      when ApplicationHelper::APP_HOST
-        preferred_domain_demarche_numerique_gouv_fr!
-      when ApplicationHelper::APP_HOST_LEGACY
-        preferred_domain_demarches_simplifiees_fr!
-      end
+  def update_preferred_domain(host)
+    case host
+    when ApplicationHelper::APP_HOST
+      preferred_domain_demarche_numerique_gouv_fr!
+    when ApplicationHelper::APP_HOST_LEGACY
+      preferred_domain_demarches_simplifiees_fr!
     end
   end
 end

--- a/app/models/concerns/dossier_correctable_concern.rb
+++ b/app/models/concerns/dossier_correctable_concern.rb
@@ -3,8 +3,9 @@
 module DossierCorrectableConcern
   extend ActiveSupport::Concern
 
+  A_CORRIGER = 'a_corriger'
+
   included do
-    A_CORRIGER = 'a_corriger'
     has_many :corrections, class_name: 'DossierCorrection', dependent: :destroy
     has_many :pending_corrections, -> { DossierCorrection.pending }, class_name: 'DossierCorrection', inverse_of: :dossier
     has_one :pending_correction, -> { DossierCorrection.pending }, class_name: 'DossierCorrection', inverse_of: :dossier
@@ -12,76 +13,76 @@ module DossierCorrectableConcern
     scope :with_pending_corrections, -> { joins(:corrections).where(corrections: { resolved_at: nil }) }
 
     validate :validate_pending_correction, on: :champs_public_value
+  end
 
-    def flag_as_pending_correction!(commentaire, reason = nil)
-      return unless may_flag_as_pending_correction?
+  def flag_as_pending_correction!(commentaire, reason = nil)
+    return unless may_flag_as_pending_correction?
 
-      reason ||= :incorrect
+    reason ||= :incorrect
 
-      corrections.create!(commentaire:, reason:)
+    corrections.create!(commentaire:, reason:)
 
-      create_dossier_notifications(commentaire.instructeur)
+    create_dossier_notifications(commentaire.instructeur)
 
-      log_pending_correction_operation(commentaire, reason) if procedure.sva_svr_enabled?
+    log_pending_correction_operation(commentaire, reason) if procedure.sva_svr_enabled?
 
-      return if en_construction?
+    return if en_construction?
 
-      repasser_en_construction_with_pending_correction!(instructeur: commentaire.instructeur)
+    repasser_en_construction_with_pending_correction!(instructeur: commentaire.instructeur)
+  end
+
+  def may_flag_as_pending_correction?
+    return false if pending_corrections.exists?
+
+    en_construction? || may_repasser_en_construction_with_pending_correction?
+  end
+
+  def pending_correction?
+    # We don't want to show any alert if user is not allowed to modify the dossier
+    return false unless en_construction?
+
+    return pending_corrections.any? if pending_corrections.loaded?
+
+    pending_corrections.exists?
+  end
+
+  def last_correction_resolved?
+    corrections.last&.resolved?
+  end
+
+  def resolve_pending_correction
+    pending_correction&.resolve
+  end
+
+  def resolve_pending_correction!
+    resolve_pending_correction
+    pending_correction&.save!
+
+    pending_corrections.reset
+  end
+
+  def validate_pending_correction
+    return unless procedure.sva_svr_enabled?
+    return if pending_correction.nil? || pending_correction.resolved?
+
+    errors.add(:pending_correction, :blank)
+  end
+
+  private
+
+  def log_pending_correction_operation(commentaire, reason)
+    operation = case reason.to_sym
+    when :incorrect
+      "demander_une_correction"
+    when :incomplete
+      "demander_a_completer"
     end
 
-    def may_flag_as_pending_correction?
-      return false if pending_corrections.exists?
+    log_dossier_operation(commentaire.instructeur, operation, commentaire)
+  end
 
-      en_construction? || may_repasser_en_construction_with_pending_correction?
-    end
-
-    def pending_correction?
-      # We don't want to show any alert if user is not allowed to modify the dossier
-      return false unless en_construction?
-
-      return pending_corrections.any? if pending_corrections.loaded?
-
-      pending_corrections.exists?
-    end
-
-    def last_correction_resolved?
-      corrections.last&.resolved?
-    end
-
-    def resolve_pending_correction
-      pending_correction&.resolve
-    end
-
-    def resolve_pending_correction!
-      resolve_pending_correction
-      pending_correction&.save!
-
-      pending_corrections.reset
-    end
-
-    def validate_pending_correction
-      return unless procedure.sva_svr_enabled?
-      return if pending_correction.nil? || pending_correction.resolved?
-
-      errors.add(:pending_correction, :blank)
-    end
-
-    private
-
-    def log_pending_correction_operation(commentaire, reason)
-      operation = case reason.to_sym
-      when :incorrect
-        "demander_une_correction"
-      when :incomplete
-        "demander_a_completer"
-      end
-
-      log_dossier_operation(commentaire.instructeur, operation, commentaire)
-    end
-
-    def create_dossier_notifications(except_instructeur)
-      DossierNotification.create_notification(self, :attente_correction)
-      DossierNotification.create_notification(self, :message, except_instructeur:)
-    end
+  def create_dossier_notifications(except_instructeur)
+    DossierNotification.create_notification(self, :attente_correction)
+    DossierNotification.create_notification(self, :message, except_instructeur:)
   end
 end

--- a/app/models/concerns/dossier_filtering_concern.rb
+++ b/app/models/concerns/dossier_filtering_concern.rb
@@ -3,14 +3,15 @@
 module DossierFilteringConcern
   extend ActiveSupport::Concern
 
+  DATE_SINCE_MAPPING = {
+    'updated_since' => 'updated_at',
+    'depose_since' => 'depose_at',
+    'en_construction_since' => 'en_construction_at',
+    'en_instruction_since' => 'en_instruction_at',
+    'processed_since' => 'processed_at',
+  }
+
   included do
-    DATE_SINCE_MAPPING = {
-      'updated_since' => 'updated_at',
-      'depose_since' => 'depose_at',
-      'en_construction_since' => 'en_construction_at',
-      'en_instruction_since' => 'en_instruction_at',
-      'processed_since' => 'processed_at',
-    }
     scope :filter_by_datetimes, lambda { |column, dates|
       if dates.present?
         case column
@@ -45,7 +46,7 @@ module DossierFilteringConcern
 
       where("unaccent(#{table_column}) ILIKE ANY (ARRAY((SELECT unaccent(unnest(ARRAY[?])))))", safe_quoted_terms)
     }
-
-    def sanitize_sql_like(q) = ActiveRecord::Base.sanitize_sql_like(q)
   end
+
+  def sanitize_sql_like(q) = ActiveRecord::Base.sanitize_sql_like(q)
 end

--- a/app/models/concerns/dossier_searchable_concern.rb
+++ b/app/models/concerns/dossier_searchable_concern.rb
@@ -3,38 +3,38 @@
 module DossierSearchableConcern
   extend ActiveSupport::Concern
 
+  SEARCH_TERMS_DEBOUNCE = 5.minutes
+
   included do
     after_commit :index_search_terms_later, if: -> { previously_new_record? || user_previously_changed? || mandataire_first_name_previously_changed? || mandataire_last_name_previously_changed? }
 
-    SEARCH_TERMS_DEBOUNCE = 5.minutes
-
     kredis_flag :debounce_index_search_terms_flag
+  end
 
-    def index_search_terms
-      DossierPreloader.load_one(self)
+  def index_search_terms
+    DossierPreloader.load_one(self)
 
-      search_terms = [
-        user&.email,
-        *project_champs_public.flat_map(&:search_terms),
-        *etablissement&.search_terms,
-        individual&.nom,
-        individual&.prenom,
-        mandataire_first_name,
-        mandataire_last_name,
-      ].compact_blank.join(' ')
+    search_terms = [
+      user&.email,
+      *project_champs_public.flat_map(&:search_terms),
+      *etablissement&.search_terms,
+      individual&.nom,
+      individual&.prenom,
+      mandataire_first_name,
+      mandataire_last_name,
+    ].compact_blank.join(' ')
 
-      private_search_terms = project_champs_private.flat_map(&:search_terms).compact_blank.join(' ')
+    private_search_terms = project_champs_private.flat_map(&:search_terms).compact_blank.join(' ')
 
-      sql = "UPDATE dossiers SET search_terms = :search_terms, private_search_terms = :private_search_terms WHERE id = :id"
-      sanitized_sql = self.class.sanitize_sql_array([sql, search_terms:, private_search_terms:, id:])
-      self.class.connection.execute(sanitized_sql)
-    end
+    sql = "UPDATE dossiers SET search_terms = :search_terms, private_search_terms = :private_search_terms WHERE id = :id"
+    sanitized_sql = self.class.sanitize_sql_array([sql, search_terms:, private_search_terms:, id:])
+    self.class.connection.execute(sanitized_sql)
+  end
 
-    def index_search_terms_later
-      return if debounce_index_search_terms_flag.marked?
+  def index_search_terms_later
+    return if debounce_index_search_terms_flag.marked?
 
-      debounce_index_search_terms_flag.mark(expires_in: SEARCH_TERMS_DEBOUNCE)
-      DossierIndexSearchTermsJob.set(wait: SEARCH_TERMS_DEBOUNCE).perform_later(self)
-    end
+    debounce_index_search_terms_flag.mark(expires_in: SEARCH_TERMS_DEBOUNCE)
+    DossierIndexSearchTermsJob.set(wait: SEARCH_TERMS_DEBOUNCE).perform_later(self)
   end
 end

--- a/app/models/concerns/dossier_sections_concern.rb
+++ b/app/models/concerns/dossier_sections_concern.rb
@@ -3,42 +3,40 @@
 module DossierSectionsConcern
   extend ActiveSupport::Concern
 
-  included do
-    def sections_for(type_de_champ)
-      @sections = Hash.new do |hash, parent|
-        case parent
-        when :public
-          hash[parent] = revision.types_de_champ_public.filter(&:header_section?)
-        when :private
-          hash[parent] = revision.types_de_champ_private.filter(&:header_section?)
-        else
-          hash[parent] = revision.children_of(parent).filter(&:header_section?)
-        end
+  def sections_for(type_de_champ)
+    @sections = Hash.new do |hash, parent|
+      case parent
+      when :public
+        hash[parent] = revision.types_de_champ_public.filter(&:header_section?)
+      when :private
+        hash[parent] = revision.types_de_champ_private.filter(&:header_section?)
+      else
+        hash[parent] = revision.children_of(parent).filter(&:header_section?)
       end
-      @sections[revision.parent_of(type_de_champ) || (type_de_champ.public? ? :public : :private)]
     end
+    @sections[revision.parent_of(type_de_champ) || (type_de_champ.public? ? :public : :private)]
+  end
 
-    def auto_numbering_section_headers_for?(type_de_champ)
-      return false if type_de_champ.child?(revision)
+  def auto_numbering_section_headers_for?(type_de_champ)
+    return false if type_de_champ.child?(revision)
 
-      sections_for(type_de_champ)&.none? { _1.libelle =~ /^\d/ }
-    end
+    sections_for(type_de_champ)&.none? { _1.libelle =~ /^\d/ }
+  end
 
-    def index_for_section_header(type_de_champ)
-      types_de_champ = type_de_champ.private? ? revision.types_de_champ_private : revision.types_de_champ_public
-      index = 1
-      types_de_champ.each do |tdc|
-        if tdc.repetition?
-          index_in_repetition = revision.children_of(tdc).find_index { _1.stable_id == type_de_champ.stable_id }
-          return "#{index}.#{index_in_repetition + 1}" if index_in_repetition
-        else
-          return index if tdc.stable_id == type_de_champ.stable_id
-          next unless project_champ(tdc).visible?
+  def index_for_section_header(type_de_champ)
+    types_de_champ = type_de_champ.private? ? revision.types_de_champ_private : revision.types_de_champ_public
+    index = 1
+    types_de_champ.each do |tdc|
+      if tdc.repetition?
+        index_in_repetition = revision.children_of(tdc).find_index { _1.stable_id == type_de_champ.stable_id }
+        return "#{index}.#{index_in_repetition + 1}" if index_in_repetition
+      else
+        return index if tdc.stable_id == type_de_champ.stable_id
+        next unless project_champ(tdc).visible?
 
-          index += 1 if tdc.header_section?
-        end
+        index += 1 if tdc.header_section?
       end
-      index
     end
+    index
   end
 end

--- a/app/models/concerns/pieces_jointes_list_concern.rb
+++ b/app/models/concerns/pieces_jointes_list_concern.rb
@@ -3,50 +3,48 @@
 module PiecesJointesListConcern
   extend ActiveSupport::Concern
 
-  included do
-    def public_wrapped_partionned_pjs
-      pieces_jointes(public_only: true, wrap_with_parent: true)
-        .partition { |(pj, _)| pj.condition.nil? }
-    end
+  def public_wrapped_partionned_pjs
+    pieces_jointes(public_only: true, wrap_with_parent: true)
+      .partition { |(pj, _)| pj.condition.nil? }
+  end
 
-    def exportables_pieces_jointes
-      pieces_jointes(exclude_titre_identite: true)
-    end
+  def exportables_pieces_jointes
+    pieces_jointes(exclude_titre_identite: true)
+  end
 
-    def exportables_pieces_jointes_for_all_versions
-      pieces_jointes(
-        exclude_titre_identite: true,
-        revision: revisions
-      ).sort_by { - _1.id }.uniq(&:stable_id)
-    end
+  def exportables_pieces_jointes_for_all_versions
+    pieces_jointes(
+      exclude_titre_identite: true,
+      revision: revisions
+    ).sort_by { - _1.id }.uniq(&:stable_id)
+  end
 
-    def outdated_exportables_pieces_jointes
-      exportables_pieces_jointes_for_all_versions - exportables_pieces_jointes
-    end
+  def outdated_exportables_pieces_jointes
+    exportables_pieces_jointes_for_all_versions - exportables_pieces_jointes
+  end
 
-    private
+  private
 
-    def pieces_jointes(
-      exclude_titre_identite: false,
-      public_only: false,
-      wrap_with_parent: false,
-      revision: active_revision
-    )
-      coordinates = ProcedureRevisionTypeDeChamp.where(revision:).includes(:type_de_champ, :parent)
+  def pieces_jointes(
+    exclude_titre_identite: false,
+    public_only: false,
+    wrap_with_parent: false,
+    revision: active_revision
+  )
+    coordinates = ProcedureRevisionTypeDeChamp.where(revision:).includes(:type_de_champ, :parent)
 
-      coordinates = coordinates.public_only if public_only
+    coordinates = coordinates.public_only if public_only
 
-      type_champ = ['piece_justificative']
-      type_champ << 'titre_identite' if !exclude_titre_identite
+    type_champ = ['piece_justificative']
+    type_champ << 'titre_identite' if !exclude_titre_identite
 
-      coordinates = coordinates.where(types_de_champ: { type_champ: })
+    coordinates = coordinates.where(types_de_champ: { type_champ: })
 
-      return coordinates.map(&:type_de_champ) if !wrap_with_parent
+    return coordinates.map(&:type_de_champ) if !wrap_with_parent
 
-      # we want pj in the form of [[pj1], [pj2, repetition], [pj3, repetition]]
-      coordinates
-        .map { |c| c.child? ? [c, c.parent] : [c] }
-        .map { |a| a.map(&:type_de_champ) }
-    end
+    # we want pj in the form of [[pj1], [pj2, repetition], [pj3, repetition]]
+    coordinates
+      .map { |c| c.child? ? [c, c.parent] : [c] }
+      .map { |a| a.map(&:type_de_champ) }
   end
 end

--- a/app/models/concerns/prefillable_from_service_public_concern.rb
+++ b/app/models/concerns/prefillable_from_service_public_concern.rb
@@ -3,89 +3,87 @@
 module PrefillableFromServicePublicConcern
   extend ActiveSupport::Concern
 
-  included do
-    def prefill_from_siret
-      future_sp = Concurrent::Future.execute { AnnuaireServicePublicService.new.call(siret:) }
-      future_api_ent = Concurrent::Future.execute { APIRechercheEntreprisesService.new.call(siret:) }
+  def prefill_from_siret
+    future_sp = Concurrent::Future.execute { AnnuaireServicePublicService.new.call(siret:) }
+    future_api_ent = Concurrent::Future.execute { APIRechercheEntreprisesService.new.call(siret:) }
 
-      result_sp = future_sp.value!
-      result_api_ent = future_api_ent.value!
+    result_sp = future_sp.value!
+    result_api_ent = future_api_ent.value!
 
-      prefill_from_service_public(result_sp)
-      prefill_from_api_entreprise(result_api_ent)
+    prefill_from_service_public(result_sp)
+    prefill_from_api_entreprise(result_api_ent)
 
-      [result_sp, result_api_ent]
+    [result_sp, result_api_ent]
+  end
+
+  private
+
+  def prefill_from_service_public(result)
+    case result
+    in Dry::Monads::Success(data)
+      self.nom = data[:nom] if nom.blank?
+      self.email = data[:adresse_courriel] if email.blank?
+      self.telephone = data[:telephone]&.first&.dig("valeur") if telephone.blank?
+      self.horaires = denormalize_plage_ouverture(data[:plage_ouverture]) if horaires.blank?
+      self.adresse = APIGeoService.inline_service_public_address(data[:adresse]&.first) if adresse.blank?
+    else
+      # NOOP
     end
+  end
 
-    private
-
-    def prefill_from_service_public(result)
-      case result
-      in Dry::Monads::Success(data)
-        self.nom = data[:nom] if nom.blank?
-        self.email = data[:adresse_courriel] if email.blank?
-        self.telephone = data[:telephone]&.first&.dig("valeur") if telephone.blank?
-        self.horaires = denormalize_plage_ouverture(data[:plage_ouverture]) if horaires.blank?
-        self.adresse = APIGeoService.inline_service_public_address(data[:adresse]&.first) if adresse.blank?
-      else
-        # NOOP
-      end
+  def prefill_from_api_entreprise(result)
+    case result
+    in Dry::Monads::Success(data)
+      self.type_organisme = detect_type_organisme(data) if type_organisme.blank?
+      self.nom = data[:nom_complet] if nom.blank?
+      self.adresse = data.dig(:siege, :geo_adresse) if adresse.blank?
+    else
+      # NOOP
     end
+  end
 
-    def prefill_from_api_entreprise(result)
-      case result
-      in Dry::Monads::Success(data)
-        self.type_organisme = detect_type_organisme(data) if type_organisme.blank?
-        self.nom = data[:nom_complet] if nom.blank?
-        self.adresse = data.dig(:siege, :geo_adresse) if adresse.blank?
-      else
-        # NOOP
-      end
-    end
+  def denormalize_plage_ouverture(data)
+    return if data.blank?
 
-    def denormalize_plage_ouverture(data)
-      return if data.blank?
+    data.map do |range|
+      day_range = range.values_at('nom_jour_debut', 'nom_jour_fin').uniq.join(' au ')
 
-      data.map do |range|
-        day_range = range.values_at('nom_jour_debut', 'nom_jour_fin').uniq.join(' au ')
+      hours_range = (1..2).each_with_object([]) do |i, hours|
+        start_hour = range["valeur_heure_debut_#{i}"]
+        end_hour = range["valeur_heure_fin_#{i}"]
 
-        hours_range = (1..2).each_with_object([]) do |i, hours|
-          start_hour = range["valeur_heure_debut_#{i}"]
-          end_hour = range["valeur_heure_fin_#{i}"]
-
-          if start_hour.present? && end_hour.present?
-            hours << "de #{format_time(start_hour)} à #{format_time(end_hour)}"
-          end
+        if start_hour.present? && end_hour.present?
+          hours << "de #{format_time(start_hour)} à #{format_time(end_hour)}"
         end
-
-        result = day_range
-        result += " : #{hours_range.join(' et ')}" if hours_range.present?
-        result += " (#{range['commentaire']})" if range['commentaire'].present?
-        result
-      end.join("\n")
-    end
-
-    def detect_type_organisme(data)
-      # Cf https://recherche-entreprises.api.gouv.fr/docs/#tag/Recherche-textuelle/paths/~1search/get
-      type = if data.dig(:complements, :collectivite_territoriale).present?
-        :collectivite_territoriale
-      elsif data.dig(:complements, :est_association)
-        :association
-      elsif data[:section_activite_principale] == "P"
-        :etablissement_enseignement
-      elsif data[:nom_complet].match?(/MINISTERE|MINISTERIEL/)
-        :administration_centrale
-      else # we can't differentiate between operateur d’état, administration centrale and service déconcentré de l’état, set the most frequent
-        :service_deconcentre_de_l_etat
       end
 
-      Service.type_organismes[type]
+      result = day_range
+      result += " : #{hours_range.join(' et ')}" if hours_range.present?
+      result += " (#{range['commentaire']})" if range['commentaire'].present?
+      result
+    end.join("\n")
+  end
+
+  def detect_type_organisme(data)
+    # Cf https://recherche-entreprises.api.gouv.fr/docs/#tag/Recherche-textuelle/paths/~1search/get
+    type = if data.dig(:complements, :collectivite_territoriale).present?
+      :collectivite_territoriale
+    elsif data.dig(:complements, :est_association)
+      :association
+    elsif data[:section_activite_principale] == "P"
+      :etablissement_enseignement
+    elsif data[:nom_complet].match?(/MINISTERE|MINISTERIEL/)
+      :administration_centrale
+    else # we can't differentiate between operateur d'état, administration centrale and service déconcentré de l'état, set the most frequent
+      :service_deconcentre_de_l_etat
     end
 
-    def format_time(str_time)
-      Time.zone
-        .parse(str_time)
-        .strftime("%-H:%M")
-    end
+    Service.type_organismes[type]
+  end
+
+  def format_time(str_time)
+    Time.zone
+      .parse(str_time)
+      .strftime("%-H:%M")
   end
 end

--- a/app/models/concerns/procedure_chorus_concern.rb
+++ b/app/models/concerns/procedure_chorus_concern.rb
@@ -3,13 +3,11 @@
 module ProcedureChorusConcern
   extend ActiveSupport::Concern
 
-  included do
-    def chorus_configuration
-      @chorus_configuration ||= ChorusConfiguration.new(chorus)
-    end
+  def chorus_configuration
+    @chorus_configuration ||= ChorusConfiguration.new(chorus)
+  end
 
-    def chorusable?
-      feature_enabled?(:engagement_juridique_type_de_champ)
-    end
+  def chorusable?
+    feature_enabled?(:engagement_juridique_type_de_champ)
   end
 end

--- a/app/models/concerns/procedure_path_concern.rb
+++ b/app/models/concerns/procedure_path_concern.rb
@@ -16,70 +16,70 @@ module ProcedurePathConcern
       normalized_path = path.downcase.strip
       left_joins(:procedure_paths).where(procedure_paths: { path: normalized_path }).limit(1)
     end
+  end
 
-    def path = canonical_path
+  def path = canonical_path
 
-    def ensure_path_exists
-      if self.procedure_paths.empty?
-        uuid = SecureRandom.uuid
-        self.procedure_paths.build(path: uuid)
+  def ensure_path_exists
+    if self.procedure_paths.empty?
+      uuid = SecureRandom.uuid
+      self.procedure_paths.build(path: uuid)
+    end
+  end
+
+  def other_procedure_with_path(path)
+    Procedure
+      .where.not(id: self.id)
+      .find_with_path(path).first
+  end
+
+  def canonical_path
+    procedure_paths.last&.path
+  end
+
+  def claim_path!(administrateur, new_path)
+    return if new_path.blank?
+
+    other_procedure = other_procedure_with_path(new_path)
+    if other_procedure.present?
+      if !administrateur.owns?(other_procedure)
+        errors.add(:path, :taken)
+      elsif other_procedure.procedure_paths.count == 1
+        errors.add(:path, :last_path)
       end
+      raise ActiveRecord::RecordInvalid if errors.any?
     end
 
-    def other_procedure_with_path(path)
-      Procedure
-        .where.not(id: self.id)
-        .find_with_path(path).first
+    procedure_path = procedure_paths.find { _1.path == new_path } || ProcedurePath.find_or_initialize_by(path: new_path)
+
+    procedure_path.updated_at = Time.zone.now
+
+    procedure_paths << procedure_path
+  end
+
+  def path_available?(path)
+    other_procedure_with_path(path).blank?
+  end
+
+  def previous_paths
+    procedure_paths.reject { |path| path.path == self.path || path.uuid_path? }
+  end
+
+  def path_customized?
+    !path.match?(/[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}/)
+  end
+
+  def suggested_path
+    if path_customized?
+      return path
     end
-
-    def canonical_path
-      procedure_paths.last&.path
+    slug = libelle&.parameterize&.first(50)
+    suggestion = slug
+    counter = 1
+    while !path_available?(suggestion)
+      counter = counter + 1
+      suggestion = "#{slug}-#{counter}"
     end
-
-    def claim_path!(administrateur, new_path)
-      return if new_path.blank?
-
-      other_procedure = other_procedure_with_path(new_path)
-      if other_procedure.present?
-        if !administrateur.owns?(other_procedure)
-          errors.add(:path, :taken)
-        elsif other_procedure.procedure_paths.count == 1
-          errors.add(:path, :last_path)
-        end
-        raise ActiveRecord::RecordInvalid if errors.any?
-      end
-
-      procedure_path = procedure_paths.find { _1.path == new_path } || ProcedurePath.find_or_initialize_by(path: new_path)
-
-      procedure_path.updated_at = Time.zone.now
-
-      procedure_paths << procedure_path
-    end
-
-    def path_available?(path)
-      other_procedure_with_path(path).blank?
-    end
-
-    def previous_paths
-      procedure_paths.reject { |path| path.path == self.path || path.uuid_path? }
-    end
-
-    def path_customized?
-      !path.match?(/[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}/)
-    end
-
-    def suggested_path
-      if path_customized?
-        return path
-      end
-      slug = libelle&.parameterize&.first(50)
-      suggestion = slug
-      counter = 1
-      while !path_available?(suggestion)
-        counter = counter + 1
-        suggestion = "#{slug}-#{counter}"
-      end
-      suggestion
-    end
+    suggestion
   end
 end

--- a/app/models/concerns/procedure_sva_svr_concern.rb
+++ b/app/models/concerns/procedure_sva_svr_concern.rb
@@ -7,50 +7,50 @@ module ProcedureSVASVRConcern
     scope :sva_svr, -> { where("sva_svr ->> 'decision' IN (?)", ['sva', 'svr']) }
     validate :sva_svr_immutable_on_published, if: :will_save_change_to_sva_svr?
     validate :validates_sva_svr_compatible
+  end
 
-    def sva_svr_enabled?
-      sva? || svr?
-    end
+  def sva_svr_enabled?
+    sva? || svr?
+  end
 
-    def sva?
-      decision == :sva
-    end
+  def sva?
+    decision == :sva
+  end
 
-    def svr?
-      decision == :svr
-    end
+  def svr?
+    decision == :svr
+  end
 
-    def sva_svr_configuration
-      @sva_svr_configuration ||= SVASVRConfiguration.new(sva_svr)
-    end
+  def sva_svr_configuration
+    @sva_svr_configuration ||= SVASVRConfiguration.new(sva_svr)
+  end
 
-    def sva_svr_decision
-      decision
-    end
+  def sva_svr_decision
+    decision
+  end
 
-    private
+  private
 
-    def decision
-      sva_svr.fetch("decision", nil)&.to_sym
-    end
+  def decision
+    sva_svr.fetch("decision", nil)&.to_sym
+  end
 
-    def decision_was
-      sva_svr_was.fetch("decision", nil)&.to_sym
-    end
+  def decision_was
+    sva_svr_was.fetch("decision", nil)&.to_sym
+  end
 
-    def sva_svr_immutable_on_published
-      return if brouillon?
-      return if [:sva, :svr].exclude?(decision_was)
+  def sva_svr_immutable_on_published
+    return if brouillon?
+    return if [:sva, :svr].exclude?(decision_was)
 
-      errors.add(:sva_svr, :immutable)
-    end
+    errors.add(:sva_svr, :immutable)
+  end
 
-    def validates_sva_svr_compatible
-      return if !sva_svr_enabled?
+  def validates_sva_svr_compatible
+    return if !sva_svr_enabled?
 
-      if declarative_with_state.present?
-        errors.add(:sva_svr, :declarative_incompatible)
-      end
+    if declarative_with_state.present?
+      errors.add(:sva_svr, :declarative_incompatible)
     end
   end
 end

--- a/app/models/concerns/routing_rule_statuses_concern.rb
+++ b/app/models/concerns/routing_rule_statuses_concern.rb
@@ -3,41 +3,39 @@
 module RoutingRuleStatusesConcern
   extend ActiveSupport::Concern
 
-  included do
-    def update_all_groupes_rule_validity_status
-      valid_ids = []
-      invalid_ids = []
+  def update_all_groupes_rule_validity_status
+    valid_ids = []
+    invalid_ids = []
 
-      self.groupe_instructeurs.includes(:procedure).find_each do |gi|
-        if gi.valid_rule?
-          valid_ids << gi.id
-        else
-          invalid_ids << gi.id
-        end
+    self.groupe_instructeurs.includes(:procedure).find_each do |gi|
+      if gi.valid_rule?
+        valid_ids << gi.id
+      else
+        invalid_ids << gi.id
       end
-
-      GroupeInstructeur.where(id: valid_ids).update_all(valid_routing_rule: true)
-      GroupeInstructeur.where(id: invalid_ids).update_all(valid_routing_rule: false)
     end
 
-    def update_all_groupes_rule_unicity_status
-      # Get ids from groupe_instructeurs with same routing rule
-      rule_gis = Hash.new { |h, k| h[k] = [] }
+    GroupeInstructeur.where(id: valid_ids).update_all(valid_routing_rule: true)
+    GroupeInstructeur.where(id: invalid_ids).update_all(valid_routing_rule: false)
+  end
 
-      self.groupe_instructeurs.each_with_object(rule_gis) do |gi, h|
-        h[gi.routing_rule] << gi.id
-      end
+  def update_all_groupes_rule_unicity_status
+    # Get ids from groupe_instructeurs with same routing rule
+    rule_gis = Hash.new { |h, k| h[k] = [] }
 
-      duplicate_ids = rule_gis.filter { |_k, gi_ids| gi_ids.size > 1 }.map(&:second).flatten
-
-      # Update unique_routing_rule in all groups
-      self.groupe_instructeurs.update_all(unique_routing_rule: true)
-      self.groupe_instructeurs.where(id: duplicate_ids).update_all(unique_routing_rule: false)
+    self.groupe_instructeurs.each_with_object(rule_gis) do |gi, h|
+      h[gi.routing_rule] << gi.id
     end
 
-    def update_all_groupes_rule_statuses
-      update_all_groupes_rule_validity_status
-      update_all_groupes_rule_unicity_status
-    end
+    duplicate_ids = rule_gis.filter { |_k, gi_ids| gi_ids.size > 1 }.map(&:second).flatten
+
+    # Update unique_routing_rule in all groups
+    self.groupe_instructeurs.update_all(unique_routing_rule: true)
+    self.groupe_instructeurs.where(id: duplicate_ids).update_all(unique_routing_rule: false)
+  end
+
+  def update_all_groupes_rule_statuses
+    update_all_groupes_rule_validity_status
+    update_all_groupes_rule_unicity_status
   end
 end

--- a/app/models/concerns/transient_models_with_purgeable_job_concern.rb
+++ b/app/models/concerns/transient_models_with_purgeable_job_concern.rb
@@ -7,6 +7,7 @@
 #   based on a state machine
 module TransientModelsWithPurgeableJobConcern
   extend ActiveSupport::Concern
+
   included do
     include AASM
 
@@ -41,18 +42,18 @@ module TransientModelsWithPurgeableJobConcern
       where(job_status: [job_statuses.fetch(:pending)])
         .where(updated_at: ...(Time.zone.now - duration))
     }
+  end
 
-    def available?
-      generated? && file.url.present?
-    end
+  def available?
+    generated? && file.url.present?
+  end
 
-    def compute_with_safe_stale_for_purge(&block)
-      restart! if failed? # restart for AASM
-      yield
-      make_available!
-    rescue => e
-      fail!         # fail for observability
-      raise e       # re-raise for retryable behaviour
-    end
+  def compute_with_safe_stale_for_purge(&block)
+    restart! if failed? # restart for AASM
+    yield
+    make_available!
+  rescue => e
+    fail!         # fail for observability
+    raise e       # re-raise for retryable behaviour
   end
 end

--- a/app/models/concerns/treeable_concern.rb
+++ b/app/models/concerns/treeable_concern.rb
@@ -6,34 +6,32 @@ module TreeableConcern
   MAX_DEPTH = 6 # deepest level for header_sections is 3.
   # but a repetition can be nested an header_section, so 3+3=6=MAX_DEPTH
 
-  included do
-    # as we progress in the list of ordered types_de_champ
-    #   we keep a reference to each level of nesting (walk)
-    # when we encounter an header_section, it depends of its own depth of nesting minus 1, ie:
-    #   h1 belongs to prior (rooted_tree)
-    #   h2 belongs to prior h1
-    #   h3 belongs to prior h2
-    #   h1 belongs to prior (rooted_tree)
-    # then, each and every types_de_champ which are not an header_section
-    #   are added to the current_tree
-    # given a root_depth at 0, we build a full tree
-    # given a root_depth > 0, we build a partial tree (aka, a repetition)
-    def to_tree(types_de_champ:)
-      rooted_tree = []
-      walk = Array.new(MAX_DEPTH)
-      walk[0] = rooted_tree
-      current_tree = rooted_tree
+  # as we progress in the list of ordered types_de_champ
+  #   we keep a reference to each level of nesting (walk)
+  # when we encounter an header_section, it depends of its own depth of nesting minus 1, ie:
+  #   h1 belongs to prior (rooted_tree)
+  #   h2 belongs to prior h1
+  #   h3 belongs to prior h2
+  #   h1 belongs to prior (rooted_tree)
+  # then, each and every types_de_champ which are not an header_section
+  #   are added to the current_tree
+  # given a root_depth at 0, we build a full tree
+  # given a root_depth > 0, we build a partial tree (aka, a repetition)
+  def to_tree(types_de_champ:)
+    rooted_tree = []
+    walk = Array.new(MAX_DEPTH)
+    walk[0] = rooted_tree
+    current_tree = rooted_tree
 
-      types_de_champ.each do |type_de_champ|
-        if type_de_champ.header_section?
-          new_tree = [type_de_champ]
-          walk[type_de_champ.header_section_level_value - 1].push(new_tree)
-          current_tree = walk[type_de_champ.header_section_level_value] = new_tree
-        else
-          current_tree.push(type_de_champ)
-        end
+    types_de_champ.each do |type_de_champ|
+      if type_de_champ.header_section?
+        new_tree = [type_de_champ]
+        walk[type_de_champ.header_section_level_value - 1].push(new_tree)
+        current_tree = walk[type_de_champ.header_section_level_value] = new_tree
+      else
+        current_tree.push(type_de_champ)
       end
-      rooted_tree
     end
+    rooted_tree
   end
 end

--- a/app/models/concerns/user_find_by_concern.rb
+++ b/app/models/concerns/user_find_by_concern.rb
@@ -3,16 +3,16 @@
 module UserFindByConcern
   extend ActiveSupport::Concern
 
-  included do
-    def self.by_email(email)
+  class_methods do
+    def by_email(email)
       find_by(users: { email: email })
     end
 
-    def self.find_all_by_identifier(ids: [], emails: [])
+    def find_all_by_identifier(ids: [], emails: [])
       find_all_by_identifier_with_emails(ids:, emails:).first
     end
 
-    def self.find_all_by_identifier_with_emails(ids: [], emails: [])
+    def find_all_by_identifier_with_emails(ids: [], emails: [])
       valid_emails, invalid_emails = emails.partition { StrictEmailValidator::REGEXP.match?(_1) }
 
       [

--- a/app/tasks/maintenance/concerns/statements_helpers_concern.rb
+++ b/app/tasks/maintenance/concerns/statements_helpers_concern.rb
@@ -4,30 +4,28 @@ module Maintenance
   module StatementsHelpersConcern
     extend ActiveSupport::Concern
 
-    included do
-      # Execute block in transaction with a local statement timeout.
-      # A value of 0 disable the timeout.
-      # IMPORTANT: it has NO effect if the block returns an lazy loaded collection, like an ActiveRecord::Relation!
-      # Instead it should be used either when `collection` returns an enumerable object, or in `count`.
-      #
-      # Examples:
-      # def collection
-      #   with_statement_timeout("0") do
-      #     Champ.all.pluck(:id)
-      #     # No effect with Dossier.all because the collection will be lazy loaded later in batches by MaintenanceTask.
-      #   end
-      # end
-      #
-      # def count
-      #   with_statement_timeout("15min") do
-      #     collection.count(:id)
-      #   end
-      # end
-      def with_statement_timeout(timeout)
-        ApplicationRecord.transaction do
-          ApplicationRecord.connection.execute("SET LOCAL statement_timeout = '#{timeout}'")
-          yield
-        end
+    # Execute block in transaction with a local statement timeout.
+    # A value of 0 disable the timeout.
+    # IMPORTANT: it has NO effect if the block returns a lazy loaded collection, like an ActiveRecord::Relation!
+    # Instead it should be used either when `collection` returns an enumerable object, or in `count`.
+    #
+    # Examples:
+    # def collection
+    #   with_statement_timeout("0") do
+    #     Champ.all.pluck(:id)
+    #     # No effect with Dossier.all because the collection will be lazy loaded later in batches by MaintenanceTask.
+    #   end
+    # end
+    #
+    # def count
+    #   with_statement_timeout("15min") do
+    #     collection.count(:id)
+    #   end
+    # end
+    def with_statement_timeout(timeout)
+      ApplicationRecord.transaction do
+        ApplicationRecord.connection.execute("SET LOCAL statement_timeout = '#{timeout}'")
+        yield
       end
     end
   end


### PR DESCRIPTION
## Summary

- Déplace les définitions de méthodes (instance et privées) hors des blocs `included` dans 36 concerns
- Conserve uniquement les appels DSL Rails dans `included` (associations, scopes, validations, callbacks, state machines)
- Déplace les constantes au niveau du module quand elles étaient définies dans `included`

Ce refactoring suit les conventions idiomatiques d'`ActiveSupport::Concern` : le bloc `included` ne devrait contenir que les macros Rails (has_many, scope, validates, etc.), tandis que les méthodes sont définies directement dans le module pour être disponibles via `include`.

## Fichiers modifiés

- 11 controller concerns
- 2 mailer concerns
- 22 model concerns
- 1 maintenance task concern

## Test plan

- [x] Vérifier que la suite de tests existante passe sans régression
- [x] Vérifier que les linters passent (rubocop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)