### PR TITLE
[ETQ instructeur] j'ai accès à toutes les actions multiples depuis l'onglet au total

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -377,6 +377,7 @@ ul.dropdown-items {
   h4 {
     font-size: 14px;
     margin-bottom: $default-spacer;
+    color: inherit;
   }
 
   p + h4,

--- a/app/components/dossiers/batch_operation_component.rb
+++ b/app/components/dossiers/batch_operation_component.rb
@@ -185,7 +185,78 @@ class Dossiers::BatchOperationComponent < ApplicationComponent
               operation: BatchOperation.operations.fetch(:create_commentaire),
               modal_data: { action: 'batch-operation#injectSelectedIdsIntoModal', 'fr-opened': "false", 'modal-type': 'commentaire' },
               aria:  'modal-commentaire-batch',
+
             },
+
+            {
+              instruction:
+                            [
+                              {
+                                label: t(".operations.accepter"),
+                                operation_description: t(".operations.accepter_description"),
+                                operation: BatchOperation.operations.fetch(:accepter),
+                                operation_class_name: 'fr-icon-checkbox-circle-fill fr-text-default--success',
+                                placeholder: t(".placeholders.accepter"),
+                                instruction_operation: 'accept',
+                              },
+
+                              {
+                                label: t(".operations.classer_sans_suite"),
+                                operation_description: t(".operations.classer_sans_suite_description"),
+                                operation: BatchOperation.operations.fetch(:classer_sans_suite),
+                                operation_class_name: 'fr-icon-intermediate-circle-fill fr-text-mention--grey',
+                                placeholder: t(".placeholders.classer_sans_suite"),
+                                instruction_operation: 'without-continuation',
+                              },
+
+                              {
+                                label: t(".operations.refuser"),
+                                operation_description: t(".operations.refuser_description"),
+                                operation: BatchOperation.operations.fetch(:refuser),
+                                operation_class_name: 'fr-icon-close-circle-fill fr-text-default--warning',
+                                placeholder: t(".placeholders.refuser"),
+                                instruction_operation: 'refuse',
+                              },
+                            ],
+            },
+
+            {
+              label: t(".operations.follow"),
+              operation: BatchOperation.operations.fetch(:follow),
+            },
+
+            {
+              label: t(".operations.unfollow"),
+              operation: BatchOperation.operations.fetch(:unfollow),
+            },
+
+            {
+              label: t(".operations.passer_en_instruction"),
+              operation: BatchOperation.operations.fetch(:passer_en_instruction),
+            },
+
+            {
+              label: t(".operations.repasser_en_construction"),
+              operation: BatchOperation.operations.fetch(:repasser_en_construction),
+            },
+
+            {
+              label: t(".operations.archiver"),
+              operation: BatchOperation.operations.fetch(:archiver),
+            },
+            {
+              label: t(".operations.supprimer"),
+              operation: BatchOperation.operations.fetch(:supprimer),
+            },
+
+            {
+              label: t(".operations.create_avis"),
+              operation: BatchOperation.operations.fetch(:create_avis),
+              modal_data: { action: 'batch-operation#injectSelectedIdsIntoModal', 'fr-opened': "false", 'modal-type': 'avis' },
+              aria:  'modal-avis-batch',
+
+            },
+
           ],
       }
     else

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.fr.yml
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.fr.yml
@@ -1,8 +1,8 @@
 fr:
   zero_selected: "0 dossier sélectionné"
   operations:
-    archiver: 'Archiver les dossiers'
-    desarchiver: 'Désarchiver les dossiers'
+    archiver: 'Déplacer les dossiers dans “à archiver“'
+    desarchiver: 'Replacer les dossiers dans “traités”'
     passer_en_instruction: 'Passer les dossiers en instruction'
     instruction: Instruire les dossiers
     repousser_expiration: Conserver un mois de plus

--- a/app/components/dossiers/batch_operation_component/batch_operation_component.html.erb
+++ b/app/components/dossiers/batch_operation_component/batch_operation_component.html.erb
@@ -34,7 +34,7 @@
             data-menu-button-target="menu"
             aria-labelledby="batch_operation_others"
           >
-            <ul class="dropdown-items">
+            <ul class="dropdown-items no-wrap">
               <% available_operations[:options][2, available_operations[:options].count].each do |opt| -%>
                 <% unless expert_review_disallowed?(opt[:operation]) -%>
                   <li>

--- a/spec/components/dossiers/batch_operation_component_spec.rb
+++ b/spec/components/dossiers/batch_operation_component_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Dossiers::BatchOperationComponent, type: :component do
     context 'statut traite' do
       let(:statut) { 'traites' }
       it do
-        is_expected.to have_button('Archiver les dossiers', disabled: true)
+        is_expected.to have_button('Déplacer les dossiers dans “à archiver“', disabled: true)
         is_expected.to have_button('Mettre les dossiers à la corbeille', disabled: true)
         is_expected.to have_button('Envoyer un message aux usagers', disabled: true)
       end
