### PR TITLE
Tech: simplification de la création des avis

### DIFF
--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -22,10 +22,10 @@ module AvisCreationConcern
     )
 
     if sent_emails.any?
-      if sent_emails.count < 5
-        flash[:notice] = "Une demande d’avis a été envoyée à #{sent_emails.join(', ')}"
+      flash[:notice] = if sent_emails.count < 5
+        t('avis_creation_concern.avis_sent.with_emails', emails: sent_emails.join(', '))
       else
-        flash[:notice] = "Une demande d’avis a été envoyée à #{sent_emails.count} destinataires"
+        t('avis_creation_concern.avis_sent.with_count', count: sent_emails.count)
       end
     end
 

--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -17,7 +17,8 @@ module AvisCreationConcern
       claimant:,
       batch: false,
       avis:,
-      avis_source:
+      avis_source:,
+      emails:
     )
 
     flash[:notice] = sent_emails_notice(sent_emails) if sent_emails.any?

--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -20,26 +20,33 @@ module AvisCreationConcern
       avis_source:
     )
 
-    if sent_emails.any?
-      flash[:notice] = if sent_emails.count < 5
-        t('avis_creation_concern.avis_sent.with_emails', emails: sent_emails.join(', '))
-      else
-        t('avis_creation_concern.avis_sent.with_count', count: sent_emails.count)
-      end
-    end
+    flash[:notice] = sent_emails_notice(sent_emails) if sent_emails.any?
 
     if failed_emails.any?
-      flash.now[:alert] = failed_emails.flat_map do |failed|
-        if failed[:email].blank?
-          failed[:messages]
-        else
-          "#{failed[:email]} : #{failed[:messages].join(', ')}"
-        end
-      end.join(' | ')
-
+      flash.now[:alert] = failed_emails_alert(failed_emails)
       render error_template, status: :unprocessable_content
     else
       redirect_to success_path
     end
+  end
+
+  private
+
+  def sent_emails_notice(sent_emails)
+    if sent_emails.count < 5
+      t('avis_creation_concern.avis_sent.with_emails', emails: sent_emails.join(', '))
+    else
+      t('avis_creation_concern.avis_sent.with_count', count: sent_emails.count)
+    end
+  end
+
+  def failed_emails_alert(failed_emails)
+    failed_emails.flat_map do |failed|
+      if failed[:email].blank?
+        failed[:messages]
+      else
+        "#{failed[:email]} : #{failed[:messages].join(', ')}"
+      end
+    end.join(' | ')
   end
 end

--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -13,7 +13,7 @@ module AvisCreationConcern
       return
     end
 
