### PR TITLE
Fix: utilise champ_for_update et non project_champ dans Dossier#enqueue_fetch_external_data_jobs

### DIFF
--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -25,7 +25,7 @@ class Champs::ReferentielChamp < Champ
       update!(hash.merge(fetch_external_data_exceptions: [])) # void previous errors
       propagate_prefill(hash[:data])
     end
-    dossier.with_champ_stream(self).enqueue_fetch_external_data_jobs
+    dossier.with_champ_stream(self).enqueue_fetch_external_data_jobs(self.updated_by)
   end
 
   def data=(data)
@@ -41,7 +41,7 @@ class Champs::ReferentielChamp < Champ
       self.value_json = cast_displayable_values(data)
       propagate_prefill(data)
 
-      dossier.with_champ_stream(self).enqueue_fetch_external_data_jobs
+      dossier.with_champ_stream(self).enqueue_fetch_external_data_jobs(self.updated_by)
     end
   end
 

--- a/app/models/concerns/dossier_prefillable_concern.rb
+++ b/app/models/concerns/dossier_prefillable_concern.rb
@@ -12,6 +12,6 @@ module DossierPrefillableConcern
     reload
     assign_attributes(attributes)
     save(validate: false)
-    with_update_stream(user).enqueue_fetch_external_data_jobs
+    with_update_stream(user).enqueue_fetch_external_data_jobs(user&.email)
   end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1177,8 +1177,14 @@ class Dossier < ApplicationRecord
     submitted_revision_id.present? && submitted_revision_id != revision_id
   end
 
-  def enqueue_fetch_external_data_jobs
-    project_champs.each do |champ|
+  def enqueue_fetch_external_data_jobs(user_email)
+    champs_on_main_stream.each do |main_stream_champ|
+      champ = if main_stream_champ.public?
+        champ_for_update(main_stream_champ.type_de_champ, row_id: main_stream_champ.row_id, updated_by: user_email)
+      else
+        main_stream_champ
+      end
+
       if champ.has_async_external_data? && champ.may_fetch_later?
         champ.fetch_later!
       end


### PR DESCRIPTION
à discuter :
- retrouver le row_id ;
- si champ référentiel privé, remplie à partir d'un champ public, on a champ_for_update qui tente une insertion du champ privé sur user_buffer