### PR TITLE
ETQ usager, ne plus crasher quand un champ référentiel n'est pas configuré

### DIFF
--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -32,7 +32,7 @@ module Dsfr
     end
 
     def referentiel_support_statut?
-      type_de_champ.referentiel? && !@champ.idle?
+      type_de_champ.referentiel? && (!@champ.idle? || type_de_champ.referentiel.blank?)
     end
 
     def pjs_statut?
@@ -68,7 +68,9 @@ module Dsfr
           { state: :info, text: dossier.text_summary }
         end
       when TypeDeChamp.type_champs[:referentiel]
-        if @champ.pending?
+        if type_de_champ.referentiel.blank?
+          { state: :error, text: t(".referentiel.not_configured") }
+        elsif @champ.pending?
           { state: :info, text: t(".referentiel.fetching") }
         elsif @champ.external_error?
           { state: :info, text: t(".referentiel.error", value: @champ.external_id) }

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
@@ -8,6 +8,7 @@ en:
     fetched: "%{raison_sociale_or_name} %{forme_juridique}"
     error: "An error occurred while retrieving SIRET information."
   referentiel:
+    not_configured: "This field has not been configured by the administrator yet."
     fetching: "Search in progress."
     error: "No item found for the reference: %{value}"
     success: "Reference found: %{value}"

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
@@ -8,6 +8,7 @@ fr:
     fetched: "%{raison_sociale_or_name} %{forme_juridique}"
     error: "Une erreur est survenue lors de la récupération des informations SIRET."
   referentiel:
+    not_configured: "Ce champ n’est pas encore configuré par l’administrateur."
     fetching: "Recherche en cours."
     error: "Aucun élément trouvé pour la référence : %{value}"
     success: "Référence trouvée : %{value}"

--- a/app/components/editable_champ/referentiel_component/referentiel_component.html.haml
+++ b/app/components/editable_champ/referentiel_component/referentiel_component.html.haml
@@ -1,4 +1,6 @@
-- if exact_match?
+- if referentiel.blank?
+  = @form.text_field :value, input_opts(id: @champ.focusable_input_id, class: "fr-input", disabled: true)
+- elsif exact_match?
   = @form.text_field :external_id, input_opts(id: @champ.focusable_input_id, required: @champ.required?, class: "width-33-desktop fr-input", novalidate: 'true', aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" })
 - else
   .fr-input-group.address-ban

--- a/spec/components/editable_champ/referentiel_component_spec.rb
+++ b/spec/components/editable_champ/referentiel_component_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EditableChamp::ReferentielComponent, type: :component do
+  let(:types_de_champ_public) { [{ type: :referentiel, referentiel:, referentiel_mapping: {} }] }
+  let(:procedure) { create(:procedure, types_de_champ_public:) }
+  let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+  let(:champ) { dossier.project_champs_public.first }
+  let(:form) do
+    ActionView::Helpers::FormBuilder.new("dossier[champs_public_attributes]", champ, ActionController::Base.new.view_context, {})
+  end
+
+  let(:component) { described_class.new(form:, champ:) }
+  subject { render_inline(component) }
+
+  context 'when referentiel is nil' do
+    let(:referentiel) { nil }
+
+    it 'renders a disabled input without crashing' do
+      expect(subject).to have_field(type: 'text', disabled: true)
+    end
+
+    it 'does not render the autocomplete combobox' do
+      expect(subject).not_to have_selector('react-fragment')
+    end
+  end
+
+  context 'when referentiel is present' do
+    let(:referentiel) { create(:api_referentiel, :autocomplete) }
+
+    it 'renders the autocomplete combobox' do
+      expect(subject).to have_selector('react-fragment')
+    end
+  end
+end


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/7305936356/?project=1429550&query=is%3Aunresolved&referrer=issue-stream

## Problème

Le `ReferentielComponent` appelle `referentiel.id` sans vérifier que `referentiel` n'est pas nil.
Or `TypeDeChamp` a `belongs_to :referentiel, optional: true` — le référentiel peut ne pas être associé (champ pas encore configuré par l'admin).

Quand un usager ouvre son brouillon avec un tel champ, la page crash avec `NoMethodError: undefined method 'id' for nil`. Le cas : un admin test sa demarche dans un onglet, modifie dans un autre. Reload la page de demarche. kaboom

## Solution

- Ajouter un guard `referentiel.blank?` dans le template du composant : affiche un input disabled au lieu de crasher
- Afficher un message d'erreur DSFR (`fr-message--error`) sous le champ : *"Ce champ n'est pas encore configuré par l'administrateur."*
- Ajout d'un spec couvrant les cas nil et present

![fix-referentiel-error-state.png](https://gist.githubusercontent.com/mfo/091aef534acd47f64ca8c65fda627762/raw/fix-referentiel-error-state.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)