### PR TITLE
Tech: ajoute des informations dans les logs sentry des erreurs FranceConnect

### DIFF
--- a/app/services/france_connect_service.rb
+++ b/app/services/france_connect_service.rb
@@ -62,6 +62,9 @@ class FranceConnectService
     user_info = access_token.userinfo!.raw_attributes
 
     [user_info, access_token.id_token]
+  rescue OpenIDConnect::HttpError => e
+    Sentry.set_extras(france_connect_status: e.status, france_connect_body: e.response.body)
+    raise
   end
 
   # rubocop:disable DS/ApplicationName


### PR DESCRIPTION
le code correspondant dans openid_connect : 

```
  class HttpError < Exception
    attr_accessor :status, :response
    def initialize(status, message = nil, response = nil)
      super message
      @status = status
      @response = response
    end
  end

  class BadRequest < HttpError
    def initialize(message = nil, response = nil)
      super 400, message, response
    end
  end

```