### PR TITLE
ETQ admin/instructeur, corriger le layout flex des notices DSFR

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -286,3 +286,14 @@ input[type='radio'] {
 .dossier-edit .fr-fieldset {
   align-items: flex-end;
 }
+
+// DSFR 1.14.3 added display:flex + flex-direction:row on .fr-notice__body
+// (absent in 1.12.1). When a notice contains rich content like a <ul>,
+// children must wrap to preserve the vertical layout.
+.fr-notice__body:has(> ul) {
+  flex-wrap: wrap;
+
+  > * {
+    flex-basis: 100%;
+  }
+}

--- a/app/components/types_de_champ_editor/info_referentiel_component/info_referentiel_component.html.haml
+++ b/app/components/types_de_champ_editor/info_referentiel_component/info_referentiel_component.html.haml
@@ -12,13 +12,14 @@
   - if !ready?
     .fr-notice.fr-notice--info.fr-mb-2w.fr-px-3w
       .fr-notice__body
-        %p.fr-notice__title Ce champ sera présenté à l’usager sous forme d’un champ de type « Texte court ».
-        %p.notice__desc.fr-mt-2w Lors de la configuration, vous pourrez choisir de :
+        %p
+          %span.fr-notice__title Ce champ sera présenté à l’usager sous forme d’un champ de type « Texte court ».
+          %span.fr-notice__desc.fr-mt-2w Lors de la configuration, vous pourrez choisir de :
         %ul.fr-mt-0
           %li proposer des autosuggestions au fur et à mesure de la saisie de l’usager (issue de la BDD du référentiel)
           %li vérifier la correspondance exacte de saisie dans la BDD du référentiel
           %li et/ou pré-remplir d’autres champ avec une donnée issues du référentiel
-        %p.notice__desc
+        %p.fr-notice__desc
           Vous pouvez vous référer à
           = link_to "notre documentation", "https://doc.demarches-simplifiees.fr/tutoriels/champ-referentiel-avance-a-configurer", target: "_blank"
           = " pour prendre en main ce champ"

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -44,9 +44,10 @@
         .fr-notice.fr-notice--warning
           .fr-container--fluid.fr-px-2w
             .fr-notice__body
-              %span.fr-notice__title= t('views.instructeurs.dossiers.archives_notice_title')
-              %span.fr-notice__desc
-                = t('views.instructeurs.dossiers.archives_notice_html', app_name: APPLICATION_NAME, duration_months: @procedure.duree_conservation_dossiers_dans_ds, doc_url: ARCHIVAGE_DOC_URL)
+              %p
+                %span.fr-notice__title= t('views.instructeurs.dossiers.archives_notice_title')
+                %span.fr-notice__desc
+                  = t('views.instructeurs.dossiers.archives_notice_html', app_name: APPLICATION_NAME, duration_months: @procedure.duree_conservation_dossiers_dans_ds, doc_url: ARCHIVAGE_DOC_URL)
 
       %div{ data: batch_operation_component.render? ? { controller: 'batch-operation', 'batch-operation-limit-value': BatchOperation::BATCH_SELECTION_LIMIT } : {} }
         .flex.align-center.fr-mt-2w


### PR DESCRIPTION
## Summary
- Corrige le layout des composants `fr-notice` du DSFR qui affichaient leurs enfants côte à côte (flex row) au lieu de verticalement
- Affecte la notice "Configuration du champ référentiel" (admin) et la notice "Archivage des dossiers" (instructeur)
- Ajout d'un `div` wrapper dans `fr-notice__body` pour grouper les enfants dans un seul conteneur flex

## screenshot

avant 
<img width="2469" height="797" alt="image (12)" src="https://github.com/user-attachments/assets/925ae788-da42-46cf-8d52-07c3fc7d7049" />
apres
<img width="1708" height="308" alt="Capture d’écran 2026-03-16 à 4 04 18 PM" src="https://github.com/user-attachments/assets/54fe059e-5c25-4d62-92b9-14f45aa3bb36" />

avant:
<img width="1435" height="1217" alt="image (13)" src="https://github.com/user-attachments/assets/06d17b40-ddee-46eb-870c-0017c6d6b055" />

apres:
<img width="1213" height="413" alt="Capture d’écran 2026-03-16 à 4 06 00 PM" src="https://github.com/user-attachments/assets/8557dda8-252c-4c9b-a1e3-2ebbffc11a6f" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)