### PR TITLE
Secu: ajouter un controle d'autorisation sur AttachmentsController#show

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -4,7 +4,8 @@ class AttachmentsController < ApplicationController
   before_action :authenticate_logged_user!
   include ActiveStorage::SetBlob
   before_action :set_attachment
-  before_action :ensure_legitimate_access, only: :destroy
+  before_action :ensure_legitimate_access_show, only: :show
+  before_action :ensure_legitimate_access_destroy, only: :destroy
 
   def show
     @user_can_edit = cast_bool(params[:user_can_edit])
@@ -41,8 +42,17 @@ class AttachmentsController < ApplicationController
 
   private
 
-  def ensure_legitimate_access
-    return if user_or_invite_changing_its_dossier?
+  def ensure_legitimate_access_show
+    return if user_or_invite_changing_an_attachment?
+    return if instructeur_changing_a_private_attachment?
+    return if expert_changing_its_avis?
+    return unless champ? || avis?
+
+    head :not_found
+  end
+
+  def ensure_legitimate_access_destroy
+    return if user_or_invite_changing_an_attachment?
     return if instructeur_changing_a_private_attachment?
     return if admin_changing_its_procedure?
     return if admin_changing_its_attestation_template?
@@ -58,7 +68,7 @@ class AttachmentsController < ApplicationController
     @attachment = @blob.attachments.find(params[:id])
   end
 
-  def user_or_invite_changing_its_dossier?
+  def user_or_invite_changing_an_attachment?
     champ&.public? && current_user.owns_or_invite?(champ.dossier)
   end
 

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -41,6 +41,91 @@ describe AttachmentsController, type: :controller do
       end
     end
 
+    context 'when another user tries to view (public champ)' do
+      let(:other_user) { create(:user) }
+      before { sign_in(other_user) }
+
+      it { is_expected.to have_http_status(404) }
+    end
+
+    context 'when invite views the attachment' do
+      let(:invited_user) { create(:user) }
+      let(:invite) { create(:invite, dossier:, user: invited_user) }
+      before do
+        invite
+        sign_in(invited_user)
+      end
+
+      it { is_expected.to have_http_status(200) }
+    end
+
+    context 'when instructeur belongs to the procedure (private champ)' do
+      let(:instructeur) { create(:instructeur) }
+      let(:procedure) { create(:procedure, instructeurs: [instructeur], types_de_champ_private: [{ type: :piece_justificative }]) }
+      let(:dossier) { create(:dossier, :with_populated_annotations, procedure:) }
+      let(:champ) { dossier.champs.private_only.first }
+
+      before { sign_in(instructeur.user) }
+
+      it { is_expected.to have_http_status(200) }
+    end
+
+    context 'when instructeur does not belong to the procedure (private champ)' do
+      let(:other_instructeur) { create(:instructeur) }
+      let(:instructeur) { create(:instructeur) }
+      let(:procedure) { create(:procedure, instructeurs: [instructeur], types_de_champ_private: [{ type: :piece_justificative }]) }
+      let(:dossier) { create(:dossier, :with_populated_annotations, procedure:) }
+      let(:champ) { dossier.champs.private_only.first }
+
+      before { sign_in(other_instructeur.user) }
+
+      it { is_expected.to have_http_status(404) }
+    end
+
+    context 'when expert owns the avis' do
+      let(:expert) { create(:expert) }
+      let(:procedure) { create(:procedure) }
+      let(:experts_procedure) { create(:experts_procedure, procedure:, expert:) }
+      let(:avis) { create(:avis, dossier:, experts_procedure:) }
+      let(:attachment) { avis.piece_justificative_file.attachments.first }
+      let(:signed_id) { attachment.blob.signed_id }
+
+      before do
+        avis.piece_justificative_file.attach({ io: Rails.root.join('spec/fixtures/files/Contrat.pdf').open, filename: 'Contrat.pdf' })
+        sign_in(expert.user)
+      end
+
+      it { is_expected.to have_http_status(200) }
+    end
+
+    context 'when another expert tries to view avis attachment' do
+      let(:expert) { create(:expert) }
+      let(:other_expert) { create(:expert) }
+      let(:procedure) { create(:procedure) }
+      let(:experts_procedure) { create(:experts_procedure, procedure:, expert:) }
+      let(:avis) { create(:avis, dossier:, experts_procedure:) }
+      let(:attachment) { avis.piece_justificative_file.attachments.first }
+      let(:signed_id) { attachment.blob.signed_id }
+
+      before do
+        avis.piece_justificative_file.attach({ io: Rails.root.join('spec/fixtures/files/Contrat.pdf').open, filename: 'Contrat.pdf' })
+        sign_in(other_expert.user)
+      end
+
+      it { is_expected.to have_http_status(404) }
+    end
+
+    context 'when admin views procedure logo (non-sensitive)' do
+      let(:procedure) { create(:procedure, :with_logo) }
+      let(:administrateur) { procedure.administrateurs.first }
+      let(:attachment) { procedure.logo.attachments.first }
+      let(:signed_id) { attachment.blob.signed_id }
+
+      before { sign_in(administrateur.user) }
+
+      it { is_expected.to have_http_status(200) }
+    end
+
     context 'when not authenticated' do
       it { is_expected.to redirect_to(new_user_session_path) }
     end


### PR DESCRIPTION
# Probleme

`AttachmentsController#show` n'a pas de controle d'autorisation applicatif. Le `before_action :ensure_legitimate_access` est scope a `only: :destroy` uniquement. L'action `show` repose uniquement sur le `signed_blob_id` (token cryptographique, expire en 1h) comme barriere d'acces.

Les attachments sensibles (pieces justificatives usager, annotations instructeur, pieces d'avis expert) contiennent des donnees personnelles qui meritent une defense en profondeur au-dela du seul token.

# Solution

Ajout d'un `before_action :ensure_legitimate_access_show` sur l'action `show` qui reutilise les methodes de verification existantes du controller :

- **Champ public** : l'usager doit etre proprietaire ou invite du dossier
- **Champ prive** : l'instructeur doit appartenir au groupe instructeur de la procedure
- **Avis** : l'expert doit etre proprietaire de l'avis

Les attachments non-sensibles (logos procedure, attestation templates, signatures groupe instructeur) ne sont pas concernes — le `signed_blob_id` suffit comme protection pour ces assets organisationnels.

7 nouveaux tests couvrent les scenarios d'acces autorise et refuse.

Generated with [Claude Code](https://claude.com/claude-code)