### PR TITLE
Correctif : ETQ usager d'un lecteur d'écran, je veux que le message d'erreur d'upload d'une pj invalide me soit restitué

### DIFF
--- a/app/components/attachment/error_wrapper_component.rb
+++ b/app/components/attachment/error_wrapper_component.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class Attachment::ErrorWrapperComponent < ApplicationComponent
-  def initialize(with_top_margin: false)
+  def initialize(with_top_margin: false, id: nil)
     @with_top_margin = with_top_margin
+    @id = id
   end
 
   def call
-    tag.div(class: class_names('fr-messages-group': true, 'hidden': true, 'fr-mt-2w': @with_top_margin), aria: { live: 'assertive' }, data: { 'attachment-error': true, 'turbo-force': 'browser' })
+    tag.div(id: @id, class: class_names('fr-messages-group': true, 'hidden': true, 'fr-mt-2w': @with_top_margin), aria: { live: 'assertive' }, data: { 'attachment-error': true, 'turbo-force': 'browser' })
   end
 end

--- a/app/components/attachment/file_field_component.rb
+++ b/app/components/attachment/file_field_component.rb
@@ -88,6 +88,10 @@ class Attachment::FileFieldComponent < ApplicationComponent
     "#{champ.focusable_input_id}-hint"
   end
 
+  def error_wrapper_id
+    champ.present? ? "attachment-error-#{champ.public_id}" : "attachment-error-generic"
+  end
+
   def hints_component
     Attachment::HintsComponent.new(
       champ:,

--- a/app/components/attachment/file_field_component/file_field_component.html.erb
+++ b/app/components/attachment/file_field_component/file_field_component.html.erb
@@ -55,7 +55,7 @@
   <% end %>
 
   <%# Error wrapper %>
-  <%= render Attachment::ErrorWrapperComponent.new(with_top_margin: !show_uploader?) %>
+  <%= render Attachment::ErrorWrapperComponent.new(with_top_margin: !show_uploader?, id: error_wrapper_id) %>
 
   <%# Progress bars container — preserved during turbo morph %>
   <div

--- a/app/components/attachment/file_input_component.rb
+++ b/app/components/attachment/file_input_component.rb
@@ -56,6 +56,7 @@ class Attachment::FileInputComponent < ApplicationComponent
     describedby << champ.describedby_id if champ&.description.present?
     describedby << parent_hint_id if parent_hint_id.present?
     describedby << champ.error_id(:value) if champ&.errors&.has_key?(:value)
+    describedby << error_wrapper_id if champ.present?
 
     options[:aria] = { describedby: describedby.join(' '), labelledby: aria_labelledby }
 
@@ -83,6 +84,10 @@ class Attachment::FileInputComponent < ApplicationComponent
 
   def attribute_name
     attached_file.name
+  end
+
+  def error_wrapper_id
+    "attachment-error-#{champ.public_id}"
   end
 
   def final_input_id

--- a/app/javascript/shared/attachment-error.ts
+++ b/app/javascript/shared/attachment-error.ts
@@ -1,7 +1,3 @@
-const AUTO_DISMISS_DELAY = 10_000;
-
-let dismissTimeoutId: ReturnType<typeof setTimeout> | undefined;
-
 /**
  * Trouve le container attachment field depuis un input
  */
@@ -12,7 +8,7 @@ function findContainer(input: HTMLInputElement): Element | null {
 /**
  * Affiche une liste de messages d'erreur inline
  * Chaque message sera affiché dans un <p class="fr-message fr-message--error">
- * Les erreurs disparaissent automatiquement après 10 secondes.
+ * Les erreurs restent visibles jusqu'à ce que l'utilisateur sélectionne un nouveau fichier.
  */
 export function showAttachmentError(
   input: HTMLInputElement,
@@ -30,9 +26,6 @@ export function showAttachmentError(
     return;
   }
 
-  // Annuler un éventuel timeout précédent
-  clearTimeout(dismissTimeoutId);
-
   // Vider le contenu précédent
   errorZone.innerHTML = '';
 
@@ -46,12 +39,6 @@ export function showAttachmentError(
 
   // Afficher la zone
   errorZone.classList.remove('hidden');
-
-  // Auto-dismiss après délai
-  dismissTimeoutId = setTimeout(() => {
-    errorZone.classList.add('hidden');
-    errorZone.innerHTML = '';
-  }, AUTO_DISMISS_DELAY);
 }
 
 /**

--- a/spec/components/attachment/file_input_component_spec.rb
+++ b/spec/components/attachment/file_input_component_spec.rb
@@ -99,10 +99,11 @@ RSpec.describe Attachment::FileInputComponent, type: :component do
     let(:parent_hint_id) { "#{champ.focusable_input_id}-pj-hint" }
     let(:context_kwargs) { { parent_hint_id: } }
     let(:describedby_attribute) { page.find('input[type="file"]')['aria-describedby'].split }
+    let(:error_wrapper_id) { "attachment-error-#{champ.public_id}" }
 
-    it 'targets describedby_id and parent_hint_id' do
+    it 'targets describedby_id, parent_hint_id and error_wrapper_id' do
       subject
-      expect(describedby_attribute).to eq([champ.describedby_id, parent_hint_id])
+      expect(describedby_attribute).to eq([champ.describedby_id, parent_hint_id, error_wrapper_id])
     end
 
     context 'when there is an error' do
@@ -110,16 +111,16 @@ RSpec.describe Attachment::FileInputComponent, type: :component do
 
       it 'targets error_id' do
         subject
-        expect(describedby_attribute).to eq([champ.describedby_id, parent_hint_id, champ.error_id(:value)])
+        expect(describedby_attribute).to eq([champ.describedby_id, parent_hint_id, champ.error_id(:value), error_wrapper_id])
       end
     end
 
     context 'without parent_hint_id' do
       let(:context_kwargs) { {} }
 
-      it 'only targets describedby_id' do
+      it 'targets describedby_id and error_wrapper_id' do
         subject
-        expect(describedby_attribute).to eq([champ.describedby_id])
+        expect(describedby_attribute).to eq([champ.describedby_id, error_wrapper_id])
       end
     end
   end


### PR DESCRIPTION
Le premier commit closes #12529.
Et le 2e supprime le comportement de disparition automatique du message d'erreur.

@mmagn j'ai re-regardé, ça me parait distinct de ta PR https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/12960