### PR TITLE
ETQ usager pro, le bouton "Professionnel" de la page d'accueil d'une démarche va vers notre page "tampon" `/pro_connect`

### DIFF
--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -83,7 +83,7 @@ module Users
       return procedure_not_found if @procedure.blank?
 
       store_user_location!(@procedure)
-      redirect_to pro_connect_login_path
+      redirect_to pro_connect_path
     end
 
     def procedure_for_help

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -455,7 +455,7 @@ describe Users::CommencerController, type: :controller do
       it 'set the path to return after sign-up to the procedure start page' do
         subject
         expect(controller.stored_location_for(:user)).to eq(commencer_path(path: published_procedure.path))
-        expect(subject).to redirect_to(pro_connect_login_path)
+        expect(subject).to redirect_to(pro_connect_path)
       end
 
       context 'when a prefill token is given' do


### PR DESCRIPTION
plutôt que d'aller directement sans prévenir chez Pro Connect
(vu en point UX)