### PR TITLE
chore: ETQ tech j'aimerais que les specs tournent plus vite

### DIFF
--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -40,16 +40,16 @@ describe Dossier, type: :model do
     end
 
     describe 'by_statut' do
-      let(:procedure) { create(:procedure) }
-      let(:dossier_en_construction) { create(:dossier, :en_construction, procedure:) }
-      let(:dossier_en_instruction) { create(:dossier, :en_instruction, procedure:) }
-      let(:dossier_accepte) { create(:dossier, :accepte, procedure:) }
-      let(:dossier_refuse) { create(:dossier, :refuse, procedure:) }
-      let(:dossier_accepte_archive) { create(:dossier, :accepte, :archived, procedure:) }
-      let(:dossier_accepte_deleted) { create(:dossier, :accepte, :hidden_by_administration, procedure:) }
-      let(:dossier_accepte_archive_deleted) { create(:dossier, :accepte, :archived, :hidden_by_administration, procedure:) }
+      let_it_be(:procedure) { create(:procedure) }
+      let_it_be(:dossier_en_construction) { create(:dossier, :en_construction, procedure:) }
+      let_it_be(:dossier_en_instruction) { create(:dossier, :en_instruction, procedure:) }
+      let_it_be(:dossier_accepte) { create(:dossier, :accepte, procedure:) }
+      let_it_be(:dossier_refuse) { create(:dossier, :refuse, procedure:) }
+      let_it_be(:dossier_accepte_archive) { create(:dossier, :accepte, :archived, procedure:) }
+      let_it_be(:dossier_accepte_deleted) { create(:dossier, :accepte, :hidden_by_administration, procedure:) }
+      let_it_be(:dossier_accepte_archive_deleted) { create(:dossier, :accepte, :archived, :hidden_by_administration, procedure:) }
 
-      let!(:dossiers) { [dossier_en_construction, dossier_en_instruction, dossier_accepte, dossier_refuse] }
+      let(:dossiers) { [dossier_en_construction, dossier_en_instruction, dossier_accepte, dossier_refuse] }
 
       context 'tous' do
         it do
@@ -165,12 +165,12 @@ describe Dossier, type: :model do
   end
 
   describe 'brouillon_close_to_expiration' do
-    let(:procedure) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 6) }
-    let!(:young_dossier) { create(:dossier, :en_construction, procedure: procedure) }
-    let!(:expiring_dossier) { create(:dossier, updated_at: 85.days.ago, procedure: procedure) }
-    let!(:expiring_dossier_with_notification) { create(:dossier, updated_at: 85.days.ago, brouillon_close_to_expiration_notice_sent_at: Time.zone.now, procedure: procedure) }
-    let!(:just_expired_dossier) { create(:dossier, updated_at: (6.months + 1.hour + 10.seconds).ago, procedure: procedure) }
-    let!(:long_expired_dossier) { create(:dossier, updated_at: 1.year.ago, procedure: procedure) }
+    let_it_be(:procedure) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 6) }
+    let_it_be(:young_dossier) { create(:dossier, :en_construction, procedure:) }
+    let_it_be(:expiring_dossier) { create(:dossier, updated_at: 85.days.ago, procedure:) }
+    let_it_be(:expiring_dossier_with_notification) { create(:dossier, updated_at: 85.days.ago, brouillon_close_to_expiration_notice_sent_at: Time.zone.now, procedure:) }
+    let_it_be(:just_expired_dossier) { create(:dossier, updated_at: (6.months + 1.hour + 10.seconds).ago, procedure:) }
+    let_it_be(:long_expired_dossier) { create(:dossier, updated_at: 1.year.ago, procedure:) }
 
     subject { Dossier.brouillon_close_to_expiration }
 
@@ -215,12 +215,12 @@ describe Dossier, type: :model do
   end
 
   describe 'en_construction_close_to_expiration' do
