### PR TITLE
ETQ Instructeur, je peux filtrer sur les regions

### DIFF
--- a/app/models/concerns/addressable_column_concern.rb
+++ b/app/models/concerns/addressable_column_concern.rb
@@ -4,19 +4,24 @@ module AddressableColumnConcern
   extend ActiveSupport::Concern
 
   def addressable_columns(procedure:, displayable: true, prefix: nil)
-    [
-      ["Code postal (5 chiffres)", '$.postal_code', :text, []],
-      ["Commune", '$.city_name', :text, []],
-      ["Département", '$.department_code', :enum, APIGeoService.departement_options],
-      ["Région", '$.region_name', :enum, APIGeoService.region_options],
-    ].map do |(label, jsonpath, type, options_for_select)|
+    column_specs = [
+      ["Code postal (5 chiffres)", '$.postal_code', :text, [], displayable, true],
+      ["Commune", '$.city_name', :text, [], displayable, true],
+      ["Département", '$.department_code', :enum, APIGeoService.departement_options, displayable, true],
+      ["Région", '$.region_code', :enum, APIGeoService.region_options, displayable, true],
+      # legacy: kept resolvable for procedure_presentations / export_templates saved before the jsonpath fix
+      ["Région", '$.region_name', :enum, APIGeoService.region_options, false, false],
+    ]
+
+    column_specs.map do |(label, jsonpath, type, options_for_select, column_displayable, column_filterable)|
       Columns::JSONPathColumn.new(
         procedure_id: procedure.id,
         stable_id:,
         tdc_type: type_champ,
         label: "#{libelle_with_prefix(prefix)} – #{label}",
         jsonpath:,
-        displayable:,
+        displayable: column_displayable,
+        filterable: column_filterable,
         options_for_select:,
         type:,
         mandatory: mandatory?

--- a/app/models/concerns/addressable_column_concern.rb
+++ b/app/models/concerns/addressable_column_concern.rb
@@ -3,15 +3,18 @@
 module AddressableColumnConcern
   extend ActiveSupport::Concern
 
-  def addressable_columns(procedure:, displayable: true, prefix: nil)
+  def addressable_columns(procedure:, displayable: true, prefix: nil, deprecated_columns: false)
     column_specs = [
       ["Code postal (5 chiffres)", '$.postal_code', :text, [], displayable, true],
       ["Commune", '$.city_name', :text, [], displayable, true],
       ["Département", '$.department_code', :enum, APIGeoService.departement_options, displayable, true],
       ["Région", '$.region_code', :enum, APIGeoService.region_options, displayable, true],
-      # legacy: kept resolvable for procedure_presentations / export_templates saved before the jsonpath fix
-      ["Région", '$.region_name', :enum, APIGeoService.region_options, false, false],
     ]
+
+    # legacy: kept resolvable for procedure_presentations / export_templates saved before the jsonpath fix
+    if deprecated_columns
+      column_specs << ["Région", '$.region_name', :enum, APIGeoService.region_options, false, false]
+    end
 
     column_specs.map do |(label, jsonpath, type, options_for_select, column_displayable, column_filterable)|
       Columns::JSONPathColumn.new(

--- a/app/models/types_de_champ/address_type_de_champ.rb
+++ b/app/models/types_de_champ/address_type_de_champ.rb
@@ -48,7 +48,7 @@ class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
 
   def columns(procedure:, displayable: true, prefix: nil)
     super
-      .concat(addressable_columns(procedure:, displayable:, prefix:))
+      .concat(addressable_columns(procedure:, displayable:, prefix:, deprecated_columns: true))
   end
 
   def info_columns(procedure:)

--- a/app/models/types_de_champ/rna_type_de_champ.rb
+++ b/app/models/types_de_champ/rna_type_de_champ.rb
@@ -25,7 +25,7 @@ class TypesDeChamp::RNATypeDeChamp < TypesDeChamp::TypeDeChampBase
     i18n_scope = [:activerecord, :attributes, :procedure_presentation, :fields, :etablissement]
 
     super
-      .concat(addressable_columns(procedure:, displayable:, prefix:))
+      .concat(addressable_columns(procedure:, displayable:, prefix:, deprecated_columns: true))
       .concat(
         Etablissement::EXPORTABLE_ASSOCIATION_COLUMNS.map do |(column, attributes)|
           Columns::JSONPathColumn.new(

--- a/app/models/types_de_champ/rnf_type_de_champ.rb
+++ b/app/models/types_de_champ/rnf_type_de_champ.rb
@@ -37,7 +37,7 @@ class TypesDeChamp::RNFTypeDeChamp < TypesDeChamp::TextTypeDeChamp
 
   def columns(procedure:, displayable: true, prefix: nil)
     super
-      .concat(addressable_columns(procedure:, displayable:, prefix:))
+      .concat(addressable_columns(procedure:, displayable:, prefix:, deprecated_columns: true))
       .concat([
         Columns::JSONPathColumn.new(
           procedure_id: procedure.id,

--- a/app/models/types_de_champ/siret_type_de_champ.rb
+++ b/app/models/types_de_champ/siret_type_de_champ.rb
@@ -12,7 +12,7 @@ class TypesDeChamp::SiretTypeDeChamp < TypesDeChamp::TypeDeChampBase
   def columns(procedure:, displayable: true, prefix: nil)
     super
       .concat(etablissement_columns(procedure:, displayable:, prefix:))
-      .concat(addressable_columns(procedure:, displayable:, prefix:))
+      .concat(addressable_columns(procedure:, displayable:, prefix:, deprecated_columns: true))
   end
 
   def info_columns(procedure:)

--- a/app/tasks/maintenance/t20260430_migrate_legacy_region_column_in_procedure_presentation_task.rb
+++ b/app/tasks/maintenance/t20260430_migrate_legacy_region_column_in_procedure_presentation_task.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Migrate ProcedurePresentation references to the legacy `$.region_name` column
+# (created before the region filter fix) over to the new `$.region_code` column.
+# Once all instances are migrated, the legacy entry in AddressableColumnConcern
+# can be removed.
+module Maintenance
+  class T20260430MigrateLegacyRegionColumnInProcedurePresentationTask < MaintenanceTasks::Task
+    include RunnableOnDeployConcern
+
+    run_on_first_deploy
+
+    LEGACY_SUFFIX = '-$.region_name'
+    NEW_SUFFIX = '-$.region_code'
+
+    def collection
+      ProcedurePresentation.where(<<~SQL.squish, pattern: "%#{LEGACY_SUFFIX}%")
+        displayed_columns::text LIKE :pattern
+        OR a_suivre_filters::text LIKE :pattern
+        OR suivis_filters::text LIKE :pattern
+        OR traites_filters::text LIKE :pattern
+        OR tous_filters::text LIKE :pattern
+        OR supprimes_filters::text LIKE :pattern
+        OR supprimes_recemment_filters::text LIKE :pattern
+        OR expirant_filters::text LIKE :pattern
+        OR archives_filters::text LIKE :pattern
+      SQL
+    end
+
+    def process(presentation)
+      migrate_displayed_columns(presentation)
+      ProcedurePresentation::ALL_FILTERS.each { migrate_filters(presentation, _1) }
+
+      presentation.save(validate: false) if presentation.changed?
+
+    # a column can fail to resolve for various reasons (deleted tdc, etc.)
+    rescue ActiveRecord::RecordNotFound
+    end
+
+    private
+
+    def migrate_displayed_columns(presentation)
+      original = presentation.displayed_columns
+      migrated = original.map { swap_to_new(_1) || _1 }.uniq(&:h_id)
+      presentation.displayed_columns = migrated if migrated != original
+    end
+
+    def migrate_filters(presentation, attr)
+      original = presentation.send(attr)
+      migrated = original.map do |fc|
+        new_column = swap_to_new(fc.column)
+        new_column ? FilteredColumn.new(column: new_column, filter: fc.filter) : fc
+      end
+      presentation[attr] = migrated if migrated != original
+    end
+
+    def swap_to_new(column)
+      return nil unless legacy_region_column?(column)
+
+      new_column_id = column.h_id[:column_id].delete_suffix(LEGACY_SUFFIX) + NEW_SUFFIX
+      Column.find(procedure_id: column.h_id[:procedure_id], column_id: new_column_id)
+    rescue ActiveRecord::RecordNotFound
+      nil
+    end
+
+    def legacy_region_column?(column)
+      column.is_a?(Columns::JSONPathColumn) && column.h_id[:column_id].end_with?(LEGACY_SUFFIX)
+    end
+  end
+end

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -160,7 +160,7 @@ describe API::V2::GraphqlController do
           expect(gql_errors).to be_nil
           expect(gql_data[:dossier][:id]).to eq(dossier.to_typed_id)
           expect(gql_data[:dossier][:champs].size).to eq(7)
-          expect(columns.size).to eq(17)
+          expect(columns.size).to eq(18)
 
           expect(columns[0]).to include(label: "label text", value: 'text')
           expect(columns[1]).to include(label: "label integer_number", value: "42")
@@ -172,7 +172,8 @@ describe API::V2::GraphqlController do
           expect(columns[6]).to include(label: "label entreprise – SIRET", value: '44011762001530')
           expect(columns[7]).to include(label: "label entreprise – Entreprise raison sociale", value: 'GRTGAZ')
           expect(columns[15]).to include(label: "label entreprise – SIRET – Département", value: '92')
-          expect(columns[16]).to include(label: "label entreprise – SIRET – Région", value: 'Île-de-France')
+          expect(columns[16]).to include(label: "label entreprise – SIRET – Région", value: '11')
+          expect(columns[17]).to include(label: "label entreprise – SIRET – Région", value: 'Île-de-France')
         }
       end
     end

--- a/spec/models/columns/champ_column_spec.rb
+++ b/spec/models/columns/champ_column_spec.rb
@@ -12,7 +12,7 @@ describe Columns::ChampColumn do
         expect_type_de_champ_values('civilite', eq(["M."]))
         expect_type_de_champ_values('email', eq(['yoda@beta.gouv.fr']))
         expect_type_de_champ_values('phone', eq(['0666666666']))
-        expect_type_de_champ_values('address', eq(["2 rue des Démarches", "38000", "grenoble", "38", "Auvergne-Rhones-Alpes"]))
+        expect_type_de_champ_values('address', eq(["2 rue des Démarches", "38000", "grenoble", "38", "84", "Auvergne-Rhones-Alpes"]))
         expect_type_de_champ_values('communes', eq(["Coye-la-Forêt", "60580", "60"]))
         expect_type_de_champ_values('departements', eq(['01']))
         expect_type_de_champ_values('regions', eq(['01']))
@@ -21,6 +21,7 @@ describe Columns::ChampColumn do
         expect_type_de_champ_values('iban', eq([nil]))
         expect_type_de_champ_values('siret', match_array(
           [
+            "11",
             "44011762001530",
             "SA à conseil d’administration (s.a.i.)",
             "440117620",
@@ -58,8 +59,8 @@ describe Columns::ChampColumn do
         expect_type_de_champ_values('mesri', eq([nil]))
         expect_type_de_champ_values('cojo', eq([nil]))
         expect_type_de_champ_values('formatted', eq([nil]))
-        expect_type_de_champ_values('rna', eq(["W173847273", "postal_code", "city_name", "department_code", "region_name", nil, nil, nil, nil, nil, nil, "LA PRÉVENTION ROUTIERE"]))
-        expect_type_de_champ_values('rnf', eq(["075-FDD-00003-01", "postal_code", "city_name", "department_code", "region_name", "Fondation SFR"]))
+        expect_type_de_champ_values('rna', eq(["W173847273", "postal_code", "city_name", "department_code", "region_code", "region_name", nil, nil, nil, nil, nil, nil, "LA PRÉVENTION ROUTIERE"]))
+        expect_type_de_champ_values('rnf', eq(["075-FDD-00003-01", "postal_code", "city_name", "department_code", "region_code", "region_name", "Fondation SFR"]))
       end
     end
 

--- a/spec/models/types_de_champ/address_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/address_type_de_champ_spec.rb
@@ -13,9 +13,48 @@ describe TypesDeChamp::AddressTypeDeChamp do
         "addr – Commune",
         "addr – Département",
         "addr – Région",
+        "addr – Région",
       ]
 
       expect(columns.map(&:label)).to match_array(expected_columns)
+    end
+
+    context 'legacy region_name column (kept for backward compat)' do
+      let(:legacy_column) { columns.find { _1.is_a?(Columns::JSONPathColumn) && _1.jsonpath == '$.region_name' } }
+
+      it 'is not displayable nor filterable' do
+        expect(legacy_column).to be_present
+        expect(legacy_column.displayable).to be(false)
+        expect(legacy_column.filterable).to be(false)
+      end
+
+      it 'is resolvable by procedure.find_column with its h_id' do
+        expect(procedure.find_column(h_id: legacy_column.h_id)).to eq(legacy_column)
+      end
+
+      it 'survives a ColumnType serialization round-trip' do
+        serialized = ColumnType.new.serialize(legacy_column)
+        deserialized = ColumnType.new.deserialize(serialized)
+
+        expect(deserialized).to eq(legacy_column)
+      end
+    end
+
+    context 'pickers expose only the new region column' do
+      it 'form_filterable_columns has a single Région entry pointing at $.region_code' do
+        region_columns = procedure.form_filterable_columns.filter { _1.label == 'addr – Région' }
+
+        expect(region_columns.size).to eq(1)
+        expect(region_columns.first).to be_a(Columns::JSONPathColumn)
+        expect(region_columns.first.jsonpath).to eq('$.region_code')
+      end
+
+      it 'displayable columns expose a single Région entry pointing at $.region_code' do
+        region_columns = procedure.columns.filter(&:displayable).filter { _1.label == 'addr – Région' }
+
+        expect(region_columns.size).to eq(1)
+        expect(region_columns.first.jsonpath).to eq('$.region_code')
+      end
     end
   end
 end

--- a/spec/services/dossier_filter_service_spec.rb
+++ b/spec/services/dossier_filter_service_spec.rb
@@ -709,13 +709,13 @@ describe DossierFilterService do
         end
       end
 
-      context "when searching by region_name" do
-        let(:value) { "60" }
+      context "when searching by region_code (enum)" do
+        let(:value) { "84" }
         let(:filter) { ["rna – Région", value] }
 
         before do
-          kept_dossier.project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "region_name" => value })
-          create(:dossier, procedure:).project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "region_name" => "unknown" })
+          kept_dossier.project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "region_code" => value })
+          create(:dossier, procedure:).project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "region_code" => "unknown" })
         end
 
         it { is_expected.to contain_exactly(kept_dossier.id) }

