### PR TITLE
Tech: convertit les normalisations de modèles vers ActiveModel `normalizes`

### DIFF
--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -26,8 +26,8 @@ class Avis < ApplicationRecord
   validates :question_answer, inclusion: { in: [true, false] }, on: :update, if: -> { question_label.present? }
   validates :piece_justificative_file, size: { less_than: FILE_MAX_SIZE }
   validates :introduction_file, size: { less_than: FILE_MAX_SIZE }
-  before_validation -> { strip_attribute(:question_label) }
 
+  normalizes :question_label, with: -> (value) { value.strip.presence }
   normalizes :answer, with: NORMALIZES_NON_PRINTABLE_PROC
 
   default_scope { joins(:dossier) }
@@ -91,11 +91,5 @@ class Avis < ApplicationRecord
   def remind_by!(revocator)
     return false if !remindable_by?(revocator) || answer.present?
     update_column(:reminded_at, Time.zone.now)
-  end
-
-  private
-
-  def strip_attribute(attribute)
-    self[attribute] = self[attribute]&.strip&.presence
   end
 end

--- a/app/models/champs/email_champ.rb
+++ b/app/models/champs/email_champ.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Champs::EmailChamp < Champs::TextChamp
-  normalizes :value, with: -> (value) { value.present? ? EmailSanitizableConcern::EmailSanitizer.sanitize(value) : value }
+  normalizes :value, with: -> (value) { EmailSanitizableConcern::EmailSanitizer.sanitize(value) }
 
   validates :value, allow_blank: true, strict_email: true, if: :should_validate_in_current_context?
 end

--- a/app/models/champs/email_champ.rb
+++ b/app/models/champs/email_champ.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class Champs::EmailChamp < Champs::TextChamp
-  include EmailSanitizableConcern
-  before_validation -> { sanitize_email(:value) }
+  normalizes :value, with: -> (value) { value.present? ? EmailSanitizableConcern::EmailSanitizer.sanitize(value) : value }
 
   validates :value, allow_blank: true, strict_email: true, if: :should_validate_in_current_context?
 end

--- a/app/models/contact_form.rb
+++ b/app/models/contact_form.rb
@@ -6,9 +6,10 @@ class ContactForm < ApplicationRecord
   belongs_to :user, optional: true
 
   after_initialize :set_options
-  before_validation :normalize_strings
-  before_validation :sanitize_email
   before_save :add_default_tags
+
+  normalizes :subject, :text, with: -> (value) { value.strip }
+  normalizes :email, with: -> (value) { value.present? ? EmailSanitizableConcern::EmailSanitizer.sanitize(value) : value }
 
   PG_BIGINT_MAX = (2**63) - 1
   PG_BIGINT_MIN = -(2**63)
@@ -74,15 +75,6 @@ class ContactForm < ApplicationRecord
   def require_email? = user.blank?
 
   private
-
-  def normalize_strings
-    self.subject = subject&.strip
-    self.text = text&.strip
-  end
-
-  def sanitize_email
-    self.email = EmailSanitizableConcern::EmailSanitizer.sanitize(email) if email.present?
-  end
 
   def add_default_tags
     self.tags = tags.push('contact form', question_type).uniq

--- a/app/models/contact_form.rb
+++ b/app/models/contact_form.rb
@@ -9,7 +9,7 @@ class ContactForm < ApplicationRecord
   before_save :add_default_tags
 
   normalizes :subject, :text, with: -> (value) { value.strip }
-  normalizes :email, with: -> (value) { value.present? ? EmailSanitizableConcern::EmailSanitizer.sanitize(value) : value }
+  normalizes :email, with: -> (value) { EmailSanitizableConcern::EmailSanitizer.sanitize(value) }
 
   PG_BIGINT_MAX = (2**63) - 1
   PG_BIGINT_MIN = -(2**63)

--- a/app/models/contact_information.rb
+++ b/app/models/contact_information.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ContactInformation < ApplicationRecord
-  include EmailSanitizableConcern
-
   belongs_to :groupe_instructeur
 
   validates :nom, presence: { message: 'doit être renseigné' }, allow_nil: false
