### PR TITLE
chore: ETQ tech j'aimerais que les specs tournent plus vite (rules_full_scenario)

### DIFF
--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -144,7 +144,7 @@ describe 'The routing with rules', js: true do
     expect(procedure.groupe_instructeurs.count).to eq(4)
 
     # add contact_information to all groupes instructeur
-    procedure.groupe_instructeurs.each { |gi| gi.update!(contact_information: create(:contact_information)) }
+    procedure.groupe_instructeurs.each { |gi| gi.update!(contact_information: create(:contact_information, nom: "Contact #{gi.label}")) }
 
     # publish
     publish_procedure(procedure)
@@ -184,7 +184,9 @@ describe 'The routing with rules', js: true do
     log_out
 
     # the scientifiques instructeurs only manage the scientifiques dossiers
-    register_instructeur_and_log_in(marie.email)
+    activate_instructeur(marie.email)
+    visit new_user_session_path
+    sign_in_with marie.user.email, password
     click_on(procedure.libelle, visible: true)
     expect(page).not_to have_text(litteraire_user.email)
     expect(page).to have_text(scientifique_user.email)
@@ -239,7 +241,9 @@ describe 'The routing with rules', js: true do
     log_out
 
     # the instructeurs who belong to scientifique AND litteraire groups manage scientifique and litteraire dossiers
-    register_instructeur_and_log_in(alain.email)
+    activate_instructeur(alain.email)
+    visit new_user_session_path
+    sign_in_with alain.user.email, password
     visit instructeur_procedure_path(procedure, statut: 'tous')
     expect(page).to have_text(litteraire_user.email)
     expect(page).to have_text(scientifique_user.email)
@@ -320,6 +324,12 @@ describe 'The routing with rules', js: true do
     click_on 'Déposer les modifications'
 
     log_out
+  end
+
+  def activate_instructeur(email)
+    user = User.find_by(email:)
+    user.update!(password: password)
+    user.instructeur.update!(bypass_email_login_token: true)
   end
 
   def register_instructeur_and_log_in(email)


### PR DESCRIPTION
## Context

iteration de plus sur le [test-optimization/SKILL.md](https://github.com/mfo/night-shift/blob/main/.claude/skills/test-optimization/SKILL.md)

## Changements

Optimise (~114s->~95s) `spec/system/routing/rules_full_scenario_spec.rb` via 2 axes :

| Commit | Technique | Description |
|---|---|---|
| `3aa8e8b` | activation programmatique | Remplace 2 `register_instructeur_and_log_in` (marie, alain) par un helper `activate_instructeur` programmatique + `sign_in_with` formulaire. Conserve `register_instructeur_and_log_in(victor)` pour le cookie `trusted_device` et la validation du chemin UI |
| `3aa8e8b` | fix flaky factory | Corrige collision de noms entre factories `contact_information` et `service` (même séquence `"Service #{n}"`) en nommant `"Contact #{gi.label}"` |

**Principe :**
- `activate_instructeur` fait l'activation en DB (password + `bypass_email_login_token`) au lieu de passer par le flow UI complet (email → lien → formulaire), économisant ~5s par instructeur
- Le cookie `trusted_device` posé par la première activation UI (victor) est partagé par le navigateur, les logins suivants passent sans blocage `redirect_if_untrusted`

## Métriques locales

| Scénario | Avant | Après | Gain |
|---|---|---|---|
| Configuration manuelle | ~90s | ~77s | ~13s (14%) |
| Configuration automatique | ~24s | ~17s | ~7s (29%) |
| **Total** | **~114s** | **~95s** | **~19s (17%)** |

- **Coverage :** stable (les mêmes assertions sont conservées, seul le mode de login change)

## Test plan

- [x] 2 runs consécutifs green en local
- [ ] **CI verte** ← c'est l'objet de cette PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)