### PR TITLE
fix: patch React 19 dev-mode crash with react-aria sections

### DIFF
--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -14,7 +14,8 @@ import {
   TagList,
   Tag,
   Virtualizer,
-  ListLayout
+  ListLayout,
+  Collection
 } from 'react-aria-components';
 import { useMemo, useRef, createContext, useContext, useId } from 'react';
 import type { RefObject } from 'react';
@@ -152,20 +153,20 @@ export function ComboBox({
               ) : undefined
             }
           >
-            {sections
-              ? sections.map((section) => (
-                  <ListBoxSection key={section.label}>
+            {sections ? (
+              <Collection items={sections}>
+                {(section) => (
+                  <ListBoxSection id={section.label}>
                     <Header className="fr-ds-combobox__section-header">
                       {section.label}
                     </Header>
-                    {section.items.map((item) => (
-                      <ComboBoxItem key={item.value} id={item.value}>
-                        {item.label}
-                      </ComboBoxItem>
-                    ))}
+                    <Collection items={section.items}>{children}</Collection>
                   </ListBoxSection>
-                ))
-              : children}
+                )}
+              </Collection>
+            ) : (
+              children
+            )}
           </ListBox>
         </Virtualizer>
       </Popover>

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
@@ -58,10 +59,10 @@
         "match-sorter": "^8.1.0",
         "p-retry": "^7.1.1",
         "pmtiles": "^4.3.0",
-        "react": "^19.2.0",
+        "react": "19.2.4",
         "react-aria-components": "^1.13.0",
         "react-coordinate-input": "^1.0.0",
-        "react-dom": "^19.2.0",
+        "react-dom": "19.2.4",
         "react-fast-compare": "^3.2.2",
         "react-use-event-hook": "^0.9.6",
         "stimulus-use": "^0.52.3",