@@ -12,7 +10,7 @@ class ContactInformation < ApplicationRecord
   validates :horaires, presence: { message: 'doivent être renseignés' }, allow_nil: false
   validates :adresse, presence: { message: 'doit être renseignée' }, allow_nil: false
   validates :groupe_instructeur, presence: { message: 'doit être renseigné' }, allow_nil: false
-  before_validation -> { sanitize_email(:email) }
+  normalizes :email, with: -> (value) { value.present? ? EmailSanitizableConcern::EmailSanitizer.sanitize(value) : value }
 
   def pretty_nom
     nom

--- a/app/models/contact_information.rb
+++ b/app/models/contact_information.rb
@@ -10,7 +10,7 @@ class ContactInformation < ApplicationRecord
   validates :horaires, presence: { message: 'doivent être renseignés' }, allow_nil: false
   validates :adresse, presence: { message: 'doit être renseignée' }, allow_nil: false
   validates :groupe_instructeur, presence: { message: 'doit être renseigné' }, allow_nil: false
-  normalizes :email, with: -> (value) { value.present? ? EmailSanitizableConcern::EmailSanitizer.sanitize(value) : value }
+  normalizes :email, with: -> (value) { EmailSanitizableConcern::EmailSanitizer.sanitize(value) }
 
   def pretty_nom
     nom

--- a/app/models/dossier_transfer.rb
+++ b/app/models/dossier_transfer.rb
@@ -6,7 +6,7 @@ class DossierTransfer < ApplicationRecord
   EXPIRATION_LIMIT = 2.weeks
 
   validates :email, strict_email: true, presence: true
-  normalizes :email, with: -> (value) { value.present? ? EmailSanitizableConcern::EmailSanitizer.sanitize(value) : value }
+  normalizes :email, with: -> (value) { EmailSanitizableConcern::EmailSanitizer.sanitize(value) }
 
   scope :pending, -> { where('created_at > ?', (Time.zone.now - EXPIRATION_LIMIT)) }
   scope :stale, -> { where(created_at: ...(Time.zone.now - EXPIRATION_LIMIT)) }

--- a/app/models/dossier_transfer.rb
+++ b/app/models/dossier_transfer.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 class DossierTransfer < ApplicationRecord
-  include EmailSanitizableConcern
   has_many :dossiers, dependent: :nullify
 
   EXPIRATION_LIMIT = 2.weeks
 
   validates :email, strict_email: true, presence: true
-  before_validation -> { sanitize_email(:email) }
+  normalizes :email, with: -> (value) { value.present? ? EmailSanitizableConcern::EmailSanitizer.sanitize(value) : value }
 
   scope :pending, -> { where('created_at > ?', (Time.zone.now - EXPIRATION_LIMIT)) }
   scope :stale, -> { where(created_at: ...(Time.zone.now - EXPIRATION_LIMIT)) }

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -26,7 +26,7 @@ class GroupeInstructeur < ApplicationRecord
   validates :label, uniqueness: { scope: :procedure }
   validates :closed, acceptance: { accept: [false] }, if: -> { (self == procedure.defaut_groupe_instructeur) }
 
-  before_validation -> { label&.strip! }
+  normalizes :label, with: -> (value) { value.strip }
 
   scope :without_group, -> (group) { where.not(id: group) }
   scope :for_api_v2, -> { includes(procedure: [:administrateurs]) }

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -5,7 +5,7 @@ class Invite < ApplicationRecord
   belongs_to :user, optional: true
   has_one :targeted_user_link, as: :target_model, dependent: :destroy, inverse_of: :target_model
 
