### PR TITLE
ETQ Usager/Instructeur, j'ai une lecture 2ddoc qui fonctionne sur plus de justificatif de domicile

### DIFF
--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -36,7 +36,7 @@ module Dsfr
     end
 
     def pjs_statut?
-      @champ.rib? && !@champ.idle?
+      (@champ.rib? || @champ.justificatif_domicile?) && !@champ.idle?
     end
 
     def dossier_link_support_statut?
@@ -102,19 +102,28 @@ module Dsfr
           { state: :valid, text: t(".referentiel.success", value: @champ.value) }
         end
       when TypeDeChamp.type_champs[:piece_justificative]
-        value_json = @champ.value_json
-        iban = value_json&.dig('rib', 'iban')
-        bank_name = value_json&.dig('rib', 'bank_name')
-
         if @champ.pending?
           { state: :info, text: t('.pj.info') }
         elsif @champ.external_error?
           { state: :warning, text: t('.pj.error') }
-        elsif iban.nil?
-          { state: :warning, text: t('.pj.warning') }
+        elsif @champ.justificatif_domicile?
+          justif = @champ.ocr_result
+          if justif&.two_ddoc
+            { state: :valid, text: t('.pj.justif_domicile.valid_html', beneficiary: justif.beneficiary, address: justif.label, issue_date: l(justif.issue_date)) }
+          else
+            { state: :warning, text: t('.pj.justif_domicile.warning') }
+          end
         else
-          text = bank_name.present? ? t('.pj.valid_with_bank', iban:, bank_name:) : t('.pj.valid', iban:)
-          { state: :valid, text: }
+          value_json = @champ.value_json
+          iban = value_json&.dig('rib', 'iban')
+          bank_name = value_json&.dig('rib', 'bank_name')
+
+          if iban.nil?
+            { state: :warning, text: t('.pj.warning') }
+          else
+            text = bank_name.present? ? t('.pj.valid_with_bank', iban:, bank_name:) : t('.pj.valid', iban:)
+            { state: :valid, text: }
+          end
         end
       end
     end

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
@@ -19,3 +19,6 @@ en:
     valid: "Our system identified the IBAN %{iban}"
     valid_with_bank: "Our system identified the IBAN %{iban} - <b>%{bank_name}</b>"
     error: "An error occurred while parsing your document.<br>Ignore this message if you are confident about your file."
+    justif_domicile:
+      warning: "We were unable to verify the address contained in the supporting document.<br>Ignore this message if you are confident your file is correct."
+      valid_html: "Proof of residence in the name of <strong>%{beneficiary}</strong> (<strong>%{address}</strong>), issued on <strong>%{issue_date}</strong>."

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
@@ -19,4 +19,7 @@ fr:
     valid: "Notre système a identifié l’IBAN %{iban}"
     valid_with_bank: "Notre système a identifié l’IBAN %{iban} - <b>%{bank_name}</b>"
     error: "Une erreur est survenue lors de l’analyse de votre document.<br>Ne tenez pas compte de ce message si vous êtes sûr(e) de votre fichier."
+    justif_domicile:
+      warning: "Nous n’avons pas pu vérifier l’adresse contenue dans le justificatif.<br>Ignorez ce message si vous êtes sûr(e) de votre fichier."
+      valid_html: "Justificatif de domicile au nom de <strong>%{beneficiary}</strong> (<strong>%{address}</strong>), émis le <strong>%{issue_date}</strong>."
 

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -5,7 +5,8 @@
 
       = @error_full_messages.to_sentence
   - elsif statutable? && statut_message.present?
-    %p.fr-message{ class: "fr-message--#{statut_message[:state]}" }= sanitize(statut_message[:text])
+    %p.fr-message{ class: "fr-message--#{statut_message[:state]}" }
+      %span= sanitize(statut_message[:text])
 
   - if prefilled?
     %p.fr-message.fr-message--info= sanitize(t('.prefilled'))

--- a/app/components/instructeurs/ocr_viewer_component.rb
+++ b/app/components/instructeurs/ocr_viewer_component.rb
@@ -18,7 +18,7 @@ class Instructeurs::OCRViewerComponent < ApplicationComponent
       h.map { |k, v| [k, v || processing_error_message, copy: v.present?] }
 
     elsif doc.is_a?(JustificatifDomicile)