@@ -115,6 +116,7 @@
     "rollup",
   ],
   "patchedDependencies": {
+    "react-dom@19.2.4": "patches/react-dom@19.2.4.patch",
     "@hotwired/turbo@7.3.0": "patches/@hotwired%2Fturbo@7.3.0.patch",
   },
   "packages": {
@@ -1632,7 +1634,7 @@
 
     "quickselect": ["quickselect@2.0.0", "", {}, "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="],
 
-    "react": ["react@19.2.0", "", {}, "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ=="],
+    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "react-aria": ["react-aria@3.44.0", "", { "dependencies": { "@internationalized/string": "^3.2.7", "@react-aria/breadcrumbs": "^3.5.29", "@react-aria/button": "^3.14.2", "@react-aria/calendar": "^3.9.2", "@react-aria/checkbox": "^3.16.2", "@react-aria/color": "^3.1.2", "@react-aria/combobox": "^3.14.0", "@react-aria/datepicker": "^3.15.2", "@react-aria/dialog": "^3.5.31", "@react-aria/disclosure": "^3.1.0", "@react-aria/dnd": "^3.11.3", "@react-aria/focus": "^3.21.2", "@react-aria/gridlist": "^3.14.1", "@react-aria/i18n": "^3.12.13", "@react-aria/interactions": "^3.25.6", "@react-aria/label": "^3.7.22", "@react-aria/landmark": "^3.0.7", "@react-aria/link": "^3.8.6", "@react-aria/listbox": "^3.15.0", "@react-aria/menu": "^3.19.3", "@react-aria/meter": "^3.4.27", "@react-aria/numberfield": "^3.12.2", "@react-aria/overlays": "^3.30.0", "@react-aria/progress": "^3.4.27", "@react-aria/radio": "^3.12.2", "@react-aria/searchfield": "^3.8.9", "@react-aria/select": "^3.17.0", "@react-aria/selection": "^3.26.0", "@react-aria/separator": "^3.4.13", "@react-aria/slider": "^3.8.2", "@react-aria/ssr": "^3.9.10", "@react-aria/switch": "^3.7.8", "@react-aria/table": "^3.17.8", "@react-aria/tabs": "^3.10.8", "@react-aria/tag": "^3.7.2", "@react-aria/textfield": "^3.18.2", "@react-aria/toast": "^3.0.8", "@react-aria/tooltip": "^3.8.8", "@react-aria/tree": "^3.1.4", "@react-aria/utils": "^3.31.0", "@react-aria/visually-hidden": "^3.8.28", "@react-types/shared": "^3.32.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-2Pq3GQxBgM4/2BlpKYXeaZ47a3tdIcYSW/AYvKgypE3XipxOdQMDG5Sr/NBn7zuJq+thzmtfRb0lB9bTbsmaRw=="],
 
@@ -1642,7 +1644,7 @@
 
     "react-coordinate-input": ["react-coordinate-input@1.0.0", "", { "dependencies": { "imask": "^6.2.2" }, "optionalDependencies": { "prop-types": ">=15.0.0" }, "peerDependencies": { "react": ">=16.9.0" } }, "sha512-9iJti+WU38mk+Pab/5+Rn24IKfgxKEwcq4yJeyttAy50NTg33K5xwc/+NcPQoEB82xG0iTW9lRlx1WZCOPjWoQ=="],
 
-    "react-dom": ["react-dom@19.2.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ=="],
+    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
     "react-fast-compare": ["react-fast-compare@3.2.2", "", {}, "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="],
 

--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
     "match-sorter": "^8.1.0",
     "p-retry": "^7.1.1",
     "pmtiles": "^4.3.0",
-    "react": "^19.2.0",
+    "react": "19.2.4",
     "react-aria-components": "^1.13.0",
     "react-coordinate-input": "^1.0.0",
-    "react-dom": "^19.2.0",
+    "react-dom": "19.2.4",
     "react-fast-compare": "^3.2.2",
     "react-use-event-hook": "^0.9.6",
     "stimulus-use": "^0.52.3",
@@ -132,6 +132,7 @@
     "trailingComma": "none"
   },
   "patchedDependencies": {
-    "@hotwired/turbo@7.3.0": "patches/@hotwired%2Fturbo@7.3.0.patch"
+    "@hotwired/turbo@7.3.0": "patches/@hotwired%2Fturbo@7.3.0.patch",
+    "react-dom@19.2.4": "patches/react-dom@19.2.4.patch"
   }
 }

--- a/patches/react-dom@19.2.4.patch
+++ b/patches/react-dom@19.2.4.patch
@@ -1,0 +1,20 @@
+diff --git a/cjs/react-dom-client.development.js b/cjs/react-dom-client.development.js
+index fa853b3a79413c8ddc553441ee259d4b34f59d69..0ccc4c8e33a401e4ea954e291c97c0983232ab36 100644
+--- a/cjs/react-dom-client.development.js
++++ b/cjs/react-dom-client.development.js
+@@ -3965,8 +3965,13 @@
+           (isDeeplyEqual = !1));
+       for (var _key in next)
+         if (_key in prev) {
+-          var key = prev[_key];
+-          var nextValue = next[_key];
++          var key, nextValue;
++          try {
++            key = prev[_key];
++            nextValue = next[_key];
++          } catch (e) {
++            continue;
++          }
+           if (key !== nextValue) {
+             if (0 === indent && "children" === _key)
+               (isDeeplyEqual = "\u00a0\u00a0".repeat(indent) + _key),


### PR DESCRIPTION
React 19.2's `logComponentRender` deeply traverses component props via `addObjectDiffToProperties`, which evaluates getters on objects. React Aria's internal `CollectionNode` has a `childNodes` getter that intentionally throws, causing an uncaught error when selecting items in ComboBox with sections.

- Patch react-dom to wrap property access in try-catch (facebook/react#35126)
- Update react/react-dom 19.2.0 → 19.2.4
- Update react-aria-components 1.13.0 → 1.15.1
- Use Collection component for dynamic section rendering in ComboBox