### PR TITLE
ETQ corrige une MT sur les Procedure Path

### DIFF
--- a/app/tasks/maintenance/t20260317_fix_procedure_paths_ending_with_trailing_separator_task.rb
+++ b/app/tasks/maintenance/t20260317_fix_procedure_paths_ending_with_trailing_separator_task.rb
@@ -12,6 +12,8 @@ module Maintenance
     def process(procedure_path)
       procedure = procedure_path.procedure
 
+      return if procedure.nil?
+
       # Only act on the canonical (current) path
       return unless procedure_path.path == procedure.canonical_path
 

--- a/spec/tasks/maintenance/t20260317_fix_procedure_paths_ending_with_trailing_separator_task_spec.rb
+++ b/spec/tasks/maintenance/t20260317_fix_procedure_paths_ending_with_trailing_separator_task_spec.rb
@@ -102,6 +102,21 @@ module Maintenance
         end
       end
 
+      context "when the associated procedure is discarded" do
+        let(:procedure) { create(:procedure) }
+        let(:procedure_path) { procedure.procedure_paths.first }
+
+        before do
+          procedure_path.update_columns(path: "orphan-path-")
+          procedure.discard
+          procedure_path.reload
+        end
+
+        it "does nothing" do
+          expect { described_class.process(procedure_path) }.not_to change { ProcedurePath.count }
+        end
+      end
+
       context "when the procedure_path is not the canonical path" do
         let(:procedure) { create(:procedure) }
         let(:old_path) { procedure.procedure_paths.first }


### PR DESCRIPTION
Corrige https://demarche.numerique.gouv.fr/manager/maintenance_tasks/tasks/Maintenance::T20260317FixProcedurePathsEndingWithTrailingSeparatorTask

