### PR TITLE
ETQ admin et non instructeur je peux ajouter des informations de contact à un groupe instructeur

### DIFF
--- a/app/controllers/administrateurs/contact_informations_controller.rb
+++ b/app/controllers/administrateurs/contact_informations_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Administrateurs
+  class ContactInformationsController < AdministrateurController
+    before_action :retrieve_procedure
+    before_action :retrieve_groupe_instructeur
+
+    def new
+      @contact_information = @groupe_instructeur.build_contact_information
+    end
+
+    def create
+      @contact_information = @groupe_instructeur.build_contact_information(contact_information_params)
+      if @contact_information.save
+        redirect_to admin_procedure_groupe_instructeur_path(@procedure, @groupe_instructeur),
+          notice: "Les informations de contact ont bien été ajoutées"
+      else
+        flash.now[:alert] = @contact_information.errors.full_messages
+        render :new
+      end
+    end
+
+    def edit
+      @contact_information = @groupe_instructeur.contact_information
+    end
+
+    def update
+      @contact_information = @groupe_instructeur.contact_information
+      if @contact_information.update(contact_information_params)
+        redirect_to admin_procedure_groupe_instructeur_path(@procedure, @groupe_instructeur),
+          notice: "Les informations de contact ont bien été modifiées"
+      else
+        flash.now[:alert] = @contact_information.errors.full_messages
+        render :edit
+      end
+    end
+
+    def destroy
+      @groupe_instructeur.contact_information.destroy
+      redirect_to admin_procedure_groupe_instructeur_path(@procedure, @groupe_instructeur),
+        notice: "Les informations de contact ont bien été supprimées"
+    end
+
+    private
+
+    def retrieve_groupe_instructeur
+      @groupe_instructeur = @procedure.groupe_instructeurs.find(params[:groupe_instructeur_id])
+    end
+
+    def contact_information_params
+      params.require(:contact_information).permit(:nom, :email, :telephone, :horaires, :adresse)
+    end
+  end
+end

--- a/app/controllers/instructeurs/contact_informations_controller.rb
+++ b/app/controllers/instructeurs/contact_informations_controller.rb
@@ -11,7 +11,7 @@ module Instructeurs
       assign_procedure_and_groupe_instructeur
       @contact_information = @groupe_instructeur.build_contact_information(contact_information_params)
       if @contact_information.save
-        redirect_to_groupe_instructeur("Les informations de contact ont bien été ajoutées")
+        redirect_to instructeur_groupe_path(@procedure, @groupe_instructeur), notice: "Les informations de contact ont bien été ajoutées"
       else
         flash[:alert] = @contact_information.errors.full_messages
         render :new
@@ -27,7 +27,7 @@ module Instructeurs
       assign_procedure_and_groupe_instructeur
       @contact_information = @groupe_instructeur.contact_information
       if @contact_information.update(contact_information_params)
-        redirect_to_groupe_instructeur("Les informations de contact ont bien été modifiées")
+        redirect_to instructeur_groupe_path(@procedure, @groupe_instructeur), notice: "Les informations de contact ont bien été modifiées"
       else
         flash[:alert] = @contact_information.errors.full_messages
         render :edit
@@ -37,18 +37,10 @@ module Instructeurs
     def destroy
       assign_procedure_and_groupe_instructeur
       @groupe_instructeur.contact_information.destroy
-      redirect_to_groupe_instructeur("Les informations de contact ont bien été supprimées")
+      redirect_to instructeur_groupe_path(@procedure, @groupe_instructeur), notice: "Les informations de contact ont bien été supprimées"
     end
 
     private
-
-    def redirect_to_groupe_instructeur(notice)
-      if params[:from_admin] == "true"
-        redirect_to admin_procedure_groupe_instructeur_path(@procedure, @groupe_instructeur), notice: notice
-      else
-        redirect_to instructeur_groupe_path(@procedure, @groupe_instructeur), notice: notice
-      end
-    end
 
     def assign_procedure_and_groupe_instructeur
       @procedure = current_instructeur.procedures.find params[:procedure_id]

