### PR TITLE
ETQ Usager/Instructeur/Adminsitrateur, le bouton pro connect est disponible sur la page `se connecter`

### DIFF
--- a/app/components/pro_connect_login_component.rb
+++ b/app/components/pro_connect_login_component.rb
@@ -15,7 +15,7 @@ class ProConnectLoginComponent < ApplicationComponent
 
   def resolved_title
     if @title == :default
-      t('.title')
+      t('views.shared.france_connect_login.commencer_pc_title')
     else
       @title
     end

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -16,7 +16,7 @@
         - else
           .fr-grid-row.fr-grid-row--gutters
             .fr-col-12.fr-col-lg-5
-              = render partial: 'shared/france_connect_login', locals: { url: commencer_france_connect_path(path: @procedure.path, prefill_token: @prefilled_dossier&.prefill_token), heading_level: :h3, title: t('views.shared.france_connect_login.commencer_title') }
+              = render partial: 'shared/france_connect_login', locals: { url: commencer_france_connect_path(path: @procedure.path, prefill_token: @prefilled_dossier&.prefill_token), heading_level: :h3 }
               -# = render ProConnectLoginComponent.new(url: commencer_pro_connect_path(path: @procedure.path, prefill_token: @prefilled_dossier&.prefill_token), heading_level: :h3, title: t('views.shared.france_connect_login.commencer_pc_title'))
             .fr-hidden.fr-unhidden-lg.fr-col-lg-1
               .fr-vr-or{ role: "separator", "aria-orientation": "vertical" }

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -44,7 +44,7 @@
                   - if request.path == new_user_registration_path
                     %li.fr-hidden-sm.fr-unhidden-lg.fr-link--sm.fr-mr-1v= t('views.shared.account.already_user_question')
                   - if request.path != new_user_session_path && !content_for?(:hide_header_signin)
-                    %li= link_to t('views.shared.account.signin'), new_user_session_path, class: "fr-btn fr-btn--tertiary fr-icon-account-circle-fill fr-btn--icon-left"
+                    %li= link_to t('views.shared.account.signin'), new_user_session_path(with_proconnect: true), class: "fr-btn fr-btn--tertiary fr-icon-account-circle-fill fr-btn--icon-left"
                   - if request.path != pro_connect_path
                     %li= link_to t('views.shared.account.professional'),
                       content_for(:pro_connect_path) || pro_connect_path,

--- a/app/views/pro_connect/index.html.haml
+++ b/app/views/pro_connect/index.html.haml
@@ -14,12 +14,12 @@
 
             .fr-mb-0.fr-fieldset
               .fr-fieldset__legend
-                %h2.fr-h6= t('.cta')
+                %h2.fr-h6= t('views.shared.france_connect_login.commencer_pc_title')
 
               .fr-fieldset__element
                 %p= t('.explanation')
 
-                = render ProConnectLoginComponent.new
+                = render ProConnectLoginComponent.new(title: nil)
 
             - if !params[:force_pro_connect]
               %p.fr-hr-or= t('views.shared.france_connect_login.separator')

--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -24,7 +24,7 @@
           %p.fr-h5= t(".fill_procedure")
 
           = link_to t(".how_to_find_procedure"), t("links.common.faq.comment_trouver_ma_demarche_url"), class: "fr-btn fr-btn--lg fr-mr-1w fr-mb-2w", title: new_tab_suffix(t(".how_to_find_procedure"))
-          = link_to t("views.users.sessions.new.connection"), new_user_session_path, class: "fr-btn fr-btn--secondary fr-btn--lg"
+          = link_to t("views.users.sessions.new.connection"), new_user_session_path(with_proconnect: true), class: "fr-btn fr-btn--secondary fr-btn--lg"
 
   .fr-py-6w
     .container

--- a/app/views/shared/_france_connect_login.html.haml
+++ b/app/views/shared/_france_connect_login.html.haml
@@ -1,7 +1,7 @@
 - if FranceConnectService.enabled?
   .france-connect-login
     = tag.public_send(local_assigns.fetch(:heading_level, :h2), class: "fr-h6 fr-mb-0") do
-      = local_assigns.fetch(:title, t('views.shared.france_connect_login.title'))
+      = t('views.shared.france_connect_login.commencer_title')
 
     .fr-connect-group.fr-my-2w
       = link_to(url, class: "fr-btn fr-connect") do

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -7,7 +7,7 @@
 
     %h1.fr-h2= t('views.registrations.new.title', name: Current.application_name)
 
