### PR TITLE
Tech: ignore les valeurs non scalaires dans le prefill API préremplissage

### DIFF
--- a/app/controllers/api/public/v1/dossiers_controller.rb
+++ b/app/controllers/api/public/v1/dossiers_controller.rb
@@ -11,7 +11,7 @@ class API::Public::V1::DossiersController < API::Public::V1::BaseController
     )
     dossier.build_default_values
     if dossier.save
-      dossier.prefill!(PrefillChamps.new(dossier, params.to_unsafe_h).to_a, PrefillIdentity.new(dossier, params.to_unsafe_h).to_h)
+      dossier.prefill!(PrefillChamps.new(dossier, params.to_unsafe_h).to_a, PrefillIdentity.new(dossier, identity_params).to_h)
       render json: serialize_dossier(dossier), status: :created
     else
       render_bad_request(dossier.errors.full_messages.to_sentence)
@@ -29,6 +29,10 @@ class API::Public::V1::DossiersController < API::Public::V1::BaseController
   end
 
   private
+
+  def identity_params
+    params.permit(:identite_prenom, :identite_nom, :identite_genre).to_h
+  end
 
   def serialize_dossier(dossier)
     if dossier.orphan?

--- a/app/models/prefill_champs.rb
+++ b/app/models/prefill_champs.rb
@@ -56,7 +56,7 @@ class PrefillChamps
     end
 
     def prefillable?
-      champ.prefillable? && valid? && champ_attributes.present?
+      champ.prefillable? && champ_attributes.present? && valid?
     end
 
     def champ_attributes

--- a/app/models/prefill_identity.rb
+++ b/app/models/prefill_identity.rb
@@ -9,14 +9,21 @@ class PrefillIdentity
   end
 
   def to_h
-    if dossier.procedure.for_individual?
-      {
-        prenom: params["identite_prenom"],
-        nom: params["identite_nom"],
-        gender: dossier.procedure.no_gender? ? nil : ["M.", "Mme"].include?(params["identite_genre"]) ? params["identite_genre"] : nil,
-      }
-    else
-      {}
-    end
+    return {} if !dossier.procedure.for_individual?
+
+    {
+      prenom: params["identite_prenom"],
+      nom: params["identite_nom"],
+      gender: gender_param,
+    }
+  end
+
+  private
+
+  def gender_param
+    return if dossier.procedure.no_gender?
+
+    valid_genders = [Individual::GENDER_MALE, Individual::GENDER_FEMALE]
+    params["identite_genre"].presence_in(valid_genders)
   end
 end

--- a/app/models/types_de_champ/prefill_address_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_address_type_de_champ.rb
@@ -2,7 +2,7 @@
 
 class TypesDeChamp::PrefillAddressTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
   def to_assignable_attributes(champ, value)
-    return if value.blank?
+    return nil if !value.is_a?(String) || value.blank?
     { id: champ.id, value: value, external_id: value }
   end
 end

--- a/app/models/types_de_champ/prefill_referentiel_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_referentiel_type_de_champ.rb
@@ -6,6 +6,7 @@ class TypesDeChamp::PrefillReferentielTypeDeChamp < TypesDeChamp::PrefillTypeDeC
   end
 
   def to_assignable_attributes(champ, value)
-    { id: champ.id, external_id: value.presence }
+    return nil if !scalar_prefill_value?(value)
+    { id: champ.id, external_id: value.to_s.presence }
   end
 end

--- a/app/models/types_de_champ/prefill_siret_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_siret_type_de_champ.rb
@@ -6,6 +6,7 @@ class TypesDeChamp::PrefillSiretTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
   end
 
   def to_assignable_attributes(champ, value)
-    { id: champ.id, external_id: value.presence }
+    return nil if !scalar_prefill_value?(value)
+    { id: champ.id, external_id: value.to_s.presence }
   end
 end

--- a/app/models/types_de_champ/prefill_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_type_de_champ.rb
@@ -68,7 +68,20 @@ class TypesDeChamp::PrefillTypeDeChamp < SimpleDelegator
   end
 
   def to_assignable_attributes(champ, value)
+    return nil if !acceptable_prefill_value?(value)
     { id: champ.id, value: value }
+  end
+
+  def acceptable_prefill_value?(value)
+    case value
+    when Hash  then false
+    when Array then value.none? { _1.is_a?(Hash) || _1.is_a?(Array) }
+    else true
+    end
+  end
+
+  def scalar_prefill_value?(value)
+    value.is_a?(String) || value.is_a?(Numeric)
   end
 
   private

--- a/spec/controllers/api/public/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/dossiers_controller_spec.rb
@@ -61,6 +61,29 @@ RSpec.describe API::Public::V1::DossiersController, type: :controller do
             end
           end
 
