### PR TITLE
Tech: restreindre la recherche d'instructeur au groupe ciblé lors du retrait

### DIFF
--- a/app/controllers/instructeurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/instructeurs/groupe_instructeurs_controller.rb
@@ -61,14 +61,14 @@ module Instructeurs
       if groupe_instructeur.instructeurs.one?
         flash[:alert] = "Suppression impossible : il doit y avoir au moins un instructeur dans le groupe"
       else
-        instructeur = Instructeur.find(instructeur_id)
-        if groupe_instructeur.remove(instructeur)
+        instructeur = groupe_instructeur.instructeurs.find_by(id: instructeur_id)
+        if instructeur && groupe_instructeur.remove(instructeur)
           flash[:notice] = "L’instructeur « #{instructeur.email} » a été retiré du groupe."
           GroupeInstructeurMailer
             .notify_removed_instructeur(groupe_instructeur, instructeur, current_user.email)
             .deliver_later
         else
-          flash[:alert] = "L’instructeur « #{instructeur.email} » n’est pas dans le groupe."
+          flash[:alert] = "L’instructeur n’est pas dans le groupe."
         end
       end
 

--- a/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
@@ -211,6 +211,29 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
         expect(response).to redirect_to(instructeur_groupe_path(procedure, gi_1_1))
       end
     end
+
+    context 'when the instructeur id belongs to an instructeur of another group' do
+      let(:other_instructeur) { create(:instructeur, email: 'other-instructeur@example.com') }
+
+      before do
+        gi_2_2.instructeurs << other_instructeur
+        delete :remove_instructeur,
+          params: {
+            procedure_id: procedure.id,
+            id: gi_1_1.id,
+            instructeur: { id: other_instructeur.id },
+          }
+      end
+
+      it 'does not reference the other instructeur email in flash messages' do
+        expect(flash[:notice].to_s).not_to include(other_instructeur.email)
+        expect(flash[:alert].to_s).not_to include(other_instructeur.email)
+      end
+
+      it 'does not remove the instructeur from their own group' do
+        expect(gi_2_2.reload.instructeurs).to include(other_instructeur)
+      end
+    end
   end
 
   describe '#add_signature' do


### PR DESCRIPTION
## Résumé

- Recherche de l'instructeur via l'association du groupe au lieu d'une recherche globale dans `GroupeInstructeursController#remove_instructeur`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)