### PR TITLE
Tente de corriger la taille du logo DN sur gmail

### DIFF
--- a/app/views/layouts/mailers/_dsfr_instance_logo.html.erb
+++ b/app/views/layouts/mailers/_dsfr_instance_logo.html.erb
@@ -1,7 +1,7 @@
 <%# Instance logo — float left, next to Marianne, light/dark variants %>
 <table
   style="border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt;"
-  width="100"
+  width="80"
   cellspacing="0"
   cellpadding="0"
   role="presentation"
@@ -36,13 +36,13 @@
 
             <tr>
               <td class="hide-black" align="left">
-                <%= image_tag image_url(MAILER_LOGO_SRC), alt: "Logo #{APPLICATION_NAME}", style: "display:block; margin-left:10px; margin-top:6px; max-height:48px; max-width:90px; height:auto; width:auto;", border: "0", class: "hide-black" %>
+                <%= image_tag image_url(MAILER_LOGO_SRC), alt: "Logo #{APPLICATION_NAME}", style: "display:block; margin-left:10px; height:auto; width:56px;", width: "56", border: "0", class: "hide-black" %>
               </td>
             </tr>
 
             <tr>
               <td class="hide-white" align="left">
-                <%= image_tag image_url(MAILER_LOGO_DARK_SRC), alt: "Logo #{APPLICATION_NAME}", style: "display:block; margin-left:10px; margin-top:6px; max-height:48px; max-width:90px; height:auto; width:auto;", border: "0", class: "hide-white" %>
+                <%= image_tag image_url(MAILER_LOGO_DARK_SRC), alt: "Logo #{APPLICATION_NAME}", style: "display:block; margin-left:10px; height:auto; width:56px;", width: "56", border: "0", class: "hide-white" %>
               </td>
             </tr>
 

--- a/app/views/layouts/mailers/_logo.html.haml
+++ b/app/views/layouts/mailers/_logo.html.haml
@@ -2,4 +2,4 @@
   %table{ width: "100%", border: "0", cellspacing: "0", cellpadding: "0" }
     %tr
       %td{ align: "center" }
-        = image_tag url, style: "display:block; height:auto; max-height:100px; max-width:300px;"
+        = image_tag url, style: "display:block; height:auto; max-height:100px; max-width:300px;", height: "100"


### PR DESCRIPTION
gmail ne respecte pas les max-width/max-height ce qui fait le logo de DN s'affichait en taille réelle, donc il faut forcer un width hardcodé + un height auto

Sur le logo de démarche, le pb est différent car on ne connait pas nous même le ratio ni la taille, on limite juste la hauteur.