### PR TITLE
ETQ usager, corrige l'affichage flex du séparateur "ou" de la drop zone

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -253,6 +253,13 @@ input[type='radio'] {
   }
 }
 
+// Variante pour afficher en flex à partir de md.
+.unhidden-flex-md {
+  @media (min-width: 48em) {
+    display: flex !important;
+  }
+}
+
 // we add fr-message--warning as only error/valid/exists
 .fr-message--warning::before {
   flex: 0 0 auto;

--- a/app/components/attachment/file_field_component/file_field_component.html.erb
+++ b/app/components/attachment/file_field_component/file_field_component.html.erb
@@ -32,7 +32,7 @@
               <%= t('.drop_zone_label', count: @max) %>
             </p>
 
-            <p class="fr-hr-or fr-mb-2v fr-hidden fr-unhidden-md">
+            <p class="fr-hr-or fr-mb-2v fr-hidden unhidden-flex-md">
               <%= t('.or') %>
             </p>
 


### PR DESCRIPTION
Corrige le layout de la drop zone en desktop car `fr-unhidden-md` remet un `display:initial`alors qu'on veut être flex ; pas le choix on doit créer notre propre helper comme on l'avait déjà fait 

Fix du fix de https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/12819 à cause de mes remarques qui ont compliqué la vie de cette PR



## APRES
<img width="1251" height="224" alt="Capture d’écran 2026-03-23 à 16 24 48" src="https://github.com/user-attachments/assets/5404c5a1-6185-40d4-93bb-75e3f17447d1" />


## AVANT
<img width="1251" height="305" alt="Capture d’écran 2026-03-23 à 16 27 52" src="https://github.com/user-attachments/assets/c987bc05-9c9a-4522-9b16-aafc7ac8816a" />
