### PR TITLE
ETQ Usager le numéro de la répétition se positionne correctement lorsque le label est long

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -428,6 +428,16 @@
         }
       }
 
+      .repetition-row-title {
+        display: flex;
+        align-items: baseline;
+        gap: 0.5rem;
+
+        strong {
+          flex-shrink: 0;
+        }
+      }
+
       .repetition-toggle-all {
         display: none;
 

--- a/app/components/editable_champ/repetition_row_component/repetition_row_component.html.erb
+++ b/app/components/editable_champ/repetition_row_component/repetition_row_component.html.erb
@@ -3,8 +3,10 @@
     <div class="width-100 champs-group fr-p-0 fr-m-0">
       <%= render Dsfr::AccordionComponent.new(id: "#{@champ.html_id}-#{row_id}-accordion", expanded: @expanded, accordion_tag: :fieldset, title_tag: :legend, title_id: repetition_row_fieldset_legend_id(@champ, row_id)) do |accordion| %>
         <% accordion.with_title do %>
-          <strong>[<%= row_number %>]</strong> &nbsp;
-          <%= @type_de_champ.libelle %>
+          <span class="repetition-row-title">
+            <strong>[<%= row_number %>]</strong>
+            <span><%= @type_de_champ.libelle %></span>
+          </span>
         <% end %>
 
         <div class="flex column"><%= render section_component %></div>


### PR DESCRIPTION
Avant
<img width="220" height="228" alt="Capture d’écran 2026-03-18 à 12 10 05" src="https://github.com/user-attachments/assets/dbbc23af-cd06-4dba-ace9-ea13b09b7faa" />

Après
<img width="808" height="384" alt="image" src="https://github.com/user-attachments/assets/acd4d354-fd4e-4d8f-bd22-d7212f22a456" />
