### PR TITLE
Tech: exiger l'authentification sur targeted_user_link d'invitation

### DIFF
--- a/app/controllers/targeted_user_links_controller.rb
+++ b/app/controllers/targeted_user_links_controller.rb
@@ -4,8 +4,15 @@ class TargetedUserLinksController < ApplicationController
   def show
     erase_user_location!
     store_user_location! if !user_signed_in?
+    # Resolve the target early so an unreachable target (e.g. invite whose dossier is hidden)
+    # surfaces the "expired link" page even for anonymous visitors.
+    targeted_user_link.target_email
     if targeted_user_link.invalid_signed_in_user?(current_user)
-      render
+      if !user_signed_in?
+        authenticate_user!
+      else
+        render
+      end
     else
       redirect_to targeted_user_link.redirect_url(Rails.application.routes.url_helpers, params.permit(:confirmation_token)["confirmation_token"])
     end

--- a/app/models/targeted_user_link.rb
+++ b/app/models/targeted_user_link.rb
@@ -7,7 +7,13 @@ class TargetedUserLink < ApplicationRecord
   enum :target_context, { avis: 'avis', invite: 'invite' }
 
   def invalid_signed_in_user?(signed_in_user)
+    return true if requires_authenticated_user? && signed_in_user.nil?
+
     signed_in_user && signed_in_user.email != target_email
+  end
+
+  def requires_authenticated_user?
+    target_context == 'invite'
   end
 
   def target_email

--- a/spec/controllers/targeted_user_links_controller_spec.rb
+++ b/spec/controllers/targeted_user_links_controller_spec.rb
@@ -88,8 +88,9 @@ describe TargetedUserLinksController, type: :controller do
       context 'when invite user does not exists' do
         let(:user) { nil }
         before { get :show, params: { id: targeted_user_link.id } }
-        it 'works' do
-          expect(response).to redirect_to(invite_path(target_model, email: target_model.email))
+        it 'requires authentication before exposing the invite' do
+          expect(response).to redirect_to(new_user_session_path)
+          expect(controller.stored_location_for(:user)).to eq(controller.request.fullpath)
         end
       end
 
@@ -145,8 +146,9 @@ describe TargetedUserLinksController, type: :controller do
       context 'when invite user does not exists' do
         let(:user) { nil }
         before { get :show, params: { id: targeted_user_link.id } }
-        it 'works' do
-          expect(response).to redirect_to(invite_path(target_model, email: target_model.email))
+        it 'requires authentication before exposing the invite' do
+          expect(response).to redirect_to(new_user_session_path)
+          expect(controller.stored_location_for(:user)).to eq(controller.request.fullpath)
         end
       end
     end
@@ -158,6 +160,27 @@ describe TargetedUserLinksController, type: :controller do
         expect(response).to redirect_to(root_path)
         expect(flash[:error]).to be_present
         expect(flash[:error]).to match(/invitation n’est plus valable/)
+      end
+    end
+
+    context 'anonymous request to an invite-targeted link' do
+      let(:invite_email) { 'guest@example.com' }
+      let(:invite) { create(:invite, user: nil, email: invite_email) }
+      let!(:targeted_user_link) do
+        create(:targeted_user_link, target_context: 'invite', target_model: invite, user: nil)
+      end
+
+      subject(:anonymous_show) { get :show, params: { id: targeted_user_link.id } }
+
+      it 'does not redirect to the invite path with the invite email prefilled' do
+        anonymous_show
+        expect(response).not_to redirect_to(invite_path(invite, email: invite_email))
+      end
+
+      it 'requires authentication and stores the location for return after sign-in' do
+        anonymous_show
+        expect(response).to redirect_to(new_user_session_path)
+        expect(controller.stored_location_for(:user)).to eq(controller.request.fullpath)
       end
     end
   end

--- a/spec/system/users/invite_spec.rb
+++ b/spec/system/users/invite_spec.rb
@@ -27,7 +27,7 @@ describe 'Invitations' do
     context 'when inviting someone without an existing account' do
       let(:invite) { create(:invite, dossier: dossier, user: nil) }
 
-      scenario 'an invited user can register using the targeted_user_link sent in the invitation email', js: true do
+      scenario 'an invited user receiving the targeted_user_link is asked to authenticate first', js: true do
         log_in(owner)
         navigate_to_brouillon(dossier)
 
@@ -45,7 +45,7 @@ describe 'Invitations' do
 
         page.reset_session!
         visit URI.parse(targeted_user_link_url(targeted_user_link)).request_uri
-        expect(page).to have_current_path("/users/sign_up?user%5Bemail%5D=user_invite%40exemple.fr")
+        expect(page).to have_current_path("/users/sign_in")
       end
     end
 


### PR DESCRIPTION
## Résumé

`TargetedUserLink#invalid_signed_in_user?` retournait une valeur falsy (`nil`) lorsqu'aucun utilisateur n'était connecté, faisant que `TargetedUserLinksController#show` redirigeait directement les visiteurs anonymes munis d'un UUID de lien vers `invite_path`. Le flow d'invitation exposait alors l'email de la cible et basculait sur la page d'inscription pré-remplie. Devise Confirmable empêche la prise de contrôle directe (l'attaquant ne peut pas se connecter sans confirmer l'email), mais l'auth fail-open reste un défaut de défense en profondeur.

## Correctif

- `TargetedUserLink#invalid_signed_in_user?` traite désormais `signed_in_user.nil?` comme invalide pour le contexte `invite`.
- Le contrôleur force `authenticate_user!` pour les visiteurs anonymes lorsqu'une auth est requise, en préservant `store_user_location!` pour un retour propre après connexion.
- Le flow `avis` (sign-up / confirmation email pour experts) reste fonctionnel pour les utilisateurs anonymes — son URL cible n'expose pas le même vecteur de takeover.
- Specs ajustées : la régression est couverte par un nouveau context `anonymous request to an invite-targeted link` et les deux tests qui codifiaient le comportement vulnérable sont mis à jour.