### PR TITLE
ETQ instructeur, corrige l'ordre d'ajout des colonnes du tableau de bord

### DIFF
--- a/app/javascript/components/Select.tsx
+++ b/app/javascript/components/Select.tsx
@@ -163,6 +163,7 @@ export function MultipleSelect(maybeProps: SelectProps<'multiple'>) {
   const {
     value: initialValue,
     className,
+    name,
     ...props
   } = useMemo(() => s.create(maybeProps, MultipleSelectProps), [maybeProps]);
   const [value, setValue] = useState<string[]>(() => initialValue);
@@ -181,6 +182,11 @@ export function MultipleSelect(maybeProps: SelectProps<'multiple'>) {
     dispatchChange();
   };
 
+  // `name` is destructured out above so the `{...props}` spread no longer carries
+  // it into <Select>. Otherwise react-aria's hidden <select multiple> picks up the
+  // name and the browser submits its selected options in DOM (collection) order —
+  // losing the user's selection order. The explicit hidden inputs below carry the
+  // form value in selection order instead.
   return (
     <>
       <Select
@@ -190,12 +196,19 @@ export function MultipleSelect(maybeProps: SelectProps<'multiple'>) {
         onChange={onChange}
         {...props}
       />
-      <input
-        ref={changeDispatchRef}
-        type="hidden"
-        name={value.length > 0 ? undefined : props.name}
-        value=""
-      />
+      {value.length === 0 ? (
+        <input ref={changeDispatchRef} type="hidden" name={name} value="" />
+      ) : (
+        value.map((v, i) => (
+          <input
+            key={v}
+            ref={i === 0 ? changeDispatchRef : undefined}
+            type="hidden"
+            name={name}
+            value={v}
+          />
+        ))
+      )}
     </>
   );
 }

--- a/spec/system/instructeurs/procedure_filters_spec.rb
+++ b/spec/system/instructeurs/procedure_filters_spec.rb
@@ -62,6 +62,14 @@ describe "procedure filters" do
       expect(page).to have_link(champ.value)
     end
 
+    # Add a column whose natural position in `procedure.columns` precedes both
+    # Demandeur and the custom type_de_champ. Columns must follow the order the
+    # instructeur picked them, not the underlying collection order.
+    add_column("Date de création")
+    within ".dossiers-table thead" do
+      expect(page).to have_content(/Demandeur.*#{Regexp.escape(type_de_champ.libelle)}.*Date de création/)
+    end
+
     remove_column(type_de_champ.libelle)
     within ".dossiers-table" do
       expect(page).not_to have_button(type_de_champ.libelle)


### PR DESCRIPTION
## Problème

Depuis le passage de `ComboBox/MultiComboBox` à `Select/MultipleSelect` pour la personnalisation des colonnes du tableau de bord instructeur, l'ordre dans lequel l'instructeur ajoute des colonnes n'est plus respecté : les colonnes apparaissent dans l'ordre du dropdown, pas dans l'ordre de sélection.

## Cause

`MultipleSelect` s'appuie sur `react-aria`'s `HiddenSelect`, qui rend un `<select multiple>` caché dont les `<option>` sont dans l'ordre de la collection. Lors de la soumission, le navigateur sérialise les options sélectionnées en **ordre DOM**, perdant l'ordre de sélection, quand il y a moins de 300 options.

## Correctif

On ne forwarde plus `name` à `<Select>` (le `<select multiple>` caché reste rendu pour l'a11y mais sans `name`, donc inerte côté formulaire), et on rend nous-mêmes des `<input type="hidden">` en parcourant `value` (qui est bien dans l'ordre de sélection, via le `Set` de react-aria). C'est exactement le pattern qu'utilisait déjà `MultiComboBox`. C'est ce que fait react-aria au de là de 300 options.


https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_dd81b0d0-3b00-4e2c-84a0-e3e3c8612a24/