### PR TITLE
ETQ administrateur et instructeur, si je suis sur une page correspondant à une démarche, je vois le numéro et le nom de la démarche dans le titre de l'onglet

### DIFF
--- a/app/views/administrateurs/archives/index.html.haml
+++ b/app/views/administrateurs/archives/index.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Archives")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/attestation_template_v2s/edit.html.haml
+++ b/app/views/administrateurs/attestation_template_v2s/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Attestation")
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [['Démarches', admin_procedures_path],
                     [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],

--- a/app/views/administrateurs/attestation_templates/edit.html.haml
+++ b/app/views/administrateurs/attestation_templates/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Attestation")
 - content_for(:root_class, 'scroll-margins-for-sticky-footer')
 - render_procedure_sticky_title(@procedure)
 

--- a/app/views/administrateurs/chorus/add_champ_engagement_juridique.html.haml
+++ b/app/views/administrateurs/chorus/add_champ_engagement_juridique.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Chorus")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/chorus/edit.html.haml
+++ b/app/views/administrateurs/chorus/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Chorus")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/contact_informations/edit.html.erb
+++ b/app/views/administrateurs/contact_informations/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, "Contact") %>
 <% render_procedure_sticky_title(@procedure) %>
 
 <%= render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/contact_informations/new.html.erb
+++ b/app/views/administrateurs/contact_informations/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, "Contact") %>
 <% render_procedure_sticky_title(@procedure) %>
 
 <%= render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/dossier_submitted_messages/edit.html.erb
+++ b/app/views/administrateurs/dossier_submitted_messages/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, "Message de fin") %>
 <% content_for(:root_class, 'scroll-margins-for-sticky-footer') %>
 <% render_procedure_sticky_title(@procedure) %>
 

--- a/app/views/administrateurs/experts_procedures/index.html.haml
+++ b/app/views/administrateurs/experts_procedures/index.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Experts")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/groupe_instructeurs/reaffecter_dossiers.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/reaffecter_dossiers.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Réaffectation")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/groupe_instructeurs/show.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/show.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, @groupe_instructeur.label)
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/ineligibilite_rules/edit.html.haml
+++ b/app/views/administrateurs/ineligibilite_rules/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Inéligibilité")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/jetons/edit_entreprise.html.haml
+++ b/app/views/administrateurs/jetons/edit_entreprise.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Jeton Entreprise")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/jetons/edit_particulier.html.haml
+++ b/app/views/administrateurs/jetons/edit_particulier.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Jeton Particulier")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/jetons/index.html.haml
+++ b/app/views/administrateurs/jetons/index.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Jetons")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/labels/order_positions.html.haml
+++ b/app/views/administrateurs/labels/order_positions.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Labels")
 - render_procedure_sticky_title(@procedure)
 
 .fr-container.fr-mt-6w.fr-mb-6w

--- a/app/views/administrateurs/mail_templates/edit.html.haml
+++ b/app/views/administrateurs/mail_templates/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Email")
 - content_for(:root_class, 'scroll-margins-for-sticky-footer')
 - render_procedure_sticky_title(@procedure)
 

--- a/app/views/administrateurs/mail_templates/index.html.haml
+++ b/app/views/administrateurs/mail_templates/index.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Emails")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/procedure_administrateurs/index.html.haml
+++ b/app/views/administrateurs/procedure_administrateurs/index.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Administrateurs")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/procedures/accuse_lecture.html.haml
+++ b/app/views/administrateurs/procedures/accuse_lecture.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Accusé de lecture")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/procedures/administrateurs.html.haml
+++ b/app/views/administrateurs/procedures/administrateurs.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Administrateurs")
 - content_for :results do
   .main-filter-header.fr-my-3w
     = form_with(url: administrateurs_admin_procedures_path, method: :get, data: { turbo_frame: 'procedures' }, html: { role: 'search' }) do |f|

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Démarches")
 - content_for :results do
   .main-filter-header.fr-my-3w
     = form_with(url: all_admin_procedures_path, method: :get, data: { turbo_frame: 'procedures' }, html: { role: 'search', class: 'search' }) do |f|