-  normalizes :email, with: -> (value) { value.present? ? EmailSanitizableConcern::EmailSanitizer.sanitize(value) : value }
+  normalizes :email, with: -> (value) { EmailSanitizableConcern::EmailSanitizer.sanitize(value) }
 
   after_create_commit :send_notification
 

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 class Invite < ApplicationRecord
-  include EmailSanitizableConcern
-
   belongs_to :dossier, optional: false
   belongs_to :user, optional: true
   has_one :targeted_user_link, as: :target_model, dependent: :destroy, inverse_of: :target_model
 
-  before_validation -> { sanitize_email(:email) }
+  normalizes :email, with: -> (value) { value.present? ? EmailSanitizableConcern::EmailSanitizer.sanitize(value) : value }
 
   after_create_commit :send_notification
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -226,10 +226,11 @@ class TypeDeChamp < ApplicationRecord
 
   before_validation :check_mandatory
   before_validation :set_default_libelle, if: -> { type_champ_changed? }
-  before_validation :normalize_libelle
   before_validation :set_drop_down_list_options, if: -> { type_champ_changed? }
   before_validation :reset_pj_format_options_if_forced_nature
   before_validation :reset_repetition_limits_if_disabled
+
+  normalizes :libelle, with: -> (value) { value.strip }
 
   before_save :remove_attachment, if: -> { type_champ_changed? }
   before_save :clean_referentiel
@@ -934,10 +935,6 @@ class TypeDeChamp < ApplicationRecord
     elsif linked_drop_down_list? && drop_down_options.none?(/^--.*--$/)
       self.drop_down_options = ['--Fromage--', 'bleu de sassenage', 'picodon', '--Dessert--', 'éclair', 'tarte aux pommes']
     end
-  end
-
-  def normalize_libelle
-    self.libelle&.strip!
   end
 
   def reset_repetition_limits_if_disabled

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,8 @@ class User < ApplicationRecord
 
   default_scope { eager_load(:instructeur, :administrateur, :expert) }
 
-  before_validation -> { sanitize_email(:email) }
+  normalizes :email, with: -> (value) { value.present? ? EmailSanitizableConcern::EmailSanitizer.sanitize(value) : value }
+
   validate :does_not_merge_on_self, if: :requested_merge_into_id_changed?
 
   before_validation :remove_devise_email_format_validator

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ApplicationRecord
 
   default_scope { eager_load(:instructeur, :administrateur, :expert) }
 
-  normalizes :email, with: -> (value) { value.present? ? EmailSanitizableConcern::EmailSanitizer.sanitize(value) : value }
+  normalizes :email, with: -> (value) { EmailSanitizableConcern::EmailSanitizer.sanitize(value) }
 
   validate :does_not_merge_on_self, if: :requested_merge_into_id_changed?
 

--- a/spec/models/champs/email_champ_spec.rb
+++ b/spec/models/champs/email_champ_spec.rb
@@ -51,8 +51,8 @@ describe Champs::EmailChamp do
     context 'when value contains white spaces plus a standard email' do
       let(:value) { "\r\n\t username@mailserver.domain\r\n\t " }
       it { is_expected.to be_truthy }
-      it 'normalize value' do
-        expect { subject }.to change { champ.value }.from(value).to('username@mailserver.domain')
+      it 'normalizes value on assignment' do
+        expect(champ.value).to eq('username@mailserver.domain')
       end
     end
 

--- a/spec/models/contact_form_spec.rb
+++ b/spec/models/contact_form_spec.rb
@@ -22,4 +22,17 @@ describe ContactForm do
       expect(form.errors[:question_type]).to be_present
     end
   end
+
+  describe 'normalization' do
+    it 'strips subject and text' do
+      form = ContactForm.new(subject: '  Hello  ', text: "  world\n")
+      expect(form.subject).to eq('Hello')
+      expect(form.text).to eq('world')
+    end
+
+    it 'sanitizes email' do
+      form = ContactForm.new(email: '  Foo@Example.COM ')
+      expect(form.email).to eq('foo@example.com')
+    end
+  end
 end

--- a/spec/models/contact_information_spec.rb
+++ b/spec/models/contact_information_spec.rb
@@ -61,4 +61,11 @@ describe ContactInformation, type: :model do
       end
     end
   end
