### PR TITLE
Tech: fix regex MonAvis permettant un bypass de validation du href

### DIFF
--- a/app/validators/mon_avis_embed_validator.rb
+++ b/app/validators/mon_avis_embed_validator.rb
@@ -4,8 +4,8 @@
 class MonAvisEmbedValidator < ActiveModel::Validator
   # from time to time, they decide to change domain just for fun. if it breaks, check the new subdomain
   KNOWN_SUBDOMAIN = ['jedonnemonavis', 'monavis', 'voxusagers']
-  HREF_CHECKER = /https:\/\/#{KNOWN_SUBDOMAIN.join('|')}.numerique.gouv.fr\/Demarches\/\d+.*key=[[:alnum:]]+.*/
-  IMG_CHECKER = /https:\/\/#{KNOWN_SUBDOMAIN.join('|')}.numerique.gouv.fr\/(monavis-)?static\/bouton-blanc|bleu.png|svg/
+  HREF_CHECKER = /https:\/\/(?:#{KNOWN_SUBDOMAIN.join('|')}).numerique.gouv.fr\/Demarches\/\d+.*key=[[:alnum:]]+.*/
+  IMG_CHECKER = /https:\/\/(?:#{KNOWN_SUBDOMAIN.join('|')}).numerique.gouv.fr\/(monavis-)?static\/bouton-(?:blanc|bleu).(?:png|svg)/
 
   ALLOWED_TAGS = %w[a img].freeze
   ALLOWED_ATTRIBUTES = %w[href src alt title target rel].freeze

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -422,7 +422,7 @@ describe Procedure do
           </a>
         MSG
         let(:procedure) { build(:procedure, monavis_embed: monavis_jedonnemonavis) }
-        it { is_expected.to eq(["Le code MonAvis contient un lien pointant vers un domaine invalide"]) }
+        it { is_expected.to include("Le code MonAvis contient un lien pointant vers un domaine invalide") }
       end
 
       context 'rejects a link to an arbitrary domain containing monavis as a substring (regex bypass)' do


### PR DESCRIPTION
## Summary

La regex `HREF_CHECKER` du `MonAvisEmbedValidator` utilisait `join('|')` sans groupement non-capturant, ce qui produisait une alternation au niveau global de la regex.

### Root cause

```ruby
HREF_CHECKER = /https:\/\/#{KNOWN_SUBDOMAIN.join('|')}.numerique.gouv.fr\/Demarches\/\d+.*/
# expandait en : /https:\/\/jedonnemonavis|monavis|voxusagers.numerique.gouv.fr\/Demarches\/\d+.*/
```

L'alternation `|` s'appliquait à toute la regex, pas seulement au sous-domaine. Toute URL contenant la chaîne `monavis` n'importe où passait la validation (ex: `https://evil.com/phishing?ref=monavis&key=abc123`).

Même problème sur `IMG_CHECKER` avec `bouton-blanc|bleu.png|svg`.

### Fix

Ajout de groupements non-capturants `(?:...)` autour des alternations.

## Setup — spec prouvant le bypass

![setup](https://gist.githubusercontent.com/mfo/e9b07c1e8cb7128fe7937624b09826f7/raw/setup.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)