### PR TITLE
Tech: fix test flaky sur SpreadDossierDeletionTask

### DIFF
--- a/app/tasks/maintenance/spread_dossier_deletion_task.rb
+++ b/app/tasks/maintenance/spread_dossier_deletion_task.rb
@@ -5,7 +5,7 @@ module Maintenance
     # Contourne un égorgement de suppression de millions de dossiers qui aurait eu lieu le même jour
     # 2024-05-27-01 PR #10062
     ERROR_OCCURED_AT = Date.new(2024, 2, 14)
-    ERROR_OCCURED_RANGE = ERROR_OCCURED_AT.at_midnight..(ERROR_OCCURED_AT + 1.day)
+    ERROR_OCCURED_RANGE = ERROR_OCCURED_AT.at_midnight...(ERROR_OCCURED_AT + 1.day)
     SPREAD_DURATION_IN_DAYS = 150
 
     def collection


### PR DESCRIPTION
# Probleme

Le test `SpreadDossierDeletionTask` est flaky (~2.6% de taux de flake).

Le range inclusif (`..`) sur `ERROR_OCCURED_RANGE` inclut la borne `2024-02-15 00:00:00`. Quand `random_date_spread` retourne `1`, la date mise à jour (`ERROR_OCCURED_AT + 1.day`) reste dans le scope de la collection, et le dossier est retraité au batch suivant — le test échoue car le count ne correspond pas.

# Solution

Passage au range exclusif (`...`) pour exclure la borne supérieure. Sémantiquement correct ("les dossiers de cette journée") et élimine le flake.

Generated with [Claude Code](https://claude.com/claude-code)