### PR TITLE
ETQ Tech : je veux effectuer les appels sur API Part de façon asynchrone 

### DIFF
--- a/app/components/editable_champ/quotient_familial_component.rb
+++ b/app/components/editable_champ/quotient_familial_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EditableChamp::QuotientFamilialComponent < EditableChamp::EditableChampBaseComponent
-  delegate :fetched?, :fc_data_incorrect?, :fc_data_approved?, to: :@champ
+  delegate :fetched?, :fc_data_incorrect?, :fc_data_approved?, :waiting_for_job?, :fetching?, :idle?, :external_error?, to: :@champ
 
   def for_preview?
     @champ.dossier.for_procedure_preview?
@@ -10,13 +10,13 @@ class EditableChamp::QuotientFamilialComponent < EditableChamp::EditableChampBas
   def render_external_champ?
     return render_external_champ_preview? if for_preview?
 
-    fetched?
+    waiting_for_job? || fetching? || fetched?
   end
 
   def render_piece_justificative_champ?
     return render_piece_justificative_champ_preview? if for_preview?
 
-    !fetched? || fc_data_incorrect?
+    idle? || external_error? || fc_data_incorrect?
   end
 
   def render_data_incorrect_callout?
@@ -33,7 +33,7 @@ class EditableChamp::QuotientFamilialComponent < EditableChamp::EditableChampBas
         )
       )
     else
-      @champ.value_json['api_part']
+      @champ.value_json&.dig('api_part')
     end
   end
 

--- a/app/components/editable_champ/quotient_familial_component/quotient_familial_component.html.haml
+++ b/app/components/editable_champ/quotient_familial_component/quotient_familial_component.html.haml
@@ -20,21 +20,22 @@
   .fr-mb-2w
     = render QuotientFamilial::QuotientFamilialComponent.new(qf_data:, with_header: true)
 
-  .fr-fieldset
-    .fr-fieldset__legend--regular.fr-fieldset__legend
-      = t('.external_champ.confirmation.question')
-      = render EditableChamp::AsteriskMandatoryComponent.new
-    .fr-fieldset__element.fr-fieldset__element--inline
-      .fr-radio-group
-        = @form.radio_button :value, true, id: "#{@champ.stable_id}_correct", aria: labelledby_id_attr(input_label_id(@champ, :correct))
-        %label.fr-label{ for: "#{@champ.stable_id}_correct", id: input_label_id(@champ, :correct) }
-          = t('.external_champ.confirmation.true')
+  - if fetched?
+    .fr-fieldset
+      .fr-fieldset__legend--regular.fr-fieldset__legend
+        = t('.external_champ.confirmation.question')
+        = render EditableChamp::AsteriskMandatoryComponent.new
+      .fr-fieldset__element.fr-fieldset__element--inline
+        .fr-radio-group
+          = @form.radio_button :value, true, id: "#{@champ.stable_id}_correct", aria: labelledby_id_attr(input_label_id(@champ, :correct))
+          %label.fr-label{ for: "#{@champ.stable_id}_correct", id: input_label_id(@champ, :correct) }
+            = t('.external_champ.confirmation.true')
 
-    .fr-fieldset__element.fr-fieldset__element--inline
-      .fr-radio-group
-        = @form.radio_button :value, false, id: "#{@champ.stable_id}_incorrect", aria: labelledby_id_attr(input_label_id(@champ, :incorrect))
-        %label.fr-label{ for: "#{@champ.stable_id}_incorrect", id: input_label_id(@champ, :incorrect) }
-          = t('.external_champ.confirmation.false')
+      .fr-fieldset__element.fr-fieldset__element--inline
+        .fr-radio-group
+          = @form.radio_button :value, false, id: "#{@champ.stable_id}_incorrect", aria: labelledby_id_attr(input_label_id(@champ, :incorrect))
+          %label.fr-label{ for: "#{@champ.stable_id}_incorrect", id: input_label_id(@champ, :incorrect) }
+            = t('.external_champ.confirmation.false')
 
   - if render_data_incorrect_callout?
     .fr-callout.fr-callout--yellow-moutarde

--- a/app/components/quotient_familial/quotient_familial_component.rb
+++ b/app/components/quotient_familial/quotient_familial_component.rb
@@ -13,6 +13,8 @@ class QuotientFamilial::QuotientFamilialComponent < ApplicationComponent
   end
 
   def data
+    return [] if qf_data.nil?
+
     qf = qf_data["quotient_familial"]
     allocataires = qf_data["allocataires"]
     enfants = qf_data["enfants"]

--- a/app/components/quotient_familial/quotient_familial_component/quotient_familial_component.en.yml
+++ b/app/components/quotient_familial/quotient_familial_component/quotient_familial_component.en.yml
@@ -2,3 +2,4 @@
 en:
   external_champ:
     header: The following data has been securely retrieved from the relevant authorities.
+    waiting_banner: Your data is being retrieved from the relevant authorities.

