### PR TITLE
Tech: lazy representation generation pour BlobProcessorJob

### DIFF
--- a/app/jobs/blob_processor_job.rb
+++ b/app/jobs/blob_processor_job.rb
@@ -62,8 +62,8 @@ class BlobProcessorJob < ApplicationJob
     # Phase 2: OCR (external API call)
     add_ocr_data
 
-    # Phase 3: Representations (ActiveStorage manages its own downloads)
-    create_representations if blob.representation_required?
+    # Phase 3: Representations — delegated to ultra_low queue
+    CreateRepresentationsJob.perform_later(blob) if blob.representation_required?
 
     mark_processed
   end
@@ -134,20 +134,6 @@ class BlobProcessorJob < ApplicationJob
     image.get_fields.include?("interlaced") && image.get("interlaced") != 0
   rescue Vips::Error # unreadable metadata should not abort processing: skip the mutation instead
     false
-  end
-
-  instrument_method
-  def create_representations
-    blob.attachments.each do |att|
-      next if !att.representable?
-      att.representation(resize_to_limit: [400, 400]).processed
-      if att.blob.content_type.in?(RARE_IMAGE_TYPES)
-        att.variant(resize_to_limit: [2000, 2000]).processed
-      end
-      if att.record.class == ActionText::RichText
-        att.variant(resize_to_limit: [1024, 768]).processed
-      end
-    end
   end
 
   instrument_method

--- a/app/jobs/create_representations_job.rb
+++ b/app/jobs/create_representations_job.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CreateRepresentationsJob < ApplicationJob
+  include Skylight::Helpers
+
+  queue_as :ultra_low
+
+  discard_on ActiveRecord::RecordNotFound
+  discard_on ActiveStorage::FileNotFoundError
+  discard_on ActiveRecord::InvalidForeignKey
+
+  retry_on "Vips::Error", attempts: 3 # not as const because vips is loaded at runtime
+
+  rescue_from ActiveStorage::PreviewError do |exception|
+    if executions < 3
+      retry_job wait: 5.minutes, error: exception
+    end
+  end
+
+  instrument_method
+  def perform(blob)
+    return if blob.nil?
+
+    blob.attachments.find_each do |att|
+      next if !att.representable?
+
+      att.representation(resize_to_limit: [400, 400]).processed
+
+      if att.blob.content_type.in?(RARE_IMAGE_TYPES)
+        att.variant(resize_to_limit: [2000, 2000]).processed
+      end
+
+      if att.record.class == ActionText::RichText
+        att.variant(resize_to_limit: [1024, 768]).processed
+      end
+    end
+  end
+end

--- a/spec/jobs/blob_processor_job_spec.rb
+++ b/spec/jobs/blob_processor_job_spec.rb
@@ -167,34 +167,16 @@ describe BlobProcessorJob, :external_deps, type: :job do
     end
 
     context 'when representation is not required' do
-      it 'does not create blob representation' do
-        expect { described_class.perform_now(blob) }.not_to change { ActiveStorage::VariantRecord.count }
+      it 'does not enqueue CreateRepresentationsJob' do
+        expect { described_class.perform_now(blob) }.not_to have_enqueued_job(CreateRepresentationsJob)
       end
     end
 
     context 'when representation is required' do
       before { allow(blob).to receive(:representation_required?).and_return(true) }
 
-      it 'creates blob representation' do
-        expect { described_class.perform_now(blob) }.to change { ActiveStorage::VariantRecord.count }.by(1)
-      end
-    end
-
-    context 'when type image is rare (TIFF)' do
-      let(:file) { fixture_file_upload('spec/fixtures/files/pencil.tiff', 'image/tiff') }
-      before { allow(blob).to receive(:representation_required?).and_return(true) }
-
-      it 'creates two variants' do
-        expect { described_class.perform_now(blob) }.to change { ActiveStorage::VariantRecord.count }.by(2)
-      end
-    end
-
-    context 'when file is a PDF' do
-      let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
-      before { allow(blob).to receive(:representation_required?).and_return(true) }
-
-      it 'creates blob representation' do
-        expect { described_class.perform_now(blob) }.to change { ActiveStorage::VariantRecord.count }.by(1)
+      it 'enqueues CreateRepresentationsJob' do
+        expect { described_class.perform_now(blob) }.to have_enqueued_job(CreateRepresentationsJob).with(blob)
       end
     end
   end
