### PR TITLE
Tech: valider le format des identifiants RDV externes

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -4,7 +4,8 @@ class Rdv < ApplicationRecord
   belongs_to :dossier
   belongs_to :instructeur
 
-  validates :rdv_plan_external_id, presence: true
+  validates :rdv_plan_external_id, presence: true, format: { with: /\A\d+\z/ }
+  validates :rdv_external_id, format: { with: /\A\d+\z/ }, allow_nil: true
   validates :starts_at, presence: true, if: -> { rdv_external_id.present? }
 
   scope :booked, -> { where.not(rdv_external_id: nil) }

--- a/spec/services/rdv_service_spec.rb
+++ b/spec/services/rdv_service_spec.rb
@@ -53,6 +53,26 @@ describe RdvService do
         )
       end
 
+      context 'when the external API returns a non-numeric id with path separators' do
+        let(:rdv_plan_result) {
+          {
+            "rdv_plan":
+            {
+              "id": "../../admin/destroy_all",
+              "created_at": "2025-01-23 15:15:20 +0100",
+              "rdv": nil,
+              "updated_at": "2025-01-23 15:15:20 +0100",
+              "url": "https://demo.rdv.anct.gouv.fr/agents/rdv_plans/10",
+              "user_id": 6425,
+            },
+          }
+        }
+
+        it 'does not persist the rdv with the untrusted id' do
+          expect { subject rescue nil }.not_to change(Rdv, :count)
+        end
+      end
+
       context 'when token is expired' do
         let(:new_token) do
           instance_double(OAuth2::AccessToken,
@@ -120,6 +140,26 @@ describe RdvService do
           starts_at: Time.zone.parse("2025-02-11 10:30:00 +0100"),
           location_type: "phone"
         )
+      end
+    end
+
+    context 'when the external API returns a non-numeric rdv id' do
+      let(:rdv_plan_result) {
+        {
+          "rdv_plan": {
+            "id": 10,
+            "rdv": {
+              "id": "../../admin/destroy_all",
+              "status": "unknown",
+              "starts_at": "2025-02-11 10:30:00 +0100",
+              "location_type": "phone",
+            },
+          },
+        }
+      }
+
+      it 'does not persist the untrusted id on the pending rdv' do
+        expect { subject rescue nil }.not_to change { pending_rdv.reload.rdv_external_id }
       end
     end
   end


### PR DESCRIPTION
## Résumé

Renforcement de la validation des `rdv_plan_external_id` et `rdv_external_id` sur le `Rdv`

### Détails

- Les colonnes `rdv_plan_external_id` et `rdv_external_id` sont alimentées à partir de la réponse de l'API RDV Service Public, puis interpolées dans des URLs sortantes (`RdvService.update_pending_rdv_plan_url`, `RdvService.list_rdvs_url`, `Rdv#rdv_plan_url`, `RdvService.rdv_sp_rdv_user_url`).
- Sans validation de format, une réponse amont crafted (compromission ou MITM TLS) pouvait persister une valeur contenant `/`, `..` ou `&`, et l'URL résultante sortait de la route prévue (ex. `/api/v1/rdv_plans/../../admin/...`) avec le Bearer token attaché.
- Fix : valider `/\A\d+\z/` avant le save en DB.

### Tests

- `spec/services/rdv_service_spec.rb` : 
  - `create_rdv_plan` ne persiste pas un Rdv lorsque l'API renvoie un `id` non numérique.
  - `update_pending_rdv_plan!` ne met pas à jour `rdv_external_id` lorsque l'API renvoie un `rdv.id` non numérique.
- En cas de réponse amont invalide, `create!` / `update!` lèvent `ActiveRecord::RecordInvalid` — l'erreur remonte dans Sentry plutôt que d'être silencieusement avalée (comportement souhaité pour ce type d'incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)