+
+  describe 'email normalization' do
+    it 'sanitizes the email on assignment' do
+      contact = ContactInformation.new(email: '  Foo@Example.COM ')
+      expect(contact.email).to eq('foo@example.com')
+    end
+  end
 end

--- a/spec/models/dossier_transfer_spec.rb
+++ b/spec/models/dossier_transfer_spec.rb
@@ -105,5 +105,13 @@ RSpec.describe DossierTransfer, type: :model do
         expect(subject).to be_invalid
       end
     end
+
+    context "when email contains spaces and uppercase characters" do
+      let(:email) { "  Foo@Example.COM " }
+
+      it "sanitizes the email on assignment" do
+        expect(subject.email).to eq("foo@example.com")
+      end
+    end
   end
 end

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -65,6 +65,15 @@ describe Invite do
     end
   end
 
+  describe "email normalization" do
+    let(:dossier) { create(:dossier) }
+
+    it "sanitizes the email on assignment" do
+      invite = build(:invite, email: "  Foo@Example.COM ", dossier: dossier)
+      expect(invite.email).to eq("foo@example.com")
+    end
+  end
+
   describe "#default_scope" do
     let!(:dossier) { create(:dossier, hidden_by_user_at: hidden_by_user_at) }
     let!(:invite) { create(:invite, email: "email@totor.com", dossier: dossier) }

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -355,10 +355,10 @@ describe TypeDeChamp do
     it_behaves_like "a non-prefillable type de champ", :type_de_champ_annuaire_education
   end
 
-  describe '#normalize_libelle' do
-    it do
-      expect(create(:type_de_champ, :header_section, libelle: " 2.3 Test").libelle).to eq("2.3 Test")
-      expect(create(:type_de_champ, libelle: " fix me ").libelle).to eq("fix me")
+  describe 'libelle normalization' do
+    it 'strips surrounding whitespace on assignment' do
+      expect(build(:type_de_champ, :header_section, libelle: " 2.3 Test").libelle).to eq("2.3 Test")
+      expect(build(:type_de_champ, libelle: " fix me ").libelle).to eq("fix me")
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 describe User, type: :model do
+  describe 'email normalization' do
+    it 'sanitizes the email on assignment' do
+      user = User.new(email: '  Foo@Example.COM ')
+      expect(user.email).to eq('foo@example.com')
+    end
+  end
+
   describe '#after_confirmation' do
     let(:email) { 'mail@beta.gouv.fr' }
     let!(:invite) { create(:invite, email: email) }


### PR DESCRIPTION
## Résumé

Remplace les callbacks `before_validation` qui normalisaient des attributs par le pattern `ActiveModel::Attributes::Normalization` (`normalizes`, disponible depuis Rails 7.1).

Modèles convertis :

- `TypeDeChamp` — `libelle` (strip)
- `Avis` — `question_label` (strip + presence)
- `GroupeInstructeur` — `label` (strip)
- `ContactForm` — `subject`, `text` (strip) + `email` (sanitize)
- `Champs::EmailChamp` — `value` (sanitize)
- `DossierTransfer` — `email` (sanitize)
- `Invite` — `email` (sanitize)
- `ContactInformation` — `email` (sanitize)
- `User` — `email` (sanitize)

Au passage, suppression des `include EmailSanitizableConcern` et des méthodes privées (`normalize_libelle`, `strip_attribute`, `normalize_strings`, `sanitize_email`) devenues inutiles dans ces modèles.

## Changement de comportement

La normalisation s'exécute désormais au moment de l'affectation de l'attribut (`record.email = "..."`) et non plus juste avant la validation. Pour les nouveaux enregistrements et les mises à jour explicites de l'attribut, le résultat est identique. Les valeurs déjà persistées non normalisées ne seront pas re-normalisées tant que l'attribut n'est pas réaffecté.

Un test de `Champs::EmailChamp` qui vérifiait la normalisation pendant `validate` a été ajusté pour vérifier la normalisation à l'affectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)