### PR TITLE
Tech: bump erb 6.0.2 => 6.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,7 @@ GEM
     dumb_delegator (1.1.0)
     email_validator (2.2.4)
       activemodel
-    erb (6.0.2)
+    erb (6.0.4)
     erubi (1.13.1)
     et-orbi (1.3.0)
       tzinfo


### PR DESCRIPTION
Fix CVE-2026-41316 (high)

Curieusement [dependabot ne pouvait pas créér la PR depuis 1 semaine](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/25053537965/job/73387461230) car gem.coop n'est pas à jour et rencontre des pb de cache d'index sur les dernières versions dispo depuis quelques semaines. A surveiller