### PR TITLE
Tech: uniformise le stockage des informations géographiques des champs

### DIFF
--- a/app/models/champs/commune_champ.rb
+++ b/app/models/champs/commune_champ.rb
@@ -7,6 +7,21 @@ class Champs::CommuneChamp < Champs::TextChamp
   validates :external_id, presence: true, if: -> { value.present? && should_validate_in_current_context? }
   after_validation :instrument_external_id_error, if: -> { errors.include?(:external_id) }
 
+  def code_postal=(v)
+    super
+    value_json['postal_code'] = v
+  end
+
+  def code_departement=(v)
+    super
+    value_json['department_code'] = v
+  end
+
+  def code_region=(v)
+    super
+    value_json['region_code'] = v
+  end
+
   def departement_name
     APIGeoService.departement_name(code_departement)
   end
@@ -93,11 +108,15 @@ class Champs::CommuneChamp < Champs::TextChamp
       self.code_departement = commune[:departement_code]
       self.code_region = commune[:region_code]
       self.value = commune[:name]
+      value_json['city_name'] = commune[:name]
+      value_json['city_code'] = commune[:code]
     else
       self.code_departement = nil
       self.code_postal = nil
       self.external_id = nil
       self.value = nil
+      value_json['city_name'] = nil
+      value_json['city_code'] = nil
     end
   end
 

--- a/app/models/champs/departement_champ.rb
+++ b/app/models/champs/departement_champ.rb
@@ -7,6 +7,11 @@ class Champs::DepartementChamp < Champs::TextChamp
   validate :external_id_in_departement_codes, if: -> { !external_id.nil? && should_validate_in_current_context? }
   before_save :store_code_region
 
+  def code_region=(v)
+    super
+    value_json['region_code'] = v
+  end
+
   def selected
     code
   end
@@ -57,5 +62,6 @@ class Champs::DepartementChamp < Champs::TextChamp
 
   def store_code_region
     self.code_region = code_region
+    value_json['department_code'] = code
   end
 end

--- a/app/models/champs/epci_champ.rb
+++ b/app/models/champs/epci_champ.rb
@@ -9,6 +9,16 @@ class Champs::EpciChamp < Champs::TextChamp
   validate :external_id_in_departement_epci_codes, if: -> { !(code_departement.nil? || external_id.nil?) && should_validate_in_current_context? }
   validate :value_in_departement_epci_names, if: -> { !(code_departement.nil? || external_id.nil? || value.nil?) && should_validate_in_current_context? }
 
+  def code_departement=(v)
+    super
+    value_json['department_code'] = v
+  end
+
+  def code_region=(v)
+    super
+    value_json['region_code'] = v
+  end
+
   def departement_name
     APIGeoService.departement_name(code_departement)
   end

--- a/app/models/champs/region_champ.rb
+++ b/app/models/champs/region_champ.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Champs::RegionChamp < Champs::TextChamp
+  store_accessor :value_json, :region_code
+  before_save :store_region_code
+
   validate :value_in_region_names, if: -> { !value.nil? && should_validate_in_current_context? }
   validate :external_id_in_region_codes, if: -> { !external_id.nil? && should_validate_in_current_context? }
 
@@ -41,5 +44,9 @@ class Champs::RegionChamp < Champs::TextChamp
     return if external_id.in?(APIGeoService.regions.pluck(:code))
 
     errors.add(:external_id, :not_in_region_codes)
+  end
+
+  def store_region_code
+    self.region_code = code
   end
 end

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -67,12 +67,12 @@ class Logic::ChampValue < Logic::Term
     when "Champs::DepartementChamp"
       {
         value: targeted_champ.code,
-        code_region: targeted_champ.code_region,
+        region_code: targeted_champ.code_region,
       }
     when "Champs::CommuneChamp", "Champs::EpciChamp", "Champs::AddressChamp"
       {
-        code_departement: targeted_champ.code_departement,
-        code_region: targeted_champ.code_region,
+        department_code: targeted_champ.code_departement,
+        region_code: targeted_champ.code_region,
       }
     end
   end

--- a/app/models/logic/in_departement_operator.rb
+++ b/app/models/logic/in_departement_operator.rb
@@ -11,7 +11,7 @@ class Logic::InDepartementOperator < Logic::BinaryOperator
 
     return false if l.nil?
 
-    l.fetch(:code_departement) == r
+    l.fetch(:department_code) == r
   end
 
   def errors(type_de_champs = [])

--- a/app/models/logic/in_region_operator.rb
+++ b/app/models/logic/in_region_operator.rb
@@ -11,7 +11,7 @@ class Logic::InRegionOperator < Logic::BinaryOperator
 
     return false if l.nil?
 
