### PR TITLE
Tech: exige une réauthentification pour activer l'OTP super admin

### DIFF
--- a/app/controllers/super_admins_controller.rb
+++ b/app/controllers/super_admins_controller.rb
@@ -9,7 +9,7 @@ class SuperAdminsController < ApplicationController
   end
 
   def enable_otp
-    unless current_super_admin.valid_password?(params[:current_password].to_s)
+    if !current_super_admin.valid_password?(params[:current_password].to_s)
       flash[:alert] = "Mot de passe incorrect."
       redirect_to(edit_super_admin_otp_path) and return
     end

--- a/app/controllers/super_admins_controller.rb
+++ b/app/controllers/super_admins_controller.rb
@@ -9,11 +9,6 @@ class SuperAdminsController < ApplicationController
   end
 
   def enable_otp
-    if current_super_admin.otp_required_for_login?
-      flash[:alert] = "L’authentification double-facteur est déjà activée pour ce compte."
-      redirect_to(root_path) and return
-    end
-
     unless current_super_admin.valid_password?(params[:current_password].to_s)
       flash[:alert] = "Mot de passe incorrect."
       redirect_to(edit_super_admin_otp_path) and return

--- a/app/controllers/super_admins_controller.rb
+++ b/app/controllers/super_admins_controller.rb
@@ -9,6 +9,16 @@ class SuperAdminsController < ApplicationController
   end
 
   def enable_otp
+    if current_super_admin.otp_required_for_login?
+      flash[:alert] = "L’authentification double-facteur est déjà activée pour ce compte."
+      redirect_to(root_path) and return
+    end
+
+    unless current_super_admin.valid_password?(params[:current_password].to_s)
+      flash[:alert] = "Mot de passe incorrect."
+      redirect_to(edit_super_admin_otp_path) and return
+    end
+
     current_super_admin.enable_otp!
     @qrcode = generate_qr_code
     sign_out :super_admin

--- a/app/views/super_admins/edit_otp.html.haml
+++ b/app/views/super_admins/edit_otp.html.haml
@@ -3,4 +3,8 @@
     %h2.huge-title Espace Manager
     %p Munissez-vous de votre téléphone sur lequel vous avez installé une application cliente 2FA (Google Authenticator, Authy, AndOTP, ...)
     %br
-    %p= link_to "Activer l’authentification double-facteur", enable_super_admin_otp_path, method: :put, class: 'fr-btn fr-btn--lg'
+    = form_with url: enable_super_admin_otp_path, method: :put, local: true do |f|
+      .fr-input-group
+        = f.label :current_password, "Mot de passe actuel", class: 'fr-label'
+        = f.password_field :current_password, autocomplete: 'current-password', required: true, class: 'fr-input'
+      = f.submit "Activer l’authentification double-facteur", class: 'fr-btn fr-btn--lg'

--- a/spec/controllers/super_admins_controller_spec.rb
+++ b/spec/controllers/super_admins_controller_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SuperAdminsController, type: :controller do
+  let(:password) { '{My-$3cure-p4ssWord}' }
+
+  describe 'PUT #enable_otp' do
+    before { sign_in super_admin }
+
+    context 'when the super admin has not enrolled OTP yet' do
+      let(:super_admin) { create(:super_admin, otp_required_for_login: false, password:) }
+
+      it 'rotates the secret and signs out when the current password is provided' do
+        previous_secret = super_admin.otp_secret
+
+        put :enable_otp, params: { current_password: password }
+
+        super_admin.reload
+        expect(super_admin.otp_secret).to be_present
+        expect(super_admin.otp_secret).not_to eq(previous_secret)
+        expect(super_admin.otp_required_for_login?).to be(true)
+        expect(controller.super_admin_signed_in?).to be(false)
+      end
+
+      it 'is rejected when no current password is provided' do
+        previous_secret = super_admin.otp_secret
+
+        put :enable_otp
+
+        super_admin.reload
+        expect(super_admin.otp_secret).to eq(previous_secret)
+        expect(super_admin.otp_required_for_login?).to be(false)
+        expect(response).to redirect_to(edit_super_admin_otp_path)
+        expect(flash[:alert]).to be_present
+      end
+
+      it 'is rejected when the current password is wrong' do
+        previous_secret = super_admin.otp_secret
+
+        put :enable_otp, params: { current_password: 'wrong-password' }
+
+        super_admin.reload
+        expect(super_admin.otp_secret).to eq(previous_secret)
+        expect(super_admin.otp_required_for_login?).to be(false)
+        expect(response).to redirect_to(edit_super_admin_otp_path)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    context 'when the super admin already enrolled OTP' do
+      let(:super_admin) { create(:super_admin, otp_required_for_login: true, password:) }
+
+      it 'refuses to regenerate the secret even with a valid password' do
+        previous_secret = super_admin.otp_secret
+
+        put :enable_otp, params: { current_password: password }
+
+        super_admin.reload
+        expect(super_admin.otp_secret).to eq(previous_secret)
+        expect(super_admin.otp_required_for_login?).to be(true)
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+end

--- a/spec/controllers/super_admins_controller_spec.rb
+++ b/spec/controllers/super_admins_controller_spec.rb
@@ -51,14 +51,26 @@ describe SuperAdminsController, type: :controller do
     context 'when the super admin already enrolled OTP' do
       let(:super_admin) { create(:super_admin, otp_required_for_login: true, password:) }
 
-      it 'refuses to regenerate the secret even with a valid password' do
+      it 'rotates the secret and signs out when the current password is provided' do
         previous_secret = super_admin.otp_secret
 
         put :enable_otp, params: { current_password: password }
 
         super_admin.reload
-        expect(super_admin.otp_secret).to eq(previous_secret)
+        expect(super_admin.otp_secret).to be_present
+        expect(super_admin.otp_secret).not_to eq(previous_secret)
         expect(super_admin.otp_required_for_login?).to be(true)
+        expect(controller.super_admin_signed_in?).to be(false)
+      end
+
+      it 'is rejected when the current password is wrong' do
+        previous_secret = super_admin.otp_secret
+
+        put :enable_otp, params: { current_password: 'wrong-password' }
+
+        super_admin.reload
+        expect(super_admin.otp_secret).to eq(previous_secret)
+        expect(response).to redirect_to(edit_super_admin_otp_path)
         expect(flash[:alert]).to be_present
       end
     end


### PR DESCRIPTION
## Résumé

`PUT /super_admins/enable_otp` régénérait inconditionnellement le secret OTP : aucune vérification du mot de passe courant. Toute personne en possession d'une session super admin pouvait donc faire pivoter le secret vers son propre authentificateur et persister son accès — y compris si le compte légitime changeait ensuite de mot de passe.

## Correctif

- Exige `valid_password?(current_password)` à chaque appel de `enable_otp` (enrôlement initial **et** ré-enrôlement après perte de l'authentificateur).
- La vue `edit_otp` rend désormais un formulaire avec champ mot de passe à la place du lien `link_to method: :put`.

Une session volée seule ne suffit donc plus à pivoter le secret OTP : il faut aussi connaître le mot de passe courant. Le ré-enrôlement reste possible pour permettre à un super admin légitime de basculer vers un nouvel appareil sans intervention console.

Spec de non-régression couvrant : enrôlement / ré-enrôlement avec mot de passe correct, refus quand le mot de passe est manquant ou incorrect (OTP actif ou non).