### PR TITLE
Tech: réduire le volume d'indexation des brouillons pour les usagers avec peu de dossiers

### DIFF
--- a/app/models/concerns/dossier_searchable_concern.rb
+++ b/app/models/concerns/dossier_searchable_concern.rb
@@ -4,6 +4,8 @@ module DossierSearchableConcern
   extend ActiveSupport::Concern
 
   SEARCH_TERMS_DEBOUNCE = 5.minutes
+  SEARCH_TERMS_DEBOUNCE_LIGHT_USER = 1.hour
+  LIGHT_USER_DOSSIERS_THRESHOLD = 5
 
   included do
     after_commit :index_search_terms_later, if: -> { previously_new_record? || user_previously_changed? || mandataire_first_name_previously_changed? || mandataire_last_name_previously_changed? }
@@ -34,7 +36,14 @@ module DossierSearchableConcern
   def index_search_terms_later
     return if debounce_index_search_terms_flag.marked?
 
-    debounce_index_search_terms_flag.mark(expires_in: SEARCH_TERMS_DEBOUNCE)
-    DossierIndexSearchTermsJob.set(wait: SEARCH_TERMS_DEBOUNCE).perform_later(self)
+    wait = light_user_brouillon? ? SEARCH_TERMS_DEBOUNCE_LIGHT_USER : SEARCH_TERMS_DEBOUNCE
+    debounce_index_search_terms_flag.mark(expires_in: wait)
+    DossierIndexSearchTermsJob.set(wait:).perform_later(self)
+  end
+
+  private
+
+  def light_user_brouillon?
+    brouillon? && user && user.dossiers.count <= LIGHT_USER_DOSSIERS_THRESHOLD
   end
 end

--- a/app/models/concerns/dossier_state_concern.rb
+++ b/app/models/concerns/dossier_state_concern.rb
@@ -41,6 +41,7 @@ module DossierStateConcern
     process_declarative!
     process_sva_svr!
 
+    debounce_index_search_terms_flag.remove
     index_search_terms_later
   end
 

--- a/spec/models/concerns/dossier_searchable_concern_spec.rb
+++ b/spec/models/concerns/dossier_searchable_concern_spec.rb
@@ -30,7 +30,7 @@ describe DossierSearchableConcern do
 
     context 'with an update' do
       before do
-        stub_const("DossierSearchableConcern::SEARCH_TERMS_DEBOUNCE", 1.second)
+        stub_const("DossierSearchableConcern::SEARCH_TERMS_DEBOUNCE_LIGHT_USER", 1.second)
 
         # dossier creation trigger a first indexation and flag,
         # so we we have to remove this flag
@@ -77,6 +77,55 @@ describe DossierSearchableConcern do
         perform_enqueued_jobs(only: DossierIndexSearchTermsJob)
 
         expect(result["search_terms"]).to include("Chris")
+      end
+    end
+  end
+
+  describe '#index_search_terms_later' do
+    let(:user) { create(:user) }
+    let(:dossier) { create(:dossier, :brouillon, user: user) }
+
+    before { dossier.debounce_index_search_terms_flag.remove }
+
+    context 'when dossier is brouillon and user has 5 or fewer dossiers' do
+      it 'enqueues with a 1 hour delay' do
+        freeze_time do
+          expect { dossier.index_search_terms_later }
+            .to have_enqueued_job(DossierIndexSearchTermsJob)
+            .with(dossier)
+            .at(1.hour.from_now)
+        end
+      end
+    end
+
+    context 'when dossier is brouillon and user has more than 5 dossiers' do
+      before { create_list(:dossier, 5, user: user) }
+
+      it 'enqueues with a 5 minutes delay' do
+        freeze_time do
+          expect { dossier.index_search_terms_later }
+            .to have_enqueued_job(DossierIndexSearchTermsJob)
+            .with(dossier)
+            .at(5.minutes.from_now)
+        end
+      end
+    end
+  end
+
+  describe 'after passer_en_construction' do
+    let(:user) { create(:user) }
+    let(:dossier) { create(:dossier, :brouillon, user: user) }
+
+    before { dossier.debounce_index_search_terms_flag.remove }
+
+    it 'resets debounce flag and enqueues a fresh job with a 5 minutes delay' do
+      dossier.debounce_index_search_terms_flag.mark(expires_in: 1.hour)
+
+      freeze_time do
+        expect { dossier.passer_en_construction }
+          .to have_enqueued_job(DossierIndexSearchTermsJob)
+          .with(dossier)
+          .at(5.minutes.from_now)
       end
     end
   end


### PR DESCRIPTION
Les brouillons d'usagers ayant 5 dossiers ou moins utilisent désormais un debounce d'1h (vs 5 min) avant indexation des `search_terms`. Ces usagers n'ont quasiment jamais besoin de la recherche dans leurs dossiers, donc l'indexation à chaud est inutile. Le flag de debounce est reset explicitement au `passer_en_construction` pour garantir une indexation rapide post-soumission (5 min).

L'objectif est de réduire le volume de `DossierIndexSearchTermsJob` (8-10k jobs/h, 2.18s moyenne en prod).