### PR TITLE
ETQ admin je suis informé de ne pas utiliser le champ Commune pour les lieux de naissance

### DIFF
--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -23,6 +23,12 @@
                   %span.fr-icon-lock-fill.fr-icon--sm
                   Aucun type de champ autorisé pour transformer ce champ
 
+              - if type_de_champ.communes?
+                .cell.fr-mt-1w
+                  = render Dsfr::NoticeComponent.new(state: "warning", closable: false) do |c|
+                    - c.with_title { "Attention :" }
+                    - c.with_desc { "ne pas utiliser ce champ pour les <strong>communes de naissance</strong>.".html_safe }
+
           .flex.column.justify-start.width-66
             .cell
               .flex.align-center


### PR DESCRIPTION
Closes #12941

<img width="1221" height="348" alt="Capture d’écran 2026-04-20 à 10 50 53" src="https://github.com/user-attachments/assets/84cb374b-62db-4daf-89f8-a4cec87ba247" />

Vu avec Marlène,  une notice doit avoir un titre et ici on met "Attention"