### PR TITLE
demander un code OTP avant un transfert de dossier dans le manager

### DIFF
--- a/app/components/manager/otp_attempt_input_component.rb
+++ b/app/components/manager/otp_attempt_input_component.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class Manager::OtpAttemptInputComponent < ApplicationComponent
+  def render?
+    SUPER_ADMIN_OTP_ENABLED
+  end
 end

--- a/app/controllers/manager/dossiers_controller.rb
+++ b/app/controllers/manager/dossiers_controller.rb
@@ -2,6 +2,10 @@
 
 module Manager
   class DossiersController < Manager::ApplicationController
+    include RequiresFreshSuperAdminOtp
+
+    before_action :verify_fresh_super_admin_otp!, only: [:transfer]
+
     #
     # Administrate overrides
     #

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -55,8 +55,8 @@ class UserDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :email,
-    :otp_attempt,
-  ].freeze
+    (:otp_attempt if SUPER_ADMIN_OTP_ENABLED),
+  ].compact.freeze
 
   # Overwrite this method to customize how users are displayed
   # across all pages of the admin dashboard.

--- a/app/views/manager/dossiers/transfer_edit.html.erb
+++ b/app/views/manager/dossiers/transfer_edit.html.erb
@@ -50,9 +50,11 @@
       </div>
     </div>
 
-    <div class="field-unit field-unit--string field-unit--required">
-      <%= render Manager::OtpAttemptInputComponent.new %>
-    </div>
+    <% if SUPER_ADMIN_OTP_ENABLED %>
+      <div class="field-unit field-unit--string field-unit--required">
+        <%= render Manager::OtpAttemptInputComponent.new %>
+      </div>
+    <% end %>
 
     <div class="form-actions"><%= f.submit "Transférer le dossier" %></div>
   <% end %>

--- a/app/views/manager/dossiers/transfer_edit.html.erb
+++ b/app/views/manager/dossiers/transfer_edit.html.erb
@@ -50,6 +50,10 @@
       </div>
     </div>
 
+    <div class="field-unit field-unit--string field-unit--required">
+      <%= render Manager::OtpAttemptInputComponent.new %>
+    </div>
+
     <div class="form-actions"><%= f.submit "Transférer le dossier" %></div>
   <% end %>
 </section>

--- a/spec/controllers/manager/dossiers_controller_spec.rb
+++ b/spec/controllers/manager/dossiers_controller_spec.rb
@@ -3,7 +3,7 @@
 include ActionView::Helpers::SanitizeHelper
 
 describe Manager::DossiersController, type: :controller do
-  let(:super_admin) { create(:super_admin) }
+  let(:super_admin) { create(:super_admin, :with_otp) }
   before do
     sign_in super_admin
     procedure = create(:procedure, :published, types_de_champ_public: types_de_champ)
@@ -38,8 +38,10 @@ describe Manager::DossiersController, type: :controller do
   end
 
   describe "POST #transfer" do
+    let(:otp_attempt) { current_otp_for(super_admin) }
+
     subject do
-      post :transfer, params: { id: @dossier.id, email: }
+      post :transfer, params: { id: @dossier.id, email:, otp_attempt: }
     end
 
     context 'with valid email' do
@@ -55,8 +57,56 @@ describe Manager::DossiersController, type: :controller do
       let(:email) { "chouette" }
 
       it do
-        expect { subject }.not_to have_enqueued_mail
+        expect { subject }.not_to have_enqueued_mail(DossierMailer, :notify_transfer)
         expect(flash[:alert]).to eq("L’adresse électronique est invalide. Saisissez une adresse électronique valide. Exemple : adresse@mail.com")
