### PR TITLE
Tech: support de bases de données isolées par git worktree

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Hook post-checkout pour gérer les bases de données séparées par worktree
+# Activé via: bin/worktree-enable
+
+set -e
+
+# Arguments du hook
+prev_head=$1
+new_head=$2
+branch_checkout=$3
+
+# Ne s'exécute que lors d'un checkout de branche
+if [ "$branch_checkout" != "1" ]; then
+  exit 0
+fi
+
+# Détecte si on est dans un worktree
+git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+git_dir=$(git rev-parse --git-dir 2>/dev/null)
+
+# Si git-dir == git-common-dir, on est dans le repo principal, pas un worktree
+if [ "$git_dir" = "$git_common_dir" ]; then
+  exit 0
+fi
+
+# Génère un nom de DB unique basé sur le nom du répertoire du worktree
+worktree_path=$(git rev-parse --show-toplevel)
+worktree_name=$(basename "$worktree_path")
+
+# Transforme le nom en format compatible DB (remplace - par _)
+db_suffix=$(echo "$worktree_name" | sed 's/demarches-simplifiees\.fr-//' | sed 's/-/_/g')
+db_name="tps_test_${db_suffix}"
+
+echo "==> Worktree détecté: $worktree_name"
+echo "==> Configuration de la base de données: $db_name"
+
+# Crée ou met à jour .env.test.local avec le nom de DB unique
+env_test_local="$worktree_path/.env.test.local"
+
+cat > "$env_test_local" <<EOF
+# Worktree-specific database configuration
+# This file overrides .env.test for this worktree only
+DB_DATABASE_TEST="${db_name}"
+DB_HOST_TEST="localhost"
+DB_USERNAME_TEST="tps_test"
+DB_PASSWORD_TEST="tps_test"
+EOF
+
+echo "==> Configuration écrite dans .env.test.local"
+
+# Vérifie si la DB existe déjà
+if psql -U tps_test -h localhost -lqt | cut -d \| -f 1 | grep -qw "$db_name"; then
+  echo "==> Base de données $db_name existe déjà"
+else
+  echo "==> Création de la base de données $db_name"
+  createdb -U tps_test -h localhost "$db_name" || {
+    echo "⚠️  Erreur lors de la création de la DB. Vérifiez vos credentials PostgreSQL."
+    exit 0
+  }
+
+  echo "==> Chargement du schema dans $db_name"
+  cd "$worktree_path"
+  RAILS_ENV=test bundle exec rails db:schema:load || {
+    echo "⚠️  Erreur lors du chargement du schema."
+    exit 0
+  }
+fi
+
+echo "✓ Configuration worktree terminée!"
+echo "  → Base de données: $db_name"
+echo "  → Config: $env_test_local"

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ uploads/*
 *.swp
 .envrc
 .env
+.env.test.local
 .tool-versions
 storage/
 /node_modules

--- a/bin/worktree-enable
+++ b/bin/worktree-enable
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Active les hooks git pour les utilisateurs de worktrees
+# À exécuter une seule fois après le clone du repo
+
+set -e
+
+git config core.hooksPath .githooks
+
+echo "✓ Hooks activés pour les worktrees"
+echo ""
+echo "Le hook post-checkout va maintenant :"
+echo "  - Créer automatiquement .env.test.local avec une DB unique"
+echo "  - Créer la base de données PostgreSQL"
+echo "  - Charger le schema"
+echo ""
+echo "À chaque création de worktree ou checkout de branche."

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,10 +20,10 @@ development:
 
 test:
   <<: *default
-  database: tps_test
-  host: localhost
-  username: tps_test
-  password: tps_test
+  database: <%= ENV["DB_DATABASE_TEST"] || "tps_test" %>
+  host: <%= ENV["DB_HOST_TEST"] || "localhost" %>
+  username: <%= ENV["DB_USERNAME_TEST"] || "tps_test" %>
+  password: <%= ENV["DB_PASSWORD_TEST"] || "tps_test" %>
   port: <%= ENV["DB_PORT"] || 5432 %>
   # Workaround for https://github.com/ged/ruby-pg/issues/311
   gssencmode: disable


### PR DESCRIPTION
Ajoute un système de hooks git optionnel pour gérer des bases de données PostgreSQL séparées par worktree, évitant les conflits de locks lors de l'utilisation de plusieurs worktrees simultanément.

Modifications :
- Hook post-checkout qui crée automatiquement .env.test.local avec une DB unique
- Script bin/worktree-enable pour activer les hooks (opt-in)
- database.yml modifié pour supporter les variables DB_*_TEST
- .env.test.local ajouté au .gitignore

Le hook crée automatiquement la base PostgreSQL et charge le schema. Aucun impact sur les développeurs n'utilisant pas de worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)