-    let(:procedure) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 6) }
-    let!(:young_dossier) { create(:dossier, procedure: procedure) }
-    let!(:expiring_dossier) { create(:dossier, :en_construction, en_construction_at: 175.days.ago, procedure: procedure) }
-    let!(:expiring_dossier_with_notification) { create(:dossier, :en_construction, en_construction_at: 175.days.ago, en_construction_close_to_expiration_notice_sent_at: Time.zone.now, procedure: procedure) }
-    let!(:just_expired_dossier) { create(:dossier, :en_construction, en_construction_at: (6.months + 1.hour + 10.seconds).ago, procedure: procedure) }
-    let!(:long_expired_dossier) { create(:dossier, :en_construction, en_construction_at: 1.year.ago, procedure: procedure) }
+    let_it_be(:procedure) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 6) }
+    let_it_be(:young_dossier) { create(:dossier, procedure:) }
+    let_it_be(:expiring_dossier) { create(:dossier, :en_construction, en_construction_at: 175.days.ago, procedure:) }
+    let_it_be(:expiring_dossier_with_notification) { create(:dossier, :en_construction, en_construction_at: 175.days.ago, en_construction_close_to_expiration_notice_sent_at: Time.zone.now, procedure:) }
+    let_it_be(:just_expired_dossier) { create(:dossier, :en_construction, en_construction_at: (6.months + 1.hour + 10.seconds).ago, procedure:) }
+    let_it_be(:long_expired_dossier) { create(:dossier, :en_construction, en_construction_at: 1.year.ago, procedure:) }
 
     subject { Dossier.en_construction_close_to_expiration }
 
@@ -276,12 +276,12 @@ describe Dossier, type: :model do
   end
 
   describe 'termine_close_to_expiration' do
-    let(:procedure) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 6, procedure_expires_when_termine_enabled: true) }
-    let!(:young_dossier) { create(:dossier, state: :accepte, procedure: procedure, processed_at: 2.days.ago) }
-    let!(:expiring_dossier) { create(:dossier, state: :accepte, procedure: procedure, processed_at: 175.days.ago) }
-    let!(:expiring_dossier_with_notification) { create(:dossier, state: :accepte, procedure: procedure, processed_at: 175.days.ago, termine_close_to_expiration_notice_sent_at: Time.zone.now) }
-    let!(:just_expired_dossier) { create(:dossier, state: :accepte, procedure: procedure, processed_at: (6.months + 1.hour + 10.seconds).ago) }
-    let!(:long_expired_dossier) { create(:dossier, state: :accepte, procedure: procedure, processed_at: 1.year.ago) }
+    let_it_be(:procedure) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 6, procedure_expires_when_termine_enabled: true) }
+    let_it_be(:young_dossier) { create(:dossier, state: :accepte, procedure:, processed_at: 2.days.ago) }
+    let_it_be(:expiring_dossier) { create(:dossier, state: :accepte, procedure:, processed_at: 175.days.ago) }
+    let_it_be(:expiring_dossier_with_notification) { create(:dossier, state: :accepte, procedure:, processed_at: 175.days.ago, termine_close_to_expiration_notice_sent_at: Time.zone.now) }
+    let_it_be(:just_expired_dossier) { create(:dossier, state: :accepte, procedure:, processed_at: (6.months + 1.hour + 10.seconds).ago) }
+    let_it_be(:long_expired_dossier) { create(:dossier, state: :accepte, procedure:, processed_at: 1.year.ago) }
 
     subject { Dossier.termine_close_to_expiration }
 
@@ -565,13 +565,13 @@ describe Dossier, type: :model do
   end
 
   describe '#avis_for' do
-    let!(:instructeur) { create(:instructeur) }
-    let!(:procedure) { create(:procedure, :published, instructeurs: [instructeur]) }
-    let!(:dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction)) }
-    let!(:experts_procedure) { create(:experts_procedure, expert: expert_1, procedure: procedure) }
-    let!(:experts_procedure_2) { create(:experts_procedure, expert: expert_2, procedure: procedure) }
-    let!(:expert_1) { create(:expert) }
-    let!(:expert_2) { create(:expert) }
+    let_it_be(:instructeur) { create(:instructeur) }
+    let_it_be(:expert_1) { create(:expert) }
+    let_it_be(:expert_2) { create(:expert) }
+    let_it_be(:procedure) { create(:procedure, :published, instructeurs: [instructeur]) }
+    let_it_be(:dossier) { create(:dossier, procedure:, state: Dossier.states.fetch(:en_construction)) }
+    let_it_be(:experts_procedure) { create(:experts_procedure, expert: expert_1, procedure:) }
+    let_it_be(:experts_procedure_2) { create(:experts_procedure, expert: expert_2, procedure:) }
 
     context 'when there is a public advice asked from the dossiers instructeur' do
       let!(:avis) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure, confidentiel: false) }
@@ -2444,15 +2444,15 @@ describe Dossier, type: :model do
   end
 
   describe "with_notifiable_procedure" do
-    let(:test_procedure) { create(:procedure) }
-    let(:published_procedure) { create(:procedure, :published) }
-    let(:closed_procedure) { create(:procedure, :closed) }
-    let(:unpublished_procedure) { create(:procedure, :unpublished) }
+    let_it_be(:test_procedure) { create(:procedure) }
+    let_it_be(:published_procedure) { create(:procedure, :published) }
+    let_it_be(:closed_procedure) { create(:procedure, :closed) }
+    let_it_be(:unpublished_procedure) { create(:procedure, :unpublished) }
 