-    result = CreateAvisService.call(
+    sent_emails, failed_emails = CreateAvisService.call(
       dossier: avis.dossier,
       claimant:,
       batch: false,
@@ -21,16 +21,16 @@ module AvisCreationConcern
       avis_source:
     )
 
-    if result.sent_emails.any?
-      if result.sent_emails.count < 5
-        flash[:notice] = "Une demande d’avis a été envoyée à #{result.sent_emails.join(', ')}"
+    if sent_emails.any?
+      if sent_emails.count < 5
+        flash[:notice] = "Une demande d’avis a été envoyée à #{sent_emails.join(', ')}"
       else
-        flash[:notice] = "Une demande d’avis a été envoyée à #{result.sent_emails.count} destinataires"
+        flash[:notice] = "Une demande d’avis a été envoyée à #{sent_emails.count} destinataires"
       end
     end
 
-    if result.failed_emails.any?
-      flash.now[:alert] = result.failed_emails.flat_map do |failed|
+    if failed_emails.any?
+      flash.now[:alert] = failed_emails.flat_map do |failed|
         if failed[:email].blank?
           failed[:messages]
         else

--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -3,7 +3,7 @@
 module AvisCreationConcern
   extend ActiveSupport::Concern
 
-  def handle_create_avis(dossier:, claimant:, avis:, success_path:, error_template:, avis_source: nil)
+  def handle_create_avis(claimant:, avis:, success_path:, error_template:, avis_source: nil)
     emails = Array(avis.emails).map(&:strip).map(&:downcase).compact_blank
 
     if emails.empty?
@@ -14,7 +14,7 @@ module AvisCreationConcern
     end
 
     result = CreateAvisService.call(
-      dossier:,
+      dossier: avis.dossier,
       claimant:,
       batch: false,
       avis:,

--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -14,7 +14,6 @@ module AvisCreationConcern
     end
 
     sent_emails, failed_emails = CreateAvisService.call(
-      dossier: avis.dossier,
       claimant:,
       batch: false,
       avis:,

--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -3,11 +3,10 @@
 module AvisCreationConcern
   extend ActiveSupport::Concern
 
-  def handle_create_avis(dossier:, user:, params:, success_path:, error_template:, avis_source: nil)
-    emails = Array(params[:emails]).map(&:strip).map(&:downcase).compact_blank
+  def handle_create_avis(dossier:, user:, avis:, success_path:, error_template:, avis_source: nil)
+    emails = Array(avis.emails).map(&:strip).map(&:downcase).compact_blank
 
     if emails.empty?
-      @new_avis = Avis.new(params)
       email_label = User.human_attribute_name(:email)
       flash.now[:alert] = format(I18n.t('errors.format'), attribute: email_label, message: I18n.t('errors.messages.blank'))
       render error_template, status: :unprocessable_content
@@ -15,11 +14,11 @@ module AvisCreationConcern
     end
 
     result = CreateAvisService.call(
-      dossier: dossier,
       instructeur_or_expert: user,
+      dossier:,
       batch: false,
-      params: params,
-      avis_source: avis_source
+      avis:,
+      avis_source:
     )
 
     if result.sent_emails.any?
@@ -31,8 +30,6 @@ module AvisCreationConcern
     end
 
     if result.failed_emails.any?
-      @new_avis = result.avis
-
       flash.now[:alert] = result.failed_emails.flat_map do |failed|
         if failed[:email].blank?
           failed[:messages]

--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -4,6 +4,16 @@ module AvisCreationConcern
   extend ActiveSupport::Concern
 
   def handle_create_avis(dossier:, user:, params:, success_path:, error_template:, avis_source: nil)
+    emails = Array(params[:emails]).map(&:strip).map(&:downcase).compact_blank
+
+    if emails.empty?
+      @new_avis = Avis.new(params)
+      email_label = User.human_attribute_name(:email)
+      flash.now[:alert] = format(I18n.t('errors.format'), attribute: email_label, message: I18n.t('errors.messages.blank'))
+      render error_template, status: :unprocessable_content
+      return
+    end
+
     result = CreateAvisService.call(
       dossier: dossier,
       instructeur_or_expert: user,

--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -3,7 +3,7 @@
 module AvisCreationConcern
   extend ActiveSupport::Concern
 
-  def handle_create_avis(dossier:, user:, avis:, success_path:, error_template:, avis_source: nil)
+  def handle_create_avis(dossier:, claimant:, avis:, success_path:, error_template:, avis_source: nil)
     emails = Array(avis.emails).map(&:strip).map(&:downcase).compact_blank
 
     if emails.empty?
@@ -14,8 +14,8 @@ module AvisCreationConcern
     end
 
     result = CreateAvisService.call(
-      instructeur_or_expert: user,
       dossier:,
+      claimant:,
       batch: false,
       avis:,
       avis_source:

--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -3,22 +3,15 @@
 module AvisCreationConcern
   extend ActiveSupport::Concern
 
-  def handle_create_avis(claimant:, avis:, success_path:, error_template:, avis_source: nil)
-    emails = Array(avis.emails).map(&:strip).map(&:downcase).compact_blank
-
-    if emails.empty?
-      email_label = User.human_attribute_name(:email)
-      flash.now[:alert] = format(I18n.t('errors.format'), attribute: email_label, message: I18n.t('errors.messages.blank'))
-      render error_template, status: :unprocessable_content
-      return
-    end
+  def handle_create_avis(claimant:, dossier:, success_path:, error_template:, avis_source: nil)
+    return render error_template, status: :unprocessable_content if handle_empty_emails
 
     sent_emails, failed_emails = CreateAvisService.call(
       claimant:,
       batch: false,
-      avis:,
+      avis: Avis.new(avis_params.merge(dossier:)),
       avis_source:,
-      emails:
+      emails: avis_emails
     )
 
     flash[:notice] = sent_emails_notice(sent_emails) if sent_emails.any?
@@ -32,6 +25,28 @@ module AvisCreationConcern
   end
 
   private
+
+  def handle_empty_emails
+    if avis_emails.empty?
+      email_label = User.human_attribute_name(:email)
+      flash.now[:alert] = format(I18n.t('errors.format'), attribute: email_label, message: I18n.t('errors.messages.blank'))
+      true
+    end
+  end
+
+  def avis_params
+    params.require(:avis).permit(
+      :introduction_file,
+      :introduction,
+      :confidentiel,
+      :invite_linked_dossiers,
+      :question_label
+    )
+  end
+
+  def avis_emails
+    Array(params[:avis][:emails]).map(&:strip).map(&:downcase).compact_blank
+  end
 
   def sent_emails_notice(sent_emails)
     if sent_emails.count < 5

--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -59,12 +59,6 @@ module AvisCreationConcern
   end
 
   def failed_emails_alert(failed_emails)
-    failed_emails.flat_map do |failed|
-      if failed[:email].blank?
-        failed[:messages]
-      else
-        "#{failed[:email]} : #{failed[:messages].join(', ')}"
-      end
-    end.join(' | ')
+    failed_emails.map { "#{it[:email]} : #{it[:messages].join(', ')}" }.join(' | ')
   end
 end

--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -20,14 +20,14 @@ module AvisCreationConcern
       end
     end
 
-    if result.failed_avis.any?
+    if result.failed_emails.any?
       @new_avis = result.avis
 
-      flash.now[:alert] = result.failed_avis.flat_map do |failed_avis|
-        if failed_avis.email.blank?
-          failed_avis.errors.full_messages_for(:email)
+      flash.now[:alert] = result.failed_emails.flat_map do |failed|
+        if failed[:email].blank?
+          failed[:messages]
         else
-          "#{failed_avis.email} : #{failed_avis.errors.full_messages_for(:email).join(', ')}"
+          "#{failed[:email]} : #{failed[:messages].join(', ')}"
         end
       end.join(' | ')
 

--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -14,12 +14,14 @@ module AvisCreationConcern
       emails: avis_emails
     )
 
-    flash[:notice] = sent_emails_notice(sent_emails) if sent_emails.any?
-
     if failed_emails.any?
-      flash.now[:alert] = failed_emails_alert(failed_emails)
+      flash.now[:notice] = sent_emails_notice(sent_emails) if sent_emails.any?
+      flash.now[:alert] = failed_emails_alert(failed_emails) if failed_emails.any?
+
       render error_template, status: :unprocessable_content
     else
+      flash[:notice] = sent_emails_notice(sent_emails) if sent_emails.any?
+
       redirect_to success_path
     end
   end

--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -94,7 +94,6 @@ module Experts
       new_avis = Avis.new(avis_create_params.merge(dossier: @dossier))
 
       handle_create_avis(
-        dossier:,
         claimant: current_expert,
         avis: new_avis,
         success_path: instruction_expert_avis_path(@procedure, @avis),

--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -91,11 +91,10 @@ module Experts
     def create_avis
       # before_action set_avis_and_dossier
       @procedure = @avis.procedure
-      new_avis = Avis.new(avis_create_params.merge(dossier: @dossier))
 
       handle_create_avis(
         claimant: current_expert,
-        avis: new_avis,
+        dossier: @dossier,
         success_path: instruction_expert_avis_path(@procedure, @avis),
         error_template: :instruction,
         avis_source: @avis
@@ -281,17 +280,6 @@ module Experts
 
     def avis_answer_params
       params.require(:avis).permit(:answer, :piece_justificative_file, :question_answer)
-    end
-
-    def avis_create_params
-      params.require(:avis).permit(
-        :introduction_file,
-        :introduction,
-        :confidentiel,
-        :invite_linked_dossiers,
-        :question_label,
-        emails: []
-      )
     end
 
     def commentaire_params

--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -91,12 +91,12 @@ module Experts
     def create_avis
       # before_action set_avis_and_dossier
       @procedure = @avis.procedure
-      @new_avis = Avis.new
+      new_avis = Avis.new(avis_create_params.merge(dossier: @dossier))
 
       handle_create_avis(
-        dossier: @dossier,
+        dossier:,
         user: current_expert,
-        params: avis_create_params,
+        avis: new_avis,
         success_path: instruction_expert_avis_path(@procedure, @avis),
         error_template: :instruction,
         avis_source: @avis

--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -95,7 +95,7 @@ module Experts
 
       handle_create_avis(
         dossier:,
-        user: current_expert,
+        claimant: current_expert,
         avis: new_avis,
         success_path: instruction_expert_avis_path(@procedure, @avis),
         error_template: :instruction,

--- a/app/controllers/instructeurs/batch_operations_controller.rb
+++ b/app/controllers/instructeurs/batch_operations_controller.rb
@@ -18,18 +18,21 @@ module Instructeurs
       invalid_emails = emails.filter { |email| email.present? && !(email =~ email_regex) }
 
       avis = Avis.new(avis_create_params.except(:emails))
-      batch = nil
+      email_label = User.human_attribute_name(:email)
 
-      if emails.empty? || invalid_emails.any?
-        avis.errors.add(:email, :blank) if emails.empty?
-        invalid_emails.each { |email| avis.errors.add(:email, "est invalide : #{email}") }
-      else
-        batch = BatchOperation.safe_create!(batch_operation_avis_params)
+      if emails.empty?
+        avis.errors.add(:base, format(I18n.t('errors.format'), attribute: email_label, message: I18n.t('errors.messages.blank')))
       end
+
+      invalid_emails.each do |email|
+        avis.errors.add(:base, format(I18n.t('errors.format'), attribute: email_label, message: "est invalide : #{email}"))
+      end
+
+      batch = avis.errors.empty? ? BatchOperation.safe_create!(batch_operation_avis_params) : nil
 
       respond_to do |format|
         format.turbo_stream do
-          if batch.blank? || avis.errors.any?
+          if batch.nil?
             @ids = Array(params.dig(:batch_operation, :dossier_ids)).flat_map do |value|
               value.is_a?(String) ? value.split(',') : value
             end.compact_blank

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -356,12 +356,12 @@ module Instructeurs
       @dossier = dossier
       @procedure = dossier.procedure
 
-      @new_avis = Avis.new(dossier: @dossier) # <- utilisé si le form échoue
+      avis = Avis.new(avis_create_params.merge(dossier:))
 
       handle_create_avis(
-        dossier: @dossier,
+        dossier:,
         user: current_instructeur,
-        params: avis_create_params,
+        avis:,
         success_path: avis_instructeur_dossier_path(@procedure, @dossier, statut: statut),
         error_template: :avis_new
       )

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -360,7 +360,7 @@ module Instructeurs
 
       handle_create_avis(
         dossier:,
-        user: current_instructeur,
+        claimant: current_instructeur,
         avis:,
         success_path: avis_instructeur_dossier_path(@procedure, @dossier, statut: statut),
         error_template: :avis_new

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -359,7 +359,6 @@ module Instructeurs
       avis = Avis.new(avis_create_params.merge(dossier:))
 
       handle_create_avis(
-        dossier:,
         claimant: current_instructeur,
         avis:,
         success_path: avis_instructeur_dossier_path(@procedure, @dossier, statut: statut),

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -356,11 +356,9 @@ module Instructeurs
       @dossier = dossier
       @procedure = dossier.procedure
 
-      avis = Avis.new(avis_create_params.merge(dossier:))
-
       handle_create_avis(
         claimant: current_instructeur,
-        avis:,
+        dossier:,
         success_path: avis_instructeur_dossier_path(@procedure, @dossier, statut: statut),
         error_template: :avis_new
       )
@@ -497,17 +495,6 @@ module Instructeurs
       else
         flash.notice = t('instructeurs.dossiers.message_sent')
       end
-    end
-
-    def avis_create_params
-      params.require(:avis).permit(
-        :introduction_file,
-        :introduction,
-        :confidentiel,
-        :invite_linked_dossiers,
-        :question_label,
-        emails: []
-      )
     end
 
     def navigate_through_dossiers_list

--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -42,9 +42,6 @@ class Avis < ApplicationRecord
   scope :not_revoked, -> { where(revoked_at: nil) }
   scope :not_termine, -> { where.not(dossiers: { state: Dossier::TERMINE }) }
 
-  # The form allows subtmitting avis requests to several emails at once,
-  # hence this virtual attribute.
-  attr_accessor :emails
   attr_accessor :invite_linked_dossiers
 
   def email_to_display

--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avis < ApplicationRecord
-  include EmailSanitizableConcern
+  self.ignored_columns += [:email]
 
   belongs_to :dossier, inverse_of: :avis, touch: true, optional: false
   belongs_to :experts_procedure, optional: false
@@ -23,11 +23,9 @@ class Avis < ApplicationRecord
     content_type: AUTHORIZED_CONTENT_TYPES,
     size: { less_than: FILE_MAX_SIZE }
 
-  validates :email, strict_email: true, allow_nil: true
   validates :question_answer, inclusion: { in: [true, false] }, on: :update, if: -> { question_label.present? }
   validates :piece_justificative_file, size: { less_than: FILE_MAX_SIZE }
   validates :introduction_file, size: { less_than: FILE_MAX_SIZE }
-  before_validation -> { sanitize_email(:email) }
   before_validation -> { strip_attribute(:question_label) }
 
   normalizes :answer, with: NORMALIZES_NON_PRINTABLE_PROC

--- a/app/models/batch_operation.rb
+++ b/app/models/batch_operation.rb
@@ -127,7 +127,7 @@ class BatchOperation < ApplicationRecord
       )
       CreateAvisService.call(
         dossier:,
-        instructeur_or_expert: instructeur,
+        claimant: instructeur,
         batch: true,
         avis:
       )

--- a/app/models/batch_operation.rb
+++ b/app/models/batch_operation.rb
@@ -126,7 +126,6 @@ class BatchOperation < ApplicationRecord
         invite_linked_dossiers: payload['invite_linked_dossiers']
       )
       CreateAvisService.call(
-        dossier:,
         claimant: instructeur,
         batch: true,
         avis:

--- a/app/models/batch_operation.rb
+++ b/app/models/batch_operation.rb
@@ -122,13 +122,13 @@ class BatchOperation < ApplicationRecord
         introduction_file:,
         confidentiel:,
         question_label:,
-        emails: emails || [],
         invite_linked_dossiers: payload['invite_linked_dossiers']
       )
       CreateAvisService.call(
         claimant: instructeur,
         batch: true,
-        avis:
+        avis:,
+        emails: emails || []
       )
     when BatchOperation.operations.fetch(:create_commentaire)
       commentaire = CommentaireService.create(instructeur, dossier, { email: dossier.user.email, body:, piece_jointe: })

--- a/app/models/batch_operation.rb
+++ b/app/models/batch_operation.rb
@@ -116,18 +116,20 @@ class BatchOperation < ApplicationRecord
     when BatchOperation.operations.fetch(:restaurer)
       dossier.restore(instructeur)
     when BatchOperation.operations.fetch(:create_avis)
+      avis = Avis.new(
+        dossier:,
+        introduction:,
+        introduction_file:,
+        confidentiel:,
+        question_label:,
+        emails: emails || [],
+        invite_linked_dossiers: payload['invite_linked_dossiers']
+      )
       CreateAvisService.call(
-        dossier: dossier,
+        dossier:,
         instructeur_or_expert: instructeur,
         batch: true,
-        params: {
-          emails: emails || [],
-          introduction: introduction,
-          introduction_file: introduction_file,
-          confidentiel: confidentiel,
-          invite_linked_dossiers: payload['invite_linked_dossiers'],
-          question_label: question_label,
-        }.with_indifferent_access
+        avis:
       )
     when BatchOperation.operations.fetch(:create_commentaire)
       commentaire = CommentaireService.create(instructeur, dossier, { email: dossier.user.email, body:, piece_jointe: })

--- a/app/services/create_avis_service.rb
+++ b/app/services/create_avis_service.rb
@@ -8,27 +8,27 @@ class CreateAvisService
       introduction_file_change = avis.attachment_changes["introduction_file"]
       introduction_file = introduction_file_change.attachable if introduction_file_change.is_a?(ActiveStorage::Attached::Changes::CreateOne)
 
-      allowed_dossiers = [dossier]
-
-      if avis.invite_linked_dossiers.present?
-        allowed_dossiers += dossier.linked_dossiers_for(claimant)
-      end
-
       if claimant.is_a?(Instructeur) &&
           !claimant.follows.exists?(dossier:)
         claimant.follow(dossier)
       end
 
+      # create experts
       users, invalids = emails.map { User.create_or_promote_to_expert(it, SecureRandom.hex) }.partition(&:valid?)
       failed_emails = invalids.map { { email: it.email, messages: it.errors.full_messages } }
 
+      # list all related dossiers
+      dossiers = avis.invite_linked_dossiers.present? ? [dossier, *dossier.linked_dossiers_for(claimant)] : [dossier]
+
+      # create expert <-> procedure
       experts = users.map(&:expert)
-      experts_procedures_h = allowed_dossiers.map(&:procedure).uniq
+      experts_procedures_h = dossiers.map(&:procedure).uniq
         .flat_map { |procedure| experts.map { |expert| [[expert, procedure], safely_create_experts_procedure(expert, procedure)] } }
         .to_h
 
-      avis_params = experts.flat_map do |expert|
-        allowed_dossiers.map do |dossier|
+      # create avis on all related dossiers
+      persisted, failed = experts.flat_map do |expert|
+        dossiers.map do |dossier|
           {
             introduction: avis.introduction,
             introduction_file:,
@@ -40,13 +40,12 @@ class CreateAvisService
           }
         end
       end
-
-      create_results = Avis.create(avis_params)
-
-      persisted, failed = create_results.partition(&:persisted?)
+        .map { |params| Avis.create(params) }
+        .partition(&:persisted?)
 
       failed_emails += failed.map { |avis| { email: avis.expert.email, messages: avis.errors.full_messages } }
 
+      # notifications
       if persisted.any?
         dossier.touch(:last_avis_updated_at)
 
@@ -61,6 +60,7 @@ class CreateAvisService
 
       dossier.avis.reload
 
+      # log operation
       persisted.each { |avis| avis.dossier.demander_un_avis!(avis) }
 
       sent_emails = persisted.filter { it.dossier == dossier }.map do |avis|

--- a/app/services/create_avis_service.rb
+++ b/app/services/create_avis_service.rb
@@ -1,27 +1,28 @@
 # frozen_string_literal: true
 
 class CreateAvisService
-  Result = Data.define(:avis, :sent_emails, :failed_emails)
+  Result = Data.define(:sent_emails, :failed_emails)
 
-  def self.call(dossier:, instructeur_or_expert:, batch:, params:, avis_source: nil)
-    new(dossier, instructeur_or_expert, batch, params, avis_source).call
+  def self.call(dossier:, instructeur_or_expert:, batch:, avis:, avis_source: nil)
+    new(dossier, instructeur_or_expert, batch, avis, avis_source).call
   end
 
-  def initialize(dossier, instructeur_or_expert, batch, params, avis_source = nil)
+  def initialize(dossier, instructeur_or_expert, batch, avis, avis_source = nil)
     @dossier = dossier
     @instructeur_or_expert = instructeur_or_expert
     @batch = batch
-    @params = params
+    @avis = avis
     @avis_source = avis_source
   end
 
   def call
-    confidentiel = @avis_source&.confidentiel || @params[:confidentiel] || false
+    confidentiel = @avis_source&.confidentiel || @avis.confidentiel || false
+    introduction_file = @avis.attachment_changes["introduction_file"]&.attachable
 
-    emails = Array(@params[:emails]).map(&:strip).map(&:downcase).uniq.compact_blank
+    emails = Array(@avis.emails).map(&:strip).map(&:downcase).uniq.compact_blank
     allowed_dossiers = [@dossier]
 
-    if @params[:invite_linked_dossiers].present?
+    if @avis.invite_linked_dossiers.present?
       allowed_dossiers += @dossier.linked_dossiers_for(@instructeur_or_expert)
     end
 
@@ -41,13 +42,13 @@ class CreateAvisService
     avis_params = experts.flat_map do |expert|
       allowed_dossiers.map do |dossier|
         {
-          introduction: @params[:introduction],
-          introduction_file: @params[:introduction_file],
+          introduction: @avis.introduction,
+          introduction_file: introduction_file,
           claimant: @instructeur_or_expert,
           dossier: dossier,
           confidentiel: confidentiel,
           experts_procedure: experts_procedures_h[[expert, dossier.procedure]],
-          question_label: @params[:question_label],
+          question_label: @avis.question_label,
         }
       end
     end
@@ -81,8 +82,6 @@ class CreateAvisService
       avis.expert.email
     end
 
-    avis_result = persisted.first || failed.first || Avis.new(@params)
-
-    Result.new(avis_result, sent_emails.uniq, failed_emails)
+    Result.new(sent_emails.uniq, failed_emails)
   end
 end

--- a/app/services/create_avis_service.rb
+++ b/app/services/create_avis_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CreateAvisService
-  Result = Data.define(:avis, :sent_emails, :failed_avis)
+  Result = Data.define(:avis, :sent_emails, :failed_emails)
 
   def self.call(dossier:, instructeur_or_expert:, batch:, params:, avis_source: nil)
     new(dossier, instructeur_or_expert, batch, params, avis_source).call
@@ -18,13 +18,13 @@ class CreateAvisService
   def call
     if @params[:emails].blank? || @params[:emails].all?(&:blank?)
       avis = Avis.new(@params)
-      avis.errors.add(:email, :blank)
-      return Result.new(avis, [], [avis])
+      blank_message = format(I18n.t('errors.format'), attribute: User.human_attribute_name(:email), message: I18n.t('errors.messages.blank'))
+      return Result.new(avis, [], [{ email: nil, messages: [blank_message] }])
     end
 
     confidentiel = @avis_source&.confidentiel || @params[:confidentiel] || false
 
-    emails = Array(@params[:emails]).map(&:strip).map(&:downcase).compact_blank
+    emails = Array(@params[:emails]).map(&:strip).map(&:downcase).uniq.compact_blank
     allowed_dossiers = [@dossier]
 
     if @params[:invite_linked_dossiers].present?
@@ -36,29 +36,33 @@ class CreateAvisService
       @instructeur_or_expert.follow(@dossier)
     end
 
-    sent_emails = []
+    users, invalids = emails.map { User.create_or_promote_to_expert(it, SecureRandom.hex) }.partition(&:valid?)
+    failed_emails = invalids.map { { email: it.email, messages: it.errors.full_messages } }
 
-    create_results = Avis.create(
-      emails.flat_map do |email|
-        user = User.create_or_promote_to_expert(email, SecureRandom.hex)
-        allowed_dossiers.map do |dossier|
-          experts_procedure = user.valid? ? ExpertsProcedure.find_or_create_by(procedure: dossier.procedure, expert: user.expert) : nil
+    experts = users.map(&:expert)
+    experts_procedures_h = allowed_dossiers.map(&:procedure).uniq
+      .flat_map { |procedure| experts.map { |expert| [[expert, procedure], ExpertsProcedure.find_or_create_by(procedure: dossier.procedure, expert: user.expert)] } }
+      .to_h
 
-          {
-            email: email,
-            introduction: @params[:introduction],
-            introduction_file: @params[:introduction_file],
-            claimant: @instructeur_or_expert,
-            dossier: dossier,
-            confidentiel: confidentiel,
-            experts_procedure: experts_procedure,
-            question_label: @params[:question_label],
-          }
-        end
+    avis_params = experts.flat_map do |expert|
+      allowed_dossiers.map do |dossier|
+        {
+          introduction: @params[:introduction],
+          introduction_file: @params[:introduction_file],
+          claimant: @instructeur_or_expert,
+          dossier: dossier,
+          confidentiel: confidentiel,
+          experts_procedure: experts_procedures_h[[expert, dossier.procedure]],
+          question_label: @params[:question_label],
+        }
       end
-    )
+    end
+
+    create_results = Avis.create(avis_params)
 
     persisted, failed = create_results.partition(&:persisted?)
+
+    failed_emails += failed.map { |avis| { email: avis.expert.email, messages: avis.errors.full_messages } }
 
     if persisted.any?
       @dossier.touch(:last_avis_updated_at)
@@ -74,19 +78,17 @@ class CreateAvisService
 
     @dossier.avis.reload
 
-    persisted.each do |avis|
-      avis.dossier.demander_un_avis!(avis)
-      if avis.dossier == @dossier
-        if avis.experts_procedure.notify_on_new_avis? && !@batch
-          avis.expert.user.invite_expert_and_send_avis!(avis)
-        end
-        sent_emails << avis.expert.email
-        avis.update_column(:email, nil)
+    persisted.each { |avis| avis.dossier.demander_un_avis!(avis) }
+
+    sent_emails = persisted.filter { it.dossier == @dossier }.map do |avis|
+      if avis.experts_procedure.notify_on_new_avis? && !@batch
+        avis.expert.user.invite_expert_and_send_avis!(avis)
       end
+      avis.expert.email
     end
 
     avis_result = persisted.first || failed.first || Avis.new(@params)
 
-    Result.new(avis_result, sent_emails.uniq, failed)
+    Result.new(avis_result, sent_emails.uniq, failed_emails)
   end
 end

--- a/app/services/create_avis_service.rb
+++ b/app/services/create_avis_service.rb
@@ -16,12 +16,6 @@ class CreateAvisService
   end
 
   def call
-    if @params[:emails].blank? || @params[:emails].all?(&:blank?)
-      avis = Avis.new(@params)
-      blank_message = format(I18n.t('errors.format'), attribute: User.human_attribute_name(:email), message: I18n.t('errors.messages.blank'))
-      return Result.new(avis, [], [{ email: nil, messages: [blank_message] }])
-    end
-
     confidentiel = @avis_source&.confidentiel || @params[:confidentiel] || false
 
     emails = Array(@params[:emails]).map(&:strip).map(&:downcase).uniq.compact_blank

--- a/app/services/create_avis_service.rb
+++ b/app/services/create_avis_service.rb
@@ -13,9 +13,12 @@ class CreateAvisService
         claimant.follow(dossier)
       end
 
+      emails, restricted_emails = filter_restricted_emails(dossier.procedure, emails)
+
       # create experts
       users, invalids = emails.map { User.create_or_promote_to_expert(it, SecureRandom.hex) }.partition(&:valid?)
       failed_emails = invalids.map { { email: it.email, messages: it.errors.full_messages } }
+      failed_emails += restricted_emails.map { { email: it, messages: [I18n.t('create_avis_service.errors.expert_not_allowed')] } }
 
       # list all related dossiers
       dossiers = avis.invite_linked_dossiers.present? ? [dossier, *dossier.linked_dossiers_for(claimant)] : [dossier]
@@ -23,7 +26,7 @@ class CreateAvisService
       # create expert <-> procedure
       experts = users.map(&:expert)
       experts_procedures_h = dossiers.map(&:procedure).uniq
-        .flat_map { |procedure| experts.map { |expert| [[expert, procedure], safely_create_experts_procedure(expert, procedure)] } }
+        .flat_map { |procedure| experts.map { |expert| [[expert, procedure], ExpertsProcedure.find_or_create_by(procedure:, expert:)] } }
         .to_h
 
       # create avis on all related dossiers
@@ -71,6 +74,15 @@ class CreateAvisService
       end
 
       [sent_emails.uniq, failed_emails]
+    end
+
+    private
+
+    def filter_restricted_emails(procedure, emails)
+      return [emails, []] if !procedure.experts_require_administrateur_invitation?
+
+      allowed = Expert.autocomplete_mails(procedure).to_set
+      emails.partition { allowed.include?(it) }
     end
   end
 end

--- a/app/services/create_avis_service.rb
+++ b/app/services/create_avis_service.rb
@@ -3,13 +3,13 @@
 class CreateAvisService
   Result = Data.define(:sent_emails, :failed_emails)
 
-  def self.call(dossier:, instructeur_or_expert:, batch:, avis:, avis_source: nil)
-    new(dossier, instructeur_or_expert, batch, avis, avis_source).call
+  def self.call(dossier:, claimant:, batch:, avis:, avis_source: nil)
+    new(dossier, claimant, batch, avis, avis_source).call
   end
 
-  def initialize(dossier, instructeur_or_expert, batch, avis, avis_source = nil)
+  def initialize(dossier, claimant, batch, avis, avis_source = nil)
     @dossier = dossier
-    @instructeur_or_expert = instructeur_or_expert
+    @claimant = claimant
     @batch = batch
     @avis = avis
     @avis_source = avis_source
@@ -23,12 +23,12 @@ class CreateAvisService
     allowed_dossiers = [@dossier]
 
     if @avis.invite_linked_dossiers.present?
-      allowed_dossiers += @dossier.linked_dossiers_for(@instructeur_or_expert)
+      allowed_dossiers += @dossier.linked_dossiers_for(@claimant)
     end
 
-    if @instructeur_or_expert.is_a?(Instructeur) &&
-       !@instructeur_or_expert.follows.exists?(dossier: @dossier)
-      @instructeur_or_expert.follow(@dossier)
+    if @claimant.is_a?(Instructeur) &&
+       !@claimant.follows.exists?(dossier: @dossier)
+      @claimant.follow(@dossier)
     end
 
     users, invalids = emails.map { User.create_or_promote_to_expert(it, SecureRandom.hex) }.partition(&:valid?)
@@ -44,7 +44,7 @@ class CreateAvisService
         {
           introduction: @avis.introduction,
           introduction_file: introduction_file,
-          claimant: @instructeur_or_expert,
+          claimant: @claimant,
           dossier: dossier,
           confidentiel: confidentiel,
           experts_procedure: experts_procedures_h[[expert, dossier.procedure]],
@@ -62,12 +62,12 @@ class CreateAvisService
     if persisted.any?
       @dossier.touch(:last_avis_updated_at)
 
-      if @instructeur_or_expert.is_a?(Instructeur)
-        follow = @instructeur_or_expert.follows.find_by(dossier: @dossier)
+      if @claimant.is_a?(Instructeur)
+        follow = @claimant.follows.find_by(dossier: @dossier)
         follow&.update_column(:avis_seen_at, Time.current)
 
         DossierNotification.create_notification(@dossier, :attente_avis)
-        @instructeur_or_expert.mark_tab_as_seen(@dossier, :avis)
+        @claimant.mark_tab_as_seen(@dossier, :avis)
       end
     end
 

--- a/app/services/create_avis_service.rb
+++ b/app/services/create_avis_service.rb
@@ -1,86 +1,76 @@
 # frozen_string_literal: true
 
 class CreateAvisService
-  def self.call(claimant:, batch:, avis:, emails:, avis_source: nil)
-    new(claimant, batch, avis, emails, avis_source).call
-  end
+  class << self
+    def call(claimant:, batch:, avis:, emails:, avis_source: nil)
+      dossier = avis.dossier
+      confidentiel = avis_source&.confidentiel || avis.confidentiel || false
+      introduction_file_change = avis.attachment_changes["introduction_file"]
+      introduction_file = introduction_file_change.attachable if introduction_file_change.is_a?(ActiveStorage::Attached::Changes::CreateOne)
 
-  def initialize(claimant, batch, avis, emails, avis_source = nil)
-    @dossier = avis.dossier
-    @claimant = claimant
-    @batch = batch
-    @avis = avis
-    @avis_source = avis_source
-    @emails = emails
-  end
+      allowed_dossiers = [dossier]
 
-  def call
-    confidentiel = @avis_source&.confidentiel || @avis.confidentiel || false
-    introduction_file_change = @avis.attachment_changes["introduction_file"]
-    introduction_file = introduction_file_change.attachable if introduction_file_change.is_a?(ActiveStorage::Attached::Changes::CreateOne)
-
-    allowed_dossiers = [@dossier]
-
-    if @avis.invite_linked_dossiers.present?
-      allowed_dossiers += @dossier.linked_dossiers_for(@claimant)
-    end
-
-    if @claimant.is_a?(Instructeur) &&
-       !@claimant.follows.exists?(dossier: @dossier)
-      @claimant.follow(@dossier)
-    end
-
-    users, invalids = @emails.map { User.create_or_promote_to_expert(it, SecureRandom.hex) }.partition(&:valid?)
-    failed_emails = invalids.map { { email: it.email, messages: it.errors.full_messages } }
-
-    experts = users.map(&:expert)
-    experts_procedures_h = allowed_dossiers.map(&:procedure).uniq
-      .flat_map { |procedure| experts.map { |expert| [[expert, procedure], ExpertsProcedure.find_or_create_by(procedure: dossier.procedure, expert: user.expert)] } }
-      .to_h
-
-    avis_params = experts.flat_map do |expert|
-      allowed_dossiers.map do |dossier|
-        {
-          introduction: @avis.introduction,
-          introduction_file:,
-          claimant: @claimant,
-          dossier:,
-          confidentiel:,
-          experts_procedure: experts_procedures_h[[expert, dossier.procedure]],
-          question_label: @avis.question_label,
-        }
+      if avis.invite_linked_dossiers.present?
+        allowed_dossiers += dossier.linked_dossiers_for(claimant)
       end
-    end
 
-    create_results = Avis.create(avis_params)
-
-    persisted, failed = create_results.partition(&:persisted?)
-
-    failed_emails += failed.map { |avis| { email: avis.expert.email, messages: avis.errors.full_messages } }
-
-    if persisted.any?
-      @dossier.touch(:last_avis_updated_at)
-
-      if @claimant.is_a?(Instructeur)
-        follow = @claimant.follows.find_by(dossier: @dossier)
-        follow&.update_column(:avis_seen_at, Time.current)
-
-        DossierNotification.create_notification(@dossier, :attente_avis)
-        @claimant.mark_tab_as_seen(@dossier, :avis)
+      if claimant.is_a?(Instructeur) &&
+          !claimant.follows.exists?(dossier:)
+        claimant.follow(dossier)
       end
-    end
 
-    @dossier.avis.reload
+      users, invalids = emails.map { User.create_or_promote_to_expert(it, SecureRandom.hex) }.partition(&:valid?)
+      failed_emails = invalids.map { { email: it.email, messages: it.errors.full_messages } }
 
-    persisted.each { |avis| avis.dossier.demander_un_avis!(avis) }
+      experts = users.map(&:expert)
+      experts_procedures_h = allowed_dossiers.map(&:procedure).uniq
+        .flat_map { |procedure| experts.map { |expert| [[expert, procedure], safely_create_experts_procedure(expert, procedure)] } }
+        .to_h
 
-    sent_emails = persisted.filter { it.dossier == @dossier }.map do |avis|
-      if avis.experts_procedure.notify_on_new_avis? && !@batch
-        avis.expert.user.invite_expert_and_send_avis!(avis)
+      avis_params = experts.flat_map do |expert|
+        allowed_dossiers.map do |dossier|
+          {
+            introduction: avis.introduction,
+            introduction_file:,
+            claimant:,
+            dossier:,
+            confidentiel:,
+            experts_procedure: experts_procedures_h[[expert, dossier.procedure]],
+            question_label: avis.question_label,
+          }
+        end
       end
-      avis.expert.email
-    end
 
-    [sent_emails.uniq, failed_emails]
+      create_results = Avis.create(avis_params)
+
+      persisted, failed = create_results.partition(&:persisted?)
+
+      failed_emails += failed.map { |avis| { email: avis.expert.email, messages: avis.errors.full_messages } }
+
+      if persisted.any?
+        dossier.touch(:last_avis_updated_at)
+
+        if claimant.is_a?(Instructeur)
+          follow = claimant.follows.find_by(dossier:)
+          follow&.update_column(:avis_seen_at, Time.current)
+
+          DossierNotification.create_notification(dossier, :attente_avis)
+          claimant.mark_tab_as_seen(dossier, :avis)
+        end
+      end
+
+      dossier.avis.reload
+
+      persisted.each { |avis| avis.dossier.demander_un_avis!(avis) }
+
+      sent_emails = persisted.filter { it.dossier == dossier }.map do |avis|
+        if avis.experts_procedure.notify_on_new_avis? && !batch
+          avis.expert.user.invite_expert_and_send_avis!(avis)
+        end
+        avis.expert.email
+      end
+
+      [sent_emails.uniq, failed_emails]
+    end
   end
 end

--- a/app/services/create_avis_service.rb
+++ b/app/services/create_avis_service.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class CreateAvisService
-  Result = Data.define(:sent_emails, :failed_emails)
-
   def self.call(dossier:, claimant:, batch:, avis:, avis_source: nil)
     new(dossier, claimant, batch, avis, avis_source).call
   end
@@ -82,6 +80,6 @@ class CreateAvisService
       avis.expert.email
     end
 
-    Result.new(sent_emails.uniq, failed_emails)
+    [sent_emails.uniq, failed_emails]
   end
 end

--- a/app/services/create_avis_service.rb
+++ b/app/services/create_avis_service.rb
@@ -15,7 +15,8 @@ class CreateAvisService
 
   def call
     confidentiel = @avis_source&.confidentiel || @avis.confidentiel || false
-    introduction_file = @avis.attachment_changes["introduction_file"]&.attachable
+    introduction_file_change = @avis.attachment_changes["introduction_file"]
+    introduction_file = introduction_file_change.attachable if introduction_file_change.is_a?(ActiveStorage::Attached::Changes::CreateOne)
 
     emails = Array(@avis.emails).map(&:strip).map(&:downcase).uniq.compact_blank
     allowed_dossiers = [@dossier]
@@ -41,10 +42,10 @@ class CreateAvisService
       allowed_dossiers.map do |dossier|
         {
           introduction: @avis.introduction,
-          introduction_file: introduction_file,
+          introduction_file:,
           claimant: @claimant,
-          dossier: dossier,
-          confidentiel: confidentiel,
+          dossier:,
+          confidentiel:,
           experts_procedure: experts_procedures_h[[expert, dossier.procedure]],
           question_label: @avis.question_label,
         }

--- a/app/services/create_avis_service.rb
+++ b/app/services/create_avis_service.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
 class CreateAvisService
-  def self.call(claimant:, batch:, avis:, avis_source: nil)
-    new(claimant, batch, avis, avis_source).call
+  def self.call(claimant:, batch:, avis:, emails:, avis_source: nil)
+    new(claimant, batch, avis, emails, avis_source).call
   end
 
-  def initialize(claimant, batch, avis, avis_source = nil)
+  def initialize(claimant, batch, avis, emails, avis_source = nil)
     @dossier = avis.dossier
     @claimant = claimant
     @batch = batch
     @avis = avis
     @avis_source = avis_source
+    @emails = emails
   end
 
   def call
@@ -18,7 +19,6 @@ class CreateAvisService
     introduction_file_change = @avis.attachment_changes["introduction_file"]
     introduction_file = introduction_file_change.attachable if introduction_file_change.is_a?(ActiveStorage::Attached::Changes::CreateOne)
 
-    emails = Array(@avis.emails).map(&:strip).map(&:downcase).uniq.compact_blank
     allowed_dossiers = [@dossier]
 
     if @avis.invite_linked_dossiers.present?
@@ -30,7 +30,7 @@ class CreateAvisService
       @claimant.follow(@dossier)
     end
 
-    users, invalids = emails.map { User.create_or_promote_to_expert(it, SecureRandom.hex) }.partition(&:valid?)
+    users, invalids = @emails.map { User.create_or_promote_to_expert(it, SecureRandom.hex) }.partition(&:valid?)
     failed_emails = invalids.map { { email: it.email, messages: it.errors.full_messages } }
 
     experts = users.map(&:expert)

--- a/app/services/create_avis_service.rb
+++ b/app/services/create_avis_service.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class CreateAvisService
-  def self.call(dossier:, claimant:, batch:, avis:, avis_source: nil)
-    new(dossier, claimant, batch, avis, avis_source).call
+  def self.call(claimant:, batch:, avis:, avis_source: nil)
+    new(claimant, batch, avis, avis_source).call
   end
 
-  def initialize(dossier, claimant, batch, avis, avis_source = nil)
-    @dossier = dossier
+  def initialize(claimant, batch, avis, avis_source = nil)
+    @dossier = avis.dossier
     @claimant = claimant
     @batch = batch
     @avis = avis

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -232,7 +232,6 @@
       %p.avis-notice L’invité pourra consulter, donner un avis sur le dossier et contribuer au fil de messagerie, mais il ne pourra le modifier.
 
       = form_for Avis.new, url: '/', html: { class: 'form' } do |f|
-        = f.email_field :email, placeholder: 'Adresse électronique', required: true
         = f.text_area :introduction, rows: 3, value: 'Bonjour, merci de me donner votre avis sur ce dossier.', required: true
         .send-wrapper
           = f.submit 'Demander un avis', class: 'button send'

--- a/config/locales/avis_creation_concern.en.yml
+++ b/config/locales/avis_creation_concern.en.yml
@@ -1,0 +1,5 @@
+en:
+  avis_creation_concern:
+    avis_sent:
+      with_emails: "An avis request has been sent to %{emails}"
+      with_count: "An avis request has been sent to %{count} recipients"

--- a/config/locales/avis_creation_concern.fr.yml
+++ b/config/locales/avis_creation_concern.fr.yml
@@ -1,0 +1,5 @@
+fr:
+  avis_creation_concern:
+    avis_sent:
+      with_emails: "Une demande d’avis a été envoyée à %{emails}"
+      with_count: "Une demande d’avis a été envoyée à %{count} destinataires"

--- a/config/locales/create_avis_service.en.yml
+++ b/config/locales/create_avis_service.en.yml
@@ -1,0 +1,4 @@
+en:
+  create_avis_service:
+    errors:
+      expert_not_allowed: "This expert is not allowed on this procedure. Ask an administrateur to invite them."

--- a/config/locales/create_avis_service.fr.yml
+++ b/config/locales/create_avis_service.fr.yml
@@ -1,0 +1,4 @@
+fr:
+  create_avis_service:
+    errors:
+      expert_not_allowed: "Cet expert n’est pas autorisé sur cette démarche. Demandez à un administrateur de l’y inviter."

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -460,7 +460,7 @@ describe Experts::AvisController, type: :controller do
 
         it do
           expect(response).to render_template :instruction
-          expect(flash.alert).to eq("toto.fr : Le champ « Email » est invalide. Saisissez une adresse électronique valide. Exemple : adresse@mail.com")
+          expect(flash.alert).to eq("toto.fr : Le champ « Adresse électronique » est invalide. Saisissez une adresse électronique valide. Exemple : adresse@mail.com")
           expect(Avis.last).to eq(previous_avis)
           expect(dossier.last_avis_updated_at).to eq(nil)
         end
@@ -491,7 +491,7 @@ describe Experts::AvisController, type: :controller do
 
         it do
           expect(response).to render_template :instruction
-          expect(flash.alert).to eq("toto.fr : Le champ « Email » est invalide. Saisissez une adresse électronique valide. Exemple : adresse@mail.com")
+          expect(flash.alert).to eq("toto.fr : Le champ « Adresse électronique » est invalide. Saisissez une adresse électronique valide. Exemple : adresse@mail.com")
           expect(flash.notice).to eq("Une demande d’avis a été envoyée à titi@titimail.com")
           expect(Avis.count).to eq(old_avis_count + 1)
         end
@@ -541,7 +541,7 @@ describe Experts::AvisController, type: :controller do
 
         context 'when the expert also shares the linked dossiers' do
           context 'and the expert can access the linked dossiers' do
-            let(:created_avis) { create(:avis, dossier: dossier, claimant: claimant, email: "toto3@gmail.com") }
+            let(:created_avis) { create(:avis, dossier: dossier, claimant: claimant) }
             let(:linked_dossier) { Dossier.find_by(id: dossier.reload.project_champs_public.filter(&:dossier_link?).filter_map(&:value)) }
             let(:linked_avis) { create(:avis, dossier: linked_dossier, claimant: claimant) }
             let(:invite_linked_dossiers) { true }
@@ -663,7 +663,7 @@ describe Experts::AvisController, type: :controller do
         end
 
         context 'and the expert does not belong to the invitation' do
-          let(:avis) { create(:avis, email: 'another_expert@avis.com', dossier: dossier, experts_procedure: experts_procedure) }
+          let(:avis) { create(:avis, dossier: dossier, experts_procedure: experts_procedure) }
 
           before { sign_in(expert.user) }
           # redirected to dossier but then the instructeur gonna be banished !

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -1077,7 +1077,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
         it do
           expect(response).to render_template :avis_new
-          expect(flash.alert).to eq("emaila.com : Le champ « Email » est invalide. Saisissez une adresse électronique valide. Exemple : adresse@mail.com")
+          expect(flash.alert).to eq("emaila.com : Le champ « Adresse électronique » est invalide. Saisissez une adresse électronique valide. Exemple : adresse@mail.com")
           expect { subject }.not_to change(Avis, :count)
           expect(dossier.last_avis_updated_at).to eq(nil)
         end
@@ -1090,7 +1090,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
         it do
           expect(response).to render_template :avis_new
-          expect(flash.alert).to eq("Le champ « Email » doit être rempli")
+          expect(flash.alert).to eq("Le champ « Adresse électronique » doit être rempli")
           expect { subject }.not_to change(Avis, :count)
           expect(dossier.last_avis_updated_at).to eq(nil)
         end
@@ -1104,7 +1104,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
           it do
             expect(response).to render_template :avis_new
-            expect(flash.alert).to eq("toto.fr : Le champ « Email » est invalide. Saisissez une adresse électronique valide. Exemple : adresse@mail.com")
+            expect(flash.alert).to eq("toto.fr : Le champ « Adresse électronique » est invalide. Saisissez une adresse électronique valide. Exemple : adresse@mail.com")
             expect(flash.notice).to eq("Une demande d’avis a été envoyée à titi@titimail.com")
             expect(Avis.count).to eq(old_avis_count + 1)
             expect(saved_avis.expert.email).to eq("titi@titimail.com")

--- a/spec/factories/avis.rb
+++ b/spec/factories/avis.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
   sequence(:expert_email) { |n| "expert#{n}@expert.com" }
 
   factory :avis do
-    email { generate(:expert_email) }
     introduction { 'Bonjour, merci de me donner votre avis sur ce dossier' }
     confidentiel { false }
 
@@ -21,11 +20,6 @@ FactoryBot.define do
 
     trait :not_confidentiel do
       confidentiel { false }
-    end
-
-    trait :with_instructeur do
-      email { nil }
-      instructeur { association :instructeur, email: generate(:expert_email) }
     end
 
     trait :with_answer do

--- a/spec/mailers/previews/avis_mailer_preview.rb
+++ b/spec/mailers/previews/avis_mailer_preview.rb
@@ -9,8 +9,7 @@ class AvisMailerPreview < ActionMailer::Preview
     AvisMailer.avis_invitation_and_confirm_email(
       avis_with_unconfirmed_user.expert.user,
       avis_with_unconfirmed_user.expert.user.confirmation_token,
-      avis_with_unconfirmed_user,
-      avis_with_unconfirmed_user.targeted_user_links.first
+      avis_with_unconfirmed_user
     )
   end
 
@@ -21,20 +20,18 @@ class AvisMailerPreview < ActionMailer::Preview
     AvisMailer.avis_invitation_and_confirm_email(
       avis_with_unverified_user.expert.user,
       avis_with_unverified_user.expert.user.confirmation_token,
-      avis_with_unverified_user,
-      avis_with_unverified_user.targeted_user_links.first
+      avis_with_unverified_user
     )
   end
 
   def avis_invitation_and_confirm_email_with_confirmed_and_verified_user_email
     avis_with_verified_user = Avis.joins(expert: :user).where.not(users: { last_sign_in_at: nil }).where.not(users: { email_verified_at: nil }).first
-    raise if avis_with_unverified_user.nil?
+    raise if avis_with_verified_user.nil?
 
     AvisMailer.avis_invitation_and_confirm_email(
-      avis_with_unverified_user.expert.user,
-      avis_with_unverified_user.expert.user.confirmation_token,
-      avis_with_unverified_user,
-      avis_with_unverified_user.targeted_user_links.first
+      avis_with_verified_user.expert.user,
+      avis_with_verified_user.expert.user.confirmation_token,
+      avis_with_verified_user
     )
   end
 end

--- a/spec/models/avis_spec.rb
+++ b/spec/models/avis_spec.rb
@@ -36,65 +36,14 @@ RSpec.describe Avis, type: :model do
     let(:experts_procedure) { create(:experts_procedure, procedure: procedure, expert: expert) }
 
     context 'an avis is linked to an experts_procedure' do
-      let!(:avis) { create(:avis, email: nil, experts_procedure: experts_procedure) }
+      let!(:avis) { create(:avis, experts_procedure: experts_procedure) }
 
       before do
         avis.reload
       end
       it do
         expect(avis.valid?).to be_truthy
-        expect(avis.email).to be_nil
         expect(avis.experts_procedure).to eq(experts_procedure)
-      end
-    end
-  end
-
-  describe "email sanitization" do
-    let(:expert) { create(:expert) }
-    let(:procedure) { create(:procedure) }
-    let!(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: procedure) }
-    subject { create(:avis, claimant: claimant, email: email, experts_procedure: experts_procedure, dossier: create(:dossier)) }
-
-    context "when there is no email" do
-      let(:email) { nil }
-      it { expect(subject.email).to be_nil }
-    end
-
-    context "when the email is in lowercase" do
-      let(:email) { "toto@tps.fr" }
-
-      it { expect(subject.email).to eq("toto@tps.fr") }
-    end
-
-    context "when the email is not in lowercase" do
-      let(:email) { "TOTO@tps.fr" }
-
-      it { expect(subject.email).to eq("toto@tps.fr") }
-    end
-
-    context "when the email has some spaces before and after" do
-      let(:email) { "  toto@tps.fr  " }
-
-      it { expect(subject.email).to eq("toto@tps.fr") }
-    end
-  end
-
-  describe 'email validation' do
-    let(:now_invalid_email) { "toto@tps" }
-    context 'new avis' do
-      before { allow(StrictEmailValidator).to receive(:eligible_to_new_validation?).and_return(true) }
-
-      it do
-        expect(build(:avis, email: now_invalid_email).valid?).to be_falsey
-        expect(build(:avis, email: nil).valid?).to be_truthy
-      end
-    end
-    context 'old avis' do
-      before { allow(StrictEmailValidator).to receive(:eligible_to_new_validation?).and_return(false) }
-
-      it do
-        expect(build(:avis, email: now_invalid_email).valid?).to be_truthy
-        expect(build(:avis, email: nil).valid?).to be_truthy
       end
     end
   end

--- a/spec/services/create_avis_service_spec.rb
+++ b/spec/services/create_avis_service_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+describe CreateAvisService do
+  let(:instructeur) { create(:instructeur) }
+  let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+  let(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure:) }
+  let(:expert_email) { 'expert@exemple.fr' }
+
+  subject(:result) do
+    avis = Avis.new(introduction: 'Merci de donner votre avis.', dossier:)
+    CreateAvisService.call(
+      claimant: instructeur,
+      batch: true,
+      avis:,
+      emails: [expert_email]
+    )
+  end
+
+  describe '#call' do
+    context 'when everything goes well' do
+      it 'creates an avis for the dossier' do
+        expect { result }.to change { dossier.avis.count }.by(1)
+      end
+    end
+
+    context 'when the procedure restricts experts to administrateur invitations' do
+      let(:procedure) { create(:simple_procedure, experts_require_administrateur_invitation: true, instructeurs: [instructeur]) }
+
+      context 'and the email is in the administrateur-approved list' do
+        let(:invited_expert) { create(:expert) }
+        let!(:invited_ep) { create(:experts_procedure, procedure:, expert: invited_expert) }
+        let(:expert_email) { invited_expert.email }
+
+        it 'creates the avis' do
+          sent_emails, failed_emails = result
+          expect(sent_emails).to eq([invited_expert.email])
+          expect(failed_emails).to be_empty
+          expect(dossier.avis.count).to eq(1)
+        end
+      end
+
+      context 'and the email is not in the administrateur-approved list' do
+        let(:expert_email) { 'rogue@example.fr' }
+
+        it 'rejects the email and does not create user, expert, or avis' do
+          sent_emails, failed_emails = result
+          expect(sent_emails).to be_empty
+          expect(failed_emails).to contain_exactly(hash_including(email: 'rogue@example.fr'))
+          expect(dossier.avis.count).to eq(0)
+          expect(User.find_by(email: 'rogue@example.fr')).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/system/accessibilite/wcag_usager_spec.rb
+++ b/spec/system/accessibilite/wcag_usager_spec.rb
@@ -80,8 +80,8 @@ describe 'wcag rules for usager', chrome: true do
 
     context 'password edit for experts' do
       let(:procedure) { create(:procedure, :published) }
-      let(:avis) { create(:avis, dossier: create(:dossier, procedure: procedure), expert: nil, email: 'k@thx.bye') }
-      let(:path) { sign_up_expert_avis_path(procedure_id: procedure.id, id: avis.id, email: avis.email) }
+      let(:avis) { create(:avis, dossier: create(:dossier, procedure: procedure)) }
+      let(:path) { sign_up_expert_avis_path(procedure_id: procedure.id, id: avis.id, email: avis.expert.email) }
       it 'pass wcag tests' do
         test_aria_label_do_not_mix_with_title_attribute
         test_expect_axe_clean_without_main_navigation

--- a/spec/system/instructeurs/batch_operation_spec.rb
+++ b/spec/system/instructeurs/batch_operation_spec.rb
@@ -202,11 +202,11 @@ describe 'BatchOperation a dossier:', js: true do
 
       click_on "Envoyer la demande d’avis"
 
-      expect(page).to have_content("Le champ « Email » doit être rempli")
+      expect(page).to have_content("Le champ « Adresse électronique » doit être rempli")
 
       fill_in('avis_emails', with: 'mljkzmljz')
       click_on "Envoyer la demande d’avis"
-      expect(page).to have_content("Le champ « Email » est invalide : mljkzmljz")
+      expect(page).to have_content("Le champ « Adresse électronique » est invalide : mljkzmljz")
 
       fill_in('avis_emails', with: 'test@test.com')
       within('form#new_avis') { click_on "Annuler" }

--- a/spec/system/instructeurs/expert_spec.rb
+++ b/spec/system/instructeurs/expert_spec.rb
@@ -127,7 +127,7 @@ describe 'Inviting an expert:', js: true do
       expect(page).to have_content('Une demande d’avis a été envoyée')
       expect(page).to have_content('Demander un avis externe')
       expect(page).to have_content('Une demande d’avis a été envoyée à expert1@gouv.fr, expert2@gouv.fr, test@test.fr')
-      expect(page).to have_content('email-invalide : Le champ « Email » est invalide. Saisissez une adresse électronique valide.')
+      expect(page).to have_content('email-invalide : Le champ « Adresse électronique » est invalide. Saisissez une adresse électronique valide.')
     end
 
     context 'when experts list is restricted by admin' do


### PR DESCRIPTION
beaucoup de commit mais c'est pour avancer par petit pas.

Le but était de retirer `avis.email` qui était un reliquat maintenant remplacé par `avis.expert.email` , l'expert étant toujours créé. Ca nous évite d'avoir 2 sources de vérité.

On en profite pour nettoyer du code : en gros, on déplace du contrôle surfacique, on mutualise plus dans le concerne, on réorganise dans dans le service et on sert d'un avis comme exemple.