### PR TITLE
ETQ tech, durcir l'inscription contre la pollution du paramètre email

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -31,7 +31,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     CurrentConfirmation.prefill_token = @prefill_token
 
     # Handle existing user trying to sign up again
-    existing_user = User.find_by(user_email_params)
+    existing_user = user_email_param.present? ? User.find_by(email: user_email_param) : nil
     if existing_user.present?
       if existing_user.confirmed?
         UserMailer.new_account_warning(existing_user, @procedure).deliver_later
@@ -96,7 +96,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   private
 
-  def user_email_params
-    params.require(:user).permit(:email)
+  def user_email_param
+    # Strong Parameters silently filters non-scalar values, so a hash like
+    # `user[email][]=x` would fall through to `find_by({})` and return the first user.
+    email = params.require(:user).permit(:email)[:email]
+    email.is_a?(String) ? email : nil
   end
 end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -116,5 +116,33 @@ describe Users::RegistrationsController, type: :controller do
         end
       end
     end
+
+    context 'when the email param is sent as a non-scalar value' do
+      let!(:other_user) { create(:user, email: 'someone-else@example.com', confirmed_at: Time.zone.now) }
+
+      before do
+        allow(UserMailer).to receive(:new_account_warning).and_return(double(deliver_later: 'deliver'))
+      end
+
+      subject(:non_scalar_email_request) do
+        post :create, params: { user: { email: ['anything'], password: password } }
+      end
+
+      it 'does not look up an unrelated existing user' do
+        expect(UserMailer).not_to receive(:new_account_warning).with(other_user, anything)
+
+        non_scalar_email_request
+      end
+
+      it 'does not redirect to a confirmation page that discloses an unrelated user email' do
+        non_scalar_email_request
+
+        if response.redirect? && response.location.match?(/\/users\/confirmation\/new\?email=/)
+          email_param = CGI.parse(URI.parse(response.location).query)['email'].first
+          decrypted_email = controller.message_encryptor_service.decrypt_and_verify(email_param, purpose: :email_confirmation)
+          expect(decrypted_email).not_to eq(other_user.email)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Résumé

- `Users::RegistrationsController#create` passait le résultat de `params.require(:user).permit(:email)` directement à `User.find_by`.
- Si l'attaquant envoie `user[email]` sous forme non scalaire (par ex. `user[email][]=x`), les Strong Parameters filtrent silencieusement la valeur et `find_by({})` renvoie le premier utilisateur de la table : un mail est envoyé à un compte arbitraire et son email est divulgué via la redirection vers `new_user_confirmation_path(email: signed_email)`.
- Le fix extrait la valeur d'`email` comme `String` avant la requête et saute le lookup si le paramètre n'est pas scalaire.

Spec de régression : `spec/controllers/users/registrations_controller_spec.rb` — contexte « when the email param is sent as a non-scalar value » (RED sur main, GREEN après le fix).