### PR TITLE
ETQ usager, je peux remplir mon identité quand FranceConnect ne l'a pas pré-remplie (ou pas entièrement)

### DIFF
--- a/app/components/dossiers/individual_form_component.rb
+++ b/app/components/dossiers/individual_form_component.rb
@@ -16,12 +16,14 @@ class Dossiers::IndividualFormComponent < ApplicationComponent
   end
 
   def identity_locked?
-    !for_tiers? && @dossier.france_connected_with_one_identity?
+    !for_tiers? && @dossier.identity_from_fc?
   end
 
   def mandataire_identity_locked?
-    @dossier.france_connected_with_one_identity?
+    @dossier.identity_from_fc?
   end
+
+  private
 
   def back_url
     helpers.commencer_path(path: @dossier.procedure.path)

--- a/app/components/dossiers/individual_form_component/individual_form_component.html.erb
+++ b/app/components/dossiers/individual_form_component/individual_form_component.html.erb
@@ -18,7 +18,7 @@
           <h2 class="fr-h5"><%= t('.for_self.self_title') %></h2>
         </legend>
 
-        <% if @dossier.france_connected_with_one_identity? %>
+        <% if mandataire_identity_locked? %>
           <div class="fr-highlight fr-text--sm">
             <%= t('.identity_locked_by_france_connect') %>
           </div>
@@ -54,7 +54,7 @@
           </h2>
         </legend>
 
-        <% if @dossier.france_connected_with_one_identity? && !for_tiers? %>
+        <% if identity_locked? %>
           <div class="fr-highlight fr-text--sm">
             <%= t('.identity_locked_by_france_connect') %>
           </div>

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -155,7 +155,9 @@ module Users
       @no_description = true
 
       respond_to do |format|
-        format.html
+        format.html do
+          @dossier.prefill_individual_from_france_connect if @dossier.identity_from_fc?
+        end
         format.turbo_stream do
           @dossier.assign_for_tiers(params.dig(:dossier, :for_tiers) == 'true')
         end
@@ -488,11 +490,11 @@ module Users
     private
 
     def identity_locked?(dossier)
-      dossier.france_connected_with_one_identity?
+      dossier.identity_from_fc?
     end
 
     def mandataire_identity_locked?(dossier)
-      dossier.for_tiers? && dossier.france_connected_with_one_identity?
+      dossier.for_tiers? && dossier.identity_from_fc?
     end
 
     # if the status tab is filled, then this tab

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -171,7 +171,7 @@ class Dossier < ApplicationRecord
   after_destroy_commit :log_destroy
 
   accepts_nested_attributes_for :champs
-  accepts_nested_attributes_for :individual
+  accepts_nested_attributes_for :individual, update_only: true
 
   include AASM
 
@@ -464,6 +464,10 @@ class Dossier < ApplicationRecord
 
   delegate :siret, :siren, to: :etablissement, allow_nil: true
   delegate :france_connected_with_one_identity?, to: :user, allow_nil: true
+
+  def identity_from_fc?
+    user&.can_prefill_from_fc?(with_gender: !procedure.no_gender?)
+  end
 
   after_save :send_web_hook
   after_save :update_expired_at, if: :brouillon?

--- a/app/models/france_connect_information.rb
+++ b/app/models/france_connect_information.rb
@@ -74,6 +74,10 @@ class FranceConnectInformation < ApplicationRecord
     self.requested_email = nil
   end
 
+  def complete?(with_gender:)
+    given_name.present? && family_name.present? && (!with_gender || gender.present?)
+  end
+
   def full_name
     [given_name, family_name].compact.join(" ")
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -219,6 +219,10 @@ class User < ApplicationRecord
     france_connect_informations.size == 1
   end
 
+  def can_prefill_from_fc?(with_gender:)
+    france_connected_with_one_identity? && france_connect_informations.first.complete?(with_gender:)
+  end
+
   def can_be_deleted?
     !administrateur? && !instructeur? && !expert?
   end

