### PR TITLE
Tech: fix NoMethodError dans schema_to_llm quand options est nil

### DIFF
--- a/app/models/concerns/revision_describable_to_llm_concern.rb
+++ b/app/models/concerns/revision_describable_to_llm_concern.rb
@@ -28,6 +28,7 @@ module RevisionDescribableToLLMConcern
 
   def options_for_llm(tdc)
     return nil unless TYPES_WITH_OPTIONS.include?(tdc.type_champ)
+    return nil if tdc.options.blank?
 
     tdc.options.slice(*TypeDeChamp::OPTS_BY_TYPE.fetch(tdc.type_champ, []).map(&:to_s)).presence
   end

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -1277,6 +1277,22 @@ describe ProcedureRevision do
 
     it { expect(draft.simple_routable_types_de_champ.pluck(:libelle)).to eq(['l2', 'l3', 'l4', 'l5', 'l6']) }
   end
+
+  describe "#schema_to_llm" do
+    context 'when a type_de_champ has nil options' do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :date, libelle: "Date de naissance" }]) }
+      let(:revision) { procedure.draft_revision }
+
+      before do
+        revision.types_de_champ_public.first.update_column(:options, nil)
+      end
+
+      it 'does not raise' do
+        expect { revision.schema_to_llm }.not_to raise_error
+      end
+    end
+  end
+
   describe "#apply_llm_rule_suggestion_items" do
     let(:procedure) { create(:procedure, types_de_champ_public:) }
     let(:revision) { procedure.draft_revision }


### PR DESCRIPTION
## Summary
- Corrige `NoMethodError: undefined method 'slice' for nil` dans `RevisionDescribableToLLMConcern#options_for_llm`
- Certains `TypeDeChamp` en base n'ont pas d'`options`, ce qui faisait crasher `LLM::ImproveProcedureJob`
- 394 occurrences sur Sentry : https://demarches-simplifiees.sentry.io/issues/7273346046/

## Changements
- Ajout d'un early return `return nil if tdc.options.blank?` dans `options_for_llm`
- Ajout d'un test de non-regression

## Test plan
- [x] Test ajouté : `schema_to_llm` avec un `TypeDeChamp` dont `options` est `nil`
