### PR TITLE
Tech: fix timeout sur la maintenance task de backfill des blobs en virus_scan_result pending

### DIFF
--- a/app/tasks/maintenance/t20260427backfill_virus_scan_blobs_task.rb
+++ b/app/tasks/maintenance/t20260427backfill_virus_scan_blobs_task.rb
@@ -9,21 +9,30 @@ module Maintenance
     # Inclut les orphelins (sans attachment) : BlobProcessorJob les marquera
     # simplement comme processed, et PurgeUnattachedBlobsJob les purgera.
     # On évite ainsi le semi-join sur 103M attachments qui timeout.
+    #
+    # On itère via Blob.in_batches (sans filtre WHERE) puis on applique le
+    # filtre virus_scan_result dans process() sur le batch déjà borné par
+    # ids. Itérer directement sur where(virus_scan_result: PENDING) timeout :
+    # avec ~7M lignes pending sur 100M, le cursor `ORDER BY id LIMIT N`
+    # avec ce filtre est trop coûteux si les pending sont concentrés sur
+    # une plage d'ids (PG parcourt l'index PK en filtrant et peut traverser
+    # des dizaines de millions de lignes avant d'en trouver N).
 
     include RunnableOnDeployConcern
     include StatementsHelpersConcern
 
     def collection
-      ActiveStorage::Blob
+      ActiveStorage::Blob.in_batches(of: 10_000)
+    end
+
+    def process(batch)
+      batch
         .where(virus_scan_result: ActiveStorage::VirusScanner::PENDING)
+        .find_each do |blob|
+          next if blob.metadata["processed"]
+
+          BlobProcessorJob.perform_later(blob)
+        end
     end
-
-    def process(blob)
-      return if blob.metadata["processed"]
-
-      BlobProcessorJob.perform_later(blob)
-    end
-
-    # pas de count : la requête sur 7M+ rows timeout même avec statement_timeout élevé
   end
 end

--- a/spec/tasks/maintenance/t20260427backfill_virus_scan_blobs_task_spec.rb
+++ b/spec/tasks/maintenance/t20260427backfill_virus_scan_blobs_task_spec.rb
@@ -5,53 +5,50 @@ require "rails_helper"
 module Maintenance
   RSpec.describe T20260427backfillVirusScanBlobsTask do
     describe '#collection' do
-      let!(:pending) do
-        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("pending"), filename: "pending.txt", content_type: "text/plain").tap do |blob|
-          blob.update_columns(virus_scan_result: ActiveStorage::VirusScanner::PENDING)
-        end
-      end
-
-      let!(:safe) do
-        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("safe"), filename: "safe.txt", content_type: "text/plain").tap do |blob|
-          blob.update_columns(virus_scan_result: ActiveStorage::VirusScanner::SAFE)
-        end
-      end
-
-      subject(:collection) { described_class.new.collection }
-
-      it 'includes pending blobs' do
-        expect(collection).to include(pending)
-      end
-
-      it 'excludes safe blobs' do
-        expect(collection).not_to include(safe)
+      it 'returns a batch enumerator over all blobs' do
+        collection = described_class.new.collection
+        expect(collection).to be_a(ActiveRecord::Batches::BatchEnumerator)
+        expect(collection.relation.model).to eq(ActiveStorage::Blob)
       end
     end
 
     describe '#process' do
-      let!(:blob) do
-        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("data"), filename: "file.txt", content_type: "text/plain").tap do |blob|
-          blob.update_columns(virus_scan_result: ActiveStorage::VirusScanner::PENDING)
+      let!(:pending_blob) do
+        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("pending"), filename: "p.txt", content_type: "text/plain").tap do |b|
+          b.update_columns(virus_scan_result: ActiveStorage::VirusScanner::PENDING)
         end
       end
 
-      let!(:already_processed) do
-        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("done"), filename: "done.txt", content_type: "text/plain").tap do |blob|
-          blob.update_columns(
+      let!(:safe_blob) do
+        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("safe"), filename: "s.txt", content_type: "text/plain").tap do |b|
+          b.update_columns(virus_scan_result: ActiveStorage::VirusScanner::SAFE)
+        end
+      end
+
+      let!(:already_processed_blob) do
+        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("done"), filename: "d.txt", content_type: "text/plain").tap do |b|
+          b.update_columns(
             virus_scan_result: ActiveStorage::VirusScanner::PENDING,
-            metadata: blob.metadata.merge("processed" => true)
+            metadata: b.metadata.merge("processed" => true)
           )
         end
       end
 
-      it 'enqueues a BlobProcessorJob' do
-        expect { described_class.new.process(blob) }
-          .to have_enqueued_job(BlobProcessorJob).with(blob)
+      let(:batch) { ActiveStorage::Blob.where(id: [pending_blob.id, safe_blob.id, already_processed_blob.id]) }
+
+      it 'enqueues a BlobProcessorJob for pending blobs in the batch' do
+        expect { described_class.new.process(batch) }
+          .to have_enqueued_job(BlobProcessorJob).with(pending_blob).exactly(:once)
+      end
+
+      it 'skips safe blobs' do
+        expect { described_class.new.process(batch) }
+          .not_to have_enqueued_job(BlobProcessorJob).with(safe_blob)
       end
 
       it 'skips already processed blobs' do
-        expect { described_class.new.process(already_processed) }
-          .not_to have_enqueued_job(BlobProcessorJob)
+        expect { described_class.new.process(batch) }
+          .not_to have_enqueued_job(BlobProcessorJob).with(already_processed_blob)
       end
     end
   end


### PR DESCRIPTION
## Contexte

La task `Maintenance::T20260427backfillVirusScanBlobsTask` timeout en prod dès le premier élement (`PG::QueryCanceled: statement timeout`). Sur ~100M blobs dont ~7,4M en `virus_scan_result = 'pending'`, le cursor par défaut de MaintenanceTasks fait `SELECT … WHERE virus_scan_result = 'pending' ORDER BY id LIMIT N` — PG doit soit trier les 7M lignes via l'index `virus_scan_result`, soit parcourir l'index PK en filtrant. Les deux plans sont trop coûteux quand les blobs `pending` sont concentrés sur une plage d'ids.

Le `count` reste instantané.

## Fix

Itération via `Blob.in_batches(of: 10_000)` sans filtre WHERE — le cursor n'utilise alors que la PK (sub-ms garantie). Le filtre `virus_scan_result = 'pending'` est appliqué dans `process()` sur le batch déjà borné par ids, ce qui reste rapide quel que soit le clustering.

Ce pattern est plus robuste que les `Champs::XxxChamp.in_batches` utilisés ailleurs (qui dépendent d'une bonne distribution du filtre dans la table).