-    l.fetch(:code_region) == r
+    l.fetch(:region_code) == r
   end
 
   def errors(type_de_champs = [])

--- a/app/models/logic/not_in_departement_operator.rb
+++ b/app/models/logic/not_in_departement_operator.rb
@@ -11,6 +11,6 @@ class Logic::NotInDepartementOperator < Logic::InDepartementOperator
 
     return false if l.nil?
 
-    l.fetch(:code_departement) != r
+    l.fetch(:department_code) != r
   end
 end

--- a/app/models/logic/not_in_region_operator.rb
+++ b/app/models/logic/not_in_region_operator.rb
@@ -11,6 +11,6 @@ class Logic::NotInRegionOperator < Logic::InRegionOperator
 
     return false if l.nil?
 
-    l.fetch(:code_region) != r
+    l.fetch(:region_code) != r
   end
 end

--- a/app/tasks/maintenance/t20260504_backfill_canonical_keys_in_commune_champs_task.rb
+++ b/app/tasks/maintenance/t20260504_backfill_canonical_keys_in_commune_champs_task.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260504BackfillCanonicalKeysInCommuneChampsTask < MaintenanceTasks::Task
+    include RunnableOnDeployConcern
+
+    def collection
+      Champs::CommuneChamp.all
+    end
+
+    def process(champ)
+      current = champ.value_json || {}
+
+      additions = {
+        'postal_code' => current['code_postal'],
+        'department_code' => current['code_departement'],
+        'region_code' => current['code_region'],
+        'city_name' => champ.value,
+        'city_code' => champ.external_id,
+      }.compact
+
+      result = current.merge(additions)
+      champ.update_column(:value_json, result) if result != current
+    end
+  end
+end

--- a/app/tasks/maintenance/t20260504_backfill_canonical_keys_in_departement_champs_task.rb
+++ b/app/tasks/maintenance/t20260504_backfill_canonical_keys_in_departement_champs_task.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260504BackfillCanonicalKeysInDepartementChampsTask < MaintenanceTasks::Task
+    include RunnableOnDeployConcern
+
+    def collection
+      Champs::DepartementChamp.all
+    end
+
+    def process(champ)
+      current = champ.value_json || {}
+
+      additions = {
+        'department_code' => champ.code,
+        'region_code' => current['code_region'],
+      }.compact
+
+      result = current.merge(additions)
+      champ.update_column(:value_json, result) if result != current
+    end
+  end
+end

--- a/app/tasks/maintenance/t20260504_backfill_canonical_keys_in_epci_champs_task.rb
+++ b/app/tasks/maintenance/t20260504_backfill_canonical_keys_in_epci_champs_task.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260504BackfillCanonicalKeysInEpciChampsTask < MaintenanceTasks::Task
+    include RunnableOnDeployConcern
+
+    def collection
+      Champs::EpciChamp.all
+    end
+
+    def process(champ)
+      current = champ.value_json || {}
+
+      additions = {
+        'department_code' => current['code_departement'],
+        'region_code' => current['code_region'],
+      }.compact
+
+      result = current.merge(additions)
+      champ.update_column(:value_json, result) if result != current
+    end
+  end
+end

--- a/app/tasks/maintenance/t20260504_backfill_canonical_keys_in_region_champs_task.rb
+++ b/app/tasks/maintenance/t20260504_backfill_canonical_keys_in_region_champs_task.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260504BackfillCanonicalKeysInRegionChampsTask < MaintenanceTasks::Task
+    include RunnableOnDeployConcern
+
+    def collection
+      Champs::RegionChamp.all
+    end
+
+    def process(champ)
+      current = champ.value_json || {}
+
+      additions = { 'region_code' => champ.code }.compact
+
+      result = current.merge(additions)
+      champ.update_column(:value_json, result) if result != current
+    end
+  end
+end

--- a/spec/models/champs/commune_champ_spec.rb
+++ b/spec/models/champs/commune_champ_spec.rb
@@ -9,6 +9,8 @@ describe Champs::CommuneChamp do
   let(:code_insee) { '63102' }
   let(:code_postal) { '63290' }
   let(:code_departement) { '63' }
+  let(:code_region) { '84' }
+  let(:city_name) { 'Châteldon' }
 
   describe 'value' do
     context 'default' do
