### PR TITLE
Secu: scoper les lookups de referentiels au type_de_champ autorise

### DIFF
--- a/app/controllers/administrateurs/referentiels_controller.rb
+++ b/app/controllers/administrateurs/referentiels_controller.rb
@@ -143,12 +143,15 @@ module Administrateurs
     end
 
     def retrieve_referentiel
-      @referentiel = Referentiel.find(params[:id])
+      @referentiel = @type_de_champ.referentiel
+      raise ActiveRecord::RecordNotFound if @referentiel.nil? || @referentiel.id != params[:id].to_i
     end
 
     def build_or_clone_by_id_params
       if params[:referentiel_id]
-        Referentiel.find(params[:referentiel_id]).attributes.slice(*%w[url_tiptap test_data_tiptap hint mode type authentication_data authentication_method])
+        referentiel = @type_de_champ.referentiel
+        raise ActiveRecord::RecordNotFound if referentiel.nil? || referentiel.id != params[:referentiel_id].to_i
+        referentiel.attributes.slice(*%w[url_tiptap test_data_tiptap hint mode type authentication_data authentication_method])
       else
         params = referentiel_params.to_h
         params = params.merge(type: Referentiels::APIReferentiel) if !Referentiels::APIReferentiel.csv_available?

--- a/spec/controllers/administrateurs/referentiels_controller_spec.rb
+++ b/spec/controllers/administrateurs/referentiels_controller_spec.rb
@@ -13,17 +13,19 @@ describe Administrateurs::ReferentielsController, type: :controller do
     let(:other_procedure) { create(:procedure, types_de_champ_public: [{ type: :referentiel, referentiel: other_referentiel }]) }
     let(:other_admin) { other_procedure.administrateurs.first }
 
-    it 'allows reading another admin referentiel via edit' do
-      get :edit, params: { procedure_id: procedure.id, stable_id:, id: other_referentiel.id }
-      expect(response).to have_http_status(:success)
+    it 'blocks reading another admin referentiel via edit' do
+      expect {
+        get :edit, params: { procedure_id: procedure.id, stable_id:, id: other_referentiel.id }
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
-    it 'allows modifying another admin referentiel via update' do
-      patch :update, params: {
-        procedure_id: procedure.id, stable_id:, id: other_referentiel.id,
-        referentiel: { hint: 'hacked' }
-      }, format: :turbo_stream
-      expect(other_referentiel.reload.hint).to eq('hacked')
+    it 'blocks modifying another admin referentiel via update' do
+      expect {
+        patch :update, params: {
+          procedure_id: procedure.id, stable_id:, id: other_referentiel.id,
+          referentiel: { hint: 'hacked' },
+        }, format: :turbo_stream
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 
@@ -32,10 +34,10 @@ describe Administrateurs::ReferentielsController, type: :controller do
     let(:other_procedure) { create(:procedure, types_de_champ_public: [{ type: :referentiel, referentiel: other_referentiel }]) }
     let(:other_admin) { other_procedure.administrateurs.first }
 
-    it 'clones authentication_data from another admin referentiel' do
-      get :new, params: { procedure_id: procedure.id, stable_id:, referentiel_id: other_referentiel.id }
-      cloned = assigns(:referentiel)
-      expect(cloned.authentication_data).to eq(other_referentiel.authentication_data)
+    it 'blocks cloning authentication_data from another admin referentiel' do
+      expect {
+        get :new, params: { procedure_id: procedure.id, stable_id:, referentiel_id: other_referentiel.id }
+      }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 
@@ -52,7 +54,8 @@ describe Administrateurs::ReferentielsController, type: :controller do
           mode: 'exact_match',
         }
       end
-      let(:referentiel) { create(:api_referentiel, :exact_match, **original_data) }
+      let(:type_de_champ) { procedure.draft_revision.types_de_champ.first }
+      let(:referentiel) { create(:api_referentiel, :exact_match, types_de_champ: [type_de_champ], **original_data) }
 
       it 'clone existing one' do
         get :new, params: { procedure_id: procedure.id, referentiel_id: referentiel.id, stable_id: }
@@ -283,7 +286,8 @@ describe Administrateurs::ReferentielsController, type: :controller do
         mode: 'exact_match',
       }
     end
-    let(:referentiel) { create(:api_referentiel, **original_tiptap_data) }
+    let(:type_de_champ) { procedure.draft_revision.types_de_champ.first }
+    let(:referentiel) { create(:api_referentiel, types_de_champ: [type_de_champ], **original_tiptap_data) }
 
     it 'clones tiptap columns' do
       get :new, params: { procedure_id: procedure.id, referentiel_id: referentiel.id, stable_id: }

--- a/spec/controllers/administrateurs/referentiels_controller_spec.rb
+++ b/spec/controllers/administrateurs/referentiels_controller_spec.rb
@@ -8,6 +8,37 @@ describe Administrateurs::ReferentielsController, type: :controller do
 
   before { sign_in(procedure.administrateurs.first.user) }
 
+  describe 'IDOR on retrieve_referentiel (edit/update)' do
+    let(:other_referentiel) { create(:api_referentiel, :exact_match, :with_authentication_data) }
+    let(:other_procedure) { create(:procedure, types_de_champ_public: [{ type: :referentiel, referentiel: other_referentiel }]) }
+    let(:other_admin) { other_procedure.administrateurs.first }
+
+    it 'allows reading another admin referentiel via edit' do
+      get :edit, params: { procedure_id: procedure.id, stable_id:, id: other_referentiel.id }
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'allows modifying another admin referentiel via update' do
+      patch :update, params: {
+        procedure_id: procedure.id, stable_id:, id: other_referentiel.id,
+        referentiel: { hint: 'hacked' }
+      }, format: :turbo_stream
+      expect(other_referentiel.reload.hint).to eq('hacked')
+    end
+  end
+
+  describe 'IDOR on build_or_clone_by_id_params (clone credentials)' do
+    let(:other_referentiel) { create(:api_referentiel, :exact_match, :with_authentication_data) }
+    let(:other_procedure) { create(:procedure, types_de_champ_public: [{ type: :referentiel, referentiel: other_referentiel }]) }
+    let(:other_admin) { other_procedure.administrateurs.first }
+
+    it 'clones authentication_data from another admin referentiel' do
+      get :new, params: { procedure_id: procedure.id, stable_id:, referentiel_id: other_referentiel.id }
+      cloned = assigns(:referentiel)
+      expect(cloned.authentication_data).to eq(other_referentiel.authentication_data)
+    end
+  end
+
   describe '#new' do
     it 'renders successifully' do
       get :new, params: { procedure_id: procedure.id, stable_id: }


### PR DESCRIPTION
# Probleme

`Administrateurs::ReferentielsController` utilise `Referentiel.find(params[:id])` dans deux methodes (`retrieve_referentiel` et `build_or_clone_by_id_params`). La chaine d'autorisation est correcte jusqu'au type_de_champ, puis casse : n'importe quel admin authentifie peut lire, modifier ou cloner le referentiel d'un autre

# Solution

Les deux lookups passent desormais par `@type_de_champ.referentiel` (deja autorise via la chaine procedure → draft_revision → type_de_champ) au lieu d'un `Referentiel.find()` global.

Preuve par les tests :
- **Commit 1** (RED) : 3 specs prouvant la faille — admin A accede/modifie/clone le referentiel de B → succes
- **Commit 2** (GREEN) : fix + inversion des assertions → `ActiveRecord::RecordNotFound`

Generated with [Claude Code](https://claude.com/claude-code)