+      end
+    end
+
+    context 'when the OTP code is missing' do
+      let(:email) { "chouette.gars@laposte.net" }
+      let(:otp_attempt) { nil }
+
+      it 'does not enqueue a transfer and sets a flash error' do
+        expect { subject }.not_to have_enqueued_mail(DossierMailer, :notify_transfer)
+        expect(flash[:error]).to include("Code OTP invalide ou manquant")
+      end
+    end
+
+    context 'when the OTP code is invalid' do
+      let(:email) { "chouette.gars@laposte.net" }
+      let(:otp_attempt) { (current_otp_for(super_admin).to_i + 1).to_s.rjust(6, '0') }
+
+      it 'does not enqueue a transfer and sets a flash error' do
+        expect { subject }.not_to have_enqueued_mail(DossierMailer, :notify_transfer)
+        expect(flash[:error]).to include("Code OTP invalide ou manquant")
+      end
+    end
+
+    context 'when the same OTP code is replayed within its drift window' do
+      let(:email) { "chouette.gars@laposte.net" }
+      let(:second_email) { "second.gars@laposte.net" }
+      let(:code) { current_otp_for(super_admin) }
+
+      it 'accepts the first submission and rejects the replay' do
+        expect {
+          post :transfer, params: { id: @dossier.id, email:, otp_attempt: code }
+        }.to have_enqueued_mail(DossierMailer, :notify_transfer)
+
+        expect {
+          post :transfer, params: { id: @dossier.id, email: second_email, otp_attempt: code }
+        }.not_to have_enqueued_mail(DossierMailer, :notify_transfer)
+        expect(flash[:error]).to include("Code OTP invalide ou manquant")
+      end
+    end
+
+    context 'when SUPER_ADMIN_OTP_ENABLED is false' do
+      let(:email) { "chouette.gars@laposte.net" }
+      let(:otp_attempt) { nil }
+
+      before { stub_const('SUPER_ADMIN_OTP_ENABLED', false) }
+
+      it 'enqueues the transfer without requiring an OTP code' do
+        expect { subject }.to have_enqueued_mail(DossierMailer, :notify_transfer)
       end
     end
   end

--- a/spec/controllers/manager/dossiers_controller_spec.rb
+++ b/spec/controllers/manager/dossiers_controller_spec.rb
@@ -39,14 +39,20 @@ describe Manager::DossiersController, type: :controller do
 
   describe "POST #transfer" do
     let(:otp_attempt) { current_otp_for(super_admin) }
+    let(:email) { "chouette.gars@laposte.net" }
 
     subject do
       post :transfer, params: { id: @dossier.id, email:, otp_attempt: }
     end
 
-    context 'with valid email' do
-      let(:email) { "chouette.gars@laposte.net" }
+    it_behaves_like "a manager action gated by a fresh super-admin OTP" do
+      let(:action_matcher) { have_enqueued_mail(DossierMailer, :notify_transfer) }
+      let(:replay_subject) do
+        -> { post :transfer, params: { id: @dossier.id, email: "second.gars@laposte.net", otp_attempt: otp_attempt } }
+      end
+    end
 
+    context 'with valid email' do
       it do
         expect { subject }.to have_enqueued_mail(DossierMailer, :notify_transfer)
         expect(flash[:notice]).to eq("Une invitation de transfert a été envoyée à chouette.gars@laposte.net")
@@ -59,54 +65,6 @@ describe Manager::DossiersController, type: :controller do
       it do
         expect { subject }.not_to have_enqueued_mail(DossierMailer, :notify_transfer)
         expect(flash[:alert]).to eq("L’adresse électronique est invalide. Saisissez une adresse électronique valide. Exemple : adresse@mail.com")
