### PR TITLE
ETQ Admin - je peux utiliser le champ quotient familial même si je n'ai pas les droits sur tout les scopes

### DIFF
--- a/app/models/champs/quotient_familial_champ.rb
+++ b/app/models/champs/quotient_familial_champ.rb
@@ -54,15 +54,17 @@ class Champs::QuotientFamilialChamp < Champ
   private
 
   def extract_value_json(data:)
-    qf_data = data[:quotient_familial]
+    if (qf_data = data[:quotient_familial])
+      extract_qf_data = {
+        fournisseur: qf_data[:fournisseur],
+        valeur: qf_data[:valeur],
+        periode_effective: Date.new(qf_data[:annee], qf_data[:mois]).iso8601,
+        periode_calcul: Date.new(qf_data[:annee_calcul], qf_data[:mois_calcul]).iso8601,
+      }
 
-    extract_qf_data = {
-      fournisseur: qf_data[:fournisseur],
-      valeur: qf_data[:valeur],
-      periode_effective: Date.new(qf_data[:annee], qf_data[:mois]).iso8601,
-      periode_calcul: Date.new(qf_data[:annee_calcul], qf_data[:mois_calcul]).iso8601,
-    }
-
-    data.merge(quotient_familial: extract_qf_data)
+      data.merge(quotient_familial: extract_qf_data)
+    else
+      data
+    end
   end
 end

--- a/app/schemas/quotient-familial.json
+++ b/app/schemas/quotient-familial.json
@@ -6,11 +6,11 @@
   "properties": {
     "data": {
       "type": "object",
-      "required": [
-        "allocataires",
-        "enfants",
-        "adresse",
-        "quotient_familial"
+      "anyOf": [
+        { "required": ["allocataires"] },
+        { "required": ["enfants"] },
+        { "required": ["adresse"] },
+        { "required": ["quotient_familial"] }
       ],
       "properties": {
         "allocataires": {

--- a/spec/lib/api_particulier/quotient_familial_spec.rb
+++ b/spec/lib/api_particulier/quotient_familial_spec.rb
@@ -54,6 +54,39 @@ describe APIParticulier::QuotientFamilial do
       end
     end
 
+    context "when success response with reduced scopes" do
+      let(:status) { 200 }
+      let(:body) {
+        {
+          data:
+            {
+              "adresse": {
+                "pays": "FRANCE",
+                "lieu_dit": nil,
+                "destinataire": "Madame ROUX Jeanne",
+                "code_postal_ville": "75002 PARIS",
+                "numero_libelle_voie": "1 RUE MONTORGUEIL",
+                "complement_information": nil,
+                "complement_information_geographique": nil,
+              },
+              "allocataires": [
+                {
+                  "sexe": "F",
+                  "prenoms": "JEANNE STEPHANIE",
+                  "nom_usage": "ROUX",
+                  "nom_naissance": "ROUX",
+                  "date_naissance": "1987-06-27",
+                },
+              ],
+            },
+        }.to_json
+      }
+
+      it 'returns a Success' do
+        expect(subject).to be_success
+      end
+    end
+
     context "when success response with not valid schema" do
       let(:status) { 200 }
       let(:body) {


### PR DESCRIPTION
dernier point de : https://github.com/demarche-numerique/demarche.numerique.gouv.fr/issues/12882

avec quelques ajustements pour permettre d'utiliser le champ si l'admin n'a pas un datapass avec tous les scopes liés au quotient familial 