+          context 'when prefill values contain malicious non-string inputs' do
+            let!(:type_de_champ) { create(:type_de_champ_text, procedure: procedure) }
+            let(:params) {
+              {
+                id: procedure.id,
+                "champ_#{type_de_champ.to_typed_id_for_query}" => { "injected" => "x" },
+                "identite_prenom" => { "injected" => "x" },
+                "identite_nom" => ["array"],
+                "identite_genre" => { "injected" => "x" },
+              }
+            }
+
+            it "ignores malicious values and does not persist them" do
+              create_request
+
+              dossier = Dossier.last
+              expect(find_champ_by_stable_id(dossier, type_de_champ.stable_id).value).to be_blank
+              expect(dossier.individual.prenom).to be_blank
+              expect(dossier.individual.nom).to be_blank
+              expect(dossier.individual.gender).to be_blank
+            end
+          end
+
           context 'when prefill given values contains more than one rows for repetitions' do
             let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
             let(:types_de_champ_public) do

--- a/spec/models/prefill_champs_spec.rb
+++ b/spec/models/prefill_champs_spec.rb
@@ -246,6 +246,50 @@ RSpec.describe PrefillChamps do
         expect(prefill_champs_array).to match([])
       end
     end
+
+    context "when the value is a Hash (malicious input)" do
+      let(:types_de_champ_public) { [{ type: :text }] }
+      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+
+      let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => { "injected" => "x" } } }
+
+      it "rejects the non-string value" do
+        expect(prefill_champs_array).to match([])
+      end
+    end
+
+    context "when the value is an Array containing a Hash on a simple type" do
+      let(:types_de_champ_public) { [{ type: :text }] }
+      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+
+      let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => [{ "injected" => "x" }] } }
+
+      it "rejects the non-string value" do
+        expect(prefill_champs_array).to match([])
+      end
+    end
+
+    context "when the address value is a Hash (malicious input)" do
+      let(:types_de_champ_public) { [{ type: :address }] }
+      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+
+      let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => { "injected" => "x" } } }
+
+      it "rejects the non-string value" do
+        expect(prefill_champs_array).to match([])
+      end
+    end
+
+    context "when the siret value is a Hash (malicious input)" do
+      let(:types_de_champ_public) { [{ type: :siret }] }
+      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+
+      let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => { "injected" => "x" } } }
+
+      it "does not set external_id to a hash" do
+        expect(prefill_champs_array).to match([])
+      end
+    end
   end
 
   private

--- a/spec/models/prefill_identity_spec.rb
+++ b/spec/models/prefill_identity_spec.rb
@@ -18,5 +18,35 @@ RSpec.describe PrefillIdentity do
         expect(prefill_identity_hash).to match({ prenom: "Prénom", nom: "Nom", gender: nil })
       end
     end
+
+    context "when identite_genre is a hash (malicious input)" do
+      let(:params) {
+        {
+          "identite_prenom" => "Prénom",
+          "identite_nom" => "Nom",
+          "identite_genre" => { "injected" => "x" },
+        }
+      }
+
+      it "rejects the non-string genre" do
+        expect(prefill_identity_hash[:gender]).to be_nil
+      end
+    end
+
+    context "when identite_genre is a valid constant value" do
+      let(:procedure) { create(:procedure, :for_individual, no_gender: false) }
+      let(:dossier) { create(:dossier, :brouillon, :with_individual, procedure:) }
+      let(:params) {
+        {
+          "identite_prenom" => "Prénom",
+          "identite_nom" => "Nom",
+          "identite_genre" => Individual::GENDER_FEMALE,
+        }
+      }
+
+      it "keeps the valid gender" do
+        expect(prefill_identity_hash[:gender]).to eq(Individual::GENDER_FEMALE)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Contexte

L'endpoint public `POST /api/public/v1/demarches/:id/dossiers` accepte un payload JSON prefill contenant des clés `champ_<typed_id>` et `identite_*`. Jusqu'ici, le controller forwardait `params.to_unsafe_h` à `PrefillChamps` et `PrefillIdentity`, puis persistait les valeurs via `save(validate: false)`.

Une valeur `Hash` ou `Array` imbriqué envoyée comme valeur d'un champ ou d'une clé identité traversait le flow et finissait type-castée en `String` (`Hash#to_s`) dans la colonne `value`, produisant des données corrompues du type `"{:foo=>\"bar\"}"`.

## Changements

- `TypesDeChamp::PrefillTypeDeChamp` (base) retourne `nil` pour un `Hash` ou un `Array` contenant un `Hash`/`Array`.
- L'override `Address` exige une `String` (sémantique textuelle).
- Les overrides `Siret` / `Referentiel` acceptent `String` ou `Numeric` et castent en `String` avant assignation de `external_id` (helper partagé `scalar_prefill_value?`).
- L'ordre de `PrefillChamps::PrefillValue#prefillable?` est ajusté pour ne pas appeler `valid?` quand `champ_attributes` est `nil`.
- Le controller filtre les paramètres identité via Strong Parameters (`permit(:identite_prenom, :identite_nom, :identite_genre)`).
- `PrefillIdentity` utilise `Individual::GENDER_MALE` / `GENDER_FEMALE` et `presence_in` pour le whitelisting du genre.

## Comportement utilisateur

Une valeur refusée laisse le champ vide. L'utilisateur complète manuellement sur la page du dossier ou la page identité — comportement identique aux autres cas de prefill invalide existants (ex. `"non integer string"` sur un champ `number`).