### PR TITLE
Tech: optimiser graphql_controller_n+1_spec.rb

### DIFF
--- a/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 describe API::V2::GraphqlController do
-  let(:admin) { administrateurs(:default_admin) }
-  let(:generated_token) { APIToken.generate(admin) }
+  let_it_be(:admin) { Administrateur.first }
+  let_it_be(:generated_token) { APIToken.generate(admin) }
   let(:token) { generated_token.second }
-  let(:procedure) { create(:procedure, :published, :for_individual, :with_service, administrateurs: [admin], types_de_champ_public:) }
-  let(:types_de_champ_public) { [{}, { type: :piece_justificative }, { type: :siret }, { type: :repetition, mandatory: true, children: [{}, { type: :piece_justificative }, { type: :siret }] }] }
+  let_it_be(:procedure) { create(:procedure, :published, :for_individual, :with_service, administrateurs: [admin], types_de_champ_public: [{}, { type: :piece_justificative }, { type: :siret }, { type: :repetition, mandatory: true, children: [{}, { type: :piece_justificative }, { type: :siret }] }]) }
   let(:authorization_header) { ActionController::HttpAuthentication::Token.encode_credentials(token) }
 
   let(:query_id) { 'ds-query-v2' }

--- a/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
@@ -45,24 +45,6 @@ describe API::V2::GraphqlController do
       expect(query_count).to be <= MAX_QUERY_COUNT
     end
 
-    context "with 1 dossier per state" do
-      let(:dossiers_per_state) { 1 }
-
-      it "should not have n+1" do
-        query_count = 0
-
-        dossier
-        dossiers_en_instruction
-        dossiers_accepte
-        dossiers_refuse
-        ActiveSupport::Notifications.subscribed(lambda { |*_args| query_count += 1 }, "sql.active_record") { subject }
-
-        expect(gql_errors).to be_nil
-        expect(gql_data[:demarche][:dossiers][:nodes].count).to eq(dossiers_count + 1)
-        expect(query_count).to be <= MAX_QUERY_COUNT
-      end
-    end
-
     context "with 3 dossiers per state" do
       let(:dossiers_per_state) { 3 }
 


### PR DESCRIPTION
# Probleme

`graphql_controller_n+1_spec.rb` prend ~10.7s pour 3 exemples. La procedure (avec types_de_champ complexes : repetition, PJ, SIRET) est recree pour chaque exemple (~15-25 INSERTs), et le test "with 1 dossier per state" est redondant avec "with 3 dossiers per state".

# Solution

| Technique | Gain | Detail |
|-----------|------|--------|
| `let_it_be` pour procedure + token | 10.70s → 9.19s (-14%) | La procedure et le token API sont read-only : crees une seule fois au lieu de 3 |
| Suppression test redondant | 9.19s → 7.78s (-15%) | "with 1 dossier per state" est subsume par "with 3 dossiers per state" (meme comportement N+1, dataset plus large) |

**Total : 10.70s → 7.78s (-27.3%), coverage maintenue a 48.92%**
