### PR TITLE
i18n(annuaire_education): extract hardcoded strings from AnnuaireEducationComponent

### DIFF
--- a/app/components/dossiers/annuaire_education_component.rb
+++ b/app/components/dossiers/annuaire_education_component.rb
@@ -17,9 +17,9 @@ class Dossiers::AnnuaireEducationComponent < ApplicationComponent
     return [] if champ.data.blank?
 
     [
-      ['Nom de l’établissement', champ.data['nom_etablissement']],
-      ['L’identifiant de l’etablissement', champ.data['identifiant_de_l_etablissement']],
-      ['SIREN/SIRET', champ.data['siren_siret']],
+      [t('.nom_etablissement'), champ.data['nom_etablissement']],
+      [t('.identifiant_etablissement'), champ.data['identifiant_de_l_etablissement']],
+      [t('.siren_siret'), champ.data['siren_siret']],
     ]
   end
 
@@ -27,15 +27,15 @@ class Dossiers::AnnuaireEducationComponent < ApplicationComponent
     return [] if champ.data.blank?
 
     [
-      ['Commune', commune],
-      ['Académie', "#{champ.data['libelle_academie']} (#{champ.data['code_academie']})"],
-      ['Nature de l’établissement', "#{champ.data['libelle_nature']} (#{champ.data['code_nature']})"],
-      ['Type de contrat privé', type_de_contrat],
-      ['Nombre d’élèves', champ.data['nombre_d_eleves']],
-      ['Adresse', adresse],
-      ['Téléphone', champ.data['telephone']],
-      ['Email', champ.data['mail']],
-      ['Site internet', champ.data['web']],
+      [t('.commune'), commune],
+      [t('.academie'), "#{champ.data['libelle_academie']} (#{champ.data['code_academie']})"],
+      [t('.nature_etablissement'), "#{champ.data['libelle_nature']} (#{champ.data['code_nature']})"],
+      [t('.type_contrat_prive'), type_de_contrat],
+      [t('.nombre_eleves'), champ.data['nombre_d_eleves']],
+      [t('.adresse'), adresse],
+      [t('.telephone'), champ.data['telephone']],
+      [t('.email'), champ.data['mail']],
+      [t('.site_internet'), champ.data['web']],
     ]
   end
 
@@ -45,11 +45,11 @@ class Dossiers::AnnuaireEducationComponent < ApplicationComponent
     elsif champ.data['nom_commune'].present?
       champ.data['nom_commune']
     else
-      'Non renseignée'
+      t('.non_renseignee')
     end
   end
 
-  def source = "Annuaire de l’Éducation Nationale"
+  def source = t('.source')
 
   def type_de_contrat
     champ.data['type_contrat_prive'] if champ.data['type_contrat_prive'] != 'SANS OBJET'

--- a/app/components/dossiers/annuaire_education_component/annuaire_education_component.en.yml
+++ b/app/components/dossiers/annuaire_education_component/annuaire_education_component.en.yml
@@ -1,0 +1,15 @@
+en:
+  nom_etablissement: School name
+  identifiant_etablissement: School identifier
+  siren_siret: SIREN/SIRET
+  commune: Municipality
+  academie: Academy
+  nature_etablissement: Type of school
+  type_contrat_prive: Private contract type
+  nombre_eleves: Number of students
+  adresse: Address
+  telephone: Phone
+  email: Email
+  site_internet: Website
+  non_renseignee: Not provided
+  source: National Education Directory

--- a/app/components/dossiers/annuaire_education_component/annuaire_education_component.fr.yml
+++ b/app/components/dossiers/annuaire_education_component/annuaire_education_component.fr.yml
@@ -1,0 +1,15 @@
+fr:
+  nom_etablissement: Nom de l’établissement
+  identifiant_etablissement: L’identifiant de l’etablissement
+  siren_siret: SIREN/SIRET
+  commune: Commune
+  academie: Académie
+  nature_etablissement: Nature de l’établissement
+  type_contrat_prive: Type de contrat privé
+  nombre_eleves: Nombre d’élèves
+  adresse: Adresse
+  telephone: Téléphone
+  email: Email
+  site_internet: Site internet
+  non_renseignee: Non renseignée
+  source: Annuaire de l’Éducation Nationale