--- a/app/views/administrateurs/procedures/apercu.html.haml
+++ b/app/views/administrateurs/procedures/apercu.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Aperçu")
 .dossiers-headers.sub-header
   .fr-container
     %h1.page-title Prévisualisation de la démarche «&nbsp;#{@dossier.procedure.libelle}&nbsp;»

--- a/app/views/administrateurs/procedures/clone_settings.html.erb
+++ b/app/views/administrateurs/procedures/clone_settings.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "Cloner") %>
+
 <%= render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [['Démarches', admin_procedures_back_path(@procedure)],
                     ["Cloner la démarche « #{@procedure.libelle.truncate_words(10)} » (N° #{@procedure.id})"]] } %>

--- a/app/views/administrateurs/procedures/close.html.haml
+++ b/app/views/administrateurs/procedures/close.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Fermeture")
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [['Démarches', admin_procedures_back_path(@procedure)],
                     [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],[t('administrateurs.procedures.close.page_title')]],

--- a/app/views/administrateurs/procedures/closing_notification.html.haml
+++ b/app/views/administrateurs/procedures/closing_notification.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Clôture")
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [['Démarches', admin_procedures_back_path(@procedure)],
                     [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],[t('administrateurs.procedures.close.page_title')]],

--- a/app/views/administrateurs/procedures/confirmation.html.haml
+++ b/app/views/administrateurs/procedures/confirmation.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Confirmation")
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [['Démarches', admin_procedures_back_path(@procedure)],
                     [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],

--- a/app/views/administrateurs/procedures/index.html.haml
+++ b/app/views/administrateurs/procedures/index.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Démarches")
 - if ENV.fetch("ADMIN_TABLEAU_SURVEY_ENABLED", "enabled") == "enabled"
   = render Dsfr::NoticeComponent.new(closable: true, data_attributes: { "data-notice-name" => "admin-sondage-champ-tableau" }) do |c|
     - c.with_title do

--- a/app/views/administrateurs/procedures/modifications.html.haml
+++ b/app/views/administrateurs/procedures/modifications.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Modifications")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/procedures/monavis.html.haml
+++ b/app/views/administrateurs/procedures/monavis.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "MonAvis")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/procedures/new.html.haml
+++ b/app/views/administrateurs/procedures/new.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Nouvelle démarche")
 - content_for(:root_class, 'scroll-margins-for-sticky-footer')
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/procedures/new_from_existing.html.haml
+++ b/app/views/administrateurs/procedures/new_from_existing.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Cloner")
 .container
   - if current_administrateur.procedures.brouillons.count == 0
     = render Dsfr::CalloutComponent.new(title: nil, icon: "fr-icon-information-line", extra_class_names: 'fr-my-4w') do |c|

--- a/app/views/administrateurs/procedures/path.html.haml
+++ b/app/views/administrateurs/procedures/path.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Lien")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/procedures/pro_connect_restricted.html.erb
+++ b/app/views/administrateurs/procedures/pro_connect_restricted.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, "ProConnect") %>
 <% render_procedure_sticky_title(@procedure) %>
 
 <%= render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/procedures/publication.html.haml
