### PR TITLE
Tech: fix virus scan pending — CRON timeout + maintenance task backfill

### DIFF
--- a/app/jobs/cron/fix_missing_antivirus_analysis_job.rb
+++ b/app/jobs/cron/fix_missing_antivirus_analysis_job.rb
@@ -4,16 +4,17 @@ class Cron::FixMissingAntivirusAnalysisJob < Cron::CronJob
   self.schedule_expression = "every day at 01:45"
 
   def perform
-    blobs_to_skip = ActiveStorage::Attachment
-      .where(record_type: "ActiveStorage::VariantRecord")
-      .or(ActiveStorage::Attachment.where(name: "preview_image"))
-      .select(:blob_id)
-
+    # Only process recent blobs (1 week → 1 day ago) to keep the query fast.
+    # Older backlog is handled by Maintenance::BackfillVirusScanBlobsTask.
+    #
+    # .in_batches plucks ids first, then loads records — avoids ORDER BY timeouts
+    # on the 150M-row blobs table (same strategy as PurgeUnattachedBlobsJob).
     ActiveStorage::Blob
+      .where(created_at: 1.week.ago..1.day.ago)
       .where(virus_scan_result: ActiveStorage::VirusScanner::PENDING)
-      .where.not(id: blobs_to_skip)
-      .find_each do |blob|
-        BlobProcessorJob.perform_later(blob)
+      .where.not("metadata::jsonb @> ?", '{"processed":true}')
+      .in_batches do |relation|
+        relation.each { BlobProcessorJob.perform_later(it) }
       end
   end
 end

--- a/app/tasks/maintenance/t20260427backfill_virus_scan_blobs_task.rb
+++ b/app/tasks/maintenance/t20260427backfill_virus_scan_blobs_task.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260427backfillVirusScanBlobsTask < MaintenanceTasks::Task
+    # Traite le stock de blobs bloqués en virus_scan_result "pending".
+    # Le CRON FixMissingAntivirusAnalysisJob gère le flux (blobs récents),
+    # cette tâche gère le stock (backlog ancien).
+    #
+    # Inclut les orphelins (sans attachment) : BlobProcessorJob les marquera
+    # simplement comme processed, et PurgeUnattachedBlobsJob les purgera.
+    # On évite ainsi le semi-join sur 103M attachments qui timeout.
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    def collection
+      ActiveStorage::Blob
+        .where(virus_scan_result: ActiveStorage::VirusScanner::PENDING)
+    end
+
+    def process(blob)
+      return if blob.metadata["processed"]
+
+      BlobProcessorJob.perform_later(blob)
+    end
+
+    # pas de count : la requête sur 7M+ rows timeout même avec statement_timeout élevé
+  end
+end

