### PR TITLE
Fix: lorsque qu'une procédure est restore, ne restore que les dossiers qui ne sont pas expirés

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -252,6 +252,7 @@ class Dossier < ApplicationRecord
   scope :hidden_by_administration,  -> { where.not(hidden_by_administration_at: nil) }
   scope :hidden_by_expired,         -> { where.not(hidden_by_expired_at: nil) }
   scope :hidden_by_not_modified_for_a_long_time, -> { hidden_by_expired.where(hidden_by_reason: :not_modified_for_a_long_time) }
+  scope :hidden_by_procedure_removed, -> { hidden_by_administration.where(hidden_by_reason: :procedure_removed) }
   scope :visible_by_user,           -> { where(for_procedure_preview: false, hidden_by_user_at: nil, hidden_by_expired_at: nil) }
   scope :visible_by_administration, -> {
     state_not_brouillon

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -649,7 +649,7 @@ class Procedure < ApplicationRecord
 
   def restore(author)
     if discarded? && undiscard
-      dossiers.hidden_by_administration.find_each do |dossier|
+      dossiers.hidden_by_procedure_removed.find_each do |dossier|
         dossier.restore(author)
       end
     end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1352,27 +1352,30 @@ describe Procedure do
 
   describe "#discard_and_keep_track!" do
     let(:super_admin) { create(:super_admin) }
-    let(:procedure) { create(:procedure) }
-    let!(:dossier) { create(:dossier, procedure: procedure) }
-    let!(:dossier2) { create(:dossier, procedure: procedure) }
-    let(:instructeur) { create(:instructeur) }
 
-    it do
-      expect(Dossier.count).to eq(2)
-      expect(Dossier.all).to include(dossier, dossier2)
+    subject { procedure.discard_and_keep_track!(super_admin) }
+
+    context "when discarding a procedure in brouillon" do
+      let(:procedure) { create(:procedure) }
+      let!(:dossier) { create(:dossier, procedure:) }
+
+      it 'destroys dossiers' do
+        subject
+        expect(procedure.dossiers.count).to eq(0)
+      end
     end
 
-    context "when discarding procedure" do
-      before do
-        instructeur.followed_dossiers << dossier
-        procedure.discard_and_keep_track!(super_admin)
-        instructeur.reload
-      end
+    context "when discarding a published procedure" do
+      let(:procedure) { create(:procedure, :published) }
+      let!(:dossier) { create(:dossier, :en_construction, procedure:, hidden_by_administration_at: nil, hidden_by_reason: nil) }
+      let!(:dossier_2) { create(:dossier, :accepte, procedure:, hidden_by_administration_at: nil, hidden_by_reason: nil) }
 
-      it do
-        expect(procedure.dossiers.count).to eq(0)
-        expect(Dossier.count).to eq(0)
-        expect(instructeur.followed_dossiers).not_to include(dossier)
+      it 'hides dossiers' do
+        subject
+        dossiers = procedure.dossiers
+        expect(dossiers.count).to eq(2)
+        expect(dossiers.pluck(:hidden_by_reason).uniq).to eq(['procedure_removed'])
+        expect(dossiers.pluck(:hidden_by_administration_at)).to all(be_present)
       end
     end
   end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1380,6 +1380,24 @@ describe Procedure do
     end
   end
 
+  describe "#restore" do
+    let(:super_admin) { create(:super_admin) }
+    let(:procedure) { create(:procedure, :discarded) }
+    let!(:dossier) { create(:dossier, :accepte, procedure:, hidden_by_administration_at: Time.zone.now, hidden_by_reason: :procedure_removed) }
+    let!(:dossier_2) { create(:dossier, :accepte, procedure:, hidden_by_administration_at: Time.zone.now, hidden_by_expired_at: Time.zone.now, hidden_by_reason: :expired) }
+
+    subject { procedure.restore(super_admin) }
+
+    it "restores only dossier that have been hidden by procedure_removed" do
+      subject
+      expect(dossier.reload.hidden_by_administration_at).to be_nil
+      expect(dossier.hidden_by_reason).to be_nil
+      expect(dossier_2.reload.hidden_by_administration_at).not_to be_nil
+      expect(dossier_2.hidden_by_expired_at).not_to be_nil
+      expect(dossier_2.hidden_by_reason).to eq('expired')
+    end
+  end
+
   describe "#organisation_name" do
     subject { procedure.organisation_name }
     context 'when the procedure has a service (and no organization)' do


### PR DESCRIPTION
sentry : https://demarches-simplifiees.sentry.io/issues/6914250928/?project=1429550&query=is%3Aunresolved%20cron&referrer=issue-stream

Explication :
- des dossiers dans un état incohérent : hidden_by_reason à nil, et hidden_by_expired_at avec une date ;
- source du problème dans Procedure#restore, qui vient restore par la même les dossiers hidden_by_administration, en faisant : hidden_by_administration_at et hidden_by_reason à nil, sans toucher/regarder hidden_by_expired_at ;
- scenario : on a deux dossiers (1 et 2), tout deux terminés, l'admin clot la procedure puis la supprime -> les dossiers deviennent hidden_by_administration_at: à now, et hidden_by_reason à :procedure_removed. Le process d'expiration fait son travail, et dossier_1 devient expiré (hidden_by_expired_at à now, et hidden_by_reason passe à :expired). L'admin restore la procedure, et par la même vient restore les dossiers 'hidden_by_administration' --> dossier_2 bien restore, mais dossier 1 dans état incohérent.
- Solution: on vient restore que les dossiers non expirés, en regardant ceux encore hidden_by_administration_at, et hidden_by_reason toujours à procedure_removed. Dit autrement, ceux qui dans l'intervalle sont devenus expirés, on les restore pas.