+++ b/app/views/administrateurs/procedures/publication.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Publication")
 
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [['Démarches', admin_procedures_back_path(@procedure)],

--- a/app/views/administrateurs/procedures/rdv.html.erb
+++ b/app/views/administrateurs/procedures/rdv.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, "Rendez-vous") %>
 <% render_procedure_sticky_title(@procedure) %>
 
 <%= render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Gestion")
 - render_procedure_sticky_title(@procedure)
 = render partial: 'administrateurs/breadcrumbs',
     locals: { steps: [['Démarches', admin_procedures_back_path(@procedure)],

--- a/app/views/administrateurs/procedures/transfert.html.haml
+++ b/app/views/administrateurs/procedures/transfert.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Transfert")
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [['Démarches', admin_procedures_back_path(@procedure)],
                     [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],

--- a/app/views/administrateurs/procedures/zones.html.haml
+++ b/app/views/administrateurs/procedures/zones.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Zones")
 - render_procedure_sticky_title(@procedure)
 
 - content_for(:root_class, 'scroll-margins-for-sticky-footer')

--- a/app/views/administrateurs/referentiels/autocomplete_configuration.html.erb
+++ b/app/views/administrateurs/referentiels/autocomplete_configuration.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, "Référentiel") %>
 <% render_procedure_sticky_title(@procedure) %>
 
 <%= render Referentiels::StepperComponent.new(

--- a/app/views/administrateurs/referentiels/mapping_type_de_champ.html.erb
+++ b/app/views/administrateurs/referentiels/mapping_type_de_champ.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, "Référentiel") %>
 <% render_procedure_sticky_title(@procedure) %>
 
 <%= render Referentiels::StepperComponent.new(

--- a/app/views/administrateurs/referentiels/new.html.erb
+++ b/app/views/administrateurs/referentiels/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, "Référentiel") %>
 <% render_procedure_sticky_title(@procedure) %>
 
 <%= render Referentiels::StepperComponent.new(

--- a/app/views/administrateurs/referentiels/prefill_and_display.html.erb
+++ b/app/views/administrateurs/referentiels/prefill_and_display.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, "Référentiel") %>
 <% render_procedure_sticky_title(@procedure) %>
 
 <%= render Referentiels::StepperComponent.new(

--- a/app/views/administrateurs/services/edit.html.haml
+++ b/app/views/administrateurs/services/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Service")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/services/index.html.haml
+++ b/app/views/administrateurs/services/index.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Service")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/services/new.html.haml
+++ b/app/views/administrateurs/services/new.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Service")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/sources_particulier/show.html.haml
+++ b/app/views/administrateurs/sources_particulier/show.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "API Particulier")
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [['Démarches', admin_procedures_path],
                     [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],

--- a/app/views/administrateurs/sva_svr/edit.html.haml
+++ b/app/views/administrateurs/sva_svr/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "SVA/SVR")
 - render_procedure_sticky_title(@procedure)
 
 = render partial: 'administrateurs/breadcrumbs',

--- a/app/views/administrateurs/types_de_champ/simplify.html.erb
+++ b/app/views/administrateurs/types_de_champ/simplify.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Amélioration de la qualité du formulaire « #{@procedure.libelle} »" %>
+<% content_for(:title, "Simplification") %>
 <% render_procedure_sticky_title(@procedure) %>
 
 <%= render partial: 'administrateurs/breadcrumbs',

--- a/app/views/instructeurs/archives/index.html.haml
+++ b/app/views/instructeurs/archives/index.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, "Archives pour #{@procedure.libelle}")
+- content_for(:title, "Archives")
 
 
 

--- a/app/views/instructeurs/contact_informations/edit.html.haml
+++ b/app/views/instructeurs/contact_informations/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Contact")
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [[@procedure.libelle.truncate_words(10), instructeur_procedure_path(@procedure)],
     ['Groupes d’instructeurs', instructeur_groupes_path(@procedure)],

--- a/app/views/instructeurs/contact_informations/new.html.haml
+++ b/app/views/instructeurs/contact_informations/new.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Contact")
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [[@procedure.libelle.truncate_words(10), instructeur_procedure_path(@procedure)],
     ['Groupes d’instructeurs', instructeur_groupes_path(@procedure)],

--- a/app/views/instructeurs/dossiers/print.html.haml
+++ b/app/views/instructeurs/dossiers/print.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Impression")
 %h1= "Dossier n° #{@dossier.id}"
 %h1.subtitle= "Démarche : #{@dossier.procedure.libelle}"
 

--- a/app/views/instructeurs/dossiers/show_submitted_revision.html.erb
+++ b/app/views/instructeurs/dossiers/show_submitted_revision.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "Dossier") %>
+
 <div class="fr-container fr-my-4v">
   <%= link_to t('instructeurs.dossiers.submitted_revision.back'), instructeur_dossier_path, class: 'fr-link fr-icon-arrow-left-line fr-link--icon-left' %>
 

--- a/app/views/instructeurs/export_templates/edit.html.haml
+++ b/app/views/instructeurs/export_templates/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Modèle d'export")
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [[@procedure.libelle.truncate_words(10), [:instructeur, @procedure]],
                       [t('instructeurs.dossiers.header.banner.export_templates'), [:export_templates, :instructeur, @procedure]],

--- a/app/views/instructeurs/export_templates/new.html.haml
+++ b/app/views/instructeurs/export_templates/new.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Modèle d'export")
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [[@procedure.libelle.truncate_words(10), [:instructeur, @procedure]],
                       [t('instructeurs.dossiers.header.banner.export_templates'), [:export_templates, :instructeur, @procedure]],

--- a/app/views/instructeurs/groupe_instructeurs/index.html.haml
+++ b/app/views/instructeurs/groupe_instructeurs/index.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, "Notifications pour #{@procedure.libelle}")
+- content_for(:title, "Instructeurs")
 
 .sub-header
   .fr-container.flex.column

--- a/app/views/instructeurs/groupe_instructeurs/show.html.haml
+++ b/app/views/instructeurs/groupe_instructeurs/show.html.haml
@@ -9,7 +9,7 @@
                           [@groupe_instructeur.label]] }
 
     - else
-      - content_for(:title, "Instructeurs de la démarche #{@procedure.libelle}")
+      - content_for(:title, "Instructeurs")
 
       = render partial: 'instructeurs/breadcrumbs',
         locals: { steps: [[@procedure.libelle, instructeur_procedure_path(@procedure)],

--- a/app/views/instructeurs/procedure_presentation/customize_filters.html.erb
+++ b/app/views/instructeurs/procedure_presentation/customize_filters.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "Filtres") %>
+
 <div class="fr-container fr-mt-6w fr-mb-15w">
   <%= link_to " #{t('.exit_customization')}", instructeur_procedure_path(@procedure, statut: @statut), class: 'fr-link fr-icon-arrow-left-line fr-link--icon--left fr-icon--sm' %>
 

--- a/app/views/instructeurs/procedures/administrateurs.html.haml
+++ b/app/views/instructeurs/procedures/administrateurs.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, "Administrateurs de #{@procedure.libelle}")
+- content_for(:title, "Administrateurs")
 
 .sub-header
   .fr-container.flex.column

--- a/app/views/instructeurs/procedures/apercu.html.haml
+++ b/app/views/instructeurs/procedures/apercu.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, t('.title_with_libelle', libelle: @dossier.procedure.libelle))
+- content_for(:title, "Aperçu")
 
 .sub-header
   .fr-container.flex.column

