### PR TITLE
Tech: workaround pour ne pas laisser un job bloqué à vie en traitement après avoir écoulé les retries

### DIFF
--- a/app/jobs/champ_fetch_external_data_job.rb
+++ b/app/jobs/champ_fetch_external_data_job.rb
@@ -4,7 +4,7 @@ class ChampFetchExternalDataJob < ApplicationJob
   discard_on ActiveJob::DeserializationError
   queue_as :critical # ui feedback, asap
 
-  retry_on RetryableFetchError, attempts: 5, wait: :polynomially_longer do |job, err|
+  retry_on RetryableFetchError, attempts: 3, wait: :polynomially_longer do |job, err|
     champ = job.arguments.first
     champ.external_data_error!
 

--- a/app/jobs/champ_fetch_external_data_job.rb
+++ b/app/jobs/champ_fetch_external_data_job.rb
@@ -8,7 +8,8 @@ class ChampFetchExternalDataJob < ApplicationJob
     champ = job.arguments.first
     champ.external_data_error!
 
-    raise err.cause
+    # Don't raise, otherwise it will pop forever as "working" queue without doing anything
+    Sentry.capture_exception(err.cause)
   end
 
   def perform(champ, external_id)

--- a/spec/jobs/champ_fetch_external_data_job_spec.rb
+++ b/spec/jobs/champ_fetch_external_data_job_spec.rb
@@ -54,16 +54,16 @@ RSpec.describe ChampFetchExternalDataJob, type: :job do
         # currently-enqueued jobs one pass at a time. Each retry_on just
         # enqueues the next attempt without executing it inline, avoiding
         # the cascade that causes hangs with Rails 7.2.3+.
-        5.times do
+        3.times do
           perform_enqueued_jobs(only: ChampFetchExternalDataJob)
         rescue StandardError
-          # After 5 RetryableFetchError retries, the exhaust block raises err.cause
+          # After 3 RetryableFetchError retries, the exhaust block raises err.cause
         end
 
         champ.reload
 
         expect(champ).to be_external_error
-        expect(champ.fetch_external_data_exceptions.size).to eq(5)
+        expect(champ.fetch_external_data_exceptions.size).to eq(3)
       end
     end
   end


### PR DESCRIPTION
La finalité est la même (on voit la trace dans sentry), mais le job est correctement terminé.

J'en ai profité pour réduire à 3 tentatives max, car tant que tous les essais ne sont pas écoulés on bloque sur "recherche en cours" et le feedback n'arrivait qu'au bout de 6 minutes. On pourrait peut-être envisager dans un second temps de décoreller retry & UI.


## TL;DR
Pour une raison inconnue pour le moment, (et par ailleurs indépendante de reliable-fetch), ces jobs reviennent dans "en cours" à vie, sans être traité et saturent petit à petit la queue.
En attendant de comprendre l'origine exacte, ce workaround évite le pb.

Détails, expériences et logs 
https://pad.numerique.gouv.fr/g5DPssaZSSCeKx22SZUxJQ?edit