### PR TITLE
Tech: scope le lookup du TypeDeChamp dans le manager à la démarche de l'URL

### DIFF
--- a/app/controllers/manager/procedures_controller.rb
+++ b/app/controllers/manager/procedures_controller.rb
@@ -193,7 +193,7 @@ module Manager
     end
 
     def type_de_champ
-      TypeDeChamp.find(params[:type_de_champ][:id])
+      procedure.draft_revision.revision_types_de_champ.find_by!(type_de_champ_id: params[:type_de_champ][:id]).type_de_champ
     end
 
     def type_de_champ_params

--- a/spec/controllers/manager/procedures_controller_spec.rb
+++ b/spec/controllers/manager/procedures_controller_spec.rb
@@ -101,6 +101,32 @@ describe Manager::ProceduresController, type: :controller do
     end
   end
 
+  describe '#change_piece_justificative_template' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
+    let(:other_procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
+    let(:other_type_de_champ) { other_procedure.draft_revision.types_de_champ.first }
+    let(:upload) do
+      Rack::Test::UploadedFile.new(
+        Rails.root.join("spec/fixtures/files/RIB.pdf"),
+        "application/pdf"
+      )
+    end
+
+    subject(:cross_procedure_request) do
+      post :change_piece_justificative_template, params: {
+        id: procedure.id,
+        type_de_champ: { id: other_type_de_champ.id, piece_justificative_template: upload },
+      }
+    rescue ActiveRecord::RecordNotFound
+      nil
+    end
+
+    it "does not update the template of a type de champ from a different procedure" do
+      expect { cross_procedure_request }
+        .not_to change { other_type_de_champ.reload.piece_justificative_template.blob.id }
+    end
+  end
+
   describe '#delete_administrateur' do
     let(:procedure) { create(:procedure, :with_service, administrateurs: [administrateur, autre_administrateur]) }
     let(:administrateur) { create(:administrateur, email: super_admin.email) }


### PR DESCRIPTION
## Contexte

Dans `Manager::ProceduresController#change_piece_justificative_template`, la recherche du `TypeDeChamp` était globale (`TypeDeChamp.find(params[:type_de_champ][:id])`), sans vérifier que le champ appartenait bien à la démarche identifiée dans l'URL.

Comme l'action est restreinte aux super-admins (qui ont par conception accès à toutes les démarches), il ne s'agit pas d'une élévation de privilège exploitable. Mais le comportement viole le contrat implicite de la route `/manager/procedures/:id/...` et brouille la traçabilité : les logs serveur montrent une requête sur la démarche A alors que l'effet réel peut porter sur la démarche B.

## Changement

Le lookup passe désormais par `procedure.draft_revision.revision_types_de_champ`, ce qui garantit que l'action n'affecte que des champs de la démarche de l'URL. Un id de `TypeDeChamp` étranger lève `RecordNotFound` → 404.

Spec de régression ajoutée dans `spec/controllers/manager/procedures_controller_spec.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)