### PR TITLE
i18n(user_mailer): extract hardcoded French subjects to YAML

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,7 +6,7 @@ class UserMailer < ApplicationMailer
 
   def new_account_warning(user, procedure = nil)
     @user = user
-    @subject = "Demande de création de compte"
+    @subject = default_i18n_subject
     @procedure = procedure
 
     mail(to: user.email, subject: @subject, procedure: @procedure)
@@ -15,7 +15,7 @@ class UserMailer < ApplicationMailer
   def ask_for_merge(user, requested_email)
     @user = user
     @requested_email = requested_email
-    @subject = "Fusion de compte"
+    @subject = default_i18n_subject
 
     mail(to: requested_email, subject: @subject)
   end
@@ -23,7 +23,7 @@ class UserMailer < ApplicationMailer
   def france_connect_merge_confirmation(email, email_merge_token, email_merge_token_created_at)
     @email_merge_token = email_merge_token
     @email_merge_token_created_at = email_merge_token_created_at
-    @subject = "Veuillez confirmer la fusion de compte"
+    @subject = default_i18n_subject
 
     mail(to: email, subject: @subject)
   end
@@ -32,18 +32,16 @@ class UserMailer < ApplicationMailer
     @user = user
 
     @token = token
-    mail(to: @user.email, subject: 'Confirmez votre adresse électronique')
+    mail(to: @user.email, subject: default_i18n_subject)
   end
 
   def invite_instructeur(user, reset_password_token)
     @reset_password_token = reset_password_token
     @user = user
-    subject = "Activez votre compte instructeur"
-
     bypass_unverified_mail_protection!
 
     mail(to: user.email,
-      subject: subject,
+      subject: default_i18n_subject,
       reply_to: CONTACT_EMAIL)
   end
 
@@ -51,24 +49,22 @@ class UserMailer < ApplicationMailer
     @token = token
     @user = user
     @dossier = dossier
-    subject = "Vérification de votre adresse électronique"
 
     bypass_unverified_mail_protection!
 
     mail(to: user.email,
-      subject: subject,
+      subject: default_i18n_subject,
       reply_to: CONTACT_EMAIL)
   end
 
   def resend_confirmation_email(user, token)
     @token = token
     @user = user
-    subject = "Vérification de votre adresse électronique"
 
     bypass_unverified_mail_protection!
 
     mail(to: user.email,
-      subject: subject,
+      subject: default_i18n_subject,
       reply_to: CONTACT_EMAIL)
   end
 
@@ -76,12 +72,11 @@ class UserMailer < ApplicationMailer
     @reset_password_token = reset_password_token
     @user = user
     @groupe_gestionnaire = groupe_gestionnaire
-    subject = "Activez votre compte gestionnaire"
 
     bypass_unverified_mail_protection!
 
     mail(to: user.email,
-      subject: subject,
+      subject: default_i18n_subject,
       reply_to: CONTACT_EMAIL)
   end
 
@@ -98,21 +93,19 @@ class UserMailer < ApplicationMailer
     when Administrateur then admin_procedure_url(@procedure)
     else raise ArgumentError("send_archive expect either an Instructeur or an Administrateur")
     end
-    subject = "Votre archive est disponible"
-
-    mail(to: administrateur_or_instructeur.email, subject: subject)
+    mail(to: administrateur_or_instructeur.email, subject: default_i18n_subject)
   end
 
   def notify_inactive_close_to_deletion(user)
     @user = user
-    @subject = "Votre compte sera supprimé dans #{Expired::REMAINING_WEEKS_BEFORE_EXPIRATION} semaines"
+    @subject = default_i18n_subject(remaining_weeks: Expired::REMAINING_WEEKS_BEFORE_EXPIRATION)
 
     mail(to: user.email, subject: @subject)
   end
 
   def notify_after_closing(user, content, procedure = nil)
     @user = user
-    @subject = "Clôture d’une démarche sur #{APPLICATION_NAME}"
+    @subject = default_i18n_subject(application_name: APPLICATION_NAME)
     @procedure = procedure
     @content = content
 
@@ -121,7 +114,7 @@ class UserMailer < ApplicationMailer
 
   def account_reactivated(user)
     @user = user
-    @subject = "Votre compte a été réactivé"
+    @subject = default_i18n_subject
 
     mail(to: user.email, subject: @subject)
   end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -99,6 +99,7 @@ search:
 ## Consider these keys used:
 ignore_unused:
 - 'errors.format'
+- 'user_mailer.*.subject'
 - 'activerecord.models.*'
 - 'activerecord.attributes.*'
 - 'activemodel.attributes.map_filter.*'

