### PR TITLE
Tech: lier la démarche au lien de confirmation d'ajout d'administrateur

### DIFF
--- a/app/controllers/manager/administrateur_confirmations_controller.rb
+++ b/app/controllers/manager/administrateur_confirmations_controller.rb
@@ -36,6 +36,10 @@ module Manager
     def decrypt_params
       @inviter_id = decrypted_params[:inviter_id]
       @invited_email = decrypted_params[:email]
+      if decrypted_params[:procedure_id] != @procedure.id
+        flash[:error] = "Le lien que vous avez utilisé est invalide. Veuillez contacter la personne qui vous l’a envoyé."
+        redirect_to manager_procedure_path(@procedure)
+      end
     rescue ActiveSupport::MessageEncryptor::InvalidMessage
       flash[:error] = "Le lien que vous avez utilisé est invalide. Veuillez contacter la personne qui vous l’a envoyé."
       redirect_to manager_procedure_path(@procedure)

--- a/app/controllers/manager/confirmation_urls_controller.rb
+++ b/app/controllers/manager/confirmation_urls_controller.rb
@@ -8,7 +8,7 @@ module Manager
     def new
       @url = new_manager_procedure_administrateur_confirmation_url(
         procedure.id,
-        q: encrypt({ email: params[:email], inviter_id: current_super_admin.id })
+        q: encrypt({ email: params[:email], inviter_id: current_super_admin.id, procedure_id: procedure.id })
       )
     end
 

--- a/spec/controllers/manager/administrateur_confirmations_controller_spec.rb
+++ b/spec/controllers/manager/administrateur_confirmations_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Manager::AdministrateurConfirmationsController, type: :controller
     subject(:new_request) do
       get :new, params: {
         procedure_id: procedure.id,
-        q: encrypt({ email: invited_administrateur.email, inviter_id: inviter_super_admin.id }),
+        q: encrypt({ email: invited_administrateur.email, inviter_id: inviter_super_admin.id, procedure_id: procedure.id }),
       }
     end
 
@@ -84,7 +84,7 @@ RSpec.describe Manager::AdministrateurConfirmationsController, type: :controller
     subject(:create_request) do
       post :create, params: {
         procedure_id: procedure.id,
-        q: encrypt({ email: invited_administrateur.email, inviter_id: inviter_super_admin.id }),
+        q: encrypt({ email: invited_administrateur.email, inviter_id: inviter_super_admin.id, procedure_id: procedure.id }),
       }
     end
 
@@ -154,6 +154,27 @@ RSpec.describe Manager::AdministrateurConfirmationsController, type: :controller
         before { post :create, params: { procedure_id: procedure.id, q: "something that is invalid" } }
 
         it { expect(flash[:error]).to match(/Le lien que vous avez utilisé est invalide/) }
+      end
+
+      context 'when the URL procedure does not match the one bound to the confirmation link' do
+        let(:other_procedure) { create(:procedure) }
+        let(:token_bound_to_procedure) do
+          encrypt({
+            email: invited_administrateur.email,
+            inviter_id: inviter_super_admin.id,
+            procedure_id: procedure.id,
+          })
+        end
+
+        before { sign_in confirmer_super_admin }
+
+        subject(:mismatched_request) do
+          post :create, params: { procedure_id: other_procedure.id, q: token_bound_to_procedure }
+        end
+
+        it "does not add the administrateur to the URL procedure" do
+          expect { mismatched_request }.not_to change { other_procedure.administrateurs.count }
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
- Le payload chiffré du lien de confirmation d'ajout d'un administrateur inclut désormais l'id de la démarche.
- L'action de confirmation vérifie que l'id de la démarche dans l'URL correspond à celle liée au lien ; en cas de désaccord, le message d'erreur est le même que pour un lien invalide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)