### PR TITLE
ETQ Admin, lorsque je modifie un csv référentiel dans l'éditeur, les types de champ du dessous sont mis à jour

### DIFF
--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -137,7 +137,7 @@ module Administrateurs
       type_de_champ.update!(referentiel_id: nil)
 
       @coordinate = draft.coordinate_for(type_de_champ)
-      @morphed = [champ_component_from(@coordinate)]
+      @morphed = champ_components_starting_at(@coordinate)
     end
 
     def import_referentiel
@@ -174,7 +174,7 @@ module Administrateurs
       end
 
       @coordinate = draft.coordinate_for(type_de_champ)
-      @morphed = [champ_component_from(@coordinate)]
+      @morphed = champ_components_starting_at(@coordinate)
     end
 
     private

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -49,7 +49,7 @@ class Logic::ChampValue < Logic::Term
 
     return nil if targeted_champ.nil?
     return nil if !targeted_champ.visible?
-    return nil if targeted_champ.blank? & !targeted_champ.drop_down_other?
+    return nil if targeted_champ.blank? && !targeted_champ.drop_down_other?
 
     case targeted_champ.type
     when "Champs::YesNoChamp",


### PR DESCRIPTION
le premier commit est une correction d'une typo