### PR TITLE
ETQ administrateur je peux exporter les informations de contact des groupes instructeurs

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -239,6 +239,17 @@ ul.dropdown-items {
   margin-bottom: 0;
 }
 
+.dropdown-menu-simple {
+  min-width: max-content;
+
+  .dropdown-items li {
+    padding: $default-spacer 2 * $default-spacer;
+    font-size: 14px;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+}
+
 // Apply custom styles to DSFR fr-translate component
 .fr-translate__btn.fr-btn.help-btn::before {
   content: none;

--- a/app/components/procedure/groupes_management_component/groupes_management_component.en.yml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.en.yml
@@ -12,6 +12,10 @@ en:
     placeholder: Enter a group name
     cancel: Cancel
     submit: Add
+  export_dropdown:
+    title: Export
+    export_instructeurs: Export groups / instructors list (.csv)
+    export_contact_informations: Export contact information by groups (.csv)
   bulk_assignment:
     title: Bulk instructor assignment (all groups)
     notification_alert_html: All instructors you add / remove from the procedure <strong>will be notified by email</strong>.

--- a/app/components/procedure/groupes_management_component/groupes_management_component.fr.yml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.fr.yml
@@ -12,6 +12,10 @@ fr:
     placeholder: Saisissez un nom de groupe
     cancel: Annuler
     submit: Ajouter
+  export_dropdown:
+    title: Exporter
+    export_instructeurs: Exporter la liste des groupes / instructeurs (.csv)
+    export_contact_informations: Exporter les informations de contact par groupes (.csv)
   bulk_assignment:
     title: Affectation en masse des instructeurs (tous les groupes)
     notification_alert_html: Tous les instructeurs que vous ajouterez / retirerez de la démarche <strong>seront notifiés par email</strong>.

--- a/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
@@ -35,8 +35,15 @@
 
 .flex.justify-between.align-baseline
   .title.fr-text--bold= table_header
-  = button_to export_groupe_instructeurs_admin_procedure_groupe_instructeurs_path(@procedure, format: :csv), method: :get, class: 'fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-download-line' do
-    Exporter la liste (.csv)
+  = render Dropdown::MenuComponent.new(wrapper: :div, button_options: { class: ['fr-btn--tertiary', 'fr-btn--icon-left', 'fr-icon-download-line'] }, menu_options: { class: ['dropdown-menu-simple'] }) do |menu|
+    - menu.with_button_inner_html do
+      = t('.export_dropdown.title')
+    - menu.with_item do
+      = link_to export_groupe_instructeurs_admin_procedure_groupe_instructeurs_path(@procedure, format: :csv), role: 'menuitem', class: 'fr-link' do
+        = t('.export_dropdown.export_instructeurs')
+    - menu.with_item do
+      = link_to export_contact_informations_admin_procedure_groupe_instructeurs_path(@procedure, format: :csv), role: 'menuitem', class: 'fr-link' do
+        = t('.export_dropdown.export_contact_informations')
 
 .fr-table.fr-table--no-caption.fr-table--layout-fixed.fr-mt-2w
   .fr-table__wrapper

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -454,6 +454,34 @@ module Administrateurs
       end
     end
 
+    def export_contact_informations
+      groupe_instructeurs = procedure.groupe_instructeurs.includes(:contact_information)
+
+      data = CSV.generate(headers: true) do |csv|
+        column_names = ["Groupe", "Nom_du_service", "Adresse_electronique_de_contact", "Telephone", "Horaires", "Adresse_postale"]
+        csv << column_names
+        groupe_instructeurs.each do |gi|
+          contact = gi.contact_information
+          if contact.present?
+            csv << [
+              gi.label,
+              contact.nom,
+              contact.email,
+              contact.telephone,
+              contact.horaires,
+              contact.adresse,
+            ]
+          else
+            csv << [gi.label, '', '', '', '', '']
+          end
+        end
+      end
+
+      respond_to do |format|
+        format.csv { send_data data, filename: "#{procedure.id}-contact-informations-#{Date.today}.csv" }
+      end
+    end
+
     def bulk_route
       BulkRouteJob.perform_later(procedure)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -768,6 +768,7 @@ Rails.application.routes.draw do
           patch 'update_instructeurs_self_management_enabled'
           post 'import'
           get 'export_groupe_instructeurs'
+          get 'export_contact_informations'
           post 'bulk_route'
           post 'add_instructeur_to_all_groupes'
           delete 'remove_instructeur_from_all_groupes'

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -902,6 +902,41 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
     end
   end
 
+  describe '#export_contact_informations' do
+    let!(:contact_info_1) { create(:contact_information, groupe_instructeur: gi_1_1, nom: 'Service A', email: 'contact@service-a.gouv.fr', telephone: '0123456789', horaires: "9h-12h\r\n14h-17h", adresse: "1 rue de la Paix\r\n75001 Paris") }
+    let!(:contact_info_2) { create(:contact_information, groupe_instructeur: gi_1_2, nom: 'Service B', email: 'contact@service-b.gouv.fr', telephone: '0987654321', horaires: '8h-16h', adresse: '2 avenue des Champs, Lyon') }
+
+    subject do
+      get :export_contact_informations, params: { procedure_id: procedure.id, format: :csv }
+    end
+
+    it 'generates a CSV file containing the contact information by group' do
+      expect(subject.status).to eq(200)
+      expect(subject.stream.body).to include("Groupe")
+      expect(subject.stream.body).to include("Nom_du_service")
+      expect(subject.stream.body).to include("Service A")
+      expect(subject.stream.body).to include("contact@service-a.gouv.fr")
+      expect(subject.stream.body).to include("Service B")
+      expect(subject.header["Content-Disposition"]).to include("#{procedure.id}-contact-informations-#{Date.today}.csv")
+    end
+
+    it 'preserves newlines in CSV fields' do
+      csv = CSV.parse(subject.stream.body, headers: true)
+      row = csv.find { |r| r['Groupe'] == gi_1_1.label }
+      expect(row['Horaires']).to eq("9h-12h\r\n14h-17h")
+      expect(row['Adresse_postale']).to eq("1 rue de la Paix\r\n75001 Paris")
+    end
+
+    context 'when a group has no contact information' do
+      before { contact_info_2.destroy }
+
+      it 'includes the group with empty contact fields' do
+        expect(subject.status).to eq(200)
+        expect(subject.stream.body).to include(gi_1_2.label)
+      end
+    end
+  end
+
   describe '#options' do
     context 'with a simple routable type de champ' do
       let!(:procedure) do


### PR DESCRIPTION
cf #12600

### Avant
On avait un simple bouton pour exporter la liste des instructeurs par groupes

<img width="2034" height="716" alt="Capture d’écran 2026-03-10 à 15 03 33" src="https://github.com/user-attachments/assets/9048a641-9662-4198-b1fe-07bed5d797f4" />


### Après
On a un bouton drop down qui permet soit d'exporter la liste des instructeurs par groupes, soit d'exporter les informations de contact des groupes
<img width="2034" height="726" alt="Capture d’écran 2026-03-10 à 15 03 07" src="https://github.com/user-attachments/assets/f138f851-c387-4e67-98a3-a7d1660e1b66" />

