### PR TITLE
ETQ Instructeur si j'exporte un champ multiple avec référentiel, j'obtient la valeur choisie par l'usager pas un id technique

### DIFF
--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -9,6 +9,10 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampB
     end
   end
 
+  def champ_value_for_export(champ, path = :value)
+    path == :value ? champ_value(champ).presence : super
+  end
+
   def champ_value_for_tag(champ, path = :value)
     ChampPresentations::MultipleDropDownListPresentation.new(selected_options(champ))
   end

--- a/spec/models/types_de_champ/multiple_drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/multiple_drop_down_list_type_de_champ_spec.rb
@@ -15,4 +15,35 @@ describe TypesDeChamp::MultipleDropDownListTypeDeChamp do
       expect(columns).to contain_exactly(an_instance_of(Columns::MultipleDropDownColumn))
     end
   end
+
+  describe '#champ_value_for_export' do
+    let(:referentiel) { create(:csv_referentiel, :with_items) }
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [{ type: :multiple_drop_down_list, referentiel:, drop_down_mode: 'advanced' }])
+    end
+    let(:multiple_dropdown_list_tdc) { procedure.active_revision.types_de_champ.first }
+    let(:selected_items) { referentiel.items.first(2) }
+    let(:champ) do
+      multiple_dropdown_list_tdc.build_champ(value: selected_items.map(&:id).to_json).tap do |c|
+        c.referentiels = selected_items.each_with_object({}) do |item, acc|
+          acc[item.id.to_s] = { 'data' => item.data.merge('headers' => referentiel.headers) }
+        end
+      end
+    end
+
+    it 'returns user values and not referentiel ids' do
+      expect(multiple_dropdown_list_tdc.champ_value_for_export(champ)).to eq('fromage, dessert')
+    end
+
+    context 'when the champ is not in advanced mode' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [{ type: :multiple_drop_down_list, drop_down_mode: 'simple' }])
+      end
+      let(:champ) { multiple_dropdown_list_tdc.build_champ(value: ['val1', 'val2'].to_json) }
+
+      it 'returns selected option labels' do
+        expect(multiple_dropdown_list_tdc.champ_value_for_export(champ)).to eq('val1, val2')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Remonté au support https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_22b773ec-77d9-4ad7-b8f1-95f1dec6ff6b/