### PR TITLE
Tech: aligne la durée de vie du cookie MFA ProConnect avec Trusted device period

### DIFF
--- a/app/controllers/concerns/pro_connect_session_concern.rb
+++ b/app/controllers/concerns/pro_connect_session_concern.rb
@@ -20,7 +20,7 @@ module ProConnectSessionConcern
       value:,
       expires: TrustedDeviceConcern::TRUSTED_DEVICE_PERIOD.from_now,
       secure: Rails.env.production?,
-      httponly: true
+      httponly: true,
     }
   end
 

--- a/app/controllers/concerns/pro_connect_session_concern.rb
+++ b/app/controllers/concerns/pro_connect_session_concern.rb
@@ -4,14 +4,24 @@ module ProConnectSessionConcern
   extend ActiveSupport::Concern
 
   SESSION_INFO_COOKIE_NAME = :pro_connect_session_info
+  # Cookies set before mfa_at was introduced have no client-side expiry and
+  # could otherwise persist indefinitely. Refuse them past this date (~1 month
+  # after deploy, aligned with TRUSTED_DEVICE_PERIOD) so any remaining ones
+  # are forced to renew their MFA assertion via ProConnect.
+  LEGACY_COOKIE_DEADLINE = Time.zone.local(2026, 6, 13).freeze
 
   included do
     helper_method :logged_in_with_pro_connect?
   end
 
   def set_pro_connect_session_info_cookie(user_id, mfa: false)
-    value = { user_id:, mfa: }.to_json
-    cookies.encrypted[SESSION_INFO_COOKIE_NAME] = { value:, secure: Rails.env.production?, httponly: true }
+    value = { user_id:, mfa:, mfa_at: Time.current.iso8601 }.to_json
+    cookies.encrypted[SESSION_INFO_COOKIE_NAME] = {
+      value:,
+      expires: TrustedDeviceConcern::TRUSTED_DEVICE_PERIOD.from_now,
+      secure: Rails.env.production?,
+      httponly: true
+    }
   end
 
   def logged_in_with_pro_connect?
@@ -19,7 +29,13 @@ module ProConnectSessionConcern
   end
 
   def pro_connect_mfa?
-    pro_connect_session['mfa'] == true
+    info = pro_connect_session
+    return false if info['mfa'] != true
+    return Time.current < LEGACY_COOKIE_DEADLINE if info['mfa_at'].blank?
+
+    Time.iso8601(info['mfa_at']) > TrustedDeviceConcern::TRUSTED_DEVICE_PERIOD.ago
+  rescue ArgumentError
+    false
   end
 
   def delete_pro_connect_session_info_cookie

--- a/spec/controllers/concerns/pro_connect_session_concern_spec.rb
+++ b/spec/controllers/concerns/pro_connect_session_concern_spec.rb
@@ -31,5 +31,40 @@ RSpec.describe ProConnectSessionConcern, type: :controller do
         expect(controller.pro_connect_mfa?).to be false
       end
     end
+
+    describe 'when the mfa assertion is older than TRUSTED_DEVICE_PERIOD' do
+      let(:user_id) { 42 }
+
+      it 'is no longer considered valid' do
+        travel_to Time.zone.local(2026, 1, 1) do
+          controller.set_pro_connect_session_info_cookie(42, mfa: true)
+        end
+
+        travel_to Time.zone.local(2026, 2, 5) do
+          expect(controller.pro_connect_mfa?).to be false
+        end
+      end
+    end
+
+    describe 'with a legacy cookie (no mfa_at)' do
+      let(:user_id) { 42 }
+
+      before do
+        legacy = { user_id: 42, mfa: true }.to_json
+        controller.send(:cookies).encrypted[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME] = legacy
+      end
+
+      it 'is accepted before the deadline' do
+        travel_to(ProConnectSessionConcern::LEGACY_COOKIE_DEADLINE - 1.day) do
+          expect(controller.pro_connect_mfa?).to be true
+        end
+      end
+
+      it 'is refused on or after the deadline' do
+        travel_to(ProConnectSessionConcern::LEGACY_COOKIE_DEADLINE) do
+          expect(controller.pro_connect_mfa?).to be false
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -133,7 +133,9 @@ describe ProConnectController, type: :controller do
               expect { subject }.to change { instructeur.user.reload.email_verified_at }.from(nil)
               expect(instructeur.user.preferred_domain_demarche_numerique_gouv_fr?).to be_truthy
 
-              expect(cookies.encrypted[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME]).to eq({ user_id: instructeur.user.id, mfa: false }.to_json)
+              cookie = JSON.parse(cookies.encrypted[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME])
+              expect(cookie).to include('user_id' => instructeur.user.id, 'mfa' => false)
+              expect(cookie['mfa_at']).to be_present
             end
           end
 
@@ -164,7 +166,9 @@ describe ProConnectController, type: :controller do
 
               subject
 
-              expect(cookies.encrypted[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME]).to eq({ user_id: instructeur.user.id, mfa: true }.to_json)
+              cookie = JSON.parse(cookies.encrypted[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME])
+              expect(cookie).to include('user_id' => instructeur.user.id, 'mfa' => true)
+              expect(cookie['mfa_at']).to be_present
             end
           end
         end


### PR DESCRIPTION
Le cookie `pro_connect_session_info` n'avait pas de borne temporelle explicite, contrairement au mécanisme parallèle `trusted_device` (1 mois côté client + check serveur).

Cette PR aligne les deux :
- `expires:` côté navigateur calé sur `TRUSTED_DEVICE_PERIOD`
- Vérification serveur du timestamp `mfa_at` dans `pro_connect_mfa?`
- Période de grâce pour les cookies sans `mfa_at` jusqu'au 2026-06-13 (~1 mois après déploiement) pour éviter de forcer une nouvelle authentification ProConnect à tous les instructeurs déjà connectés au déploiement