@@ -360,21 +342,6 @@ describe BlobProcessorJob, :external_deps, type: :job do
 
       it 'marks blob as integrity error after retries' do
         expect(blob.reload.virus_scanner.corrupt?).to be_truthy
-      end
-    end
-
-    context 'when Vips raises an error' do
-      before do
-        allow(ClamavService).to receive(:safe_file?).and_return(true)
-        allow(blob).to receive(:representation_required?).and_return(true)
-        allow_any_instance_of(described_class).to receive(:create_representations)
-          .and_raise(Vips::Error.new("unable to load source"))
-      end
-
-      it 're-enqueues the job for retry' do
-        expect {
-          described_class.perform_now(blob)
-        }.to have_enqueued_job(described_class).with(blob)
       end
     end
 

--- a/spec/jobs/create_representations_job_spec.rb
+++ b/spec/jobs/create_representations_job_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+describe CreateRepresentationsJob, :external_deps, type: :job do
+  let(:procedure) do
+    create(:procedure).tap { allow(_1).to receive(:valid?).and_return(true) }
+  end
+
+  let(:file) { fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png') }
+
+  let(:blob) do
+    procedure.notice.attach(file)
+    procedure.notice.blob
+  end
+
+  before do
+    require "vips"
+    allow(ClamavService).to receive(:safe_file?).and_return(true)
+    # Ensure blob is virus-scanned so we can test representations
+    blob.update_columns(virus_scan_result: ActiveStorage::VirusScanner::SAFE)
+  end
+
+  context 'when attachment is representable' do
+    it 'creates blob representation' do
+      expect { described_class.perform_now(blob) }.to change { ActiveStorage::VariantRecord.count }.by(1)
+    end
+  end
+
+  context 'when type image is rare (TIFF)' do
+    let(:file) { fixture_file_upload('spec/fixtures/files/pencil.tiff', 'image/tiff') }
+
+    it 'creates two variants' do
+      expect { described_class.perform_now(blob) }.to change { ActiveStorage::VariantRecord.count }.by(2)
+    end
+  end
+
+  context 'when file is a PDF' do
+    let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
+
+    it 'creates blob representation' do
+      expect { described_class.perform_now(blob) }.to change { ActiveStorage::VariantRecord.count }.by(1)
+    end
+  end
+
+  context 'when blob is nil' do
+    it 'does nothing' do
+      expect { described_class.perform_now(nil) }.not_to change { ActiveStorage::VariantRecord.count }
+    end
+  end
+
+  context 'when Vips raises an error' do
+    before do
+      allow_any_instance_of(ActiveStorage::Attachment).to receive(:representable?).and_return(true)
+      allow_any_instance_of(ActiveStorage::Attachment).to receive(:representation)
+        .and_raise(Vips::Error.new("unable to load source"))
+    end
+
+    it 're-enqueues the job for retry' do
+      expect {
+        described_class.perform_now(blob)
+      }.to have_enqueued_job(described_class).with(blob)
+    end
+  end
+end


### PR DESCRIPTION
# Proposition : Lazy Representation Generation pour BlobProcessorJob

## Contexte

BlobProcessorJob est le job le plus consommateur de notre infrastructure Sidekiq :
- hier, le [blobprocessorjob 88/min, ±22s](https://www.skylight.io/app/applications/auuzqe8XhJIx/1777845600/1d/endpoints)
> <img width="1301" height="155" alt="Capture d’écran 2026-05-05 à 9 54 04 AM" src="https://github.com/user-attachments/assets/09a7d1e7-caf0-4a20-95cc-dc3584193866" />

- La queue `:low` est régulièrement engorgée en journée
> <img width="1341" height="722" alt="Screenshot 2026-05-05 at 09-29-47 Sidekiq - Dashboards - Grafana" src="https://github.com/user-attachments/assets/46df57ed-ccae-47cf-8474-62aa1abbc1ec" />

- [57% du temps du job est consacré à `create_representations`](https://www.skylight.io/app/applications/auuzqe8XhJIx/recent/6h/endpoints/BlobProcessorJob?responseType=low)
> <img width="1288" height="303" alt="Capture d’écran 2026-05-05 à 9 23 15 AM" src="https://github.com/user-attachments/assets/912fcb51-6831-4dde-b8d0-29c8bc136b1b" />

Sauf que...les representations/variantes ne sont utiles que lorsqu'un **instructeur consulte** un dossier.

---

## Proposition d'architecture

1. **BlobProcessorJob à l'upload** : scan antivirus + mutations + OCR uniquement
2. **Deporter la gestion des variantes** : dans une queue ultra_low
~~3. (on a abandonné l'idée d'enqueue a la demande sur les pages instructeur pour au moins gerer une ux minimale)~~
---

## Tableau de synthèse

| Situation | % des dossiers | Variants utiles ? | Stratégie |
|-----------|---------------|-------------------|-----------|
| Brouillons abandonnés | 7.3% | Non (jamais soumis) | Jamais générées |
| Démarches déclaratives | 26.5% | Non (instruction auto) | Jamais générées sauf consultation |
| Instruction J+1 ou plus | 53.4% | Oui, mais pas urgent | Cron nocturne |
| Instruction le même jour (non-déclaratif) | ~35% | Oui, urgent | After_action on-demand |

---

## Détail des données

### 1. Brouillons abandonnés : 7.3%

Dossiers créés il y a plus de 30 jours et toujours en brouillon — jamais soumis, leurs PJ ne seront jamais consultées.

```sql
SELECT
  COUNT(*) AS total,
  COUNT(*) FILTER (WHERE state = 'brouillon') AS restes_brouillon,
  ROUND(100.0 * COUNT(*) FILTER (WHERE state = 'brouillon') / COUNT(*), 1) AS pct_abandonnes
FROM dossiers
WHERE created_at < NOW() - INTERVAL '30 days';
```

| total | restes_brouillon | pct_abandonnes |
|-------|-----------------|----------------|
| 10 950 630 | 803 924 | 7.3% |

---

### 2. Démarches déclaratives : 26.5%

Dossiers soumis sur des procédures à instruction automatique (`declarative_with_state IS NOT NULL`). "Aucun" instructeur ne consulte les PJ (enfin, on est pas dans le besoin instantanné).

```sql
WITH declarative_procedure_ids AS (
  SELECT id FROM procedures WHERE declarative_with_state IS NOT NULL
)
SELECT COUNT(*)
FROM dossiers
JOIN groupe_instructeurs ON groupe_instructeurs.id = dossiers.groupe_instructeur_id
WHERE groupe_instructeurs.procedure_id IN (SELECT id FROM declarative_procedure_ids)
  AND dossiers.state != 'brouillon';
```

| dossiers déclaratifs | total soumis | % |
|---------------------|-------------|---|
| 2 694 064 | ~10 150 000 | 26.5% |

---

### 3. Délai dépôt → instruction : 53.4% instruits après J+0

Sur les 30 derniers jours, plus de la moitié des dossiers ne sont pas instruits le jour du dépôt → un cron nocturne suffit pour pré-générer les variants.

```sql
SELECT
  COUNT(*) AS total_instruits,
  COUNT(*) FILTER (WHERE depose_at::date = en_instruction_at::date) AS instruit_meme_jour,
  ROUND(100.0 * COUNT(*) FILTER (WHERE depose_at::date = en_instruction_at::date) / COUNT(*), 1) AS pct_meme_jour
FROM dossiers
WHERE en_instruction_at IS NOT NULL
  AND en_instruction_at > NOW() - INTERVAL '30 days';
```

| total_instruits | instruit_meme_jour | pct_meme_jour |
|-----------------|-------------------|---------------|
| 420 043 | 195 828 | 46.6% |

**53.4% ne sont pas instruits le jour du dépôt** — le cron nocturne couvre ces cas sans impact UX.

---

### 4. Délai création → dépôt (pour info)

78.5% des dossiers sont déposés le même jour que leur création — la fenêtre brouillon est courte.

```sql
SELECT
  COUNT(*) AS total_deposes,
  COUNT(*) FILTER (WHERE created_at::date = depose_at::date) AS depose_meme_jour,
  ROUND(100.0 * COUNT(*) FILTER (WHERE created_at::date = depose_at::date) / COUNT(*), 1) AS pct_meme_jour
FROM dossiers
WHERE depose_at IS NOT NULL
  AND depose_at > NOW() - INTERVAL '30 days';
```

| total_deposes | depose_meme_jour | pct_meme_jour |
|--------------|-----------------|---------------|
| 430 741 | 338 158 | 78.5% |

---
