### PR TITLE
ETQ Instructeur, corrections sur les colonnes

### DIFF
--- a/app/components/editable_champ/pays_component.rb
+++ b/app/components/editable_champ/pays_component.rb
@@ -10,7 +10,7 @@ class EditableChamp::PaysComponent < EditableChamp::EditableChampBaseComponent
   private
 
   def options
-    options = APIGeoService.countries.map { [_1[:name], _1[:code]] }
+    options = APIGeoService.country_options
     # For legacy fields, selected value is non standard country name. Add it to the list.
     if (@champ.selected&.size || 0) > 2
       options.unshift([@champ.selected, @champ.selected])

--- a/app/models/columns/champ_column.rb
+++ b/app/models/columns/champ_column.rb
@@ -6,7 +6,7 @@ class Columns::ChampColumn < Column
   def initialize(procedure_id:, label:, stable_id:, tdc_type:, displayable: true, filterable: true, type: :text, options_for_select: [], mandatory:)
     @stable_id = stable_id
     @tdc_type = tdc_type
-    column = tdc_type.in?(['departements', 'regions']) ? :external_id : :value
+    column = tdc_type.in?(['departements', 'regions', 'pays']) ? :external_id : :value
 
     super(
       procedure_id:,

--- a/app/models/columns/linked_drop_down_column.rb
+++ b/app/models/columns/linked_drop_down_column.rb
@@ -23,6 +23,8 @@ class Columns::LinkedDropDownColumn < Columns::ChampColumn
   end
 
   def filtered_ids_for_values(dossiers, search_terms)
+    return dossiers.ids if search_terms.blank?
+
     relation = dossiers.with_type_de_champ(@stable_id)
 
     search_terms = Array(search_terms).compact.reject(&:empty?)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -498,6 +498,8 @@ class TypeDeChamp < ApplicationRecord
       APIGeoService.departement_options
     elsif regions?
       APIGeoService.region_options
+    elsif pays?
+      APIGeoService.country_options
     elsif any_drop_down_list?
       if drop_down_advanced?
         Array.wrap(referentiel&.options_for_select)
@@ -590,7 +592,7 @@ class TypeDeChamp < ApplicationRecord
       :decimal
     when type_champs.fetch(:multiple_drop_down_list)
       :enums
-    when type_champs.fetch(:drop_down_list), type_champs.fetch(:departements), type_champs.fetch(:regions), type_champs.fetch(:civilite)
+    when type_champs.fetch(:drop_down_list), type_champs.fetch(:departements), type_champs.fetch(:regions), type_champs.fetch(:civilite), type_champs.fetch(:pays)
       :enum
     when type_champs.fetch(:checkbox), type_champs.fetch(:yes_no)
       :boolean

--- a/app/services/api_geo_service.rb
+++ b/app/services/api_geo_service.rb
@@ -20,6 +20,8 @@ class APIGeoService
       end
     end
 
+    def country_options = countries.map { [_1[:name], _1[:code]] }
+
     def country_name(code, locale: I18n.locale)
       countries(locale:).find { _1[:code] == code }&.dig(:name)
     end

--- a/spec/models/columns/champ_column_spec.rb
+++ b/spec/models/columns/champ_column_spec.rb
@@ -16,7 +16,7 @@ describe Columns::ChampColumn do
         expect_type_de_champ_values('communes', eq(["60580", "Coye-la-Forêt", "60", "32", "Coye-la-Forêt", "60580", "60"]))
         expect_type_de_champ_values('departements', eq(["01", "84", "01"]))
         expect_type_de_champ_values('regions', eq(['01', '01']))
-        expect_type_de_champ_values('pays', eq(['France']))
+        expect_type_de_champ_values('pays', eq(['FR']))
         expect_type_de_champ_values('epci', eq([nil, nil, nil]))
         expect_type_de_champ_values('iban', eq([nil]))
         expect_type_de_champ_values('siret', match_array(
@@ -349,6 +349,28 @@ describe Columns::ChampColumn do
 
         it "returns the correct ids" do
           expect(subject).to match_array([dossier_with_fromage.id, dossier_with_dessert.id])
+        end
+      end
+    end
+
+    context "with a pays champ" do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :pays, libelle: "pays" }]) }
+      let(:dossier_fr) { create(:dossier, :en_instruction, procedure:) }
+      let(:dossier_de) { create(:dossier, :en_instruction, procedure:) }
+
+      before do
+        dossier_fr.champs.first.update!(value: 'FR')
+        dossier_de.champs.first.update!(value: 'DE')
+      end
+
+      let(:column) { procedure.find_column(label: "pays") }
+      let(:dossiers) { procedure.dossiers }
+
+      context "when filtering by country code" do
+        let(:search_terms) { ["FR"] }
+
+        it "matches only the dossier with this code" do
+          expect(subject).to match_array([dossier_fr.id])
         end
       end
     end

--- a/spec/models/columns/linked_drop_down_column_spec.rb
+++ b/spec/models/columns/linked_drop_down_column_spec.rb
@@ -19,15 +19,17 @@ describe Columns::LinkedDropDownColumn do
     context "when filter value is nil" do
       let(:column) { procedure.find_column(label: 'linked') }
       let(:search_terms) { nil }
+      before { kept_dossier; discarded_dossier }
 
-      it { expect { subject }.not_to raise_error }
+      it { is_expected.to match_array([kept_dossier.id, discarded_dossier.id]) }
     end
 
     context "when filter value is missing" do
       let(:column) { procedure.find_column(label: 'linked') }
       subject { column.filtered_ids(Dossier.all, { operator: 'match' }) }
+      before { kept_dossier; discarded_dossier }
 
-      it { expect { subject }.not_to raise_error }
+      it { is_expected.to match_array([kept_dossier.id, discarded_dossier.id]) }
     end
 
     context 'when path is :value' do


### PR DESCRIPTION
- pays devient une `enum` qui peut être filtrée.
:warning: breaking change dans les export graphql des colonnes pays, au lieu de renvoyer le nom du pays, on va renvoyer le code. Je suppose que c'est désirable et qu il est raisonnable de penser que personne n'utiliser l export colonne des champs sachant que graphql renvoit par ailleurs pays / code.

- correction d'un bug concernant le filtrage de champ liste liée : avant si le filtre n'avait aucune valeur, tous les dossiers disparaissaient (étaient filtrés)