### PR TITLE
ETQ super admin, sécuriser le token de confirmation d'ajout d'administrateur

### DIFF
--- a/app/controllers/manager/administrateur_confirmations_controller.rb
+++ b/app/controllers/manager/administrateur_confirmations_controller.rb
@@ -36,6 +36,11 @@ module Manager
     def decrypt_params
       @inviter_id = decrypted_params[:inviter_id]
       @invited_email = decrypted_params[:email]
+
+      if decrypted_params[:procedure_id].present? && decrypted_params[:procedure_id].to_s != params[:procedure_id].to_s
+        flash[:error] = "Le lien que vous avez utilisé est invalide. Veuillez contacter la personne qui vous l’a envoyé."
+        redirect_to manager_procedure_path(@procedure)
+      end
     rescue ActiveSupport::MessageEncryptor::InvalidMessage
       flash[:error] = "Le lien que vous avez utilisé est invalide. Veuillez contacter la personne qui vous l’a envoyé."
       redirect_to manager_procedure_path(@procedure)

--- a/app/controllers/manager/confirmation_urls_controller.rb
+++ b/app/controllers/manager/confirmation_urls_controller.rb
@@ -8,7 +8,7 @@ module Manager
     def new
       @url = new_manager_procedure_administrateur_confirmation_url(
         procedure.id,
-        q: encrypt({ email: params[:email], inviter_id: current_super_admin.id })
+        q: encrypt({ email: params[:email], inviter_id: current_super_admin.id, procedure_id: procedure.id })
       )
     end
 

--- a/spec/controllers/manager/administrateur_confirmations_controller_spec.rb
+++ b/spec/controllers/manager/administrateur_confirmations_controller_spec.rb
@@ -155,6 +155,23 @@ RSpec.describe Manager::AdministrateurConfirmationsController, type: :controller
 
         it { expect(flash[:error]).to match(/Le lien que vous avez utilisé est invalide/) }
       end
+
+      context 'when the procedure_id is tampered in the URL' do
+        let(:other_procedure) { create(:procedure) }
+
+        before { sign_in confirmer_super_admin }
+
+        subject(:tampered_request) do
+          post :create, params: {
+            procedure_id: other_procedure.id,
+            q: encrypt({ email: invited_administrateur.email, inviter_id: inviter_super_admin.id }),
+          }
+        end
+
+        it "adds the admin to the tampered procedure (proving the vulnerability)" do
+          expect { tampered_request }.to change { other_procedure.administrateurs.count }.by(1)
+        end
+      end
     end
   end
 

--- a/spec/controllers/manager/administrateur_confirmations_controller_spec.rb
+++ b/spec/controllers/manager/administrateur_confirmations_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Manager::AdministrateurConfirmationsController, type: :controller
     subject(:new_request) do
       get :new, params: {
         procedure_id: procedure.id,
-        q: encrypt({ email: invited_administrateur.email, inviter_id: inviter_super_admin.id }),
+        q: encrypt({ email: invited_administrateur.email, inviter_id: inviter_super_admin.id, procedure_id: procedure.id }),
       }
     end
 
@@ -84,7 +84,7 @@ RSpec.describe Manager::AdministrateurConfirmationsController, type: :controller
     subject(:create_request) do
       post :create, params: {
         procedure_id: procedure.id,
-        q: encrypt({ email: invited_administrateur.email, inviter_id: inviter_super_admin.id }),
+        q: encrypt({ email: invited_administrateur.email, inviter_id: inviter_super_admin.id, procedure_id: procedure.id }),
       }
     end
 
@@ -164,12 +164,14 @@ RSpec.describe Manager::AdministrateurConfirmationsController, type: :controller
         subject(:tampered_request) do
           post :create, params: {
             procedure_id: other_procedure.id,
-            q: encrypt({ email: invited_administrateur.email, inviter_id: inviter_super_admin.id }),
+            q: encrypt({ email: invited_administrateur.email, inviter_id: inviter_super_admin.id, procedure_id: procedure.id }),
           }
         end
 
-        it "adds the admin to the tampered procedure (proving the vulnerability)" do
-          expect { tampered_request }.to change { other_procedure.administrateurs.count }.by(1)
+        it "rejects the tampered request and does not add the admin" do
+          expect { tampered_request }.not_to change { other_procedure.administrateurs.count }
+          expect(flash[:error]).to match(/Le lien que vous avez utilisé est invalide/)
+          expect(response).to redirect_to(manager_procedure_path(other_procedure))
         end
       end
     end


### PR DESCRIPTION
## Problème

### La faille en 30 secondes
Un bon de commande signé qui dit "livrer à Jean" mais sans préciser l'adresse. L'adresse est écrite au crayon sur l'enveloppe — n'importe qui peut l'effacer et en écrire une autre.

Le token chiffré contenait `{email, inviter_id}` mais pas le `procedure_id`. Un super admin confirmeur pouvait changer l'ID de procédure dans l'URL pour ajouter un administrateur à n'importe quelle procédure.

### Steps to reproduce (avant ce fix)
1. Super Admin A génère un lien de confirmation pour la procédure 42
2. Super Admin B reçoit le lien, change `42` en `999` dans l'URL
3. Super Admin B confirme → l'admin est ajouté à la procédure 999 au lieu de 42

## Solution

### Ce qui a été corrigé
- **`confirmation_urls_controller.rb`** : le `procedure_id` est maintenant inclus dans le payload chiffré du token
- **`administrateur_confirmations_controller.rb`** : `decrypt_params` valide que le `procedure_id` du token correspond à celui de l'URL. En cas de mismatch → rejet avec message d'erreur

### Preuve par les tests
- **Test rouge** (commit 1) : un token généré pour la procédure A est utilisé avec la procédure B dans l'URL → l'admin est ajouté à B (faille prouvée)
- **Test vert** (commit 2) : même scénario → rejet avec flash error, admin non ajouté (faille corrigée)



🤖 Generated with [Claude Code](https://claude.com/claude-code)