### PR TITLE
Tech: amélioration du référencement via robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,3 +12,8 @@ Disallow: /connexion-par-jeton/
 Disallow: */reset-link-sent*
 Disallow: /lien-envoye
 Disallow: /france_connect/
+Disallow: /commencer/*/sign_in
+Disallow: /commencer/*/sign_up
+Disallow: /commencer/*/france_connect
+Disallow: /commencer/*/dossier_vide
+Disallow: /commencer/test/


### PR DESCRIPTION
- Exclut les pages de redirection vers 'authentification sous `/commencer/` : `sign_in`, `sign_up`, `france_connect` qui redirigent vers leurs formulaires respectifs, mais restaient référencées sans rien n'apporter
- Exclut les dossiers vides PDF (`/commencer/*/dossier_vide`) car ils sont souvent mieux référencés que les démarches elles même 
- Exclut toutes les démarches de test (`/commencer/test/`), malgré qu'elles ont un noindex qui n'est pas toujours respecté