--- a/app/components/quotient_familial/quotient_familial_component/quotient_familial_component.fr.yml
+++ b/app/components/quotient_familial/quotient_familial_component/quotient_familial_component.fr.yml
@@ -2,3 +2,4 @@
 fr:
   external_champ:
     header: Les données suivantes ont été récupérées de façon sécurisée auprès des administrations en charge.
+    waiting_banner: Vos données sont en cours de récupération auprès des administrations en charge.

--- a/app/components/quotient_familial/quotient_familial_component/quotient_familial_component.html.haml
+++ b/app/components/quotient_familial/quotient_familial_component/quotient_familial_component.html.haml
@@ -3,4 +3,4 @@
     - c.with_header do
       = render Dsfr::AlertComponent.new(state: :info, with_prefix: false, extra_class_names: 'fr-mb-2w clearfix') do |c|
         - c.with_body do
-          = t('.external_champ.header')
+          = data.present? ? t('.external_champ.header') : t('.external_champ.waiting_banner')

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -779,7 +779,7 @@ module Users
     end
 
     def set_default_value_for_france_connect_champs
-      @dossier.set_default_value_for_france_connect_champs
+      @dossier.set_default_value_for_france_connect_champs(current_user.email)
     end
   end
 end

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -43,7 +43,7 @@ module ChampExternalDataConcern
       end
 
       event :fetch, after_commit: :fetch_and_handle_result do
-        transitions from: [:idle, :waiting_for_job], to: :fetching, guard: :ready_for_external_call?
+        transitions from: [:waiting_for_job], to: :fetching
       end
 
       event :external_data_fetched do

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -252,11 +252,11 @@ module DossierChampsConcern
     champs.filter(&:history_stream?)
   end
 
-  def set_default_value_for_france_connect_champs
-    revision.types_de_champ_public.filter(&:france_connect?).filter_map do |type_de_champ|
-      champ = project_champ(type_de_champ)
+  def set_default_value_for_france_connect_champs(user_email)
+    revision.types_de_champ_public.filter(&:france_connect?).each do |type_de_champ|
+      champ = champ_for_update(type_de_champ, updated_by: user_email)
 
-      champ.fetch! if champ.may_fetch?
+      champ.fetch_later! if champ.may_fetch_later?
     end
   end
 

--- a/spec/components/editable_champ/quotient_familial_component_spec.rb
+++ b/spec/components/editable_champ/quotient_familial_component_spec.rb
@@ -90,4 +90,12 @@ describe EditableChamp::QuotientFamilialComponent, type: :component do
       end
     end
   end
+
+  context 'when data is being retrieved' do
+    before { champ.update(external_state: 'waiting_for_job') }
+
+    it 'informs the user that their data is being retrieved' do
+      expect(subject).to have_text('Vos données sont en cours de récupération auprès des administrations en charge.')
+    end
+  end
 end

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -988,13 +988,13 @@ RSpec.describe DossierChampsConcern do
     let(:champ_qf) { dossier.champs.first }
     let!(:fci) { create(:france_connect_information, user: dossier.user) }
 
-    subject { dossier.set_default_value_for_france_connect_champs }
+    subject { dossier.set_default_value_for_france_connect_champs(dossier.user.email) }
 
     context 'when the user starts a new dossier' do
-      before { allow(champ_qf).to receive(:fetch!).and_return(nil) }
+      before { allow(champ_qf).to receive(:fetch_later!).and_return(nil) }
       it 'set a default value for the quotient_familial champ' do
         subject
-        expect(champ_qf).to have_received(:fetch!)
+        expect(champ_qf).to have_received(:fetch_later!)
       end
     end
 
@@ -1002,12 +1002,12 @@ RSpec.describe DossierChampsConcern do
       before do
         champ_qf.update(external_state: 'fetched')
         dossier.reload
-        allow(champ_qf).to receive(:fetch!).and_return(nil)
+        allow(champ_qf).to receive(:fetch_later!).and_return(nil)
       end
 
       it 'does not attempt to set the champ again' do
         subject
-        expect(champ_qf).not_to have_received(:fetch!)
+        expect(champ_qf).not_to have_received(:fetch_later!)
       end
     end
 
@@ -1028,7 +1028,7 @@ RSpec.describe DossierChampsConcern do
         @fetched_instances = []
 
         allow_any_instance_of(Champs::QuotientFamilialChamp)
-          .to receive(:fetch!) do |instance|
+          .to receive(:fetch_later!) do |instance|
             @fetched_instances << instance
             nil
           end


### PR DESCRIPTION
Dans la perspective d'accueillir d'autres champs api part, on va faire finalement de l'asynchrone, et on prévoit donc une petite bannière d'attente pour l'usager

Message en attente de récupération des données (vu avec Marlène) :
<img width="1448" height="753" alt="image" src="https://github.com/user-attachments/assets/a3f50111-704e-420e-a970-05f765e667ed" />

Puis dès que les données sont récupérées :
<img width="1242" height="829" alt="Capture d’écran 2026-04-22 à 14 30 09" src="https://github.com/user-attachments/assets/aac0efea-b76d-4032-a434-151557ec24ae" />
