### PR TITLE
[Fix] Les actions multiples en erreur affichent correctement l’alerte et le message final disparaît automatiquement

### DIFF
--- a/app/components/dossiers/batch_alert_component.rb
+++ b/app/components/dossiers/batch_alert_component.rb
@@ -6,12 +6,13 @@ class Dossiers::BatchAlertComponent < ApplicationComponent
   def initialize(batch:, procedure:)
     @batch = batch
     @procedure = procedure
-    set_seen_at! if batch.finished_at.present?
+
+    @finished_unseen = @batch.finished_unseen?
+    @batch.seen! if @finished_unseen
   end
 
-  def set_seen_at!
-    @batch.seen_at = Time.zone.now
-    @batch.save
+  def should_refresh?
+    !@batch.finished_at? || @finished_unseen
   end
 
   def procedure_path

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
@@ -1,12 +1,10 @@
-.batch-alert-component{ data: !@batch.finished_at? ? { controller: "turbo-poll", turbo_poll_url_value: polling_batch_operation_instructeur_procedure_path(@procedure, batch: @batch), turbo_poll_interval_value: 2_000 } : {} }
+.batch-alert-component{ data: should_refresh? ? { controller: "turbo-poll", turbo_poll_url_value: polling_batch_operation_instructeur_procedure_path(@procedure, batch: @batch), turbo_poll_interval_value: 2_000 } : {} }
   .fr-mb-5v
     - if @batch.finished_at.present?
       = render Dsfr::AlertComponent.new(title: t(".title.finish"), state: (@batch.errors? ? :warning : :success), heading_level: 'h2', extra_class_names: 'fr-my-2w') do |c|
         - c.with_body do
           %p
             = t(".#{batch.operation}.finish.text_success", count: @batch.total_count, success_count: @batch.success_count)
-
-
     - else
       = render Dsfr::AlertComponent.new(title: t(".title.in_progress"), state: :info, heading_level: 'h2', extra_class_names: 'fr-my-2w') do |c|
         - c.with_body do

--- a/app/jobs/batch_operation_process_one_job.rb
+++ b/app/jobs/batch_operation_process_one_job.rb
@@ -16,9 +16,9 @@ class BatchOperationProcessOneJob < ApplicationJob
         batch_operation.track_processed_dossier(false, dossier)
       end
       raise error
+    ensure
+      batch_operation.finalize_if_complete!
     end
-
-    batch_operation.finalize_if_complete!
   rescue ActiveRecord::RecordNotFound
     dossier.update_column(:batch_operation_id, nil)
     batch_operation.finalize_if_complete!

--- a/app/models/batch_operation.rb
+++ b/app/models/batch_operation.rb
@@ -192,6 +192,14 @@ class BatchOperation < ApplicationRecord
     dossiers.empty? ? super : nil
   end
 
+  def seen!
+    update!(seen_at: Time.zone.now)
+  end
+
+  def finished_unseen?
+    finished_at.present? && seen_at.blank?
+  end
+
   def after_all_processed
     return unless create_avis?
 

--- a/spec/jobs/batch_operation_process_one_job_spec.rb
+++ b/spec/jobs/batch_operation_process_one_job_spec.rb
@@ -25,6 +25,13 @@ describe BatchOperationProcessOneJob, type: :job do
       expect(batch_operation.dossier_operations.error.pluck(:dossier_id)).to eq([dossier_job.id])
     end
 
+    it 'calls finalize_if_complete! even when process_one raises' do
+      allow_any_instance_of(BatchOperation).to receive(:process_one).with(dossier_job).and_raise("boom")
+      expect_any_instance_of(BatchOperation).to receive(:finalize_if_complete!)
+
+      expect { subject.perform_now }.to raise_error("boom")
+    end
+
     context 'when operation is "archiver"' do
       it 'archives the dossier in the batch' do
         expect { subject.perform_now }


### PR DESCRIPTION
Suite à l’amélioration des perfs dans #12833, les batch operations en erreur ne finalisaient plus correctement.
finished_at n’était pas toujours renseigné et la dernière alerte “terminé” restait affichée