### PR TITLE
Correctif: ETQ instructeur, corriger le lien des archives dans le mail

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -89,7 +89,7 @@ class UserMailer < ApplicationMailer
     @archive = archive
     @procedure = procedure
     @archive_url = case administrateur_or_instructeur
-    when Instructeur then instructeur_archives_url(@procedure)
+    when Instructeur then list_instructeur_archives_url(@procedure)
     when Administrateur then admin_procedure_archives_url(@procedure)
     else raise ArgumentError("send_archive expect either an Instructeur or an Administrateur")
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe UserMailer, type: :mailer do
       let(:role) { create(:instructeur) }
       it 'sends email with correct links to instructeur' do
         expect(subject.to).to eq([role.user.email])
-        expect(subject.body).to have_link('Consulter mes archives', href: instructeur_archives_url(procedure))
+        expect(subject.body).to have_link('Consulter mes archives', href: list_instructeur_archives_url(procedure))
         expect(subject.body).to have_link("#{procedure.id} − #{procedure.libelle}", href: instructeur_procedure_url(procedure))
       end
     end


### PR DESCRIPTION
# Problème

Le mail "Votre archive est disponible" envoyé aux instructeurs contient un lien "Consulter mes archives" qui pointe vers la route POST `/archives/create` au lieu de la page GET `/archives/list`.

Bug introduit en novembre 2024 lors de la restructuration des routes instructeur (`c260c43dac`) : les routes archives sont passées de `resources :archives, only: [:index, :create]` à des routes custom (`get 'list'` / `post 'create'`), ce qui a changé le helper `instructeur_archives_url` pour pointer vers create au lieu de l'index — mais le mailer n'a pas été mis à jour.

# Solution

Utiliser `list_instructeur_archives_url` (le bon helper GET) au lieu de `instructeur_archives_url` (qui pointe vers le POST create).

Generated with [Claude Code](https://claude.com/claude-code)

# TODO post mep

- [ ] crisp : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_b25a45e8-0a81-42f6-bdf3-727a3183c477/