@@ -61,6 +63,27 @@ describe Champs::CommuneChamp do
         expect(champ.type_de_champ.champ_value_for_export(champ, :value)).to eq 'Châteldon (63290)'
         expect(champ.type_de_champ.champ_value_for_export(champ, :code)).to eq '63102'
         expect(champ.type_de_champ.champ_value_for_export(champ, :departement)).to eq '63 – Puy-de-Dôme'
+      end
+    end
+  end
+
+  describe 'double-write of canonical value_json keys' do
+    context 'when commune is set via code=' do
+      before do
+        champ.code = '63102-63290'
+        champ.save
+      end
+
+      it 'persists canonical keys alongside legacy keys in value_json' do
+        expect(champ.value_json['code_postal']).to eq('63290')
+        expect(champ.value_json['code_departement']).to eq('63')
+        expect(champ.value_json['code_region']).to eq('84')
+
+        expect(champ.value_json['postal_code']).to eq('63290')
+        expect(champ.value_json['department_code']).to eq('63')
+        expect(champ.value_json['region_code']).to eq('84')
+        expect(champ.value_json['city_name']).to eq('Châteldon')
+        expect(champ.value_json['city_code']).to eq('63102')
       end
     end
   end

--- a/spec/models/champs/departement_champ_spec.rb
+++ b/spec/models/champs/departement_champ_spec.rb
@@ -146,4 +146,15 @@ describe Champs::DepartementChamp, type: :model do
       expect(champ.to_s).to eq('2B – Haute-Corse')
     end
   end
+
+  describe 'double-write of canonical value_json keys' do
+    it 'persists department_code and region_code alongside code_region after save' do
+      champ.value = '01'
+      champ.save
+
+      expect(champ.value_json['code_region']).to eq('84')
+      expect(champ.value_json['region_code']).to eq('84')
+      expect(champ.value_json['department_code']).to eq('01')
+    end
+  end
 end

--- a/spec/models/champs/epci_champ_spec.rb
+++ b/spec/models/champs/epci_champ_spec.rb
@@ -164,4 +164,18 @@ describe Champs::EpciChamp, type: :model do
       expect(champ.to_s).to eq(epci[:name])
     end
   end
+
+  describe 'double-write of canonical value_json keys' do
+    it 'mirrors code_departement to department_code' do
+      champ.code_departement = '01'
+      expect(champ.value_json['code_departement']).to eq('01')
+      expect(champ.value_json['department_code']).to eq('01')
+    end
+
+    it 'mirrors code_region to region_code' do
+      champ.code_region = '84'
+      expect(champ.value_json['code_region']).to eq('84')
+      expect(champ.value_json['region_code']).to eq('84')
+    end
+  end
 end

--- a/spec/models/champs/region_champ_spec.rb
+++ b/spec/models/champs/region_champ_spec.rb
@@ -109,4 +109,13 @@ describe Champs::RegionChamp, type: :model do
       expect(champ.to_s).to eq('Guadeloupe')
     end
   end
+
+  describe 'double-write of canonical value_json keys' do
+    it 'persists region_code in value_json after save' do
+      champ.value = '01'
+      champ.save
+
+      expect(champ.value_json['region_code']).to eq('01')
+    end
+  end
 end

--- a/spec/models/logic/champ_value_spec.rb
+++ b/spec/models/logic/champ_value_spec.rb
@@ -113,7 +113,7 @@ describe Logic::ChampValue do
 
       it do
         expect(champ_value(champ.stable_id).type([champ.type_de_champ])).to eq(:departement_enum)
-        is_expected.to eq({ value: '02', code_region: '32' })
+        is_expected.to eq({ value: '02', region_code: '32' })
       end
     end
 
@@ -135,7 +135,7 @@ describe Logic::ChampValue do
       let(:external_id) { '92063' }
 
       it do
-        is_expected.to eq({ code_departement: '92', code_region: '11' })
+        is_expected.to eq({ department_code: '92', region_code: '11' })
       end
     end
 
@@ -148,7 +148,7 @@ describe Logic::ChampValue do
       let(:code_departement) { '43' }
       let(:external_id) { '244301016' }
 
-      it { is_expected.to eq({ code_departement: '43', code_region: '84' }) }
+      it { is_expected.to eq({ department_code: '43', region_code: '84' }) }
     end
 
     describe 'errors' do


### PR DESCRIPTION
Cette pr comprend l'écriture en Y et la tache de rattrapage de données pour une migration de
```
code_departement -> departement_code
code_region -> region_code
code_postal -> postal_code
commune.value -> city_name
```

des champs communes / epci / departement / region. Le but étant de pouvoir réutiliser après les colonnes décrite dans `AddressableColumnConcern` et les logiques associées.

Une autre pr viendra nettoyer l'ancien code.