### PR TITLE
Secu: corriger CSRF GET sur la relance d'avis expert

### DIFF
--- a/app/controllers/instructeurs/avis_controller.rb
+++ b/app/controllers/instructeurs/avis_controller.rb
@@ -9,7 +9,7 @@ module Instructeurs
     def revoquer
       avis = Avis.find(params[:id])
       if avis.revoke_by!(current_instructeur)
-        flash.notice = "#{avis.expert.email} ne peut plus donner son avis sur ce dossier."
+        flash.notice = t('.revoked', email: avis.expert.email)
         DossierNotification.destroy_notifications_by_dossier_and_type(avis.dossier, :attente_avis) if avis.dossier.avis.without_answer.empty?
 
         redirect_back(fallback_location: avis_instructeur_dossier_path(avis.procedure, params[:statut], avis.dossier))
@@ -20,7 +20,7 @@ module Instructeurs
       avis = Avis.find(params[:id])
       if avis.remind_by!(current_instructeur)
         avis.expert.user.invite_expert_and_send_avis!(avis)
-        flash.notice = "Un mail de relance a été envoyé à #{avis.expert.email}"
+        flash.notice = t('.reminded', email: avis.expert.email)
         redirect_back(fallback_location: avis_instructeur_dossier_path(avis.procedure, params[:statut], avis.dossier))
       end
     end

--- a/app/views/shared/avis/_list.html.haml
+++ b/app/views/shared/avis/_list.html.haml
@@ -43,7 +43,7 @@
               = t('relance_effectuee_le', scope: 'views.shared.avis', date: l(avis.reminded_at, format: :short_with_time))
           - if expert_or_instructeur.is_a?(Instructeur)
             - if avis.answer.blank? && !avis.dossier.termine?
-              = link_to(t('remind', scope: 'helpers.label'), remind_instructeur_avis_path(avis.procedure, params[:statut], avis), class:'fr-btn fr-btn--sm fr-btn--tertiary-no-outline', data: { confirm: t('remind', scope: 'helpers.confirmation', email: avis.expert.email) })
+              = button_to(t('remind', scope: 'helpers.label'), remind_instructeur_avis_path(avis.procedure, params[:statut], avis), class:'fr-btn fr-btn--sm fr-btn--tertiary-no-outline', method: :patch, data: { confirm: t('remind', scope: 'helpers.confirmation', email: avis.expert.email) })
 
               - if avis.revokable_by?(expert_or_instructeur)
                 = link_to(t('revoke', scope: 'helpers.label'), revoquer_instructeur_avis_path(avis.procedure, params[:statut], avis), class:'fr-btn fr-btn--sm fr-btn--tertiary-no-outline', data: { confirm: t('revoke', scope: 'helpers.confirmation', email: avis.expert.email) }, method: :patch)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1022,6 +1022,11 @@ en:
       alert_error_annotations: The private annotations were not filled out correctly and are necessary to make a decision on the file.
       alert_error_annotations_link: Complete the private annotations
       alert_unspecified_attestation_champs: 'Please note, the following values have not been entered but are necessary to send a valid certificate:'
+    avis:
+      revoquer:
+        revoked: "%{email} can no longer give their opinion on this file."
+      remind:
+        reminded: "A reminder email has been sent to %{email}"
     procedure_presentation:
       customize_filters:
         exit_customization: "Exit customization"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1019,6 +1019,11 @@ fr:
       alert_error_annotations: Les annotations privées n’ont pas été correctement renseignées. Elles sont indispensables à l’instruction du dossier.
       alert_error_annotations_link: Compléter les annotations privées
       alert_unspecified_attestation_champs: 'Attention, les valeurs suivantes n’ont pas été renseignées mais sont nécessaires pour pouvoir envoyer une attestation valide :'
+    avis:
+      revoquer:
+        revoked: "%{email} ne peut plus donner son avis sur ce dossier."
+      remind:
+        reminded: "Un mail de relance a été envoyé à %{email}"
     procedure_presentation:
       customize_filters:
         exit_customization: "Quitter la personnalisation"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -545,7 +545,7 @@ Rails.application.routes.draw do
           resources :avis, only: [], path: "(:statut)/dossiers", defaults: { statut: 'a-suivre' } do
             member do
               patch 'revoquer'
-              get 'remind'
+              patch 'remind'
             end
           end
 

--- a/spec/controllers/instructeurs/avis_controller_spec.rb
+++ b/spec/controllers/instructeurs/avis_controller_spec.rb
@@ -41,7 +41,7 @@ describe Instructeurs::AvisController, type: :controller do
         let!(:avis) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure) }
 
         it 'sends a reminder to the expert' do
