### PR TITLE
fix(security): ETQ usager, empêcher le transfert implicite de tous mes dossiers

### DIFF
--- a/app/controllers/users/transfers_controller.rb
+++ b/app/controllers/users/transfers_controller.rb
@@ -3,7 +3,9 @@
 module Users
   class TransfersController < UserController
     def create
-      transfer = DossierTransfer.new(transfer_params)
+      dossier = current_user.dossiers.find(params[:id])
+      email = params.require(:dossier_transfer).permit(:email)[:email]
+      transfer = DossierTransfer.new(email:, dossiers: [dossier])
 
       if transfer.valid?
         transfer.save!
@@ -11,7 +13,7 @@ module Users
         redirect_to dossiers_path
       else
         flash.alert = transfer.errors.full_messages
-        redirect_to transferer_dossier_path(transfer_params[:dossiers].first)
+        redirect_to transferer_dossier_path(dossier)
       end
     end
 
@@ -34,18 +36,5 @@ module Users
     end
 
     private
-
-    def transfer_params
-      transfer_params = params.require(:dossier_transfer).permit(:email, :dossier)
-
-      dossier_id = transfer_params.delete(:dossier)
-      dossiers = if dossier_id.present?
-        [current_user.dossiers.find(dossier_id)]
-      else
-        current_user.dossiers
-      end
-
-      transfer_params.merge(dossiers: dossiers)
-    end
   end
 end

--- a/app/views/users/dossiers/transferer.html.haml
+++ b/app/views/users/dossiers/transferer.html.haml
@@ -11,10 +11,9 @@
       .fr-highlight
         %p= t(".irrevocable_html").html_safe
 
-      = form_for @transfer, url: transfers_path, class: "fr-mt-4w" do |f|
+      = form_for @transfer, url: transfer_dossier_path(@dossier), class: "fr-mt-4w" do |f|
         .fr-input-group
           = f.label :email, t('.email_label'), class: "fr-label"
           = f.email_field :email, required: true, class: "fr-input"
 
-        = f.hidden_field :dossier, value: @dossier.id
         = f.submit t('.submit'), class: 'fr-btn'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -394,6 +394,7 @@ Rails.application.routes.draw do
         patch 'restore', to: 'dossiers#restore'
         get 'attestation'
         get 'transferer', to: 'dossiers#transferer'
+        post 'transferer', to: 'transfers#create', as: :transfer
         get 'attestation_depot', format: :pdf
         get 'papertrail', to: 'dossiers#attestation_depot', format: :pdf
         get 'set_accuse_lecture_agreement_at'
@@ -402,7 +403,7 @@ Rails.application.routes.draw do
       end
 
       collection do
-        resources :transfers, only: [:create, :update, :destroy]
+        resources :transfers, only: [:update, :destroy]
       end
     end
 

--- a/spec/controllers/users/transfers_controller_spec.rb
+++ b/spec/controllers/users/transfers_controller_spec.rb
@@ -65,23 +65,19 @@ describe Users::TransfersController, type: :controller do
   end
 
   describe "POST create" do
-    subject { post :create, params: { dossier_transfer: { email: email, dossier: dossier.id } } }
-
     before do
       sign_in(sender_user)
     end
 
-    context "when dossier param is missing" do
-      let(:email) { "attacker@evil.com" }
+    subject { post :create, params: { id: dossier.id, dossier_transfer: { email: email } } }
+
+    context "transfers only the targeted dossier, not all" do
+      let(:email) { "test@rspec.net" }
       let!(:other_dossier) { create(:dossier, user: sender_user) }
 
-      subject { post :create, params: { dossier_transfer: { email: email } } }
-
-      it "transfers all user dossiers instead of rejecting" do
-        dossier # ensure created
-
+      it "transfers only the dossier from the URL" do
         expect { subject }.to change { DossierTransfer.count }.by(1)
-        expect(DossierTransfer.last.dossiers).to match_array(sender_user.dossiers)
+        expect(DossierTransfer.last.dossiers).to eq([dossier])
       end
     end
 

--- a/spec/controllers/users/transfers_controller_spec.rb
+++ b/spec/controllers/users/transfers_controller_spec.rb
@@ -69,11 +69,26 @@ describe Users::TransfersController, type: :controller do
 
     before do
       sign_in(sender_user)
-      subject
+    end
+
+    context "when dossier param is missing" do
+      let(:email) { "attacker@evil.com" }
+      let!(:other_dossier) { create(:dossier, user: sender_user) }
+
+      subject { post :create, params: { dossier_transfer: { email: email } } }
+
+      it "transfers all user dossiers instead of rejecting" do
+        dossier # ensure created
+
+        expect { subject }.to change { DossierTransfer.count }.by(1)
+        expect(DossierTransfer.last.dossiers).to match_array(sender_user.dossiers)
+      end
     end
 
     context "with valid email" do
       let(:email) { "test@rspec.net" }
+
+      before { subject }
 
       it do
         expect(DossierTransfer.last.email).to eq(email)
@@ -83,6 +98,7 @@ describe Users::TransfersController, type: :controller do
 
     context 'with upper case email' do
       let(:email) { "Test@rspec.net" }
+      before { subject }
       it { expect(DossierTransfer.last.email).to eq(email.strip.downcase) }
     end
 


### PR DESCRIPTION
## Problème

`Users::TransfersController#transfer_params` contenait un fallback : quand le paramètre `dossier` était absent du body, tous les dossiers de l'utilisateur étaient sélectionnés pour le transfert. Ce fallback n'était utilisé par aucune UI (code mort). Le transfert en masse intentionnel existe déjà via `profil#transfer_all_dossiers`.

## Solution

Approche safe by design : déplacer la route `transfers#create` de collection vers member (`POST /dossiers/:id/transferer`). Le `dossier_id` fait partie de l'URL — sans lui, la route ne matche pas.

- Suppression du `hidden_field :dossier` dans le formulaire (plus nécessaire)
- Suppression de la méthode `transfer_params` et son fallback
- Utilisation directe de `params[:id]` scopé à `current_user.dossiers`

### Preuve par les tests

- **Commit 1** : test prouvant que sans param dossier, tous les dossiers sont transférés
- **Commit 2** : fix — le dossier_id vient de l'URL, seul le dossier ciblé est transféré


🤖 Generated with [Claude Code](https://claude.com/claude-code)