### PR TITLE
ETQ tech, durcir sign_in_by_link contre le détournement vers un autre compte instructeur

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -95,6 +95,10 @@ class Users::SessionsController < Devise::SessionsController
       flash[:alert] = 'Votre lien est invalide.'
 
       redirect_to root_path
+    elsif instructeur_signed_in? && current_user != instructeur.user
+      flash[:alert] = 'Votre lien est invalide.'
+
+      redirect_to root_path
     elsif trusted_device_token.token_valid?
       trust_device(trusted_device_token.created_at, trusted_device_token)
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -287,6 +287,25 @@ describe Users::SessionsController, type: :controller do
         end
       end
     end
+
+    context 'when a different instructeur is signed in than the one bound to the token' do
+      let(:link_instructeur) { create(:instructeur) }
+      let(:other_instructeur) { create(:instructeur) }
+      let!(:link_token) { link_instructeur.create_trusted_device_token }
+
+      before do
+        sign_in(other_instructeur.user)
+        allow_any_instance_of(TrustedDeviceToken).to receive(:token_valid?).and_return(true)
+      end
+
+      subject(:cross_instructeur_request) do
+        post :sign_in_by_link, params: { id: link_instructeur.id, jeton: link_token }
+      end
+
+      it 'does not mark the signed-in user email as verified using another instructeur token' do
+        expect { cross_instructeur_request }.not_to change { other_instructeur.user.reload.email_verified_at }
+      end
+    end
   end
 
   describe '#trust_device and #trusted_device?' do


### PR DESCRIPTION
## Résumé

- `Users::SessionsController#sign_in_by_link` validait le `trusted_device_token` pour l'instructeur ciblé par l'URL, puis appliquait `current_user.update!(email_verified_at: Time.zone.now)` sur l'utilisateur **actuellement connecté**.
- Un instructeur authentifié qui visitait un lien `connexion-par-jeton` valide d'un autre instructeur (boîte partagée, fuite de mail, etc.) voyait alors **son propre** email marqué comme vérifié et son navigateur posé en *trusted device*, contournant la 2FA email exigée par `redirect_if_untrusted`.
- Le fix refuse la requête lorsque le `current_user` ne correspond pas à l'instructeur dont le jeton vient d'être validé.

Spec de régression : `spec/controllers/users/sessions_controller_spec.rb` — contexte « when a different instructeur is signed in than the one bound to the token » (RED sur main, GREEN après le fix).