### PR TITLE
Tech: étaler le backfill du scan antivirus pour préserver la queue low

### DIFF
--- a/app/tasks/maintenance/t20260427backfill_virus_scan_blobs_task.rb
+++ b/app/tasks/maintenance/t20260427backfill_virus_scan_blobs_task.rb
@@ -17,12 +17,36 @@ module Maintenance
     # avec ce filtre est trop coûteux si les pending sont concentrés sur
     # une plage d'ids (PG parcourt l'index PK en filtrant et peut traverser
     # des dizaines de millions de lignes avant d'en trouver N).
+    #
+    # Pour ne pas saturer la queue low ni Redis, le backfill
+    # est découpé en tranches d'IDs (param `id_start`) et chaque BlobProcessorJob
+    # est planifié avec un wait_until aléatoire qui cible majoritairement les
+    # heures creuses (nuit + weekend), avec un peu de débordement diurne.
+    # À lancer successivement avec id_start = 0, 20_000_000, …, 200_000_000.
+    #
+    # Calibrage (last id ≈ 200M, ~7M pending sur 144M blobs ≈ 3.5% des IDs) :
+    # - une tranche de 20M IDs ≈ 700k jobs enqueued = ~500 MB Redis au pic
+    # - les variant blobs (preview, sans attachment) sortent vite
+    #   (download + clamav), accélérant le throughput moyen
+    # - fenêtre creuse = weekend complet + semaine 19h-8h, soit ~113h/168h
+    # - sur 7j : ~113h creuses absorbent 85% des jobs (~5.3k/h sous une
+    #   capacité ~30k/h) ; ~55h diurnes (semaine 8h-19h) absorbent 15%
+    #   (~1.9k/h sous ~2-3k/h de headroom réel) — flux normal préservé
+
+    BATCH_SIZE_IDS = 20_000_000
+    BATCH_SPREAD_DAYS = 7
+    OFFPEAK_TARGET_SHARE = 0.85
+
+    attribute :id_start, :integer
+    validates :id_start, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
     include RunnableOnDeployConcern
     include StatementsHelpersConcern
 
     def collection
-      ActiveStorage::Blob.in_batches(of: 10_000)
+      ActiveStorage::Blob
+        .where(id: id_start..(id_start + BATCH_SIZE_IDS))
+        .in_batches(of: 10_000)
     end
 
     def process(batch)
@@ -31,8 +55,24 @@ module Maintenance
         .find_each do |blob|
           next if blob.metadata["processed"]
 
-          BlobProcessorJob.perform_later(blob)
+          BlobProcessorJob
+            .set(wait_until: random_wait_until)
+            .perform_later(blob)
         end
+    end
+
+    private
+
+    def random_wait_until
+      want_offpeak = rand < OFFPEAK_TARGET_SHARE
+      loop do
+        t = Time.current + rand(0...BATCH_SPREAD_DAYS.days.to_i)
+        return t if offpeak?(t) == want_offpeak
+      end
+    end
+
+    def offpeak?(time)
+      time.saturday? || time.sunday? || time.hour >= 19 || time.hour < 8
     end
   end
 end

--- a/spec/tasks/maintenance/t20260427backfill_virus_scan_blobs_task_spec.rb
+++ b/spec/tasks/maintenance/t20260427backfill_virus_scan_blobs_task_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 module Maintenance
   RSpec.describe T20260427backfillVirusScanBlobsTask do
     describe '#collection' do
-      it 'returns a batch enumerator over all blobs' do
-        collection = described_class.new.collection
+      it 'returns a batch enumerator bounded by id_start' do
+        collection = described_class.new.tap { _1.id_start = 0 }.collection
         expect(collection).to be_a(ActiveRecord::Batches::BatchEnumerator)
         expect(collection.relation.model).to eq(ActiveStorage::Blob)
       end
@@ -37,17 +37,17 @@ module Maintenance
       let(:batch) { ActiveStorage::Blob.where(id: [pending_blob.id, safe_blob.id, already_processed_blob.id]) }
 
       it 'enqueues a BlobProcessorJob for pending blobs in the batch' do
-        expect { described_class.new.process(batch) }
+        expect { described_class.new.tap { _1.id_start = 0 }.process(batch) }
           .to have_enqueued_job(BlobProcessorJob).with(pending_blob).exactly(:once)
       end
 
       it 'skips safe blobs' do
-        expect { described_class.new.process(batch) }
+        expect { described_class.new.tap { _1.id_start = 0 }.process(batch) }
           .not_to have_enqueued_job(BlobProcessorJob).with(safe_blob)
       end
 
       it 'skips already processed blobs' do
-        expect { described_class.new.process(batch) }
+        expect { described_class.new.tap { _1.id_start = 0 }.process(batch) }
           .not_to have_enqueued_job(BlobProcessorJob).with(already_processed_blob)
       end
     end


### PR DESCRIPTION
## Contexte

Réanalyse du stock de ~7M blobs bloqués en `virus_scan_result = pending`. Lancée d'un bloc, la tâche enqueue 7M `BlobProcessorJob` sur la queue low et saturerait Redis avant meme de saturer sidekiq pendant des semaines.

## Approche

- **Découpage par tranches d'IDs** via param `id_start` (10 runs de 20M IDs : 0, 20M, …, 200M).
- **Étalement temporel** : chaque job reçoit un `wait_until` tiré aléatoirement sur 7 jours, biaisé à 85% vers les heures creuses (weekend complet + semaine 19h-8h).
- **Calibrage** : ~700k jobs/run, débit ~5.3k/h en creuse (capacité `low`de ~30k/h) et ~1.9k/h en pleine. Le flux normal de la queue low n'est pas perturbé. On verra si on ajuste ou augmente plus tard en fonction de comment ça réagit.
- En pratique ça ira probablement pas mal plus vite car une grande partie des blobs semblent être des previews qui n'avaient pas été flaggués, pour lesquels aucune autre représentation ne sera créée.

À lancer ~1×/semaine pendant 10-12 semaines.