### PR TITLE
ETQ usager, je peux à nouveau ouvrir la modale d'invitation après expiration de session

### DIFF
--- a/app/javascript/controllers/lazy_modal_controller.ts
+++ b/app/javascript/controllers/lazy_modal_controller.ts
@@ -18,6 +18,19 @@ export default class LazyModalController extends ApplicationController {
 
     const src = button.getAttribute('src');
     if (src) {
+      // Si la session a expiré (ex: bfcache iOS), la réponse ne contient pas le frame
+      // attendu. On recharge la page courante : authenticate_user! sera rejoué sur
+      // la bonne URL, qui sera donc stockée comme retour après login (au lieu de
+      // l'URL interne de la modale, qui afficherait un fragment orphelin).
+      frame.addEventListener(
+        'turbo:frame-missing',
+        (event) => {
+          event.preventDefault();
+          window.location.reload();
+        },
+        { once: true }
+      );
+
       frame.src = src;
 
       frame.addEventListener(

--- a/spec/system/users/invite_spec.rb
+++ b/spec/system/users/invite_spec.rb
@@ -133,6 +133,23 @@ describe 'Invitations' do
       expect(page).to have_button('Vérifier le dossier', disabled: true)
       expect(page).to have_button('Prévenir le titulaire de vos modifications', disabled: true)
     end
+
+    scenario 'opening invite modal after session expired redirects to sign in then back to dossier', js: true do
+      log_in(owner)
+      navigate_to_brouillon(dossier)
+
+      # Simulate session expiration (e.g. logged out in another tab, or iOS bfcache)
+      logout(:user)
+
+      click_on "Inviter une personne à modifier ce dossier"
+
+      expect(page).to have_current_path(new_user_session_path, ignore_query: true)
+
+      # After signing in, the user must come back to the dossier page,
+      # not to the orphaned invites modal fragment URL.
+      sign_in_with(owner.email, owner.password)
+      expect(page).to have_current_path(brouillon_dossier_path(dossier))
+    end
   end
 
   context 'when the dossier is en_construction' do


### PR DESCRIPTION
## Contexte

Erreur Sentry [JAVASCRIPT-D69](https://demarches-simplifiees.sentry.io/issues/6781479288/) : `TurboFrameMissingError` sur `<turbo-frame id="dossier-invites-modal">`. 2 387 occurrences, **594 usagers impactés**

## Cause

Quand l'usager clique sur le bouton « Inviter » alors que sa session a expiré (typiquement au retour sur l'app après réouverture d'une page en cache), Turbo charge `/dossiers/X/invites` mais reçoit la page de connexion. Le frame attendu est absent → `TurboFrameMissingError` non gérée → bouton qui tourne indéfiniment + erreur dans Sentry.

## Fix

Le contrôleur Stimulus `lazy-modal` écoute désormais `turbo:frame-missing` sur le frame lazy chargé (reco Hotwire) et recharge la page courante. Devise rejoue `authenticate_user!` sur l'URL du dossier (et non sur l'URL interne de la modale), la stocke comme `user_return_to`, et après reconnexion l'usager revient sur sa page de dossier.

Closes JAVASCRIPT-D69