### PR TITLE
correctif: ETQ tech, si on arrive pas a contacter l'api bretagne, pas de 500

### DIFF
--- a/app/controllers/data_sources/chorus_controller.rb
+++ b/app/controllers/data_sources/chorus_controller.rb
@@ -4,27 +4,32 @@ class DataSources::ChorusController < ApplicationController
   before_action :authenticate_administrateur!
 
   def search_domaine_fonct
-    result_json = APIBretagneService.new.search_domaine_fonct(code_or_label: params[:q])
-    render json: format_result(result_json:,
-                               label_formatter: ChorusConfiguration.method(:format_domaine_fonctionnel_label))
+    result = APIBretagneService.new.search_domaine_fonct(code_or_label: params[:q])
+    render json: format_or_error(result:,
+                                 label_formatter: ChorusConfiguration.method(:format_domaine_fonctionnel_label))
   end
 
   def search_centre_couts
-    result_json = APIBretagneService.new.search_centre_couts(code_or_label: params[:q])
-    render json: format_result(result_json:,
-                               label_formatter: ChorusConfiguration.method(:format_centre_de_cout_label))
-    end
+    result = APIBretagneService.new.search_centre_couts(code_or_label: params[:q])
+    render json: format_or_error(result:,
+                                 label_formatter: ChorusConfiguration.method(:format_centre_de_cout_label))
+  end
 
   def search_ref_programmation
-    result_json = APIBretagneService.new.search_ref_programmation(code_or_label: params[:q])
-    render json: format_result(result_json:,
-                               label_formatter: ChorusConfiguration.method(:format_ref_programmation_label))
+    result = APIBretagneService.new.search_ref_programmation(code_or_label: params[:q])
+    render json: format_or_error(result:,
+                                 label_formatter: ChorusConfiguration.method(:format_ref_programmation_label))
   end
 
   private
 
-  def format_result(result_json:, label_formatter:)
-    result_json.map do |item|
+  def format_or_error(result:, label_formatter:)
+    if result.is_a?(Dry::Monads::Failure)
+      Sentry.capture_message("APIBretagneService error", extra: { code: result.failure.code, error: result.failure.error.to_s })
+      return []
+    end
+
+    result.map do |item|
       {
         label: label_formatter.call(item),
         value: item[:code],

--- a/app/services/api_bretagne_service.rb
+++ b/app/services/api_bretagne_service.rb
@@ -31,7 +31,10 @@ class APIBretagneService
   def request(endpoint:, code_or_label:)
     return [] if (code_or_label || "").strip.size < 3
     url = build_url(endpoint)
-    fetch_page(url:, params: { query: code_or_label, page_number: 1 })[:items] || []
+    result = fetch_page(url:, params: { query: code_or_label, page_number: 1 })
+    return result if result.is_a?(Dry::Monads::Failure)
+
+    result[:items] || []
   end
 
   def fetch_page(url:, params:, remaining_retry_count: 1)
@@ -43,7 +46,7 @@ class APIBretagneService
         login
         fetch_page(url:, params:, remaining_retry_count: 0)
       else
-        fail "APIBretagneService, #{error} #{code}"
+        result
       end
     in Success(body:)
       body
@@ -53,7 +56,10 @@ class APIBretagneService
   end
 
   def call(url:, params:)
-    API::Client.new.(url:, params:, authorization_token:, method:)
+    token = authorization_token
+    return token if token.is_a?(Dry::Monads::Failure)
+
+    API::Client.new.(url:, params:, authorization_token: token, method:)
   end
 
   def method
@@ -61,12 +67,13 @@ class APIBretagneService
   end
 
   def authorization_token
-    result = login
-    case result
+    return @token if @token
+
+    case login
     in Success(token:)
       @token = token
-    in Failure(error:, code:)
-      fail "APIBretagneService, #{error} #{code}"
+    in Failure => failure
+      return failure
     end
   end
 
@@ -80,7 +87,7 @@ class APIBretagneService
     case result
     in Success(body:)
       Success(token: body.split("Bearer ")[1])
-    in Failure(code:, error:) if code.in?(403)
+    in Failure(code:, error:) if code == 403
       Failure(API::Client::Error[:invalid_credential, code, false, error])
     else
       Failure(API::Client::Error[:api_down])

--- a/spec/controllers/data_sources/chorus_controller_spec.rb
+++ b/spec/controllers/data_sources/chorus_controller_spec.rb
@@ -37,6 +37,21 @@ describe DataSources::ChorusController do
       get :search_centre_couts, params: { q: "Dépenses" }
       expect(response.parsed_body.size).to eq(mock_api_response.size)
     end
+
+    context 'when API Bretagne login returns 403 (invalid credentials)' do
+      before do
+        allow_any_instance_of(APIBretagneService).to receive(:search_centre_couts).and_call_original
+        allow_any_instance_of(API::Client).to receive(:call)
+          .and_return(Dry::Monads::Failure(API::Client::Error[:http, 403, true, "Forbidden"]))
+      end
+
+      it 'returns an empty JSON array and logs to Sentry' do
+        expect(Sentry).to receive(:capture_message).with("APIBretagneService error", extra: { code: 403, error: "Forbidden" })
+        get :search_centre_couts, params: { q: "Dépenses" }
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq([])
+      end
+    end
   end
 
   describe 'search_ref_programmation' do


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/7357110864/?project=1429550&

code.in?(403) dans APIBretagneService#login passait un Integer à #in? qui attend un objet répondant à #include?, provoquant une 500 sur /data_sources/search_centre_couts.                                                                                                                                     

Corrigé en propageant les Failure monads (Dry::Monads) depuis le service jusqu'au controller, qui retourne maintenant un JSON vide + log Sentry au lieu de crasher.    