--- a/config/locales/views/user_mailer/en.yml
+++ b/config/locales/views/user_mailer/en.yml
@@ -1,0 +1,26 @@
+en:
+  user_mailer:
+    new_account_warning:
+      subject: Account creation request
+    ask_for_merge:
+      subject: Account merge
+    france_connect_merge_confirmation:
+      subject: Please confirm the account merge
+    custom_confirmation_instructions:
+      subject: Confirm your email address
+    invite_instructeur:
+      subject: Activate your instructor account
+    invite_tiers:
+      subject: Verify your email address
+    resend_confirmation_email:
+      subject: Verify your email address
+    invite_gestionnaire:
+      subject: Activate your manager account
+    send_archive:
+      subject: Your archive is available
+    notify_inactive_close_to_deletion:
+      subject: "Your account will be deleted in %{remaining_weeks} weeks"
+    notify_after_closing:
+      subject: "Closing of a procedure on %{application_name}"
+    account_reactivated:
+      subject: Your account has been reactivated

--- a/config/locales/views/user_mailer/fr.yml
+++ b/config/locales/views/user_mailer/fr.yml
@@ -1,0 +1,26 @@
+fr:
+  user_mailer:
+    new_account_warning:
+      subject: Demande de création de compte
+    ask_for_merge:
+      subject: Fusion de compte
+    france_connect_merge_confirmation:
+      subject: Veuillez confirmer la fusion de compte
+    custom_confirmation_instructions:
+      subject: Confirmez votre adresse électronique
+    invite_instructeur:
+      subject: Activez votre compte instructeur
+    invite_tiers:
+      subject: Vérification de votre adresse électronique
+    resend_confirmation_email:
+      subject: Vérification de votre adresse électronique
+    invite_gestionnaire:
+      subject: Activez votre compte gestionnaire
+    send_archive:
+      subject: Votre archive est disponible
+    notify_inactive_close_to_deletion:
+      subject: "Votre compte sera supprimé dans %{remaining_weeks} semaines"
+    notify_after_closing:
+      subject: "Clôture d’une démarche sur %{application_name}"
+    account_reactivated:
+      subject: Votre compte a été réactivé


### PR DESCRIPTION
## Probleme

Textes francais en dur dans `app/mailers/user_mailer.rb` — non internationalisable, non maintenable.

## Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 12 cles i18n vers `config/locales/views/user_mailer/fr.yml`.

### Cles extraites

| Cle | Valeur |
|-----|--------|
| `user_mailer.new_account_warning.subject` | "Demande de creation de compte" |
| `user_mailer.ask_for_merge.subject` | "Fusion de compte" |
| `user_mailer.france_connect_merge_confirmation.subject` | "Veuillez confirmer la fusion de compte" |
| `user_mailer.custom_confirmation_instructions.subject` | "Confirmez votre adresse electronique" |
| `user_mailer.invite_instructeur.subject` | "Activez votre compte instructeur" |
| `user_mailer.invite_tiers.subject` | "Verification de votre adresse electronique" |
| `user_mailer.resend_confirmation_email.subject` | "Verification de votre adresse electronique" |
| `user_mailer.invite_gestionnaire.subject` | "Activez votre compte gestionnaire" |
| `user_mailer.send_archive.subject` | "Votre archive est disponible" |
| `user_mailer.notify_inactive_close_to_deletion.subject` | "Votre compte sera supprime dans %{remaining_weeks} semaines" |
| `user_mailer.notify_after_closing.subject` | "Cloture d'une demarche sur %{application_name}" |
| `user_mailer.account_reactivated.subject` | "Votre compte a ete reactive" |

### Validation visuelle — IDENTIQUE

**Avant :**
![before-1](https://gist.githubusercontent.com/mfo/6a075570dfb54ab34eb2cb65b01bc73f/raw/before-1.png)

**Apres :**
![after-1](https://gist.githubusercontent.com/mfo/6a075570dfb54ab34eb2cb65b01bc73f/raw/after-1.png)

**Avant (interpolation) :**
![before-2](https://gist.githubusercontent.com/mfo/6a075570dfb54ab34eb2cb65b01bc73f/raw/before-2.png)

**Apres (interpolation) :**
![after-2](https://gist.githubusercontent.com/mfo/6a075570dfb54ab34eb2cb65b01bc73f/raw/after-2.png)

**Avant (APPLICATION_NAME) :**
![before-3](https://gist.githubusercontent.com/mfo/6a075570dfb54ab34eb2cb65b01bc73f/raw/before-3.png)

**Apres (APPLICATION_NAME) :**
![after-3](https://gist.githubusercontent.com/mfo/6a075570dfb54ab34eb2cb65b01bc73f/raw/after-3.png)

**Couverture :**
- ✅ `localhost:3000/rails/mailers/user_mailer/new_account_warning` — preview mail simple
- ✅ `localhost:3000/rails/mailers/user_mailer/notify_inactive_close_to_deletion` — interpolation remaining_weeks
- ✅ `localhost:3000/rails/mailers/user_mailer/notify_after_closing` — interpolation APPLICATION_NAME

[Voir tous les screenshots](https://gist.github.com/mfo/6a075570dfb54ab34eb2cb65b01bc73f)

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante
- [x] Apostrophes typographiques verifiees
- [x] Tests passes (27 examples, 0 failures)
- [x] Rubocop OK
- [x] Screenshots avant/apres identiques

🤖 Generated with [Claude Code](https://claude.com/claude-code)
