### PR TITLE
ETQ tech, comparer la signature du webhook Crisp en temps constant

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -33,6 +33,8 @@ class WebhookController < ActionController::Base
     timestamp = request.headers['X-Crisp-Request-Timestamp']
     signature = request.headers['X-Crisp-Signature']
 
+    return head :bad_request if signature.blank? || timestamp.blank?
+
     body = request.body.read
     concatenated_string = "[#{timestamp};#{body}]"
 
@@ -40,6 +42,6 @@ class WebhookController < ActionController::Base
       ENV.fetch("CRISP_WEBHOOK_SECRET"),
       concatenated_string)
 
-    head :bad_request unless signature == expected_signature
+    head :bad_request unless ActiveSupport::SecurityUtils.secure_compare(signature, expected_signature)
   end
 end

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -46,5 +46,27 @@ describe WebhookController, type: :controller do
       post :crisp, params: body, as: :json
       expect(response).not_to have_http_status(:ok)
     end
+
+    it 'compares signatures using a constant-time primitive' do
+      expect(Crisp::WebhookProcessor).not_to receive(:new)
+      expect(ActiveSupport::SecurityUtils).to receive(:secure_compare).at_least(:once).and_call_original
+
+      request.headers.merge!({
+        'X-Crisp-Request-Timestamp' => timestamp,
+        'X-Crisp-Signature' => '0' * 64,
+      })
+
+      post :crisp, params: body, as: :json
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'rejects requests with a missing signature header without invoking the comparison' do
+      expect(Crisp::WebhookProcessor).not_to receive(:new)
+
+      request.headers['X-Crisp-Request-Timestamp'] = timestamp
+
+      post :crisp, params: body, as: :json
+      expect(response).to have_http_status(:bad_request)
+    end
   end
 end


### PR DESCRIPTION
## Résumé

- `WebhookController#verify_crisp_signature!` comparait la signature HMAC fournie via `==`, qui s'arrête au premier octet divergent.
- Ce canal latéral temporel permettait, octet par octet, de reconstruire une signature HMAC valide sans connaître `CRISP_WEBHOOK_SECRET`, puis d'injecter des payloads arbitraires dans `Crisp::WebhookProcessor` (jobs `CrispUpdatePeopleDataJob` et `CrispMattermostTechNotificationJob`).
- Le fix utilise `ActiveSupport::SecurityUtils.secure_compare` et rejette explicitement les requêtes sans en-tête `X-Crisp-Request-Timestamp` ou `X-Crisp-Signature` avant toute comparaison.

Spec de régression : `spec/controllers/webhook_controller_spec.rb` — exemples « compares signatures using a constant-time primitive » et « rejects requests with a missing signature header » (RED sur main, GREEN après le fix).