### PR TITLE
Tech: améliore la performance des cas pathologiques de suppression de lignes dans un bloc repetable

### DIFF
--- a/app/controllers/champs/champ_controller.rb
+++ b/app/controllers/champs/champ_controller.rb
@@ -19,6 +19,7 @@ class Champs::ChampController < ApplicationController
     dossier.with_update_stream(current_user) if type_de_champ.public?
 
     if type_de_champ.repetition?
+      DossierPreloader.load_one(dossier, pj_template: true)
       dossier.project_champ(type_de_champ)
     else
       dossier.champ_for_update(type_de_champ, row_id: params_row_id, updated_by: current_user.email)


### PR DESCRIPTION
En prod, nous avons un cas pathologique avec un champ repetition avec 42 lignes contenant 35 champs chacun dont 8 pj.
La suppression d'une ligne entraînait des explosions mémoire.

Cela est du à un non préchargements du dossier entraînant n+1 sql et ruby dans la partie visibilité.

Le fix est simple : précharger le dossier.
 
impact pour un cas similaire en local :
avant :  
` Completed 200 OK in 502442ms (Views: 501777.8ms | ActiveRecord: 254.3ms (4907 queries, 4436 cached) | GC: 325340.3ms)`
apres :
`Completed 200 OK in 10218ms (Views: 9556.5ms | ActiveRecord: 43.0ms (25 queries, 3 cached) | GC: 702.3ms)`

50* plus rapide :tada:

Pour les cas non pathologique, le pire cas ne doit pas être impactant car on utilise le preloader de toutes les facons pour afficher la page dossier.