### PR TITLE
Tech: retire le fallback cookie pour les notifications d'export

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -525,17 +525,10 @@ module Instructeurs
 
     def notify_exports?(instructeur_procedure)
       scope = Export.generated.for_groupe_instructeurs(groupe_instructeur_ids)
-      # TODO: remove legacy cookie support once deployed (Export retention is 48h)
-      last_seen_at = instructeur_procedure.last_export_seen_at || legacy_cookie_export_seen_at
+      last_seen_at = instructeur_procedure.last_export_seen_at
       scope = scope.where(updated_at: last_seen_at...) if last_seen_at
 
       scope.exists?
-    end
-
-    def legacy_cookie_export_seen_at
-      DateTime.parse(cookies.encrypted["exports_#{@procedure.id}_seen_at"])
-    rescue
-      nil
     end
 
     def notify_unseen_revisions?(instructeur_procedure)

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -557,17 +557,12 @@ describe Instructeurs::ProceduresController, type: :controller do
         context 'with generated export' do
           render_views
           let(:exports_seen_at) { nil }
-          let(:legacy_cookie_seen_at) { nil }
 
           before do
             create(:export, :generated, groupe_instructeurs: [gi_2], updated_at: 1.minute.ago)
 
             if exports_seen_at
               create(:instructeurs_procedure, instructeur:, procedure:, last_export_seen_at: exports_seen_at)
-            end
-
-            if legacy_cookie_seen_at
-              cookies.encrypted["exports_#{procedure.id}_seen_at"] = legacy_cookie_seen_at.to_datetime.to_s
             end
 
             subject
@@ -587,11 +582,6 @@ describe Instructeurs::ProceduresController, type: :controller do
 
           context 'with last_export_seen_at after the last generated export' do
             let(:exports_seen_at) { 10.seconds.ago }
-            it { expect(assigns(:has_export_notification)).to be(false) }
-          end
-
-          context 'with legacy cookie fallback after the last generated export' do
-            let(:legacy_cookie_seen_at) { 10.seconds.ago }
             it { expect(assigns(:has_export_notification)).to be(false) }
           end
         end


### PR DESCRIPTION
Suite à #13022 qui a introduit `last_export_seen_at` sur `instructeurs_procedures`, le code lisant l'ancien cookie a été conservé le temps du déploiement.

La colonne est en place depuis plusieurs jours et la rétention des exports est de 48h, donc plus aucun cookie legacy n'est utile : on retire le fallback et la méthode `legacy_cookie_export_seen_at`.