### PR TITLE
Correctif : le composant toggle affiche la bonne valeur

### DIFF
--- a/app/components/dsfr/toggle_component.rb
+++ b/app/components/dsfr/toggle_component.rb
@@ -25,6 +25,12 @@ class Dsfr::ToggleComponent < ApplicationComponent
 
   private
 
+  def check_box_options
+    opts = { class: 'fr-toggle__input', id: label_for, disabled: disabled }
+    opts[:checked] = @checked unless @checked.nil?
+    opts
+  end
+
   def label_for
     return input_id if @form.object.present?
 

--- a/app/components/dsfr/toggle_component/toggle_component.html.haml
+++ b/app/components/dsfr/toggle_component/toggle_component.html.haml
@@ -1,5 +1,5 @@
 %div{ class: "fr-toggle #{extra_class_names}" }
-  = @form.check_box target, { class: 'fr-toggle__input',id: label_for,disabled: disabled, checked: @checked }
+  = @form.check_box target, check_box_options
   = @form.label target,
     title || html_title&.html_safe,
     for: label_for,

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -1036,6 +1036,33 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         expect(procedure.reload.routing_enabled).to be_truthy
       end
     end
+
+    context 'instructeurs_self_management_enabled toggle reflects the database value' do
+      let(:selector) { 'input[name="procedure[instructeurs_self_management_enabled]"]' }
+
+      context 'when instructeurs_self_management_enabled is true' do
+        let!(:procedure) { create(:procedure, administrateurs: [admin], instructeurs_self_management_enabled: true) }
+
+        before { get :options, params: { procedure_id: procedure.id } }
+
+        it 'renders the toggle as checked' do
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to have_selector("#{selector}[checked=checked]")
+        end
+      end
+
+      context 'when instructeurs_self_management_enabled is false' do
+        let!(:procedure) { create(:procedure, administrateurs: [admin], instructeurs_self_management_enabled: false) }
+
+        before { get :options, params: { procedure_id: procedure.id } }
+
+        it 'renders the toggle as unchecked' do
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to have_selector(selector)
+          expect(response.body).not_to have_selector("#{selector}[checked=checked]")
+        end
+      end
+    end
   end
 
   describe '#create_simple_routing' do


### PR DESCRIPTION
Les toggles sont cassés depuis la release 2026-04-14-01, suite à ce [commit](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/12798/changes/330c5f15353ee31a74b7d5b002411cc2b54da3fd). 
On a corrigé et ajouté un test avec @lisa-durand 