### PR TITLE
Tech: normaliser les extensions JPEG legacy (.jfif/.jfi/.jif/.jpe) en .jpg à l'upload

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -25,6 +25,18 @@ ActiveSupport.on_load(:active_storage_blob) do
     self.metadata = metadata.merge("analyzed" => true)
   end
 
+  # Marcel maps legacy JPEG extensions (.jfif/.jfi/.jif/.jpe — emitted by older
+  # Outlook/Edge/Office builds) to image/jpeg, but libvips has no saver for them
+  # so variants fail at write time. We rewrite the filename to .jpg at upload:
+  # the file content is bit-for-bit a JPEG already, only the extension is
+  # legacy. Also makes the downloaded original portable on Windows/Office where
+  # those extensions are still poorly supported.
+  before_create do
+    if content_type == "image/jpeg" && filename.extension.to_s.downcase.in?(%w[jfif jfi jif jpe])
+      self.filename = "#{filename.base}.jpg"
+    end
+  end
+
   ActiveStorage::Blob.class_eval do
     def purge_later
       DelayedPurgeJob.perform_later(self)

--- a/spec/config/active_storage_spec.rb
+++ b/spec/config/active_storage_spec.rb
@@ -48,4 +48,39 @@ describe "ActiveStorage configuration" do
       expect(blob_updates).to be_empty
     end
   end
+
+  describe "JPEG filename normalization on upload" do
+    let(:image_path) { Rails.root.join("spec/fixtures/files/image-no-rotation.jpg") }
+
+    def create_blob(filename:, content_type: "image/jpeg")
+      ActiveStorage::Blob.create_and_upload!(
+        io: File.open(image_path),
+        filename:,
+        content_type:
+      )
+    end
+
+    %w[jfif jfi jif jpe].each do |ext|
+      it "rewrites a .#{ext} JPEG filename to .jpg at upload" do
+        expect(create_blob(filename: "photo.#{ext}").filename.to_s).to eq("photo.jpg")
+      end
+    end
+
+    it "is case-insensitive on the extension" do
+      expect(create_blob(filename: "photo.JFIF").filename.to_s).to eq("photo.jpg")
+    end
+
+    it "leaves a standard .jpg filename untouched" do
+      expect(create_blob(filename: "photo.jpg").filename.to_s).to eq("photo.jpg")
+    end
+
+    it "does not rewrite when the content-type is not image/jpeg" do
+      pdf_blob = ActiveStorage::Blob.create_and_upload!(
+        io: Rails.root.join("spec/fixtures/files/dossierPDF.pdf").open,
+        filename: "weird.jfif",
+        content_type: "application/pdf"
+      )
+      expect(pdf_blob.filename.to_s).to eq("weird.jfif")
+    end
+  end
 end


### PR DESCRIPTION
## Contexte

L'event Sentry [RAILS-KHW](https://demarches-simplifiees.sentry.io/issues/RAILS-KHW) regroupe des échecs de `CreateRepresentationsJob` (574 occurrences, 199 utilisateurs impactés). ~60 % sont des `VipsForeignSave: "/tmp/image_processing***.jfif" is not a known file format`.

## Cause

Marcel mappe les extensions JPEG legacy (`.jfif`, `.jfi`, `.jif`, `.jpe` — encore émises par d'anciennes versions d'Outlook/Edge/Office) à `image/jpeg`. `ActiveStorage::Blob::Representable#default_variant_format` propage alors l'extension du blob comme format de sortie. libvips n'a aucun *saver* pour ces extensions et la génération de variants échoue à l'écriture.

## Fix

Au moment de l'INSERT du blob (`before_create`), on réécrit `filename = "<base>.jpg"` lorsque le content-type est `image/jpeg` et que l'extension fait partie de la liste legacy. Le contenu binaire est strictement un JPEG, seule l'extension est legacy — l'opération est sans risque.

Bénéfice annexe : le téléchargement de la pièce jointe par l'instructeur est désormais portable (Windows < 2020 et certaines versions d'Office refusent `.jfif`).

## Hors scope

Les blobs `.jfif` déjà en base ne sont pas renommés et les variantes concernées pas créées — impact trop faible. Les autres erreurs de l'event Sentry (PSD bloqué par policy ImageMagick, JPEG corrompus en stockage, autres `VipsForeignLoad`) restent à traiter à part.