### PR TITLE
ETQ tech, ancrer la vérification de domaine email sur le domaine complet

### DIFF
--- a/app/controllers/users/profil_controller.rb
+++ b/app/controllers/users/profil_controller.rb
@@ -115,7 +115,13 @@ module Users
     end
 
     def target_email_allowed?
-      LEGIT_ADMIN_DOMAINS.any? { |d| requested_email.end_with?(d) }
+      domain = requested_email.to_s.split('@', 2).last&.downcase
+      return false if domain.blank?
+
+      LEGIT_ADMIN_DOMAINS.any? do |d|
+        legit = d.to_s.downcase
+        domain == legit || domain.end_with?(".#{legit}")
+      end
     end
 
     def next_owner_email

--- a/spec/controllers/users/profil_controller_spec.rb
+++ b/spec/controllers/users/profil_controller_spec.rb
@@ -119,6 +119,16 @@ describe Users::ProfilController, type: :controller do
           expect(flash.alert).to include('contactez le support')
         end
       end
+
+      context 'when the requested email is on a domain that only matches a legit suffix without an `@` boundary' do
+        let(:requested_email) { 'admin@evilgouv.fr' }
+
+        it 'rejects the email change' do
+          expect(user.unconfirmed_email).to be_nil
+          expect(response).to redirect_to(profil_path)
+          expect(flash.alert).to include('contactez le support')
+        end
+      end
     end
 
     context 'when the user has an administrateur role but no instructeur role' do


### PR DESCRIPTION
## Résumé

- `Users::ProfilController#target_email_allowed?` utilisait `requested_email.end_with?(d)` pour valider l'appartenance d'un email à `LEGIT_ADMIN_DOMAINS`.
- Tout domaine attaquant qui se terminait textuellement par l'un des suffixes (`evilgouv.fr`, `notjustice.fr`, etc.) passait la vérification : un instructeur ou administrateur pouvait déplacer son compte vers un domaine qu'il contrôle entièrement, tout en conservant son rôle privilégié et ses notifications (dossiers, reset de mot de passe, demandes de fusion).
- Le fix extrait la partie domaine de l'email et impose une égalité stricte avec `LEGIT_ADMIN_DOMAINS`, ou un préfixe de sous-domaine ancré sur `.`.

Spec de régression : `spec/controllers/users/profil_controller_spec.rb` — contexte « when the requested email is on a domain that only matches a legit suffix without an `@` boundary » (RED sur main, GREEN après le fix).