-      h = doc.attributes.slice('beneficiary', 'address', 'locality', 'postal_code', 'country', 'issue_date')
+      h = doc.attributes.slice('beneficiary', 'label', 'issue_date')
       h['issue_date'] = I18n.l(h['issue_date'], format: :short) if h['issue_date']
       h
     end

--- a/app/models/justificatif_domicile.rb
+++ b/app/models/justificatif_domicile.rb
@@ -4,11 +4,24 @@ class JustificatifDomicile
   include ActiveModel::Model
   include ActiveModel::Attributes
 
+  # 2ddoc-specific
   attribute :beneficiary, :string
-  attribute :address, :string
-  attribute :postal_code, :string
-  attribute :locality, :string
-  attribute :country, :string
   attribute :issue_date, :date
   attribute :two_ddoc, :boolean
+
+  # APIGeoService.parse_ban_address output
+  attribute :label, :string
+  attribute :type, :string
+  attribute :street_address, :string
+  attribute :street_number, :string
+  attribute :street_name, :string
+  attribute :postal_code, :string
+  attribute :city_code, :string
+  attribute :city_name, :string
+  attribute :department_code, :string
+  attribute :department_name, :string
+  attribute :region_code, :string
+  attribute :region_name, :string
+  attribute :country_code, :string
+  attribute :country_name, :string
 end

--- a/app/models/types_de_champ/piece_justificative_type_de_champ.rb
+++ b/app/models/types_de_champ/piece_justificative_type_de_champ.rb
@@ -69,17 +69,17 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBas
       end
     elsif justificatif_domicile?
       cs += [
-        ['Bénéficiaire', '$.beneficiary', :text],
-        ['Adresse', '$.label', :text],
-        ['Date d’émission', '$.issue_date', :date],
-      ].map do |label, jsonpath, type|
+        [:beneficiary, :text],
+        [:label, :text],
+        [:issue_date, :date],
+      ].map do |attribute, type|
         Columns::JSONPathColumn.new(
           procedure_id:,
           stable_id:,
           tdc_type: type_champ,
-          label: "#{libelle_with_prefix(prefix)} – #{label}",
+          label: "#{libelle_with_prefix(prefix)} – #{JustificatifDomicile.human_attribute_name(attribute)}",
           type:,
-          jsonpath:,
+          jsonpath: "$.#{attribute}",
           displayable: true,
           mandatory: mandatory?
         )

--- a/app/models/types_de_champ/piece_justificative_type_de_champ.rb
+++ b/app/models/types_de_champ/piece_justificative_type_de_champ.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBase
+  include AddressableColumnConcern
+
   def estimated_fill_duration(revision)
     FILL_DURATION_LONG
   end
@@ -66,21 +68,23 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBas
        )
       end
     elsif justificatif_domicile?
-      cs += JustificatifDomicile.attribute_types
-        .map { |attr, type| [attr, active_model_type_to_column_type(type)] }
-        .map do |attr, type|
-        jsonpath = "$.#{attr}"
+      cs += [
+        ['Bénéficiaire', '$.beneficiary', :text],
+        ['Adresse', '$.label', :text],
+        ['Date d’émission', '$.issue_date', :date],
+      ].map do |label, jsonpath, type|
         Columns::JSONPathColumn.new(
           procedure_id:,
           stable_id:,
           tdc_type: type_champ,
-          label: "#{libelle_with_prefix(prefix)} – #{attr}",
+          label: "#{libelle_with_prefix(prefix)} – #{label}",
           type:,
           jsonpath:,
           displayable: true,
           mandatory: mandatory?
         )
       end
