### PR TITLE
ETQ Admin je ne veux pas d'erreur dans l'aperçu de ma démarche s'il manque un niveau de titre

### DIFF
--- a/app/models/concerns/treeable_concern.rb
+++ b/app/models/concerns/treeable_concern.rb
@@ -26,7 +26,9 @@ module TreeableConcern
     types_de_champ.each do |type_de_champ|
       if type_de_champ.header_section?
         new_tree = [type_de_champ]
-        walk[type_de_champ.header_section_level_value - 1].push(new_tree)
+        parent_level = type_de_champ.header_section_level_value - 1
+        parent_level -= 1 while parent_level > 0 && walk[parent_level].nil?
+        walk[parent_level].push(new_tree)
         current_tree = walk[type_de_champ.header_section_level_value] = new_tree
       else
         current_tree.push(type_de_champ)

--- a/spec/models/concerns/treeable_concern_spec.rb
+++ b/spec/models/concerns/treeable_concern_spec.rb
@@ -142,6 +142,27 @@ describe TreeableConcern do
       end
     end
 
+    context 'with skipped header level (h1 then h3, no h2)' do
+      let(:header_1_3) { { type: :header_section, level: 3, stable_id: 799 } }
+      let(:header_1_3_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 799 } }
+
+      let(:types_de_champ_public) do
+        [
+          header_1,
+          champ_text,
+          header_1_3,
+          champ_textarea,
+        ]
+      end
+
+      it 'attaches to nearest existing ancestor instead of crashing' do
+        expect(subject.size).to eq(1)
+        expect(subject).to eq([
+          [header_1_tdc, champ_text_tdc, [header_1_3_tdc, champ_textarea_tdc]],
+        ])
+      end
+    end
+
     context 'with one sub sections and one subsub section' do
       let(:header_1_2_3) { { type: :header_section, level: 3, stable_id: 799 } }
       let(:header_1_2_3_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 799 } }


### PR DESCRIPTION
## Summary
- Corrige un crash (`NoMethodError: undefined method 'push' for nil`) dans `TreeableConcern#to_tree` quand un formulaire a des niveaux de titres incohérents (ex: h1 → h3 sans h2)
- Le tree builder remonte maintenant au plus proche ancêtre existant au lieu de crasher
- Ajout d'un test couvrant ce cas

[RAILS-JZM](https://demarches-simplifiees.sentry.io/issues/RAILS-JZM) — 22 occurrences, 2 users affectés

🤖 Generated with [Claude Code](https://claude.com/claude-code)