### PR TITLE
fix(security): ETQ instructeur, whitelist des formats bilans_bdf

### DIFF
--- a/app/controllers/concerns/bilans_bdf_concern.rb
+++ b/app/controllers/concerns/bilans_bdf_concern.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module BilansBdfConcern
+  extend ActiveSupport::Concern
+
+  ALLOWED_BILANS_BDF_FORMATS = %w[xlsx ods csv].freeze
+
+  private
+
+  def bilans_bdf_response(etablissement, format, fallback_path)
+    extension = validated_bilans_bdf_format(format)
+
+    if extension && etablissement&.entreprise_bilans_bdf.present?
+      render extension.to_sym => etablissement.entreprise_bilans_bdf_to_sheet(extension)
+    else
+      redirect_to fallback_path
+    end
+  end
+
+  def validated_bilans_bdf_format(format)
+    format if format.in?(ALLOWED_BILANS_BDF_FORMATS)
+  end
+end

--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -2,6 +2,7 @@
 
 module Experts
   class AvisController < ExpertController
+    include BilansBdfConcern
     include Zipline
     include AvisCreationConcern
 
@@ -205,18 +206,8 @@ module Experts
       end
     end
 
-    ALLOWED_FORMATS = %w[xlsx ods csv].freeze
-
     def bilans_bdf
-      if avis.dossier.etablissement&.entreprise_bilans_bdf.present?
-        extension = params[:format]
-
-        return redirect_to expert_avis_path(avis) if !extension.in?(ALLOWED_FORMATS)
-
-        render extension.to_sym => avis.dossier.etablissement.entreprise_bilans_bdf_to_sheet(extension)
-      else
-        redirect_to expert_avis_path(avis)
-      end
+      bilans_bdf_response(avis.dossier.etablissement, params[:format], expert_avis_path(avis))
     end
 
     def telecharger_pjs

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -9,6 +9,7 @@ module Instructeurs
     include TurboChampsConcern
     include InstructeurConcern
     include ActionController::Streaming
+    include BilansBdfConcern
     include Zipline
 
     before_action :redirect_on_dossier_not_found, only: [:show, :show_submitted_revision]
@@ -55,8 +56,7 @@ module Instructeurs
     end
 
     def bilans_bdf
-      extension = params[:format]
-      render extension.to_sym => dossier.etablissement.entreprise_bilans_bdf_to_sheet(extension)
+      bilans_bdf_response(dossier.etablissement, params[:format], instructeur_procedure_path(procedure))
     end
 
     def show

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -2147,8 +2147,9 @@ describe Instructeurs::DossiersController, type: :controller do
     context 'with a disallowed format' do
       let(:format) { :inline }
 
-      it 'raises because format reaches SpreadsheetArchitect.send without whitelist' do
-        expect { subject }.to raise_error(NoMethodError, /to_inline/)
+      it 'redirects without invoking the dynamic render' do
+        subject
+        expect(response).to redirect_to(instructeur_procedure_path(procedure))
       end
     end
   end

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -2128,4 +2128,28 @@ describe Instructeurs::DossiersController, type: :controller do
       end
     end
   end
+
+  describe '#bilans_bdf' do
+    let(:etablissement) { create(:etablissement, entreprise_bilans_bdf: [{ "date_arret_exercice" => "2024", "chiffre_affaires_ht" => "1000" }]) }
+    let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure:, etablissement:) }
+
+    subject { get :bilans_bdf, params: { procedure_id: procedure.id, dossier_id: dossier.id, format: } }
+
+    context 'with an allowed format' do
+      let(:format) { :csv }
+
+      it 'returns the spreadsheet' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'with a disallowed format' do
+      let(:format) { :inline }
+
+      it 'raises because format reaches SpreadsheetArchitect.send without whitelist' do
+        expect { subject }.to raise_error(NoMethodError, /to_inline/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problème

### Le harden en 30 secondes

cf: vulns/experts_expert_controller.md

Le controller experts avait été corrigé avec une whitelist `ALLOWED_FORMATS`, mais le controller instructeurs — qui a le même pattern — n'avait pas reçu le même fix. Un instructeur authentifié pouvait envoyer un format arbitraire (ex: `.inline`) qui atteignait `SpreadsheetArchitect.send("to_#{format}")` sans validation.

### Steps to reproduce (avant ce fix)

1. Se connecter comme instructeur
2. `GET /procedures/:id/dossiers/:id/bilans_bdf.inline`
3. → `NoMethodError: undefined method 'to_inline' for module SpreadsheetArchitect`

## Solution

### Ce qui a été corrigé

- Extraction d'un `BilansBdfConcern` partagé entre les controllers instructeurs et experts
- Whitelist `%w[xlsx ods csv]` appliquée avant tout appel à `send` ou `render`
- Le controller experts utilise maintenant le même concern (remplacement de sa whitelist locale)

### Preuve par les tests

- **Commit 1** (test rouge) : prouve que le format `inline` atteint `SpreadsheetArchitect.send` → `NoMethodError`
- **Commit 2** (test vert) : même scénario → redirect propre, le `send` n'est jamais atteint

🤖 Generated with [Claude Code](https://claude.com/claude-code)