### PR TITLE
ETQ agent qui se proconnecte pour une démarche, je peux directement me connecter depuis le bouton de la page "Commencer"

### DIFF
--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -83,7 +83,7 @@ module Users
       return procedure_not_found if @procedure.blank?
 
       store_user_location!(@procedure)
-      redirect_to new_user_session_path
+      redirect_to pro_connect_login_path
     end
 
     def procedure_for_help

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -428,6 +428,24 @@ describe Users::CommencerController, type: :controller do
     end
   end
 
+  describe '#pro_connect' do
+    context 'for a published procedure' do
+      subject { get :pro_connect, params: { path: published_procedure.path } }
+
+      it 'set the path to return after sign-up to the procedure start page' do
+        subject
+        expect(controller.stored_location_for(:user)).to eq(commencer_path(path: published_procedure.path))
+        expect(subject).to redirect_to(pro_connect_login_path)
+      end
+
+      context 'when a prefill token is given' do
+        subject { get :pro_connect, params: { path: published_procedure.path, prefill_token: 'prefill_token' } }
+
+        it_behaves_like 'a prefill token storage'
+      end
+    end
+  end
+
   describe '#dossier_vide_pdf' do
     let(:procedure) { create(:procedure, :published, :with_service, :with_path) }
     before { get :dossier_vide_pdf, params: { path: procedure.path } }


### PR DESCRIPTION
Corrige régression introduite dans #12709  pour rétablir la redirection depuis /commencer/$demarche/pro_connect directement vers ProConnect plutôt que vers notre form de connexion

https://mattermost.incubateur.net/betagouv/pl/p7ktxe6pftn3mxqs8jmym7uf1c