--- a/app/views/administrateurs/contact_informations/_form.html.erb
+++ b/app/views/administrateurs/contact_informations/_form.html.erb
@@ -1,0 +1,25 @@
+<%= form_with url: admin_procedure_groupe_instructeur_contact_information_path(@procedure, @groupe_instructeur), model: @contact_information, local: true do |f| %>
+  <%= render "shared/groupe_instructeurs/contact_information_fields", f: f %>
+
+  <div class="fixed-footer">
+    <div class="fr-container">
+      <ul class="fr-btns-group fr-btns-group--inline-md">
+        <li><%= f.submit "Enregistrer", class: "fr-btn" %></li>
+
+        <li>
+          <%= link_to "Annuler", admin_procedure_groupe_instructeur_path(@procedure, @groupe_instructeur), class: "fr-btn fr-btn--secondary" %>
+        </li>
+
+        <% if ["edit", "update"].include?(params[:action]) %>
+          <li>
+            <%= link_to 'Supprimer',
+              admin_procedure_groupe_instructeur_contact_information_path(@procedure, @groupe_instructeur),
+              method: :delete,
+              data: { confirm: "Confirmez vous la suppression de ces informations de contact ?" },
+              class: 'fr-btn fr-btn--secondary' %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/views/administrateurs/contact_informations/edit.html.erb
+++ b/app/views/administrateurs/contact_informations/edit.html.erb
@@ -1,0 +1,13 @@
+<%= render partial: 'administrateurs/breadcrumbs',
+  locals: { steps: [['Démarches', admin_procedures_path],
+    [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],
+    ["Groupes d'instructeurs", admin_procedure_groupe_instructeurs_path(@procedure)],
+    [@groupe_instructeur.label, admin_procedure_groupe_instructeur_path(@procedure, @groupe_instructeur)],
+    ['Informations de contact']]} %>
+
+<div class="container">
+  <h1>Modifier les informations de contact</h1>
+
+  <%= render partial: 'form',
+    locals: { contact_information: @contact_information } %>
+</div>

--- a/app/views/administrateurs/contact_informations/new.html.erb
+++ b/app/views/administrateurs/contact_informations/new.html.erb
@@ -1,0 +1,13 @@
+<%= render partial: 'administrateurs/breadcrumbs',
+  locals: { steps: [['Démarches', admin_procedures_path],
+    [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],
+    ["Groupes d'instructeurs", admin_procedure_groupe_instructeurs_path(@procedure)],
+    [@groupe_instructeur.label, admin_procedure_groupe_instructeur_path(@procedure, @groupe_instructeur)],
+    ['Informations de contact']]} %>
+
+<div class="container">
+  <h1>Informations de contact</h1>
+
+  <%= render partial: 'form',
+    locals: { contact_information: @contact_information } %>
+</div>

--- a/app/views/instructeurs/contact_informations/_form.html.haml
+++ b/app/views/instructeurs/contact_informations/_form.html.haml
@@ -1,29 +1,5 @@
 = form_with url: instructeur_groupe_contact_information_path, model: @contact_information, local: true do |f|
-  = hidden_field_tag :from_admin, params[:from_admin]
-
-  = render Dsfr::CalloutComponent.new(title: "Informations de contact") do |c|
-    - c.with_body do
-      Votre démarche est hébergée par #{Current.application_name} – mais nous ne pouvons pas assurer le support des démarches. Et malgré la dématérialisation, les usagers se posent parfois des questions légitimes sur le processus administratif.
-      %br
-      %br
-      %strong Il est donc indispensable que les usagers puissent vous contacter
-      par le moyen de leur choix s’ils ont des questions sur votre démarche.
-      %br
-      %br
-      Ces informations de contact seront visibles par les utilisateurs de la démarche, affichées dans le menu « Aide », ainsi qu’en pied de page lors du dépôt d’un dossier.
-      %br
-      %br
-      ⚠️  En cas d’informations invalides, #{Current.application_name} se réserve le droit de suspendre la publication de la démarche.
-
-  = render Dsfr::InputComponent.new(form: f, attribute: :nom, input_type: :text_field) do |c|
-    - c.with_hint do
-      Indiquez le nom à utiliser pour contacter le groupe instructeur
-      (Exemple: Secrétariat de la Mairie)
-
-  = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field)
-  = render Dsfr::InputComponent.new(form: f, attribute: :telephone, input_type: :telephone_field)
-  = render Dsfr::InputComponent.new(form: f, attribute: :horaires, input_type: :text_area)
-  = render Dsfr::InputComponent.new(form: f, attribute: :adresse, input_type: :text_area)
+  = render "shared/groupe_instructeurs/contact_information_fields", f: f
 
   - if procedure_id.present?
     = hidden_field_tag :procedure_id, procedure_id