--- a/spec/components/dossiers/annuaire_education_component_spec.rb
+++ b/spec/components/dossiers/annuaire_education_component_spec.rb
@@ -37,24 +37,24 @@ RSpec.describe Dossiers::AnnuaireEducationComponent, type: :component do
     it 'renders ExternalChampComponent with correct arguments' do
       expect(Dossiers::ExternalChampComponent).to have_received(:new) do |data:, details:, source:|
         expected_data = [
-          ["Nom de l’établissement", "Lycée Jean Moulin"],
-          ["L’identifiant de l’etablissement", "0123456A"],
+          ["Nom de l\u2019\u00e9tablissement", "Lycée Jean Moulin"],
+          ["L\u2019identifiant de l\u2019etablissement", "0123456A"],
           ["SIREN/SIRET", "12345678901234"],
         ]
 
         expected_details = [
           ["Commune", "Paris (75001)"],
-          ["Académie", "Paris (01)"],
-          ["Nature de l’établissement", "Lycée général (LGT)"],
-          ["Type de contrat privé", nil],
-          ["Nombre d’élèves", "450"],
+          ["Acad\u00e9mie", "Paris (01)"],
+          ["Nature de l\u2019\u00e9tablissement", "Lycée général (LGT)"],
+          ["Type de contrat priv\u00e9", nil],
+          ["Nombre d\u2019\u00e9l\u00e8ves", "450"],
           ["Adresse", "123 rue de la République<br>75001 Paris<br>Île-de-France (11)"],
-          ["Téléphone", "0145123456"],
+          ["T\u00e9l\u00e9phone", "0145123456"],
           ["Email", "contact@lycee-moulin.fr"],
           ["Site internet", "https://lycee-moulin.fr"],
         ]
 
-        expected_source = "Annuaire de l’Éducation Nationale"
+        expected_source = "Annuaire de l\u2019\u00c9ducation Nationale"
 
         expect(data).to eq(expected_data)
         expect(details).to eq(expected_details)
@@ -71,7 +71,7 @@ RSpec.describe Dossiers::AnnuaireEducationComponent, type: :component do
         expect(Dossiers::ExternalChampComponent).to have_received(:new) do |args|
           details = args[:details]
           expect(details.find { |label, _| label == 'Commune' }[1]).to eq('Paris')
-          expect(details.find { |label, _| label == 'Type de contrat privé' }[1]).to eq('SOUS CONTRAT')
+          expect(details.find { |label, _| label == "Type de contrat priv\u00e9" }[1]).to eq('SOUS CONTRAT')
         end
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe Dossiers::AnnuaireEducationComponent, type: :component do
       it do
         expect(Dossiers::ExternalChampComponent).to have_received(:new) do |args|
           details = args[:details]
-          expect(details.find { |label, _| label == 'Commune' }[1]).to eq('Non renseignée')
+          expect(details.find { |label, _| label == 'Commune' }[1]).to eq("Non renseign\u00e9e")
         end
       end
     end


### PR DESCRIPTION
## Probleme

Textes francais en dur dans `app/components/dossiers/annuaire_education_component.rb` — non internationalisable, non maintenable.

## Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 14 cles i18n vers `app/components/dossiers/annuaire_education_component/annuaire_education_component.fr.yml`.

### Cles extraites

| Cle | Valeur |
|-----|--------|
| `nom_etablissement` | "Nom de l'etablissement" |
| `identifiant_etablissement` | "L'identifiant de l'etablissement" |
| `siren_siret` | "SIREN/SIRET" |
| `commune` | "Commune" |
| `academie` | "Academie" |
| `nature_etablissement` | "Nature de l'etablissement" |
| `type_contrat_prive` | "Type de contrat prive" |
| `nombre_eleves` | "Nombre d'eleves" |
| `adresse` | "Adresse" |
| `telephone` | "Telephone" |
| `email` | "Email" |
| `site_internet` | "Site internet" |
| `non_renseignee` | "Non renseignee" |
| `source` | "Annuaire de l'Education Nationale" |

### Validation visuelle

- Pas de preview ViewComponent disponible pour ce composant
- Pas de serveur de dev actif

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante
- [x] Apostrophes typographiques verifiees (`lint:apostrophe:fix`)
- [x] Tests passes (3 examples, 0 failures)
- [x] Rubocop OK (0 offenses)

Generated with [Claude Code](https://claude.com/claude-code)
