### PR TITLE
ETQ instructeur, ne pas afficher le libellé d'un autre groupe d'instructeurs dans la recherche

### DIFF
--- a/app/views/recherche/index.html.haml
+++ b/app/views/recherche/index.html.haml
@@ -4,7 +4,7 @@
 
   - if @dossier_not_in_instructor_group.present?
     .fr-alert.fr-alert--info.fr-alert--sm.fr-mt-3w
-      = p t('views.instructeurs.search.dossier_not_in_instructor_group', dossier_id: @dossier_not_in_instructor_group.id, procedure_libelle: @dossier_not_in_instructor_group.procedure.libelle, groupe_instructeur_label: @dossier_not_in_instructor_group.groupe_instructeur.label)
+      = p t('views.instructeurs.search.dossier_not_in_instructor_group', dossier_id: @dossier_not_in_instructor_group.id, procedure_libelle: @dossier_not_in_instructor_group.procedure.libelle)
   - elsif @deleted_dossier.present?
     .fr-alert.fr-alert--info.fr-alert--sm.fr-mt-3w
       = p t('views.instructeurs.search.deleted_dossier', dossier_id: @deleted_dossier.dossier_id, procedure_libelle: @deleted_dossier.procedure.libelle, deleted_at: l(@deleted_dossier.deleted_at))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -468,7 +468,7 @@ en:
       avis:
         introduction_file_explaination: "File attached to the request for advice"
       search:
-        dossier_not_in_instructor_group: "File no. %{dossier_id} of the procedure “%{procedure_libelle}” matches your search but it is attached to the “%{groupe_instructeur_label}” instructor group."
+        dossier_not_in_instructor_group: "File no. %{dossier_id} of the procedure “%{procedure_libelle}” matches your search but it is attached to another instructor group."
         deleted_dossier: "The File no. %{dossier_id} of the procedure “%{procedure_libelle}” matches your search but it was deleted on %{deleted_at}."
         hidden_dossier: "The File no. %{dossier_id} of the procedure “%{procedure_libelle}” matches your search but it was move to the "
         hidden_dossier_link: "bin"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -472,7 +472,7 @@ fr:
       avis:
         introduction_file_explaination: "Fichier joint à la demande d’avis"
       search:
-        dossier_not_in_instructor_group: "Le dossier n° %{dossier_id} de la procédure « %{procedure_libelle} » correspond à votre recherche mais il est rattaché au groupe d’instructeurs « %{groupe_instructeur_label} »."
+        dossier_not_in_instructor_group: "Le dossier n° %{dossier_id} de la procédure « %{procedure_libelle} » correspond à votre recherche mais il est rattaché à un autre groupe d’instructeurs."
         deleted_dossier: "Le dossier n° %{dossier_id} de la procédure « %{procedure_libelle} » correspond à votre recherche mais il a été supprimé le %{deleted_at}."
         hidden_dossier: "Le dossier n° %{dossier_id} de la procédure « %{procedure_libelle} » correspond à votre recherche mais il a été placé dans la "
         hidden_dossier_link: "corbeille"

--- a/spec/controllers/recherche_controller_spec.rb
+++ b/spec/controllers/recherche_controller_spec.rb
@@ -79,6 +79,15 @@ describe RechercheController, type: :controller do
           expect(assigns(:projected_dossiers)).to eq(nil)
           expect(assigns(:dossier_not_in_instructor_group)).to eq(dossier3)
         end
+
+        context 'rendered response' do
+          render_views
+
+          it 'does not disclose the label of the other groupe instructeur' do
+            subject
+            expect(response.body).not_to include(gi_p1_2.label)
+          end
+        end
       end
 
       context 'when dossier is deleted' do


### PR DESCRIPTION
## Résumé

- On retire le libellé du groupe du message que l'instructeur n'est pas censé connaitre. Le libellé de la procédure est conservé : l'instructeur en est membre légitime.
