### PR TITLE
ETQ admin, mieux gérer les services partagés entre démarches

### DIFF
--- a/app/controllers/administrateurs/services_controller.rb
+++ b/app/controllers/administrateurs/services_controller.rb
@@ -39,6 +39,7 @@ module Administrateurs
     def edit
       @service = service
       @procedure = procedure
+      @other_procedures = @service.procedures.where.not(id: @procedure.id).order(:id)
     end
 
     def update

--- a/app/controllers/administrateurs/services_controller.rb
+++ b/app/controllers/administrateurs/services_controller.rb
@@ -83,7 +83,7 @@ module Administrateurs
     end
 
     def destroy
-      service_to_destroy = service
+      service_to_destroy = current_administrateur.services.find(params[:id])
 
       if service_to_destroy.procedures.present?
         if service_to_destroy.procedures.count == 1

--- a/app/views/administrateurs/services/edit.html.haml
+++ b/app/views/administrateurs/services/edit.html.haml
@@ -16,14 +16,16 @@
   %h1.fr-h2
     Modifier le service
 
-  - other_services = @service.procedures.reject {|procedure| procedure.id == @procedure.id }
-  - if other_services.count > 1
-    = render Dsfr::AlertComponent.new(state: :warning, title: "Modifier ce service impactera la ou les démarches qui sont rattachée/s", extra_class_names: 'fr-mb-3w') do |c|
+  - if @other_procedures.any?
+    = render Dsfr::AlertComponent.new(state: :warning, title: "Modifier ce service impactera également les démarches suivantes", extra_class_names: 'fr-mb-3w') do |c|
       - c.with_body do
         %ul
-          - other_services.each do |proc|
-            %li= "#{proc.libelle} (N° #{proc.id})"
-        %p.fr-mt-6v Si vous souhaitez modifier uniquement les informations pour ce service, créez un nouveau service puis associez-le à la démarche
+          - @other_procedures.each do |proc|
+            %li= procedure_libelle_with_number(proc)
+        %p.fr-mt-6v
+          Si vous souhaitez modifier uniquement les informations pour cette démarche,
+          = link_to "créez un nouveau service", new_admin_service_path(procedure_id: @procedure.id)
+          puis associez-le à la démarche.
 
   = render partial: 'form',
     locals: { service: @service, procedure: @procedure }

--- a/app/views/administrateurs/services/index.html.haml
+++ b/app/views/administrateurs/services/index.html.haml
@@ -42,6 +42,6 @@
                     method: :delete,
                     data: { confirm: "Confirmez vous la suppression de #{service.nom}" },
                     class: 'fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-delete-line',
-                    disabled: (@procedure.service == service)
+                    disabled: (@procedure.service == service || service.administrateur_id != current_administrateur.id)
 
 = render Procedure::FixedFooterComponent.new(procedure: @procedure)

--- a/spec/controllers/administrateurs/services_controller_spec.rb
+++ b/spec/controllers/administrateurs/services_controller_spec.rb
@@ -156,6 +156,54 @@ describe Administrateurs::ServicesController, type: :controller do
     end
   end
 
+  describe '#edit' do
+    render_views
+
+    let!(:service) { create(:service, administrateur: admin) }
+    let!(:procedure) { create(:procedure, administrateur: admin, service: service) }
+
+    before { sign_in(admin.user) }
+
+    subject { get :edit, params: { id: service.id, procedure_id: procedure.id } }
+
+    context 'when the service is used only by the current procedure' do
+      it 'assigns no other procedures and does not render the warning' do
+        subject
+        expect(assigns(:other_procedures)).to be_empty
+        expect(response.body).not_to include("impactera également les démarches publiées")
+      end
+    end
+
+    context 'when the service is used by other procedures' do
+      let!(:other_published) { create(:procedure, :published, administrateur: admin, service: service, libelle: 'Démarche partagée') }
+      let!(:other_draft) { create(:procedure, administrateur: admin, service: service) }
+      let!(:other_closed) { create(:procedure, :closed, administrateur: admin, service: service) }
+
+      it 'assigns all other procedures regardless of state and lists them in the warning' do
+        subject
+        expect(assigns(:other_procedures)).to contain_exactly(other_published, other_draft, other_closed)
+        expect(response.body).to include("impactera également les démarches suivantes")
+        expect(response.body).to include("Démarche partagée - n°#{other_published.id}")
+        expect(response.body).to include("n°#{other_draft.id}")
+        expect(response.body).to include("n°#{other_closed.id}")
+      end
+    end
+
+    context 'when the service is shared with a co-administrateur' do
+      let(:other_admin) { create(:administrateur) }
+      let!(:service) { create(:service, administrateur: other_admin) }
+      let!(:procedure) { create(:procedure, administrateurs: [other_admin, admin], service: service) }
+      let!(:other_published) { create(:procedure, :published, administrateur: other_admin, service: service) }
+
+      it 'allows the co-administrateur to access the edit form and warns about other procedures' do
+        subject
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:service)).to eq(service)
+        expect(assigns(:other_procedures)).to contain_exactly(other_published)
+      end
+    end
+  end
+
   describe '#update' do
     let!(:service) { create(:service, administrateur: admin) }
     let(:service_params) { { nom: 'nom', type_organisme: Service.type_organismes.fetch(:association), siret: "13002526500013" } }
