### PR TITLE
Correctif: ETQ admin, tronquer les libellés trop longs dans les tableaux référentiel

### DIFF
--- a/app/assets/stylesheets/referentiel_table.scss
+++ b/app/assets/stylesheets/referentiel_table.scss
@@ -1,0 +1,11 @@
+.referentiel-table {
+  td,
+  th {
+    &.referentiel-cell-truncate {
+      max-width: 30ch;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}

--- a/app/components/referentiels/autocomplete_configuration_component/autocomplete_configuration_component.html.haml
+++ b/app/components/referentiels/autocomplete_configuration_component/autocomplete_configuration_component.html.haml
@@ -12,7 +12,7 @@
           .fr-table__wrapper
             .fr-table__container
               .fr-table__content
-                %table
+                %table.referentiel-table
                   %caption Sélectionnez la source de données à exploiter pour les autosuggestions
                   %thead
                     %tr
@@ -22,7 +22,7 @@
                   %tbody
                     - maybe_datasources.each do |jsonpath, value|
                       %tr
-                        %td.fr-cell--fixed= jsonpath
+                        %td.fr-cell--fixed.referentiel-cell-truncate{ title: jsonpath }= jsonpath
                         %td.fr-cell--multiline
                           %pre= JSON.pretty_generate(value)
                         %td.fr-cell--center= select_datasource_radio_tag(jsonpath)

--- a/app/components/referentiels/mapping_form_component/mapping_form_component.html.haml
+++ b/app/components/referentiels/mapping_form_component/mapping_form_component.html.haml
@@ -7,7 +7,7 @@
         .fr-table__wrapper
           .fr-table__container
             .fr-table__content
-              %table
+              %table.referentiel-table
                 %caption Complétez le tableau de mapping ci-dessous en fonction des données que vous souhaitez exploiter
                 %thead
                   %tr
@@ -29,11 +29,11 @@
                 %tbody
                   - last_request_keys.each do |jsonpath, example_value|
                     %tr{ data: { controller: "referentiel-mapping" } }
-                      %td.fr-cell--multiline.fr-cell--fixed
+                      %td.fr-cell--multiline.fr-cell--fixed.referentiel-cell-truncate{ title: jsonpath }
                         %span.hidden{ id: label_check_prefill(jsonpath) }= "Utiliser #{jsonpath} pour préremplir le formulaire"
                         = jsonpath
                         = hidden_field_tag attribute_name(jsonpath, "example_value"), example_value
-                      %td.fr-cell--multiline= example_value
+                      %td.fr-cell--multiline.referentiel-cell-truncate{ title: example_value }= example_value
                       %td= cast_tag(jsonpath, example_value)
                       %td.text-center= prefill_tag(jsonpath)
                       %td

--- a/app/components/referentiels/referentiel_display_component/referentiel_display_component.html.haml
+++ b/app/components/referentiels/referentiel_display_component/referentiel_display_component.html.haml
@@ -2,7 +2,7 @@
   .fr-table__wrapper
     .fr-table__container
       .fr-table__content
-        %table
+        %table.referentiel-table
           %caption.fr-text--regular.fr-text--sm Indiquez les données issues du référentiel que vous souhaitez voir affichées pour l’usager et/ou l’instructeur
           %thead
             %tr
@@ -16,8 +16,8 @@
           %tbody
             - display_mapping.sort.each do |jsonpath, mapping_opts|
               %tr
-                %td.fr-cell--multiline.fr-cell--fixed= jsonpath
-                %td.fr-cell--multiline= mapping_opts[:example_value] || mapping_opts["example_value"]
+                %td.fr-cell--multiline.fr-cell--fixed.referentiel-cell-truncate{ title: jsonpath }= jsonpath
+                %td.fr-cell--multiline.referentiel-cell-truncate{ title: (mapping_opts[:example_value] || mapping_opts["example_value"]) }= mapping_opts[:example_value] || mapping_opts["example_value"]
                 %td= mapping_opts[:type] || mapping_opts["type"]
                 %td= mapping_opts[:libelle] || mapping_opts["libelle"]
                 - unless type_de_champ.private?

--- a/app/components/referentiels/referentiel_prefill_component/referentiel_prefill_component.html.haml
+++ b/app/components/referentiels/referentiel_prefill_component/referentiel_prefill_component.html.haml
@@ -2,7 +2,7 @@
   .fr-table__wrapper
     .fr-table__container
       .fr-table__content
-        %table
+        %table.referentiel-table
           %caption.fr-text--regular.fr-text--sm Indiquez les champs du formulaire usager qui doivent être préremplis avec les données issues du référentiel
           %thead
             %tr
@@ -13,7 +13,7 @@
           %tbody
             - referentiel_mapping_prefillable.sort.each do |jsonpath, mapping_opts|
               %tr
-                %td.fr-cell--multiline.fr-cell--fixed= jsonpath
-                %td.fr-cell--multiline= mapping_opts[:example_value]
+                %td.fr-cell--multiline.fr-cell--fixed.referentiel-cell-truncate{ title: jsonpath }= jsonpath
+                %td.fr-cell--multiline.referentiel-cell-truncate{ title: mapping_opts[:example_value] }= mapping_opts[:example_value]
                 %td= mapping_opts[:type]
                 %td= prefill_stable_id_tag(jsonpath, mapping_opts)


### PR DESCRIPTION
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_6a8104e4-4315-4a36-a7b0-e4b89979c66c/

# Problème

Les colonnes "Propriété" et "Exemple de donnée" des tableaux de mapping référentiel affichent des jsonpaths et valeurs insécables très longs (ex: `$.records[0].fields.commune_code_departement`, hash base64). Le navigateur ne peut pas les couper car ils ne contiennent **aucun espace**, ce qui force le tableau à déborder de son conteneur et le rend illisible.

# Solution

Ajout d'une classe CSS `referentiel-cell-truncate` (`max-width: 30ch`, `text-overflow: ellipsis`) sur les cellules concernées des 4 composants de tableau référentiel, avec un attribut `title` pour voir le texte complet au survol.

apres:
<img width="1213" height="535" alt="Capture d’écran 2026-05-12 à 11 27 02 AM" src="https://github.com/user-attachments/assets/8b329b60-f524-454a-8c39-3535058182a1" />
 
avant:
<img width="1224" height="539" alt="Capture d’écran 2026-05-12 à 11 27 24 AM" src="https://github.com/user-attachments/assets/5f67a1cc-38f7-4418-9028-8961bc260890" />

Generated with [Claude Code](https://claude.com/claude-code)