### PR TITLE
Migrate select procedure dropdown to React on Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ gem 'rails-i18n' # Locales par défaut
 gem 'rails-pg-extras'
 gem 'rake-progressbar', require: false
 gem 'reactionview'
+gem 'react_on_rails'
 gem 'redcarpet'
 gem 'redis'
 gem 'rexml' # add missing gem due to ruby3 (https://github.com/Shopify/bootsnap/issues/325)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,7 @@ GEM
     event_stream_parser (1.0.0)
     excon (1.3.0)
       logger
+    execjs (2.10.1)
     factory_bot (6.5.5)
       activesupport (>= 6.1.0)
     faraday (2.14.1)
@@ -558,6 +559,7 @@ GEM
       webfinger (~> 2.0)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
+    package_json (0.2.0)
     parallel (1.27.0)
     parsby (1.1.1)
     parser (3.3.9.0)
@@ -691,6 +693,13 @@ GEM
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
+    react_on_rails (16.6.0)
+      addressable
+      connection_pool
+      execjs (~> 2.5)
+      rails (>= 5.2)
+      rainbow (~> 3.0)
+      shakapacker (>= 6.0)
     reactionview (0.1.2)
       actionview (>= 7.0)
       herb (>= 0.7.0, < 1.0.0)
@@ -813,6 +822,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    semantic_range (3.1.1)
     sentry-delayed_job (5.27.0)
       delayed_job (>= 4.0)
       sentry-ruby (~> 5.27.0)
@@ -825,6 +835,12 @@ GEM
     sentry-sidekiq (5.27.0)
       sentry-ruby (~> 5.27.0)
       sidekiq (>= 3.0)
+    shakapacker (10.0.0)
+      activesupport (>= 5.2)
+      package_json
+      rack-proxy (>= 0.6.1)
+      railties (>= 5.2)
+      semantic_range (>= 2.3.0)
     shoulda-matchers (6.5.0)
       activesupport (>= 5.2.0)
     sib-api-v3-sdk (9.1.0)
@@ -1102,6 +1118,7 @@ DEPENDENCIES
   rails-i18n
   rails-pg-extras
   rake-progressbar
+  react_on_rails
   reactionview
   redcarpet
   redis

--- a/app/components/select_procedure_drop_down_list_component/select_procedure_drop_down_list_component.html.haml
+++ b/app/components/select_procedure_drop_down_list_component/select_procedure_drop_down_list_component.html.haml
@@ -5,8 +5,10 @@
 
   .fr-col-12.fr-col-sm-10.fr-col-md-8.flex.align-center
     = label_tag :procedure_id, t('.label_html'), class: 'fr-label fr-text--bold fr-mr-2w', id: 'select-procedure-drop-down-list-label', for: 'select-procedure-drop-down-list'
