### PR TITLE
ETQ Usager, je peux renseigner le numéro d'un dossier supprimé dans les champs dossier-lié

### DIFF
--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -63,9 +63,17 @@ module Dsfr
       when TypeDeChamp.type_champs[:rna]
         { state: :info, text: t(".rna.data_fetched", title: @champ.title, address: @champ.full_address) }
       when TypeDeChamp.type_champs[:dossier_link]
-        dossier = Dossier.visible_by_administration.find_by(id: @champ.value)
+        dossier = Dossier.find_by(id: @champ.value)
         if dossier.present?
-          { state: :info, text: dossier.text_summary }
+          if dossier.hidden_by_user_at.present?
+            { state: :info, text: I18n.t('shared.champs.dossier_link.hidden',
+                                         depose_at: l(dossier.depose_at.to_date),
+                                         procedure_libelle: dossier.procedure.libelle,
+                                         hidden_at: l(dossier.hidden_by_user_at.to_date)),
+            }
+          else
+            { state: :info, text: dossier.text_summary }
+          end
         end
       when TypeDeChamp.type_champs[:referentiel]
         if type_de_champ.referentiel.blank?

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -65,8 +65,16 @@ module Dsfr
       when TypeDeChamp.type_champs[:dossier_link]
         dossier = Dossier.find_by(id: @champ.value)
         if dossier.present?
