### PR TITLE
Correctif: ETQ instructeur, exporter la valeur des dropdown avec referentiel

### DIFF
--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -28,19 +28,25 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBase
 
   def columns(procedure:, displayable: true, prefix: nil)
     if drop_down_advanced?
-      referentiel.present? ? referentiel.headers_with_path.map do |(header, path)|
-        Columns::JSONPathColumn.new(
-          procedure_id: procedure.id,
-          stable_id:,
-          tdc_type: type_champ,
-          label: "#{libelle_with_prefix(prefix)} – Référentiel #{header}",
-          type: :enum,
-          jsonpath: "$.referentiel.data.row.#{path}",
-          displayable:,
-          options_for_select: referentiel.options_for_path(path),
-          mandatory: mandatory?
-        )
-      end : []
+      referentiel_columns = if referentiel.present?
+        referentiel.headers_with_path.map do |(header, path)|
+          Columns::JSONPathColumn.new(
+            procedure_id: procedure.id,
+            stable_id:,
+            tdc_type: type_champ,
+            label: "#{libelle_with_prefix(prefix)} – Référentiel #{header}",
+            type: :enum,
+            jsonpath: "$.referentiel.data.row.#{path}",
+            displayable:,
+            options_for_select: referentiel.options_for_path(path),
+            mandatory: mandatory?
+          )
+        end
+      else
+        []
+      end
+
+      super + referentiel_columns
     else
       super
     end

--- a/spec/models/concerns/columns_concern_spec.rb
+++ b/spec/models/concerns/columns_concern_spec.rb
@@ -149,6 +149,7 @@ describe ColumnsConcern do
         let(:referentiel) { create(:csv_referentiel, :with_items) }
         let(:types_de_champ_private) { [] }
         it {
+          expect(subject.map(&:label)).to include('liste csv')
           expect(subject.map(&:label)).to include('liste csv – Référentiel calorie (kcal)')
           expect(subject.map(&:label)).to include('liste csv – Référentiel poids (g)')
         }

--- a/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
@@ -3,11 +3,25 @@
 describe TypesDeChamp::DropDownListTypeDeChamp do
   describe '#columns' do
     let(:procedure) { create(:procedure, types_de_champ_public:) }
-    let(:types_de_champ_public) { [{ type: :drop_down_list, referentiel:, drop_down_mode: 'advanced' }] }
+    let(:types_de_champ_public) { [{ type: :drop_down_list, referentiel:, drop_down_mode: }] }
     let(:referentiel) { create(:csv_referentiel, :with_items) }
+    let(:dropdown_list_tdc) { procedure.active_revision.types_de_champ.first }
+    subject { dropdown_list_tdc.columns(procedure:) }
 
-    context 'when referentiel_mode is true' do
-      let(:dropdown_list_tdc) { procedure.active_revision.types_de_champ.first }
+    context 'when drop_down_mode is advanced (referentiel)' do
+      let(:drop_down_mode) { 'advanced' }
+
+      it 'includes value column and referentiel columns' do
+        labels = subject.map(&:label)
+        expect(labels).to include(dropdown_list_tdc.libelle)
+        expect(labels).to include("#{dropdown_list_tdc.libelle} – Référentiel calorie (kcal)")
+        expect(labels).to include("#{dropdown_list_tdc.libelle} – Référentiel poids (g)")
+      end
+
+      it 'returns a ChampColumn for value followed by JSONPathColumns for referentiel' do
+        expect(subject.first).to be_a(Columns::ChampColumn)
+        expect(subject.drop(1)).to all(be_a(Columns::JSONPathColumn))
+      end
 
       context 'when an item has nil for a specific header' do
         before do
@@ -17,9 +31,20 @@ describe TypesDeChamp::DropDownListTypeDeChamp do
           item.update(data:)
         end
 
-        let(:calorie_column) { dropdown_list_tdc.columns(procedure:).find { _1.label =~ /calorie/ } }
+        let(:calorie_column) { subject.find { _1.label =~ /calorie/ } }
 
         it { expect(calorie_column.options_for_select).to eq([["100", "100"], ["170", "170"]]) }
+      end
+    end
+
+    context 'when drop_down_mode is simple' do
+      let(:drop_down_mode) { 'simple' }
+      let(:referentiel) { nil }
+
+      it 'returns only the value column' do
+        expect(subject.size).to eq(1)
+        expect(subject.first).to be_a(Columns::ChampColumn)
+        expect(subject.first.label).to eq(dropdown_list_tdc.libelle)
       end
     end
   end


### PR DESCRIPTION
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_9ca8efe4-ed91-4fa6-ba18-9d07409171cc/

# Probleme

Quand un champ dropdown est en mode avancé (associé à un référentiel CSV), le système d'export ne propose **que les colonnes du référentiel** (ex: `calorie (kcal)`, `poids (g)`), sans jamais inclure la colonne `value` standard.

Deux conséquences :
- **Cas "Autre"** : quand l'usager sélectionne "Autre" et saisit un texte libre, le référentiel est `nil` → toutes les colonnes référentiel retournent `nil` → laissant croire que la saisie est **totalement perdue** à l'export
- **Cas normal** : on ne peut pas exporter le libellé de l'option sélectionnée comme pour un dropdown simple, uniquement les données détaillées du référentiel

# Solution

Dans `DropDownListTypeDeChamp`, la méthodes `columns` retourne désormais la colonne `value` standard**en plus** des colonnes du référentiel.

Cela permet :
- D'exporter la valeur sélectionnée (ou le texte "Autre") comme pour n'importe quel dropdown
- De conserver les colonnes détaillées du référentiel en complément
- À l'instructeur de choisir dans l'export template les colonnes qu'il souhaite

Generated with [Claude Code](https://claude.com/claude-code)