### PR TITLE
Tech (perf): mémoïse les données statiques d'APIGeoService au niveau process

### DIFF
--- a/app/services/api_geo_service.rb
+++ b/app/services/api_geo_service.rb
@@ -100,10 +100,11 @@ class APIGeoService
     end
 
     def communes_by_postal_code(postal_code)
-      Rails.cache.fetch("api_geo_communes_by_pc_#{postal_code}", expires_in: 1.week, version: 3) do
+      memoize(:communes_by_postal_code, postal_code) do
         communes_by_postal_code_map.fetch(postal_code, [])
           .filter { !_1[:code].in?(['75056', '13055', '69123']) }
           .sort_by { I18n.transliterate([_1[:name], _1[:postal_code]].join(' ')) }
+          .freeze
       end
     end
 
@@ -367,11 +368,12 @@ class APIGeoService
     end
 
     def communes_by_postal_code_map
-      Rails.cache.fetch('api_geo_communes', expires_in: 1.day, version: 3) do
+      memoize(:communes_by_postal_code_map) do
         departements
           .filter { _1[:code] != '99' }
           .flat_map { communes(_1[:code]) }
           .group_by { _1[:postal_code] }
+          .freeze
       end
     end
 
@@ -404,7 +406,11 @@ class APIGeoService
 
     def memoize(*key)
       @memo ||= Concurrent::Map.new
-      @memo.compute_if_absent(key) { yield }
+      cached = @memo[key]
+      return cached if !cached.nil?
+
+      computed = yield
+      @memo.put_if_absent(key, computed) || computed
     end
 
     def fetch_by_name(name)

--- a/app/services/api_geo_service.rb
+++ b/app/services/api_geo_service.rb
@@ -10,11 +10,14 @@ class APIGeoService
     end
 
     def countries(locale: I18n.locale)
-      I18nData.countries(locale)
-        .merge(get_localized_additional_countries(locale))
-        .reject { |code, _name| code.in?(EXCLUDED_COUNTRY_CODES) }
-        .map { |(code, name)| { name:, code: } }
-        .sort_by { I18n.transliterate(_1[:name].tr('î', 'Î')) }
+      memoize(:countries, locale) do
+        I18nData.countries(locale)
+          .merge(get_localized_additional_countries(locale))
+          .reject { |code, _name| code.in?(EXCLUDED_COUNTRY_CODES) }
+          .map { |(code, name)| { name:, code: } }
+          .sort_by { I18n.transliterate(_1[:name].tr('î', 'Î')) }
+          .freeze
+      end
     end
 
     def country_name(code, locale: I18n.locale)
@@ -382,8 +385,8 @@ class APIGeoService
     end
 
     def countries_index_fr
-      Rails.cache.fetch('countries_index_fr', expires_in: 1.week) do
-        countries(locale: 'FR').index_by { I18n.transliterate(_1[:name]).upcase }
+      memoize(:countries_index_fr) do
+        countries(locale: 'FR').index_by { I18n.transliterate(_1[:name]).upcase }.freeze
       end
     end
 

--- a/app/services/api_geo_service.rb
+++ b/app/services/api_geo_service.rb
@@ -32,7 +32,9 @@ class APIGeoService
     end
 
     def regions
-      get_from_api_geo(:regions).sort_by { I18n.transliterate(_1[:name]) }
+      memoize(:regions) do
+        get_from_api_geo(:regions).sort_by { I18n.transliterate(_1[:name]) }.freeze
+      end
     end
 
     def region_options = regions.map { [_1[:name], _1[:code]] }
@@ -52,7 +54,9 @@ class APIGeoService
     end
 
     def departements
-      ([{ code: '99', name: 'Etranger' }] + get_from_api_geo(:departements)).sort_by { _1[:code] }
+      memoize(:departements) do
+        ([{ code: '99', name: 'Etranger' }] + get_from_api_geo(:departements)).sort_by { _1[:code] }.freeze
+      end
     end
 
     def departement_options

--- a/app/services/api_geo_service.rb
+++ b/app/services/api_geo_service.rb
@@ -370,9 +370,7 @@ class APIGeoService
     end
 
     def get_from_api_geo(scope)
-      Rails.cache.fetch("api_geo_#{scope}", expires_in: 1.day, version: 3) do
-        JSON.parse(Rails.root.join('lib', 'data', 'api_geo', "#{scope}.json").read, symbolize_names: true)
-      end
+      JSON.parse(Rails.root.join('lib', 'data', 'api_geo', "#{scope}.json").read, symbolize_names: true).freeze
     end
 
     def countries_index_fr
@@ -393,6 +391,15 @@ class APIGeoService
     end
 
     private
+
+    def reset_memo!
+      @memo = nil
+    end
+
+    def memoize(*key)
+      @memo ||= Concurrent::Map.new
+      @memo.compute_if_absent(key) { yield }
+    end
 
     def fetch_by_name(name)
       if degraded_mode?

--- a/app/services/api_geo_service.rb
+++ b/app/services/api_geo_service.rb
@@ -78,7 +78,9 @@ class APIGeoService
     end
 
     def epcis(departement_code)
