### PR TITLE
Correctif: ETQ usager, corriger le crash lors du prefill d'annotations privees par un referentiel autocomplete

### DIFF
--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -212,9 +212,15 @@ class Champs::ReferentielChamp < Champ
   end
 
   def update_prefillable_champ(type_de_champ:, raw_value:, row_id: nil)
-    prefill_champ = dossier.champ_for_update(type_de_champ, row_id:, updated_by: :api)
-
-    prefill_champ.update(cast_value_for_type_de_champ(raw_value, type_de_champ))
+    if type_de_champ.private?
+      dossier.with_main_stream do
+        prefill_champ = dossier.champ_for_update(type_de_champ, row_id:, updated_by: :api)
+        prefill_champ.update(cast_value_for_type_de_champ(raw_value, type_de_champ))
+      end
+    else
+      prefill_champ = dossier.champ_for_update(type_de_champ, row_id:, updated_by: :api)
+      prefill_champ.update(cast_value_for_type_de_champ(raw_value, type_de_champ))
+    end
   end
 
   def rewrap_selected_object_in_datasource(data)

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1505,6 +1505,58 @@ describe Users::DossiersController, type: :controller do
         expect { subject }.to have_enqueued_job(ChampFetchExternalDataJob)
       end
     end
+
+    context 'when the champ is an autocomplete with prefillable private champs' do
+      render_views
+      let(:datasource) { '$.data' }
+      let(:referentiel) { create(:api_referentiel, :autocomplete, :with_autocomplete_response, datasource:) }
+      let(:referentiel_stable_id) { 1 }
+      let(:types_de_champ_public) do
+        [
+          {
+            type: :referentiel,
+            referentiel: referentiel,
+            stable_id: referentiel_stable_id,
+            referentiel_mapping: {
+              "$.data[0].finess" => { prefill: "1", prefill_stable_id: 100 },
+            },
+          },
+        ]
+      end
+      let(:types_de_champ_private) do
+        [
+          {
+            type: :text,
+            stable_id: 100,
+          },
+        ]
+      end
+      let(:procedure) { create(:procedure, :published, types_de_champ_public:, types_de_champ_private:) }
+      let(:suggestion_value) { 'osf' }
+      let(:suggestion_data) { { finess: "123" } }
+      let(:message_encryptor_service) { MessageEncryptorService.new }
+      let(:submit_payload) do
+        {
+          id: dossier.id,
+          dossier: {
+            champs_public_attributes: {
+              first_champ.public_id => {
+                value: suggestion_value,
+                data: message_encryptor_service.encrypt_and_sign(suggestion_data, purpose: :storage, expires_in: 1.hour),
+              },
+            },
+          },
+        }
+      end
+
+      it 'prefills the private annotation from the referentiel data' do
+        subject
+
+        dossier.reload
+        annotation = dossier.project_champs_private.find { it.stable_id == 100 }
+        expect(annotation.value).to eq(suggestion_data[:finess])
+      end
+    end
   end
 
   describe '#index' do


### PR DESCRIPTION
# Probleme

Quand un champ referentiel public en mode autocomplete a un mapping vers une annotation privee, la mise a jour du dossier **en_construction** crashe avec :

```
RuntimeError: Can not write a private champ to "user:buffer" stream
```

**Sentry :** https://demarches-simplifiees.sentry.io/issues/7443907160/

**Root cause :** `propagate_prefill` herite du stream du champ source (public → `user:buffer`), puis tente d'ecrire l'annotation privee sur ce stream. Or le guard `check_valid_stream_on_write?` interdit l'ecriture de champs prives sur un stream autre que `main`.

Le bug est latent depuis juin 2025 (introduction du guard stream + support des annotations dans les mappings referentiel), mais ne se declenchait pas car aucune procedure n'avait encore configure un mapping public → annotation privee sur un dossier en_construction.

# Solution

Dans `update_prefillable_champ`, on switch temporairement sur `main` stream via `dossier.with_main_stream` (block form) pour ecrire les annotations privees. Le block form restaure automatiquement le stream precedent, evitant tout side effect sur les champs publics suivants.

## TODO apres merge

- [x] Repondre sur [Crisp](https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_6094ff2c-4621-43b0-9912-07e1f30ec3be/)
- [x] Fermer [Sentry #7443907160](https://demarches-simplifiees.sentry.io/issues/7443907160/)

Generated with [Claude Code](https://claude.com/claude-code)