### PR TITLE
ETQ professionnel, je retrouve un lien vers la page ProConnect dans le header depuis (presque) toutes les pages

### DIFF
--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -1,6 +1,7 @@
 - content_for(:title, @procedure.libelle)
 - content_for(:meta_robots, @procedure.publiee? && @procedure.robots_indexable? ? "index,follow" : "noindex,nofollow")
-- content_for(:hide_header_login, true)
+- content_for(:hide_header_signin, true)
+- content_for(:pro_connect_path, commencer_pro_connect_path(path: @procedure.path, prefill_token: @prefilled_dossier&.prefill_token))
 
 .commencer.form
   - if !user_signed_in?

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -40,13 +40,15 @@
                 - if instructeur_signed_in? || user_signed_in?
                   %li
                     = render AccountDropdownComponent.new(dossier: @dossier, nav_bar_profile:)
-                - elsif request.path != new_user_session_path && !content_for?(:hide_header_login)
+                - else
                   - if request.path == new_user_registration_path
                     %li.fr-hidden-sm.fr-unhidden-lg.fr-link--sm.fr-mr-1v= t('views.shared.account.already_user_question')
-                  %li= link_to 'Professionnel',
-                    content_for(:pro_connect_path) || pro_connect_path,
-                    class: "fr-btn fr-btn--tertiary fr-icon-government-fill fr-btn--icon-left"
-                  %li= link_to t('views.shared.account.signin'), new_user_session_path, class: "fr-btn fr-btn--tertiary fr-icon-account-circle-fill fr-btn--icon-left"
+                  - if request.path != new_user_session_path && !content_for?(:hide_header_signin)
+                    %li= link_to t('views.shared.account.signin'), new_user_session_path, class: "fr-btn fr-btn--tertiary fr-icon-account-circle-fill fr-btn--icon-left"
+                  - if request.path != pro_connect_path
+                    %li= link_to t('views.shared.account.professional'),
+                      content_for(:pro_connect_path) || pro_connect_path,
+                      class: "fr-btn fr-btn--tertiary fr-icon-government-fill fr-btn--icon-left"
 
                 %li
                   - if dossier.present? && nav_bar_profile == :user

--- a/app/views/pro_connect/index.html.haml
+++ b/app/views/pro_connect/index.html.haml
@@ -1,4 +1,5 @@
 - content_for(:title, t('.cta'))
+- content_for(:hide_header_signin, true)
 
 #proconnect
   .fr-container

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -27,6 +27,7 @@ en:
         already_user: "I already have an account"
         create: 'Create an account on %{application_name}'
         signin: 'Sign in'
+        professional: "Professional"
         email_unverified: "Your email address is not verified, so you will not receive messages from %{application_name}. Please check your inbox and click on the verification link. Didn't receive the email?"
         cta_email_unverified: "Resend verification email"
       messages:

--- a/config/locales/views/shared/fr.yml
+++ b/config/locales/views/shared/fr.yml
@@ -27,6 +27,7 @@ fr:
         already_user: "J’ai déjà un compte"
         create: "Créer un compte %{application_name}"
         signin: "Se connecter"
+        professional: "Professionnel"
         email_unverified: "Votre adresse électronique n’est pas vérifiée, vous ne recevrez donc pas les messages de %{application_name}. Veuillez vérifier votre boîte de réception et cliquer sur le lien de vérification. Vous n’avez pas reçu l’email ?"
         cta_email_unverified: "Renvoyer l’email de vérification"
       messages:


### PR DESCRIPTION
cf https://mattermost.incubateur.net/betagouv/pl/1psrwhoajbfh5rwgyu8wn7stdr

## Homepage et pages neutres
<img width="973" height="262" alt="Capture d’écran 2026-03-23 à 13 07 09" src="https://github.com/user-attachments/assets/0c62280f-e433-432d-8270-75d4f625146e" />

## Page de connexion
<img width="973" height="262" alt="Capture d’écran 2026-03-23 à 13 07 33" src="https://github.com/user-attachments/assets/e0bafdc7-9871-4172-bbc4-de6585dd4e41" />

## Page ProConnect
<img width="973" height="307" alt="Capture d’écran 2026-03-23 à 13 07 51" src="https://github.com/user-attachments/assets/4936a203-b49b-4496-8219-369209c48b7a" />

## Page commencer d'une démarche
<img width="973" height="263" alt="Capture d’écran 2026-03-23 à 13 08 12" src="https://github.com/user-attachments/assets/06f97063-3b74-41e8-9e77-373f64f33079" />

## Page de création de compte
<img width="973" height="263" alt="Capture d’écran 2026-03-23 à 13 08 29" src="https://github.com/user-attachments/assets/04013c73-9f7e-45f8-bfb9-28b1772c9605" />
