### PR TITLE
Correction : la signature est complète dans l'attestation de dépôt envoyé par email

### DIFF
--- a/app/views/users/dossiers/papertrail.pdf.prawn
+++ b/app/views/users/dossiers/papertrail.pdf.prawn
@@ -100,7 +100,7 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
     pdf.fill_color black
     pdf.pad_top(100) do
       pdf.text t('.generated_at', date: l(Time.zone.now.to_date, format: :long)), size: 10, character_spacing: -0.2, align: :right
-      pdf.text t('.signature', app_name: Current.application_name), size: 10, character_spacing: -0.2, align: :right
+      pdf.text t('.signature', app_name: APPLICATION_NAME), size: 10, character_spacing: -0.2, align: :right
     end
   end
 end


### PR DESCRIPTION
cf https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_059feef6-627e-4a9a-9476-dfc6409721cf/

## Résumé

Corrige un bug où le PDF d'attestation de dépôt envoyé par email affichait "La direction de" au lieu de "La direction de demarche.numerique.gouv.fr". Alors que téléchargé depuis l'interface, le pdf affiche la signature complète

**Cause :** `Current.application_name` n'est défini que dans le contexte d'une requête HTTP, pas quand le PDF est généré en arrière-plan pour l'email.

**Solution :** Utiliser la constante `APPLICATION_NAME` qui est toujours disponible.

## A tester

- [ ] Vérifier que le PDF téléchargé depuis l'interface affiche toujours la bonne signature
- [ ] Vérifier que le PDF envoyé par email affiche maintenant "La direction de demarche.numerique.gouv.fr"

🤖 Generated with [Claude Code](https://claude.ai/code)