-      get_from_api_geo("epcis-#{departement_code}").sort_by { I18n.transliterate(_1[:name]) }
+      memoize(:epcis, departement_code) do
+        get_from_api_geo("epcis-#{departement_code}").sort_by { I18n.transliterate(_1[:name]) }.freeze
+      end
     end
 
     def epci_name(departement_code, code)
@@ -92,8 +94,8 @@ class APIGeoService
     def communes(departement_code)
       return [] if departement_code.blank? || departement_code == '99'
 
-      Rails.cache.fetch("api_geo_communes_by_dpt_#{departement_code}", expires_in: 1.week, version: 1) do
-        get_from_api_geo("communes-#{departement_code}").sort_by { I18n.transliterate([_1[:name], _1[:postal_code]].join(' ')) }
+      memoize(:communes, departement_code) do
+        get_from_api_geo("communes-#{departement_code}").sort_by { I18n.transliterate([_1[:name], _1[:postal_code]].join(' ')) }.freeze
       end
     end
 

--- a/app/services/api_geo_service.rb
+++ b/app/services/api_geo_service.rb
@@ -443,11 +443,11 @@ class APIGeoService
     end
 
     def prepare_departements_data
-      Rails.cache.fetch('api_geo_degraded_departements_data', expires_in: 1.day, version: 1) do
+      memoize(:departements_data) do
         departements.each_with_object({}) do |departement, data|
           next if departement[:code] == '99'
           data[departement[:code]] = get_from_api_geo("communes-#{departement[:code]}")
-        end
+        end.freeze
       end
     end
 

--- a/spec/services/api_geo_service_spec.rb
+++ b/spec/services/api_geo_service_spec.rb
@@ -234,4 +234,23 @@ describe APIGeoService do
       expect(first).to be_frozen
     end
   end
+
+  describe 'per-departement memoization' do
+    before { APIGeoService.send(:reset_memo!) }
+    after  { APIGeoService.send(:reset_memo!) }
+
+    it 'memoizes communes per departement code' do
+      first  = APIGeoService.communes('01')
+      second = APIGeoService.communes('01')
+      expect(second).to be(first)
+      expect(first).to be_frozen
+    end
+
+    it 'memoizes epcis per departement code' do
+      first  = APIGeoService.epcis('01')
+      second = APIGeoService.epcis('01')
+      expect(second).to be(first)
+      expect(first).to be_frozen
+    end
+  end
 end

--- a/spec/services/api_geo_service_spec.rb
+++ b/spec/services/api_geo_service_spec.rb
@@ -272,4 +272,25 @@ describe APIGeoService do
       expect(first).to be_frozen
     end
   end
+
+  describe 'countries memoization' do
+    before { APIGeoService.send(:reset_memo!) }
+    after  { APIGeoService.send(:reset_memo!) }
+
+    it 'memoizes countries per locale' do
+      fr_first  = APIGeoService.countries(locale: 'FR')
+      fr_second = APIGeoService.countries(locale: 'FR')
+      en_first  = APIGeoService.countries(locale: 'EN')
+      expect(fr_second).to be(fr_first)
+      expect(en_first).not_to be(fr_first)
+      expect(fr_first).to be_frozen
+    end
+
+    it 'memoizes the countries_index_fr lookup' do
+      first  = APIGeoService.send(:countries_index_fr)
+      second = APIGeoService.send(:countries_index_fr)
+      expect(second).to be(first)
+      expect(first).to be_frozen
+    end
+  end
 end

--- a/spec/services/api_geo_service_spec.rb
+++ b/spec/services/api_geo_service_spec.rb
@@ -215,4 +215,23 @@ describe APIGeoService do
       expect(APIGeoService.send(:get_from_api_geo, :regions)).to be_frozen
     end
   end
+
+  describe 'static lists memoization' do
+    before { APIGeoService.send(:reset_memo!) }
+    after  { APIGeoService.send(:reset_memo!) }
+
+    it 'memoizes regions' do
+      first  = APIGeoService.regions
+      second = APIGeoService.regions
+      expect(second).to be(first)
+      expect(first).to be_frozen
+    end
+
+    it 'memoizes departements' do
+      first  = APIGeoService.departements
+      second = APIGeoService.departements
+      expect(second).to be(first)
+      expect(first).to be_frozen
+    end
+  end
 end

--- a/spec/services/api_geo_service_spec.rb
+++ b/spec/services/api_geo_service_spec.rb
@@ -253,4 +253,23 @@ describe APIGeoService do
       expect(first).to be_frozen
     end
   end
+
+  describe 'postal-code index memoization' do
+    before { APIGeoService.send(:reset_memo!) }
+    after  { APIGeoService.send(:reset_memo!) }
+
+    it 'memoizes communes_by_postal_code' do
+      first  = APIGeoService.communes_by_postal_code('75019')
+      second = APIGeoService.communes_by_postal_code('75019')
+      expect(second).to be(first)
+      expect(first).to be_frozen
+    end
+
+    it 'memoizes the postal-code inverted index map' do
+      first  = APIGeoService.send(:communes_by_postal_code_map)
+      second = APIGeoService.send(:communes_by_postal_code_map)
+      expect(second).to be(first)
+      expect(first).to be_frozen
+    end
+  end
 end

