### PR TITLE
ETQ Instructeur, je peux filtrer sur les regions

### DIFF
--- a/app/models/columns/json_path_column.rb
+++ b/app/models/columns/json_path_column.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class Columns::JSONPathColumn < Columns::ChampColumn
-  attr_reader :jsonpath
+  attr_reader :jsonpath, :filter_jsonpath
 
-  def initialize(procedure_id:, label:, stable_id:, tdc_type:, jsonpath:, options_for_select: [], displayable:, filterable: true, type: :text, mandatory:)
+  def initialize(procedure_id:, label:, stable_id:, tdc_type:, jsonpath:, filter_jsonpath: nil, options_for_select: [], displayable:, filterable: true, type: :text, mandatory:)
     @jsonpath = quote_string(jsonpath)
+    @filter_jsonpath = quote_string(filter_jsonpath || jsonpath)
 
     super(
       procedure_id:,
@@ -48,7 +49,7 @@ class Columns::JSONPathColumn < Columns::ChampColumn
     parts << %(@ >= "#{start_date}") if start_date
     parts << %(@ <= "#{end_date}") if end_date
 
-    condition = sanitize_sql(%{champs.value_json @? '#{jsonpath} ? (#{parts.join(' && ')})'})
+    condition = sanitize_sql(%{champs.value_json @? '#{filter_jsonpath} ? (#{parts.join(' && ')})'})
 
     targeted_dossiers(dossiers, condition).ids
   end
@@ -63,10 +64,10 @@ class Columns::JSONPathColumn < Columns::ChampColumn
 
       return dossiers.ids if integers.empty?
 
-      condition = sanitize_sql(%{champs.value_json @? '#{jsonpath} ? (#{integers.map { |i| "@ == #{i}" }.join(" || ")})'})
+      condition = sanitize_sql(%{champs.value_json @? '#{filter_jsonpath} ? (#{integers.map { |i| "@ == #{i}" }.join(" || ")})'})
     else
       value = quote_string(search_terms.join('|'))
-      condition = sanitize_sql(%{champs.value_json @? '#{jsonpath} ? (@ like_regex "#{value}" flag "i")'})
+      condition = sanitize_sql(%{champs.value_json @? '#{filter_jsonpath} ? (@ like_regex "#{value}" flag "i")'})
     end
 
     targeted_dossiers(dossiers, condition).ids

--- a/app/models/concerns/addressable_column_concern.rb
+++ b/app/models/concerns/addressable_column_concern.rb
@@ -8,14 +8,15 @@ module AddressableColumnConcern
       ["Code postal (5 chiffres)", '$.postal_code', :text, []],
       ["Commune", '$.city_name', :text, []],
       ["Département", '$.department_code', :enum, APIGeoService.departement_options],
-      ["Région", '$.region_name', :enum, APIGeoService.region_options],
-    ].map do |(label, jsonpath, type, options_for_select)|
+      ["Région", '$.region_name', :enum, APIGeoService.region_options, '$.region_code'],
+    ].map do |(label, jsonpath, type, options_for_select, filter_jsonpath)|
       Columns::JSONPathColumn.new(
         procedure_id: procedure.id,
         stable_id:,
         tdc_type: type_champ,
         label: "#{libelle_with_prefix(prefix)} – #{label}",
         jsonpath:,
+        filter_jsonpath:,
         displayable:,
         options_for_select:,
         type:,

--- a/spec/services/dossier_filter_service_spec.rb
+++ b/spec/services/dossier_filter_service_spec.rb
@@ -709,13 +709,13 @@ describe DossierFilterService do
         end
       end
 
-      context "when searching by region_name" do
+      context "when searching by region_code" do
         let(:value) { "60" }
         let(:filter) { ["rna – Région", value] }
 
         before do
-          kept_dossier.project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "region_name" => value })
-          create(:dossier, procedure:).project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "region_name" => "unknown" })
+          kept_dossier.project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "region_code" => value })
+          create(:dossier, procedure:).project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "region_code" => "unknown" })
         end
 
         it { is_expected.to contain_exactly(kept_dossier.id) }


### PR DESCRIPTION
Le filtre actuel sur les régions ne fonctionne pas : il se base sur region_options == [nom, code] ,  envoie le code pour filtrer alors que le json_path cible le nom.

On ne peut pas changer le jsonpath, sinon on change la valeur dans le tableau de bord et dans graphql.

On introduit donc une indirection dans la colonne pour cibler un filter_path différent que le json_path affiché