-      end
-    end
-
-    context 'when the OTP code is missing' do
-      let(:email) { "chouette.gars@laposte.net" }
-      let(:otp_attempt) { nil }
-
-      it 'does not enqueue a transfer and sets a flash error' do
-        expect { subject }.not_to have_enqueued_mail(DossierMailer, :notify_transfer)
-        expect(flash[:error]).to include("Code OTP invalide ou manquant")
-      end
-    end
-
-    context 'when the OTP code is invalid' do
-      let(:email) { "chouette.gars@laposte.net" }
-      let(:otp_attempt) { (current_otp_for(super_admin).to_i + 1).to_s.rjust(6, '0') }
-
-      it 'does not enqueue a transfer and sets a flash error' do
-        expect { subject }.not_to have_enqueued_mail(DossierMailer, :notify_transfer)
-        expect(flash[:error]).to include("Code OTP invalide ou manquant")
-      end
-    end
-
-    context 'when the same OTP code is replayed within its drift window' do
-      let(:email) { "chouette.gars@laposte.net" }
-      let(:second_email) { "second.gars@laposte.net" }
-      let(:code) { current_otp_for(super_admin) }
-
-      it 'accepts the first submission and rejects the replay' do
-        expect {
-          post :transfer, params: { id: @dossier.id, email:, otp_attempt: code }
-        }.to have_enqueued_mail(DossierMailer, :notify_transfer)
-
-        expect {
-          post :transfer, params: { id: @dossier.id, email: second_email, otp_attempt: code }
-        }.not_to have_enqueued_mail(DossierMailer, :notify_transfer)
-        expect(flash[:error]).to include("Code OTP invalide ou manquant")
-      end
-    end
-
-    context 'when SUPER_ADMIN_OTP_ENABLED is false' do
-      let(:email) { "chouette.gars@laposte.net" }
-      let(:otp_attempt) { nil }
-
-      before { stub_const('SUPER_ADMIN_OTP_ENABLED', false) }
-
-      it 'enqueues the transfer without requiring an OTP code' do
-        expect { subject }.to have_enqueued_mail(DossierMailer, :notify_transfer)
       end
     end
   end

--- a/spec/controllers/manager/users_controller_spec.rb
+++ b/spec/controllers/manager/users_controller_spec.rb
@@ -30,13 +30,19 @@ describe Manager::UsersController, type: :controller do
     let(:super_admin) { create(:super_admin, :with_otp) }
     let(:user) { create(:user, email: 'ancien.email@domaine.fr', password: '{My-$3cure-p4ssWord}') }
     let(:otp_attempt) { current_otp_for(super_admin) }
+    let(:nouvel_email) { 'nouvel.email@domaine.fr' }
 
     subject { patch :update, params: { id: user.id, user: { email: nouvel_email }, otp_attempt: otp_attempt } }
 
+    it_behaves_like "a manager action gated by a fresh super-admin OTP" do
+      let(:action_matcher) { change { user.reload.email } }
+      let(:replay_subject) do
+        -> { patch :update, params: { id: user.id, user: { email: 'second.email@domaine.fr' }, otp_attempt: otp_attempt } }
+      end
+    end
+
     context 'when the targeted email does not exist' do
       describe 'with a valid email' do
-        let(:nouvel_email) { 'nouvel.email@domaine.fr' }
-
         it 'updates the user email' do
           subject
 
@@ -68,53 +74,6 @@ describe Manager::UsersController, type: :controller do
 
         expect(flash[:notice]).to match("Le compte « email.existant@domaine.fr » a absorbé le compte « ancien.email@domaine.fr ».")
         expect(response).to redirect_to(edit_manager_user_path(targeted_user))