-          get :remind, params: { procedure_id: procedure.id, id: avis.id, statut: 'a-suivre' }
+          patch :remind, params: { procedure_id: procedure.id, id: avis.id, statut: 'a-suivre' }
           expect(AvisMailer).to have_received(:avis_invitation_and_confirm_email)
           expect(flash.notice).to eq("Un mail de relance a été envoyé à #{avis.expert.email}")
           expect(avis.reload.reminded_at).to be_present
@@ -52,22 +52,22 @@ describe Instructeurs::AvisController, type: :controller do
         let!(:avis) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure, question_label: '123') }
 
         it 'sends a reminder to the expert' do
-          get :remind, params: { procedure_id: procedure.id, id: avis.id, statut: 'a-suivre' }
+          patch :remind, params: { procedure_id: procedure.id, id: avis.id, statut: 'a-suivre' }
           expect(AvisMailer).to have_received(:avis_invitation_and_confirm_email)
           expect(flash.notice).to eq("Un mail de relance a été envoyé à #{avis.expert.email}")
           expect(avis.reload.reminded_at).to be_present
         end
       end
 
-      context 'CSRF vulnerability: GET triggers mutation' do
+      context 'CSRF protection: GET no longer routes to remind' do
         let!(:avis) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure) }
 
-        it 'GET triggers DB update and email (proves CSRF vulnerability)' do
-          expect {
-            get :remind, params: { procedure_id: procedure.id, id: avis.id, statut: 'a-suivre' }
-          }.to change { avis.reload.reminded_at }.from(nil)
+        it 'GET /remind is not routable' do
+          expect(get: remind_instructeur_avis_path(procedure, 'a-suivre', avis)).not_to be_routable
+        end
 
-          expect(AvisMailer).to have_received(:avis_invitation_and_confirm_email)
+        it 'PATCH /remind is routable' do
+          expect(patch: remind_instructeur_avis_path(procedure, 'a-suivre', avis)).to be_routable
         end
       end
     end

--- a/spec/controllers/instructeurs/avis_controller_spec.rb
+++ b/spec/controllers/instructeurs/avis_controller_spec.rb
@@ -58,6 +58,18 @@ describe Instructeurs::AvisController, type: :controller do
           expect(avis.reload.reminded_at).to be_present
         end
       end
+
+      context 'CSRF vulnerability: GET triggers mutation' do
+        let!(:avis) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure) }
+
+        it 'GET triggers DB update and email (proves CSRF vulnerability)' do
+          expect {
+            get :remind, params: { procedure_id: procedure.id, id: avis.id, statut: 'a-suivre' }
+          }.to change { avis.reload.reminded_at }.from(nil)
+
+          expect(AvisMailer).to have_received(:avis_invitation_and_confirm_email)
+        end
+      end
     end
   end
 end

--- a/spec/system/instructeurs/expert_spec.rb
+++ b/spec/system/instructeurs/expert_spec.rb
@@ -172,6 +172,26 @@ describe 'Inviting an expert:', js: true do
       end
     end
 
+    context 'when avis is pending' do
+      let(:experts_procedure) { create(:experts_procedure, expert:, procedure:) }
+      let!(:pending_avis) { create(:avis, dossier:, claimant: instructeur, experts_procedure:) }
+
+      scenario 'I can remind the expert' do
+        login_as instructeur.user, scope: :user
+        visit instructeur_dossier_path(procedure, dossier)
+
+        click_on 'Avis externes'
+        expect(page).to have_content(expert.email)
+        accept_confirm("Souhaitez-vous relancer #{expert.email}") do
+          click_on "Relancer l’expert"
+        end
+
+        expect(page).to have_content("Un mail de relance a été envoyé à #{expert.email}")
+        expect(page).to have_content('Relance effectuée le')
+        expect(pending_avis.reload.reminded_at).to be_present
+      end
+    end
+
     context 'when experts submitted their answer' do
       let(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: procedure) }
       let!(:answered_avis) { create(:avis, :with_answer, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure) }


### PR DESCRIPTION
# Problème

L'action `remind` du controller `Instructeurs::AvisController` est routée en GET
mais effectue une mutation (update `reminded_at` + envoi d'email de relance).

Rails exempte les GET de la vérification CSRF, ce qui permet à un attaquant de
forcer un instructeur à envoyer des relances non voulues via une simple balise
`<img src="…/remind">` embarquée dans une page externe.

# Solution

- Route `get 'remind'` → `patch 'remind'` (aligné sur `revoquer` qui était déjà en PATCH)
- Vue : `link_to` → `button_to method: :patch` (formulaire avec token CSRF)
- Extraction des flash messages en dur vers i18n (lazy lookup `t('.key')`)
- Test de routing prouvant que GET n'est plus routable
- System spec couvrant le flow complet "Relancer l'expert"

Generated with [Claude Code](https://claude.com/claude-code)