### PR TITLE
Tech: corrige les AASM::InvalidTransition récurrents sur les batches

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -13,6 +13,18 @@ ActiveSupport.on_load(:active_storage_blob) do
   include BlobVirusScannerConcern
   include BlobSignedIdConcern
 
+  # With analyzers disabled, ActiveStorage falls back to NullAnalyzer whose
+  # `analyze_later? == false`, so `analyze_blob_later` (after_create_commit on
+  # Attachment) ends up calling `blob.update! metadata: ...` synchronously.
+  # Under contention (e.g. a batch op where N workers attach the same blob),
+  # those UPDATEs serialize on the same row and hit PG statement_timeout.
+  # Pre-marking the blob as analyzed at INSERT time short-circuits the
+  # `unless blob.analyzed?` guard in `Attachment#analyze_blob_later`, so no
+  # extra UPDATE is ever issued.
+  before_create do
+    self.metadata = metadata.merge("analyzed" => true)
+  end
+
   ActiveStorage::Blob.class_eval do
     def purge_later
       DelayedPurgeJob.perform_later(self)

--- a/spec/config/active_storage_spec.rb
+++ b/spec/config/active_storage_spec.rb
@@ -2,14 +2,16 @@
 
 describe "ActiveStorage configuration" do
   describe "blob analysis" do
-    it "does not enqueue AnalyzeJob when an image blob is created" do
+    let(:blob) do
       image_path = Rails.root.join("spec/fixtures/files/logo_test_procedure.png")
-      blob = ActiveStorage::Blob.create_and_upload!(
+      ActiveStorage::Blob.create_and_upload!(
         io: File.open(image_path),
         filename: "test.png",
         content_type: "image/png"
       )
+    end
 
+    it "does not enqueue AnalyzeJob when an image blob is created" do
       expect {
         ActiveStorage::Attachment.create!(
           name: "test",
@@ -17,6 +19,33 @@ describe "ActiveStorage configuration" do
           blob: blob
         )
       }.not_to have_enqueued_job(ActiveStorage::AnalyzeJob)
+    end
+
+    it "pre-marks blobs as analyzed and does not UPDATE active_storage_blobs when an attachment is created" do
+      # The blob must be pre-marked as analyzed at INSERT time so that
+      # `Attachment#analyze_blob_later` (after_create_commit) short-circuits
+      # via its `unless blob.analyzed?` guard. Otherwise, with `analyzers = []`,
+      # ActiveStorage falls back to NullAnalyzer whose `analyze_later? == false`,
+      # and `analyze` runs inline, issuing an unnecessary UPDATE on
+      # `active_storage_blobs`. Under contention (e.g., a batch op with N
+      # workers attaching the same blob), this UPDATE serializes on the same
+      # row and hits PG statement_timeout in production.
+      blob_updates = []
+      callback = -> (_, _, _, _, payload) {
+        sql = payload[:sql]
+        blob_updates << sql if sql.match?(/UPDATE\s+"active_storage_blobs"/i)
+      }
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        ActiveStorage::Attachment.create!(
+          name: "test",
+          record: create(:dossier),
+          blob: blob
+        )
+      end
+
+      expect(blob.analyzed?).to be(true)
+      expect(blob_updates).to be_empty
     end
   end
 end


### PR DESCRIPTION
## Symptôme

Sur Sentry, ~1370 occurrences de `AASM::InvalidTransition: Event 'fail' cannot transition from 'success'` dans `BatchOperationProcessOneJob` ([RAILS-GG7](https://demarches-simplifiees.sentry.io/issues/RAILS-GG7)), souvent doublées d'un `PG::QueryCanceled` apparemment sans rapport sur `active_storage_blobs`.

## Cause racine

Les deux erreurs sont en fait liées. Le piège vient de `config/initializers/active_storage.rb` qui fait `Rails.application.config.active_storage.analyzers = []` avec l'intention de désactiver l'analyse — mais en réalité la liste vide fait tomber ActiveStorage sur le `NullAnalyzer` interne, dont `analyze_later? == false`. Du coup `analyze_blob_later` (callback `after_create_commit` sur `Attachment`) finit par appeler `blob.update! metadata: ...` **synchroneusement**.

Cas concret de prod : un instructeur lance une batch "accepter" avec un justificatif partagé sur des dizaines de dossiers. Le justificatif est uploadé **une seule fois** (une ligne `active_storage_blobs`), puis chaque `BatchOperationProcessOneJob` l'attache à son dossier. Avec N workers Sidekiq en parallèle, tous déclenchent simultanément un `UPDATE active_storage_blobs SET metadata = ... WHERE id = <même id>` sur **la même ligne**. PG les sérialise sur le row lock (cf. `while rechecking updated tuple (5069473,21)` dans le `CONTEXT` Sentry), et les workers en queue finissent par taper `statement_timeout` → `PG::QueryCanceled`.

Cette exception remonte **après** que la transaction principale du job ait déjà été committée (le dossier est `accepte`, le `dossier_operation` est `:success` en DB). Le `rescue` du job tente alors `dossier_operation.fail!`, ce qui lève l'`AASM::InvalidTransition` qui masque la vraie cause dans Sentry.

## Correctif

`before_create` sur `ActiveStorage::Blob` qui pré-marque `metadata["analyzed"] = true` au moment de l'INSERT. Le `unless blob.analyzed?` interne d'ActiveStorage court-circuite alors le `update!` post-commit. Plus aucun UPDATE parasite → plus de contention → plus de timeout PG → plus de cascade AASM.

Le pattern est déjà utilisé ponctuellement dans `app/services/archive_uploader.rb`, ce changement le généralise — cohérent avec l'intention déjà déclarée par le commentaire `# Disable automatic blob analysis` dans l'initializer.