### PR TITLE
ETQ Usager les erreurs de validation sur un champ SIRET s'affichent en rouge

### DIFF
--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -32,7 +32,7 @@ module Dsfr
         # When the object is a Champ, errors can be stored as nested errors on the dossier
         # or directly on the champ object
         if object.is_a?(Champ)
-          dossier_errors_for_champ.any?
+          dossier_errors_for_champ.any? || errors.any?
         else
           errors.has_key?(attribute_or_rich_body)
         end

--- a/spec/components/input_status_message_component_spec.rb
+++ b/spec/components/input_status_message_component_spec.rb
@@ -149,6 +149,22 @@ RSpec.describe Dsfr::InputStatusMessageComponent, type: :component do
       let(:errors_on_attribute) { false }
       let(:error_full_messages) { [] }
 
+      context "when the champ has direct validation errors (external_error with code_404)" do
+        let(:form) { instance_double(ActionView::Helpers::FormBuilder, object_name: "dossier[champs_public_attributes]", object: champ) }
+        let(:champ_component) { EditableChamp::SiretComponent.new(form:, champ:) }
+
+        before do
+          champ.update_columns(external_id: '80879023200025', external_state: 'external_error')
+          champ.errors.add(:value, :code_404)
+        end
+
+        it "renders the error message with error styling, not valid styling" do
+          expect(subject).to have_css(".fr-message--error")
+          expect(subject).not_to have_css(".fr-message--valid")
+          expect(subject).to have_text("Résultat introuvable. Vérifiez vos informations.")
+        end
+      end
+
       context "when etablissement is non-diffusible (diffusable_commercialement: false)" do
         before do
           etablissement = create(:etablissement, :non_diffusable, entreprise_raison_sociale: "SECRET EI", entreprise_forme_juridique: "Entrepreneur individuel")


### PR DESCRIPTION
## Summary

- Corrige un bug dans `InputErrorable` où les erreurs directes sur un champ (ex: SIRET introuvable, `code_404`) n'étaient pas détectées comme erreurs, ce qui faisait apparaître le message avec le style "valid" (vert) au lieu de "error" (rouge).
- Ajoute la condition `errors.any?` en complément de `dossier_errors_for_champ.any?` pour couvrir les erreurs sur le champ.
- Ajoute un test de composant vérifiant que le message d'erreur SIRET utilise bien `.fr-message--error`.

Avant
<img width="440" height="162" alt="Capture d’écran 2026-03-23 à 16 18 25" src="https://github.com/user-attachments/assets/55ef8e9e-0c0b-4b5e-b6c8-d21c03bd2d6d" />

Après
<img width="440" height="161" alt="Capture d’écran 2026-03-23 à 16 17 34" src="https://github.com/user-attachments/assets/86702ad5-0edd-477d-9785-f73c95867290" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)