--- a/app/views/instructeurs/procedures/deleted_dossiers.html.haml
+++ b/app/views/instructeurs/procedures/deleted_dossiers.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, "#{@procedure.libelle}")
+- content_for(:title, "Supprimés")
 
 .sub-header
   .fr-container.flex.column

--- a/app/views/instructeurs/procedures/email_usagers.html.haml
+++ b/app/views/instructeurs/procedures/email_usagers.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, "Contacter les usagers pour #{@procedure.libelle}")
+- content_for(:title, "Contacter")
 
 .sub-header
   .fr-container.flex.column

--- a/app/views/instructeurs/procedures/export_templates.html.haml
+++ b/app/views/instructeurs/procedures/export_templates.html.haml
@@ -1,5 +1,4 @@
-- title = t('.page_title', procedure: @procedure.libelle)
-- content_for(:title, title)
+- content_for(:title, "Modèles d'export")
 
 .sub-header
   .fr-container.flex.column

--- a/app/views/instructeurs/procedures/exports.html.haml
+++ b/app/views/instructeurs/procedures/exports.html.haml
@@ -1,5 +1,4 @@
-- title = "Exports · #{@procedure.libelle}"
-- content_for(:title, title)
+- content_for(:title, "Exports")
 
 .sub-header
   .fr-container.flex.column

