### PR TITLE
Tech: passer les emails d'invitation et de transfert dans la queue Sidekiq critical

### DIFF
--- a/app/mailers/administration_mailer.rb
+++ b/app/mailers/administration_mailer.rb
@@ -28,6 +28,6 @@ class AdministrationMailer < ApplicationMailer
   end
 
   def self.critical_email?(action_name)
-    false
+    action_name == "invite_admin"
   end
 end

--- a/app/mailers/avis_mailer.rb
+++ b/app/mailers/avis_mailer.rb
@@ -65,6 +65,6 @@ class AvisMailer < ApplicationMailer
   end
 
   def self.critical_email?(action_name)
-    false
+    action_name == "avis_invitation_and_confirm_email"
   end
 end

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -216,7 +216,7 @@ class DossierMailer < ApplicationMailer
   end
 
   def self.critical_email?(action_name)
-    false
+    action_name == "notify_transfer"
   end
 
   protected

--- a/app/mailers/groupe_instructeur_mailer.rb
+++ b/app/mailers/groupe_instructeur_mailer.rb
@@ -83,7 +83,7 @@ class GroupeInstructeurMailer < ApplicationMailer
   end
 
   def self.critical_email?(action_name)
-    false
+    ["confirm_and_notify_added_instructeur", "confirm_and_notify_added_instructeur_in_many_groupes"].include?(action_name)
   end
 
   def confirm_and_notify_added_instructeur_in_many_groupes(instructeur, groups, current_instructeur_email)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -132,6 +132,8 @@ class UserMailer < ApplicationMailer
       "new_account_warning",
       "ask_for_merge",
       "invite_instructeur",
+      "invite_tiers",
+      "resend_confirmation_email",
       "custom_confirmation_instructions",
     ].include?(action_name)
   end


### PR DESCRIPTION
 ## Summary

Ces actions de mailer concernent des emails qu'on qualifie d'"urgent", on les passe donc dans la queue `critical` pour ne pas les recevoir jusqu'à 3h plus tard.

Actions concernées :
- `UserMailer#invite_tiers`
- `UserMailer#resend_confirmation_email`
- `DossierMailer#notify_transfer`
- `AdministrationMailer#invite_admin`
- `AvisMailer#avis_invitation_and_confirm_email`
- `GroupeInstructeurMailer#confirm_and_notify_added_instructeur`
- `GroupeInstructeurMailer#confirm_and_notify_added_instructeur_in_many_groupes`

## Effets de `critical_email?`

Marquer une action comme `critical_email?` pilote 3 mécanismes distincts :

1. **Queue Sidekiq** (via `PriorizedMailDeliveryJob#queue_name`) — `default` → `critical`. C'est l'effet recherché par cette PR.

2. **Sélection du provider d'envoi via `SafeMailer.forced_delivery_method`** (via `PriorityDeliveryConcern#set_forced_delivery_method_header`, header `X-deliver-with`). Si un provider est forcé pour les emails critiques, ces 7 actions l'utiliseront désormais. Effet de bord souhaitable : ce sont des emails à enjeu utilisateur, on veut le canal le plus fiable.

3. **Bypass de `BalancerDeliveryMethod#prevent_delivery?`** (via le header `CRITICAL_HEADER`), qui filtre les emails dont le destinataire a un compte avec email non vérifié ou désabonné. **Aucun changement effectif ici** : les 7 actions appellent déjà `bypass_unverified_mail_protection!`, qui pose le header `BYPASS_UNVERIFIED_MAIL_PROTECTION` ayant le même effet de bypass.