### PR TITLE
fix(avis): corriger la race condition lors des demandes d'avis en masse

### DIFF
--- a/app/services/create_avis_service.rb
+++ b/app/services/create_avis_service.rb
@@ -42,7 +42,13 @@ class CreateAvisService
       emails.flat_map do |email|
         user = User.create_or_promote_to_expert(email, SecureRandom.hex)
         allowed_dossiers.map do |dossier|
-          experts_procedure = user.valid? ? ExpertsProcedure.find_or_create_by(procedure: dossier.procedure, expert: user.expert) : nil
+          experts_procedure = if user.valid?
+            begin
+              ExpertsProcedure.find_or_create_by(procedure: dossier.procedure, expert: user.expert)
+            rescue ActiveRecord::RecordNotUnique
+              ExpertsProcedure.find_by!(procedure: dossier.procedure, expert: user.expert)
+            end
+          end
 
           {
             email: email,

--- a/spec/services/create_avis_service_spec.rb
+++ b/spec/services/create_avis_service_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe CreateAvisService do
+  let(:instructeur) { create(:instructeur) }
+  let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+  let(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure:) }
+  let(:expert_email) { 'expert@exemple.fr' }
+
+  subject(:result) do
+    CreateAvisService.call(
+      dossier:,
+      instructeur_or_expert: instructeur,
+      batch: true,
+      params: { emails: [expert_email], introduction: 'Merci de donner votre avis.' }
+    )
+  end
+
+  describe '#call' do
+    context 'when everything goes well' do
+      it 'creates an avis for the dossier' do
+        expect { result }.to change { dossier.avis.count }.by(1)
+      end
+    end
+
+    context 'when a concurrent job raises RecordNotUnique on ExpertsProcedure creation' do
+      it 'creates the avis without raising an error' do
+        existing_ep = create(:experts_procedure, procedure:)
+        allow(ExpertsProcedure).to receive(:find_or_create_by).and_raise(ActiveRecord::RecordNotUnique)
+        allow(ExpertsProcedure).to receive(:find_by!).and_return(existing_ep)
+
+        expect { result }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problème

cf [ce retour au support](https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_17d25585-6d0a-4ee9-9179-682e611cfc14/)

Lors d'une demande d'avis en masse, les jobs s'exécutent en parallèle. Chaque job appelle `find_or_create_by` sur `ExpertsProcedure` avec les mêmes ids (`expert_id` et `procedure_id`).

Il peut y avoir une race condition lors de ce traitement parallèle.

Au niveau du `find_or_create_by`, deux jobs peuvent faire le `SELECT` (rien trouvé) puis tenter le `INSERT` simultanément. Le second lève `ActiveRecord::RecordNotUnique`. Comme le job n'a pas de retry (`attempts: 1`), le dossier concerné ne reçoit pas sa demande d'avis.

Observé en production : 3 échecs sur 117 demandes envoyées simultanément.

## Solution

Rescue `RecordNotUnique` sur `ExpertsProcedure.find_or_create_by` dans `CreateAvisService` et fallback sur `find_by!`.
