### PR TITLE
ETQ admin, je ne peux changer mon email en autonomie que vers un domaine autorisé

### DIFF
--- a/app/controllers/users/profil_controller.rb
+++ b/app/controllers/users/profil_controller.rb
@@ -100,7 +100,7 @@ module Users
     end
 
     def ensure_update_email_is_authorized
-      if current_user.instructeur? && !target_email_allowed?
+      if (current_user.instructeur? || current_user.administrateur?) && !target_email_allowed?
         flash.alert = t('users.profil.ensure_update_email_is_authorized.email_not_allowed', contact_email: Current.contact_email, requested_email: requested_email)
         redirect_to profil_path
       end

--- a/spec/controllers/users/profil_controller_spec.rb
+++ b/spec/controllers/users/profil_controller_spec.rb
@@ -120,6 +120,36 @@ describe Users::ProfilController, type: :controller do
         end
       end
     end
+
+    context 'when the user has an administrateur role but no instructeur role' do
+      let(:administrateur_email) { 'administrateur_email@a.com' }
+      let!(:user) { create(:administrateur, email: administrateur_email, instructeur: nil).user }
+
+      before do
+        patch :update_email, params: { user: { email: requested_email } }
+        user.reload
+      end
+
+      context 'when the requested email is allowed' do
+        let(:requested_email) { 'legit@gouv.fr' }
+
+        it do
+          expect(user.unconfirmed_email).to eq('legit@gouv.fr')
+          expect(response).to redirect_to(profil_path)
+          expect(flash.notice).to eq(I18n.t('devise.registrations.update_needs_confirmation'))
+        end
+      end
+
+      context 'when the requested email is not allowed' do
+        let(:requested_email) { 'weird@gmail.com' }
+
+        it do
+          expect(user.unconfirmed_email).to be_nil
+          expect(response).to redirect_to(profil_path)
+          expect(flash.alert).to include('contactez le support')
+        end
+      end
+    end
   end
 
   context 'POST #transfer_all_dossiers' do


### PR DESCRIPTION
## Résumé

- Le filtre `ensure_update_email_is_authorized` ne contrôlait que le rôle `instructeur?`, alors que `config/env.example.optional` documente la restriction `LEGIT_ADMIN_DOMAINS` pour « Admins and instructeurs ».
- Un administrateur sans rôle instructeur pouvait donc changer son email vers un domaine externe arbitraire, contournant la liste blanche.
- Ajout de `current_user.administrateur?` dans la condition du filtre, et couverture par tests dédiés au cas admin pur.