### PR TITLE
Secu: filtrer les groupes instructeurs dans l'envoi de message en masse

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -408,7 +408,9 @@ module Instructeurs
 
     def reachable_brouillons
       if procedure.routing_enabled?
-        procedure.dossiers.state_brouillon.visible_by_user.where(groupe_instructeur_id: groupe_instructeur_ids_params)
+        allowed_ids = groupe_instructeur_ids.intersection(groupe_instructeur_ids_params.compact.map(&:to_i))
+        allowed_ids.concat([nil]) if groupe_instructeur_ids_params.include?(nil)
+        procedure.dossiers.state_brouillon.visible_by_user.where(groupe_instructeur_id: allowed_ids)
       else
         procedure.dossiers.state_brouillon.visible_by_user
       end

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -913,6 +913,24 @@ describe Instructeurs::ProceduresController, type: :controller do
         end
       end
 
+      context 'when instructeur forges a request targeting a group they do not belong to (IDOR)' do
+        subject do
+          post :create_multiple_commentaire_for_brouillons,
+                params: {
+                  procedure_id: procedure.id,
+                  bulk_message: {
+                    body: body,
+                    groupe_instructeur_ids: { gi_p1_2.id => true },
+                  },
+                }
+        end
+
+        it "does not send messages to dossiers in the unauthorized group" do
+          expect { subject }.not_to change { Commentaire.count }
+          expect(dossier_3.commentaires.count).to eq(0)
+        end
+      end
+
       context 'when without_group is specified' do
         subject do
           post :create_multiple_commentaire_for_brouillons,


### PR DESCRIPTION
# Probleme

Quand le routage est activé sur une procédure, un instructeur assigné au Groupe A peut forger un POST sur `create_multiple_commentaire_for_brouillons` en injectant l'ID du Groupe B dans les paramètres. Le serveur ne vérifie pas que l'instructeur appartient réellement aux groupes ciblés — seule l'appartenance à la procédure est vérifiée (`ensure_ownership!`).

L'instructeur peut ainsi envoyer des messages aux usagers de groupes auxquels il n'a pas accès (IDOR, CWE-639, OWASP A01).

# Solution

Intersection des IDs de groupes soumis par l'utilisateur (`groupe_instructeur_ids_params`) avec les groupes légitimes de l'instructeur (`groupe_instructeur_ids`, déjà scopé via `assign_tos`). Seuls les groupes autorisés sont conservés pour la requête.

Test de non-régression ajouté : un instructeur forge un POST ciblant un groupe non autorisé → aucun commentaire créé.