### PR TITLE
i18n(notification_mailer): extract hardcoded strings from NotificationMailer

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -35,7 +35,7 @@ class NotificationMailer < ApplicationMailer
       return
     end
 
-    @subject = "Votre dossier rempli par le mandataire #{@dossier.mandataire_first_name} #{@dossier.mandataire_last_name} a été mis à jour"
+    @subject = default_i18n_subject(first_name: @dossier.mandataire_first_name, last_name: @dossier.mandataire_last_name)
     @email = @dossier.individual.email
     @logo_url = procedure_logo_url(@dossier.procedure)
 
@@ -45,7 +45,7 @@ class NotificationMailer < ApplicationMailer
   def send_accuse_lecture_notification(dossier)
     @dossier = dossier
     @dossier.with_revision
-    @subject = "La décision a été rendue pour votre dossier n°#{@dossier.id} (#{@dossier.procedure.libelle.truncate_words(50)})"
+    @subject = default_i18n_subject(dossier_id: @dossier.id, libelle: @dossier.procedure.libelle.truncate_words(50))
     @email = @dossier.user_email_for(:notification)
 
     @logo_url = procedure_logo_url(@dossier.procedure)

--- a/config/locales/views/notification_mailer/send_accuse_lecture_notification/fr.yml
+++ b/config/locales/views/notification_mailer/send_accuse_lecture_notification/fr.yml
@@ -1,0 +1,4 @@
+fr:
+  notification_mailer:
+    send_accuse_lecture_notification:
+      subject: "La décision a été rendue pour votre dossier n°%{dossier_id} (%{libelle})"

--- a/config/locales/views/notification_mailer/send_notification_for_tiers/fr.yml
+++ b/config/locales/views/notification_mailer/send_notification_for_tiers/fr.yml
@@ -1,0 +1,4 @@
+fr:
+  notification_mailer:
+    send_notification_for_tiers:
+      subject: "Votre dossier rempli par le mandataire %{first_name} %{last_name} a été mis à jour"

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     subject { described_class.send_notification_for_tiers(dossier_for_tiers) }
 
     it 'verifies email subject, recipient, and body content for updated dossier by mandataire' do
-      expect(subject.subject).to include("Votre dossier rempli par le mandataire #{dossier_for_tiers.mandataire_first_name} #{dossier_for_tiers.mandataire_last_name} a été mis à jour")
+      expect(subject.subject).to include(I18n.t("notification_mailer.send_notification_for_tiers.subject", first_name: dossier_for_tiers.mandataire_first_name, last_name: dossier_for_tiers.mandataire_last_name))
       expect(subject.to).to eq([dossier_for_tiers.individual.email])
       expect(subject.body).to include("a été déposé le")
       expect(subject.body).to include("Pour en savoir plus, veuillez vous rapprocher de\r\n<a href=\"mailto:#{dossier_for_tiers.user.email}\">#{dossier_for_tiers.user.email}</a>.")
@@ -24,7 +24,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     subject { described_class.send_notification_for_tiers(dossier_for_tiers, repasser_en_instruction: true) }
 
     it 'verifies email subject, recipient, and body content for dossier re-examination notification' do
-      expect(subject.subject).to include("Votre dossier rempli par le mandataire #{dossier_for_tiers.mandataire_first_name} #{dossier_for_tiers.mandataire_last_name} a été mis à jour")
+      expect(subject.subject).to include(I18n.t("notification_mailer.send_notification_for_tiers.subject", first_name: dossier_for_tiers.mandataire_first_name, last_name: dossier_for_tiers.mandataire_last_name))
       expect(subject.to).to eq([dossier_for_tiers.individual.email])
       expect(subject.body).to include("va être réexaminé, la précédente décision sur ce dossier est caduque.")
       expect(subject.body).to include("Pour en savoir plus, veuillez vous rapprocher de\r\n<a href=\"mailto:#{dossier_for_tiers.user.email}\">#{dossier_for_tiers.user.email}</a>.")
@@ -37,7 +37,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     subject { described_class.send_notification_for_tiers(dossier_for_tiers) }
 
     it 'sends proper notification for tiers with correct subject, recipient, and body content' do
-      expect(subject.subject).to include("Votre dossier rempli par le mandataire #{dossier_for_tiers.mandataire_first_name} #{dossier_for_tiers.mandataire_last_name} a été mis à jour")
+      expect(subject.subject).to include(I18n.t("notification_mailer.send_notification_for_tiers.subject", first_name: dossier_for_tiers.mandataire_first_name, last_name: dossier_for_tiers.mandataire_last_name))
       expect(subject.to).to eq([dossier_for_tiers.individual.email])
       expect(subject.body).to include("a été traité le")
       expect(subject.body).to include("Pour en savoir plus, veuillez vous rapprocher de\r\n<a href=\"mailto:#{dossier_for_tiers.user.email}\">#{dossier_for_tiers.user.email}</a>.")
@@ -49,7 +49,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     subject { described_class.send_accuse_lecture_notification(dossier) }
 
     it "works" do
-      expect(subject.subject).to include("La décision a été rendue pour votre dossier n°#{dossier.id} (#{dossier.procedure.libelle})")
+      expect(subject.subject).to include(I18n.t("notification_mailer.send_accuse_lecture_notification.subject", dossier_id: dossier.id, libelle: dossier.procedure.libelle))
       expect(subject.body).to include("Pour en connaitre la nature, veuillez consulter votre dossier dans votre compte #{APPLICATION_NAME}")
       expect(subject.body).to have_link("Consulter mon dossier", href: dossier_url(dossier))
     end


### PR DESCRIPTION
## Probleme

Textes francais en dur dans `app/mailers/notification_mailer.rb` — non internationalisable, non maintenable.

## Solution

Extraction de 2 cles i18n vers les fichiers YAML de locale, en utilisant `default_i18n_subject` de Rails.

### Changements

| Fichier | Modification |
|---------|-------------|
| `app/mailers/notification_mailer.rb` | 2 appels `default_i18n_subject` remplaces |
| `config/locales/views/notification_mailer/send_notification_for_tiers/fr.yml` | 1 cle ajoutee |
| `config/locales/views/notification_mailer/send_accuse_lecture_notification/fr.yml` | 1 cle ajoutee |
| `spec/mailers/notification_mailer_spec.rb` | 4 assertions mises a jour avec `I18n.t` |

### Cles extraites

| Cle | Valeur |
|-----|--------|
| `notification_mailer.send_notification_for_tiers.subject` | "Votre dossier rempli par le mandataire %{first_name} %{last_name} a ete mis a jour" |
| `notification_mailer.send_accuse_lecture_notification.subject` | "La decision a ete rendue pour votre dossier n°%{dossier_id} (%{libelle})" |

### Validation

- [x] Chaque `t()` a sa cle YAML correspondante
- [x] Apostrophes typographiques verifiees
- [x] Tests passes (15 examples, 0 failures)
- [x] Rubocop OK

Generated with [Claude Code](https://claude.com/claude-code)
