### PR TITLE
ETQ usager, je peux soumettre un commentaire avec pièce jointe même si la validation échoue

### DIFF
--- a/app/components/attachment/file_field_component.rb
+++ b/app/components/attachment/file_field_component.rb
@@ -41,7 +41,7 @@ class Attachment::FileFieldComponent < ApplicationComponent
     @hidden = hidden
     @input_id = id
 
-    # Get attachments
+    # Get attachments (filter unpersisted ones — they have nil IDs and can't generate routes)
     @attachments = if attachments
       Array(attachments).compact
     elsif attached_file.is_a?(ActiveStorage::Attached::Many)
@@ -50,7 +50,7 @@ class Attachment::FileFieldComponent < ApplicationComponent
       [attached_file.attachment]
     else
       []
-    end
+    end.filter(&:persisted?)
 
     @current_count = @attachments.size
 

--- a/spec/components/attachment/file_field_component_spec.rb
+++ b/spec/components/attachment/file_field_component_spec.rb
@@ -65,6 +65,19 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
     end
   end
 
+  describe 'with unpersisted attachments' do
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champs.first }
+    let(:context) { Attachment::Context.new(champ:) }
+    let(:unpersisted_attachment) { ActiveStorage::Attachment.new(blob: ActiveStorage::Blob.create_and_upload!(io: StringIO.new('fake'), filename: 'test.pdf', content_type: 'application/pdf')) }
+
+    it 'filters out unpersisted attachments' do
+      component = described_class.new(context:, drop_zone: :none, attachments: [unpersisted_attachment])
+      expect(component.attachments).to be_empty
+    end
+  end
+
   describe 'drop_zone validation' do
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
     let(:dossier) { create(:dossier, procedure:) }


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/7341075924/?project=1429550&query=&referrer=issue-stream

## Problème

Quand un usager soumet un commentaire avec une pièce jointe via direct upload mais que la validation échoue (ex: body vide), le controller fait `render :messagerie` avec le commentaire non-persisté. Le formulaire tente alors d'afficher les attachments en mémoire (id: nil) via `AttachmentRowComponent`, qui crash en générant `attachment_path(nil, ...)`.

**Sentry:** #7341075924 — `ActionController::UrlGenerationError` dans `Users::DossiersController#create_commentaire`

**Régression introduite par** 2e1ad248d3 (migration vers `FileFieldComponent` unifié). L'ancien `EditComponent` (V1) avait un guard `if attachment.persisted?` qui filtrait les attachments non-persistés. Ce guard a été perdu lors de la migration.

### Solution

Ajout de `.select(&:persisted?)` sur les attachments récupérés dans `FileFieldComponent#initialize`. Reproduit le comportement défensif de la V1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)