### PR TITLE
chore(tech): debloque la MT T20260427backfillVirusScanBlobsTask

### DIFF
--- a/app/tasks/maintenance/t20260427backfill_virus_scan_blobs_task.rb
+++ b/app/tasks/maintenance/t20260427backfill_virus_scan_blobs_task.rb
@@ -34,8 +34,11 @@ module Maintenance
 
       scope.find_each do |blob|
         next if blob.metadata["processed"]
-
-        BlobProcessorJob.perform_later(blob)
+        begin
+          BlobProcessorJob.perform_later(blob)
+        rescue RuntimeError
+          # Type De Champ 2945644 not found in Revision 263352
+        end
       end
     end
   end


### PR DESCRIPTION
# probleme

on a une inconsistance au niveau de la donnée, un champ ne trouve pas son tdc, certainement une histoire de rebase. mais je suis pas arrivé a la conclusion

```
RuntimeError

Type De Champ 2945644 not found in Revision 263352
app/models/champ.rb:27:in 'block in Champ#type_de_champ'
app/models/champ.rb:27:in 'Enumerable#find'
app/models/champ.rb:27:in 'Champ#type_de_champ'
app/models/champ.rb:34:in 'Champ#rib?'
app/models/champ.rb:342:in 'Champ#ocr_compatible?'
app/jobs/blob_processor_job.rb:153:in 'BlobProcessorJob#ocr_compatible?'
app/jobs/blob_processor_job.rb:10:in 'block in <class:BlobProcessorJob>'
app/tasks/maintenance/t20260427backfill_virus_scan_blobs_task.rb:38:in 'block in Maintenance::T20260427backfillVirusScanBlobsTask#process'
app/tasks/maintenance/t20260427backfill_virus_scan_blobs_task.rb:35:in 'Maintenance::T20260427backfillVirusScanBlobsTask#process'
```

# solution

on avale l'erreur silencieusement via un rescue

# TODO 

- [ ] reprendre Maintenance::T20260427backfillVirusScanBlobsTask