### PR TITLE
Tech: fix erreur JS autosave sur upload de fichier

### DIFF
--- a/app/javascript/controllers/autosave_status_controller.ts
+++ b/app/javascript/controllers/autosave_status_controller.ts
@@ -82,7 +82,7 @@ export class AutosaveStatusController extends ApplicationController {
     if (error.isNetworkError) return;
 
     console.error(error);
-    return error.response.headers.get('X-Request-Id') ?? undefined;
+    return error.response?.headers.get('X-Request-Id') ?? undefined;
   }
 
   private renderErrorMessage(error: ResponseError, eventId?: string) {
@@ -130,7 +130,7 @@ export class AutosaveStatusController extends ApplicationController {
   }
 
   private isAuthError(error: ResponseError): boolean {
-    return error.response.status == 401 || error.response.status == 403;
+    return error.response?.status == 401 || error.response?.status == 403;
   }
 
   private setState(state: 'succeeded' | 'failed' | 'idle') {


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/7357687696/

- Corrige un `TypeError: Cannot read properties of undefined (reading 'headers')` dans le status controller d'autosave
- L'event `autosave:error` peut transporter un `FileUploadError` (upload de fichier) qui n'a pas de propriété `response`, contrairement au `ResponseError` attendu
- Ajout d'optional chaining (`?.`) sur `error.response` dans `captureError` et `isAuthError`



Avec ce fix on affiche bien le bandeau d'erreur si le direct upload ne marche pas