### PR TITLE
ETQ Tech, j'améliore le message d'erreur pour les Commune API failure 

### DIFF
--- a/app/controllers/data_sources/commune_controller.rb
+++ b/app/controllers/data_sources/commune_controller.rb
@@ -12,8 +12,14 @@ class DataSources::CommuneController < ApplicationController
       elsif response.timed_out?
         return head :gateway_timeout
       else
-        Sentry.set_extras(body: response.body, code: response.code)
-        Sentry.capture_message("Commune API failure: #{response.return_message}")
+        if response.code == 0
+          error_message = response.return_message
+        else
+          Sentry.set_extras(body: response.body, code: response.code)
+          error_message = "HTTP #{response.code}"
+        end
+
+        Sentry.capture_message("Commune API failure: #{error_message}")
         return head :bad_gateway
       end
     else


### PR DESCRIPTION
Pour https://demarches-simplifiees.sentry.io/issues/7327011437/

Change le title de l'event sentry comme dans `DataSources::AdresseController` de 

`Commune API failure: No error` en `Commune API failure: code http de l'erreur`