### PR TITLE
Tech: corrige une race condition Dir.chdir dans DownloadableFileService

### DIFF
--- a/app/services/downloadable_file_service.rb
+++ b/app/services/downloadable_file_service.rb
@@ -16,10 +16,8 @@ class DownloadableFileService
         download_manager = DownloadManager::ProcedureAttachmentsExport.new(procedure, attachments, export_dir)
         download_manager.download_all
 
-        Dir.chdir(tmp_dir) do
-          File.delete(zip_path) if File.exist?(zip_path)
-          system 'zip', '-0', '-r', zip_path, EXPORT_DIRNAME
-        end
+        File.delete(zip_path) if File.exist?(zip_path)
+        system 'zip', '-0', '-r', zip_path, EXPORT_DIRNAME, chdir: tmp_dir
         yield(zip_path)
       ensure
         FileUtils.remove_entry_secure(export_dir) if Dir.exist?(export_dir)

--- a/spec/services/downloadable_file_service_spec.rb
+++ b/spec/services/downloadable_file_service_spec.rb
@@ -29,7 +29,7 @@ describe DownloadableFileService do
 
     it 'creates a zip with zip utility' do
       expected_zip_path = File.join(DownloadableFileService::ARCHIVE_CREATION_DIR, "#{service.send(:zip_root_folder, archive)}.zip")
-      expect(DownloadableFileService).to receive(:system).with('zip', '-0', '-r', expected_zip_path, an_instance_of(String))
+      expect(DownloadableFileService).to receive(:system).with('zip', '-0', '-r', expected_zip_path, an_instance_of(String), chdir: an_instance_of(String))
       DownloadableFileService.download_and_zip(procedure, [], filename) { |zip_path| }
     end
 


### PR DESCRIPTION
Fix https://demarches-simplifiees.sentry.io/issues/RAILS-KPF

On remplace `Dir.chdir(tmp_dir) do … system 'zip', … end` par l'option `chdir:` de `system`, qui ne fixe le cwd que pour le sous-processus `zip` (thread-safe, sans effet sur le processus Ruby parent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)