### PR TITLE
Correctif: ETQ usager, corriger la perte de fichiers lors d'uploads concurrents

### DIFF
--- a/app/components/attachment/file_field_component.rb
+++ b/app/components/attachment/file_field_component.rb
@@ -93,7 +93,8 @@ class Attachment::FileFieldComponent < ApplicationComponent
       champ:,
       attached_file:,
       show_identity_hint: champ&.titre_identite?,
-      html_id: describedby_hint_id
+      html_id: describedby_hint_id,
+      max: @max
     )
   end
 

--- a/app/components/attachment/hints_component.rb
+++ b/app/components/attachment/hints_component.rb
@@ -7,11 +7,12 @@ class Attachment::HintsComponent < ApplicationComponent
 
   delegate :max_file_size, :allowed_extensions, to: :validation
 
-  def initialize(champ:, attached_file: nil, show_identity_hint: false, html_id: nil)
+  def initialize(champ:, attached_file: nil, show_identity_hint: false, html_id: nil, max: nil)
     @champ = champ
     @attached_file = attached_file
     @show_identity_hint = show_identity_hint
     @html_id = html_id
+    @max = max
   end
 
   def validation

--- a/app/components/attachment/hints_component/hints_component.en.yml
+++ b/app/components/attachment/hints_component/hints_component.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   identity_hint: "Required document: National identity card (front side only), passport, residency permit or other proof of identity."
-  max_file_size: "Maximum size allowed: %{max_file_size}"
+  max_file_size: "Maximum size per file: %{max_file_size}"
   allowed_formats: "Supported formats: %{formats}"
   format_category_line: "%{category}: %{extensions}"
   formats_tooltip_label: "See all accepted formats"

--- a/app/components/attachment/hints_component/hints_component.en.yml
+++ b/app/components/attachment/hints_component/hints_component.en.yml
@@ -1,7 +1,9 @@
 ---
 en:
   identity_hint: "Required document: National identity card (front side only), passport, residency permit or other proof of identity."
-  max_file_size: "Maximum size per file: %{max_file_size}"
+  max_file_size:
+    one: "Maximum size per file: %{max_file_size}"
+    other: "Maximum size per file: %{max_file_size}. Multiple files allowed"
   allowed_formats: "Supported formats: %{formats}"
   format_category_line: "%{category}: %{extensions}"
   formats_tooltip_label: "See all accepted formats"

--- a/app/components/attachment/hints_component/hints_component.fr.yml
+++ b/app/components/attachment/hints_component/hints_component.fr.yml
@@ -1,7 +1,9 @@
 ---
 fr:
   identity_hint: "Pièce attendue : Carte nationale d’identité (uniquement le recto), passeport, titre de séjour ou autre justificatif d’identité."
-  max_file_size: "Taille maximale par fichier : %{max_file_size}"
+  max_file_size:
+    one: "Taille maximale par fichier : %{max_file_size}"
+    other: "Taille maximale par fichier : %{max_file_size}. Plusieurs fichiers possibles"
   allowed_formats: "Formats acceptés : %{formats}"
   format_category_line: "%{category} : %{extensions}"
   formats_tooltip_label: "Voir tous les formats acceptés"

--- a/app/components/attachment/hints_component/hints_component.fr.yml
+++ b/app/components/attachment/hints_component/hints_component.fr.yml
@@ -1,7 +1,7 @@
 ---
 fr:
   identity_hint: "Pièce attendue : Carte nationale d’identité (uniquement le recto), passeport, titre de séjour ou autre justificatif d’identité."
-  max_file_size: "Taille maximale autorisée : %{max_file_size}"
+  max_file_size: "Taille maximale par fichier : %{max_file_size}"
   allowed_formats: "Formats acceptés : %{formats}"
   format_category_line: "%{category} : %{extensions}"
   formats_tooltip_label: "Voir tous les formats acceptés"

--- a/app/components/attachment/hints_component/hints_component.html.erb
+++ b/app/components/attachment/hints_component/hints_component.html.erb
@@ -5,7 +5,7 @@
   <%- end -%>
 
   <%- if max_file_size.present? -%>
-    <%= t('.max_file_size', max_file_size: number_to_human_size(max_file_size)) %>
+    <%= t('.max_file_size', max_file_size: number_to_human_size(max_file_size), count: @max || 1) %>
   <%- end -%>
 
   <%- if show_format_families? -%>

--- a/app/controllers/champs/piece_justificative_controller.rb
+++ b/app/controllers/champs/piece_justificative_controller.rb
@@ -23,13 +23,7 @@ class Champs::PieceJustificativeController < Champs::ChampController
   private
 
   def attach_piece_justificative
-    save_succeed = nil
-
-    ActiveStorage::Attachment.transaction do
-      @champ.piece_justificative_file.attach(params[:blob_signed_id])
-      context = @champ.public? ? :champs_public_value : :champs_private_value
-      save_succeed = @champ.save(context:)
-    end
+    save_succeed = Attachment::PieceJustificativeService.attach_champ_pj(@champ, params[:blob_signed_id])
 
     if save_succeed
       @champ.fetch_later! if @champ.has_async_external_data? && @champ.may_fetch_later?

--- a/app/services/attachment/piece_justificative_service.rb
+++ b/app/services/attachment/piece_justificative_service.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
 class Attachment::PieceJustificativeService
