### PR TITLE
Tech : durcit le formulaire de fusion FranceConnect

### DIFF
--- a/app/controllers/france_connect_controller.rb
+++ b/app/controllers/france_connect_controller.rb
@@ -63,6 +63,21 @@ class FranceConnectController < ApplicationController
   end
 
   def send_email_merge_request
+    user = User.find_by(email: sanitized_email_params)
+
+    if user.present?
+      if params[:password].blank?
+        @merge_email = sanitized_email_params
+        return render :confirm_email_merge_password
+      end
+
+      if !user.valid_for_authentication? { user.valid_password?(params[:password]) }
+        flash.now[:alert] = t('france_connect.flash.invalid_password')
+        @merge_email = sanitized_email_params
+        return render :confirm_email_merge_password
+      end
+    end
+
     @fci.update(requested_email: sanitized_email_params)
 
     @fci.create_email_merge_token!

--- a/app/views/france_connect/choose_email.html.haml
+++ b/app/views/france_connect/choose_email.html.haml
@@ -11,6 +11,7 @@
       %fieldset.fr-fieldset
         = form_with url: france_connect_merge_using_fc_email_path,
           method: :post,
+          authenticity_token: form_authenticity_token,
           data: { controller: 'email-france-connect',
             email_france_connect_fc_email_path_value: france_connect_merge_using_fc_email_path,
             email_france_connect_custom_email_path_value: france_connect_send_email_merge_request_path,

--- a/app/views/france_connect/confirm_email_merge_password.html.erb
+++ b/app/views/france_connect/confirm_email_merge_password.html.erb
@@ -1,0 +1,25 @@
+<div class="fr-container fr-my-5w">
+  <div class="fr-grid-row fr-col-offset-md-2 fr-col-md-8">
+    <div class="fr-col-12">
+      <h1 class="text-center fr-mt-2v"><%= t('.title') %></h1>
+
+      <p><%= t('.intro_html', email: h(@merge_email)).html_safe %></p>
+
+      <%= form_with url: france_connect_send_email_merge_request_path, method: :post, class: 'fr-mt-4v fconnect-form' do %>
+        <%= hidden_field_tag :merge_token, @fci.merge_token %>
+        <%= hidden_field_tag :email, @merge_email %>
+
+        <div class="<%= class_names('fr-input-group', 'fr-input-group--error': flash[:alert].present?) %>">
+          <%= label_tag :password, t('.password_label'), class: 'fr-label' %>
+          <%= password_field_tag :password, nil, autocomplete: 'current-password', class: 'fr-input', required: true %>
+
+          <% if flash[:alert].present? %>
+            <p class="fr-error-text"><%= flash[:alert] %></p>
+          <% end %>
+        </div>
+
+        <%= submit_tag t('.submit'), class: 'fr-btn' %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/user_mailer/france_connect_merge_confirmation.haml
+++ b/app/views/user_mailer/france_connect_merge_confirmation.haml
@@ -11,7 +11,7 @@
 %p
   Vous pouvez aussi visiter ce lien : #{link_to merge_link, merge_link}
 
-%p Ce lien est valide #{distance_of_time_in_words(FranceConnectInformation::MERGE_VALIDITY)}, jusqu'à #{I18n.l(@email_merge_token_created_at, format: :long_with_time_and_timezone)}
+%p Ce lien est valide #{distance_of_time_in_words(FranceConnectInformation::MERGE_VALIDITY)}, jusqu'à #{I18n.l(@email_merge_token_created_at + FranceConnectInformation::MERGE_VALIDITY, format: :long_with_time_and_timezone)}
 
 %p
   Si vous n’êtes pas à l’origine de cette demande, vous pouvez ignorer ce message. Et si vous avez besoin d’assistance, n’hésitez pas à nous contacter à

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1033,6 +1033,11 @@ en:
       alternative_email: "Please provide the email to use for contacting you."
       keep_fc_email_html: Yes, use <b class='bold'>%{email}</b> as contact email.
       use_another_email: No, use another address.
+    confirm_email_merge_password:
+      title: Confirm the association with your account
+      intro_html: "An account already exists for <b>%{email}</b>. To authorise its association with FranceConnect, please enter the password of this account."
+      password_label: Password
+      submit: Confirm
     merge:
       title: "Merge your account FranceConnect and %{application_name}"
       subtitle_html: "Hello,<br><br>Your account FranceConnect uses <b class='bold'>%{email}</b> as contact email.<br>But there is an existing %{application_name} account using this email."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1092,6 +1092,11 @@ fr:
       use_another_email: Non, utiliser une autre adresse électronique
       email_suggest:
         wanna_say: 'Voulez-vous dire ?'
+    confirm_email_merge_password:
+      title: Confirmer l’association à votre compte
+      intro_html: "Un compte existe déjà à l’adresse <b>%{email}</b>. Pour autoriser son association à FranceConnect, veuillez saisir le mot de passe de ce compte."
+      password_label: Mot de passe
+      submit: Confirmer
     merge:
       title: "Fusion des comptes FranceConnect et %{application_name}"
       subtitle_html: "Bonjour,<br><br>Votre compte FranceConnect utilise <b class='bold'>%{email}</b> comme adresse électronique de contact.<br>Or il existe un compte sur %{application_name} avec cette adresse électronique."

--- a/spec/controllers/france_connect_controller_spec.rb
+++ b/spec/controllers/france_connect_controller_spec.rb
@@ -531,19 +531,66 @@ describe FranceConnectController, type: :controller do
     let(:merge_token) { fci.create_merge_token! }
     let(:email) { 'requested_email@.a.com' }
 
-    subject { post :send_email_merge_request, params: { merge_token: merge_token, email: } }
+    subject { post :send_email_merge_request, params: { merge_token: merge_token, email: }.merge(extra_params) }
+    let(:extra_params) { {} }
 
-    it 'renew token' do
-      allow(UserMailer).to receive_message_chain(:france_connect_merge_confirmation, :deliver_later)
-      subject
+    context 'when no account exists at the requested email' do
+      it 'sends the confirmation email and redirects' do
+        allow(UserMailer).to receive_message_chain(:france_connect_merge_confirmation, :deliver_later)
+        subject
 
-      fci.reload
-      expect(fci.requested_email).to eq(email)
-      expect(fci.email_merge_token).to be_present
+        fci.reload
+        expect(fci.requested_email).to eq(email)
+        expect(fci.email_merge_token).to be_present
 
-      expect(UserMailer).to have_received(:france_connect_merge_confirmation).with(email, fci.email_merge_token, fci.email_merge_token_created_at)
+        expect(UserMailer).to have_received(:france_connect_merge_confirmation).with(email, fci.email_merge_token, fci.email_merge_token_created_at)
 
-      expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'when an account already exists at the requested email' do
+      let(:email) { 'existing_user@a.com' }
+      let!(:user) { create(:user, email:, password: SECURE_PASSWORD) }
+
+      context 'and no password is provided' do
+        it 'renders the password confirmation page and does not send the email' do
+          expect(UserMailer).not_to receive(:france_connect_merge_confirmation)
+          subject
+
+          expect(response).to render_template(:confirm_email_merge_password)
+          expect(fci.reload.email_merge_token).to be_nil
+          expect(fci.reload.requested_email).to be_nil
+        end
+      end
+
+      context 'and the password is invalid' do
+        let(:extra_params) { { password: 'wrong_password' } }
+
+        it 'renders the password confirmation page with an error and does not send the email' do
+          expect(UserMailer).not_to receive(:france_connect_merge_confirmation)
+          subject
+
+          expect(response).to render_template(:confirm_email_merge_password)
+          expect(flash[:alert]).to eq(I18n.t('france_connect.flash.invalid_password'))
+          expect(fci.reload.email_merge_token).to be_nil
+        end
+      end
+
+      context 'and the password is valid' do
+        let(:extra_params) { { password: SECURE_PASSWORD } }
+
+        it 'sends the confirmation email and redirects' do
+          allow(UserMailer).to receive_message_chain(:france_connect_merge_confirmation, :deliver_later)
+          subject
+
+          fci.reload
+          expect(fci.requested_email).to eq(email)
+          expect(fci.email_merge_token).to be_present
+          expect(UserMailer).to have_received(:france_connect_merge_confirmation).with(email, fci.email_merge_token, fci.email_merge_token_created_at)
+          expect(response).to redirect_to(root_path)
+        end
+      end
     end
   end
 end

--- a/spec/system/france_connect/france_connect_spec.rb
+++ b/spec/system/france_connect/france_connect_spec.rb
@@ -121,7 +121,7 @@ describe 'FranceConnect Connexion' do
             context 'and the user wants an email that belongs to another account', js: true do
               let!(:another_user) { create(:user, email: 'an_existing_email@a.com', password: SECURE_PASSWORD) }
 
-              scenario 'it uses another email that belongs to another account' do
+              scenario 'it asks for the existing account password before sending the confirmation email' do
                 find('label[for="it-is-not-mine"]').click
 
                 expect(page).to have_css('.new-account', visible: true)
@@ -131,7 +131,30 @@ describe 'FranceConnect Connexion' do
                   click_on 'Utiliser cette adresse électronique'
                 end
 
+                expect(page).to have_content('Confirmer l’association à votre compte')
+
+                fill_in 'Mot de passe', with: SECURE_PASSWORD
+                click_on 'Confirmer'
+
                 expect(page).to have_content('Nous venons de vous envoyer le mail de confirmation')
+              end
+
+              scenario 'it refuses to send the email when the password is wrong' do
+                find('label[for="it-is-not-mine"]').click
+
+                expect(page).to have_css('.new-account', visible: true)
+
+                within '.new-account' do
+                  fill_in 'email', with: 'an_existing_email@a.com'
+                  click_on 'Utiliser cette adresse électronique'
+                end
+
+                expect(page).to have_content('Confirmer l’association à votre compte')
+
+                fill_in 'Mot de passe', with: 'wrong_password'
+                click_on 'Confirmer'
+
+                expect(page).to have_content('Mot de passe incorrect')
               end
             end
           end


### PR DESCRIPTION
- Exige une preuve de mot de passe avant l'envoi du lien de confirmation lorsque l'adresse saisie correspond à un compte existant.
- Le clic sur le lien e-mail est conservé après la validation du mot de passe : l'attache FranceConnect étant persistante, on combine deux preuves distinctes (connaissance du mot de passe + accès à la boîte mail) pour la déclencher
- Corrige le token CSRF du formulaire de choix : Stimulus modifie l'action entre deux endpoints, ce qui cassait la protection per-form sur la branche "autre adresse".
- Corrige l'affichage de l'expiration du lien dans le mail de confirmation : la phrase « jusqu'à <horodatage> » montrait la date de création au lieu de la fin de validité.

<img width="870" height="352" alt="Capture d’écran 2026-04-29 à 17 38 53" src="https://github.com/user-attachments/assets/bfeb814b-e502-4de1-8d59-d5c15f075752" />