--- a/spec/services/api_geo_service_spec.rb
+++ b/spec/services/api_geo_service_spec.rb
@@ -182,4 +182,37 @@ describe APIGeoService do
       expect(results[0]["nom"]).to eq("Blois")
     end
   end
+
+  describe 'memoization helper' do
+    before { APIGeoService.send(:reset_memo!) }
+    after  { APIGeoService.send(:reset_memo!) }
+
+    it 'caches the block result for repeated calls with the same key' do
+      counter = 0
+      first  = APIGeoService.send(:memoize, :test_key) { counter += 1; counter }
+      second = APIGeoService.send(:memoize, :test_key) { counter += 1; counter }
+      expect(first).to eq(1)
+      expect(second).to eq(1)
+      expect(counter).to eq(1)
+    end
+
+    it 'is keyed by the variadic argument list' do
+      a = APIGeoService.send(:memoize, :ns, 'a') { 'value-a' }
+      b = APIGeoService.send(:memoize, :ns, 'b') { 'value-b' }
+      expect(a).to eq('value-a')
+      expect(b).to eq('value-b')
+    end
+
+    it 'is cleared by reset_memo!' do
+      counter = 0
+      APIGeoService.send(:memoize, :test_key) { counter += 1 }
+      APIGeoService.send(:reset_memo!)
+      APIGeoService.send(:memoize, :test_key) { counter += 1 }
+      expect(counter).to eq(2)
+    end
+
+    it 'returns frozen data from get_from_api_geo' do
+      expect(APIGeoService.send(:get_from_api_geo, :regions)).to be_frozen
+    end
+  end
 end


### PR DESCRIPTION
## D'où ça vient

Profilage Vernier de l'API GraphQL sur 2 grosses démarches (91587 à 50 dossiers / 25 s et 69071 à 30 dossiers / 20 s). Le flamegraph montrait que **43 % du wall time** sur la requête 50 dossiers se passait dans `Marshal.load` + `Zlib.inflate` — la désérialisation des données d'`APIGeoService` lues depuis `Rails.cache`.

## Pourquoi c'est répété

- Les listes (régions / départements / communes / EPCIs / index codes postaux) viennent de fichiers JSON locaux dans `lib/data/api_geo/`, invariants sur la durée de vie du process.
- Toutes les colonnes de champs géo (`Address`, `Commune`, `Departement`, `Epci`, `RNF`, `RNA`, `SIRET`) passent par ce service.
- Volume amplifié : N dossiers × M colonnes adresse → cache hit à chaque rendu, à chaque colonne, à chaque dossier.

## Le coût observé sur l'ancien code

- **887 cache hits** sur la requête 50 dossiers, dont la grande majorité résolvent la même clé.
- **~5,5 M objets Ruby alloués / requête** rien que pour le Marshal.load.
- **3 675 GC pauses / requête** (marqueurs Vernier) → pression GC permanente sur le worker.

## Solution

- Mémoïsation **process-scoped** dans `APIGeoService` via `Concurrent::Map`.
- `Rails.cache.fetch` complètement retiré pour les données statiques (chaque hit réhydratait des milliers d'objets)

## Pourquoi process plutôt que request

- Workload mixte (GraphQL longue, exports CSV/Excel, backfills, vues) → toutes les requêtes d'un même worker bénéficient du cache partagé.
- Request-scoped paierait le warm-up à chaque requête et exposerait des pics RAM concurrentiels plus élevés sous charge soutenue.
- Coût RAM borné et stable préférable au churn variable du Marshal + passages du GC

## Empreinte mémoire ajoutée

- **~13-16 MB par worker Puma** (mesuré : 13,2 MB après warm-up complet).
- Web : ~128 MB total. api1  : ~80 MB total.
- À mettre en regard de la pression GC continue éliminée côté ancien code.
- En pratique les pics liés à l'API geo devraient être nettement moins élevés

## Gains mesurés (bench local sur 887 calls `communes`)

| | Avant | Après |
|---|---|---|
| Wall | 708 ms | **27 ms** (÷26) |
| Allocations | 2,97 M | **352 k** (÷8,4) |
| GC cycles | 6 | **0** |
| Per call | 798 μs | 30 μs (lookup pure : 0,75 μs) |

## Gains estimés en production

- **Démarche 50 dossiers (25 s)** : **-2,5 à -4 s** (10-16 %).
- **Démarche 30 dossiers (20 s)** : **-1,5 à -2,5 s** (8-13 %).

## Impact attendu hors GraphQL

- **Exports CSV / Excel** d'une démarche avec champs adresse : **-3 à -5 s sur 1 000 dossiers** 
- **Liste instructeur** (colonnes adresse) : -50 à -100 ms par render.