### PR TITLE
ETQ Usager/Instructeur: possibilité de soumettre/voir un choix autre d'une liste déroulante sans en spécifier la valeur 

### DIFF
--- a/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
+++ b/app/components/editable_champ/drop_down_list_component/drop_down_list_component.html.haml
@@ -2,7 +2,12 @@
   .fr-fieldset__content
     - items.each do |value, option_id|
       .fr-radio-group
-        = @form.radio_button :value, option_id, id: @champ.radio_id(option_id), translate: 'no', aria: labelledby_id_attr(input_label_id(@champ, option_id))
+        = @form.radio_button :value,
+          option_id,
+          checked: @champ.selected == option_id,
+          id: @champ.radio_id(option_id),
+          translate: 'no',
+          aria: labelledby_id_attr(input_label_id(@champ, option_id))
         %label.fr-label{ for: @champ.radio_id(option_id), id: input_label_id(@champ, option_id) }
           = value
 

--- a/app/models/columns/champ_column.rb
+++ b/app/models/columns/champ_column.rb
@@ -105,7 +105,11 @@ class Columns::ChampColumn < Column
 
   def column_id = "type_de_champ/#{stable_id}"
 
-  def string_value(champ) = champ.public_send(column)
+  def string_value(champ)
+    return drop_down_other_value(champ) if drop_down_other_filled?(champ)
+
+    champ.public_send(column)
+  end
 
   def typed_value(champ)
     value = string_value(champ)
@@ -225,6 +229,15 @@ class Columns::ChampColumn < Column
     [:multiple_drop_down_list, :textarea] => -> (v) { v.join("\n") },
     [:multiple_drop_down_list, :formatted] => -> (v) { v.join(', ') },
   }
+
+  def drop_down_other_filled?(champ)
+    champ.is_a?(Champs::DropDownListChamp) && champ.other == true
+  end
+
+  def drop_down_other_value(champ)
+    other_label = I18n.t('shared.champs.drop_down_list.other_short')
+    champ.value.present? ? "#{other_label} : #{champ.value}" : other_label
+  end
 
   def parse_boolean(value)
     case value

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::DropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBase
+  def champ_blank?(champ)
+    !champ.other? && champ.value.blank?
+  end
+
   def champ_value(champ)
     if drop_down_advanced? && champ.respond_to?(:referentiel) && champ.referentiel.present?
       path = champ.referentiel_headers&.first&.second

--- a/app/views/shared/champs/drop_down_list/_show.html.haml
+++ b/app/views/shared/champs/drop_down_list/_show.html.haml
@@ -17,4 +17,8 @@
       %span{ data: { copy_message_placeholder: true } }
 
   - else
-    %p= champ.value
+    - if champ.other?
+      - other_label = I18n.t('shared.champs.drop_down_list.other_short')
+      %p= champ.value.present? ? "#{other_label} : #{champ.value}" : other_label
+    - else
+      %p= champ.value

--- a/config/locales/shared.en.yml
+++ b/config/locales/shared.en.yml
@@ -46,3 +46,4 @@ en:
       drop_down_list:
         other: Enter another option
         other_label: Enter your option
+        other_short: other

--- a/config/locales/shared.fr.yml
+++ b/config/locales/shared.fr.yml
@@ -55,3 +55,4 @@ fr:
       drop_down_list:
         other: Entrer une autre option
         other_label: Saisir votre option
+        other_short: autre

--- a/spec/models/columns/champ_column_spec.rb
+++ b/spec/models/columns/champ_column_spec.rb
@@ -145,6 +145,35 @@ describe Columns::ChampColumn do
         end
       end
 
+      context "with a drop_down_list with 'other' option enabled" do
+        let(:other_procedure) do
+          create(:procedure, types_de_champ_public: [
+            { type: :drop_down_list, libelle: 'drop_down_list', drop_down_other: true },
+          ])
+        end
+        let(:column_drop_down) { other_procedure.find_column(label: 'drop_down_list') }
+        let(:dossier) { create(:dossier, procedure: other_procedure) }
+        let(:champ) { dossier.champs.first }
+
+        context "when the user picked 'other' without typing a value" do
+          before { champ.update!(value: Champs::DropDownListChamp::OTHER) }
+
+          it do
+            expect(column_drop_down.value(champ)).to eq('autre')
+            expect(column('date').value(champ)).to be_nil
+          end
+        end
+
+        context "when the user picked 'other' and typed a custom value" do
+          before do
+            champ.update!(value: Champs::DropDownListChamp::OTHER)
+            champ.update!(value_other: 'ma valeur')
+          end
+
+          it { expect(column_drop_down.value(champ)).to eq('autre : ma valeur') }
+        end
+      end
+
       context 'from a multiple_drop_down_list' do
         let(:champ) { Champs::MultipleDropDownListChamp.new(value:) }
         let(:value) { '["val1","val2"]' }


### PR DESCRIPTION
**contexte** :  une drop_down_list avec l'option autre activé et non obligatoire

**Aujourd'hui** : un usager peut soumettre son dossier en cliquant sur autre et en ne précisant pas son choix

<img width="1261" height="221" alt="Screenshot 2026-05-11 at 13-37-17 Modifier · Dossier n° 24577150 (test) · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/39ed5ead-7c64-4475-bdfd-2695bfa1d19b" />

**Pb** :
- au rechargement de la page, `Entrer une autre option` n'est plus coché
- dans la vue en lecture du dossier, on affiche `non saisi` alors qu'en fait si, l'usager a coché `autre option`
- dans la vue tableau de bord de l'instructeur, on n'affiche rien

**proposition** :
- on affiche `autre`, ou `autre : mon option` aux différents endroits

**conséquence** :
- :warning: c'est un breaking change au niveau des exports tabulaires / graphql : on passe de 
  - `'' -> autre`
  - `'mon option' -> 'autre : mon option'`
- on change fonctionnellement le comportement du champ pour les cas obligatoires ou on permet à présent de soumettre sans préciser la valeur.

**autre possibilité** :
on force, mm dans le cas ou le champ n'est pas obligatoire, l'usager doit préciser son autre option