@@ -187,6 +235,17 @@ describe Administrateurs::ServicesController, type: :controller do
       it do
         expect(flash.alert).not_to be_nil
         expect(response).to render_template(:edit)
+      end
+    end
+
+    context 'when a co-administrateur updates a shared service' do
+      let(:other_admin) { create(:administrateur) }
+      let!(:service) { create(:service, administrateur: other_admin, nom: 'Original') }
+      let!(:procedure) { create(:procedure, administrateurs: [other_admin, admin], service: service) }
+
+      it 'updates the service' do
+        expect(flash.alert).to be_nil
+        expect(service.reload.nom).to eq('nom')
       end
     end
   end

--- a/spec/controllers/administrateurs/services_controller_spec.rb
+++ b/spec/controllers/administrateurs/services_controller_spec.rb
@@ -332,6 +332,20 @@ describe Administrateurs::ServicesController, type: :controller do
         expect(procedure.reload.service_id).to be_nil
       end
     end
+
+    context 'when a co-administrateur tries to destroy a shared service owned by another admin' do
+      let(:other_admin) { create(:administrateur) }
+      let!(:service) { create(:service, administrateur: other_admin) }
+      let!(:procedure) { create(:procedure, administrateurs: [other_admin, admin]) }
+
+      before { sign_in(admin.user) }
+
+      it 'forbids the destruction even if no procedure references the service' do
+        expect { delete :destroy, params: { id: service.id, procedure_id: procedure.id } }
+          .to raise_error(ActiveRecord::RecordNotFound)
+        expect { service.reload }.not_to raise_error
+      end
+    end
   end
 
   describe "#index" do
@@ -362,6 +376,22 @@ describe Administrateurs::ServicesController, type: :controller do
         expect(procedure.service).to be nil
         expect(flash.alert.first).to eq "Certaines de vos démarches n’ont pas de service associé."
         expect(flash.alert.last).to include "démarche #{procedure.id}"
+      end
+    end
+
+    context 'when listing services on a procedure shared with a co-administrateur' do
+      render_views
+
+      let(:other_admin) { create(:administrateur) }
+      let!(:foreign_service) { create(:service, administrateur: other_admin) }
+      let!(:procedure) { create(:procedure, administrateurs: [other_admin, admin], service: foreign_service) }
+
+      it 'disables the destroy button for services not owned by the current administrateur' do
+        get :index, params: { procedure_id: procedure.id }
+
+        destroy_form = response.parsed_body
+          .css("form[action='#{admin_service_path(foreign_service, procedure_id: procedure.id)}'][method='post']")
+        expect(destroy_form.css("button[disabled]")).not_to be_empty
       end
     end
   end


### PR DESCRIPTION
La modification d'un service partagé entre plusieurs démarches reste autorisée pour les co-administrateurs : le formulaire d'édition liste désormais les autres démarches concernées par la modification dans une alerte DSFR, pour informer du périmètre de l'impact.

La suppression d'un service est en revanche restreinte à son administrateur propriétaire (un service est un élément d'inventaire personnel, indépendant du périmètre de gestion partagée). Côté interface, le bouton « Supprimer » de l'index est désormais désactivé pour les services non possédés par l'administrateur courant ; côté contrôleur, l'action `destroy` lève `RecordNotFound` si on tente de la déclencher quand même.

Dans une prochaine PR : migration de la policy vers Pundit.