@@ -36,10 +12,10 @@
         %li
           = link_to "Annuler", instructeur_groupe_path(@groupe_instructeur, procedure_id: procedure_id), class: "fr-btn fr-btn--secondary"
 
-        - if [ "edit", "update"].include? params[:action]
+        - if ["edit", "update"].include?(params[:action])
           %li
             = link_to 'Supprimer',
-            instructeur_groupe_contact_information_path(procedure_id: @procedure.id, groupe_id: @groupe_instructeur.id),
+              instructeur_groupe_contact_information_path(procedure_id: @procedure.id, groupe_id: @groupe_instructeur.id),
               method: :delete,
-                data: { confirm: "Confirmez vous la suppression de ces informations de contact ?" },
-                  class: 'fr-btn fr-btn--secondary'
+              data: { confirm: "Confirmez vous la suppression de ces informations de contact ?" },
+              class: 'fr-btn fr-btn--secondary'

--- a/app/views/shared/groupe_instructeurs/_contact_information.html.haml
+++ b/app/views/shared/groupe_instructeurs/_contact_information.html.haml
@@ -6,8 +6,10 @@
     %strong= groupe_instructeur.label
     %span n’a pas d’informations de contact spécifiques.
     %p Les informations de contact affichées à l’usager seront celles du service porteur de la démarche.
-    - if groupe_instructeur.instructeurs.include?(current_user&.instructeur)
-      = link_to "Personnaliser les informations de contact", new_instructeur_groupe_contact_information_path(procedure_id: procedure.id, groupe_id: groupe_instructeur.id, from_admin: true), class: "fr-btn"
+    - if controller.try(:nav_bar_profile) == :administrateur
+      = link_to "Personnaliser les informations de contact", new_admin_procedure_groupe_instructeur_contact_information_path(procedure, groupe_instructeur), class: "fr-btn"
+    - elsif groupe_instructeur.instructeurs.include?(current_user&.instructeur)
+      = link_to "Personnaliser les informations de contact", new_instructeur_groupe_contact_information_path(procedure_id: procedure.id, groupe_id: groupe_instructeur.id), class: "fr-btn"
     - else
       %p Si vous souhaitez créer un service pour ce groupe, vous devez faire partie du groupe instructeur
   - else
@@ -18,7 +20,7 @@
       %p= service.telephone
     - if service.horaires.present?
       %p= service.horaires
-    - if groupe_instructeur.instructeurs.include?(current_user&.instructeur)
-      = link_to "Modifier les informations de contact", edit_instructeur_groupe_contact_information_path(procedure_id: procedure.id, groupe_id: groupe_instructeur.id, from_admin: true), class: "fr-btn"
-    - else
-      %p Si vous souhaitez modifier ce service, vous devez faire partie du groupe instructeur
+    - if controller.try(:nav_bar_profile) == :administrateur
+      = link_to "Modifier les informations de contact", edit_admin_procedure_groupe_instructeur_contact_information_path(procedure, groupe_instructeur), class: "fr-btn"
+    - elsif groupe_instructeur.instructeurs.include?(current_user&.instructeur)
+      = link_to "Modifier les informations de contact", edit_instructeur_groupe_contact_information_path(procedure_id: procedure.id, groupe_id: groupe_instructeur.id), class: "fr-btn"

