### PR TITLE
Tech: diminue le nombre d'allocation mémoire lors du calcul de typo dans un email

### DIFF
--- a/app/lib/email_checker.rb
+++ b/app/lib/email_checker.rb
@@ -638,6 +638,7 @@ class EmailChecker
 
   def self.closest_domains(domain:)
     KNOWN_DOMAINS.filter do |known_domain|
+      next false if (known_domain.size - domain.size).abs > 2
       distance = String::Similarity.levenshtein_distance(domain, known_domain)
       distance == 1 || (distance == 2 && domain.chars.sort == known_domain.chars.sort)
     end

--- a/app/lib/email_checker.rb
+++ b/app/lib/email_checker.rb
@@ -613,7 +613,7 @@ class EmailChecker
     'ac-verseilles.fr',
     'ac-ais-marseille.fr',
     'ac-horizon.fr',
-    'ac-bordeaux.ft',
+    'ac-bordeaux.fr',
     'ac-toulouses.fr',
     'ac-toulous.fr',
   ].freeze
@@ -638,17 +638,9 @@ class EmailChecker
 
   def self.closest_domains(domain:)
     KNOWN_DOMAINS.filter do |known_domain|
-      close_by_distance_of(domain, known_domain, distance: 1) ||
-      with_same_chars_and_close_by_distance_of(domain, known_domain, distance: 2)
+      distance = String::Similarity.levenshtein_distance(domain, known_domain)
+      distance == 1 || (distance == 2 && domain.chars.sort == known_domain.chars.sort)
     end
-  end
-
-  def self.close_by_distance_of(a, b, distance:)
-    String::Similarity.levenshtein_distance(a, b) == distance
-  end
-
-  def self.with_same_chars_and_close_by_distance_of(a, b, distance:)
-    close_by_distance_of(a, b, distance: 2) && a.chars.sort == b.chars.sort
   end
 
   def self.suggestions(parsed_email:, similar_domains:)


### PR DESCRIPTION
lors d'un debug j'ai vu en prod que cette méthode ressortait parmi celle qui allouait le plus (parfois > 100k objects).
Ca devrait diminuer le pb.