### PR TITLE
ETQ Usager, on me propose à nouveau de me connecter avec proconnect pour les nouvelles démarches morales

### DIFF
--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -80,6 +80,7 @@ module ProcedureCloneConcern
     'api_particulier_token',
     'no_gender',
     'pro_connect_restriction',
+    'pro_connect_for_moral_procedure',
     'robots_indexable',
     'admin_default_procedure_presentation_active',
     'admin_default_procedure_presentation_id',

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -223,6 +223,8 @@ class Procedure < ApplicationRecord
     all: 'all',
   }, prefix: true
 
+  before_create :enable_pro_connect_for_moral_procedure
+
   validates :libelle, presence: true, allow_blank: false, allow_nil: false
   validates :description, presence: true, allow_blank: false, allow_nil: false
   validates :administrateurs, presence: true
@@ -842,6 +844,10 @@ class Procedure < ApplicationRecord
       .filter_map(&:routing_rule)
       .flat_map(&:terms)
       .any? { _1.is_a?(Logic::ChampValue) }
+  end
+
+  def enable_pro_connect_for_moral_procedure
+    self.pro_connect_for_moral_procedure = true if !for_individual?
   end
 
   def stable_ids_used_by_routing_rules

--- a/app/views/commencer/show.html.erb
+++ b/app/views/commencer/show.html.erb
@@ -23,7 +23,9 @@
             <div class="fr-col-12 fr-col-lg-5">
               <%= render partial: 'shared/france_connect_login', locals: { url: commencer_france_connect_path(path: @procedure.path, prefill_token: @prefilled_dossier&.prefill_token), heading_level: :h3 } %>
 
-              <%# = render ProConnectLoginComponent.new(url: commencer_pro_connect_path(path: @procedure.path, prefill_token: @prefilled_dossier&.prefill_token), heading_level: :h3, title: t('views.shared.france_connect_login.commencer_pc_title')) %>
+              <%- if @procedure.pro_connect_for_moral_procedure? -%>
+                <%= render ProConnectLoginComponent.new(url: commencer_pro_connect_path(path: @procedure.path, prefill_token: @prefilled_dossier&.prefill_token), heading_level: :h3, title: t('views.shared.france_connect_login.commencer_pc_title')) %>
+              <%- end -%>
             </div>
 
             <div class="fr-hidden fr-unhidden-lg fr-col-lg-1">

--- a/db/migrate/20260423120000_add_pro_connect_for_moral_procedure_to_procedures.rb
+++ b/db/migrate/20260423120000_add_pro_connect_for_moral_procedure_to_procedures.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProConnectForMoralProcedureToProcedures < ActiveRecord::Migration[7.2]
+  def change
+    add_column :procedures, :pro_connect_for_moral_procedure, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1126,6 +1126,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_21_105001) do
     t.bigint "parent_procedure_id"
     t.string "path"
     t.boolean "piece_justificative_multiple", default: true, null: false
+    t.boolean "pro_connect_for_moral_procedure", default: false, null: false
     t.boolean "pro_connect_restricted", default: false, null: false
     t.string "pro_connect_restriction", default: "none", null: false
     t.boolean "procedure_expires_when_termine_enabled", default: true

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -514,6 +514,48 @@ describe Users::CommencerController, type: :controller do
     end
   end
 
+  describe '#commencer for moral procedure with pro_connect_for_moral_procedure flag' do
+    render_views
+    subject { get :commencer, params: { path: procedure.path } }
+
+    before { allow(ProConnectService).to receive(:enabled?).and_return(true) }
+
+    context 'when procedure is moral and flag is enabled' do
+      let(:procedure) { create(:procedure, :published, for_individual: false) }
+
+      it 'shows both FranceConnect and ProConnect' do
+        subject
+        assert_response :success
+        expect(response.body).to include('FranceConnect')
+        expect(response.body).to include('ProConnect')
+      end
+    end
+
+    context 'when procedure is moral but flag is disabled (legacy procedure)' do
+      let(:procedure) { create(:procedure, :published, for_individual: false) }
+
+      before { procedure.update_column(:pro_connect_for_moral_procedure, false) }
+
+      it 'shows FranceConnect but not ProConnect' do
+        subject
+        assert_response :success
+        expect(response.body).to include('FranceConnect')
+        expect(response.body).not_to include('ProConnect')
+      end
+    end
+
+    context 'when procedure is for individuals' do
+      let(:procedure) { create(:procedure, :for_individual, :published) }
+
+      it 'shows FranceConnect but not ProConnect' do
+        subject
+        assert_response :success
+        expect(response.body).to include('FranceConnect')
+        expect(response.body).not_to include('ProConnect')
+      end
+    end
+  end
+
   describe '#commencer with pro_connect_restriction' do
     render_views
     let(:procedure) { create(:procedure, :for_individual, :published, pro_connect_restriction: :all) }

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1891,6 +1891,37 @@ describe Procedure do
     end
   end
 
+  describe 'enable_pro_connect_for_moral_procedure callback' do
+    context 'when creating a procedure for moral persons' do
+      let(:procedure) { create(:procedure, for_individual: false) }
+
+      it 'enables pro_connect_for_moral_procedure' do
+        expect(procedure.pro_connect_for_moral_procedure).to be true
+      end
+    end
+
+    context 'when creating a procedure for individuals' do
+      let(:procedure) { create(:procedure, for_individual: true) }
+
+      it 'does not enable pro_connect_for_moral_procedure' do
+        expect(procedure.pro_connect_for_moral_procedure).to be false
+      end
+    end
+
+    context 'when updating an existing moral procedure with the flag disabled' do
+      let(:procedure) { create(:procedure, for_individual: false) }
+
+      before do
+        procedure.update_column(:pro_connect_for_moral_procedure, false)
+      end
+
+      it 'does not re-enable the flag on update' do
+        procedure.update!(libelle: 'new libelle')
+        expect(procedure.reload.pro_connect_for_moral_procedure).to be false
+      end
+    end
+  end
+
   describe '#enable_pro_connect_restriction!' do
     let(:procedure) { create(:procedure, opendata: true, robots_indexable: true) }
 


### PR DESCRIPTION
On active l'affichage **uniquement** pour les nouvelles démarches morales.

<img width="1865" height="995" alt="Screenshot 2026-04-23 at 17-14-42 avec siret · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/1ab68434-229d-4a19-ae61-8208f3602b02" />

- [x] attendre une semaine que #13012 soit passé
- [x] refaire un point avec proconnect