### PR TITLE
Correctif: ETQ usager, voir la page ProConnect au lieu de 'Vous êtes déjà connecté(e)'

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -600,8 +600,9 @@ module Users
       return if !procedure.pro_connect_restriction_all?
       return if logged_in_with_pro_connect?
 
+      store_location_for(:user, request.fullpath)
       flash.alert = t('users.dossiers.pro_connect_restriction_required')
-      redirect_to new_user_session_path
+      redirect_to pro_connect_required_path
     end
 
     def page

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -2462,15 +2462,15 @@ describe Users::DossiersController, type: :controller do
     end
 
     context 'when user is not ProConnected' do
-      it 'does not allow create new dossier and redirects to pro_connect' do
+      it 'does not allow create new dossier and redirects to pro_connect_required' do
         expect { post :new, params: { procedure_id: procedure.id } }.not_to change { Dossier.count }
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to redirect_to(pro_connect_required_path)
         expect(flash[:alert]).to include("ProConnect")
       end
 
-      it 'redirects to pro_connect' do
+      it 'redirects to pro_connect_required' do
         post :submit_brouillon, params: { id: brouillon.id, dossier: {} }
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to redirect_to(pro_connect_required_path)
         expect(flash[:alert]).to include("ProConnect")
         brouillon.reload
         expect(brouillon).to be_brouillon


### PR DESCRIPTION
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_47027cc3-56fa-4027-bfdd-5ea0243ec1eb/

# Problème

Quand une démarche exige ProConnect (`pro_connect_restriction: :all`) et qu'un usager est connecté avec email/mot de passe classique, le clic sur "Continuer à remplir" provoque une boucle confuse :

1. `ensure_pro_connect_for_procedure` redirige vers `new_user_session_path`
2. Devise intercepte (l'usager est déjà authentifié), **écrase le flash** avec "Vous êtes déjà connecté(e)." et redirige vers l'index
3. L'usager ne voit jamais le message "Cette démarche nécessite une authentification via ProConnect" et ne comprend pas ce qui se passe

Signalé par un usager invité sur le dossier n° 29 213 508 (démarche MEGALIS BRETAGNE).

# Solution

Rediriger vers `pro_connect_required_path` au lieu de `new_user_session_path`, comme le font déjà les controllers instructeur et administrateur. La page dédiée affiche un message clair et le bouton ProConnect.

Ajout de `store_location_for(:user, request.fullpath)` pour que l'usager soit redirigé vers son dossier après connexion ProConnect.

Generated with [Claude Code](https://claude.com/claude-code)