--- a/spec/jobs/cron/fix_missing_antivirus_analysis_job_spec.rb
+++ b/spec/jobs/cron/fix_missing_antivirus_analysis_job_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe Cron::FixMissingAntivirusAnalysisJob, type: :job do
+  let(:blob_pending) do
+    ActiveStorage::Blob.create_and_upload!(io: StringIO.new("pending"), filename: "pending.txt", content_type: "text/plain").tap do |blob|
+      blob.update_columns(virus_scan_result: ActiveStorage::VirusScanner::PENDING, created_at: 3.days.ago)
+    end
+  end
+
+  let(:blob_too_recent) do
+    ActiveStorage::Blob.create_and_upload!(io: StringIO.new("recent"), filename: "recent.txt", content_type: "text/plain").tap do |blob|
+      blob.update_columns(virus_scan_result: ActiveStorage::VirusScanner::PENDING, created_at: 1.hour.ago)
+    end
+  end
+
+  let(:blob_too_old) do
+    ActiveStorage::Blob.create_and_upload!(io: StringIO.new("old"), filename: "old.txt", content_type: "text/plain").tap do |blob|
+      blob.update_columns(virus_scan_result: ActiveStorage::VirusScanner::PENDING, created_at: 2.weeks.ago)
+    end
+  end
+
+  let(:blob_already_safe) do
+    ActiveStorage::Blob.create_and_upload!(io: StringIO.new("safe"), filename: "safe.txt", content_type: "text/plain").tap do |blob|
+      blob.update_columns(virus_scan_result: ActiveStorage::VirusScanner::SAFE, created_at: 3.days.ago)
+    end
+  end
+
+  let(:blob_already_processed) do
+    ActiveStorage::Blob.create_and_upload!(io: StringIO.new("processed"), filename: "processed.txt", content_type: "text/plain").tap do |blob|
+      blob.update_columns(
+        virus_scan_result: ActiveStorage::VirusScanner::PENDING,
+        created_at: 3.days.ago,
+        metadata: blob.metadata.merge("processed" => true)
+      )
+    end
+  end
+
+  before do
+    blob_pending
+    blob_too_recent
+    blob_too_old
+    blob_already_safe
+    blob_already_processed
+  end
+
+  subject(:perform_job) { described_class.perform_now }
+
+  describe '#perform' do
+    it 'enqueues BlobProcessorJob only for pending blobs within the time window' do
+      expect { perform_job }
+        .to have_enqueued_job(BlobProcessorJob).with(blob_pending)
+    end
+
+    it 'does not enqueue for blobs created less than 1 day ago' do
+      expect { perform_job }
+        .not_to have_enqueued_job(BlobProcessorJob).with(blob_too_recent)
+    end
+
+    it 'does not enqueue for blobs older than 1 week' do
+      expect { perform_job }
+        .not_to have_enqueued_job(BlobProcessorJob).with(blob_too_old)
+    end
+
+    it 'does not enqueue for already safe blobs' do
+      expect { perform_job }
+        .not_to have_enqueued_job(BlobProcessorJob).with(blob_already_safe)
+    end
+
+    it 'does not enqueue for already processed blobs' do
+      expect { perform_job }
+        .not_to have_enqueued_job(BlobProcessorJob).with(blob_already_processed)
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20260427backfill_virus_scan_blobs_task_spec.rb
+++ b/spec/tasks/maintenance/t20260427backfill_virus_scan_blobs_task_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260427backfillVirusScanBlobsTask do
+    describe '#collection' do
+      let!(:pending) do
+        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("pending"), filename: "pending.txt", content_type: "text/plain").tap do |blob|
+          blob.update_columns(virus_scan_result: ActiveStorage::VirusScanner::PENDING)
+        end
+      end
+
+      let!(:safe) do
+        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("safe"), filename: "safe.txt", content_type: "text/plain").tap do |blob|
+          blob.update_columns(virus_scan_result: ActiveStorage::VirusScanner::SAFE)
+        end
+      end
+
+      subject(:collection) { described_class.new.collection }
+
+      it 'includes pending blobs' do
+        expect(collection).to include(pending)
+      end
+
+      it 'excludes safe blobs' do
+        expect(collection).not_to include(safe)
+      end
+    end
+
+    describe '#process' do
+      let!(:blob) do
+        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("data"), filename: "file.txt", content_type: "text/plain").tap do |blob|
+          blob.update_columns(virus_scan_result: ActiveStorage::VirusScanner::PENDING)
+        end
+      end
+
+      let!(:already_processed) do
+        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("done"), filename: "done.txt", content_type: "text/plain").tap do |blob|
+          blob.update_columns(
+            virus_scan_result: ActiveStorage::VirusScanner::PENDING,
+            metadata: blob.metadata.merge("processed" => true)
+          )
+        end
+      end
+
+      it 'enqueues a BlobProcessorJob' do
+        expect { described_class.new.process(blob) }
+          .to have_enqueued_job(BlobProcessorJob).with(blob)
+      end
+
+      it 'skips already processed blobs' do
+        expect { described_class.new.process(already_processed) }
+          .not_to have_enqueued_job(BlobProcessorJob)
+      end
+    end
+  end
+end


### PR DESCRIPTION
sentry : https://demarches-simplifiees.sentry.io/issues/7330992356/?environment=production&project=1429550&query=&referrer=issue-stream

## Contexte

Un blob (CNI TYL.pdf, 25 mars) est resté bloqué en `virus_scan_result: "pending"` — le `VirusScannerJob` initial s'est perdu dans les limbes (jamais arrivé dans Sidekiq, absent de la dead queue et des logs Kibana).

Le filet de sécurité `FixMissingAntivirusAnalysisJob` aurait dû le rattraper, mais il **timeout systématiquement** (~60s) sur les 7M blobs pending avec un `NOT IN` sur toute la table attachments (150M rows). Il tournait 25+ fois/jour (retry_on) sans jamais traiter un seul blob.

## Fix

**Flux** (CRON `FixMissingAntivirusAnalysisJob`) :
- Fenêtre temporelle `1.week.ago..1.day.ago` (comme `PurgeUnattachedBlobsJob`)
- `in_batches` pluck ids d'abord → évite ORDER BY timeout
- Exclut les blobs déjà `metadata.processed`

**Stock** (maintenance task `T20260427backfillVirusScanBlobsTask`) :
- Traite le backlog de ~2M blobs pending accumulés
- Collection simple `WHERE virus_scan_result = 'pending'` (index scan)
- Filtre `metadata["processed"]` en Ruby (le cast `metadata::jsonb` timeout sur 7M rows)
- Pas de `count` (timeout aussi)
- `BlobProcessorJob` gère le reste (scan, mutations, OCR, representations)

## Test plan

- [x] Specs CRON : fenêtre temporelle, exclusion safe/processed/trop récent/trop ancien
- [x] Specs maintenance task : collection pending, filtre processed en Ruby, enqueue BlobProcessorJob
- [x] CRON testé en local (`perform_now`) sans erreur
- [x] Maintenance task lancée en prod (2.1M items en cours de traitement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)