### PR TITLE
i18n(address_component): extract hardcoded strings from AddressComponent

### DIFF
--- a/app/components/dossiers/address_component.rb
+++ b/app/components/dossiers/address_component.rb
@@ -42,6 +42,6 @@ class Dossiers::AddressComponent < ApplicationComponent
   end
 
   def source
-    tag.acronym(title: 'Base Adresse Nationale') { 'BAN' } if champ.ban?
+    tag.acronym(title: t('.ban_title')) { 'BAN' } if champ.ban?
   end
 end

--- a/app/components/dossiers/address_component/address_component.en.yml
+++ b/app/components/dossiers/address_component/address_component.en.yml
@@ -3,3 +3,4 @@ en:
   insee_code: INSEE Code
   department: Department
   country: Country
+  ban_title: National Address Database

--- a/app/components/dossiers/address_component/address_component.fr.yml
+++ b/app/components/dossiers/address_component/address_component.fr.yml
@@ -3,3 +3,4 @@ fr:
   insee_code: Code INSEE
   department: Département
   country: Pays
+  ban_title: Base Adresse Nationale


### PR DESCRIPTION
## Probleme

Texte francais en dur dans `app/components/dossiers/address_component.rb` — non internationalisable, non maintenable.

## Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 1 cle i18n vers `app/components/dossiers/address_component/address_component.fr.yml`.

### Cles extraites

| Cle | Valeur |
|-----|--------|
| `.ban_title` | "Base Adresse Nationale" |

### Validation visuelle

- :next_track_button: Screenshots non captures — serveur de dev non disponible dans le worktree (Redis absent)
- Le changement est purement cosmétique (titre d'attribut `<acronym>`) — aucun impact visuel attendu

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante
- [x] Apostrophes typographiques verifiees
- [ ] Tests non executables (Redis non disponible dans le worktree)
- [x] Rubocop OK

:robot: Generated with [Claude Code](https://claude.com/claude-code)