-      end
-    end
-
-    context 'when the OTP code is missing' do
-      let(:nouvel_email) { 'nouvel.email@domaine.fr' }
-      let(:otp_attempt) { nil }
-
-      it 'does not change the email and sets a flash error' do
-        expect { subject }.not_to change { user.reload.email }
-        expect(flash[:error]).to include("Code OTP invalide ou manquant")
-      end
-    end
-
-    context 'when the OTP code is invalid' do
-      let(:nouvel_email) { 'nouvel.email@domaine.fr' }
-      let(:otp_attempt) { (current_otp_for(super_admin).to_i + 1).to_s.rjust(6, '0') }
-
-      it 'does not change the email and sets a flash error' do
-        expect { subject }.not_to change { user.reload.email }
-        expect(flash[:error]).to include("Code OTP invalide ou manquant")
-      end
-    end
-
-    context 'when the same OTP code is replayed within its drift window' do
-      let(:nouvel_email) { 'nouvel.email@domaine.fr' }
-      let(:second_email) { 'second.email@domaine.fr' }
-      let(:code) { current_otp_for(super_admin) }
-
-      it 'accepts the first submission and rejects the replay' do
-        patch :update, params: { id: user.id, user: { email: nouvel_email }, otp_attempt: code }
-        expect(user.reload.email).to eq(nouvel_email)
-
-        patch :update, params: { id: user.id, user: { email: second_email }, otp_attempt: code }
-        expect(user.reload.email).to eq(nouvel_email)
-        expect(flash[:error]).to include("Code OTP invalide ou manquant")
-      end
-    end
-
-    context 'when SUPER_ADMIN_OTP_ENABLED is false' do
-      let(:nouvel_email) { 'nouvel.email@domaine.fr' }
-      let(:otp_attempt) { nil }
-
-      before { stub_const('SUPER_ADMIN_OTP_ENABLED', false) }
-
-      it 'updates the email without requiring an OTP code' do
-        subject
-        expect(user.reload.email).to eq(nouvel_email)
       end
     end
   end

--- a/spec/support/shared_examples_for_manager_otp_step_up.rb
+++ b/spec/support/shared_examples_for_manager_otp_step_up.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Shared coverage for Manager controller actions protected by
+# RequiresFreshSuperAdminOtp. Callers must define:
+#
+#   subject         - the request closure that reads let(:otp_attempt) for the
+#                     OTP code
+#   action_matcher  - an RSpec matcher proving the action ran end-to-end
+#                     (e.g. `change { user.reload.email }` or
+#                     `have_enqueued_mail(DossierMailer, :notify_transfer)`)
+#   replay_subject  - a callable issuing a second, distinct request that reuses
+#                     the same OTP code; used only by the replay context
+#
+# Requires a super_admin built with `create(:super_admin, :with_otp)` and
+# signed in by the surrounding context.
+RSpec.shared_examples "a manager action gated by a fresh super-admin OTP" do
+  context 'when the OTP code is missing' do
+    let(:otp_attempt) { nil }
+
+    it 'rejects the action and sets a flash error' do
+      expect { subject }.not_to action_matcher
+      expect(flash[:error]).to include("Code OTP invalide ou manquant")
+    end
+  end
+
+  context 'when the OTP code is invalid' do
+    let(:otp_attempt) { (current_otp_for(super_admin).to_i + 1).to_s.rjust(6, '0') }
+
+    it 'rejects the action and sets a flash error' do
+      expect { subject }.not_to action_matcher
+      expect(flash[:error]).to include("Code OTP invalide ou manquant")
+    end
+  end
+
+  context 'when the same OTP code is replayed within its drift window' do
+    let(:otp_attempt) { current_otp_for(super_admin) }
+
+    it 'accepts the first submission and rejects the replay' do
+      expect { subject }.to action_matcher
+      expect { replay_subject.call }.not_to action_matcher
+      expect(flash[:error]).to include("Code OTP invalide ou manquant")
+    end
+  end
+
+  context 'when SUPER_ADMIN_OTP_ENABLED is false' do
+    let(:otp_attempt) { nil }
+
+    before { stub_const('SUPER_ADMIN_OTP_ENABLED', false) }
+
+    it 'performs the action without requiring an OTP code' do
+      expect { subject }.to action_matcher
+    end
+  end
+end


### PR DESCRIPTION
On étend la demande d'OTP frais au sein du manager au transfert d'un dossier vers un autre usager (`Manager::DossiersController#transfer`) : même avec une session super-admin compromise, l'attaquant a aussi besoin d'un OTP valide et non consommé pour exfiltrer un dossier.

Les contextes RSpec de step-up OTP (code manquant, invalide, rejeu, `SUPER_ADMIN_OTP_ENABLED` désactivé) étaient dupliqués entre `users_controller_spec` et `dossiers_controller_spec` ; ils sont extraits dans un shared example commun.

Suite de #13117.