### PR TITLE
ETQ usager, ne pas pré-confirmer le compte du tiers à partir de l'email saisi par le propriétaire du dossier

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,11 +148,14 @@ class User < ApplicationRecord
   end
 
   def self.create_or_promote_to_tiers(email, password, dossier = nil)
+    # The email comes from the dossier owner and is therefore third-party data:
+    # we must not pre-confirm the account, nor disrupt a pending confirmation
+    # flow already in progress for an existing user.
     user = User
-      .create_with(password: password, confirmed_at: Time.zone.now)
+      .create_with(password: password)
       .find_or_create_by(email: email)
 
-    if user.valid? && user.unverified_email?
+    if user.valid? && user.previously_new_record?
       user.invite_tiers!(dossier)
     end
     user

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -376,6 +376,46 @@ describe Users::DossiersController, type: :controller do
         end
       end
     end
+
+    context 'when a for_tiers dossier is updated with an arbitrary email' do
+      let(:procedure) { create(:procedure, :for_individual, for_tiers_enabled: true) }
+      let(:dossier) { create(:dossier, :for_tiers_without_notification, state: 'brouillon', user: user, procedure: procedure) }
+      let(:other_email) { 'beneficiaire@example.com' }
+      let(:dossier_params) do
+        {
+          for_tiers: 'true',
+          individual_attributes: { gender: 'M', nom: 'Mouse', prenom: 'Mickey', email: other_email, notification_method: 'email' },
+        }
+      end
+
+      it 'does not create a pre-confirmed account for the submitted email' do
+        subject
+        created_user = User.find_by(email: other_email)
+        # The submitted email is third-party data: the resulting account must
+        # not be considered email-verified or confirmed before the owner acts.
+        expect(created_user).to be_present
+        expect(created_user.email_verified_at).to be_nil
+        expect(created_user.confirmed?).to be false
+      end
+
+      context 'when an unverified user already exists for the submitted email' do
+        let!(:existing_user) do
+          create(:user,
+            email: other_email,
+            confirmation_token: 'existing-token',
+            confirmation_sent_at: 2.hours.ago,
+            confirmed_at: nil)
+        end
+
+        it 'does not overwrite the existing confirmation_token' do
+          expect { subject }.not_to change { existing_user.reload.confirmation_token }
+        end
+
+        it 'does not send a new invite_tiers email to the existing user' do
+          expect { subject }.not_to have_enqueued_mail(UserMailer, :invite_tiers)
+        end
+      end
+    end
   end
 
   describe '#siret' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -616,4 +616,47 @@ describe User, type: :model do
       end
     end
   end
+
+  describe '.create_or_promote_to_tiers' do
+    let(:dossier) { create(:dossier) }
+    let(:email) { 'beneficiaire@example.com' }
+
+    subject(:promote) { User.create_or_promote_to_tiers(email, SecureRandom.hex, dossier) }
+
+    context 'when no user exists for that email' do
+      it 'creates a new user without marking the email as verified' do
+        expect { promote }.to change { User.where(email: email).count }.from(0).to(1)
+
+        created_user = User.find_by(email: email)
+        expect(created_user.email_verified_at).to be_nil
+        expect(created_user.unverified_email?).to be true
+      end
+
+      it 'does not authenticate the new user via Devise (confirmation must still happen)' do
+        promote
+        created_user = User.find_by(email: email)
+        # The Devise confirmable contract: a freshly-created tiers account
+        # must not be considered confirmed before its owner clicks the email link.
+        expect(created_user.confirmed?).to be false
+      end
+    end
+
+    context 'when an unverified user already exists for that email' do
+      let!(:existing_user) do
+        create(:user,
+          email: email,
+          confirmation_token: 'existing-token',
+          confirmation_sent_at: 2.hours.ago,
+          confirmed_at: nil)
+      end
+
+      it 'does not overwrite the active confirmation_token of the existing user' do
+        expect { promote }.not_to change { existing_user.reload.confirmation_token }
+      end
+
+      it 'does not enqueue an invite_tiers email for the unverified user' do
+        expect { promote }.not_to have_enqueued_mail(UserMailer, :invite_tiers)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Résumé

`Users::DossiersController#update_identite` appelle `User.create_or_promote_to_tiers` avec un email entièrement contrôlé par le propriétaire du dossier. L'implémentation actuelle :

- créait un compte Devise marqué `confirmed_at: Time.zone.now` pour une adresse arbitraire, sans aucune vérification de possession (squat / phishing potentiel) ;
- pour un utilisateur déjà existant mais non vérifié, écrasait son `confirmation_token` actif et lui renvoyait un email d'invitation, invalidant la confirmation en cours.

Le correctif :

- supprime `confirmed_at: Time.zone.now` du `create_with` afin que le nouveau compte tiers suive le flux Devise standard (le mail `invite_tiers` contient déjà un token de confirmation) ;
- n'appelle `invite_tiers!` que lorsque le compte vient d'être créé (`previously_new_record?`), pour ne pas perturber une confirmation déjà en cours pour un utilisateur existant.

Le flux légitime « dossier pour un tiers » continue de fonctionner : un compte est créé pour le bénéficiaire et un email d'invitation lui est envoyé. La seule différence est que ce compte n'est plus considéré comme confirmé tant que le bénéficiaire n'a pas cliqué sur le lien.

Specs de non-régression ajoutées dans `spec/models/user_spec.rb` et `spec/controllers/users/dossiers_controller_spec.rb`.