-    = render partial: 'shared/france_connect_login', locals: { url: france_connect_path, title: t('views.shared.france_connect_login.signup_title') }
+    = render partial: 'shared/france_connect_login', locals: { url: france_connect_path }
     -# = render ProConnectLoginComponent.new(title: t('views.shared.france_connect_login.signup_pc_title'))
 
     %p.fr-hr-or= t('views.shared.france_connect_login.separator')

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -7,7 +7,8 @@
     %h1.fr-h2= t('views.users.sessions.new.sign_in', application_name: Current.application_name)
 
     = render partial: 'shared/france_connect_login', locals: { url: france_connect_path }
-    -# = render ProConnectLoginComponent.new
+    - if params[:with_proconnect]
+      = render ProConnectLoginComponent.new
 
     %p.fr-hr-or= t('views.shared.france_connect_login.separator')
 

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -13,8 +13,6 @@ en:
         en_attente: "Waiting for response"
         avis_non_rendu: "Response not given"
       france_connect_login:
-        title: "Sign in with FranceConnect"
-        signup_title: "Create an account with FranceConnect"
         # signup_pc_title: "Create an account with ProConnect"
         commencer_title: "Are you an individual?"
         # commencer_pc_title: "Are you a professional?"

--- a/config/locales/views/shared/fr.yml
+++ b/config/locales/views/shared/fr.yml
@@ -13,8 +13,6 @@ fr:
         en_attente: "En attente d’avis"
         avis_non_rendu: "Avis non rendu"
       france_connect_login:
-        title: "Se connecter avec FranceConnect"
-        signup_title: "Se créer un compte avec FranceConnect"
         # signup_pc_title: "Se créer un compte avec ProConnect"
         commencer_title: "Vous êtes un particulier ?"
         commencer_pc_title: "Vous êtes un professionnel ?"

--- a/config/locales/views/shared/fr.yml
+++ b/config/locales/views/shared/fr.yml
@@ -17,7 +17,7 @@ fr:
         signup_title: "Se créer un compte avec FranceConnect"
         # signup_pc_title: "Se créer un compte avec ProConnect"
         commencer_title: "Vous êtes un particulier ?"
-        # commencer_pc_title: "Vous êtes un professionnel ?"
+        commencer_pc_title: "Vous êtes un professionnel ?"
         login_button: "S’identifier avec"
         help_link: "Qu’est-ce que FranceConnect ?"
         separator: ou

--- a/spec/controllers/root_controller_spec.rb
+++ b/spec/controllers/root_controller_spec.rb
@@ -71,7 +71,7 @@ describe RootController, type: :controller do
     end
 
     it "won't have instructeur login link" do
-      expect(response.body).to have_css("a[href='#{new_user_session_path}']")
+      expect(response.body).to have_css("a[href='#{new_user_session_path(with_proconnect: true)}']")
     end
   end
 end

--- a/spec/views/users/sessions/new.html.haml_spec.rb
+++ b/spec/views/users/sessions/new.html.haml_spec.rb
@@ -8,7 +8,10 @@ describe 'users/sessions/new', type: :view do
 
   before do
     assign(:user, User.new)
+    params[:with_proconnect] = with_proconnect if with_proconnect
   end
+
+  let(:with_proconnect) { nil }
 
   context 'when FranceConnect and ProConnect are enabled' do
     before do
@@ -27,8 +30,16 @@ describe 'users/sessions/new', type: :view do
       expect(rendered).to have_css('.france-connect-login')
     end
 
-    xit 'renders ProConnect login button' do
-      expect(rendered).to have_css('.pro-connect-login')
+    it 'does not render ProConnect login button by default' do
+      expect(rendered).not_to have_css('.pro-connect-login')
+    end
+
+    context 'when with_proconnect query param is present' do
+      let(:with_proconnect) { 'true' }
+
+      it 'renders ProConnect login button' do
+        expect(rendered).to have_css('.pro-connect-login')
+      end
     end
   end
 


### PR DESCRIPTION
on reprend le design précédent pour la page users/sign_in

<img width="1865" height="995" alt="Screenshot 2026-04-23 at 11-22-11 Se connecter · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/9dec659a-4fcb-476b-b1cb-385a36d7039c" />

Cette page est affichée :
- depuis le lien `Se connecter` depuis la page d'accueil
- depuis le lien `j'ai déjà un compte` depuis la page commencer d'une démarche

**proposition** : dans un premier temps, on n'affiche ce bouton **uniquement si on vient du lien `se connecter`** , ca devrait permettre aux agents de trouver facilement le bouton lorsqu'ils se connectent sur dn (cad sans passer par la page `commencer`) tout en limitant le gros du traffic venant des usagers.

- [x] attendre le go de pro connect


**A la demande de pro connect** : on modifie le texte au dessus du bouton pro connect pour faire comprendre que cela ne concerne que les professionnels

<img width="1225" height="1118" alt="Screenshot 2026-05-21 at 17-39-14 Se connecter · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/2dcfc8dd-3e10-4de2-a0c9-589f4be9088f" />
