### PR TITLE
Tech: retourner 406 pour les requêtes avec un format non supporté

### DIFF
--- a/app/controllers/application_controller/error_handling.rb
+++ b/app/controllers/application_controller/error_handling.rb
@@ -7,5 +7,13 @@ module ApplicationController::ErrorHandling
     rescue_from ActionController::InvalidAuthenticityToken do
       render file: Rails.public_path.join('403.html'), layout: false, status: :forbidden
     end
+
+    rescue_from ActionView::MissingTemplate do |exception|
+      if request.format.html? || request.format.turbo_stream?
+        raise exception
+      else
+        head :not_acceptable
+      end
+    end
   end
 end

--- a/spec/controllers/application_controller/error_handling_spec.rb
+++ b/spec/controllers/application_controller/error_handling_spec.rb
@@ -7,10 +7,17 @@ RSpec.describe ApplicationController::ErrorHandling, type: :controller do
     def invalid_authenticity_token
       raise ActionController::InvalidAuthenticityToken
     end
+
+    def show
+      render template: 'nonexistent/template'
+    end
   end
 
   before do
-    routes.draw { post 'invalid_authenticity_token' => 'anonymous#invalid_authenticity_token' }
+    routes.draw do
+      post 'invalid_authenticity_token' => 'anonymous#invalid_authenticity_token'
+      get 'show' => 'anonymous#show'
+    end
   end
 
   describe 'handling ActionController::InvalidAuthenticityToken' do
@@ -26,6 +33,21 @@ RSpec.describe ApplicationController::ErrorHandling, type: :controller do
     it 'returns a 403 forbidden status' do
       post :invalid_authenticity_token
       expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'handling unsupported format requests' do
+    it 'returns 406 for unsupported formats like zip' do
+      get :show, format: :zip
+      expect(response).to have_http_status(:not_acceptable)
+    end
+
+    it 'raises MissingTemplate for html format' do
+      expect { get :show, format: :html }.to raise_error(ActionView::MissingTemplate)
+    end
+
+    it 'raises MissingTemplate for turbo_stream format' do
+      expect { get :show, format: :turbo_stream }.to raise_error(ActionView::MissingTemplate)
     end
   end
 end


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/7328782244/?project=1429550&query=is%3Aunresolved&referrer=issue-stream

# Problème

Des requêtes comme `GET /graphql.zip` provoquent une erreur **500** (`ActionView::MissingTemplate`) en production. Rails infère le format depuis l'extension de l'URL, cherche un template `.zip.erb` qui n'existe pas, et lève une exception non gérée.

Ce n'est pas isolé au playground GraphQL — toutes les actions avec render implicite sont touchées (`/stats.zip`, `/contact.zip`, `/carte.zip`, etc.).

C'est du bruit dans sentry, c'est infernal.

# Solution

`rescue_from ActionView::MissingTemplate` global dans `ApplicationController::ErrorHandling` :

- **Format HTML ou Turbo Stream** → re-raise l'exception (vrai bug, doit remonter dans Sentry)
- **Tout autre format** → **406 Not Acceptable**

### Pourquoi cette approche ?

- **`respond_to` par contrôleur** : trop verbeux, dizaines de contrôleurs à modifier, les futurs oublieront.
- **Contrainte de format dans les routes** : `/graphql.zip` servirait du HTML, trompeur.
- **Filtrage Sentry** : on perdrait le signal des vrais templates manquants.
- **`before_action` avec liste blanche de formats** : liste à maintenir à chaque nouveau format.

Le `rescue_from` avec re-raise sélectif est le pattern standard Rails. Il couvre toutes les routes existantes et futures sans maintenance.

Turbo Stream est dans la liste des re-raise car l'app en est un heavy user — un template `.turbo_stream` manquant est un vrai bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)