### PR TITLE
Tech: restreindre la recherche du dossier pour le menu d'aide à l'utilisateur courant

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -484,8 +484,14 @@ module Users
     end
 
     def dossier_for_help
+      return @dossier if @dossier
+
       dossier_id = params[:id] || params[:dossier_id]
-      @dossier || (dossier_id.present? && Dossier.visible_by_user.find_by(id: dossier_id.to_i))
+      return nil if dossier_id.blank?
+
+      id = dossier_id.to_i
+      current_user.dossiers.visible_by_user.find_by(id:) ||
+        current_user.dossiers_invites.visible_by_user.find_by(id:)
     end
 
     def transferer

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -2089,11 +2089,27 @@ describe Users::DossiersController, type: :controller do
 
     subject { controller.dossier_for_help }
 
-    context 'when the id matches an existing dossier' do
-      let(:dossier) { create(:dossier) }
+    context 'when the id matches a dossier owned by the current user' do
+      let(:dossier) { create(:dossier, user:) }
       let(:dossier_id) { dossier.id }
 
       it { is_expected.to eq dossier }
+    end
+
+    context 'when the id matches a dossier the current user was invited to' do
+      let(:dossier) { create(:dossier) }
+      let(:dossier_id) { dossier.id }
+      before { create(:invite, dossier:, user:) }
+
+      it { is_expected.to eq dossier }
+    end
+
+    context 'when the id matches a dossier from another user' do
+      let(:other_user) { create(:user) }
+      let(:other_dossier) { create(:dossier, user: other_user) }
+      let(:dossier_id) { other_dossier.id }
+
+      it { is_expected.to be nil }
     end
 
     context 'when the id doesn’t match an existing dossier' do
@@ -2103,7 +2119,7 @@ describe Users::DossiersController, type: :controller do
 
     context 'when the id is empty' do
       let(:dossier_id) { nil }
-      it { is_expected.to be_falsy }
+      it { is_expected.to be nil }
     end
   end
 


### PR DESCRIPTION
## Résumé

- La méthode `dossier_for_help` (utilisée par le menu d'aide dans l'en-tête) cherchait un dossier par id sans filtrer sur l'utilisateur courant.
- Le lookup est maintenant restreint aux dossiers appartenant à `current_user` ou à ceux auxquels il a été invité.
- Couverture de tests ajoutée pour les trois cas : propriétaire, invité, dossier d'un autre utilisateur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)