--- a/app/views/instructeurs/procedures/history.html.haml
+++ b/app/views/instructeurs/procedures/history.html.haml
@@ -1,5 +1,4 @@
-- title = t('instructeurs.dossiers.header.banner.history.title', procedure_libelle: @procedure.libelle)
-- content_for(:title, title)
+- content_for(:title, "Historique")
 
 .sub-header
   .fr-container.flex.column

--- a/app/views/instructeurs/procedures/notification_preferences.html.haml
+++ b/app/views/instructeurs/procedures/notification_preferences.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, "Notifications pour #{@procedure.libelle}")
+- content_for(:title, "Notifications")
 
 .sub-header
   .fr-container.flex.column

--- a/app/views/instructeurs/procedures/order_positions.html.haml
+++ b/app/views/instructeurs/procedures/order_positions.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Ordre")
 .fr-container.fr-mt-6w.fr-mb-15w
   = link_to " Liste des démarches", instructeur_procedures_path, class: 'fr-link fr-icon-arrow-left-line fr-link--icon--left fr-icon--sm'
   %h3.fr-my-3w

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -5,7 +5,7 @@
     - c.with_link do
       = link_to "Personnaliser l’affichage dès maintenant !", notification_preferences_instructeur_procedure_path(@procedure, tab: :badge), class: "fr-notice__link"
 
-- content_for(:title, "#{@procedure.libelle}")
+- content_for(:title, "Dossiers")
 
 #procedure-show
   .sub-header

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,7 +41,15 @@
     <% end %>
 
     <title>
-      <%= content_for?(:title) ? "#{sanitize(yield(:title)).gsub("&nbsp;", " ")} · #{Current.application_name}" : Current.application_name %>
+      <% if content_for?(:title) && @procedure&.libelle.present? %>
+        <%= "#{sanitize(yield(:title)).gsub("&nbsp;", " ")} · ##{@procedure.id} · #{truncate(sanitize(@procedure.libelle).gsub("&nbsp;", " "), length: 30)} · #{Current.application_name}" %>
+      <% elsif content_for?(:title) %>
+        <%= "#{sanitize(yield(:title)).gsub("&nbsp;", " ")} · #{Current.application_name}" %>
+      <% elsif @procedure&.libelle.present? %>
+        <%= "##{@procedure.id} · #{truncate(sanitize(@procedure.libelle).gsub("&nbsp;", " "), length: 30)} · #{Current.application_name}" %>
+      <% else %>
+        <%= Current.application_name %>
+      <% end %>
     </title>
 
     <%= render partial: "layouts/favicons" %>

--- a/app/views/users/dossiers/transferer.html.haml
+++ b/app/views/users/dossiers/transferer.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, "Transfert")
 .fr-container.fr-mt-3w
   .fr-grid-row
     .fr-col-lg-8.fr-col-offset-lg-2

--- a/config/locales/views/instructeurs/procedures/exports/en.yml
+++ b/config/locales/views/instructeurs/procedures/exports/en.yml
@@ -32,5 +32,4 @@ en:
         modify_template: Edit
         delete_template: Delete
         delete_template_alert: Are you sure you want to delete this template? It will be removed for all instructors in the group
-        page_title: 'Export templates · %{procedure}'
         actions: Actions

--- a/config/locales/views/instructeurs/procedures/exports/fr.yml
+++ b/config/locales/views/instructeurs/procedures/exports/fr.yml
@@ -32,5 +32,4 @@ fr:
         modify_template: Modifier
         delete_template: Supprimer
         delete_template_alert: Voulez-vous vraiment supprimer ce modèle ? Il sera supprimé pour tous les instructeurs qui y ont accès.
-        page_title: 'Modèles d’export · %{procedure}'
         actions: Actions

--- a/config/locales/views/instructeurs/procedures/notification_preferences/en.yml
+++ b/config/locales/views/instructeurs/procedures/notification_preferences/en.yml
@@ -62,5 +62,4 @@ en:
           desc_expiration: When this option is disabled, you will no longer receive alerts about files expiring before they are automatically moved to the trash.
           desc_expired: When this option is disabled, you will no longer receive alerts about the upcoming permanent deletion of files. Be sure to download them or extend their retention period before they are permanently deleted.
       apercu:
