### PR TITLE
Tech: ne plus exposer les annotations privées sur les endpoints opendata

### DIFF
--- a/app/controllers/prefill_type_de_champs_controller.rb
+++ b/app/controllers/prefill_type_de_champs_controller.rb
@@ -14,7 +14,7 @@ class PrefillTypeDeChampsController < ApplicationController
   end
 
   def set_prefill_type_de_champ
-    type_de_champ = @procedure.active_revision.types_de_champ.filter(&:fillable?).find { _1.stable_id == params[:id].to_i }
+    type_de_champ = @procedure.active_revision.types_de_champ_public.filter(&:fillable?).find { _1.stable_id == params[:id].to_i }
     raise ActiveRecord::RecordNotFound if type_de_champ.blank?
     @type_de_champ = TypesDeChamp::PrefillTypeDeChamp.build(type_de_champ, @procedure.active_revision)
   end

--- a/app/graphql/api/v2/context.rb
+++ b/app/graphql/api/v2/context.rb
@@ -82,7 +82,7 @@ class API::V2::Context < GraphQL::Query::Context
 
   def compute_demarche_authorization(demarche)
     # procedure_ids and token are passed from graphql controller
-    self[:procedure_ids].include?(demarche.id)
+    self[:procedure_ids]&.include?(demarche.id) || false
   end
 
   # This is a query AST visitor that we use to check

--- a/app/graphql/types/revision_type.rb
+++ b/app/graphql/types/revision_type.rb
@@ -10,7 +10,7 @@ module Types
     field :annotation_descriptors, [Types::ChampDescriptorType], null: false
 
     def annotation_descriptors
-      if context.authorized_demarche?(object.procedure, opendata: true)
+      if context.authorized_demarche?(object.procedure)
         object.revision_types_de_champ_private
       else
         []

--- a/spec/controllers/api/public/v1/json_description_procedures_controller_spec.rb
+++ b/spec/controllers/api/public/v1/json_description_procedures_controller_spec.rb
@@ -37,5 +37,18 @@ RSpec.describe API::Public::V1::JSONDescriptionProceduresController, type: :cont
         expect(response).to have_failed_with("procedure error is not found")
       end
     end
+
+    context "when the opendata procedure has private annotations" do
+      let(:procedure) { create(:procedure, :published, opendata: true) }
+      let(:params) { { path: procedure.path } }
+
+      it "does not expose the private annotation libelle in the public schema" do
+        create(:type_de_champ_text, :private, procedure: procedure, libelle: "annotation interne secrete")
+        get :show, params: params
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).not_to include("annotation interne secrete")
+      end
+    end
   end
 end

--- a/spec/controllers/prefill_type_de_champs_controller_spec.rb
+++ b/spec/controllers/prefill_type_de_champs_controller_spec.rb
@@ -53,6 +53,17 @@ RSpec.describe PrefillTypeDeChampsController, type: :controller do
 
         it { expect { show_request }.to raise_error(ActiveRecord::RecordNotFound) }
       end
+
+      context 'when the requested type de champ is a private annotation' do
+        let(:procedure) { create(:procedure, :published, opendata: true) }
+        let(:type_de_champ) { create(:type_de_champ_text, :private, procedure: procedure) }
+
+        subject(:show_request) { get :show, params: { path: procedure.path, id: type_de_champ.stable_id } }
+
+        it 'does not expose the private annotation' do
+          expect { show_request }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
     end
 
     context 'when the procedure is not found' do


### PR DESCRIPTION
## Résumé

Deux endpoints opendata non authentifiés divulguaient le schéma des **annotations privées** (champs réservés aux instructeurs : libellé, description, valeurs possibles, exemples) :

- `GET /procedures/:path/prefill_type_de_champs/:id` — `prefill_type_de_champs#show` interrogeait `active_revision.types_de_champ` (publics + privés) au lieu de `types_de_champ_public`. Énumération triviale du `stable_id`.
- `GET /preremplir/:path/schema` — la query GraphQL `getDemarcheDescriptor` demandait `annotationDescriptors`, et `RevisionType#annotation_descriptors` autorisait tout appelant anonyme dès lors que `authorized_demarche?(opendata: true)` était vrai.

## Correctifs

- `prefill_type_de_champs_controller.rb` : `types_de_champ` → `types_de_champ_public`.
- `RevisionType#annotation_descriptors` : retrait de `opendata: true` — les annotations ne sont renvoyées qu'aux callers `internal_use?` ou aux admins authentifiés autorisés sur la procédure.
- `Context#compute_demarche_authorization` : rendu défensif (`self[:procedure_ids]&.include?(...) || false`). L'ancien fast-path opendata masquait un `nil#include?` quand le contexte public n'initialisait pas `procedure_ids`.

## Couverture

Specs ajoutés (RED → GREEN) :
- `spec/controllers/prefill_type_de_champs_controller_spec.rb` — refus de divulgation d'une annotation privée par `stable_id`.
- `spec/controllers/api/public/v1/json_description_procedures_controller_spec.rb` — le libellé d'une annotation privée n'apparaît plus dans la réponse JSON publique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)