### PR TITLE
Correctif: ETQ instructeur, ne pas proposer d'archive quand les dossiers ont été supprimés

### DIFF
--- a/app/controllers/administrateurs/archives_controller.rb
+++ b/app/controllers/administrateurs/archives_controller.rb
@@ -14,7 +14,7 @@ module Administrateurs
         .dossiers
         .visible_by_administration
         .where(processed_at: ...Date.current.beginning_of_month)
-        .processed_by_month(all_groupe_instructeurs)
+        .archivable_by_month(all_groupe_instructeurs)
         .count
       @archives = Archive.for_groupe_instructeur(all_groupe_instructeurs).to_a
     end

--- a/app/controllers/administrateurs/archives_controller.rb
+++ b/app/controllers/administrateurs/archives_controller.rb
@@ -12,7 +12,6 @@ module Administrateurs
       @average_dossier_weight = @procedure.average_dossier_weight
       @count_dossiers_termines_by_month = @procedure
         .dossiers
-        .visible_by_administration
         .where(processed_at: ...Date.current.beginning_of_month)
         .archivable_by_month(all_groupe_instructeurs)
         .count

--- a/app/controllers/instructeurs/archives_controller.rb
+++ b/app/controllers/instructeurs/archives_controller.rb
@@ -10,7 +10,7 @@ module Instructeurs
 
     def index
       @average_dossier_weight = @procedure.average_dossier_weight
-      @count_dossiers_termines_by_month = @procedure.dossiers.processed_by_month(groupe_instructeurs).count
+      @count_dossiers_termines_by_month = @procedure.dossiers.archivable_by_month(groupe_instructeurs).count
       @archives = Archive.for_groupe_instructeur(groupe_instructeurs).where(user_profile: current_instructeur).to_a
     end
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -283,15 +283,17 @@ class Dossier < ApplicationRecord
   scope :en_instruction,              -> { not_archived.state_en_instruction }
   scope :termine,                     -> { not_archived.state_termine }
 
