### PR TITLE
ETQ instructeur, corrige le JS sur l'onglet "au total", notamment l'option "inclure les dossiers archivés"

### DIFF
--- a/app/components/dsfr/toggle_component.rb
+++ b/app/components/dsfr/toggle_component.rb
@@ -26,25 +26,20 @@ class Dsfr::ToggleComponent < ApplicationComponent
   private
 
   def check_box_options
-    opts = { class: 'fr-toggle__input', id: label_for, disabled: disabled }
+    opts = { class: 'fr-toggle__input', disabled: disabled }
+    opts[:id] = input_id if @form.object.present?
     opts[:checked] = @checked unless @checked.nil?
     opts
   end
 
-  def label_for
-    return input_id if @form.object.present?
-
-    return "#{@form.options[:namespace]}_#{target}" if @form.options[:namespace].present?
-
-    target.to_s
+  def label_options
+    opts = { data: label_data, class: 'fr-toggle__label' }
+    opts[:for] = input_id if @form.object.present?
+    opts
   end
 
   def input_id
-    if @form.object.present?
-      dom_id(@form.object, target)
-    else
-      target.to_s
-    end
+    dom_id(@form.object, target)
   end
 
   def label_data

--- a/app/components/dsfr/toggle_component/toggle_component.html.haml
+++ b/app/components/dsfr/toggle_component/toggle_component.html.haml
@@ -1,10 +1,6 @@
 %div{ class: "fr-toggle #{extra_class_names}" }
   = @form.check_box target, check_box_options
-  = @form.label target,
-    title || html_title&.html_safe,
-    for: label_for,
-    data: label_data,
-    class: 'fr-toggle__label'
+  = @form.label target, title || html_title&.html_safe, label_options
 
   - if hint
     %p.fr-hint-text= hint

--- a/spec/components/dsfr/toggle_component_spec.rb
+++ b/spec/components/dsfr/toggle_component_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Dsfr::ToggleComponent, type: :component do
+  def render_with_form(**form_options)
+    cmp = nil
+    ActionView::Base.empty.form_with(**form_options) do |form|
+      cmp = described_class.new(form:, target: :include_archived, html_title: "Include archived")
+    end
+    render_inline(cmp).to_html
+  end
+
+  def extract_input_id(html)
+    html[/<input class="fr-toggle__input"[^>]*id="([^"]+)"/, 1]
+  end
+
+  def extract_label_for(html)
+    html[/<label[^>]*for="([^"]+)"/, 1]
+  end
+
+  context "with a form_with and a namespace but no object" do
+    let(:html) { render_with_form(url: "/fake", namespace: "export1") }
+
+    it "produces identical values for the input id and the label for attributes" do
+      expect(extract_input_id(html)).to eq("export1_include_archived")
+      expect(extract_label_for(html)).to eq("export1_include_archived")
+    end
+
+    it "does not double-prefix the namespace" do
+      expect(html).not_to include("export1_export1_include_archived")
+    end
+  end
+
+  context "with a form_with without namespace nor object" do
+    let(:html) { render_with_form(url: "/fake") }
+
+    it "produces identical values for the input id and the label for attributes" do
+      expect(extract_input_id(html)).to be_present
+      expect(extract_input_id(html)).to eq(extract_label_for(html))
+    end
+  end
+
+  context "with a form_with bound to a model" do
+    let(:procedure) { build_stubbed(:procedure) }
+    let(:html) { render_with_form(model: procedure, url: "/fake") }
+
+    it "produces identical values for the input id and the label for attributes" do
+      expect(extract_input_id(html)).to be_present
+      expect(extract_input_id(html)).to eq(extract_label_for(html))
+    end
+  end
+
+  context "with two forms using different namespaces on the same page" do
+    it "generates distinct ids so multiple toggles can coexist without breaking DSFR init" do
+      first = render_with_form(url: "/fake", namespace: "export1")
+      second = render_with_form(url: "/fake", namespace: "export_template_1")
+
+      expect(extract_input_id(first)).to eq("export1_include_archived")
+      expect(extract_label_for(first)).to eq("export1_include_archived")
+      expect(extract_input_id(second)).to eq("export_template_1_include_archived")
+      expect(extract_label_for(second)).to eq("export_template_1_include_archived")
+    end
+  end
+end


### PR DESCRIPTION
AKA fix double préfixe namespace dans Dsfr::ToggleComponent

Fix https://demarches-simplifiees.sentry.io/issues/7411391847/
Fix https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_501eaa8d-1b7c-47ea-9d29-ca09e2599114/
Fix https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_60b50bce-8f1c-4005-b715-7ee802fb5301/

## Summary

- Un toggle DSFR rendu dans un `form_with url: ..., namespace: "..."` (sans objet) générait un `id` avec le namespace préfixé deux fois (`id="export1_export1_include_archived"`), alors que le `for` du label ne l'était qu'une fois — mismatch qui faisait crasher l'init DSFR (`toggle.module.js`) et cassait les autres JS de la page comme le menu ou l'accès aux modèles d'export
- Cas visible sur l'onglet d'export instructeur, onglet "au total" (deux toggles « Inclure le dossier à archiver »). 
- Cause : Rails 7.2 préfixe le `namespace:` à l'`id:` passé explicitement, mais pas au `for:` (contexte form builder vs tag helper dans `ActionView::Helpers::Tags::Base#add_default_name_and_id` et `Tags::Label#render`).
- Fix : ne forcer `id`/`for` que lorsque le form a un objet (cas `dom_id`). Sinon, laisser Rails les calculer — le namespace est alors appliqué de façon cohérente des deux côtés.