### PR TITLE
Tech: garde-fou contre l'open redirect via omniauth.origin (RDV)

### DIFF
--- a/spec/controllers/rdv_service_public/oauth_controller_spec.rb
+++ b/spec/controllers/rdv_service_public/oauth_controller_spec.rb
@@ -85,6 +85,16 @@ RSpec.describe RdvServicePublic::OauthController, type: :controller do
           expect(flash[:notice]).to eq('Votre compte RDV Service Public a été connecté avec succès')
         end
       end
+
+      context 'when omniauth.origin points to an external host' do
+        before do
+          request.env['omniauth.origin'] = 'https://evil.example/phish'
+        end
+
+        it 'raises an unsafe redirect error rather than redirecting off-site' do
+          expect { subject }.to raise_error(ActionController::Redirecting::UnsafeRedirectError)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Test pour valider que la protection contre la redirection vers une URL externe est bien active.