### PR TITLE
Correctif : le signe `<` ne s'affiche plus `&lt;` dans l'attestation v1

### DIFF
--- a/app/views/administrateurs/attestation_templates/show.pdf.prawn
+++ b/app/views/administrateurs/attestation_templates/show.pdf.prawn
@@ -22,7 +22,9 @@ max_logo_height = 50.mm
 max_signature_size = 50.mm
 
 def normalize_pdf_text(text)
-  strip_tags(text&.tr("\t", '  '))
+  stripped = strip_tags(text&.tr("\t", '  '))
+  return if stripped.nil?
+  CGI.unescapeHTML(stripped)
 end
 
 title = normalize_pdf_text(@attestation.fetch(:title))

--- a/spec/models/attestation_template_spec.rb
+++ b/spec/models/attestation_template_spec.rb
@@ -115,6 +115,28 @@ describe AttestationTemplate, type: :model do
         expect(subject.title).to eq('title libelle1')
         expect(subject.pdf).to be_attached
       end
+
+      context 'when a tag value contains a < character' do
+        before do
+          dossier.project_champs_public
+            .find { |champ| champ.libelle == 'libelleB' }
+            .update(value: 'age < 18')
+        end
+
+        it 'renders < literally in the PDF body, not as &lt;' do
+          text_calls = []
+          allow_any_instance_of(Prawn::Document).to receive(:text).and_wrap_original do |m, text, *args|
+            text_calls << text
+            m.call(text, *args)
+          end
+
+          attestation_template.generate_attestation_for(dossier)
+
+          body_call = text_calls.find { _1.include?('age') }
+          expect(body_call).to include('age < 18')
+          expect(body_call).not_to include('&lt;')
+        end
+      end
     end
 
     context 'when dossier is not in accepte or refuse state' do


### PR DESCRIPTION
cf https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_95946612-d1c0-4a72-b258-46b2dd3ba147/

## Résumé

- `strip_tags` (via Nokogiri + `to_html`) encode `<` en `&lt;` dans les nœuds texte lors de la sérialisation HTML
- Prawn n'interprète pas les entités HTML — `&lt;` était rendu littéralement dans le PDF
- Le problème survenait dès qu'une valeur de balise contient `<` (ex. un champ texte avec `"age < 18"`)

**Correction** : ajout de `CGI.unescapeHTML` après `strip_tags` dans `normalize_pdf_text` (`show.pdf.prawn`).

## Plan de test

- [ ] Créer une procédure avec un champ texte
- [ ] Dans l'attestation v1, insérer la balise correspondante dans le corps
- [ ] Soumettre un dossier avec une valeur contenant `<` (ex. `"note < 10"`)
- [ ] Accepter le dossier et télécharger l'attestation PDF
- [ ] Vérifier que le PDF affiche `<` et non `&lt;`

PS : résout aussi https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_c0768897-e256-4e08-9071-eff0987ff38c/