### PR TITLE
ETQ instructeur, les infos spécifiques des préférences de notifications sont de nouveau visibles

### DIFF
--- a/app/components/dsfr/toggle_component.rb
+++ b/app/components/dsfr/toggle_component.rb
@@ -29,6 +29,7 @@ class Dsfr::ToggleComponent < ApplicationComponent
     opts = { class: 'fr-toggle__input', disabled: disabled }
     opts[:id] = input_id if @form.object.present?
     opts[:checked] = @checked unless @checked.nil?
+    opts[:data] = @data if @data.present?
     opts
   end
 

--- a/spec/components/dsfr/toggle_component_spec.rb
+++ b/spec/components/dsfr/toggle_component_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Dsfr::ToggleComponent, type: :component do
-  def render_with_form(**form_options)
+  def render_with_form(component_options: {}, **form_options)
     cmp = nil
     ActionView::Base.empty.form_with(**form_options) do |form|
-      cmp = described_class.new(form:, target: :include_archived, html_title: "Include archived")
+      cmp = described_class.new(form:, target: :include_archived, html_title: "Include archived", **component_options)
     end
     render_inline(cmp).to_html
   end
@@ -48,6 +48,19 @@ RSpec.describe Dsfr::ToggleComponent, type: :component do
     it "produces identical values for the input id and the label for attributes" do
       expect(extract_input_id(html)).to be_present
       expect(extract_input_id(html)).to eq(extract_label_for(html))
+    end
+  end
+
+  context "with opt: data attributes (used as Stimulus targets)" do
+    let(:html) do
+      render_with_form(
+        url: "/fake",
+        component_options: { opt: { "hide-target_target": "source" } }
+      )
+    end
+
+    it "renders the data attributes on the input element" do
+      expect(html).to match(/<input class="fr-toggle__input"[^>]*data-hide-target-target="source"/)
     end
   end
 

--- a/spec/system/instructeurs/notification_preferences_spec.rb
+++ b/spec/system/instructeurs/notification_preferences_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+describe 'Instructeur notification preferences:', js: true do
+  let(:instructeur) { create(:instructeur) }
+  let(:procedure) { create(:procedure, :published, instructeurs: [instructeur]) }
+
+  before do
+    login_as instructeur.user, scope: :user
+    visit notification_preferences_instructeur_procedure_path(procedure)
+  end
+
+  scenario 'toggling instant_email_new_message reveals the followed-dossiers notice' do
+    notice = ".fr-notice--info"
+
+    expect(page).to have_css(notice, visible: :hidden, text: 'Vous devez impérativement')
+    expect(page).to have_no_css(notice, visible: true)
+
+    find('label', text: 'Recevoir un email à chaque message envoyé par l’usager').click
+
+    expect(page).to have_css(notice, visible: true, text: 'Vous devez impérativement')
+
+    find('label', text: 'Recevoir un email à chaque message envoyé par l’usager').click
+
+    expect(page).to have_no_css(notice, visible: true)
+  end
+end


### PR DESCRIPTION
https://mattermost.incubateur.net/betagouv/pl/owti7684ntfw7ckxqei1qd83oo

## Résumé

- Le paramètre `opt:` du `Dsfr::ToggleComponent` n'était plus injecté sur l'`<input>`, ce qui empêchait tous les contrôleurs Stimulus de se brancher sur un toggle (ex: `hide-target_target="source"`).
- Symptôme visible côté instructeur : sur la page de préférences de notifications par email, basculer le toggle « Recevoir un email à chaque message envoyé par l'usager » ne révélait plus la notice contextuelle « Vous devez impérativement suivre le dossier… ». Même problème pour les toggles d'expiration/suppression de dossier.
- Autres usages affectés : `closing_notification` (admin), `bulk_message_form_component` (instructeurs).

## Correctif

- `app/components/dsfr/toggle_component.rb` : on réinjecte `@data` dans les options du `check_box`.
- `spec/components/dsfr/toggle_component_spec.rb` : test de régression du composant.
- `spec/system/instructeurs/notification_preferences_spec.rb` : test système qui exerce le flux complet `toggle` → `hide-target` sur la page de préférences emails.