### PR TITLE
ETQ instructeur, corriger la 404 sur l'édition d'un modèle d'export avec un champ supprimé

### DIFF
--- a/app/models/export_template.rb
+++ b/app/models/export_template.rb
@@ -87,6 +87,11 @@ class ExportTemplate < ApplicationRecord
     @template_exported_columns.include?(exported_column.column)
   end
 
+  # Filter out stale column references (e.g. type_de_champ removed from procedure after template was saved)
+  def exported_columns
+    super.compact
+  end
+
   def set_default_export_items
     self.dossier_folder ||= ExportItem.default(prefix: 'dossier')
     self.export_pdf ||= ExportItem.default(prefix: 'export')

--- a/app/types/exported_column_type.rb
+++ b/app/types/exported_column_type.rb
@@ -21,7 +21,14 @@ class ExportedColumnType < ActiveRecord::Type::Value
   end
 
   # db -> ruby
-  def deserialize(value) = cast(value&.then { JSON.parse(_1) })
+  # Returns nil when the referenced column no longer exists in the procedure
+  # (e.g. a type_de_champ was removed after the export template was saved).
+  # Callers of exported_columns must compact the resulting array.
+  def deserialize(value)
+    cast(value&.then { JSON.parse(_1) })
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
 
   # ruby -> db
   def serialize(value)

--- a/spec/models/export_template_tabular_spec.rb
+++ b/spec/models/export_template_tabular_spec.rb
@@ -83,6 +83,28 @@ describe ExportTemplate do
     end
   end
 
+  describe 'exported_columns with a stale column reference' do
+    it 'filters out columns that no longer exist in the procedure' do
+      export_template.exported_columns = [
+        ExportedColumn.new(libelle: 'Ça va ?', column: procedure.find_column(label: "Ca va ?")),
+      ]
+      export_template.save!
+
+      # Inject a stale column reference directly in the DB (simulates a TDC removed on a test procedure after template was saved)
+      stale_entry = JSON.generate(id: { procedure_id: procedure.id, column_id: "type_de_champ/580046" }, libelle: "Removed field")
+      valid_entry = ExportedColumnType.new.serialize(export_template.exported_columns.first)
+
+      ExportTemplate.where(id: export_template.id)
+        .update_all(Arel.sql("exported_columns = ARRAY[#{ActiveRecord::Base.connection.quote(valid_entry)}::jsonb, #{ActiveRecord::Base.connection.quote(stale_entry)}::jsonb]"))
+
+      Current.procedure_columns = {}
+      reloaded = ExportTemplate.find(export_template.id)
+      expect { reloaded.exported_columns }.not_to raise_error
+      expect(reloaded.exported_columns.size).to eq(1)
+      expect(reloaded.exported_columns.first.libelle).to eq('Ça va ?')
+    end
+  end
+
   describe 'dossier_exported_columns' do
     context 'when exported_columns is empty' do
       it 'returns an empty array' do

--- a/spec/types/exported_column_type_spec.rb
+++ b/spec/types/exported_column_type_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe ExportedColumnType do
+  let(:type) { ExportedColumnType.new }
+
+  describe 'deserialize' do
+    context 'when the referenced column no longer exists in the procedure' do
+      let(:raw) do
+        JSON.generate(id: { procedure_id: 1, column_id: 'type_de_champ/999' }, libelle: 'Removed')
+      end
+
+      before do
+        allow(Column).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
+      end
+
+      it 'returns nil instead of raising RecordNotFound' do
+        expect { type.deserialize(raw) }.not_to raise_error
+        expect(type.deserialize(raw)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Remonté au support https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_da97fd7f-28e7-4618-b29f-5433ffa1b77c/

Lorsqu'on a des colonnes supprimées sérialisées dans un modèle d'export, la lecture de celle ci fait planter l'app silencieusement (RecordNotFound), l'instructeur se retrouve avec une page 404. Cette PR permet d'ignorer ces colonnes.