### PR TITLE
Tech: corrige bypass de filtre SIRET dans RecoveryService

### DIFF
--- a/app/services/recovery_service.rb
+++ b/app/services/recovery_service.rb
@@ -21,8 +21,10 @@ class RecoveryService
     dossiers = procedure_ids
       .filter { |id| id.in?(recoverable_procedure_ids) }
       .then do |p_ids|
-        previous_user.dossiers.joins(:procedure)
+        previous_user.dossiers
+          .joins(:procedure, :etablissement)
           .where(procedure: { id: p_ids })
+          .where(etablissements: { siret: })
       end
 
     dossiers.pluck(:id).map do |id|

--- a/spec/services/recovery_service_spec.rb
+++ b/spec/services/recovery_service_spec.rb
@@ -78,5 +78,35 @@ RSpec.describe RecoveryService, type: :service do
         expect(dossier_transfer_log.to).to eq(next_user.email)
       end
     end
+
+    context 'when the previous_user has dossiers on the same procedure for several siret' do
+      let!(:previous_user) { create(:user) }
+      let!(:next_user) { create(:user) }
+
+      let!(:procedure) { create(:procedure) }
+      let!(:siret) { '123' }
+      let!(:other_siret) { 'other_123' }
+
+      let!(:dossier_for_requested_siret) do
+        create(:dossier, procedure: procedure,
+               etablissement: create(:etablissement, siret:),
+               user: previous_user)
+      end
+
+      let!(:dossier_for_other_siret) do
+        create(:dossier, procedure: procedure,
+               etablissement: create(:etablissement, siret: other_siret),
+               user: previous_user)
+      end
+
+      let(:procedure_ids) { [procedure.id] }
+
+      it 'only transfers the dossiers attached to the requested siret' do
+        subject
+
+        expect(next_user.dossiers).to contain_exactly(dossier_for_requested_siret)
+        expect(dossier_for_other_siret.reload.user).to eq(previous_user)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Résumé

Le filtre SIRET de `RecoveryService.recover_procedure!` n'était appliqué qu'à la liste des procédures éligibles (`def self.recoverable_procedures`), pas à la requête finale qui transférait les dossiers. Les dossiers d'un même usager pour la même procédure mais rattachés à un autre établissement étaient donc transférés à tort.

Le correctif rejoint la table `etablissements` et applique le filtre `siret:` directement sur la requête de transfert. Une régression dédiée fixe l'invariant.