-  def self.attach(champ, blob_signed_id)
-    ActiveStorage::Attachment.transaction do
+  # ActiveStorage::Attached::Many#attach uses a read-modify-write pattern:
+  #   record.piece_justificative_file = blobs + [new_blob]
+  # With concurrent uploads, each request reads a stale `blobs` list and
+  # overwrites attachments added by other requests (last writer wins).
+  # We serialize access with SELECT FOR UPDATE so each request sees
+  # the attachments left by the previous one.
+  def self.attach_champ_pj(champ, blob_signed_id)
+    updated_by = champ.updated_by
+
+    Champ.transaction do
+      champ.reload(lock: true) # SELECT FOR UPDATE + clear association cache
+      champ.updated_by = updated_by # keep record dirty so attach defers save to us
       champ.piece_justificative_file.attach(blob_signed_id)
       context = champ.public? ? :champs_public_value : :champs_private_value
       champ.save(context:)

--- a/app/services/attachment/piece_justificative_service.rb
+++ b/app/services/attachment/piece_justificative_service.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Attachment::PieceJustificativeService
+  def self.attach(champ, blob_signed_id)
+    ActiveStorage::Attachment.transaction do
+      champ.piece_justificative_file.attach(blob_signed_id)
+      context = champ.public? ? :champs_public_value : :champs_private_value
+      champ.save(context:)
+    end
+  end
+end

--- a/spec/components/attachment/file_field_component_spec.rb
+++ b/spec/components/attachment/file_field_component_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
       let(:context) { Attachment::Context.new(champ:) }
 
       it 'does not render format info, only max size' do
-        expect(subject).to have_content(/Taille maximale autorisée/)
+        expect(subject).to have_content(/Taille maximale par fichier/)
         expect(subject).to have_no_content('Formats acceptés')
       end
     end

--- a/spec/services/attachment/piece_justificative_service_spec.rb
+++ b/spec/services/attachment/piece_justificative_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe Attachment::PieceJustificativeService do
+  let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
+  let(:dossier) { create(:dossier, procedure:) }
+  let(:champ) { dossier.champs.first }
+
+  let(:blob_1) { ActiveStorage::Blob.create_and_upload!(io: StringIO.new("file1"), filename: "file1.pdf", content_type: "application/pdf") }
+  let(:blob_2) { ActiveStorage::Blob.create_and_upload!(io: StringIO.new("file2"), filename: "file2.pdf", content_type: "application/pdf") }
+
+  describe '.attach_champ_pj' do
+    context 'with sequential uploads' do
+      it 'preserves all attachments' do
+        described_class.attach_champ_pj(champ, blob_1.signed_id)
+        described_class.attach_champ_pj(champ, blob_2.signed_id)
+
+        expect(champ.reload.piece_justificative_file.count).to eq(2)
+      end
+    end
+
+    context 'with concurrent uploads (simulated stale state)' do
+      it 'preserves all attachments' do
+        champ_a = Champ.find(champ.id)
+        champ_b = Champ.find(champ.id)
+
+        # Force-load the blobs association on both instances before either attaches.
+        # This simulates two concurrent requests that both read blobs = [] at the same time.
+        champ_a.piece_justificative_file.blobs.to_a
+        champ_b.piece_justificative_file.blobs.to_a
+
+        described_class.attach_champ_pj(champ_a, blob_1.signed_id)
+        described_class.attach_champ_pj(champ_b, blob_2.signed_id)
+
+        expect(champ.reload.piece_justificative_file.count).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/system/users/piece_justificative_drag_drop_spec.rb
+++ b/spec/system/users/piece_justificative_drag_drop_spec.rb
@@ -63,7 +63,7 @@ describe 'Piece justificative drag and drop', js: true do
       fill_individual
 
       within find('.editable-champ', text: 'Document') do
-        expect(page).to have_text('Taille maximale autorisée : 200 Mo')
+        expect(page).to have_text('Taille maximale par fichier : 200 Mo')
       end
     end
 
@@ -75,7 +75,7 @@ describe 'Piece justificative drag and drop', js: true do
       fill_individual
 
       within find('.editable-champ', text: 'Pièce d\'identité') do
-        expect(page).to have_text('Taille maximale autorisée : 20 Mo')
+        expect(page).to have_text('Taille maximale par fichier : 20 Mo')
         expect(page).to have_text(/Pièce attendue :.*Carte nationale.*passeport.*titre de séjour/i)
         expect(page).to have_text(/jpeg|png/i)
       end


### PR DESCRIPTION
# Probleme

Lors d'un multi-upload de pieces justificatives, des fichiers sont perdus. Par exemple, 4 fichiers uploades simultanement → seulement 3 attaches.

La cause est dans `ActiveStorage::Attached::Many#attach` qui utilise un pattern read-modify-write :

```ruby
# activestorage/lib/active_storage/attached/many.rb:52
record.piece_justificative_file = blobs + [new_blob]
```

Avec des requetes concurrentes, chaque requete lit une liste `blobs` stale et ecrase les ajouts des autres (last writer wins).

# Solution

- Extraction de la logique d'attach dans `Attachment::PieceJustificativeService`
- Serialisation des uploads concurrents via `SELECT FOR UPDATE` (`reload(lock: true)`) : chaque requete attend que la precedente ait committe avant de lire les blobs
- Test qui simule le stale state et prouve la race condition

Generated with [Claude Code](https://claude.com/claude-code)