### PR TITLE
Correctif : gère une deuxième race condition lors des demandes d'avis en masse

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -177,7 +177,7 @@ class User < ApplicationRecord
 
     if user.valid? && user.expert.nil?
       begin
-        user.create_expert!
+        User.transaction(requires_new: true) { user.create_expert! }
       rescue ActiveRecord::RecordNotUnique
         user.reload
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -176,7 +176,11 @@ class User < ApplicationRecord
       .find_or_create_by(email: email)
 
     if user.valid? && user.expert.nil?
-      user.create_expert!
+      begin
+        user.create_expert!
+      rescue ActiveRecord::RecordNotUnique
+        user.reload
+      end
     end
 
     user

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -216,6 +216,15 @@ describe User, type: :model do
         end
       end
     end
+
+    context 'when a concurrent job raises RecordNotUnique on Expert creation' do
+      it 'does not raise and returns the user' do
+        allow_any_instance_of(User).to receive(:create_expert!).and_raise(ActiveRecord::RecordNotUnique)
+
+        expect { subject }.not_to raise_error
+        expect(subject).to be_a(User)
+      end
+    end
   end
 
   describe '.create_or_promote_to_gestionnaire' do


### PR DESCRIPTION
WIP : le descriptif ci-dessous ne corrige pas le bug

## Contexte

Suite au bug persistant après la PR #12961 : lors d'une demande d'avis en masse sur N dossiers vers une adresse email sans compte User existant, seuls M < N avis sont créés (ex : 3 sur 5).

## Cause

La PR #12961 avait corrigé la race condition sur `ExpertsProcedure.find_or_create_by`, mais en avait laissé une identique dans `User.create_or_promote_to_expert` :

```ruby
if user.valid? && user.expert.nil?  # ← check
  user.create_expert!               # ← sans rescue
end
```

`BatchOperation#enqueue_all` crée un job Sidekiq par dossier. Pour N dossiers, N jobs s'exécutent en parallèle et appellent tous `create_or_promote_to_expert` avec le même email. Ils voient tous `expert.nil? == true`, appellent tous `create_expert!`. Un seul réussit ; les autres lèvent `ActiveRecord::RecordNotUnique` non rescuée → crash silencieux → dossier sans avis.

Le résultat est non-déterministe : les jobs qui démarrent après que le premier a terminé trouvent l'expert déjà créé et réussissent — d'où le "3 sur 5" variable.

**Note :** `find_or_create_by` en Rails 7.2 délègue déjà à `create_or_find_by` en interne, donc la race sur la création du User est déjà gérée par Rails. Seule la création de l'Expert nécessitait un fix.

## Solution

Même pattern que PR #12961 pour `ExpertsProcedure` : rescue `RecordNotUnique` sur `create_expert!` + reload de l'objet user.