### PR TITLE
Tech: remplace les cookies exports seen_at par une entrée dans `instructeurs_procedures`

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -203,7 +203,7 @@ module Instructeurs
 
       @statut_with_notifications = DossierNotification.notifications_sticker_for_instructeur_procedure(groupe_instructeur_ids, current_instructeur)
       @notifications = DossierNotification.notifications_for_instructeur_dossiers(current_instructeur, @filtered_sorted_paginated_ids)
-      @has_export_notification = notify_exports?
+      @has_export_notification = notify_exports?(@instructeur_procedure)
       @has_unseen_revision_notification = notify_unseen_revisions?(@instructeur_procedure)
 
       cache_show_procedure_state # don't move in callback, inherited by Instructeurs::DossiersController
@@ -313,12 +313,7 @@ module Instructeurs
     def exports
       @procedure = procedure
       @exports = Export.for_groupe_instructeurs(groupe_instructeur_ids).ante_chronological
-      cookies.encrypted[cookies_export_key] = {
-        value: DateTime.current,
-        expires: Export::MAX_DUREE_GENERATION + Export::MAX_DUREE_CONSERVATION_EXPORT,
-        httponly: true,
-        secure: Rails.env.production?,
-      }
+      find_or_create_instructeur_procedure(@procedure).update!(last_export_seen_at: Time.current)
 
       respond_to do |format|
         format.turbo_stream
@@ -520,17 +515,19 @@ module Instructeurs
       params.require(:bulk_message).permit(:body)
     end
 
-    def notify_exports?
-      last_seen_at = begin
-                       DateTime.parse(cookies.encrypted[cookies_export_key])
-                     rescue
-                       nil
-                     end
-
+    def notify_exports?(instructeur_procedure)
       scope = Export.generated.for_groupe_instructeurs(groupe_instructeur_ids)
+      # TODO: remove legacy cookie support once deployed (Export retention is 48h)
+      last_seen_at = instructeur_procedure.last_export_seen_at || legacy_cookie_export_seen_at
       scope = scope.where(updated_at: last_seen_at...) if last_seen_at
 
       scope.exists?
+    end
+
+    def legacy_cookie_export_seen_at
+      DateTime.parse(cookies.encrypted["exports_#{@procedure.id}_seen_at"])
+    rescue
+      nil
     end
 
     def notify_unseen_revisions?(instructeur_procedure)
@@ -543,10 +540,6 @@ module Instructeurs
 
     def last_export_for(statut)
       Export.where(user_profile: current_instructeur, statut: statut, updated_at: 1.hour.ago..).last
-    end
-
-    def cookies_export_key
-      "exports_#{@procedure.id}_seen_at"
     end
 
     def ordered_procedure_ids_params

--- a/db/migrate/20260427100611_add_last_export_seen_at_to_instructeurs_procedures.rb
+++ b/db/migrate/20260427100611_add_last_export_seen_at_to_instructeurs_procedures.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastExportSeenAtToInstructeursProcedures < ActiveRecord::Migration[7.2]
+  def change
+    add_column :instructeurs_procedures, :last_export_seen_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_21_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_27_100611) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -887,6 +887,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_21_120000) do
     t.boolean "instant_email_new_expert_avis", default: false, null: false
     t.boolean "instant_email_new_message", default: false, null: false
     t.bigint "instructeur_id", null: false
+    t.datetime "last_export_seen_at"
     t.bigint "last_revision_seen_id"
     t.integer "position", null: false
     t.bigint "procedure_id", null: false

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -556,22 +556,28 @@ describe Instructeurs::ProceduresController, type: :controller do
 
         context 'with generated export' do
           render_views
+          let(:exports_seen_at) { nil }
+          let(:legacy_cookie_seen_at) { nil }
+
           before do
             create(:export, :generated, groupe_instructeurs: [gi_2], updated_at: 1.minute.ago)
 
             if exports_seen_at
-              cookies.encrypted["exports_#{procedure.id}_seen_at"] = exports_seen_at.to_datetime.to_s
+              create(:instructeurs_procedure, instructeur:, procedure:, last_export_seen_at: exports_seen_at)
+            end
+
+            if legacy_cookie_seen_at
+              cookies.encrypted["exports_#{procedure.id}_seen_at"] = legacy_cookie_seen_at.to_datetime.to_s
             end
 
             subject
           end
 
-          context 'without cookie' do
-            let(:exports_seen_at) { nil }
+          context 'without instructeur_procedure record' do
             it { expect(assigns(:has_export_notification)).to be(true) }
           end
 
-          context 'with cookie in past' do
+          context 'with last_export_seen_at in the past' do
             let(:exports_seen_at) { 1.hour.ago }
             it do
               expect(assigns(:has_export_notification)).to be(true)
@@ -579,8 +585,13 @@ describe Instructeurs::ProceduresController, type: :controller do
             end
           end
 
-          context 'with cookie set after last generated export' do
+          context 'with last_export_seen_at after the last generated export' do
             let(:exports_seen_at) { 10.seconds.ago }
+            it { expect(assigns(:has_export_notification)).to be(false) }
+          end
+
+          context 'with legacy cookie fallback after the last generated export' do
+            let(:legacy_cookie_seen_at) { 10.seconds.ago }
             it { expect(assigns(:has_export_notification)).to be(false) }
           end
         end
@@ -1123,6 +1134,13 @@ describe Instructeurs::ProceduresController, type: :controller do
     context 'when logged in through super admin' do
       let(:manager) { true }
       it { is_expected.to have_http_status(:forbidden) }
+    end
+
+    it 'records last_export_seen_at on the instructeur_procedure' do
+      freeze_time do
+        subject
+        expect(InstructeursProcedure.find_by(instructeur:, procedure:).last_export_seen_at).to eq(Time.current)
+      end
     end
   end
 


### PR DESCRIPTION
- Ces cookies parfois très nombreux peuvent poser des pb côté nginx ou session dans le manager
- maintenant on a la table `instructeurs_procedures`
- `instructeurs_procedures#last_revision_seen_id`  fait le même genre d'activité

Dans une seconde PR après déploiement on enlèvera complètement le code qui lit ces cookies.