### PR TITLE
ETQ usager, je peux envoyer des fichiers .md et .xlsm en PJ

### DIFF
--- a/config/initializers/authorized_content_types.rb
+++ b/config/initializers/authorized_content_types.rb
@@ -77,6 +77,7 @@ AUTHORIZED_CONTENT_TYPES = PROCESSABLE_TYPES + AUTHORIZED_SPREADSHEET_TYPES + [
   'application/vnd.oasis.opendocument.text', # text x 46229
   'application/msword', # text x 30167
   'text/plain', # text x 24477
+  'text/markdown', # text .md
   'application/vnd.openxmlformats-officedocument.presentationml.presentation', # text x 3231
   'application/rtf', # text x 1438
   'application/vnd.apple.pages', # text x 609
@@ -110,6 +111,7 @@ FORMAT_FAMILIES = {
     'application/vnd.oasis.opendocument.text',
     'application/msword',
     'text/plain',
+    'text/markdown',
     'application/rtf',
     'application/vnd.apple.pages',
   ],

--- a/config/initializers/authorized_content_types.rb
+++ b/config/initializers/authorized_content_types.rb
@@ -28,6 +28,7 @@ AUTHORIZED_SPREADSHEET_TYPES = [
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   'application/vnd.oasis.opendocument.spreadsheet',
   'application/vnd.ms-excel.sheet.macroenabled.12',
+  'application/vnd.ms-excel.sheet.macroEnabled.12', # .xlsm (variante sensible à la casse renvoyée par MiniMime)
   'application/vnd.openxmlformats-officedocument.spreadsheetml.template',
   'application/vnd.ms-excel.sheet.binary.macroenabled.12',
   'application/vnd.oasis.opendocument.spreadsheet-template',


### PR DESCRIPTION
Possible fix https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_f6a844f5-1299-4acf-a108-3238710b287f/



- Ajoute la variante camelCase `application/vnd.ms-excel.sheet.macroEnabled.12`. La variante minuscule renvoyée par Marcel était déjà présente (donc l'upload passait la validation), mais `MiniMime` — utilisé par `TypeDeChamp#allowed_extensions` pour construire l'attribut HTML `accept` — ne reconnaît que la variante camelCase. Sans cette entrée, l'extension `.xlsm` n'apparaissait pas dans le sélecteur de fichier du navigateur et empêchait l'envoi des fichiers ayant le mime type avec cette case

- Ajoute `text/markdown` à `AUTHORIZED_CONTENT_TYPES` et à la famille `document_texte` pour autoriser les fichiers `.md`