### PR TITLE
Correctif : ETQ admin, l'import de groupes avec écrasement ne supprime plus le groupe par défaut

### DIFF
--- a/app/components/procedure/one_groupe_management_component/one_groupe_management_component.html.haml
+++ b/app/components/procedure/one_groupe_management_component/one_groupe_management_component.html.haml
@@ -30,6 +30,9 @@
       method: :delete,
       data: { confirm: t('.delete_confirmation', group_name: @groupe_instructeur.label) } do
         Supprimer ce groupe
+    - elsif @groupe_instructeur.id == @procedure.defaut_groupe_instructeur.id
+      .fr-mt-3w
+        %em Vous ne pouvez pas supprimer le groupe d’instructeurs par défaut.
     - else
       .fr-mt-3w
         %em Vous ne pouvez pas supprimer ce groupe car des dossiers lui sont affectés.

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -79,7 +79,9 @@ class GroupeInstructeur < ApplicationRecord
   end
 
   def can_delete?
-    dossiers.empty? && (procedure.groupe_instructeurs.active.many? || (procedure.groupe_instructeurs.active.one? && closed))
+    id != procedure.defaut_groupe_instructeur_id &&
+      dossiers.empty? &&
+      (procedure.groupe_instructeurs.active.many? || (procedure.groupe_instructeurs.active.one? && closed))
   end
 
   def can_close?

--- a/app/services/instructeurs_import_service.rb
+++ b/app/services/instructeurs_import_service.rb
@@ -69,6 +69,10 @@ class InstructeursImportService
         if groupe.dossiers.any? && administrateur&.instructeur
           groupe.add(administrateur.instructeur)
           preserved_groupes << groupe.label
+        elsif groupe.id == procedure.defaut_groupe_instructeur_id
+          new_defaut = procedure.groupe_instructeurs.where(label: target_labels).first
+          procedure.update!(defaut_groupe_instructeur: new_defaut)
+          groupe.destroy
         elsif groupe.can_delete?
           groupe.destroy
         end

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -735,6 +735,23 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
           expect(GroupeInstructeurMailer).not_to have_received(:notify_added_instructeurs)
         end
       end
+
+      context 'with overwrite and multiple new groups not including the default group' do
+        let(:csv_file) { fixture_file_upload('spec/fixtures/files/groupe-import-overwrite-two-groups.csv', 'text/csv') }
+
+        before do
+          allow(GroupeInstructeurMailer).to receive(:confirm_and_notify_added_instructeur_in_many_groupes)
+            .and_return(double(deliver_later: true))
+          allow(GroupeInstructeurMailer).to receive(:notify_removed_instructeur_from_many_groupes)
+            .and_return(double(deliver_later: true))
+          post :import, params: { procedure_id: procedure.id, csv_file: csv_file, overwrite: '1' }
+        end
+
+        it 'ensures defaut_groupe_instructeur is never nil after overwrite' do
+          expect(response.status).to eq(302)
+          expect(procedure.reload.defaut_groupe_instructeur).not_to be_nil
+        end
+      end
     end
 
     context 'unrouted procedures' do

--- a/spec/fixtures/files/groupe-import-overwrite-two-groups.csv
+++ b/spec/fixtures/files/groupe-import-overwrite-two-groups.csv
@@ -1,0 +1,3 @@
+Email,Groupe
+instructeur1@example.gouv.fr,Groupe A
+instructeur2@example.gouv.fr,Groupe B


### PR DESCRIPTION
cf https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_31ecd877-9033-4565-9e0c-96ef6615851a/

## Résumé

- Lors d'un import CSV avec overwrite, les groupes absents du CSV pouvaient être supprimés, y compris le groupe par défaut, laissant `defaut_groupe_instructeur_id = nil` et causant une 500 sur `/admin/procedures/[id]/groupe_instructeurs`.
- `can_delete?` retourne maintenant `false` pour le groupe par défaut, cohérent avec le contrôleur `destroy` qui bloquait déjà ce cas via une vérification séparée.
- Le service `InstructeursImportService` réassigne explicitement `defaut_groupe_instructeur` vers un groupe du CSV avant de détruire l'ancien (l'ordre est important pour contourner le `dependent: :nullify`).
- Le composant haml affiche désormais un message explicite quand on tente de supprimer le groupe par défaut.

## Plan de test

- [ ] Créer une procédure routée avec plusieurs groupes instructeurs
- [ ] Importer un CSV avec overwrite contenant des groupes aux labels différents du groupe par défaut
- [ ] Vérifier que la page `/admin/procedures/[id]/groupe_instructeurs` ne renvoie pas de 500
- [ ] Vérifier qu'un groupe par défaut est bien défini après l'import
- [ ] Vérifier que le bouton de suppression du groupe par défaut affiche le bon message

🤖 Generated with [Claude Code](https://claude.com/claude-code)