### PR TITLE
ETQ instructeur, ne reçoit plus d'emails redondants de renouvellement de token

### DIFF
--- a/app/jobs/cron/trusted_device_token_renewal_job.rb
+++ b/app/jobs/cron/trusted_device_token_renewal_job.rb
@@ -10,7 +10,12 @@ class Cron::TrustedDeviceTokenRenewalJob < Cron::CronJob
       .distinct
       .find_each do |instructeur|
         begin
-          tokens = instructeur.trusted_device_tokens.expiring_in_one_week
+          # Skip if the instructeur still has a valid token not yet approaching expiration,
+          # or if we already sent a renewal email recently.
+          # The goal is to send exactly one email before the *last* token expires.
+          next if instructeur.trusted_device_tokens.renewal_not_needed.exists?
+
+          tokens = instructeur.trusted_device_tokens
 
           ActiveRecord::Base.transaction do
             tokens.update_all(renewal_notified_at: Time.current)

--- a/app/models/trusted_device_token.rb
+++ b/app/models/trusted_device_token.rb
@@ -14,6 +14,12 @@ class TrustedDeviceToken < ApplicationRecord
           renewal_notified_at: nil)
   end
 
+  scope :renewal_not_needed, -> do
+    not_expiring_soon = where(activated_at: (TrustedDeviceConcern::TRUSTED_DEVICE_PERIOD - 1.week).ago..)
+    recently_notified = where(renewal_notified_at: 1.week.ago..)
+    not_expiring_soon.or(recently_notified)
+  end
+
   def token_valid?
     LOGIN_TOKEN_VALIDITY.ago < created_at
   end

--- a/spec/jobs/cron/trusted_device_token_renewal_job_spec.rb
+++ b/spec/jobs/cron/trusted_device_token_renewal_job_spec.rb
@@ -75,4 +75,53 @@ describe Cron::TrustedDeviceTokenRenewalJob do
       subject
     end
   end
+
+  context 'when the instructeur has a more recent valid token not yet expiring' do
+    before do
+      create(:trusted_device_token,
+        instructeur: token_to_notify.instructeur,
+        activated_at: 1.week.ago,
+        renewal_notified_at: nil)
+    end
+
+    it 'skips entirely: no email, no marking, no new token' do
+      expect(InstructeurMailer).not_to receive(:trusted_device_token_renewal)
+      expect { subject }.not_to change { TrustedDeviceToken.count }
+      expect(token_to_notify.reload.renewal_notified_at).to be_nil
+    end
+  end
+
+  context 'when the instructeur was already notified recently' do
+    before do
+      create(:trusted_device_token,
+        instructeur: token_to_notify.instructeur,
+        activated_at: (TrustedDeviceConcern::TRUSTED_DEVICE_PERIOD - 2.days).ago,
+        renewal_notified_at: 2.days.ago)
+    end
+
+    it 'skips: no email, no marking' do
+      expect(InstructeurMailer).not_to receive(:trusted_device_token_renewal)
+      subject
+      expect(token_to_notify.reload.renewal_notified_at).to be_nil
+    end
+  end
+
+  context 'when tokens enter the expiring window on consecutive days' do
+    before do
+      create(:trusted_device_token,
+        instructeur: token_to_notify.instructeur,
+        activated_at: (TrustedDeviceConcern::TRUSTED_DEVICE_PERIOD - 4.days).ago,
+        renewal_notified_at: nil)
+    end
+
+    it 'sends only one email across two runs on consecutive days' do
+      expect(InstructeurMailer)
+        .to receive(:trusted_device_token_renewal).once
+        .and_return(double(deliver_later: true))
+
+      described_class.new.perform_now
+      travel_to(now + 1.day)
+      described_class.new.perform_now
+    end
+  end
 end


### PR DESCRIPTION

## Contexte

Des instructeurs reçoivent plusieurs fois par semaine l'email « Votre connexion sécurisée expirera dans une semaine », alors qu'ils se connectent quotidiennement.

https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_1a1489f7-885d-42fa-bbc8-cb4414e10300/

## Cause

Quand un instructeur a plusieurs `TrustedDeviceToken` activés à des dates différentes (multi-navigateurs, cookies effacés…), chaque token entre dans la fenêtre d'expiration un jour différent. Le cron envoie alors un email par token au lieu d'un seul par cycle, ce qui perpétue la boucle infernale.


## Correctif

Ajout d'un scope `renewal_not_needed` et d'une garde dans le cron job pour ne pas envoyer l'email si :
- l'instructeur a encore un token pas encore proche de l'expiration
- ou s'il a déjà été notifié récemment (< 1 semaine)

L'objectif est d'envoyer un seul email avant l'expiration du *dernier* token actif.
