### PR TITLE
Tech: limiter l'édition OCR instructeur aux champs RIB

### DIFF
--- a/app/controllers/instructeurs/champs_controller.rb
+++ b/app/controllers/instructeurs/champs_controller.rb
@@ -4,8 +4,8 @@ module Instructeurs
   class ChampsController < InstructeurController
     before_action :set_dossier
     before_action :set_dossier_stream
-    before_action :set_champ, only: [:edit]
-    before_action :set_champ_for_update, only: [:update]
+    before_action :set_rib_champ, only: [:edit]
+    before_action :set_rib_champ_for_update, only: [:update]
 
     def edit
       render layout: "empty_layout"
@@ -14,11 +14,11 @@ module Instructeurs
     def update
       rib = RIB.new(rib_params).to_h
 
-      @champ_for_update.update!(value_json: { rib:, hint: 'rib' })
+      @rib_champ_for_update.update!(value_json: { rib:, hint: 'rib' })
 
       @dossier.merge_instructeur_buffer_stream!
 
-      redirect_to instructeur_dossier_path(@dossier.procedure, @dossier), notice: t(".success", libelle: @champ_for_update.libelle)
+      redirect_to instructeur_dossier_path(@dossier.procedure, @dossier), notice: t(".success", libelle: @rib_champ_for_update.libelle)
     end
 
     private
@@ -33,16 +33,21 @@ module Instructeurs
       @dossier.with_instructeur_buffer_stream
     end
 
-    def set_champ
-      stable_id, row_id = params[:public_id].split("-")
-      type_de_champ = @dossier.find_type_de_champ_by_stable_id(stable_id)
-      @champ = @dossier.project_champ(type_de_champ, row_id:)
+    def set_rib_champ
+      type_de_champ, row_id = find_rib_type_de_champ!
+      @rib_champ = @dossier.project_champ(type_de_champ, row_id:)
     end
 
-    def set_champ_for_update
+    def set_rib_champ_for_update
+      type_de_champ, row_id = find_rib_type_de_champ!
+      @rib_champ_for_update = @dossier.champ_for_update(type_de_champ, row_id:, updated_by: current_instructeur.email)
+    end
+
+    def find_rib_type_de_champ!
       stable_id, row_id = params[:public_id].split("-")
       type_de_champ = @dossier.find_type_de_champ_by_stable_id(stable_id)
-      @champ_for_update = @dossier.champ_for_update(type_de_champ, row_id:, updated_by: current_instructeur.email)
+      raise ActiveRecord::RecordNotFound unless type_de_champ&.rib?
+      [type_de_champ, row_id]
     end
 
     def rib_params = params.require(:rib).permit(:account_holder, :bank_name, :bic, :iban)

--- a/app/views/instructeurs/champs/edit.html.erb
+++ b/app/views/instructeurs/champs/edit.html.erb
@@ -17,10 +17,10 @@
 
   <div class="fr-container flex-grow flex fr-py-2w">
     <div class="fr-col flex column fr-pr-2w width-50">
-      <p><%= @champ.libelle %></p>
+      <p><%= @rib_champ.libelle %></p>
 
       <embed
-        src="<%= @champ.piece_justificative_file.blobs.first.url %>"
+        src="<%= @rib_champ.piece_justificative_file.blobs.first.url %>"
         type="application/pdf"
         scrolling="auto"
         class="border-background-contrast-grey"
@@ -30,8 +30,8 @@
     <div class="fr-col fr-pl-2w">
       <p><%= t('.attachment_data') %></p>
 
-      <%= form_with model: RIB.new(@champ.value_json&.dig('rib')),
-        url: instructeurs_dossier_champ_path(@champ.dossier_id, @champ.public_id), 
+      <%= form_with model: RIB.new(@rib_champ.value_json&.dig('rib')),
+        url: instructeurs_dossier_champ_path(@rib_champ.dossier_id, @rib_champ.public_id), 
         method: :patch,
         html: { id: 'attachment-data-form', class: 'border-background-contrast-grey fr-p-2w' } do |f| %>
         <div class="fr-input-group">

--- a/spec/controllers/instructeurs/champs_controller_spec.rb
+++ b/spec/controllers/instructeurs/champs_controller_spec.rb
@@ -54,5 +54,32 @@ describe Instructeurs::ChampsController, type: :controller do
       history_champ = others.first
       expect(history_champ.stream).to start_with('history:')
     end
+
+    context 'when the public_id points to a public champ that is not a RIB' do
+      let(:types_de_champ_public) do
+        [
+          { type: :piece_justificative, nature: 'rib' },
+          { type: :address, libelle: 'Adresse' },
+        ]
+      end
+
+      let(:address_champ) { dossier.champs.find { _1.type_champ == TypeDeChamp.type_champs.fetch(:address) } }
+      let(:original_address) { { 'label' => '12 rue du Test, 75000 Paris', 'postal_code' => '75000', 'city_name' => 'Paris' } }
+
+      before { address_champ.update!(value: original_address['label'], value_json: original_address) }
+
+      subject(:cross_type_request) do
+        put :update, params: { dossier_id: dossier.id, public_id: address_champ.public_id, rib: rib_params }
+      end
+
+      it 'rejects the request and does not overwrite the address champ' do
+        expect { cross_type_request }.to raise_error(ActiveRecord::RecordNotFound)
+
+        main_address = Champ.find_by!(dossier_id: dossier.id, stable_id: address_champ.stable_id, stream: Champ::MAIN_STREAM)
+        expect(main_address.value_json).not_to have_key('rib')
+        expect(main_address.value_json).to include('label' => original_address['label'])
+        expect(main_address.type).to eq('Champs::AddressChamp')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Contexte

L'éditeur OCR de l'instructeur (`PATCH /instructeurs/dossiers/:dossier_id/champs/:public_id`) résolvait le `TypeDeChamp` à partir du `public_id` sans vérifier sa nature, puis écrivait `value_json: { rib:, hint: 'rib' }` dessus. En pratique, tout `public_id` valide du dossier passait — un instructeur pouvait écrire la structure RIB sur n'importe quel champ public (adresse, SIRET, etc.) et écraser la valeur saisie par l'usager sur le stream principal.

## Changements

- `find_rib_type_de_champ!` centralise la résolution du `TypeDeChamp` depuis le `public_id` et renvoie `ActiveRecord::RecordNotFound` si la nature n'est pas `rib`.
- Renommage : `set_champ` → `set_rib_champ`, `set_champ_for_update` → `set_rib_champ_for_update`, ivars associés (`@rib_champ`, `@rib_champ_for_update`), vue `edit.html.erb` ajustée.
- Spec contrôleur : un `PATCH` ciblant un champ adresse renvoie `RecordNotFound` et la valeur d'origine reste intacte sur le stream `main`.

Les autres appels à `find_type_de_champ_by_stable_id` dans l'app passent déjà un scope explicite ; ce contrôleur était le seul cas non scopé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)