-    %react-fragment.flex-1
-      = render ReactComponent.new "ComboBox/SingleComboBox", **react_props
+    = helpers.react_component("SelectProcedureDropDownList",
+      props: react_props,
+      id: 'select-procedure-drop-down-list-react-component',
+      html_options: { class: 'flex-1' })
 
     %input.hidden{
       type: 'submit',

--- a/app/javascript/components/SelectProcedureDropDownList.tsx
+++ b/app/javascript/components/SelectProcedureDropDownList.tsx
@@ -1,0 +1,9 @@
+import type { ComponentProps } from 'react';
+
+import { SingleComboBox } from './ComboBox';
+
+type Props = ComponentProps<typeof SingleComboBox>;
+
+export default function SelectProcedureDropDownList(props: Props) {
+  return <SingleComboBox {...props} />;
+}

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -10,6 +10,7 @@ import '../shared/activestorage/ujs';
 import '../shared/safari-11-empty-file-workaround';
 import '../shared/toggle-target';
 import '../shared/intl-listformat';
+import '../startup/reactOnRails';
 
 import { registerControllers } from '../shared/stimulus-loader';
 

--- a/app/javascript/startup/reactOnRails.ts
+++ b/app/javascript/startup/reactOnRails.ts
@@ -1,0 +1,9 @@
+import ReactOnRails from 'react-on-rails/client';
+
+import SelectProcedureDropDownList from '../components/SelectProcedureDropDownList';
+
+try {
+  ReactOnRails.getComponent('SelectProcedureDropDownList');
+} catch {
+  ReactOnRails.register({ SelectProcedureDropDownList });
+}

--- a/bun.lock
+++ b/bun.lock
@@ -63,6 +63,7 @@
         "react-coordinate-input": "^1.0.0",
         "react-dom": "19.2.5",
         "react-fast-compare": "^3.2.2",
+        "react-on-rails": "16.6.0",
         "react-use-event-hook": "^0.9.6",
         "stimulus-use": "^0.52.3",
         "superstruct": "^2.0.2",
@@ -1788,6 +1789,8 @@
     "react-fast-compare": ["react-fast-compare@3.2.2", "", {}, "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "react-on-rails": ["react-on-rails@16.6.0", "", { "peerDependencies": { "react": ">= 16", "react-dom": ">= 16" } }, "sha512-LqLi7A0n0Tv5c3yMYlwS9s6rE82gvXNMj3sscmK2LOgIJ+mLQlOX65n0Jq5ZJ4Nsl9SRgxEOOQmcrfvDeB9F1g=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.0", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-sGsQtcjMqdQyijAHytfGEELB8FufGbfXIsvUTe+NLx1GDRJCXtCFLBLUI1eyZCKXXvbEU2C6gai0PZKoIE9Vbg=="],
 

--- a/config/initializers/react_on_rails.rb
+++ b/config/initializers/react_on_rails.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+ReactOnRails.configure do |config|
+  # This app still uses Vite for client bundles, so React on Rails only provides
+  # the Rails-side mounting contract for the migrated slice.
+  config.auto_load_bundle = false
+  config.prerender = false
+end

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "pmtiles": "^4.3.0",
     "react": "19.2.5",
     "react-aria-components": "^1.16.0",
+    "react-on-rails": "16.6.0",
     "react-coordinate-input": "^1.0.0",
     "react-dom": "19.2.5",
     "react-fast-compare": "^3.2.2",

--- a/spec/components/select_procedure_drop_down_list_component_spec.rb
+++ b/spec/components/select_procedure_drop_down_list_component_spec.rb
@@ -21,8 +21,13 @@ RSpec.describe SelectProcedureDropDownListComponent, type: :component do
   let(:action_path) { '/test/path' }
   let(:form_class) { 'ml-auto' }
 
-  let(:react_component) { page.find('react-component') }
-  let(:react_props_items) { JSON.parse(react_component['props']) }
+  let(:react_component) do
+    page.find(
+      'script.js-react-on-rails-component[data-component-name="SelectProcedureDropDownList"]',
+      visible: false
+    )
+  end
+  let(:react_props_items) { JSON.parse(react_component.text(:all)) }
 
   it 'renders the label' do
     expect(subject).to have_text('Accès direct')
@@ -42,6 +47,11 @@ RSpec.describe SelectProcedureDropDownListComponent, type: :component do
   it 'includes the action path in the props' do
     subject
     expect(react_props_items["data"]["action_path"]).to eq('/test/path')
+  end
+
+  it 'renders the React on Rails mount point' do
+    subject
+    expect(page).to have_selector('#select-procedure-drop-down-list-react-component.flex-1')
   end
 
   it 'applies the form class' do


### PR DESCRIPTION
## Summary
- add a client-only React on Rails setup that coexists with the existing Vite pipeline
- migrate `SelectProcedureDropDownListComponent` from the custom Coldwired mount to `react_component(...)`
- add focused component coverage for the new React on Rails mount contract

## Why this change
I maintain both `react-rails` and `react_on_rails`, and my recommendation for Rails apps that already use React is to move toward React on Rails as the better-supported Rails integration path.

React on Rails has active maintenance, current documentation, and a clearer long-term Rails + React story than older or repo-specific mount glue.

Relevant docs:
- [React on Rails docs](https://www.reactonrails.com/docs/)
- [Shakapacker docs](https://www.shakapacker.com/)

For this repository specifically, the main benefit is maintainability.

Today this component is mounted through a custom `coldwired/react` bridge. That means the project owns a project-specific Rails-to-React contract, helper surface, and future compatibility work. Moving one slice to React on Rails replaces that custom mount contract with a maintained and documented one, which is easier for future contributors to understand and easier to migrate incrementally.

This change also keeps the door open to future React on Rails capabilities, including server rendering or a more standardized integration path later, without forcing that broader architecture decision now.

## Scope
This PR intentionally does **not** replace Vite or rewrite the frontend boot path.

It keeps the existing Vite and Turbo setup in place and only swaps one narrow component boundary from a custom bridge to a standard Rails helper contract. The point is to prove an incremental migration path, not to impose a big-bang bundler change.

## Testing
- `bun lint:types`
- `DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:drop db:create db:schema:load RAILS_ENV=test`
- `bundle exec rspec spec/components/select_procedure_drop_down_list_component_spec.rb`
