### PR TITLE
ETQ Administrateur: les agents qui se connectent sur mes nouvelles procédures doivent être pro connectés par défaut

### DIFF
--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -186,7 +186,6 @@ module ProcedureCloneConcern
     procedure.template = false
     procedure.labels = labels.map(&:dup)
     procedure.routing_alert = false
-    procedure.pro_connect_restriction = :none
     procedure.robots_indexable = true
     procedure.admin_default_procedure_presentation_active = false
     procedure.admin_default_procedure_presentation_id = nil

--- a/db/migrate/20260423140000_change_pro_connect_restriction_default_to_instructeurs.rb
+++ b/db/migrate/20260423140000_change_pro_connect_restriction_default_to_instructeurs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeProConnectRestrictionDefaultToInstructeurs < ActiveRecord::Migration[7.2]
+  def change
+    change_column_default :procedures, :pro_connect_restriction, from: "none", to: "instructeurs"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_21_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_23_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -1125,7 +1125,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_21_120000) do
     t.string "path"
     t.boolean "piece_justificative_multiple", default: true, null: false
     t.boolean "pro_connect_restricted", default: false, null: false
-    t.string "pro_connect_restriction", default: "none", null: false
+    t.string "pro_connect_restriction", default: "instructeurs", null: false
     t.boolean "procedure_expires_when_termine_enabled", default: true
     t.datetime "published_at", precision: nil
     t.bigint "published_revision_id"

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
     sva_svr { {} }
     no_gender { true }
     api_entreprise_token { JWT.encode({ exp: 2.months.from_now.to_i }, nil, 'none') }
+    pro_connect_restriction { :none }
 
     groupe_instructeurs { [association(:groupe_instructeur, :default, procedure: instance, strategy: :build)] }
     administrateurs { [administrateur] }

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1872,6 +1872,12 @@ describe Procedure do
     end
   end
 
+  describe 'pro_connect_restriction default' do
+    it 'defaults to :instructeurs for new procedures' do
+      expect(Procedure.new.pro_connect_restriction).to eq('instructeurs')
+    end
+  end
+
   describe '#enable_pro_connect_restriction!' do
     let(:procedure) { create(:procedure, opendata: true, robots_indexable: true) }
 

--- a/spec/system/administrateurs/procedure_creation_spec.rb
+++ b/spec/system/administrateurs/procedure_creation_spec.rb
@@ -26,6 +26,11 @@ describe 'Creating a new procedure', js: true do
     fill_in_dummy_procedure_details
     click_on 'Créer la démarche'
 
+    expect(page).to have_current_path(pro_connect_required_path)
+
+    allow_any_instance_of(Administrateurs::AdministrateurController).to receive(:logged_in_with_pro_connect?).and_return(true)
+
+    visit champs_admin_procedure_path(Procedure.last)
     expect(page).to have_current_path(champs_admin_procedure_path(Procedure.last))
   end
 


### PR DESCRIPTION
Les administrateurs peuvent toujours modifié le réglage dans l'administration de leur procédure

- [ ] attendre le go de proconnect