### PR TITLE
ETQ instructeur, ne fait pas passer le bouton de c/c du lien de démarche sur une nouvelle ligne

### DIFF
--- a/app/assets/stylesheets/procedure_list.scss
+++ b/app/assets/stylesheets/procedure_list.scss
@@ -17,6 +17,27 @@
     display: inline;
   }
 
+  // Fix when the procedure label is too long,
+  // the button should not wrap to the next line when hovering over copy zone.
+  .copy-zone {
+    position: relative;
+  }
+
+  .copy-zone:hover .copy-zone-trigger-icon,
+  .copy-zone:has(.copy-btn:focus-visible) .copy-zone-trigger-icon {
+    visibility: hidden !important;
+    display: inline !important;
+  }
+
+  .copy-zone:hover .copy-btn,
+  .copy-zone .copy-btn:focus-visible {
+    position: absolute !important;
+    left: 0;
+    top: 0;
+    white-space: nowrap !important;
+    max-width: none;
+  }
+
   .fr-nav {
     position: absolute;
     top: 0.8125rem;


### PR DESCRIPTION
meilleur compromis de le faire déborder que passer à la ligne 🤯 



https://github.com/user-attachments/assets/41a6e12f-adab-4c73-88cb-8ab36b0dd941