+      cs.concat(addressable_columns(procedure_id:, displayable:, prefix:))
     elsif titre_identite?
       cs += [
         Columns::TitreIdentiteColumn.new(
@@ -96,20 +100,5 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBas
     end
 
     cs
-  end
-
-  private
-
-  def active_model_type_to_column_type(am_type)
-    case am_type
-    in ActiveModel::Type::String
-      :text
-    in ActiveModel::Type::Date
-      :date
-    in ActiveModel::Type::Boolean
-      :boolean
-    else
-      raise "unknown type #{am_type}"
-    end
   end
 end

--- a/app/services/ocr_service.rb
+++ b/app/services/ocr_service.rb
@@ -25,7 +25,7 @@ class OCRService
 
     API::Client.new.call(url: ocr_url, method: :post, headers:, json:, timeout: 31)
       .fmap { |ok| { value_json: ok.body } } # store directly in value_json without transformation
-      .or { to_retryable_failure(it) }
+      .or { to_not_retryable_failure(it) }
   end
 
   def self.analyze_2ddoc(blob_url)
@@ -37,7 +37,7 @@ class OCRService
 
     API::Client.new.call(url:, headers:, method: :post, body:)
       .fmap { |ok| { data: ok.body, value_json: extract_2ddoc(ok.body) } }
-      .or { to_retryable_failure(it) }
+      .or { to_not_retryable_failure(it) }
   end
 
   def self.extract_2ddoc(body)
@@ -77,7 +77,7 @@ class OCRService
     Failure(retryable: false, error: StandardError.new("#{message} not configured"))
   end
 
-  def self.to_retryable_failure(data)
+  def self.to_not_retryable_failure(data)
     case data
     in code:, error:
       Failure(retryable: false, error:, code:)

--- a/app/services/ocr_service.rb
+++ b/app/services/ocr_service.rb
@@ -41,25 +41,19 @@ class OCRService
   end
 
   def self.extract_2ddoc(body)
-    barcode = body
+    doc_type, raw_issue_date, raw_data = body
       .dig(:data, :result, :barcodes)
       &.find { it[:type] == '2D_DOC' && it[:is_valid] } # take the first valid 2ddoc
+      &.fetch_values(:doc_type, :issue_date, :raw_data)
 
-    return nil if barcode.nil?
+    return nil if raw_data.nil? || !justif_domicile?(doc_type)
 
-    ddoc = barcode[:raw_data]
-    return nil if ddoc.nil? || !justif_domicile?(ddoc)
-
-    fields = ddoc[:fields]
     # format : '2026-01-02'
-    issue_date = barcode[:issue_date]&.then { Date.strptime(it, '%Y-%m-%d') }
+    issue_date = raw_issue_date&.then { Date.strptime(it, '%Y-%m-%d') }
+    beneficiary = raw_data[:"10"]&.tr('/', ' ')
 
     attr = {
-      beneficiary: fields[:"10"]&.tr('/', ' '),
-      address: fields[:"22"],
-      postal_code: fields[:"24"],
-      locality: fields[:"25"],
-      country: fields[:"26"],
+      beneficiary:,
       issue_date:,
       two_ddoc: true,
     }
@@ -68,7 +62,7 @@ class OCRService
     JustificatifDomicile.new(attr).attributes
   end
 
-  def self.justif_domicile?(ddoc) = ddoc[:doc_type].in?(['00', '01', '02'])
+  def self.justif_domicile?(doc_type) = doc_type.in?(['00', '01', '02'])
 
   def self.ocr_url = ENV.fetch("OCR_SERVICE_URL", nil)
   def self.document_ia_url = ENV.fetch("DOCUMENT_IA_URL", nil)

--- a/app/services/ocr_service.rb
+++ b/app/services/ocr_service.rb
@@ -40,6 +40,16 @@ class OCRService
       .or { to_not_retryable_failure(it) }
   end
 
+  TWODDOC_MAPPING = {
+    beneficiary: 10, # Quality / Name / FirstName
+    ligne_2: 20,
+    ligne_3: 21,
+    ligne_4: 22,
+    ligne_5: 23,
+    code_postal: 24,
+    localite: 25,
+  }
+
   def self.extract_2ddoc(body)
     doc_type, raw_issue_date, raw_data = body
       .dig(:data, :result, :barcodes)
@@ -58,11 +68,34 @@ class OCRService
       two_ddoc: true,
     }
 
+    query = TWODDOC_MAPPING
+      .fetch_values(:ligne_2, :ligne_3, :ligne_4, :ligne_5, :code_postal, :localite)
+      .map { raw_data[it.to_s.to_sym] }
+      .compact_blank
+      .join(' ')
+
+    fetch_ban_address(query)
+      .fmap { attr.merge!(it.except(:geometry)) }
+
     # force parsing to ensure compat
-    JustificatifDomicile.new(attr).attributes
+    JustificatifDomicile.new(attr).attributes.compact
   end
 
   def self.justif_domicile?(doc_type) = doc_type.in?(['00', '01', '02'])
+
+  MIN_BAN_CONFIDENCE = 0.9
+
+  # TODO: check if enough 2ddoc properly stode postal_code
+  # and if enough at least call api geo to fetch region / departement
+  def self.fetch_ban_address(query)
+    return Failure(:no_query) if query.blank?
+
+    API::Client.new.call(url: "#{API_ADRESSE_URL}/search", params: { q: query, limit: 1 })
+      .fmap { it.body[:features]&.first }
+      .bind { it.present? ? Success(it) : Failure(:no_feature) }
+      .bind { it[:properties][:score] >= MIN_BAN_CONFIDENCE ? Success(it) : Failure(:bad) }
+      .fmap { APIGeoService.parse_ban_address(it.deep_stringify_keys) }
+  end
 
   def self.ocr_url = ENV.fetch("OCR_SERVICE_URL", nil)
   def self.document_ia_url = ENV.fetch("DOCUMENT_IA_URL", nil)

--- a/config/locales/models/justificatif_domicile/en.yml
+++ b/config/locales/models/justificatif_domicile/en.yml
@@ -4,8 +4,5 @@ en:
     attributes:
       justificatif_domicile:
         beneficiary: Beneficiary
-        address: Address
-        postal_code: Postcode
-        locality: Locality
-        country: Country
+        label: Address
         issue_date: Issue date

--- a/config/locales/models/justificatif_domicile/fr.yml
+++ b/config/locales/models/justificatif_domicile/fr.yml
@@ -4,8 +4,5 @@ fr:
     attributes:
       justificatif_domicile:
         beneficiary: Bénéficiaire
-        address: Adresse
-        postal_code: Code postal
-        locality: Localité
-        country: Pays
+        label: Adresse
         issue_date: Date d’émission

--- a/spec/components/instructeurs/ocr_viewer_component_spec.rb
+++ b/spec/components/instructeurs/ocr_viewer_component_spec.rb
@@ -68,10 +68,7 @@ RSpec.describe Instructeurs::OCRViewerComponent, type: :component do
     let(:doc) do
       JustificatifDomicile.new(
         beneficiary: 'Jane Smith',
-        address: '123 Main St',
-        locality: 'Paris',
-        postal_code: '75001',
-        country: 'France',
+        label: 'a superbe address',
         issue_date: Date.new(2026, 1, 2),
         two_ddoc: true
       )
@@ -79,14 +76,8 @@ RSpec.describe Instructeurs::OCRViewerComponent, type: :component do
 
     it 'renders justificatif domicile data' do
       expect(subject).to have_css('.champ-content', text: 'Jane Smith')
-      expect(subject).to have_css('.champ-content', text: '123 Main St')
-      expect(subject).to have_css('.champ-content', text: 'Paris')
-      expect(subject).to have_css('.champ-content', text: '75001')
-      expect(subject).to have_css('.champ-content', text: 'France')
+      expect(subject).to have_css('.champ-content', text: 'a superbe address')
       expect(subject).to have_css('.champ-content', text: I18n.l(Date.new(2026, 1, 2), format: :short))
-    end
-
-    it 'shows 2D-Doc source' do
       expect(subject).to have_css('acronym', text: '2D-Doc')
     end
 
@@ -94,10 +85,7 @@ RSpec.describe Instructeurs::OCRViewerComponent, type: :component do
       let(:doc) do
         JustificatifDomicile.new(
           beneficiary: 'Jane Smith',
-          address: '123 Main St',
-          locality: 'Paris',
-          postal_code: '75001',
-          country: 'France',
+          label: 'a superbe address',
           two_ddoc: true
         )
       end

--- a/spec/fixtures/files/doc_ia/success.json
+++ b/spec/fixtures/files/doc_ia/success.json
@@ -12,12 +12,10 @@
                           "position": { "top_left": [80, 348], "top_right": [195, 348], "bottom_left": [80, 464], "bottom_right": [195, 464] },
                           "raw_data":
                            {
-                             "fields": { "10": "ROBERT/JEAN", "18": "1438330425", "22": "123 RUE DES PIETONS", "24": "38000", "25": "GRENOBLE", "26": "FR" },
-                            "country": "FR",
-                            "doc_type": "01",
-                            "perimeter": "01"
+                             "10": "ROBERT/JEAN", "18": "1438330425", "22": "123 RUE DES PIETONS", "24": "38000", "25": "GRENOBLE", "26": "FR"
                            },
                           "ants_type": null,
+                          "doc_type": "01",
                           "issue_date": "2026-01-02",
                           "typed_data": [],
                           "page_number": 1

--- a/spec/models/champs/piece_justificative_champ_spec.rb
+++ b/spec/models/champs/piece_justificative_champ_spec.rb
@@ -177,7 +177,7 @@ describe Champs::PieceJustificativeChamp do
     end
 
     context 'when fetched with value_json' do
-      let(:value_json) { { 'beneficiary' => 'Jane Smith', 'address' => '123 Main St' } }
+      let(:value_json) { { 'beneficiary' => 'Jane Smith' } }
 
       before do
         allow(champ).to receive(:fetched?).and_return(true)

--- a/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
@@ -13,6 +13,15 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
       expect(labels.any? { _1.include?('BIC') }).to be true
       expect(labels.any? { _1.include?('Nom de la Banque') }).to be true
     end
+
+    it 'adds justificatif de domicile columns with i18n labels' do
+      tdc = create(:type_de_champ_piece_justificative, procedure:, nature: 'justificatif_domicile')
+      cols = tdc.dynamic_type.columns(procedure_id: procedure.id, displayable: true)
+      labels = cols.map(&:label)
+      expect(labels.any? { _1.include?('Bénéficiaire') }).to be true
+      expect(labels.any? { _1.include?('Adresse') }).to be true
+      expect(labels.any? { _1.include?('Date d’émission') }).to be true
+    end
   end
 
   describe '#champ_value_for_export' do

--- a/spec/services/ocr_service_spec.rb
+++ b/spec/services/ocr_service_spec.rb
@@ -73,6 +73,38 @@ describe OCRService do
     let(:headers) { { 'X-API-KEY': document_ia_key } }
     let(:url) { "#{document_ia_url}/api/v1/workflows/document-barcode-extraction/execute-sync" }
     let(:body) { File.read('spec/fixtures/files/doc_ia/success.json') }
+    let(:best_ban_score) { 0.97 }
+    let(:ban_query) { '123 RUE DES PIETONS 38000 GRENOBLE' }
+    let(:ban_body) do
+      {
+        features: [
+          {
+            type: 'Feature',
+                    geometry: { type: 'Point', coordinates: [5.7245, 45.1885] },
+                    properties: {
+                      label: '123 Rue des Piétons 38000 Grenoble',
+                      score: best_ban_score,
+                      name: '123 Rue des Piétons',
+                      housenumber: '123',
+                      street: 'Rue des Piétons',
+                      postcode: '38000',
+                      citycode: '38185',
+                      city: 'Grenoble',
+                      context: '38, Isère, Auvergne-Rhône-Alpes',
+                      type: 'housenumber',
+                    },
+          },
+        ],
+      }.to_json
+    end
+
+    let(:expected_2ddoc_result) do
+      {
+        "beneficiary" => 'ROBERT JEAN',
+        "issue_date" => Date.parse('2026-01-02'),
+        "two_ddoc" => true,
+      }
+    end
 
     subject { described_class.analyze(blob, nature: 'justificatif_domicile') }
 
@@ -85,6 +117,9 @@ describe OCRService do
 
       stub_request(:post, url).with(headers:, body: { file_url: blob.url })
         .to_return(body:, status: 200)
+      stub_request(:get, "#{API_ADRESSE_URL}/search")
+        .with(query: { q: ban_query, limit: 1 })
+        .to_return(body: ban_body, status: 200)
     end
 
     context 'when there is no document ia url' do
@@ -94,10 +129,63 @@ describe OCRService do
     end
 
     context 'when the result is ok' do
-      it do
-        expected = { "address" => "123 RUE DES PIETONS", "beneficiary" => "ROBERT JEAN", "country" => "FR", "issue_date" => Date.parse("2026-01-02"), "locality" => "GRENOBLE", "postal_code" => "38000", "two_ddoc" => true }
+      it 'returns a BAN-normalized address merged with 2ddoc fields' do
+        value_json = subject.value![:value_json]
 
-        expect(subject.value![:value_json]).to eq(expected)
+        expect(value_json).to include(
+          "label" => '123 Rue des Piétons 38000 Grenoble',
+          "street_address" => '123 Rue des Piétons',
+          "postal_code" => '38000',
+          "city_code" => '38185',
+          "city_name" => 'Grenoble',
+          "department_code" => '38',
+          "department_name" => 'Isère',
+          "region_code" => '84',
+          "region_name" => 'Auvergne-Rhône-Alpes',
+          "country_code" => 'FR',
+          "beneficiary" => 'ROBERT JEAN',
+          "issue_date" => Date.parse('2026-01-02'),
+          "two_ddoc" => true
+        )
+      end
+    end
+
+    context 'when the best ban result is not enough' do
+      let(:best_ban_score) { 0.89 }
+
+      it { expect(subject.value![:value_json]).to eq(expected_2ddoc_result) }
+    end
+
+    context 'when BAN returns no feature' do
+      let(:ban_body) { { features: [] }.to_json }
+
+      it 'returns nil value_json (raw data kept for replay)' do
+        expect(subject.value![:value_json]).to eq(expected_2ddoc_result)
+        expect(subject.value![:data]).not_to be_nil
+      end
+    end
+
+    context 'when the 2ddoc has no address lines (empty BAN query)' do
+      let(:body) do
+        {
+          data: {
+            result: {
+              barcodes: [
+                {
+                  type: '2D_DOC',
+                  is_valid: true,
+                  raw_data: { "10": 'ROBERT/JEAN' },
+                  doc_type: '01',
+                  issue_date: '2026-01-02',
+                },
+              ],
+            },
+          },
+        }.to_json
+      end
+
+      it 'does not raise and keeps the 2ddoc fields' do
+        expect(subject.value![:value_json]).to eq(expected_2ddoc_result)
       end
     end
 


### PR DESCRIPTION
1. On adapte le connecteur a DocumentIA pour prendre le nouveau format en compte
2. On passe le retour de DocumentIA à l'API ban pour une normalisation des adresses, on prend le résultat si confiance >= 90%
3. On expose les colonnes adresses pour le tableau de bord et les conditions
4. On affiche un joli message pour les usagers lors du traitement de leurs pjs

# Images

**Usager OK**

<img width="1470" height="364" alt="Screenshot 2026-06-04 at 16-21-16 Dossier 24577162 en brouillon (old and new pjs) - Étape 2 Formulaire · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/d3a303b2-be8e-46ba-9214-453862d0a603" />

**Usager KO**

<img width="1256" height="214" alt="Screenshot 2026-06-04 at 17-23-55 Dossier 24577157 en brouillon (old and new pjs) - Étape 2 Formulaire · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/59f523d8-0d5b-494b-b9b2-87a14b06f51f" />

**Instructeur dossier**
<img width="1600" height="856" alt="Screenshot 2026-06-04 at 16-32-19 Demande · Dossier n° 24577162 (n o) · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/e8a511a8-646c-4f43-81c5-77016746d9c2" />

**Instructeur Tableau de bord**
<img width="3718" height="326" alt="Screenshot 2026-06-04 at 16-45-19 Dossiers · #15322 · old and new pjs · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/0bccab35-610e-498f-8dc3-b8bcfe30dca8" />

**Condition Admin**
<img width="2088" height="446" alt="Screenshot From 2026-06-04 16-59-47" src="https://github.com/user-attachments/assets/b146d1b6-db08-495d-b8cb-b29798376fce" />

# Questions

- est ce que le message d'erreur usager n'est pas trop angoissant ? j'ai peur qu'une grande quantité de document justificatif ne comporte pas de 2ddoc et qu'on fasse flipper les gens rien
- est ce qu'on ne devrait pas exposer une colonne booléenne 2ddoc ? Pour que les admins qui font des conditions ne le fassent que si la données est certifiées (2ddoc == true) ?  (ca prévoit le coup ou on fait de l'ocr mais non 2ddoc).