### PR TITLE
ETQ Instructeur je n'ai plus d'erreur sur la page de gallerie de PJ

### DIFF
--- a/app/helpers/gallery_helper.rb
+++ b/app/helpers/gallery_helper.rb
@@ -16,6 +16,8 @@ module GalleryHelper
     else
       if attachment.name == 'justificatif_motivation'
         'Pièce jointe à la décision'
+      else
+        record.class.model_name.human
       end
     end
   end

--- a/spec/components/attachment/gallery_item_component_spec.rb
+++ b/spec/components/attachment/gallery_item_component_spec.rb
@@ -135,6 +135,17 @@ RSpec.describe Attachment::GalleryItemComponent, type: :component do
     end
   end
 
+  context "when attachment is from a sans_suite dossier attestation (orphaned)" do
+    let(:attachment) { dossier.attestation.pdf }
+
+    before { dossier.update_column(:state, :sans_suite) }
+
+    it "renders without error" do
+      expect(subject).to have_link(filename)
+      expect(subject).to have_css('.fr-text--sm', text: 'Attestation')
+    end
+  end
+
   context "when attachment is from an avis" do
     context 'from an instructeur' do
       let(:avis) { create(:avis, :with_introduction, dossier: dossier) }


### PR DESCRIPTION
Corrige https://demarches-simplifiees.sentry.io/issues/7306324361/ 

La gallerie ne plantera plus.

Par contre ne corrige pas le problème sous jacent : on a des attestation sur des dossiers sans_suite.
Sans doute un problème de race condition que je continue de creuser.