### PR TITLE
Tech: corrige création de compte expert via confirmation_token

### DIFF
--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -144,7 +144,11 @@ module Experts
       procedure_id = params[:procedure_id]
       avis_id = params[:id]
       email = params[:email]
-      confirmation_token = params[:user][:confirmation_token]
+      confirmation_token = params.dig(:user, :confirmation_token).presence
+      if confirmation_token.nil?
+        return redirect_to root_path, alert: "Vous n’avez pas accès à cet avis."
+      end
+
       avis = Avis.joins(:procedure, expert: :user)
         .find_by(id: avis_id, procedure: { id: procedure_id }, user: { email:, confirmation_token: })
       if avis.nil?

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -697,6 +697,43 @@ describe Experts::AvisController, type: :controller do
         it { is_expected.to redirect_to(root_path) }
       end
 
+      # Sécurité: un confirmation_token absent ou vide ne doit jamais matcher,
+      # même si un expert déjà confirmé a confirmation_token = NULL en base
+      # (cas d’un user créé via User.create_or_promote_to_expert avec confirmed_at).
+      context 'when the expert user has a NULL confirmation_token in database' do
+        let(:password) { '{Another-$3cure-p4ssWord}' }
+        before { avis.expert.user.update_column(:confirmation_token, nil) }
+
+        context 'when the confirmation_token param is omitted' do
+          subject do
+            post :update_expert, params: {
+              id: avis_id,
+              procedure_id:,
+              email:,
+              user: { password: },
+            }
+          end
+
+          it { is_expected.to redirect_to(root_path) }
+
+          it 'does not change the expert password' do
+            subject
+            expect(avis.expert.user.reload.valid_password?(password)).to be false
+          end
+        end
+
+        context 'when the confirmation_token param is empty' do
+          let(:confirmation_token) { "" }
+
+          it { is_expected.to redirect_to(root_path) }
+
+          it 'does not change the expert password' do
+            subject
+            expect(avis.expert.user.reload.valid_password?(password)).to be false
+          end
+        end
+      end
+
       context 'when valid token is provided' do
         let(:confirmation_token) { valid_confirmation_token }
 


### PR DESCRIPTION
## Résumé

Dans `Experts::AvisController#update_expert`, le `confirmation_token` lu dans `params[:user]` était passé tel quel à `Avis.find_by(... user: { confirmation_token: })`. Lorsque le paramètre est absent, ActiveRecord traduit `nil` en `WHERE users.confirmation_token IS NULL` — or `User.create_or_promote_to_expert` crée le user avec `confirmed_at` mais sans générer de `confirmation_token`. Tout expert confirmé matche donc, et l'action enchaîne sur `reset_password` puis `sign_in`, permettant à un attaquant non authentifié de prendre le contrôle d'un compte expert dont il connaît l'email.

Le fix rejette explicitement les tokens blank en début d'action, avant qu'ils n'atteignent la clause WHERE.