### PR TITLE
Tech: fix N+1 sur geo_areas/etablissement dans DossierCloneConcern#clone

### DIFF
--- a/app/models/concerns/dossier_clone_concern.rb
+++ b/app/models/concerns/dossier_clone_concern.rb
@@ -15,9 +15,10 @@ module DossierCloneConcern
     discarded_row_ids = champs_on_main_stream
       .filter { _1.row? && _1.discarded? }
       .to_set(&:row_id)
-    cloned_champs = champs_on_main_stream
+    champs_to_clone = champs_on_main_stream
       .reject { discarded_row_ids.member?(_1.row_id) }
-      .map(&:clone)
+    ActiveRecord::Associations::Preloader.new(records: champs_to_clone, associations: [:geo_areas, :etablissement]).call
+    cloned_champs = champs_to_clone.map(&:clone)
 
     cloned_dossier = deep_clone(only: dossier_attributes, include: relationships) do |original, kopy|
       ClonePiecesJustificativesService.clone_attachments(original, kopy)


### PR DESCRIPTION
# Probleme

Requetes N+1 **de production** detectees sur `DossierCloneConcern#clone` par Prosopite.

Triage : 2 patterns PROD (call stack dans app/) / ~20 patterns TEST ignores (flipper, toggle_routing, factories).

Le pattern restant (dossiers N+1 pendant `save!`) est cause par `belongs_to :dossier, inverse_of: false` sur Champ — modification trop risquee pour ce scope.

# Solution

Skill [`/n1-query-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/n1-query-fix/SKILL.md)

### Patterns corriges (PROD uniquement)

| Association | Table | Strategy | Endpoint impacte | RPM | Waste estime |
|-------------|-------|----------|------------------|-----|--------------|
| `geo_areas` | geo_areas | `Preloader` avant clone | DossiersController#clone | 0.3 | ~42ms/req |
| `etablissement` | etablissements | `Preloader` avant clone | DossiersController#clone | 0.3 | inclus |

### Pattern non corrige (PROD)

| Association | Table | Raison | Endpoint impacte |
|-------------|-------|--------|------------------|
| `dossier` | dossiers | `inverse_of: false` sur Champ — changement trop large | DossiersController#clone |

### Validation

- [x] Tests passes (rspec spec/models/concerns/dossier_clone_concern_spec.rb — 16 examples, 0 failures)
- [x] Rubocop OK
- [x] Seuls des fichiers app/ sont commites

Generated with [Claude Code](https://claude.com/claude-code)