### PR TITLE
ETQ instructeur, admin : une page tampon m'informe que je dois me ProConnecter pour accéder à une démarche

### DIFF
--- a/app/controllers/administrateurs/administrateur_controller.rb
+++ b/app/controllers/administrateurs/administrateur_controller.rb
@@ -47,8 +47,9 @@ module Administrateurs
       return if @procedure.pro_connect_restriction_none?
       return if logged_in_with_pro_connect?
 
+      store_location_for(:user, request.fullpath)
       flash.alert = "Vous devez vous connecter par ProConnect pour accéder à cette démarche"
-      redirect_to new_user_session_path
+      redirect_to pro_connect_required_path
     end
 
     private

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -483,8 +483,9 @@ module Instructeurs
       return if procedure.pro_connect_restriction_none?
       return if logged_in_with_pro_connect?
 
+      store_location_for(:user, request.fullpath)
       flash[:alert] = "Vous devez vous connecter par ProConnect pour accéder à cette démarche"
-      redirect_to new_user_session_path
+      redirect_to pro_connect_required_path
     end
 
     def redirect_to_avis_if_needed

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -16,6 +16,8 @@ class ProConnectController < ApplicationController
     redirect_to new_user_session_path, status: :moved_permanently
   end
 
+  def required; end
+
   def login
     uri, state, nonce = ProConnectService.authorization_uri
 

--- a/app/views/pro_connect/required.html.erb
+++ b/app/views/pro_connect/required.html.erb
@@ -1,0 +1,15 @@
+<div class="fr-container fr-py-5w">
+  <div class="fr-grid-row fr-grid-row--center">
+    <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+      <%= render Dsfr::CalloutComponent.new(title: t('.title'), heading_level: 'h1') do |c| %>
+        <% c.with_body do %>
+          <p><%= t('.explanation') %></p>
+
+          <div class="fr-mt-3w">
+            <%= render ProConnectLoginComponent.new(title: nil) %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/views/pro_connect/en.yml
+++ b/config/locales/views/pro_connect/en.yml
@@ -1,0 +1,5 @@
+en:
+  pro_connect:
+    required:
+      title: "ProConnect login required"
+      explanation: "This procedure requires ProConnect authentication. Please sign in with ProConnect to access it."

--- a/config/locales/views/pro_connect/fr.yml
+++ b/config/locales/views/pro_connect/fr.yml
@@ -1,0 +1,5 @@
+fr:
+  pro_connect:
+    required:
+      title: "Connexion ProConnect requise"
+      explanation: "Cette démarche nécessite une authentification via ProConnect. Seuls les agents disposant d’un compte ProConnect peuvent y accéder."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,6 +209,7 @@ Rails.application.routes.draw do
   get 'pro_connect' => 'pro_connect#index'
   get 'pro_connect/login' => 'pro_connect#login'
   get 'pro_connect/callback' => 'pro_connect#callback'
+  get 'pro_connect/required' => 'pro_connect#required'
 
   namespace :champs do
     post ':dossier_id/:stable_id/repetition', to: 'repetition#add', as: :repetition

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -1830,10 +1830,10 @@ describe Administrateurs::ProceduresController, type: :controller do
 
     context 'when ProConnect is required' do
       let(:procedure) { create(:procedure, pro_connect_restriction: :instructeurs, administrateur: admin) }
-      it 'redirects to sign_in and sets a flash message' do
+      it 'redirects to pro_connect_required and sets a flash message' do
         subject
 
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to redirect_to(pro_connect_required_path)
         expect(flash[:alert]).to eq("Vous devez vous connecter par ProConnect pour accéder à cette démarche")
       end
 

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -1281,7 +1281,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
       it "redirects to pro_connect_restricted page" do
         get :show, params: { procedure_id: procedure.id, dossier_id: dossier.id, statut: 'a-suivre' }
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to redirect_to(pro_connect_required_path)
       end
     end
   end

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -644,10 +644,10 @@ describe Instructeurs::ProceduresController, type: :controller do
           procedure.update!(pro_connect_restriction: :instructeurs)
         end
 
-        it 'redirects to sign_in and sets a flash message' do
+        it 'redirects to pro_connect_required and sets a flash message' do
           subject
 
-          expect(response).to redirect_to(new_user_session_path)
+          expect(response).to redirect_to(pro_connect_required_path)
           expect(flash[:alert]).to eq("Vous devez vous connecter par ProConnect pour accéder à cette démarche")
         end
 

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 describe ProConnectController, type: :controller do
+  describe '#required' do
+    subject { get :required }
+    render_views
+
+    it 'renders the required template' do
+      subject
+      expect(response.body).to have_text("Connexion ProConnect")
+    end
+  end
+
   describe '#login' do
     let(:uri) { 'https://www.proconnect.gouv.fr' }
     let(:state) { 'state' }


### PR DESCRIPTION
Ré-introduit une page tampon qui informe qu'il faut être ProConnecté pour accéder à une démarche.
https://mattermost.incubateur.net/betagouv/pl/nj1uhmfn37rategj5m94eo6pcr

Fix le cas suivant : 

- on a un admin ou instructeur connecté par mdp
- une démarche limitée à ProConnect à laquelle il est admin/instructeur
- il clique sur le lien admin/instructeur de cette démarche

Jusqu'à la PR #12709, on détectait qu'il n'était pas ProConnecté, on le redirigeait vers notre page ProConnect avec un message expliquant qu'il faut se ProC. Il suivait le bouton et revenait sur la démarche.

Depuis cette PR 12709, plus cette page tampon ProC, mais redirection vers page de connexion. Comme il est connecté, on le redirige vers une autre page avec le msg "Vous êtes déjà connecté" et il ne peut pas se Pro.
<img width="1257" height="548" alt="Capture d’écran 2026-03-12 à 18 27 12" src="https://github.com/user-attachments/assets/07c459ed-79bd-4bdd-a208-035aba7bcadd" />

