### PR TITLE
Tech: ne pas cloner les feature flags basés sur un pourcentage

### DIFF
--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -132,7 +132,7 @@ module ProcedureCloneConcern
 
     Flipper.features.each do |feature|
       next if feature.enabled? # don't clone features globally enabled
-      next if feature.percentage_of_time_value > 0 # don't clone randomly enabled features
+      next if feature.percentage_of_time_value > 0 || feature.percentage_of_actors_value > 0 # don't clone percentage-based features
       next unless feature_enabled?(feature.key)
 
       Flipper.enable(feature.key, procedure)

--- a/spec/models/concerns/procedure_clone_concern_spec.rb
+++ b/spec/models/concerns/procedure_clone_concern_spec.rb
@@ -410,6 +410,28 @@ describe ProcedureCloneConcern, type: :model do
         end
       end
 
+      context 'with a feature flag enabled by percentage of actors' do
+        before do
+          Flipper.enable_percentage_of_actors(:dossier_pdf_vide, 50)
+          Flipper.enable(:dossier_pdf_vide, procedure)
+        end
+
+        it 'should not clone actor gate for percentage-based feature' do
+          expect(Flipper.feature(:dossier_pdf_vide).actors_value).not_to include(subject.flipper_id)
+        end
+      end
+
+      context 'with a feature flag enabled by percentage of time' do
+        before do
+          Flipper.enable_percentage_of_time(:dossier_pdf_vide, 50)
+          Flipper.enable(:dossier_pdf_vide, procedure)
+        end
+
+        it 'should not clone actor gate for percentage-based feature' do
+          expect(Flipper.feature(:dossier_pdf_vide).actors_value).not_to include(subject.flipper_id)
+        end
+      end
+
       context 'with a feature flag disabled' do
         before do
           Flipper.disable(:dossier_pdf_vide, procedure)


### PR DESCRIPTION
## Contexte

Un feature flag aléatoirement activé se retrouvait cloné (comme le ff du simpliscore), ce qui au bout d'un moment ferait atteindre la limite à 500 acteurs, qui casserait l'action de clone.
On faisait déjà pareil pour les flags activés sur un % de temps, ici c'est un % d'acteurs

https://demarches-simplifiees.sentry.io/issues/7358199959/