### PR TITLE
Tech: restreint la résolution des modèles d'export aux groupe_instructeurs de l'instructeur

### DIFF
--- a/app/controllers/administrateurs/exports_controller.rb
+++ b/app/controllers/administrateurs/exports_controller.rb
@@ -40,7 +40,10 @@ module Administrateurs
     end
 
     def export_template
-      @export_template ||= ExportTemplate.find(params[:export_template_id]) if params[:export_template_id].present?
+      return @export_template if defined?(@export_template)
+      return @export_template = nil if params[:export_template_id].blank?
+
+      @export_template = @procedure.export_templates.find(params[:export_template_id])
     end
 
     def export_options

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -450,7 +450,15 @@ module Instructeurs
     end
 
     def export_template
-      @export_template ||= ExportTemplate.find(params[:export_template_id]) if params[:export_template_id].present?
+      return @export_template if defined?(@export_template)
+      return @export_template = nil if params[:export_template_id].blank?
+
+      template_id = params[:export_template_id].to_i
+      own = current_instructeur.export_templates_for(procedure).find { it.id == template_id }
+      @export_template = own || procedure.export_templates.shareable.find_by(id: template_id)
+      raise ActiveRecord::RecordNotFound if @export_template.nil?
+
+      @export_template
     end
 
     def export_options

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -84,6 +84,8 @@ class Export < ApplicationRecord
 
     recent_export = pending
       .or(generated.where(updated_at: (5.minutes.ago)..))
+      .joins(:groupe_instructeurs)
+      .where(groupe_instructeurs: { id: groupe_instructeurs })
       .includes(:procedure_presentation)
       .find_by(attributes)
 

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -979,7 +979,7 @@ describe Instructeurs::ProceduresController, type: :controller do
       it { expect { subject }.to change { Export.where(user_profile: instructeur).count }.by(1) }
 
       context 'with an export template' do
-        let(:export_template) { create(:export_template) }
+        let(:export_template) { create(:export_template, groupe_instructeur: gi_0) }
         subject do
           get :download_export, params: { export_template_id: export_template.id, procedure_id: procedure.id }
         end
@@ -1041,6 +1041,31 @@ describe Instructeurs::ProceduresController, type: :controller do
         expect(response.media_type).to eq('text/vnd.turbo-stream.html')
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(polling_last_export_instructeur_procedure_path(procedure))
+      end
+    end
+
+    context 'when an export_template_id from another procedure is supplied' do
+      let(:other_procedure) { create(:procedure) }
+      let(:other_groupe_instructeur) { create(:groupe_instructeur, procedure: other_procedure) }
+      let(:other_export_template) do
+        create(:export_template, kind: 'csv', groupe_instructeur: other_groupe_instructeur)
+      end
+      let!(:other_export) do
+        export = create(:export,
+          groupe_instructeurs: [other_groupe_instructeur],
+          export_template: other_export_template,
+          format: Export.formats.fetch(:csv),
+          job_status: 'generated')
+        export.file.attach(io: StringIO.new('other procedure export'), filename: 'other.csv')
+        export
+      end
+
+      subject do
+        get :download_export, params: { procedure_id: procedure.id, export_template_id: other_export_template.id }
+      end
+
+      it 'does not resolve the export template to one bound to a procedure the instructeur cannot access' do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 


### PR DESCRIPTION
## Contexte

`export_template_id` côté téléchargement d'export instructeur était résolu via un `ExportTemplate.find` non scopé. Combiné au cache `Export.find_or_create_fresh_export` qui faisait un `find_by` global non restreint aux `groupe_instructeurs`, un instructeur pouvait obtenir le fichier d'un export d'une procédure à laquelle il n'a pas accès en passant l'ID d'un template d'un autre périmètre.

## Changements

- `Instructeurs::ProceduresController#export_template` : résolution restreinte à `current_instructeur.export_templates_for(procedure)` + templates `shareable` de la procédure courante.
- `Administrateurs::ExportsController#export_template` : scopé à `@procedure.export_templates` (défense en profondeur).
- `Export.find_or_create_fresh_export` : `find_by(attributes)` joint à `groupe_instructeurs` et restreint aux groupes passés en argument.
- Spec de régression + correction d'un test existant qui utilisait un template hors périmètre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)