--- a/spec/tasks/maintenance/t20260430_migrate_legacy_region_column_in_procedure_presentation_task_spec.rb
+++ b/spec/tasks/maintenance/t20260430_migrate_legacy_region_column_in_procedure_presentation_task_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260430MigrateLegacyRegionColumnInProcedurePresentationTask do
+    subject(:process) { described_class.process(ProcedurePresentation.find(presentation.id)) }
+
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :address, libelle: 'addr' }]) }
+    let(:instructeur) { create(:instructeur) }
+    let(:presentation) do
+      assign_to = create(:assign_to, instructeur:, groupe_instructeur: procedure.defaut_groupe_instructeur)
+      assign_to.procedure_presentation_or_default_and_errors.first
+    end
+
+    let(:legacy_column) { procedure.columns.find { _1.is_a?(Columns::JSONPathColumn) && _1.jsonpath == '$.region_name' } }
+    let(:new_column) { procedure.columns.find { _1.is_a?(Columns::JSONPathColumn) && _1.jsonpath == '$.region_code' } }
+
+    def reload_displayed_column_ids
+      ProcedurePresentation
+        .connection
+        .select_value("SELECT array_to_json(displayed_columns) FROM procedure_presentations WHERE id = #{presentation.id}")
+        .then { JSON.parse(_1) }
+        .map { _1['column_id'] }
+    end
+
+    def reload_filter_column_id(attr)
+      ProcedurePresentation
+        .connection
+        .select_value("SELECT array_to_json(#{attr}) FROM procedure_presentations WHERE id = #{presentation.id}")
+        .then { JSON.parse(_1) }
+        .first
+        &.dig('id', 'column_id')
+    end
+
+    describe '#process' do
+      context 'when displayed_columns contains the legacy region column' do
+        before do
+          presentation.update(displayed_columns: [legacy_column])
+          Current.procedure_columns = nil
+        end
+
+        it 'rewrites the column_id to point at $.region_code' do
+          expect(reload_displayed_column_ids).to all(end_with('-$.region_name'))
+
+          process
+
+          expect(reload_displayed_column_ids).to all(end_with('-$.region_code'))
+        end
+      end
+
+      context 'when an *_filters attribute contains the legacy region column' do
+        before do
+          presentation.update(a_suivre_filters: [FilteredColumn.new(column: legacy_column, filter: 'filter')])
+          Current.procedure_columns = nil
+        end
+
+        it 'rewrites the filter column_id to point at $.region_code' do
+          expect(reload_filter_column_id(:a_suivre_filters)).to end_with('-$.region_name')
+
+          process
+
+          expect(reload_filter_column_id(:a_suivre_filters)).to end_with('-$.region_code')
+        end
+      end
+
+      context 'when displayed_columns has both the legacy and the new column' do
+        before do
+          presentation.update(displayed_columns: [legacy_column, new_column])
+          Current.procedure_columns = nil
+        end
+
+        it 'dedupes to a single $.region_code column' do
+          process
+
+          expect(reload_displayed_column_ids.count { _1.end_with?('-$.region_code') }).to eq(1)
+          expect(reload_displayed_column_ids).not_to include(end_with('-$.region_name'))
+        end
+      end
+
+      context 'when displayed_columns contains an unrelated column' do
+        let(:other_column) { procedure.columns.find { _1.is_a?(Columns::JSONPathColumn) && _1.jsonpath == '$.postal_code' } }
+
+        before do
+          presentation.update(displayed_columns: [other_column])
+          Current.procedure_columns = nil
+        end
+
+        it 'leaves it untouched' do
+          before_ids = reload_displayed_column_ids
+
+          process
+
+          expect(reload_displayed_column_ids).to eq(before_ids)
+        end
+      end
+
+      context 'with an invalid column reference' do
+        let(:invalid_column) do
+          column = legacy_column
+          def column.h_id
+            original = super
+            original[:column_id] = 'INVALID'
+            original
+          end
+          column
+        end
+
+        before do
+          presentation.update(displayed_columns: [invalid_column])
+          Current.procedure_columns = nil
+        end
+
+        it 'does not raise' do
+          expect { process }.not_to raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
les méthodes de filtrage fonctionne avec les colonnes de type enum qui ciblent le code `json_path: region_code`.

On introduit donc la nouvelle colonne qui marche.
On ne supprime pas l'ancienne pour garder la rétro compat pour les colonnes fournit dans l'export graphql mais on rajoute les variables `displayable: false` et `filterable: false` pour empêcher leur utilisation.

On rajoute également une migration pour bouger toutes les anciennes colonnes vers les nouvelles.