@@ -79,7 +79,7 @@ RSpec.describe Dossiers::BatchOperationComponent, type: :component do
         is_expected.to have_button('Ne plus suivre les dossiers', disabled: true)
         is_expected.to have_button('Passer les dossiers en instruction', disabled: true)
         is_expected.to have_button('Repasser les dossiers en construction', disabled: true)
-        is_expected.to have_button('Archiver les dossiers', disabled: true)
+        is_expected.to have_button('Déplacer les dossiers dans “à archiver“', disabled: true)
         is_expected.to have_button('Mettre les dossiers à la corbeille', disabled: true)
         is_expected.to have_button('Demander un avis externe', disabled: true)
       end

--- a/spec/components/dossiers/batch_operation_component_spec.rb
+++ b/spec/components/dossiers/batch_operation_component_spec.rb
@@ -25,7 +25,11 @@ RSpec.describe Dossiers::BatchOperationComponent, type: :component do
 
     context 'statut traite' do
       let(:statut) { 'traites' }
-      it { is_expected.to have_button('Archiver les dossiers', disabled: true) }
+      it do
+        is_expected.to have_button('Archiver les dossiers', disabled: true)
+        is_expected.to have_button('Mettre les dossiers à la corbeille', disabled: true)
+        is_expected.to have_button('Envoyer un message aux usagers', disabled: true)
+      end
     end
 
     context 'statut suivis' do
@@ -58,13 +62,26 @@ RSpec.describe Dossiers::BatchOperationComponent, type: :component do
 
     context 'statut a-suivre' do
       let(:statut) { 'a-suivre' }
-      it { is_expected.to have_button('Suivre les dossiers', disabled: true) }
+      it do
+        is_expected.to have_button('Passer les dossiers en instruction', disabled: true)
+        is_expected.to have_button('Suivre les dossiers', disabled: true)
+        is_expected.to have_button('Envoyer un message aux usagers', disabled: true)
+      end
     end
 
     context 'statut tous' do
       let(:statut) { 'tous' }
       it do
         is_expected.to have_button('Envoyer un message aux usagers', disabled: true)
+        is_expected.to have_button('Instruire les dossiers', disabled: true)
+        is_expected.to have_button('Autres actions multiples', disabled: true)
+        is_expected.to have_button('Suivre les dossiers', disabled: true)
+        is_expected.to have_button('Ne plus suivre les dossiers', disabled: true)
+        is_expected.to have_button('Passer les dossiers en instruction', disabled: true)
+        is_expected.to have_button('Repasser les dossiers en construction', disabled: true)
+        is_expected.to have_button('Archiver les dossiers', disabled: true)
+        is_expected.to have_button('Mettre les dossiers à la corbeille', disabled: true)
+        is_expected.to have_button('Demander un avis externe', disabled: true)
       end
     end
 

--- a/spec/system/instructeurs/batch_operation_spec.rb
+++ b/spec/system/instructeurs/batch_operation_spec.rb
@@ -20,17 +20,17 @@ describe 'BatchOperation a dossier:', js: true do
       # check a11y with enabled checkbox
       expect(page).to be_axe_clean
       # ensure button is disabled by default
-      expect(page).to have_button("Archiver les dossiers", disabled: true)
+      expect(page).to have_button("Déplacer les dossiers dans “à archiver“", disabled: true)
 
       checkbox_id = dom_id(BatchOperation.new, "checkbox_#{dossier_1.id}")
       # batch one dossier
       check(checkbox_id)
-      expect(page).to have_button("Archiver les dossiers")
+      expect(page).to have_button("Déplacer les dossiers dans “à archiver“")
 
       # ensure batch is created
 
       accept_alert do
-        click_on "Archiver les dossiers"
+        click_on "Déplacer les dossiers dans “à archiver“"
       end
 
       # ensure batched dossier is disabled
@@ -79,7 +79,7 @@ describe 'BatchOperation a dossier:', js: true do
 
       # submit checkall
       accept_alert do
-        click_on "Archiver les dossiers"
+        click_on "Déplacer les dossiers dans “à archiver“"
       end
 
       # reload


### PR DESCRIPTION
Suite à une demande sur Mattermost : https://mattermost.incubateur.net/betagouv/pl/n15bh89fo7gszbqa98hhnbfwfe

On se dit que pour certains utilisateurs, ça permet de tout gérer depuis l'onglet "total" avec les filtres et que l'interface est déjà pensée pour gérer l'affichage de plusieurs boutons.


<img width="1342" height="582" alt="Capture d’écran 2026-05-06 à 12 30 36" src="https://github.com/user-attachments/assets/af5e7018-aa50-4182-8fc1-be631ba6a967" />
