### PR TITLE
Tech: cantonner le groupe instructeur à sa procédure sur les infos de contact

### DIFF
--- a/app/controllers/instructeurs/contact_informations_controller.rb
+++ b/app/controllers/instructeurs/contact_informations_controller.rb
@@ -43,8 +43,10 @@ module Instructeurs
     private
 
     def assign_procedure_and_groupe_instructeur
-      @procedure = current_instructeur.procedures.find params[:procedure_id]
-      @groupe_instructeur = current_instructeur.groupe_instructeurs.find params[:groupe_id]
+      @procedure = current_instructeur.procedures.find(params[:procedure_id])
+      @groupe_instructeur = @procedure.groupe_instructeurs
+        .merge(current_instructeur.groupe_instructeurs)
+        .find(params[:groupe_id])
     end
 
     def contact_information_params

--- a/spec/controllers/instructeurs/contact_informations_controller_spec.rb
+++ b/spec/controllers/instructeurs/contact_informations_controller_spec.rb
@@ -7,6 +7,10 @@ describe Instructeurs::ContactInformationsController, type: :controller do
   let(:gi) { assign_to.groupe_instructeur }
   let(:from_admin) { nil }
 
+  let(:other_procedure) { create(:procedure) }
+  let(:other_assign_to) { create(:assign_to, instructeur: instructeur, groupe_instructeur: build(:groupe_instructeur, procedure: other_procedure)) }
+  let(:other_gi) { other_assign_to.groupe_instructeur }
+
   before do
     sign_in(instructeur.user)
   end
@@ -114,6 +118,71 @@ describe Instructeurs::ContactInformationsController, type: :controller do
       expect(flash.alert).to be_nil
       expect(flash.notice).to eq("Les informations de contact ont bien été supprimées")
       expect(response).to redirect_to(instructeur_groupe_path(gi, procedure_id: procedure.id))
+    end
+  end
+
+  context 'when procedure_id and groupe_id belong to different procedures' do
+    before do
+      gi       # instructeur has legitimate access to `procedure` via gi
+      other_gi # instructeur is also a member of other_gi on other_procedure
+    end
+
+    let(:valid_contact_information_params) do
+      {
+        nom: 'cross service',
+        email: 'email@toto.com',
+        telephone: '1234',
+        horaires: 'horaires',
+        adresse: 'adresse',
+      }
+    end
+
+    describe '#create' do
+      subject(:mismatched_create) do
+        post :create, params: {
+          contact_information: valid_contact_information_params,
+          procedure_id: procedure.id,
+          groupe_id: other_gi.id,
+        }
+      end
+
+      it 'does not create a contact_information on the other procedure groupe' do
+        expect { mismatched_create rescue nil }.not_to change { ContactInformation.count }
+        expect(other_gi.reload.contact_information).to be_nil
+      end
+    end
+
+    describe '#update' do
+      let!(:other_contact_information) { create(:contact_information, groupe_instructeur: other_gi, nom: 'original') }
+
+      subject(:mismatched_update) do
+        patch :update, params: {
+          id: other_contact_information.id,
+          contact_information: { nom: 'tampered' },
+          procedure_id: procedure.id,
+          groupe_id: other_gi.id,
+        }
+      end
+
+      it 'does not modify the other procedure groupe contact_information' do
+        expect { mismatched_update rescue nil }.not_to change { other_contact_information.reload.nom }
+      end
+    end
+
+    describe '#destroy' do
+      let!(:other_contact_information) { create(:contact_information, groupe_instructeur: other_gi) }
+
+      subject(:mismatched_destroy) do
+        delete :destroy, params: {
+          id: other_contact_information.id,
+          procedure_id: procedure.id,
+          groupe_id: other_gi.id,
+        }
+      end
+
+      it 'does not destroy the other procedure groupe contact_information' do
+        expect { mismatched_destroy rescue nil }.not_to change { ContactInformation.exists?(other_contact_information.id) }
+      end
     end
   end
 end


### PR DESCRIPTION
## Résumé

Dans `Instructeurs::ContactInformationsController`, `@procedure` et `@groupe_instructeur` étaient recherchés indépendamment, chacun scopé à l'instructeur courant, sans vérification que le groupe appartienne bien à la procédure. Un instructeur membre de groupes sur plusieurs procédures pouvait ainsi agir sur un groupe d'une autre procédure sous le contexte d'autorisation d'une procédure qui ne le contient pas.

La recherche du groupe est maintenant chaînée via `@procedure.groupe_instructeurs.merge(current_instructeur.groupe_instructeurs)`, garantissant la cohérence procédure/groupe à la fois avec la procédure ciblée et les groupes accessibles à l'instructeur.

## Couverture

Ajout d'un `context` de régression couvrant `#create`, `#update`, `#destroy` avec `procedure_id` et `groupe_id` appartenant à deux procédures distinctes — les requêtes incohérentes ne doivent plus modifier l'état.

🤖 Generated with [Claude Code](https://claude.com/claude-code)