### PR TITLE
Tech: fix XSS dans le menu de suggestion des balises tiptap

### DIFF
--- a/app/javascript/shared/tiptap/tags.ts
+++ b/app/javascript/shared/tiptap/tags.ts
@@ -101,17 +101,29 @@ class SuggestionMenu {
     this.#element ??= this.createMenu();
     const list = this.#element.firstChild as HTMLUListElement;
 
-    const html = this.#props.items
-      .map((item, i) => {
-        return `<li><button class="fr-tag fr-tag--sm" aria-pressed="${
-          i == this.#selectedIndex ? 'true' : 'false'
-        }" data-tag-index="${i}">${item.label}</button></li>`;
-      })
-      .join('');
+    list.textContent = '';
 
-    const hint =
-      '<li><span class="fr-hint-text">Tapez le nom d’une balise, naviguez avec les flèches, validez avec Entrée ou en cliquant sur la balise.</span></li>';
-    list.innerHTML = hint + html;
+    const hintLi = document.createElement('li');
+    const hintSpan = document.createElement('span');
+    hintSpan.className = 'fr-hint-text';
+    hintSpan.textContent =
+      'Tapez le nom d\u2019une balise, naviguez avec les flèches, validez avec Entrée ou en cliquant sur la balise.';
+    hintLi.append(hintSpan);
+    list.append(hintLi);
+
+    this.#props.items.forEach((item, i) => {
+      const li = document.createElement('li');
+      const button = document.createElement('button');
+      button.className = 'fr-tag fr-tag--sm';
+      button.setAttribute(
+        'aria-pressed',
+        i == this.#selectedIndex ? 'true' : 'false'
+      );
+      button.dataset.tagIndex = String(i);
+      button.textContent = item.label;
+      li.append(button);
+      list.append(li);
+    });
     list.querySelector<HTMLElement>('.selected')?.focus();
   }
 


### PR DESCRIPTION
## Summary

Le menu de suggestion des balises tiptap (attestation, emails) utilisait `innerHTML` avec interpolation de `item.label` pour construire la liste des tags. Un administrateur pouvait créer un champ avec un libellé malveillant (ex: `<img src=x onerror=alert('XSS')>`) qui s'exécutait dans le navigateur de tout utilisateur ouvrant l'éditeur.

### Root cause

Dans `app/javascript/shared/tiptap/tags.ts`, la méthode `render()` construisait le HTML du menu par concaténation de chaînes puis injection via `innerHTML` :

```js
const html = this.#props.items
  .map((item, i) => `<li><button ...>${item.label}</button></li>`)
  .join('');
list.innerHTML = hint + html;
```

`item.label` (le libellé du TypeDeChamp) n'était pas échappé → XSS stored.

### Fix

Remplacement de `innerHTML` + interpolation par les API DOM (`createElement`, `textContent`), qui échappent automatiquement le contenu texte.

## Avant / Après

### 1. Setup — champ avec libellé malveillant
![setup](https://gist.githubusercontent.com/mfo/f2d693a678b4136e335a61a07b5fb6d3/raw/setup.png)

### 2. Avant (faille) — l'alert JS s'exécute dans le menu de suggestion
![faille](https://gist.githubusercontent.com/mfo/f2d693a678b4136e335a61a07b5fb6d3/raw/faille.png)

### 3. Après (fix) — le libellé est affiché en texte brut
![fix](https://gist.githubusercontent.com/mfo/f2d693a678b4136e335a61a07b5fb6d3/raw/fix.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)