### PR TITLE
Correctif : etq instructeur je n'ai pas de titre identite dans les exports zip

### DIFF
--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -137,7 +137,7 @@ class PiecesJustificativesService
 
   def pjs_for_champs(dossiers)
     champs = liste_documents_allows?(:with_champs_private) ? dossiers.flat_map(&:filled_champs) : dossiers.flat_map(&:filled_champs_public)
-    champs = champs.filter { _1.piece_justificative? && _1.is_type?(_1.type_de_champ.type_champ) }
+    champs = champs.filter { _1.piece_justificative? && !_1.titre_identite_nature? && _1.is_type?(_1.type_de_champ.type_champ) }
 
     champs_id_row_index = compute_champ_id_row_index(champs)
 

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -51,6 +51,19 @@ describe PiecesJustificativesService do
       end
     end
 
+    context 'with a titre_identite champ' do
+      # Regression test: after T20260303MigrateTitreIdentiteToPieceJustificativeTask,
+      # titre_identite champs have type_champ='piece_justificative' and nature='TITRE_IDENTITE'.
+      # They must not appear in zip exports for security reasons.
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: :TITRE_IDENTITE }]) }
+
+      before { attach_file_to_champ(pj_champ(dossier)) }
+
+      it 'does not include titre_identite file in the export' do
+        expect(subject).to be_empty
+      end
+    end
+
     context 'with a repetition' do
       let(:first_champ) { champ_for_update(repetition(dossier).rows.first.first) }
       let(:second_champ) { champ_for_update(repetition(dossier).rows.second.first) }


### PR DESCRIPTION
Suite à une remontée au [support](https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_f18b486a-bf40-4230-b4b9-93988a2af643/)