### PR TITLE
ETQ instructeur, corriger la faille IDOR dans CommentairesController

### DIFF
--- a/app/controllers/instructeurs/commentaires_controller.rb
+++ b/app/controllers/instructeurs/commentaires_controller.rb
@@ -47,7 +47,11 @@ module Instructeurs
     end
 
     def dossier
-      Dossier.find(params[:dossier_id])
+      @dossier ||= if current_instructeur
+        current_instructeur.dossiers.find(params[:dossier_id])
+      else
+        current_expert.dossiers.find(params[:dossier_id])
+      end
     end
 
     def commentaire

--- a/spec/controllers/instructeurs/commentaires_controller_spec.rb
+++ b/spec/controllers/instructeurs/commentaires_controller_spec.rb
@@ -130,12 +130,13 @@ describe Instructeurs::CommentairesController, type: :controller do
     end
 
     describe 'IDOR protection' do
+      # instructeur is assigned to procedure but NOT to other_procedure
       let(:other_procedure) { create(:procedure, :published, :for_individual) }
       let(:other_dossier) { create(:dossier, :en_construction, :with_individual, procedure: other_procedure) }
       let(:other_commentaire) { create(:commentaire, dossier: other_dossier) }
 
       context 'destroy on a dossier the instructeur has no access to' do
-        subject { delete :destroy, params: { dossier_id: other_dossier.id, procedure_id: other_procedure.id, id: other_commentaire.id, statut: 'a-suivre' }, format: :turbo_stream }
+        subject { delete :destroy, params: { dossier_id: other_dossier.id, procedure_id: procedure.id, id: other_commentaire.id, statut: 'a-suivre' }, format: :turbo_stream }
 
         it 'raises ActiveRecord::RecordNotFound' do
           expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
@@ -144,7 +145,7 @@ describe Instructeurs::CommentairesController, type: :controller do
 
       context 'cancel_correction on a dossier the instructeur has no access to' do
         let!(:correction) { create(:dossier_correction, commentaire: other_commentaire, dossier: other_dossier) }
-        subject { post :cancel_correction, params: { dossier_id: other_dossier.id, procedure_id: other_procedure.id, id: other_commentaire.id, statut: 'a-suivre' }, format: :turbo_stream }
+        subject { post :cancel_correction, params: { dossier_id: other_dossier.id, procedure_id: procedure.id, id: other_commentaire.id, statut: 'a-suivre' }, format: :turbo_stream }
 
         it 'raises ActiveRecord::RecordNotFound' do
           expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
@@ -154,6 +155,9 @@ describe Instructeurs::CommentairesController, type: :controller do
   end
 
   context 'as expert' do
+    let!(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: procedure) }
+    let!(:avis) { create(:avis, dossier: dossier, experts_procedure: experts_procedure, claimant: instructeur) }
+
     before { sign_in(expert.user) }
 
     describe 'destroy' do


### PR DESCRIPTION
## Problème

`CommentairesController#dossier` utilise `Dossier.find(params[:dossier_id])` sans scoper au `current_instructeur` ni au `current_expert`.

Un instructeur authentifié peut donc appeler `destroy` ou `cancel_correction` avec l'id d'un dossier auquel il n'a pas accès. Même si les vérifications au niveau modèle empêchent la modification effective, la différence de réponse HTTP (200 vs 404) permet l'énumération des dossiers existants (IDOR).

## Solution

Remplacer `Dossier.find(params[:dossier_id])` par un lookup scopé :
- `current_instructeur.dossiers.find(...)` pour les instructeurs
- `current_expert.dossiers.find(...)` pour les experts

Un `ActiveRecord::RecordNotFound` (404) est désormais levé si le dossier n'appartient pas au périmètre de l'utilisateur connecté, aligné avec le pattern utilisé dans `DossiersController`, `ChampsController`, `RdvsController`, etc.


🤖 Generated with [Claude Code](https://claude.com/claude-code)