### PR TITLE
Tech: utilise POST pour enregistrer l'accusé de lecture

### DIFF
--- a/app/components/dossiers/accuse_lecture_component/accuse_lecture_component.html.erb
+++ b/app/components/dossiers/accuse_lecture_component/accuse_lecture_component.html.erb
@@ -3,7 +3,7 @@
     <%= t('.text_accuse_lecture') %>
 
     <%= form_for @dossier,
-      method: :get,
+      method: :post,
       url: set_accuse_lecture_agreement_at_dossier_path(@dossier),
       data: { controller: 'autosubmit', turbo: 'true' } do |f| %>
       <%= f.submit t('.btn_accuse_lecture'), class: "fr-btn fr-mt-2w" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -392,6 +392,9 @@ Rails.application.routes.draw do
         post 'transferer', to: 'transfers#create', as: :transfer
         get 'attestation_depot', format: :pdf
         get 'papertrail', to: 'dossiers#attestation_depot', format: :pdf
+        post 'set_accuse_lecture_agreement_at'
+        # Deploy transition: legacy GET kept for in-flight pages still rendering the old form.
+        # TODO: remove once the deploy is stable (and un-pend the matching controller spec).
         get 'set_accuse_lecture_agreement_at'
         get 'corbeille', to: 'dossiers#show_in_trash'
         get 'supprime', to: 'dossiers#show_deleted'

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -2087,6 +2087,31 @@ describe Users::DossiersController, type: :controller do
     end
   end
 
+  describe '#set_accuse_lecture_agreement_at' do
+    let(:dossier) { create(:dossier, :en_instruction, :with_individual, user: user) }
+
+    before { sign_in(user) }
+
+    context 'on a state-changing verb (POST)' do
+      it 'updates accuse_lecture_agreement_at' do
+        expect { post :set_accuse_lecture_agreement_at, params: { id: dossier.id } }
+          .to change { dossier.reload.accuse_lecture_agreement_at }.from(nil)
+      end
+    end
+
+    context 'on a safe HTTP verb (GET)' do
+      # Pending: the legacy GET route is intentionally kept during the deploy
+      # transition so in-flight pages rendering the old form keep working.
+      # Once the GET route is removed in the follow-up, un-pend this example
+      # — it should pass without further changes.
+      it 'does not update accuse_lecture_agreement_at via a GET request' do
+        pending 'GET route is kept during deploy transition; remove route then un-pend'
+        expect { get :set_accuse_lecture_agreement_at, params: { id: dossier.id } }
+          .not_to change { dossier.reload.accuse_lecture_agreement_at }
+      end
+    end
+  end
+
   describe '#restore' do
     before { sign_in(user) }
     subject { patch :restore, params: { id: dossier.id } }


### PR DESCRIPTION
Le formulaire de l'accusé de lecture soumettait en GET une action qui
met à jour `accuse_lecture_agreement_at`. Les verbes safe ne devraient
pas avoir d'effet de bord (RFC 9110), et Rails ne vérifie le jeton CSRF
que sur les verbes non-safe.

- Route et formulaire passés en POST (le jeton CSRF est ajouté automatiquement).
- Specs contrôleur et composant ajoutées.

La route GET est conservée le temps du déploiement pour ne pas casser
les pages déjà rendues. Suppression prévue en suivi (TODO dans `routes.rb`,
spec `pending` à dé-pendre).