### PR TITLE
Tech: renforce la sécurité du lien de confirmation

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -42,6 +42,12 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   # If the user clicks the confirmation link before the maximum delay,
   # they will be signed in directly.
   def sign_in_after_confirmation?(resource)
+    # Only auto-sign-in when the confirmation actually just happened.
+    # When the token is replayed after the account was already confirmed,
+    # Devise adds an :already_confirmed error: in that case, the link must
+    # not be turned into a reusable login token.
+    return false if resource.errors.any?
+
     # Avoid keeping auto-sign-in links in users inboxes for too long.
     # 95% of users confirm their account within two hours.
     auto_sign_in_timeout = 2.hours

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -69,6 +69,26 @@ describe Users::ConfirmationsController, type: :controller do
         expect(flash.notice).to include("Votre compte a déjà été activé")
       end
     end
+
+    context 'when the confirmation link is replayed within the auto-sign-in delay after the account was already confirmed' do
+      let!(:user) { create(:user, confirmed_at: 30.minutes.ago, confirmation_sent_at: 30.minutes.ago, confirmation_token: "mytoken") }
+
+      subject do
+        get :show, params: { confirmation_token: confirmation_token }
+      end
+
+      it 'does not sign the user in' do
+        expect(user).to be_confirmed
+        subject
+        expect(controller.current_user).to be_nil
+        expect(controller.current_instructeur).to be_nil
+        expect(controller.current_administrateur).to be_nil
+      end
+
+      it 'redirects to the sign-in path' do
+        expect(subject).to redirect_to(new_user_session_path)
+      end
+    end
   end
 
   describe '#new' do


### PR DESCRIPTION
## Résumé

- Quand le lien de confirmation est rejoué après que l'email a déjà été confirmé, Devise ajoute l'erreur `:already_confirmed`. Le `show` override redirigeait quand même vers `after_confirmation_path_for`, qui appelait `sign_in(resource)` avec `remember_me=true` si `confirmation_sent_at` datait de moins de 2 h. Le lien devenait donc un identifiant de session réutilisable pendant 2 heures, sans mot de passe ni 2FA.
- Le correctif court-circuite l'auto sign-in dès que la ressource porte des erreurs (cas `:already_confirmed`), en conservant le comportement nominal pour la confirmation initiale.
- Voir le commit: 13fd3d6265ed51610c3f90559bdf852d5a26e4c6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)