### PR TITLE
Tech: restreindre la modification de l'affichage par défaut admin aux administrateurs de la démarche

### DIFF
--- a/app/controllers/instructeurs/procedure_presentation_controller.rb
+++ b/app/controllers/instructeurs/procedure_presentation_controller.rb
@@ -90,8 +90,7 @@ module Instructeurs
     end
 
     def current_instructeur_administrates_procedure?
-      administrateur = current_instructeur.user.administrateur
-      administrateur.present? && administrateur.owns?(procedure)
+      current_instructeur.user.administrateur&.owns?(procedure)
     end
 
     def set_admin_pp_default

--- a/app/controllers/instructeurs/procedure_presentation_controller.rb
+++ b/app/controllers/instructeurs/procedure_presentation_controller.rb
@@ -34,7 +34,7 @@ module Instructeurs
     def update
       if @procedure_presentation.update(procedure_presentation_params)
         toggle_admin_default = params.dig(:procedure_presentation, :admin_default_procedure_presentation_active_virtual)
-        set_admin_pp_default if toggle_admin_default.present?
+        set_admin_pp_default if toggle_admin_default.present? && current_instructeur_administrates_procedure?
       else
         # complicated way to display inner error messages
         flash.alert = @procedure_presentation.errors
@@ -87,6 +87,11 @@ module Instructeurs
       end
 
       FilteredColumnType.new.cast(params_hash)
+    end
+
+    def current_instructeur_administrates_procedure?
+      administrateur = current_instructeur.user.administrateur
+      administrateur.present? && administrateur.owns?(procedure)
     end
 
     def set_admin_pp_default

--- a/spec/controllers/instructeurs/procedure_presentation_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedure_presentation_controller_spec.rb
@@ -88,6 +88,9 @@ describe Instructeurs::ProcedurePresentationController, type: :controller do
     end
 
     context 'with an admin who set presentation as default for other instructeurs' do
+      let(:administrateur) { create(:administrateur, user: instructeur.user) }
+      let(:procedure) { create(:procedure, administrateurs: [administrateur], types_de_champ_public: [{ type: :drop_down_list, libelle: 'Votre ville', options: ['Paris', 'Lyon', 'Marseille'] }]) }
+
       before { sign_in(instructeur.user) }
 
       let(:presentation_params) do
@@ -111,6 +114,24 @@ describe Instructeurs::ProcedurePresentationController, type: :controller do
         expect(procedure_presentation.displayed_columns).to eq([state_column])
         expect(procedure_presentation.procedure.admin_default_procedure_presentation_id).to eq(instructeur.procedure_presentation_for_procedure_id(procedure.id).id)
         expect(procedure_presentation.procedure.admin_default_procedure_presentation_active).to eq(true)
+      end
+    end
+
+    context 'when the signed-in instructeur is not an administrateur of the procedure' do
+      before { sign_in(instructeur.user) }
+
+      let(:presentation_params) do
+        {
+          procedure_presentation: { admin_default_procedure_presentation_active_virtual: true },
+        }
+      end
+
+      it 'does not change the procedure-level admin default presentation' do
+        expect {
+          subject
+          procedure.reload
+        }.to not_change { procedure.admin_default_procedure_presentation_id }
+          .and not_change { procedure.admin_default_procedure_presentation_active }
       end
     end
   end


### PR DESCRIPTION
## Description

Sur l'écran de personnalisation des colonnes (côté instructeur), la bascule **« Appliquer cette personnalisation pour tous les instructeurs de la démarche »** n'est affichée qu'aux instructeurs qui sont aussi administrateurs de la démarche (`instructeur_is_admin?` dans le composant).

Côté contrôleur en revanche, `Instructeurs::ProcedurePresentationController#update` appliquait le changement dès que le paramètre `admin_default_procedure_presentation_active_virtual` était présent dans la requête, sans revérifier que l'instructeur connecté est bien administrateur de la démarche.

Cette PR aligne le contrôleur sur ce que le composant supposait déjà : `set_admin_pp_default` n'est appelé que si l'instructeur connecté est un administrateur de la démarche (`Administrateur#owns?`).

## Changements

- `Instructeurs::ProcedurePresentationController#update` : garde sur l'appel à `set_admin_pp_default`.
- Spec contrôleur : ajout d'un cas qui vérifie que `procedure.admin_default_procedure_presentation_id` et `admin_default_procedure_presentation_active` ne changent pas quand l'instructeur connecté n'est pas administrateur de la démarche.
- Spec contrôleur : le cas existant « admin qui définit la présentation par défaut » liait un instructeur seul ; il crée maintenant un véritable `Administrateur` lié à `instructeur.user`, ce qui reflète la situation réelle.