### PR TITLE
Tech: réduit la lock contention sur batch_operations

### DIFF
--- a/app/jobs/batch_operation_process_one_job.rb
+++ b/app/jobs/batch_operation_process_one_job.rb
@@ -10,22 +10,17 @@ class BatchOperationProcessOneJob < ApplicationJob
       ActiveRecord::Base.transaction do
         batch_operation.process_one(dossier)
         batch_operation.track_processed_dossier(true, dossier)
-
-        if batch_operation.dossiers.empty?
-          batch_operation.after_all_processed
-        end
       end
     rescue => error
       ActiveRecord::Base.transaction do
         batch_operation.track_processed_dossier(false, dossier)
-
-        if batch_operation.dossiers.empty?
-          batch_operation.after_all_processed
-        end
       end
       raise error
     end
+
+    batch_operation.finalize_if_complete!
   rescue ActiveRecord::RecordNotFound
     dossier.update_column(:batch_operation_id, nil)
+    batch_operation.finalize_if_complete!
   end
 end

--- a/app/models/batch_operation.rb
+++ b/app/models/batch_operation.rb
@@ -84,7 +84,8 @@ class BatchOperation < ApplicationRecord
   end
 
   def enqueue_all
-    dossiers_safe_scope # later in batch .
+    touch(:run_at)
+    dossiers_safe_scope
       .map { |dossier| BatchOperationProcessOneJob.perform_later(self, dossier) }
   end
 
@@ -138,13 +139,24 @@ class BatchOperation < ApplicationRecord
 
   def track_processed_dossier(success, dossier)
     dossiers.delete(dossier)
-    touch(:run_at) if called_for_first_time?
-    touch(:finished_at)
 
     if success
       dossier_operation(dossier).done!
     else
       dossier_operation(dossier).fail!
+    end
+  end
+
+  def finalize_if_complete!
+    return if dossiers.exists?
+
+    updated_rows = self.class
+      .where(id:, finished_at: nil)
+      .update_all(finished_at: Time.current, updated_at: Time.current)
+
+    if updated_rows == 1
+      # we are the worker what the "win" the finished state
+      after_all_processed
     end
   end
 
@@ -162,10 +174,6 @@ class BatchOperation < ApplicationRecord
         instance
       end
     end
-  end
-
-  def called_for_first_time?
-    run_at.nil?
   end
 
   def total_count

--- a/spec/components/dossiers/batch_alert_component_spec.rb
+++ b/spec/components/dossiers/batch_alert_component_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -58,6 +59,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
         batch_operation.track_processed_dossier(false, dossier)
         batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.finalize_if_complete!
         batch_operation.reload
       }
 
@@ -103,6 +105,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -118,6 +121,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
         batch_operation.track_processed_dossier(false, dossier)
         batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.finalize_if_complete!
         batch_operation.reload
       }
 
@@ -163,6 +167,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -178,6 +183,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
         batch_operation.track_processed_dossier(false, dossier)
         batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.finalize_if_complete!
         batch_operation.reload
       }
 
@@ -223,6 +229,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -238,6 +245,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
         batch_operation.track_processed_dossier(false, dossier)
         batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.finalize_if_complete!
         batch_operation.reload
       }
 
@@ -283,6 +291,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -298,6 +307,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
         batch_operation.track_processed_dossier(false, dossier)
         batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.finalize_if_complete!
         batch_operation.reload
       }
 
@@ -343,6 +353,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -383,6 +394,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -423,6 +435,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -438,6 +451,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
         batch_operation.track_processed_dossier(false, dossier)
         batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.finalize_if_complete!
         batch_operation.reload
       }
 
@@ -483,6 +497,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -498,6 +513,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
         batch_operation.track_processed_dossier(false, dossier)
         batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.finalize_if_complete!
         batch_operation.reload
       }
 
@@ -543,6 +559,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -558,6 +575,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
         batch_operation.track_processed_dossier(false, dossier)
         batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.finalize_if_complete!
         batch_operation.reload
       }
 
@@ -603,6 +621,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -618,6 +637,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
         batch_operation.track_processed_dossier(false, dossier)
         batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.finalize_if_complete!
         batch_operation.reload
       }
 
@@ -663,6 +683,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -678,6 +699,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
         batch_operation.track_processed_dossier(false, dossier)
         batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.finalize_if_complete!
         batch_operation.reload
       }
 
@@ -723,6 +745,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -738,6 +761,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
         batch_operation.track_processed_dossier(false, dossier)
         batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.finalize_if_complete!
         batch_operation.reload
       }
 
