### PR TITLE
Correctif : ETQ instructeur, je peux recevoir une notification si l'expert répond moins de 30 minutes après la demande d'avis

### DIFF
--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -103,6 +103,7 @@ module Experts
     end
 
     def update
+      was_unanswered = @avis.answer.nil?
       updated_recently = @avis.updated_recently?
       if @avis.update(avis_answer_params)
         flash.notice = 'Votre réponse est enregistrée.'
@@ -115,7 +116,7 @@ module Experts
         DossierNotification.destroy_notifications_by_dossier_and_type(@avis.dossier, :attente_avis) if @avis.dossier.avis.without_answer.empty?
         DossierNotification.create_notification(@avis.dossier, :avis_externe)
 
-        if !updated_recently
+        if was_unanswered || !updated_recently
           @avis.dossier.followers_instructeurs
             .with_instant_email_new_expert_avis(@avis.procedure)
             .each do |instructeur|

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -301,6 +301,15 @@ describe Experts::AvisController, type: :controller do
           expect(DossierMailer).to receive(:notify_new_avis_to_instructeur).once.with(avis_without_answer, instructeur_with_instant_avis_notification.email).and_return(double(deliver_later: true))
           subject
         end
+
+        it 'notifies the instructeur even when the expert answers within 30 minutes of the avis creation' do
+          avis_without_answer.update_column(:updated_at, 13.minutes.ago)
+
+          expect(DossierMailer).to receive(:notify_new_avis_to_instructeur).once
+            .with(avis_without_answer, instructeur_with_instant_avis_notification.email)
+            .and_return(double(deliver_later: true))
+          subject
+        end
       end
 
       context 'with attachment' do


### PR DESCRIPTION
Cf [ce retour au support](https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_967d716f-3fc9-4185-b5ff-960acf7cc766/)

### Problème
Si l'avis avait été mis à jour dans les 30 dernières minutes avant une réponse de l'expert, on ne notifiait pas l'instructeur. Or la mise à jour peut correspondre à une réponse de l'expert ou à la demande d'avis elle-même.
Ce qui faisait que l'instructeur n'était pas notifié si l'expert répondait moins de 30 minutes après la demande d'avis.

### Solution
S'il s'agit de la première réponse de l'expert, on envoie systématiquement la notification