### PR TITLE
ETQ admin je vois dans ma page de gestion des groupes instructeurs lesquels ont des informations de contact personnalisées

### DIFF
--- a/app/components/procedure/groupes_management_component.rb
+++ b/app/components/procedure/groupes_management_component.rb
@@ -26,4 +26,8 @@ class Procedure::GroupesManagementComponent < ApplicationComponent
       end
     end
   end
+
+  def any_custom_contact_information?
+    @procedure.groupe_instructeurs.joins(:contact_information).exists?
+  end
 end

--- a/app/components/procedure/groupes_management_component/groupes_management_component.en.yml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.en.yml
@@ -6,6 +6,10 @@ en:
   found:
     one: found
     other: found
+  table:
+    contact_informations: Contact information
+    custom: Custom
+    not_custom: Not custom
   add_groupe_modal:
     title: Add a group
     label: New group

--- a/app/components/procedure/groupes_management_component/groupes_management_component.fr.yml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.fr.yml
@@ -6,6 +6,10 @@ fr:
   found:
     one: trouvé
     other: trouvés
+  table:
+    contact_informations: Informations de contact
+    custom: Personnalisé
+    not_custom: Non personnalisé
   add_groupe_modal:
     title: Ajouter un groupe
     label: Nouveau groupe

--- a/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
+++ b/app/components/procedure/groupes_management_component/groupes_management_component.html.haml
@@ -53,8 +53,11 @@
           %caption= table_header
           %thead
             %tr
-              %th.fr-col-9{ scope: 'col' }
+              %th{ scope: 'col', class: any_custom_contact_information? ? 'fr-col-6' : 'fr-col-9' }
                 Groupes
+              - if any_custom_contact_information?
+                %th.fr-col-3{ scope: 'col' }
+                  = t('.table.contact_informations')
               %th.fr-col-1{ scope: 'col' }
                 Dossiers
               %th.fr-col-2.fr-cell--right{ scope: 'col' }
@@ -74,6 +77,13 @@
                     %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-mt-1w règle invalide
                   - elsif gi.non_unique_rule?
                     %p.fr-badge.fr-badge--warning.fr-badge--sm.fr-mt-1w règle déjà attribuée à #{gi.groups_with_same_rule}
+
+                - if any_custom_contact_information?
+                  %td{ scope: 'col' }
+                    - if gi.contact_information.present?
+                      %p.fr-badge.fr-badge--success.fr-badge--sm= t('.table.custom').upcase
+                    - else
+                      %p.fr-badge.fr-badge--sm.fr-badge--no-icon= t('.table.not_custom').upcase
 
                 %td{ scope: 'col' }
                   %span.fr-mr-1w


### PR DESCRIPTION
cf #12600

# Avant

<img width="2170" height="606" alt="Capture d’écran 2026-03-12 à 16 20 12" src="https://github.com/user-attachments/assets/170ab350-ce50-4f19-88b5-fdeed2f03c42" />

# Après

<img width="2170" height="606" alt="Capture d’écran 2026-03-12 à 16 19 49" src="https://github.com/user-attachments/assets/482b2797-5a9a-4c84-83ba-aa529a45fac5" />

Une colonne "Informations de contact" apparaît si au moins un groupe a des informations de contact personnalisées