### PR TITLE
Correctif: ETQ usager, j'aimerais que le champ api ne fige pas l'interface

### DIFF
--- a/app/services/referentiel_autocomplete_render_service.rb
+++ b/app/services/referentiel_autocomplete_render_service.rb
@@ -12,11 +12,14 @@ class ReferentielAutocompleteRenderService
 
   def format_response
     objects = JsonPath.on(api_response, referentiel.datasource).first
-    objects.take(MAX_RENDERED_OBJECTS).map do |data|
+    objects.take(MAX_RENDERED_OBJECTS).map.with_index do |data, index|
       label = render_template(json_template, data.with_indifferent_access).join("")
+      # Use index as unique value prefix to prevent duplicate keys when multiple items have the same label
+      # This prevents infinite loops in react-stately's internal linked list structure
+      # The value is only used as a React key - the actual data sent to server is the encrypted 'data' field
       {
         label:,
-        value: label,
+        value: "#{index}:#{label}",
         data: message_encryptor_service.encrypt_and_sign(data, purpose: :storage, expires_in: 1.hour),
       }
     end

--- a/spec/controllers/data_sources/referentiel_controller_spec.rb
+++ b/spec/controllers/data_sources/referentiel_controller_spec.rb
@@ -25,7 +25,7 @@ describe DataSources::ReferentielController, type: :controller do
             expect(response.parsed_body).to be_an(Array)
             expect(response.parsed_body.size).to eq(1)
             expect(response.parsed_body.first["label"]).to eq("010002699 (CENTRE MEDICAL REGINA)")
-            expect(response.parsed_body.first["value"]).to eq("010002699 (CENTRE MEDICAL REGINA)")
+            expect(response.parsed_body.first["value"]).to eq("0:010002699 (CENTRE MEDICAL REGINA)")
             expect(response.parsed_body.first["data"]).to be_an_instance_of(String)
           end
         end
@@ -64,7 +64,7 @@ describe DataSources::ReferentielController, type: :controller do
             expect(response.parsed_body).to be_an(Array)
             expect(response.parsed_body.size).to eq(4)
             expect(response.parsed_body.first["label"]).to eq("DIPLOME NATIONAL / DIPLOME D'ETAT – AGRO-ALIMENTAIRE, ALIMENTATION, CUISINE ")
-            expect(response.parsed_body.first["value"]).to eq("DIPLOME NATIONAL / DIPLOME D'ETAT – AGRO-ALIMENTAIRE, ALIMENTATION, CUISINE ")
+            expect(response.parsed_body.first["value"]).to eq("0:DIPLOME NATIONAL / DIPLOME D'ETAT – AGRO-ALIMENTAIRE, ALIMENTATION, CUISINE ")
             expect(response.parsed_body.first["data"]).to be_an_instance_of(String)
           end
         end

--- a/spec/services/referentiel_autocomplete_render_service_spec.rb
+++ b/spec/services/referentiel_autocomplete_render_service_spec.rb
@@ -20,15 +20,32 @@ RSpec.describe ReferentielAutocompleteRenderService do
       expect(subject.format_response).to match_array([
         {
           label: 'Tango (Charlie)',
-          value: 'Tango (Charlie)',
+          value: '0:Tango (Charlie)',
           data: anything,
         },
         {
           label: 'Bob (Delta)',
-          value: 'Bob (Delta)',
+          value: '1:Bob (Delta)',
           data: anything,
         },
       ])
+    end
+
+    context 'with duplicate labels' do
+      let(:api_response) do
+        {
+          'items' => [
+            { 'finess' => 'Dupli', 'ej_rs' => 'A' },
+            { 'finess' => 'Dupli', 'ej_rs' => 'A' },
+          ],
+        }
+      end
+
+      it 'ensures unique values to prevent infinite loops' do
+        result = subject.format_response
+        expect(result.map { |item| item[:value] }.uniq.count).to eq(2)
+        expect(result.map { |item| item[:value] }).to match_array(['0:Dupli (A)', '1:Dupli (A)'])
+      end
     end
   end
 


### PR DESCRIPTION
https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_f8a4a9d7-0463-4544-a2cb-2471bfb14aad/

le prob venait qu'on pouvait remonter des clé non unique qui declenchaient une boucle infinie cote react