### PR TITLE
Secu: utiliser request.remote_ip au lieu du header X-Forwarded-For pour le gate 2FA

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -157,6 +157,17 @@ Le projet utilise plusieurs linters pour vérifier la lisibilité et la qualité
 
 Voir les notes de déploiement dans [DEPLOYMENT.md](doc/DEPLOYMENT.md)
 
+> [!IMPORTANT]
+> L'application doit être déployée derrière un reverse proxy (par exemple nginx, HAProxy) qui réécrit le header `X-Forwarded-For` avec l'IP réelle du client.
+>
+> Plusieurs mécanismes de sécurité s'appuient sur `request.remote_ip` pour identifier le client :
+>
+> - le rate limiting (`Rack::Attack`)
+> - le gate « réseau de confiance » (instructeurs dispensés de 2FA quand ils viennent d'une IP trusted)
+> - la restriction d'IP pour les jetons d'API (`whitelisted_ip_*` sur les API tokens)
+>
+> Sans un proxy qui assainit `X-Forwarded-For`, un client peut spoofer le header et contourner ces protections.
+
 ## Tâches courantes
 
 ### Tâches de gestion des comptes super-admin

--- a/README.md
+++ b/README.md
@@ -160,6 +160,17 @@ The project uses several linters to check code readability and quality.
 
 See deployment notes in [DEPLOYMENT.md](doc/DEPLOYMENT.md)
 
+> [!IMPORTANT]
+> The application must be deployed behind a reverse proxy (e.g. nginx, HAProxy) that overwrites the `X-Forwarded-For` header with the real client IP.
+>
+> Several IP-based security mechanisms rely on `request.remote_ip` to identify the client:
+>
+> - rate limiting (`Rack::Attack`)
+> - trusted networks gate (skip 2FA for instructeurs coming from a trusted IP)
+> - IP allow-lists for API tokens (`whitelisted_ip_*` on API tokens)
+>
+> Without a proxy that sanitizes `X-Forwarded-For`, a client can spoof the header and bypass these protections.
+
 ## Common tasks
 
 ### Super-admin account management tasks

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -285,7 +285,7 @@ class ApplicationController < ActionController::Base
       user_agent: request.user_agent,
       user_id: current_user&.id,
       user_roles: current_user_roles,
-      client_ip: request.headers['X-Forwarded-For'],
+      client_ip: request.remote_ip,
       request_id: Current.request_id,
     })
 
@@ -321,7 +321,7 @@ class ApplicationController < ActionController::Base
     if instructeur_signed_in? &&
         sensitive_path &&
         !current_instructeur.bypass_email_login_token &&
-        !IPService.ip_trusted?(request.headers['X-Forwarded-For']) &&
+        !IPService.ip_trusted?(request.remote_ip) &&
         !trusted_device? &&
         !pro_connect_mfa?
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -45,6 +45,7 @@ describe ApplicationController, type: :controller do
         expect(payload[:to_log].compact).to eq({
           user_agent: 'Rails Testing',
           user_roles: 'Guest',
+          client_ip: request.remote_ip,
         })
       end
     end
@@ -65,6 +66,7 @@ describe ApplicationController, type: :controller do
           user_agent: 'Rails Testing',
           user_id: current_user.id,
           user_roles: 'User',
+          client_ip: request.remote_ip,
         })
       end
     end
@@ -88,6 +90,7 @@ describe ApplicationController, type: :controller do
           user_agent: 'Rails Testing',
           user_id: current_user.id,
           user_roles: 'User, Instructeur, Administrateur, SuperAdmin',
+          client_ip: request.remote_ip,
         })
       end
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -249,6 +249,29 @@ describe ApplicationController, type: :controller do
     end
   end
 
+  describe '#redirect_if_untrusted IP source (security: 2FA bypass via X-Forwarded-For spoofing)' do
+    let(:current_instructeur) { create(:instructeur) }
+
+    before do
+      current_instructeur.update!(bypass_email_login_token: false)
+      allow(@controller).to receive(:current_instructeur).and_return(current_instructeur)
+      allow(@controller).to receive(:redirect_to)
+      allow(@controller).to receive(:trusted_device?).and_return(false)
+      allow(@controller).to receive(:instructeur_signed_in?).and_return(true)
+      allow(@controller).to receive(:sensitive_path).and_return(true)
+      allow(@controller).to receive(:send_login_token_or_bufferize)
+      allow(@controller).to receive(:get_stored_location_for).and_return(nil)
+      allow(@controller).to receive(:store_location_for)
+      allow(@controller).to receive(:pro_connect_mfa?).and_return(false)
+      @request.headers['X-Forwarded-For'] = '10.0.0.1'
+    end
+
+    it 'passes request.remote_ip to IPService, not the raw X-Forwarded-For header' do
+      expect(IPService).to receive(:ip_trusted?).with(@controller.request.remote_ip)
+      @controller.send(:redirect_if_untrusted)
+    end
+  end
+
   describe 'crisp_config and crisp_segments' do
     before do
       allow(ENV).to receive(:enabled?).with("CRISP").and_return(true)


### PR DESCRIPTION
# Problème

`redirect_if_untrusted` (le gate 2FA des instructeurs) utilise `request.headers['X-Forwarded-For']` pour vérifier si l'IP est dans un réseau de confiance. Ce header HTTP est directement contrôlable par le client — un attaquant avec un mot de passe compromis peut spoofer une IP trusted et bypasser le challenge 2FA email.

Scénario : phishing instructeur → credential stuffing → header `X-Forwarded-For: <ip_trusted>` → accès aux dossiers sans 2FA.

À noter : `rack_attack.rb` utilise déjà correctement `req.remote_ip` pour le même appel `IPService.ip_trusted?`.

# Solution

Remplacer `request.headers['X-Forwarded-For']` par `request.remote_ip` aux deux endroits concernés (gate 2FA L324, logging L288).

`request.remote_ip` passe par le middleware `ActionDispatch::RemoteIp` qui filtre les IPs de proxies connus — une IP privée spoofée (ex: `10.0.0.1`) est traitée comme un proxy et ignorée.

Le test vérifie que `IPService.ip_trusted?` reçoit bien `request.remote_ip` et non le header brut.

Generated with [Claude Code](https://claude.com/claude-code)