-    let!(:dossier_on_test_procedure) { create(:dossier, procedure: test_procedure) }
-    let!(:dossier_on_published_procedure) { create(:dossier, procedure: published_procedure) }
-    let!(:dossier_on_closed_procedure) { create(:dossier, procedure: closed_procedure) }
-    let!(:dossier_on_unpublished_procedure) { create(:dossier, procedure: unpublished_procedure) }
+    let_it_be(:dossier_on_test_procedure) { create(:dossier, procedure: test_procedure) }
+    let_it_be(:dossier_on_published_procedure) { create(:dossier, procedure: published_procedure) }
+    let_it_be(:dossier_on_closed_procedure) { create(:dossier, procedure: closed_procedure) }
+    let_it_be(:dossier_on_unpublished_procedure) { create(:dossier, procedure: unpublished_procedure) }
 
     let(:notify_on_closed) { false }
     let(:dossiers) { Dossier.with_notifiable_procedure(notify_on_closed: notify_on_closed) }
@@ -2862,11 +2862,11 @@ describe Dossier, type: :model do
   end
 
   describe '#never_touched_brouillon_expired' do
-    let!(:dossier) { travel_to(3.weeks.ago) { create(:dossier, :brouillon, last_champ_updated_at: nil) } }
-    let!(:dossier_2) { travel_to(1.week.ago) { create(:dossier, :brouillon, last_champ_updated_at: nil) } }
-    let!(:dossier_with_champ_updated) { travel_to(3.weeks.ago) { create(:dossier, :brouillon, last_champ_updated_at: 1.day.ago) } }
+    let_it_be(:dossier) { travel_to(3.weeks.ago) { create(:dossier, :brouillon, last_champ_updated_at: nil) } }
+    let_it_be(:dossier_2) { travel_to(1.week.ago) { create(:dossier, :brouillon, last_champ_updated_at: nil) } }
+    let_it_be(:dossier_with_champ_updated) { travel_to(3.weeks.ago) { create(:dossier, :brouillon, last_champ_updated_at: 1.day.ago) } }
 
-    let!(:dossier_en_construction) { create(:dossier, :en_construction, last_champ_updated_at: nil) }
+    let_it_be(:dossier_en_construction) { create(:dossier, :en_construction, last_champ_updated_at: nil) }
 
     subject { Dossier.never_touched_brouillon_expired }
 


### PR DESCRIPTION
## Context

**Skill :** [test-optimization/SKILL.md](https://github.com/mfo/night-shift/blob/main/.claude/skills/test-optimization/SKILL.md)

## Changements

Applique `let_it_be` (test-prof) sur 7 blocs read-only de `spec/models/dossier_spec.rb` :

| Bloc | Examples | Conversions |
|---|---|---|
| `by_statut` | 4 | 8 let → let_it_be |
| `brouillon_close_to_expiration` | 3 | 6 let!/let → let_it_be |
| `en_construction_close_to_expiration` | 4 | 6 let!/let → let_it_be |
| `termine_close_to_expiration` | 4 | 6 let!/let → let_it_be |
| `avis_for` | 8 | 7 let! → let_it_be (réordonné pour FK) |
| `with_notifiable_procedure` | 2 | 8 let/let! → let_it_be |
| `never_touched_brouillon_expired` | 3 | 4 let! → let_it_be |

**Principe :** `let_it_be` crée les records une seule fois par `describe` (via `before_all`) au lieu de les recréer pour chaque `it`. Applicable uniquement sur les blocs qui ne mutent pas leurs objets.

## Métriques locales

- **Temps :** 64.03s → 54.79s (médiane 3 runs, **-14.4%**)
- **Coverage :** 83.38% → 83.38% (identique)

## Learnings du POC

- `let_it_be` **sans modifiers** (`reload:`/`refind:` indisponibles car test-prof chargé avant Rails dans `spec_helper.rb:25`) — limité aux blocs read-only
- Ordre des `let_it_be` important pour les FK (ex: `expert` avant `experts_procedure`)
- `aggregate_failures` (T09) testé et rollback — gain non mesurable sur ce fichier
- ~70% des blocs de dossier_spec mutent leurs objets → non convertibles sans activer les modifiers
- La factory `:dossier` cascade ~15-25 INSERTs → `factory_default` (T11) ou trait `:minimal` (G05) seraient les prochains leviers

## Test plan

- [x] Médiane 3 runs locale
- [x] Coverage stable
- [x] **CI verte** ← c'est l'objet de cette PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)