-        title_with_libelle: Preview of « %{libelle} »
         title: Procedure preview

--- a/config/locales/views/instructeurs/procedures/notification_preferences/fr.yml
+++ b/config/locales/views/instructeurs/procedures/notification_preferences/fr.yml
@@ -63,5 +63,4 @@ fr:
           desc_expired: Lorsque cette option est désactivée, vous ne recevez plus aucune alerte concernant la suppression définitive à venir des dossiers. Veillez à les télécharger ou à étendre leur durée de conservation avant qu’ils ne soient supprimés définitivement.
 
       apercu:
-        title_with_libelle: Prévisualisation de « %{libelle} »
         title: Prévisualisation de la démarche

--- a/spec/views/layouts/application_html_spec.rb
+++ b/spec/views/layouts/application_html_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+describe 'layouts/application', type: :view do
+  let(:procedure) { create(:simple_procedure) }
+
+  before do
+    allow(view).to receive(:administrateur_signed_in?).and_return(false)
+    allow(view).to receive(:instructeur_signed_in?).and_return(false)
+    allow(view).to receive(:user_signed_in?).and_return(false)
+    allow(view).to receive(:chatbot_disabled_page?).and_return(false)
+    allow(view).to receive(:localization_enabled?).and_return(false)
+    allow(view).to receive(:extra_query_params).and_return({})
+    view.content_for(:footer, "footer")
+  end
+
+  subject { render html: '', layout: 'layouts/application' }
+
+  def title_text
+    Nokogiri::HTML(subject).at("title")&.text&.strip
+  end
+
+  context "without content_for(:title) or @procedure" do
+    it "does not include a separator in the title" do
+      expect(title_text).not_to include("·")
+    end
+  end
+
+  context "with content_for(:title) set" do
+    before { view.content_for(:title, "Custom title") }
+
+    it "displays the custom title" do
+      expect(title_text).to include("Custom title")
+    end
+  end
+
+  context "with @procedure and no content_for(:title)" do
+    before { assign(:procedure, procedure) }
+
+    it "includes the procedure id" do
+      expect(title_text).to include("##{procedure.id}")
+    end
+
+    it "includes the procedure libelle" do
+      expect(title_text).to include(procedure.libelle)
+    end
+  end
+
+  context "with both @procedure and content_for(:title) set" do
+    before do
+      assign(:procedure, procedure)
+      view.content_for(:title, "Specific title")
+    end
+
+    it "includes both the custom title and the procedure info" do
+      expect(title_text).to include("Specific title")
+      expect(title_text).to include("##{procedure.id}")
+    end
+  end
+
+  context "with @procedure whose libelle contains HTML" do
+    let(:procedure) { create(:simple_procedure, libelle: "<script>xss</script>") }
+
+    before { assign(:procedure, procedure) }
+
+    it "escapes the libelle in the title" do
+      expect(title_text).not_to include("<script>")
+    end
+  end
+end


### PR DESCRIPTION
## Résumé

- Modifie `application.html.erb` pour afficher dans le titre de l'onglet : 
  - `title · #id · libelle · appname`  quand `content_for(:title)` et `@procedure` sont définis
  - `#id · libelle · appname`  quand `@procedure` est défini mais pas `content_for(:title)`
  - `title · appname`  quand `content_for(:title)` est défini mais pas `@procedure` 
  - `appname`  quand `content_for(:title)` et `@procedure` ne sont pas définis

- J'en ai profité pour ajouter des `content_for(:title)` dans les vues qui n'en avaient pas

## Avant
<img width="2370" height="1178" alt="Capture d’écran 2026-05-06 à 14 00 55" src="https://github.com/user-attachments/assets/52fea081-00e3-49f5-8c40-fb43e17d9863" />


## Après
<img width="2370" height="1178" alt="Capture d’écran 2026-05-06 à 14 00 22" src="https://github.com/user-attachments/assets/f1bc4be4-c200-4b3d-a30f-4868833575bc" />

