### PR TITLE
Tech: exige l'OTP super admin sur les endpoints hors manager

### DIFF
--- a/app/controllers/concerns/requires_enrolled_super_admin_otp.rb
+++ b/app/controllers/concerns/requires_enrolled_super_admin_otp.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RequiresEnrolledSuperAdminOtp
+  extend ActiveSupport::Concern
+
+  protected
+
+  def authenticate_super_admin!
+    super
+
+    return unless super_admin_signed_in?
+    return unless SUPER_ADMIN_OTP_ENABLED
+    return if current_super_admin.otp_required_for_login?
+
+    redirect_to edit_super_admin_otp_path
+  end
+end

--- a/app/controllers/manager/application_controller.rb
+++ b/app/controllers/manager/application_controller.rb
@@ -2,6 +2,8 @@
 
 module Manager
   class ApplicationController < Administrate::ApplicationController
+    include RequiresEnrolledSuperAdminOtp
+
     protect_from_forgery with: :exception, store: :cookie
     before_action :authenticate_super_admin!
     before_action :default_params
@@ -15,18 +17,6 @@ module Manager
 
     def message_encryptor_service
       @message_encryptor_service ||= MessageEncryptorService.new
-    end
-
-    protected
-
-    def authenticate_super_admin!
-      if super_admin_signed_in? && current_super_admin.otp_required_for_login?
-        super
-      elsif super_admin_signed_in?
-        SUPER_ADMIN_OTP_ENABLED ? (redirect_to edit_super_admin_otp_path) : super
-      else
-        redirect_to new_super_admin_session_path
-      end
     end
 
     private

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class StatsController < ApplicationController
+  include RequiresEnrolledSuperAdminOtp
+
   before_action :authenticate_super_admin!, only: [:download]
 
   MEAN_NUMBER_OF_CHAMPS_IN_A_FORM = 24.0

--- a/app/controllers/super_admins/release_notes_controller.rb
+++ b/app/controllers/super_admins/release_notes_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SuperAdmins::ReleaseNotesController < ApplicationController
+  include RequiresEnrolledSuperAdminOtp
+
   before_action :authenticate_super_admin!
   before_action :set_note, only: [:edit, :update, :destroy]
 

--- a/app/dashboards/super_admin_dashboard.rb
+++ b/app/dashboards/super_admin_dashboard.rb
@@ -22,6 +22,7 @@ class SuperAdminDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     failed_attempts: Field::Number,
+    otp_required_for_login: Field::Boolean,
     locked_at: Field::DateTime,
   }.freeze
 
@@ -30,11 +31,11 @@ class SuperAdminDashboard < Administrate::BaseDashboard
   #
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
-  COLLECTION_ATTRIBUTES = [:id, :email, :created_at, :updated_at, :reset_password_sent_at, :failed_attempts, :locked_at].freeze
+  COLLECTION_ATTRIBUTES = [:id, :email, :created_at, :updated_at, :reset_password_sent_at, :failed_attempts, :otp_required_for_login, :locked_at].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
-  SHOW_PAGE_ATTRIBUTES = [:id, :email, :created_at, :updated_at, :reset_password_sent_at, :failed_attempts, :locked_at].freeze
+  SHOW_PAGE_ATTRIBUTES = [:id, :email, :created_at, :updated_at, :reset_password_sent_at, :failed_attempts, :otp_required_for_login, :locked_at].freeze
 
   COLLECTION_FILTERS = {}.freeze
 end

--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -3,6 +3,19 @@
 describe StatsController, type: :controller do
   before { travel_to(Date.parse("2021/12/15")) }
 
+  describe "GET #download" do
+    context "when super admin has not enrolled OTP yet" do
+      let(:super_admin) { create(:super_admin, otp_required_for_login: false) }
+
+      before { sign_in super_admin }
+
+      it "redirects to OTP enrollment" do
+        get :download, format: :csv
+        expect(response).to redirect_to(edit_super_admin_otp_path)
+      end
+    end
+  end
+
   describe "#last_four_months_hash" do
     context "while a regular user is logged in" do
       before do

--- a/spec/controllers/super_admins/release_notes_controller_spec.rb
+++ b/spec/controllers/super_admins/release_notes_controller_spec.rb
@@ -80,5 +80,41 @@ describe SuperAdmins::ReleaseNotesController, type: :controller do
         expect { release_note.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+
+    context 'when super admin has not enrolled OTP yet' do
+      let(:super_admin) { create(:super_admin, otp_required_for_login: false) }
+      let!(:release_note) { create(:release_note, published: false) }
+
+      it 'redirects index to OTP enrollment' do
+        get :index
+        expect(response).to redirect_to(edit_super_admin_otp_path)
+      end
+
+      it 'forbids create' do
+        expect { post :create, params: { release_note: { categories: ['api'], released_on: Date.current, published: "1", body: "phishing" } } }.not_to change(ReleaseNote, :count)
+        expect(response).to redirect_to(edit_super_admin_otp_path)
+      end
+
+      it 'forbids update' do
+        expect {
+          put :update, params: {
+            id: release_note.id,
+            release_note: {
+              released_on: Date.current,
+              published: "1",
+              categories: release_note.categories,
+              body: "hacked body",
+            },
+          }
+        }.not_to change { release_note.reload.body.to_plain_text }
+        expect(response).to redirect_to(edit_super_admin_otp_path)
+      end
+
+      it 'forbids destroy' do
+        delete :destroy, params: { id: release_note.id }
+        expect(release_note.reload).to be_persisted
+        expect(response).to redirect_to(edit_super_admin_otp_path)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Résumé

Plusieurs contrôleurs super-admin héritent de l'`ApplicationController` global et s'appuyaient sur le `authenticate_super_admin!` par défaut de Devise, qui ne vérifie que la présence d'une session. Un compte super admin avec `otp_required_for_login` à `false` (compte historique, fraîchement créé ou jamais enrôlé) pouvait donc, avec email + mot de passe uniquement :

- publier, modifier ou supprimer des release notes via `SuperAdmins::ReleaseNotesController` — alors que ces notes sont rendues publiquement sur `/release_notes` ;
- télécharger via `StatsController#download` un CSV de tous les dossiers (id dossier, id démarche, id usager, état, durées).

## Correctif

Extraction du garde OTP de `Manager::ApplicationController` dans un concern `RequiresEnrolledSuperAdminOtp` qui override `authenticate_super_admin!` : une fois authentifié, redirection vers la page d'enrôlement OTP quand l'OTP est activé globalement mais que le super admin n'a pas encore enrôlé.

Le concern est inclus dans :
- `Manager::ApplicationController` (refactor sans changement de comportement) ;
- `SuperAdmins::ReleaseNotesController` ;
- `StatsController` (le `before_action` reste limité à `:download`, les autres actions publiques ne sont pas impactées).

Ajout de `otp_required_for_login` aux colonnes index/show du `SuperAdminDashboard` pour faciliter le repérage des comptes non enrôlés.

Specs de non-régression couvrant `index/create/update/destroy` des release notes et `#download` des stats pour un super admin sans OTP.