### PR TITLE
ETQ usager, répare l'affichage des couches d'aires protégées sur les champs carte

### DIFF
--- a/app/javascript/components/shared/maplibre/styles/base.ts
+++ b/app/javascript/components/shared/maplibre/styles/base.ts
@@ -22,20 +22,16 @@ const OPTIONAL_LAYERS: { label: string; id: string; layers: string[][] }[] = [
     label: 'UNESCO',
     id: 'unesco',
     layers: [
-      ['Aires protégées Géoparcs', 'PROTECTEDAREAS.GP', 'normal'],
-      ['Réserves de biosphère', 'PROTECTEDAREAS.BIOS', 'PROTECTEDAREAS.BIOS']
+      ['Aires protégées Géoparcs', 'Patrinat_GEOPARC', 'normal'],
+      ['Réserves de biosphère', 'Patrinat_BIOS', 'normal']
     ]
   },
   {
     label: 'Arrêtés de protection',
     id: 'arretes_protection',
     layers: [
-      [
-        'Arrêtés de protection de biotope',
-        'PROTECTEDAREAS.APB',
-        'PROTECTEDAREAS.APB'
-      ],
-      ['Arrêtés de protection de géotope', 'PROTECTEDAREAS.APG', 'normal']
+      ['Arrêtés de protection de biotope', 'Patrinat_APB', 'normal'],
+      ['Arrêtés de protection de géotope', 'Patrinat_APG', 'normal']
     ]
   },
   {
@@ -44,12 +40,12 @@ const OPTIONAL_LAYERS: { label: string; id: string; layers: string[][] }[] = [
     layers: [
       [
         'Conservatoire du littoral : parcelles protégées',
-        'PROTECTEDAREAS.MNHN.CDL.PARCELS',
-        'PROTECTEDAREAS.MNHN.CDL.PARCELS'
+        'CONSERVATOIRE_LITTORAL.PARCELLES',
+        'normal'
       ],
       [
         'Conservatoire du littoral : périmètres d’intervention',
-        'PROTECTEDAREAS.MNHN.CDL.PERIMETER',
+        'CONSERVATOIRE_LITTORAL.PERIMETRES',
         'normal'
       ]
     ]
@@ -60,7 +56,7 @@ const OPTIONAL_LAYERS: { label: string; id: string; layers: string[][] }[] = [
     layers: [
       [
         'Réserves nationales de chasse et de faune sauvage',
-        'PROTECTEDAREAS.RNCF',
+        'Patrinat_RNCFS',
         'normal'
       ]
     ]
@@ -68,59 +64,35 @@ const OPTIONAL_LAYERS: { label: string; id: string; layers: string[][] }[] = [
   {
     label: 'Réserves biologiques',
     id: 'reserves_biologiques',
-    layers: [['Réserves biologiques', 'PROTECTEDAREAS.RB', 'normal']]
+    layers: [['Réserves biologiques', 'Patrinat_RB', 'normal']]
   },
   {
     label: 'Réserves naturelles',
     id: 'reserves_naturelles',
     layers: [
-      [
-        'Réserves naturelles nationales',
-        'PROTECTEDAREAS.RN',
-        'PROTECTEDAREAS.RN'
-      ],
+      ['Réserves naturelles nationales', 'Patrinat_RNN', 'normal'],
       [
         'Périmètres de protection de réserves naturelles',
-        'PROTECTEDAREAS.MNHN.RN.PERIMETER',
+        'Patrinat_PPRNN',
         'normal'
       ],
-      [
-        'Réserves naturelles de Corse',
-        'PROTECTEDAREAS.RNC',
-        'PROTECTEDAREAS.RNC'
-      ],
-      [
-        'Réserves naturelles régionales',
-        'PROTECTEDSITES.MNHN.RESERVES-REGIONALES',
-        'PROTECTEDSITES.MNHN.RESERVES-REGIONALES'
-      ]
+      ['Réserves naturelles de Corse', 'Patrinat_RNC', 'normal'],
+      ['Réserves naturelles régionales', 'Patrinat_RNR', 'normal']
     ]
   },
   {
     label: 'Natura 2000',
     id: 'natura_2000',
     layers: [
-      [
-        'Sites Natura 2000 (Directive Habitats)',
-        'PROTECTEDAREAS.SIC',
-        'PROTECTEDAREAS.SIC'
-      ],
-      [
-        'Sites Natura 2000 (Directive Oiseaux)',
-        'PROTECTEDAREAS.ZPS',
-        'PROTECTEDAREAS.ZPS'
-      ]
+      ['Sites Natura 2000 (Directive Habitats)', 'Patrinat_SIC', 'normal'],
+      ['Sites Natura 2000 (Directive Oiseaux)', 'Patrinat_ZPS', 'normal']
     ]
   },
   {
     label: 'Zones humides d’importance internationale',
     id: 'zones_humides',
     layers: [
-      [
-        'Zones humides d’importance internationale',
-        'PROTECTEDAREAS.RAMSAR',
-        'PROTECTEDAREAS.RAMSAR'
-      ]
+      ['Zones humides d’importance internationale', 'Patrinat_RAMSAR', 'normal']
     ]
   },
   {
@@ -129,23 +101,23 @@ const OPTIONAL_LAYERS: { label: string; id: string; layers: string[][] }[] = [
     layers: [
       [
         'Zones naturelles d’intérêt écologique faunistique et floristique de type 1 (ZNIEFF 1 mer)',
-        'PROTECTEDAREAS.ZNIEFF1.SEA',
+        'Patrinat_ZNIEFF1_MER',
         'normal'
       ],
       [
         'Zones naturelles d’intérêt écologique faunistique et floristique de type 1 (ZNIEFF 1)',
-        'PROTECTEDAREAS.ZNIEFF1',
-        'PROTECTEDAREAS.ZNIEFF1'
+        'Patrinat_ZNIEFF1',
+        'normal'
       ],
       [
         'Zones naturelles d’intérêt écologique faunistique et floristique de type 2 (ZNIEFF 2 mer)',
-        'PROTECTEDAREAS.ZNIEFF2.SEA',
+        'Patrinat_ZNIEFF2_MER',
         'normal'
       ],
       [
         'Zones naturelles d’intérêt écologique faunistique et floristique de type 2 (ZNIEFF 2)',
-        'PROTECTEDAREAS.ZNIEFF2',
-        'PROTECTEDAREAS.ZNIEFF2'
+        'Patrinat_ZNIEFF2',
+        'normal'
       ]
     ]
   },


### PR DESCRIPTION
## Contexte

Sur le champ carte, toutes les couches d'aires protégées renvoyaient une erreur HTTP 400 du WMTS de la Géoplateforme. Les couches affectées sont :

- Aires protégées Géoparcs et Réserves de biosphère (UNESCO)
- Arrêtés de protection (biotope, géotope)
- Conservatoire du Littoral (parcelles, périmètres)
- Réserves nationales de chasse et de faune sauvage
- Réserves biologiques
- Réserves naturelles (nationales, périmètres de protection, Corse, régionales)
- Sites Natura 2000 (Directive Habitats et Directive Oiseaux)
- Zones humides d'importance internationale (Ramsar)
- ZNIEFF 1 et 2 (terre et mer)

Exemple d'erreur :

```
Layer PROTECTEDAREAS.SIC unknown
```

https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_5ccd492e-9ec0-4ac2-b556-f491e6c34318/

## Cause

L'IGN/Géoplateforme a renommé toute la famille `PROTECTEDAREAS.*` et `PROTECTEDSITES.MNHN.*` sous le namespace `Patrinat_*` (du nom du nouveau diffuseur des données, [PatriNat](https://www.patrinat.fr), unité d'expertise du MNHN). Le Conservatoire du Littoral a son propre préfixe `CONSERVATOIRE_LITTORAL.*`. Les anciens styles (ex. `style=PROTECTEDAREAS.SIC`) n'existent plus non plus, tous les nouveaux layers utilisent `style=normal`.

Vérification reproductible via le GetCapabilities WMTS :

```sh
curl -s 'https://data.geopf.fr/wmts?service=WMTS&request=GetCapabilities' \
  | grep -oE '<ows:Identifier>(PROTECTEDAREAS|Patrinat_)[^<]*' | sort -u
```

Plus aucun \`PROTECTEDAREAS.*\` (sauf \`PROTECTEDAREAS.PRSF\` qu'on n'utilise pas).

## Correctif

Renommage des codes WMTS dans \`app/javascript/components/shared/maplibre/styles/base.ts\` selon la nouvelle nomenclature. Les ids de groupe (\`natura_2000\`, \`znieff\`, …), les labels UI et le \`tilematrixset=PM\` restent inchangés (les nouveaux layers sont compatibles \`PM\`).

## Après
<img width="1299" height="5367" alt="carte-fix-after" src="https://github.com/user-attachments/assets/d573f7e7-bc49-40da-9086-b47e565c0419" />
<img width="1240" height="523" alt="Capture d’écran 2026-05-11 à 12 17 44" src="https://github.com/user-attachments/assets/d687b7d3-f6be-426d-93d8-29fd1ff4bb5b" />

## Avant : le néant
<img width="1240" height="523" alt="Capture d’écran 2026-05-11 à 12 21 16" src="https://github.com/user-attachments/assets/62124e52-3b52-45d1-a391-e1a37781425c" />
