### PR TITLE
Tech: restreindre la recherche de gestionnaire et d'administrateur au groupe gestionnaire courant

### DIFF
--- a/app/controllers/gestionnaires/groupe_gestionnaire_administrateurs_controller.rb
+++ b/app/controllers/gestionnaires/groupe_gestionnaire_administrateurs_controller.rb
@@ -66,36 +66,28 @@ module Gestionnaires
     end
 
     def destroy
-      @administrateur = Administrateur.find(params[:id])
-      if @groupe_gestionnaire.id != @administrateur.groupe_gestionnaire_id
-        flash[:alert] = I18n.t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_administrateur.not_in_groupe_gestionnaire', email: @administrateur.email)
-      else
-        result = AdministrateurDeletionService.new(current_gestionnaire, @administrateur).call
+      @administrateur = @groupe_gestionnaire.administrateurs.find(params[:id])
+      result = AdministrateurDeletionService.new(current_gestionnaire, @administrateur).call
 
-        case result
-        in Dry::Monads::Result::Success
-          logger.info("L’administrateur #{@administrateur.id} est supprimé par le gestionnaire #{current_gestionnaire.id} depuis le groupe gestionnaire #{@groupe_gestionnaire.id}")
-          flash[:notice] = I18n.t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_administrateur.destroy', email: @administrateur.email)
-          GroupeGestionnaireMailer
-            .notify_removed_administrateur(@groupe_gestionnaire, @administrateur.email, current_gestionnaire.email)
-            .deliver_later
-        in Dry::Monads::Result::Failure(reason)
-          flash[:alert] = I18n.t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_administrateur.cannot_be_deleted', email: @administrateur.email)
-        end
+      case result
+      in Dry::Monads::Result::Success
+        logger.info("L’administrateur #{@administrateur.id} est supprimé par le gestionnaire #{current_gestionnaire.id} depuis le groupe gestionnaire #{@groupe_gestionnaire.id}")
+        flash[:notice] = I18n.t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_administrateur.destroy', email: @administrateur.email)
+        GroupeGestionnaireMailer
+          .notify_removed_administrateur(@groupe_gestionnaire, @administrateur.email, current_gestionnaire.email)
+          .deliver_later
+      in Dry::Monads::Result::Failure(reason)
+        flash[:alert] = I18n.t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_administrateur.cannot_be_deleted', email: @administrateur.email)
       end
     end
 
     def remove
-      @administrateur = Administrateur.find(params[:id])
-      if @groupe_gestionnaire.id != @administrateur.groupe_gestionnaire_id
-        flash[:alert] = I18n.t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_administrateur.not_in_groupe_gestionnaire', email: @administrateur.email)
-      else
-        @administrateur.update(groupe_gestionnaire_id: nil)
-        flash[:notice] = I18n.t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_administrateur.remove', email: @administrateur.email)
-        GroupeGestionnaireMailer
-          .notify_removed_administrateur(@groupe_gestionnaire, @administrateur.email, current_gestionnaire.email)
-          .deliver_later
-      end
+      @administrateur = @groupe_gestionnaire.administrateurs.find(params[:id])
+      @administrateur.update(groupe_gestionnaire_id: nil)
+      flash[:notice] = I18n.t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_administrateur.remove', email: @administrateur.email)
+      GroupeGestionnaireMailer
+        .notify_removed_administrateur(@groupe_gestionnaire, @administrateur.email, current_gestionnaire.email)
+        .deliver_later
     end
   end
 end

--- a/app/controllers/gestionnaires/groupe_gestionnaire_gestionnaires_controller.rb
+++ b/app/controllers/gestionnaires/groupe_gestionnaire_gestionnaires_controller.rb
@@ -54,9 +54,9 @@ module Gestionnaires
       if @groupe_gestionnaire.is_root? && @groupe_gestionnaire.gestionnaires.one?
         flash[:alert] = I18n.t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_gestionnaire.destroy_at_least_one')
       else
-        @gestionnaire = Gestionnaire.find(params[:id])
+        @gestionnaire = @groupe_gestionnaire.gestionnaires.find(params[:id])
 
-        if !@groupe_gestionnaire.in?(@gestionnaire.groupe_gestionnaires) || !@gestionnaire.groupe_gestionnaires.destroy(@groupe_gestionnaire)
+        if !@gestionnaire.groupe_gestionnaires.destroy(@groupe_gestionnaire)
           flash[:alert] = I18n.t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_gestionnaire.not_in_groupe_gestionnaire', email: @gestionnaire.email)
         else
           if @gestionnaire.groupe_gestionnaires.empty?

--- a/spec/controllers/gestionnaires/groupe_gestionnaire_administrateurs_controller_spec.rb
+++ b/spec/controllers/gestionnaires/groupe_gestionnaire_administrateurs_controller_spec.rb
@@ -68,11 +68,11 @@ describe Gestionnaires::GroupeGestionnaireAdministrateursController, type: :cont
 
     context 'when administrateur is not in the groupe_gestionnaire' do
       let(:other_administrateur) { administrateurs(:default_admin) }
-      before { destroy(other_administrateur) }
 
-      it do
+      it 'does not disclose the unrelated administrateur email' do
+        expect { destroy(other_administrateur) }.to raise_error(ActiveRecord::RecordNotFound)
         expect(groupe_gestionnaire.reload.administrateurs.count).to eq(1)
-        expect(flash.alert).to eq("L’administrateur « #{other_administrateur.email} » n’est pas dans le groupe gestionnaire.")
+        expect(flash.alert.to_s).not_to include(other_administrateur.email)
       end
     end
   end
@@ -105,11 +105,11 @@ describe Gestionnaires::GroupeGestionnaireAdministrateursController, type: :cont
 
     context 'when administrateur is not in the groupe_gestionnaire' do
       let(:other_administrateur) { create(:administrateur) }
-      before { remove(other_administrateur) }
 
-      it do
+      it 'does not disclose the unrelated administrateur email' do
+        expect { remove(other_administrateur) }.to raise_error(ActiveRecord::RecordNotFound)
         expect(groupe_gestionnaire.reload.administrateurs.count).to eq(1)
-        expect(flash.alert).to eq("L’administrateur « #{other_administrateur.email} » n’est pas dans le groupe gestionnaire.")
+        expect(flash.alert.to_s).not_to include(other_administrateur.email)
       end
     end
   end

--- a/spec/controllers/gestionnaires/groupe_gestionnaire_gestionnaires_controller_spec.rb
+++ b/spec/controllers/gestionnaires/groupe_gestionnaire_gestionnaires_controller_spec.rb
@@ -65,5 +65,16 @@ describe Gestionnaires::GroupeGestionnaireGestionnairesController, type: :contro
         expect(flash.alert).to eq('Suppression impossible : il doit y avoir au moins un gestionnaire dans le groupe racine')
       end
     end
+
+    context 'when the id belongs to a gestionnaire outside the group' do
+      let(:unrelated_gestionnaire) { create(:gestionnaire) }
+
+      subject(:cross_group_request) { remove_gestionnaire(unrelated_gestionnaire) }
+
+      it 'does not disclose the unrelated gestionnaire email' do
+        expect { cross_group_request }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(flash.alert.to_s).not_to include(unrelated_gestionnaire.email)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Restreint la recherche de `gestionnaires` ou `administrateurs` à `@groupe_gestionnaire.gestionnaires` / `@groupe_gestionnaire.administrateurs` : un `id` qui ne correspond à aucun membre du groupe géré déclenche `ActiveRecord::RecordNotFound`.