-          if dossier.hidden_by_user_at.present?
-            { state: :info, text: I18n.t('shared.champs.dossier_link.hidden',
+          if dossier.hidden_by_expired_at.present?
+            {
+              state: :info, text: I18n.t('shared.champs.dossier_link.expired',
+                                         depose_at: l(dossier.depose_at.to_date),
+                                         procedure_libelle: dossier.procedure.libelle,
+                                         expired_at: l(dossier.hidden_by_expired_at.to_date)),
+            }
+          elsif dossier.hidden_by_user_at.present?
+            {
+              state: :info, text: I18n.t('shared.champs.dossier_link.hidden',
                                          depose_at: l(dossier.depose_at.to_date),
                                          procedure_libelle: dossier.procedure.libelle,
                                          hidden_at: l(dossier.hidden_by_user_at.to_date)),

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -64,7 +64,15 @@ module Dsfr
         { state: :info, text: t(".rna.data_fetched", title: @champ.title, address: @champ.full_address) }
       when TypeDeChamp.type_champs[:dossier_link]
         dossier = Dossier.find_by(id: @champ.value)
-        if dossier.present?
+        deleted_dossier = DeletedDossier.find_by(dossier_id: @champ.value) if dossier.nil?
+        if deleted_dossier.present?
+          {
+            state: :info, text: I18n.t('shared.champs.dossier_link.hidden',
+                                       depose_at: l(deleted_dossier.depose_at),
+                                       procedure_libelle: deleted_dossier.procedure.libelle,
+                                       hidden_at: l(deleted_dossier.deleted_at.to_date)),
+          }
+        elsif dossier.present?
           if dossier.hidden_by_expired_at.present?
             {
               state: :info, text: I18n.t('shared.champs.dossier_link.expired',

--- a/app/models/champs/dossier_link_champ.rb
+++ b/app/models/champs/dossier_link_champ.rb
@@ -9,9 +9,9 @@ class Champs::DossierLinkChamp < Champ
 
   def dossier_exists
     linked_dossier = Dossier.find_by(id: value)
-    if linked_dossier.nil?
+    if linked_dossier.nil? && !DeletedDossier.exists?(dossier_id: value)
       errors.add(:value, :not_found)
-    elsif linked_dossier.brouillon?
+    elsif linked_dossier&.brouillon?
       errors.add(:value, :brouillon_not_allowed)
     end
   end
@@ -23,7 +23,10 @@ class Champs::DossierLinkChamp < Champ
     allowed_ids = type_de_champ.dossier_link_procedure_ids
     return if allowed_ids.empty?
 
-    if !Dossier.joins(:revision).exists?(id: value, user: dossier.user, procedure_revisions: { procedure_id: allowed_ids })
+    dossier_matches = Dossier.joins(:revision).exists?(id: value, user: dossier.user, procedure_revisions: { procedure_id: allowed_ids })
+    deleted_dossier_matches = DeletedDossier.exists?(dossier_id: value, user_id: dossier.user_id, procedure_id: allowed_ids)
+
+    if !dossier_matches && !deleted_dossier_matches
       errors.add(:value, :not_in_allowed_procedures)
     end
   end

--- a/app/models/champs/dossier_link_champ.rb
+++ b/app/models/champs/dossier_link_champ.rb
@@ -8,8 +8,11 @@ class Champs::DossierLinkChamp < Champ
   private
 
   def dossier_exists
-    if !Dossier.exists?(value)
+    linked_dossier = Dossier.find_by(id: value)
+    if linked_dossier.nil?
       errors.add(:value, :not_found)
+    elsif linked_dossier.brouillon?
+      errors.add(:value, :brouillon_not_allowed)
     end
   end
 

--- a/app/views/shared/champs/dossier_link/_show.html.haml
+++ b/app/views/shared/champs/dossier_link/_show.html.haml
@@ -2,7 +2,12 @@
 - profile = controller.try(:nav_bar_profile)
 - hidden_at = dossier && ((profile == :user && dossier.hidden_by_user_at) || (profile == :instructeur && dossier.hidden_by_administration_at))
 - if dossier
-  - if hidden_at.present?
+  - if dossier.hidden_by_expired_at.present?
+    %p Dossier n° #{dossier.id}
+    %br
+    .copy-zone
+      %p= t('shared.champs.dossier_link.expired', depose_at: l(dossier.depose_at.to_date), procedure_libelle: dossier.procedure.libelle, expired_at: l(dossier.hidden_by_expired_at.to_date))
+  - elsif hidden_at.present?
     %p Dossier n° #{dossier.id}
     %br
     .copy-zone

--- a/app/views/shared/champs/dossier_link/_show.html.haml
+++ b/app/views/shared/champs/dossier_link/_show.html.haml
@@ -1,12 +1,18 @@
 - dossier = Dossier.includes(:procedure).find_by(id: champ.to_s)
 - if dossier
-  - path = dossier_linked_path(current_instructeur || current_user, dossier)
-  - if path.present?
-    %p= link_to("Dossier n° #{dossier.id}", path, target: '_blank', rel: 'noopener')
-  - else
+  - if controller.try(:nav_bar_profile) == :user && dossier.hidden_by_user_at.present?
     %p Dossier n° #{dossier.id}
-  %br
-  .copy-zone
-    %p= sanitize(dossier.text_summary)
+    %br
+    .copy-zone
+      %p= t('shared.champs.dossier_link.hidden_by_user', depose_at: l(dossier.depose_at.to_date), procedure_libelle: dossier.procedure.libelle, hidden_at: l(dossier.hidden_by_user_at.to_date))
+  - else
+    - path = dossier_linked_path(current_instructeur || current_user, dossier)
+    - if path.present?
+      %p= link_to("Dossier n° #{dossier.id}", path, target: '_blank', rel: 'noopener')
+    - else
+      %p Dossier n° #{dossier.id}
+    %br
+    .copy-zone
+      %p= sanitize(dossier.text_summary)
 - else
   %p Pas de dossier associé

--- a/app/views/shared/champs/dossier_link/_show.html.haml
+++ b/app/views/shared/champs/dossier_link/_show.html.haml
@@ -1,10 +1,12 @@
 - dossier = Dossier.includes(:procedure).find_by(id: champ.to_s)
+- profile = controller.try(:nav_bar_profile)
+- hidden_at = dossier && ((profile == :user && dossier.hidden_by_user_at) || (profile == :instructeur && dossier.hidden_by_administration_at))
 - if dossier
-  - if controller.try(:nav_bar_profile) == :user && dossier.hidden_by_user_at.present?
+  - if hidden_at.present?
     %p Dossier n° #{dossier.id}
     %br
     .copy-zone
-      %p= t('shared.champs.dossier_link.hidden_by_user', depose_at: l(dossier.depose_at.to_date), procedure_libelle: dossier.procedure.libelle, hidden_at: l(dossier.hidden_by_user_at.to_date))
+      %p= t('shared.champs.dossier_link.hidden', depose_at: l(dossier.depose_at.to_date), procedure_libelle: dossier.procedure.libelle, hidden_at: l(hidden_at.to_date))
   - else
     - path = dossier_linked_path(current_instructeur || current_user, dossier)
     - if path.present?

--- a/app/views/shared/champs/dossier_link/_show.html.haml
+++ b/app/views/shared/champs/dossier_link/_show.html.haml
@@ -1,7 +1,13 @@
 - dossier = Dossier.includes(:procedure).find_by(id: champ.to_s)
+- deleted_dossier = dossier.nil? ? DeletedDossier.includes(:procedure).find_by(dossier_id: champ.to_s) : nil
 - profile = controller.try(:nav_bar_profile)
 - hidden_at = dossier && ((profile == :user && dossier.hidden_by_user_at) || (profile == :instructeur && dossier.hidden_by_administration_at))
-- if dossier
+- if deleted_dossier
+  %p Dossier n° #{champ}
+  %br
+  .copy-zone
+    %p= t('shared.champs.dossier_link.deleted', procedure_libelle: deleted_dossier.procedure&.libelle)
+- elsif dossier
   - if dossier.hidden_by_expired_at.present?
     %p Dossier n° #{dossier.id}
     %br

--- a/config/locales/models/champs/dossier_link_champ/en.yml
+++ b/config/locales/models/champs/dossier_link_champ/en.yml
@@ -11,4 +11,5 @@ en:
           attributes:
             value:
               not_found: "File not found"
+              brouillon_not_allowed: "This file has not been submitted yet"
               not_in_allowed_procedures: "This file is not in an allowed procedure"

--- a/config/locales/models/champs/dossier_link_champ/fr.yml
+++ b/config/locales/models/champs/dossier_link_champ/fr.yml
@@ -11,4 +11,5 @@ fr:
           attributes:
             value:
               not_found: "Le dossier n’existe pas"
+              brouillon_not_allowed: "Le dossier n’a pas encore été déposé"
               not_in_allowed_procedures: "Ce dossier n’est pas dans une démarche autorisée"

--- a/config/locales/views/shared/champs/dossier_link/en.yml
+++ b/config/locales/views/shared/champs/dossier_link/en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  shared:
+    champs:
+      dossier_link:
+        hidden: "File submitted on %{depose_at} for the procedure “%{procedure_libelle}” but deleted on %{hidden_at}"

--- a/config/locales/views/shared/champs/dossier_link/en.yml
+++ b/config/locales/views/shared/champs/dossier_link/en.yml
@@ -5,3 +5,4 @@ en:
       dossier_link:
         hidden: "File submitted on %{depose_at} for the procedure “%{procedure_libelle}” but deleted on %{hidden_at}"
         expired: "File submitted on %{depose_at} for the procedure “%{procedure_libelle}” but expired on %{expired_at}"
+        deleted: "The file referenced at submission for the procedure “%{procedure_libelle}” no longer exists"

--- a/config/locales/views/shared/champs/dossier_link/en.yml
+++ b/config/locales/views/shared/champs/dossier_link/en.yml
@@ -4,3 +4,4 @@ en:
     champs:
       dossier_link:
         hidden: "File submitted on %{depose_at} for the procedure “%{procedure_libelle}” but deleted on %{hidden_at}"
+        expired: "File submitted on %{depose_at} for the procedure “%{procedure_libelle}” but expired on %{expired_at}"

--- a/config/locales/views/shared/champs/dossier_link/fr.yml
+++ b/config/locales/views/shared/champs/dossier_link/fr.yml
@@ -1,0 +1,6 @@
+---
+fr:
+  shared:
+    champs:
+      dossier_link:
+        hidden: "Dossier déposé le %{depose_at} sur la démarche « %{procedure_libelle} » mais supprimé le %{hidden_at}"

--- a/config/locales/views/shared/champs/dossier_link/fr.yml
+++ b/config/locales/views/shared/champs/dossier_link/fr.yml
@@ -5,3 +5,4 @@ fr:
       dossier_link:
         hidden: "Dossier déposé le %{depose_at} sur la démarche « %{procedure_libelle} » mais supprimé le %{hidden_at}"
         expired: "Dossier déposé le %{depose_at} sur la démarche « %{procedure_libelle} » mais expiré le %{expired_at}"
+        deleted: "Le dossier renseigné lors du dépôt sur la démarche « %{procedure_libelle} » n’existe plus"

--- a/config/locales/views/shared/champs/dossier_link/fr.yml
+++ b/config/locales/views/shared/champs/dossier_link/fr.yml
@@ -4,3 +4,4 @@ fr:
     champs:
       dossier_link:
         hidden: "Dossier déposé le %{depose_at} sur la démarche « %{procedure_libelle} » mais supprimé le %{hidden_at}"
+        expired: "Dossier déposé le %{depose_at} sur la démarche « %{procedure_libelle} » mais expiré le %{expired_at}"

--- a/spec/components/input_status_message_component_spec.rb
+++ b/spec/components/input_status_message_component_spec.rb
@@ -55,6 +55,19 @@ RSpec.describe Dsfr::InputStatusMessageComponent, type: :component do
           expect(subject).to have_css(".fr-message--info", text: /Dossier/)
         end
       end
+
+      context "when the linked dossier has been hidden by the user" do
+        let(:linked_dossier) do
+          create(:dossier, :en_instruction, hidden_by_user_at: Time.zone.local(2026, 3, 15))
+        end
+
+        it "renders the hidden_by_user message" do
+          expect(subject).to have_css(
+            ".fr-message--info",
+            text: /Dossier déposé le .* sur la démarche .* mais supprimé le 15 mars 2026/
+          )
+        end
+      end
     end
 
     context 'with referentiel champs' do

--- a/spec/models/champs/dossier_link_champ_spec.rb
+++ b/spec/models/champs/dossier_link_champ_spec.rb
@@ -66,6 +66,12 @@ describe Champs::DossierLinkChamp, type: :model do
         it { is_expected.to be_falsey }
       end
 
+      context 'when id of a deleted dossier' do
+        let(:value) { create(:deleted_dossier).dossier_id }
+
+        it { is_expected.to be_truthy }
+      end
+
       context 'when id of a brouillon dossier' do
         let(:value) { create(:dossier).id }
 
@@ -109,6 +115,28 @@ describe Champs::DossierLinkChamp, type: :model do
 
     context 'when dossier belongs to another user' do
       let(:value) { create(:dossier, :en_construction, procedure: allowed_procedure).id }
+
+      it 'is invalid' do
+        is_expected.to be_falsey
+      end
+    end
+
+    context 'when deleted dossier belongs to an allowed procedure and to the current user' do
+      let(:value) { create(:deleted_dossier, procedure: allowed_procedure, user_id: user.id).dossier_id }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when deleted dossier does not belong to an allowed procedure' do
+      let(:value) { create(:deleted_dossier, procedure: other_procedure, user_id: user.id).dossier_id }
+
+      it 'is invalid with correct error message' do
+        is_expected.to be_falsey
+        expect(champ.errors.full_messages).to include("Ce dossier n’est pas dans une démarche autorisée")
+      end
+    end
+
+    context 'when deleted dossier belongs to another user' do
+      let(:value) { create(:deleted_dossier, procedure: allowed_procedure).dossier_id }
 
       it 'is invalid' do
         is_expected.to be_falsey

--- a/spec/models/champs/dossier_link_champ_spec.rb
+++ b/spec/models/champs/dossier_link_champ_spec.rb
@@ -3,13 +3,13 @@
 describe Champs::DossierLinkChamp, type: :model do
   let(:types_de_champ_public) { [{ type: :dossier_link, mandatory: }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
-  let(:dossier) { create(:dossier, procedure:) }
+  let(:dossier) { create(:dossier, :en_construction, procedure:) }
   let(:champ) { dossier.champs.first.tap { _1.update(value:) } }
   let(:value) { nil }
   let(:mandatory) { false }
 
   describe 'prefilling validations' do
-    let(:linked_dossier) { create(:dossier) }
+    let(:linked_dossier) { create(:dossier, :en_construction) }
     describe 'value' do
       subject { champ.valid?(:prefill) }
 
@@ -57,13 +57,22 @@ describe Champs::DossierLinkChamp, type: :model do
     context 'when mandatory' do
       let(:mandatory) { true }
       context 'when valid id' do
-        let(:value) { create(:dossier).id }
+        let(:value) { create(:dossier, :en_construction).id }
         it { is_expected.to be_truthy }
       end
 
       context 'when invalid id' do
         let(:value) { 'kthxbye' }
         it { is_expected.to be_falsey }
+      end
+
+      context 'when id of a brouillon dossier' do
+        let(:value) { create(:dossier).id }
+
+        it 'is invalid with brouillon_not_allowed error' do
+          is_expected.to be_falsey
+          expect(champ.errors.added?(:value, :brouillon_not_allowed)).to be(true)
+        end
       end
     end
   end
@@ -85,12 +94,12 @@ describe Champs::DossierLinkChamp, type: :model do
     end
 
     context 'when dossier belongs to an allowed procedure and to the current user' do
-      let(:value) { create(:dossier, procedure: allowed_procedure, user:).id }
+      let(:value) { create(:dossier, :en_construction, procedure: allowed_procedure, user:).id }
       it { is_expected.to be_truthy }
     end
 
     context 'when dossier does not belong to an allowed procedure' do
-      let(:value) { create(:dossier, procedure: other_procedure, user:).id }
+      let(:value) { create(:dossier, :en_construction, procedure: other_procedure, user:).id }
 
       it 'is invalid with correct error message' do
         is_expected.to be_falsey
@@ -99,7 +108,7 @@ describe Champs::DossierLinkChamp, type: :model do
     end
 
     context 'when dossier belongs to another user' do
-      let(:value) { create(:dossier, procedure: allowed_procedure).id }
+      let(:value) { create(:dossier, :en_construction, procedure: allowed_procedure).id }
 
       it 'is invalid' do
         is_expected.to be_falsey
@@ -111,7 +120,7 @@ describe Champs::DossierLinkChamp, type: :model do
         type_de_champ.update!(options: type_de_champ.options.merge('procedures_limit' => nil))
       end
 
-      let(:value) { create(:dossier, procedure: other_procedure, user:).id }
+      let(:value) { create(:dossier, :en_construction, procedure: other_procedure, user:).id }
       it { is_expected.to be_truthy }
     end
 
@@ -120,7 +129,7 @@ describe Champs::DossierLinkChamp, type: :model do
         type_de_champ.update!(options: type_de_champ.options.merge('dossier_link_procedure_ids' => []))
       end
 
-      let(:value) { create(:dossier, procedure: other_procedure, user:).id }
+      let(:value) { create(:dossier, :en_construction, procedure: other_procedure, user:).id }
       it { is_expected.to be_truthy }
     end
   end


### PR DESCRIPTION
closes #12552 

- dans l'édition d'un dossier, l'usager utiliser le numéro d'un dossier présent dans la corbeille suite à une suppression, ou supprimé définitivement. L'interface lui indiquera : 

<img width="628" height="163" alt="Screenshot 2026-04-08 at 15-49-35 Modifier · Dossier n° 24577125 (test) · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/a10efeb9-d8ae-425f-b168-aa4b86130a9e" />

Si le dossier est dans la corbeille suite à une expiration

<img width="572" height="141" alt="Screenshot 2026-04-08 at 16-13-03 Modifier · Dossier n° 24577132 (test) · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/e5a3878e-b8e2-4a7e-a363-4c8386f5528e" />

la date correspond soit à la date de mise à la corbeille, soit à la date de suppression définitive

- dans la vue du dossier, point de vue usager on aura maintenant :
  - si le dossier est dans la corbeille suite à une manipulation de l'usager
<img width="900" height="168" alt="Screenshot 2026-04-08 at 15-51-52 Votre dossier · Dossier 24577125 (test) · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/90f8a718-5c31-4cd8-960a-f14bb7745f84" />

  - si le dossier est dans la corbeille car il est expiré
<img width="900" height="168" alt="Screenshot 2026-04-08 at 15-52-22 Votre dossier · Dossier 24577132 (test) · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/42d1f54a-961f-41ce-afac-4e7b5f7eec09" />

  - s'il est supprimé définitivement
<img width="900" height="168" alt="Screenshot 2026-04-08 at 16-08-36 Votre dossier · Dossier 24577125 (test) · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/8d0c6731-7e32-4f46-8399-9be7ce579fa3" />

mm affichage pour les instructeurs