--- a/spec/components/dossiers/individual_form_component_spec.rb
+++ b/spec/components/dossiers/individual_form_component_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe Dossiers::IndividualFormComponent, type: :component do
       end
     end
 
+    context "for self, when France Connect did not provide all identity fields" do
+      let(:user) { create(:user, france_connect_informations: [build(:france_connect_information, family_name: nil)]) }
+
+      it "all identity fields are editable" do
+        subject
+        expect(page).to have_field("Prénom", disabled: false)
+        expect(page).to have_field("Nom", disabled: false)
+        expect(page).not_to have_css("input[name='dossier[individual_attributes][gender]'][disabled]")
+        expect(page).not_to have_text("par FranceConnect et ne peuvent pas être modifiées")
+      end
+    end
+
     context "for tiers" do
       let(:dossier) { create(:dossier, :for_tiers_without_notification, procedure:, user:) }
 

--- a/spec/system/users/dossier_creation_spec.rb
+++ b/spec/system/users/dossier_creation_spec.rb
@@ -72,6 +72,37 @@ describe 'Creating a new dossier:', js: true do
         it_behaves_like 'the user can create a new draft'
       end
 
+      context 'when user is connected via France Connect with incomplete identity' do
+        let(:procedure) { create(:procedure, :published, :for_individual, :with_service, libelle:) }
+        let(:user) { create(:user, france_connect_informations: [build(:france_connect_information, family_name: nil)]) }
+
+        it 'allows the user to fill in missing fields and edit them later' do
+          find('label', text: "Pour vous").click
+
+          expect(page).to have_field('Prénom', disabled: false)
+          expect(page).to have_field('Nom', disabled: false)
+          expect(page).not_to have_text("par FranceConnect et ne peuvent pas être modifiées")
+
+          fill_in('Prénom', with: 'prenom')
+          fill_in('Nom', with: 'nom')
+
+          within "#identite-form" do
+            click_button('Continuer')
+          end
+
+          dossier = procedure.dossiers.last
+          expect(page).to have_current_path(brouillon_dossier_path(dossier))
+          expect(dossier.individual.reload.prenom).to eq('prenom')
+          expect(dossier.individual.nom).to eq('nom')
+
+          # Return to identity page to verify values are preserved
+          visit identite_dossier_path(dossier)
+
+          expect(page).to have_field('Prénom', with: 'prenom', disabled: false)
+          expect(page).to have_field('Nom', with: 'nom', disabled: false)
+        end
+      end
+
       context 'when for tiers is disabled' do
         let(:procedure) { create(:procedure, :published, :for_individual, :with_service, for_tiers_enabled: false, libelle:) }
 


### PR DESCRIPTION
## Problème

Quand un usager est connecté via FranceConnect mais que FC n'a pas fourni tous les champs d'identité (nom ou prénom manquant), les champs sont disabled et vides → l'usager est bloqué.

Cas identifiés :
- FranceConnect ne fournit pas certains champs (given_name ou family_name absents)
- Le dossier a été créé avant la connexion FC, l'Individual n'a jamais été pré-rempli

## Solution
- plutôt que faire un blocage champ par champ en fonction de ce qui est pré-rempli, l'identité est soit bloquée en entier, soit pas du tout
- **Vérifier les données FCI** (pas l'Individual) pour déterminer le verrouillage : `fc_identity_complete?` vérifie que FC a fourni `given_name` ET `family_name`
- **`update_only: true`** sur `accepts_nested_attributes_for :individual` pour éviter un DELETE + INSERT qui perdait les valeurs préremplies en mémoire
- **Prefill sur le page load HTML** de la page identité, uniquement quand l'identité FC est complète (pour ne pas écraser les valeurs saisies manuellement)

On a tout petit peu de duplication de code, pour le moment j'ai pas trouvé où/comment éviter ça sans compliquer encore +