-  scope :processed_by_month, -> (all_groupe_instructeurs) {
-    state_termine
+  scope :archivable, -> { visible_by_administration.state_termine }
+
+  scope :archivable_by_month, -> (all_groupe_instructeurs) {
+    archivable
       .where(groupe_instructeur: all_groupe_instructeurs)
       .group_by_period(:month, :processed_at, reverse: true)
   }
 
-  scope :processed_in_month, -> (date) do
+  scope :archivable_in_month, -> (date) do
     date = date.to_datetime
-    state_termine
+    archivable
       .where(processed_at: date.all_month)
   end
   scope :ordered_for_export, -> {

--- a/app/services/procedure_archive_service.rb
+++ b/app/services/procedure_archive_service.rb
@@ -8,14 +8,10 @@ class ProcedureArchiveService
   end
 
   def make_and_upload_archive(archive)
-    dossiers = Dossier.visible_by_administration
+    dossiers = Dossier.archivable
       .where(groupe_instructeur: archive.groupe_instructeurs)
 
-    dossiers = if archive.time_span_type == 'everything'
-      dossiers.state_termine
-    else
-      dossiers.processed_in_month(archive.month)
-    end
+    dossiers = dossiers.where(processed_at: archive.month.to_datetime.all_month) if archive.monthly?
 
     attachments = ActiveStorage::DownloadableFile.create_list_from_dossiers(dossiers:, user_profile: archive.user_profile)
 

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -2695,7 +2695,31 @@ describe Dossier, type: :model do
     end
   end
 
-  describe '#processed_in_month' do
+  describe '#archivable' do
+    let(:procedure) { create(:procedure, :published) }
+
+    it 'includes visible termine dossiers' do
+      dossier = create(:dossier, :accepte, procedure:)
+      expect(Dossier.archivable).to include(dossier)
+    end
+
+    it 'excludes dossiers hidden by administration' do
+      dossier = create(:dossier, :accepte, :hidden_by_administration, procedure:)
+      expect(Dossier.archivable).not_to include(dossier)
+    end
+
+    it 'excludes dossiers hidden by expired' do
+      dossier = create(:dossier, :accepte, :hidden_by_expired, procedure:)
+      expect(Dossier.archivable).not_to include(dossier)
+    end
+
+    it 'excludes dossiers en construction' do
+      dossier = create(:dossier, :en_construction, procedure:)
+      expect(Dossier.archivable).not_to include(dossier)
+    end
+  end
+
+  describe '#archivable_in_month' do
     let(:dossier_accepte_at) { DateTime.new(2022, 3, 31, 12, 0) }
     before do
       travel_to(dossier_accepte_at) do
@@ -2706,19 +2730,31 @@ describe Dossier, type: :model do
     context 'given a date' do
       let(:archive_date) { Date.new(2022, 3, 1) }
       it 'includes a dossier processed_at at last day of month' do
-        expect(Dossier.processed_in_month(archive_date).count).to eq(1)
+        expect(Dossier.archivable_in_month(archive_date).count).to eq(1)
       end
     end
 
     context 'given a datetime' do
       let(:archive_date) { DateTime.new(2022, 3, 1, 12, 0) }
       it 'includes a dossier processed_at at last day of month' do
-        expect(Dossier.processed_in_month(archive_date).count).to eq(1)
+        expect(Dossier.archivable_in_month(archive_date).count).to eq(1)
+      end
+    end
+
+    context 'with a dossier hidden by administration' do
+      before do
+        travel_to(dossier_accepte_at) do
+          create(:dossier, :accepte, :hidden_by_administration)
+        end
+      end
+
+      it 'excludes hidden dossiers' do
+        expect(Dossier.archivable_in_month(Date.new(2022, 3, 1)).count).to eq(1)
       end
     end
   end
 
-  describe '#processed_by_month' do
+  describe '#archivable_by_month' do
     let(:procedure) { create(:procedure, :published, groupe_instructeurs: [groupe_instructeurs]) }
     let(:groupe_instructeurs) { create(:groupe_instructeur) }
 
@@ -2731,7 +2767,7 @@ describe Dossier, type: :model do
 
     subject do
       travel_to(Time.zone.local(2021, 3, 5)) do
-        Dossier.processed_by_month(groupe_instructeurs).count
+        Dossier.archivable_by_month(groupe_instructeurs).count
       end
     end
 
@@ -2743,6 +2779,18 @@ describe Dossier, type: :model do
     it 'returns descending order by month' do
       expect(subject.keys.first.month).to eq 3
       expect(subject.keys.last.month).to eq 2
+    end
+
+    context 'with a dossier hidden by administration' do
+      before do
+        travel_to(Time.zone.local(2021, 3, 5)) do
+          create(:dossier, :accepte, :hidden_by_administration, procedure:)
+        end
+      end
+
+      it 'excludes hidden dossiers from count' do
+        expect(count_for_month(subject, 3)).to eq 3
+      end
     end
   end
 
@@ -2894,8 +2942,8 @@ describe Dossier, type: :model do
 
   private
 
-  def count_for_month(processed_by_month, month)
-    processed_by_month.find { |date, _count| date.month == month }[1]
+  def count_for_month(archivable_by_month, month)
+    archivable_by_month.find { |date, _count| date.month == month }[1]
   end
 
   def create_dossier_for_month(procedure, year, month)


### PR DESCRIPTION
# Problème

Remontée support sur la démarche 144143 : un instructeur demande le téléchargement d'une archive mensuelle, mais le zip généré est vide/corrompu.

**Root cause** : incohérence entre le comptage UI et le contenu de l'archive.

- Le scope `processed_by_month` (affiché dans le tableau) comptait **tous** les dossiers terminés, y compris ceux supprimés par l'administration
- Le service `ProcedureArchiveService` filtrait avec `visible_by_administration`, excluant les dossiers supprimés
- Résultat : l'UI affichait "2 dossiers terminés" avec un bouton de téléchargement, mais l'archive générée ne contenait rien

# Solution

Introduction d'un scope `archivable` (`visible_by_administration.state_termine`) comme source unique de vérité pour définir quels dossiers sont archivables.

Les scopes `processed_by_month` et `processed_in_month` utilisent désormais `archivable` au lieu de `state_termine`, ce qui :
- corrige le comptage UI côté instructeur (le mois n'apparaît plus s'il n'y a rien à archiver)
- centralise la logique en un seul endroit au lieu de la disperser entre contrôleurs et service
- permet de retirer les `visible_by_administration` redondants du contrôleur admin et du service

Generated with [Claude Code](https://claude.com/claude-code)