### PR TITLE
ETQ instructeur, je n'ai accès qu'aux archives que j'ai créées

### DIFF
--- a/app/controllers/instructeurs/archives_controller.rb
+++ b/app/controllers/instructeurs/archives_controller.rb
@@ -11,7 +11,7 @@ module Instructeurs
     def index
       @average_dossier_weight = @procedure.average_dossier_weight
       @count_dossiers_termines_by_month = @procedure.dossiers.processed_by_month(groupe_instructeurs).count
-      @archives = Archive.for_groupe_instructeur(groupe_instructeurs).to_a
+      @archives = Archive.for_groupe_instructeur(groupe_instructeurs).where(user_profile: current_instructeur).to_a
     end
 
     def create

--- a/spec/controllers/instructeurs/archives_controller_spec.rb
+++ b/spec/controllers/instructeurs/archives_controller_spec.rb
@@ -4,7 +4,7 @@ describe Instructeurs::ArchivesController, type: :controller do
   let(:procedure1) { create(:procedure, :published, groupe_instructeurs: [assign_to.groupe_instructeur]) }
   let(:procedure2) { create(:procedure, :published, groupe_instructeurs: [gi2]) }
   let!(:instructeur) { create(:instructeur, groupe_instructeurs: [gi2]) }
-  let!(:archive1) { create(:archive, :generated, groupe_instructeurs: [assign_to.groupe_instructeur]) }
+  let!(:archive1) { create(:archive, :generated, groupe_instructeurs: [assign_to.groupe_instructeur], user_profile: instructeur) }
   let!(:archive2) { create(:archive, :generated, groupe_instructeurs: [gi2]) }
   let!(:assign_to) { create(:assign_to, instructeur: instructeur, groupe_instructeur: build(:groupe_instructeur), manager: manager) }
   let(:gi2) { create(:groupe_instructeur) }
@@ -29,6 +29,16 @@ describe Instructeurs::ArchivesController, type: :controller do
       it 'assigns archives' do
         subject
         expect(assigns(:archives)).to eq([archive1])
+      end
+
+      context "IDOR: archive créée par un autre instructeur du même groupe" do
+        let(:other_instructeur) { create(:instructeur, groupe_instructeurs: [assign_to.groupe_instructeur]) }
+        let!(:archive_from_other) { create(:archive, :generated, groupe_instructeurs: [assign_to.groupe_instructeur], user_profile: other_instructeur) }
+
+        it "n'expose pas l'archive de l'autre instructeur" do
+          subject
+          expect(assigns(:archives)).not_to include(archive_from_other)
+        end
       end
     end
 


### PR DESCRIPTION
## Résumé

- La liste des archives dans le controller instructeur est désormais filtrée par `user_profile: current_instructeur`
- Un instructeur ne voit que les archives qu'il a lui-même demandées, même s'il partage un groupe avec d'autres instructeurs