### PR TITLE
correctif: ETQ admin, je ne veux pas de page 500 quand je passe un champ choix simple avec referentiel csv en referentiel a configurer

### DIFF
--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -241,6 +241,7 @@ class TypeDeChamp < ApplicationRecord
   before_validation :reset_pj_format_options_if_forced_nature
 
   before_save :remove_attachment, if: -> { type_champ_changed? }
+  before_save :clean_referentiel
 
   def valid?(context = nil)
     super
@@ -899,6 +900,11 @@ class TypeDeChamp < ApplicationRecord
     elsif !explication? && notice_explicative.attached?
       notice_explicative.purge_later
     end
+  end
+
+  def clean_referentiel
+    return unless persisted? && type_champ_changed? && referentiel_id?
+    self.referentiel_id = nil
   end
 
   def set_drop_down_list_options

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -78,6 +78,29 @@ describe TypeDeChamp do
       end
     end
 
+    describe 'changing the type_champ clears referentiel_id' do
+      let(:csv_referentiel) { create(:csv_referentiel) }
+      let(:tdc) { create(:type_de_champ_drop_down_list, referentiel: csv_referentiel) }
+
+      context 'from drop_down_list to referentiel' do
+        before { tdc.update(type_champ: TypeDeChamp.type_champs.fetch(:referentiel)) }
+
+        it { expect(tdc.referentiel_id).to be_nil }
+      end
+
+      context 'from drop_down_list to text' do
+        before { tdc.update(type_champ: TypeDeChamp.type_champs.fetch(:text)) }
+
+        it { expect(tdc.referentiel_id).to be_nil }
+      end
+
+      context 'from drop_down_list to multiple_drop_down_list (both use csv referentiel)' do
+        before { tdc.update(type_champ: TypeDeChamp.type_champs.fetch(:multiple_drop_down_list)) }
+
+        it { expect(tdc.referentiel_id).to be_nil }
+      end
+    end
+
     describe 'changing the type_champ from a drop_down_list' do
       let(:tdc) { create(:type_de_champ_drop_down_list) }
 


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/7344076782/?project=1429550
## Problème

Quand un administrateur change le type d'un champ de "choix simple" (`drop_down_list`) vers "référentiel à configurer" (`referentiel`), et que ce champ avait un CSV importé (`CsvReferentiel`), l'application renvoie une erreur 500.

Le `referentiel_id` (pointant vers le `CsvReferentiel`) n'était pas nettoyé au changement de type. La validation `ReferentielReadyValidator` appelait alors `CsvReferentiel#ready?`, méthode qui n'existe que sur `APIReferentiel`.

## Solution

Ajout d'un callback `before_save :clean_referentiel` qui nille `referentiel_id` à chaque changement de `type_champ`. C'est cohérent car changer de type implique toujours de reconfigurer le référentiel associé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)