### PR TITLE
Tech: accélère le stalled_declarative_procedure_job

### DIFF
--- a/app/jobs/cron/stalled_declarative_procedures_job.rb
+++ b/app/jobs/cron/stalled_declarative_procedures_job.rb
@@ -6,7 +6,7 @@ class Cron::StalledDeclarativeProceduresJob < Cron::CronJob
   def perform
     Dossier.state_en_construction
       .where(declarative_triggered_at: nil)
-      .joins(:procedure).merge(Procedure.declarative)
+      .joins(:procedure).merge(Procedure.declarative.publiees_ou_closes)
       .find_each { ProcessStalledDeclarativeDossierJob.perform_later(it) }
   end
 end

--- a/app/jobs/cron/stalled_declarative_procedures_job.rb
+++ b/app/jobs/cron/stalled_declarative_procedures_job.rb
@@ -4,9 +4,12 @@ class Cron::StalledDeclarativeProceduresJob < Cron::CronJob
   self.schedule_expression = "every 10 minutes"
 
   def perform
+    recent_or_open = Procedure.where(aasm_state: [:publiee, :depubliee])
+      .or(Procedure.where(closed_at: 24.hours.ago..))
+
     Dossier.state_en_construction
       .where(declarative_triggered_at: nil)
-      .joins(:procedure).merge(Procedure.declarative.publiees_ou_closes)
+      .joins(:procedure).merge(Procedure.declarative.merge(recent_or_open))
       .find_each { ProcessStalledDeclarativeDossierJob.perform_later(it) }
   end
 end

--- a/app/jobs/cron/stalled_declarative_procedures_job.rb
+++ b/app/jobs/cron/stalled_declarative_procedures_job.rb
@@ -4,10 +4,9 @@ class Cron::StalledDeclarativeProceduresJob < Cron::CronJob
   self.schedule_expression = "every 10 minutes"
 
   def perform
-    Procedure.declarative.find_each do |procedure|
-      procedure.dossiers.state_en_construction.where(declarative_triggered_at: nil).find_each do |dossier|
-        ProcessStalledDeclarativeDossierJob.perform_later(dossier)
-      end
-    end
+    Dossier.state_en_construction
+      .where(declarative_triggered_at: nil)
+      .joins(:procedure).merge(Procedure.declarative)
+      .find_each { ProcessStalledDeclarativeDossierJob.perform_later(it) }
   end
 end

--- a/db/migrate/20260421120000_add_partial_index_for_stalled_declarative_dossiers.rb
+++ b/db/migrate/20260421120000_add_partial_index_for_stalled_declarative_dossiers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddPartialIndexForStalledDeclarativeDossiers < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :dossiers,
+              :revision_id,
+              name: 'index_dossiers_stalled_declarative',
+              where: "state = 'en_construction' AND declarative_triggered_at IS NULL",
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_07_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_21_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -564,6 +564,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_07_120000) do
     t.index ["parent_dossier_id"], name: "index_dossiers_on_parent_dossier_id"
     t.index ["prefill_token"], name: "index_dossiers_on_prefill_token", unique: true
     t.index ["revision_id"], name: "index_dossiers_on_revision_id"
+    t.index ["revision_id"], name: "index_dossiers_stalled_declarative", where: "(((state)::text = 'en_construction'::text) AND (declarative_triggered_at IS NULL))"
     t.index ["state"], name: "index_dossiers_on_state"
     t.index ["user_id"], name: "index_dossiers_on_user_id"
   end

--- a/spec/jobs/cron/stalled_declarative_procedures_job_spec.rb
+++ b/spec/jobs/cron/stalled_declarative_procedures_job_spec.rb
@@ -45,5 +45,14 @@ RSpec.describe Cron::StalledDeclarativeProceduresJob, type: :job do
         expect(ProcessStalledDeclarativeDossierJob).not_to have_been_enqueued
       }
     end
+
+    context "declarative procedure in brouillon" do
+      let(:procedure) { create(:procedure, :for_individual, :with_instructeur, declarative_with_state: Dossier.states.fetch(:en_instruction)) }
+
+      it {
+        perform_job
+        expect(ProcessStalledDeclarativeDossierJob).not_to have_been_enqueued.with(en_construction)
+      }
+    end
   end
 end

--- a/spec/jobs/cron/stalled_declarative_procedures_job_spec.rb
+++ b/spec/jobs/cron/stalled_declarative_procedures_job_spec.rb
@@ -54,5 +54,32 @@ RSpec.describe Cron::StalledDeclarativeProceduresJob, type: :job do
         expect(ProcessStalledDeclarativeDossierJob).not_to have_been_enqueued.with(en_construction)
       }
     end
+
+    context "declarative procedure recently closed" do
+      let(:procedure) { create(:procedure, :closed, :for_individual, :with_instructeur, declarative_with_state: Dossier.states.fetch(:en_instruction), closed_at: 1.hour.ago) }
+
+      it {
+        perform_job
+        expect(ProcessStalledDeclarativeDossierJob).to have_been_enqueued.with(en_construction)
+      }
+    end
+
+    context "declarative procedure closed more than 24h ago" do
+      let(:procedure) { create(:procedure, :closed, :for_individual, :with_instructeur, declarative_with_state: Dossier.states.fetch(:en_instruction), closed_at: 2.days.ago) }
+
+      it {
+        perform_job
+        expect(ProcessStalledDeclarativeDossierJob).not_to have_been_enqueued.with(en_construction)
+      }
+    end
+
+    context "declarative procedure depubliee" do
+      let(:procedure) { create(:procedure, :unpublished, :for_individual, :with_instructeur, declarative_with_state: Dossier.states.fetch(:en_instruction)) }
+
+      it {
+        perform_job
+        expect(ProcessStalledDeclarativeDossierJob).to have_been_enqueued.with(en_construction)
+      }
+    end
   end
 end


### PR DESCRIPTION
on réduit le scope de recherche et surtout on rajoute un index partiel, ca devrait passer de qq seconds à des ms sans avoir d'impact sur les écritures.