### PR TITLE
Tech: restreint la recherche du SuperAdminDashboard aux attributs affichés

### DIFF
--- a/app/dashboards/super_admin_dashboard.rb
+++ b/app/dashboards/super_admin_dashboard.rb
@@ -12,7 +12,6 @@ class SuperAdminDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     email: Field::String,
-    encrypted_password: Field::String,
     reset_password_sent_at: Field::DateTime,
     remember_created_at: Field::DateTime,
     sign_in_count: Field::Number,

--- a/spec/controllers/manager/super_admins_controller_spec.rb
+++ b/spec/controllers/manager/super_admins_controller_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Manager::SuperAdminsController, type: :controller do
+  let!(:signed_in_super_admin) { create(:super_admin) }
+
+  before { sign_in signed_in_super_admin }
+
+  describe '#index' do
+    render_views
+
+    let!(:other_super_admin) { create(:super_admin) }
+
+    context 'when the search term is a fragment of another super_admin encrypted_password' do
+      let(:hash_fragment) { other_super_admin.encrypted_password[20, 15] }
+
+      subject(:search_request) { get :index, params: { search: hash_fragment } }
+
+      it 'does not match records by their password hash' do
+        search_request
+        expect(response.body).not_to include(other_super_admin.email)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Les Field::String sont searchable dans Administrate.
https://github.com/thoughtbot/administrate/blob/main/lib/administrate/field/string.rb

`encrypted_password` y était déclaré — supprimé. Spec de régression ajouté.