### PR TITLE
Tech: corrige une injection dans Zone.default_for

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -39,7 +39,6 @@ class Zone < ApplicationRecord
   end
 
   def self.default_for(tchap_hs)
-    sanitized_sql = ActiveRecord::Base.sanitize_sql "'#{tchap_hs}' = ANY (tchap_hs)"
-    Zone.where(sanitized_sql)
+    Zone.where("? = ANY (tchap_hs)", tchap_hs)
   end
 end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -131,6 +131,11 @@ describe Zone do
         expect(Zone.default_for('agent.education.tchap.gouv.fr').map(&:acronym)).to match_array(['MEN', 'ESR'])
         expect(Zone.default_for('agent.tchap.gouv.fr').map(&:acronym)).to eq []
       end
+
+      it 'safely handles values with quotes (no SQL injection)' do
+        expect(Zone.default_for("x') OR 1=1 OR ('").map(&:acronym)).to eq []
+        expect(Zone.default_for("agent's.tchap.gouv.fr").map(&:acronym)).to eq []
+      end
     end
   end
 end


### PR DESCRIPTION
## Résumé

- `ActiveRecord::Base.sanitize_sql` appelé avec une simple chaîne déjà interpolée ne fait aucun échappement : la valeur de `tchap_hs` était concaténée brute dans la clause `WHERE`.
- Passage à un binding paramétré `Zone.where("? = ANY (tchap_hs)", tchap_hs)`.
- La valeur provient de l'API externe Tchap (`APITchap::API.get_hs`) via `AdminUpdateDefaultZonesJob` lors de la promotion d'un user en administrateur — exploitabilité conditionnée à la fiabilité de cette API, mais le pattern reste à corriger en défense en profondeur.