### PR TITLE
Tech: partage du filtre FeaturesField entre vue et contrôleur

### DIFF
--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -46,10 +46,17 @@ module Manager
       redirect_to manager_user_path(user)
     end
 
+    # Only the administrateur dashboard currently exposes FeaturesField;
+    # revisit (e.g. accept the group as a param) if usager/instructeur dashboards start using it.
+    FEATURES_GROUP = "administrateur"
+
     def enable_feature
       user = User.find(params[:id])
+      allowed_keys = FeaturesField.available_features(FEATURES_GROUP).map(&:key).to_set
 
-      params[:features].each do |key, enable|
+      params.fetch(:features, {}).each do |key, enable|
+        next unless allowed_keys.include?(key)
+
         if enable
           Flipper.enable_actor(key.to_sym, user)
         else

--- a/app/fields/features_field.rb
+++ b/app/fields/features_field.rb
@@ -3,4 +3,11 @@
 require "administrate/field/base"
 
 class FeaturesField < Administrate::Field::Base
+  def self.available_features(group)
+    Flipper.features.filter { it.key.start_with?("#{group}_") }
+  end
+
+  def available_features
+    self.class.available_features(resource.class.name.downcase)
+  end
 end

--- a/app/views/fields/features_field/_show.html.erb
+++ b/app/views/fields/features_field/_show.html.erb
@@ -1,9 +1,8 @@
-<% group = field.resource.class.name.downcase %>
 <% user = field.resource.user %>
 <% url = enable_feature_manager_user_path(user) %>
 
 <table id="features">
-  <% Flipper.features.select { |feature| feature.key.start_with?("#{group}_") }.each do |feature| %>
+  <% field.available_features.each do |feature| %>
     <tr>
       <td><%= feature %></td>
 

--- a/spec/controllers/manager/users_controller_spec.rb
+++ b/spec/controllers/manager/users_controller_spec.rb
@@ -82,6 +82,37 @@ describe Manager::UsersController, type: :controller do
     end
   end
 
+  describe '#enable_feature' do
+    let(:user) { create(:user) }
+
+    subject do
+      put :enable_feature, params: { id: user.id, features: features }
+    end
+
+    before do
+      Flipper.add(:administrateur_web_hook)
+      Flipper.add(:arbitrary_unrelated_flag)
+    end
+
+    context 'with an allow-listed feature key' do
+      let(:features) { { administrateur_web_hook: "true" } }
+
+      it 'enables the flag for the user' do
+        subject
+        expect(Flipper.enabled?(:administrateur_web_hook, user)).to be true
+      end
+    end
+
+    context 'with a key outside the administrateur allow-list' do
+      let(:features) { { arbitrary_unrelated_flag: "true" } }
+
+      it 'ignores the key' do
+        subject
+        expect(Flipper.enabled?(:arbitrary_unrelated_flag, user)).to be false
+      end
+    end
+  end
+
   describe '#reactivate' do
     subject { put :reactivate, params: { id: user.id } }
 


### PR DESCRIPTION
## Résumé

- Extraction de `FeaturesField#available_features` (+ variante de classe) pour centraliser le filtre des flags Flipper par groupe.
- La vue Administrate et `Manager::UsersController#enable_feature` s'appuient désormais sur la même source.
- Seul le dashboard `Administrateur` expose aujourd'hui ce champ ; un commentaire signale à faire évoluer si d'autres dashboards l'utilisent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)