### PR TITLE
amelioration: ETQ instructeur, lorsque je decide d'etre notifié pour recevoir un mail quand un usager utilise la messagerie, je suis alerté par un popup que je dois suivre le dossier

### DIFF
--- a/app/views/instructeurs/procedures/_email_preferences.html.haml
+++ b/app/views/instructeurs/procedures/_email_preferences.html.haml
@@ -25,7 +25,7 @@
               extra_class_names: 'fr-toggle',
               opt: { "hide-target_target": "source" })
 
-            .fr-notice.fr-notice--info.fr-mt-1w{ class: class_names("fr-hidden" => instant_email_new_message), data: { "hide-target_target": "toHide" } }
+            .fr-notice.fr-notice--info.fr-mt-1w{ class: class_names("fr-hidden" => !instant_email_new_message), data: { "hide-target_target": "toHide" } }
               .fr-container
                 .fr-notice__body
                   %p


### PR DESCRIPTION
inverse le sens de la notif quand on active les notifications pour un nouveau message sur un dossier : 

toggle actif:
<img width="1020" height="167" alt="Capture d’écran 2026-03-18 à 6 33 38 PM" src="https://github.com/user-attachments/assets/556952c8-7758-4448-8af3-59ed564c059f" />

toggle inactif: 
<img width="1006" height="223" alt="Capture d’écran 2026-03-18 à 6 33 34 PM" src="https://github.com/user-attachments/assets/734c95eb-4fa3-4de4-a25f-3301561ffd00" />

j'avais implem l'inverse