### PR TITLE
Correctif: ETQ admin, corriger l'affichage des cellules referentiel avec de longs labels

### DIFF
--- a/app/components/referentiels/referentiel_display_component/referentiel_display_component.html.haml
+++ b/app/components/referentiels/referentiel_display_component/referentiel_display_component.html.haml
@@ -16,7 +16,7 @@
           %tbody
             - display_mapping.sort.each do |jsonpath, mapping_opts|
               %tr
-                %td.fr-cell--fixed= jsonpath
+                %td.fr-cell--multiline.fr-cell--fixed= jsonpath
                 %td.fr-cell--multiline= mapping_opts[:example_value] || mapping_opts["example_value"]
                 %td= mapping_opts[:type] || mapping_opts["type"]
                 %td= mapping_opts[:libelle] || mapping_opts["libelle"]

--- a/app/components/referentiels/referentiel_prefill_component/referentiel_prefill_component.html.haml
+++ b/app/components/referentiels/referentiel_prefill_component/referentiel_prefill_component.html.haml
@@ -13,7 +13,7 @@
           %tbody
             - referentiel_mapping_prefillable.sort.each do |jsonpath, mapping_opts|
               %tr
-                %td.fr-cell--fixed= jsonpath
+                %td.fr-cell--multiline.fr-cell--fixed= jsonpath
                 %td.fr-cell--multiline= mapping_opts[:example_value]
                 %td= mapping_opts[:type]
                 %td= prefill_stable_id_tag(jsonpath, mapping_opts)


### PR DESCRIPTION
# Probleme

Dans les tableaux de mapping referentiel (prefill et display), la colonne jsonpath utilise `fr-cell--fixed` sans `fr-cell--multiline`. Quand le label est long, le contenu deborde et l'interface devient inutilisable (pas de scroll possible).

# Solution

Ajout de la classe `fr-cell--multiline` sur les cellules jsonpath des deux composants (`referentiel_display_component` et `referentiel_prefill_component`), ce qui permet au texte long de passer a la ligne dans la cellule fixe.

Generated with [Claude Code](https://claude.com/claude-code)

apres
<img width="2378" height="1544" alt="Screenshot 2026-04-27 at 10-06-48 demarche numerique gouv fr" src="https://github.com/user-attachments/assets/8b5d0afc-8ee9-4066-bb28-ccf5bb43cdc0" />

avant
<img width="2346" height="1424" alt="Screenshot 2026-04-27 at 10-07-25 demarche numerique gouv fr" src="https://github.com/user-attachments/assets/127d46cb-9425-4ae2-82e0-a3980466de79" />