--- a/app/views/shared/groupe_instructeurs/_contact_information_fields.html.erb
+++ b/app/views/shared/groupe_instructeurs/_contact_information_fields.html.erb
@@ -1,0 +1,33 @@
+<%= render Dsfr::CalloutComponent.new(title: "Informations de contact") do |c| %>
+  <% c.with_body do %>
+    Votre démarche est hébergée par <%= Current.application_name %> – mais nous
+    ne pouvons pas assurer le support des démarches. Et malgré la
+    dématérialisation, les usagers se posent parfois des questions légitimes
+    sur le processus administratif.
+    <br>
+    <br>
+    <strong>Il est donc indispensable que les usagers puissent vous contacter</strong>
+    par le moyen de leur choix s’ils ont des questions sur votre démarche.
+    <br>
+    <br>
+    Ces informations de contact seront visibles par les utilisateurs de la
+    démarche, affichées dans le menu « Aide », ainsi qu’en pied de page lors du
+    dépôt d'un dossier.
+    <br>
+    <br>
+    ⚠️ En cas d'informations invalides, <%= Current.application_name %> se
+    réserve le droit de suspendre la publication de la démarche.
+  <% end %>
+<% end %>
+
+<%= render Dsfr::InputComponent.new(form: f, attribute: :nom, input_type: :text_field) do |c| %>
+  <% c.with_hint do %>
+    Indiquez le nom à utiliser pour contacter le groupe instructeur (Exemple:
+    Secrétariat de la Mairie)
+  <% end %>
+<% end %>
+
+<%= render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field) %>
+<%= render Dsfr::InputComponent.new(form: f, attribute: :telephone, input_type: :telephone_field) %>
+<%= render Dsfr::InputComponent.new(form: f, attribute: :horaires, input_type: :text_area) %>
+<%= render Dsfr::InputComponent.new(form: f, attribute: :adresse, input_type: :text_area) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -750,6 +750,7 @@ Rails.application.routes.draw do
 
       resources :groupe_instructeurs, only: [:index, :show, :create, :update, :destroy] do
         patch 'update_state' => 'groupe_instructeurs#update_state'
+        resource :contact_information, only: [:new, :create, :edit, :update, :destroy]
 
         member do
           post 'add_instructeurs'

