### PR TITLE
ETQ Instructeur je veux exporter toutes les colonnes du référentiel pour les choix multiples dans les modèles d'export

### DIFF
--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -19,20 +19,19 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampB
 
   def columns(procedure:, displayable: true, prefix: nil)
     if drop_down_advanced?
-      path = referentiel.present? ? referentiel_path_to_get_user_value : nil
-      path.present? ? [
+      referentiel.present? ? referentiel.headers_with_path.map do |(header, path)|
         Columns::MultipleDropDownColumn.new(
           procedure_id: procedure.id,
           stable_id:,
           tdc_type: type_champ,
-          label: libelle,
+          label: "#{libelle_with_prefix(prefix)} – Référentiel #{header}",
           type: :enum,
           jsonpath: "$.referentiels.*.data.row.#{path}",
           displayable:,
           options_for_select: referentiel.options_for_path(path),
           mandatory: mandatory?
-        ),
-      ] : []
+        )
+      end : []
     else
       super
     end
@@ -50,10 +49,6 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampB
     end
   rescue JSON::ParserError
     []
-  end
-
-  def referentiel_path_to_get_user_value
-    referentiel.headers_with_path.first.second
   end
 
   private

--- a/spec/models/types_de_champ/multiple_drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/multiple_drop_down_list_type_de_champ_spec.rb
@@ -8,11 +8,30 @@ describe TypesDeChamp::MultipleDropDownListTypeDeChamp do
     end
     let(:multiple_dropdown_list_tdc) { procedure.active_revision.types_de_champ.first }
 
-    it 'returns a collection of columns in advanced mode' do
+    it 'returns one column per referentiel header in advanced mode' do
       columns = multiple_dropdown_list_tdc.columns(procedure:)
 
-      expect(columns).to be_an(Array)
-      expect(columns).to contain_exactly(an_instance_of(Columns::MultipleDropDownColumn))
+      expect(columns.size).to eq(3)
+      expect(columns).to all(be_an_instance_of(Columns::MultipleDropDownColumn))
+      expect(columns.map(&:label)).to eq([
+        "#{multiple_dropdown_list_tdc.libelle} – Référentiel option",
+        "#{multiple_dropdown_list_tdc.libelle} – Référentiel calorie (kcal)",
+        "#{multiple_dropdown_list_tdc.libelle} – Référentiel poids (g)",
+      ])
+    end
+  end
+
+  describe '#libelles_for_export' do
+    let(:referentiel) { create(:csv_referentiel, :with_items) }
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [{ type: :multiple_drop_down_list, referentiel:, drop_down_mode: 'advanced' }])
+    end
+    let(:multiple_dropdown_list_tdc) { procedure.active_revision.types_de_champ.first }
+
+    it 'returns a single column with path :value for standard export' do
+      libelles = multiple_dropdown_list_tdc.libelles_for_export
+
+      expect(libelles).to eq([[multiple_dropdown_list_tdc.libelle, :value]])
     end
   end
 


### PR DESCRIPTION
## Problème

Lorsqu'un champ à choix multiples utilise un référentiel importé (CSV), seule la première colonne du référentiel apparaît dans l'export via un modèle d'export. En comparaison, un champ à choix unique avec référentiel importé exporte correctement toutes les colonnes.


<img width="506" height="664" alt="Capture d’écran 2026-03-24 à 09 43 13" src="https://github.com/user-attachments/assets/1e7bc522-b151-44ae-af7a-554cebcb61dc" />


## Solution

Aligner le comportement de `MultipleDropDownListTypeDeChamp#columns` sur celui de `DropDownListTypeDeChamp#columns` : itérer sur tous les `referentiel.headers_with_path` pour créer une `Columns::MultipleDropDownColumn` par header du référentiel.

L'export standard (sans modèle d'export) n'est pas modifié — un test a été ajouté pour verrouiller ce comportement.

<img width="403" height="689" alt="Capture d’écran 2026-03-24 à 09 57 51" src="https://github.com/user-attachments/assets/4abeeab4-8293-44d4-b207-957dd653db7b" />
