### PR TITLE
ETQ usager d'un lecteur d'écran, je suis informé de l'échec du transfert d'une pièce jointe

### DIFF
--- a/app/components/dsfr/progress_bar_component/progress_bar_component.html.erb
+++ b/app/components/dsfr/progress_bar_component/progress_bar_component.html.erb
@@ -3,7 +3,11 @@
   id="direct-upload-<%= id %>"
   data-direct-upload-id="<%= id %>"
 >
-  <div class="direct-upload__error fr-messages-group hidden">
+  <div
+    class="direct-upload__error fr-messages-group hidden"
+    aria-live="assertive"
+    aria-atomic="true"
+  >
     <p class="fr-message fr-message--error fr-mt-0 direct-upload__error-message"></p>
   </div>
 


### PR DESCRIPTION
Closes #11167 (point 2 uniquement — le point 1, indication "traitement en cours", n'est plus d'actualité)

Ajout de `aria-live="assertive"` et `aria-atomic="true"` sur la zone d'erreur de la barre de progression d'upload