### PR TITLE
Tech: empêche l'énumération d'utilisateurs (emails) par timing attack à la connexion

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -13,16 +13,17 @@ class Users::SessionsController < Devise::SessionsController
   skip_before_action :redirect_if_untrusted, only: [:reset_link_sent]
   # POST /resource/sign_in
   def create
-    user = User.find_by(user_email_params)
-
-    if user&.valid_password?(user_password_params[:password])
+    # NOTE: do not look up the user or check the password before delegating to
+    # `super`. Devise's paranoid mode normalises the bcrypt timing for unknown
+    # emails inside `warden.authenticate!`; a manual pre-check would only run
+    # bcrypt for existing accounts and reintroduce a timing-based enumeration.
+    super do |resource|
       delete_france_connect_cookies
       delete_pro_connect_session_info_cookie
-      user.update(loged_in_with_france_connect: nil)
-      user.update_preferred_domain(Current.host)
+      resource.update(loged_in_with_france_connect: nil)
+      resource.update_preferred_domain(Current.host)
     end
 
-    super
     if current_account.count > 1
       flash[:notice] = t("devise.sessions.signed_in_multiple_profile", roles: current_account.keys.map { |role| t("layouts.#{role}") }.to_sentence)
     end
@@ -147,13 +148,5 @@ class Users::SessionsController < Devise::SessionsController
     Instructeur.by_email(email)
   rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveSupport::MessageEncryptor::InvalidMessage
     nil
-  end
-
-  def user_email_params
-    params.require(:user).permit(:email)
-  end
-
-  def user_password_params
-    params.require(:user).permit(:password)
   end
 end


### PR DESCRIPTION
## Contexte

`Users::SessionsController#create` faisait un `User.find_by(email)` puis `user&.valid_password?(...)` **avant** de déléguer à `super` (Devise). Conséquence : bcrypt ne s'exécutait que lorsque l'email correspondait à un compte existant, créant un délai de réponse mesurable (~100 ms) qui permettait à un attaquant de distinguer un email enregistré d'un email inconnu — alors même que Devise est configuré en `paranoid` et égalise normalement le timing dans `warden.authenticate!`.

Ce pré-check est un reliquat d'une transition incomplète : la méthode avait un temps réimplémenté l'authentification à la main, puis on est revenu à Devise (`super`) en gardant ce bloc comme garde pour les side-effects FranceConnect. La duplication d'auth est restée.

## Correctif

Suppression du pré-check. Les side-effects (cookies FranceConnect / ProConnect, reset `loged_in_with_france_connect`, `update_preferred_domain`) sont déplacés dans le block yieldé par `super do |resource|`, lequel n'est invoqué qu'après authentification Devise réussie. bcrypt ne s'exécute donc plus que par le chemin timing-safe de Devise.