@@ -783,6 +807,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
          batch_operation.track_processed_dossier(true, dossier)
          batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
@@ -798,6 +823,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       before {
         batch_operation.track_processed_dossier(false, dossier)
         batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.finalize_if_complete!
         batch_operation.reload
       }
 

--- a/spec/models/batch_operation_spec.rb
+++ b/spec/models/batch_operation_spec.rb
@@ -41,6 +41,47 @@ describe BatchOperation, type: :model do
         expect(subject).to receive(:dossiers_safe_scope).and_return(subject.dossiers)
         subject.enqueue_all
       end
+
+      it 'sets run_at' do
+        expect { subject.enqueue_all }
+          .to change { subject.reload.run_at }
+          .from(nil)
+          .to(anything)
+      end
+    end
+  end
+
+  describe '#finalize_if_complete!' do
+    let(:instructeur) { create(:instructeur) }
+    let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+    let(:dossier) { create(:dossier, :accepte, :with_individual, archived: true, procedure: procedure) }
+    let(:batch_operation) { create(:batch_operation, operation: :archiver, instructeur: instructeur, dossiers: [dossier]) }
+
+    context 'when dossiers remain' do
+      it 'does not set finished_at' do
+        expect { batch_operation.finalize_if_complete! }
+          .not_to change { batch_operation.reload.finished_at }
+      end
+    end
+
+    context 'when all dossiers are processed' do
+      before { batch_operation.dossiers.delete_all }
+
+      it 'sets finished_at' do
+        expect { batch_operation.finalize_if_complete! }
+          .to change { batch_operation.reload.read_attribute(:finished_at) }
+          .from(nil)
+          .to(anything)
+      end
+
+      it 'is idempotent (only one caller wins)' do
+        batch_operation.finalize_if_complete!
+        finished_at = batch_operation.reload.read_attribute(:finished_at)
+
+        expect { batch_operation.finalize_if_complete! }
+          .not_to change { batch_operation.reload.read_attribute(:finished_at) }
+          .from(finished_at)
+      end
     end
   end
 
@@ -85,32 +126,6 @@ describe BatchOperation, type: :model do
           .to change { batch_operation.dossier_operations.error.pluck(:dossier_id) }
           .from([])
           .to([dossier.id])
-      end
-    end
-
-    context 'when it is the first job' do
-      it 'sets run_at at first' do
-        expect { batch_operation.track_processed_dossier(false, dossier) }
-          .to change { batch_operation.reload.run_at }
-          .from(nil)
-          .to(anything)
-      end
-    end
-
-    context 'when it is the second job (meaning run_at was already set) but not the last' do
-      let(:batch_operation) { create(:batch_operation, operation: :archiver, instructeur: instructeur, dossiers: [dossier], run_at: 2.days.ago) }
-      it 'does not change run_at' do
-        expect { batch_operation.track_processed_dossier(true, dossier) }
-          .not_to change { batch_operation.reload.run_at }
-      end
-    end
-
-    context 'when it is the last job' do
-      it 'sets finished_at' do
-        expect { batch_operation.track_processed_dossier(true, dossier) }
-          .to change { batch_operation.reload.finished_at }
-          .from(nil)
-          .to(anything)
       end
     end
   end


### PR DESCRIPTION
On ne touch plus les dates à chaque opération dans une transaction qui lock, et en particulier on ne touch plus finished_at à chaque opération. On fait tout ça avant ou après les traitements. En détail : 

- Supprime les `touch(:finished_at)` et `touch(:run_at)` appelés à chaque dossier dans `track_processed_dossier`, qui causaient une contention de row-level lock sur la table `batch_operations` (mean 1.94s, max 46.6s pour 43k appels/mois) quand une dizaine ou vingtaine de workers font la même op au même moment.
- `run_at` est maintenant setté une seule fois dans `enqueue_all`
- La détection de complétion est déplacée dans `finalize_if_complete!` avec un `UPDATE ... WHERE finished_at IS NULL` atomique (un seul worker peut "gagner")
- Zéro UPDATE sur `batch_operations` pendant le traitement parallèle des dossiers

**Ce qui ne change pas :** `process_one` et `track_processed_dossier` restent dans la même transaction. En cas de crash/OOM pendant le traitement, PostgreSQL rollback la TX automatiquement : le dossier reste dans son état initial, aucun email n'est envoyé (les `after_commit` ne firent pas), et le `batch_operation_id` reste positionné. Tout continue d'être nettoyé par un cron.

Closes #12755