### PR TITLE
correctif: ETQ instructeur/administrateur, je peux prévisualiser l'attestation d'acceptation avec tampon sur une démarche v2    

### DIFF
--- a/app/controllers/concerns/groupe_instructeurs_signature_concern.rb
+++ b/app/controllers/concerns/groupe_instructeurs_signature_concern.rb
@@ -27,10 +27,21 @@ module GroupeInstructeursSignatureConcern
   end
 
   def preview_attestation_acceptation
-    attestation_acceptation_template = procedure.attestation_acceptation_template || procedure.build_attestation_acceptation_template
-    @attestation = attestation_acceptation_template.render_attributes_for({ groupe_instructeur: groupe_instructeur })
+    attestation_template = procedure.attestation_acceptation_template || procedure.build_attestation_acceptation_template
+    attributes = attestation_template.render_attributes_for({ groupe_instructeur: groupe_instructeur })
 
-    render 'administrateurs/attestation_templates/show', formats: [:pdf]
+    if attestation_template.version == 2
+      @attestation_template = attestation_template
+      @body = attributes.fetch(:body)
+      @signature = attributes.fetch(:signature)
+
+      html = render_to_string('/administrateurs/attestation_template_v2s/show', layout: 'attestation', formats: [:html])
+      pdf = WeasyprintService.generate_pdf(html, procedure_id: procedure.id, path: request.path)
+      send_data(pdf, filename: 'attestation.pdf', type: 'application/pdf', disposition: 'inline')
+    else
+      @attestation = attributes
+      render 'administrateurs/attestation_templates/show', formats: [:pdf]
+    end
   end
 
   private

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -1291,11 +1291,13 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
     context 'with v2 attestation template' do
       before do
         create(:attestation_template, :v2, procedure:, state: :published, kind: 'acceptation')
+        allow(WeasyprintService).to receive(:generate_pdf).and_return('PDF_DATA')
       end
 
       it 'returns a PDF' do
         subject
         expect(response).to have_http_status(:ok)
+        expect(WeasyprintService).to have_received(:generate_pdf)
       end
     end
   end


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/7342031793/?project=1429550&query=is%3Aunresolved%20title&referrer=issue-stream

# Problème
La prévisualisation PDF de l'attestation d'acceptation (avec tampon) crashe avec `KeyError: key not found: :title` pour les démarches utilisant une attestation v2. Le template Prawn (v1) exige une clé `:title` que les attestations v2 ne fournissent pas, car le titre est intégré dans le body tiptap.

# Solution
Brancher sur la version du template dans `preview_attestation_acceptation` : les attestations v2 utilisent le pipeline Weasyprint/HTML (comme `AttestationTemplateV2sController#show`), les v1 continuent d'utiliser Prawn.
