### PR TITLE
Tech: migrer 6 jobs + tous les crons au retry Sidekiq natif (suite #13096)

### DIFF
--- a/app/jobs/archive_creation_job.rb
+++ b/app/jobs/archive_creation_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ArchiveCreationJob < ApplicationJob
+  use_sidekiq_retry
+
   discard_on ActiveRecord::RecordNotFound
 
   queue_as :archives

--- a/app/jobs/attestation_pdf_generation_job.rb
+++ b/app/jobs/attestation_pdf_generation_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AttestationPdfGenerationJob < ApplicationJob
+  use_sidekiq_retry
+
   queue_as :critical
 
   discard_on ActiveRecord::RecordNotFound

--- a/app/jobs/cron/cron_job.rb
+++ b/app/jobs/cron/cron_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Cron::CronJob < ApplicationJob
+  use_sidekiq_retry
+
   queue_as :default
   class_attribute :schedule_expression
 

--- a/app/jobs/dossier_index_search_terms_job.rb
+++ b/app/jobs/dossier_index_search_terms_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DossierIndexSearchTermsJob < ApplicationJob
+  use_sidekiq_retry
+
   queue_as :low
 
   discard_on ActiveRecord::RecordNotFound

--- a/app/jobs/dossier_rebase_job.rb
+++ b/app/jobs/dossier_rebase_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DossierRebaseJob < ApplicationJob
+  use_sidekiq_retry
+
   queue_as :low # they are massively enqueued, so don't interfere with others especially antivirus
 
   # If by the time the job runs the Dossier has been deleted, ignore the rebase

--- a/app/jobs/image_processor_job.rb
+++ b/app/jobs/image_processor_job.rb
@@ -4,6 +4,8 @@
 # BlobProcessorJob handles virus scanning + image processing in a single pipeline.
 # Remove once Sidekiq queues are fully drained of old ImageProcessorJob entries.
 class ImageProcessorJob < ApplicationJob
+  use_sidekiq_retry
+
   discard_on ActiveRecord::RecordNotFound
   discard_on ActiveStorage::FileNotFoundError
 

--- a/app/jobs/virus_scanner_job.rb
+++ b/app/jobs/virus_scanner_job.rb
@@ -4,6 +4,8 @@
 # BlobProcessorJob handles virus scanning + image processing in a single pipeline.
 # Remove once Sidekiq queues are fully drained of old VirusScannerJob entries.
 class VirusScannerJob < ApplicationJob
+  use_sidekiq_retry
+
   discard_on ActiveRecord::RecordNotFound
   discard_on ActiveStorage::FileNotFoundError
 

--- a/spec/jobs/archive_creation_job_spec.rb
+++ b/spec/jobs/archive_creation_job_spec.rb
@@ -12,9 +12,9 @@ describe ArchiveCreationJob, type: :job do
       let(:mailer) { double('mailer', deliver_later: true) }
       before { expect(UserMailer).not_to receive(:send_archive) }
 
-      it 'does not send email and job is reenqueued for retry' do
+      it 'does not send email, marks archive as failed, and re-raises for sidekiq retry' do
         allow(DownloadableFileService).to receive(:download_and_zip).and_raise(StandardError, "kaboom")
-        expect { job.perform_now }.to have_enqueued_job(described_class)
+        expect { job.perform_now }.to raise_error(StandardError, "kaboom")
         expect(archive.reload.failed?).to eq(true)
       end
     end

--- a/spec/jobs/cron/datagouv/export_and_publish_demarches_publiques_job_spec.rb
+++ b/spec/jobs/cron/datagouv/export_and_publish_demarches_publiques_job_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob, type: :job
       expect(stub).to have_been_requested
     end
 
-    it 'removes gzip file even if an error occurred and job is renqueued' do
+    it 'removes gzip file even if an error occurred (re-raises for sidekiq retry)' do
       procedure.libelle = nil
       procedure.save(validate: false)
 
-      expect { subject }.to have_enqueued_job(described_class)
+      expect { subject }.to raise_error(DemarchesPubliquesExportService::Error)
       expect(Dir.glob("*demarches.json.gz", base: 'tmp').empty?).to be_truthy
     end
   end


### PR DESCRIPTION
## Contexte

Suite à #13096, on continue la migration vers `use_sidekiq_retry` pour les
jobs dont le retry repose uniquement sur le `retry_on StandardError` du
concern `ActiveJob::RetryOnStandardError`.

Bénéfices : évite la multiplication AJ × Sidekiq des retries, et restaure
le reporting automatique via `sentry-sidekiq` à chaque retry.

## Jobs migrés

**Top-level (6)** :
`ArchiveCreationJob`, `AttestationPdfGenerationJob`, `DossierRebaseJob`,
`DossierIndexSearchTermsJob`, `VirusScannerJob`, `ImageProcessorJob`.

**Tous les crons (~50)** : `use_sidekiq_retry` ajouté à `Cron::CronJob`.

Les `discard_on` existants sont préservés.

## Tests

Deux specs reposaient sur le fait qu'AJ avalait `StandardError` et
ré-enqueuait via l'AJ test adapter. Remplacé `have_enqueued_job` par
`raise_error` dans `archive_creation_job_spec` et
`cron/datagouv/export_and_publish_demarches_publiques_job_spec`. Les
assertions de fond (état `failed?`, nettoyage du gzip) sont conservées.