--- a/spec/controllers/administrateurs/contact_informations_controller_spec.rb
+++ b/spec/controllers/administrateurs/contact_informations_controller_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+describe Administrateurs::ContactInformationsController, type: :controller do
+  let(:admin) { administrateurs(:default_admin) }
+  let(:procedure) { create(:procedure, administrateurs: [admin]) }
+  let(:groupe_instructeur) { procedure.defaut_groupe_instructeur }
+
+  before do
+    sign_in(admin.user)
+  end
+
+  describe '#new' do
+    it 'renders the new template' do
+      get :new, params: { procedure_id: procedure.id, groupe_instructeur_id: groupe_instructeur.id }
+      expect(response).to render_template(:new)
+      expect(assigns(:contact_information)).to be_a_new(ContactInformation)
+    end
+  end
+
+  describe '#create' do
+    let(:valid_params) do
+      {
+        procedure_id: procedure.id,
+        groupe_instructeur_id: groupe_instructeur.id,
+        contact_information: {
+          nom: 'Service Test',
+          email: 'contact@test.gouv.fr',
+          telephone: '0123456789',
+          horaires: '9h-17h',
+          adresse: '1 rue de la Paix, 75001 Paris',
+        },
+      }
+    end
+
+    context 'with valid params' do
+      it 'creates the contact information and redirects' do
+        expect { post :create, params: valid_params }
+          .to change { ContactInformation.count }.by(1)
+
+        expect(flash[:notice]).to eq('Les informations de contact ont bien été ajoutées')
+        expect(response).to redirect_to(admin_procedure_groupe_instructeur_path(procedure, groupe_instructeur))
+      end
+    end
+
+    context 'with invalid params' do
+      let(:invalid_params) do
+        valid_params.deep_merge(contact_information: { nom: '', email: '' })
+      end
+
+      it 'renders the new template with errors' do
+        post :create, params: invalid_params
+        expect(response).to render_template(:new)
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+
+  describe '#edit' do
+    let!(:contact_information) { create(:contact_information, groupe_instructeur:) }
+
+    it 'renders the edit template' do
+      get :edit, params: { procedure_id: procedure.id, groupe_instructeur_id: groupe_instructeur.id }
+      expect(response).to render_template(:edit)
+      expect(assigns(:contact_information)).to eq(contact_information)
+    end
+  end
+
+  describe '#update' do
+    let!(:contact_information) { create(:contact_information, groupe_instructeur:, nom: 'Old Name') }
+
+    let(:update_params) do
+      {
+        procedure_id: procedure.id,
+        groupe_instructeur_id: groupe_instructeur.id,
+        contact_information: { nom: 'New Name' },
+      }
+    end
+
+    context 'with valid params' do
+      it 'updates the contact information and redirects' do
+        patch :update, params: update_params
+
+        expect(contact_information.reload.nom).to eq('New Name')
+        expect(flash[:notice]).to eq('Les informations de contact ont bien été modifiées')
+        expect(response).to redirect_to(admin_procedure_groupe_instructeur_path(procedure, groupe_instructeur))
+      end
+    end
+
+    context 'with invalid params' do
+      let(:invalid_params) do
+        update_params.deep_merge(contact_information: { email: 'invalid' })
+      end
+
+      it 'renders the edit template with errors' do
+        patch :update, params: invalid_params
+        expect(response).to render_template(:edit)
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+
+  describe '#destroy' do
+    let!(:contact_information) { create(:contact_information, groupe_instructeur:) }
+
+    it 'destroys the contact information and redirects' do
+      expect {
+        delete :destroy, params: { procedure_id: procedure.id, groupe_instructeur_id: groupe_instructeur.id }
+      }.to change { ContactInformation.count }.by(-1)
+
+      expect(flash[:notice]).to eq('Les informations de contact ont bien été supprimées')
+      expect(response).to redirect_to(admin_procedure_groupe_instructeur_path(procedure, groupe_instructeur))
+    end
+  end
+
+  context 'when admin is not an instructeur in the groupe' do
+    it 'still allows access to create contact information' do
+      expect(groupe_instructeur.instructeurs).not_to include(admin.user.instructeur)
+
+      get :new, params: { procedure_id: procedure.id, groupe_instructeur_id: groupe_instructeur.id }
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/controllers/instructeurs/contact_informations_controller_spec.rb
+++ b/spec/controllers/instructeurs/contact_informations_controller_spec.rb
@@ -24,7 +24,6 @@ describe Instructeurs::ContactInformationsController, type: :controller do
           },
           procedure_id: procedure.id,
           groupe_id: gi.id,
-          from_admin: from_admin,
         }
       end
 
@@ -37,14 +36,6 @@ describe Instructeurs::ContactInformationsController, type: :controller do
         expect(ContactInformation.last.telephone).to eq('1234')
         expect(ContactInformation.last.horaires).to eq('horaires')
         expect(ContactInformation.last.adresse).to eq('adresse')
-      end
-
-      context 'from admin' do
-        let(:from_admin) { true }
-        it do
-          post :create, params: params
-          expect(response).to redirect_to(admin_procedure_groupe_instructeur_path(gi, procedure_id: procedure.id))
-        end
       end
     end
 
@@ -99,11 +90,6 @@ describe Instructeurs::ContactInformationsController, type: :controller do
         expect(ContactInformation.last.nom).to eq('nom')
         expect(response).to redirect_to(instructeur_groupe_path(gi, procedure_id: procedure.id))
       end
-    end
-
-    context 'when updating a contact_information as an admin' do
-      let(:from_admin) { true }
-      it { expect(response).to redirect_to(admin_procedure_groupe_instructeur_path(gi, procedure_id: procedure.id)) }
     end
 
     context 'when updating a contact_information with invalid data' do


### PR DESCRIPTION
cf une partie de #12600

- Jusqu'à présent un admin pouvait ajouter des informations de contact à un groupe instructeur uniquement s'il était membre du groupe instructeur. Désormais ce n'est plus nécessaire
- Et si l'admin était aussi instructeur, il était redirigé vers son interface instructeur après avoir ajouté des informations de contact. Ce n'est plus le cas
- Pas de changement d'UI