### PR TITLE
Tech: documente le comportement du mail d'activation à l'ajout d'instructeur

### DIFF
--- a/app/controllers/concerns/instructeur_email_notification_concern.rb
+++ b/app/controllers/concerns/instructeur_email_notification_concern.rb
@@ -3,6 +3,10 @@
 module InstructeurEmailNotificationConcern
   extend ActiveSupport::Concern
 
+  # Tout user dont email_verified_at est nil — y compris un compte préexistant non encore
+  # activé — reçoit le mail d'activation. Choix UX assumé : ces comptes peuvent activer
+  # leur accès en un clic depuis le mail d'ajout au groupe, sans repasser par
+  # « mot de passe oublié ».
   def notify_instructeurs(groupe, added_instructeurs, current_user)
     known_instructeurs, new_instructeurs = added_instructeurs.partition { |instructeur| instructeur.user.email_verified_at }
 


### PR DESCRIPTION
Ajoute un commentaire pour clarifier que l'envoi du mail d'activation lors de l'ajout d'un instructeur cible aussi les comptes préexistants non encore activés.

Un rapport interne pointait un risque d'envoi de mail d'activation non sollicité vers des comptes préexistants non vérifiés (vecteur potentiel type phishing). Risque et impact sécurité jugés faibles : ces comptes n'ont par définition pas encore d'usage actif sur la plateforme.