### PR TITLE
Tech: migrate APIEntreprise jobs to Sidekiq native retry

### DIFF
--- a/app/jobs/api_entreprise/job.rb
+++ b/app/jobs/api_entreprise/job.rb
@@ -3,6 +3,8 @@
 class APIEntreprise::Job < ApplicationJob
   queue_as :default
 
+  use_sidekiq_retry
+
   # If by the time the job runs the Etablissement has been deleted
   # (it can happen through EtablissementUpdateJob for instance), ignore the job
   discard_on ActiveRecord::RecordNotFound

--- a/spec/jobs/api_entreprise/job_spec.rb
+++ b/spec/jobs/api_entreprise/job_spec.rb
@@ -3,8 +3,6 @@
 include ActiveJob::TestHelper
 
 RSpec.describe APIEntreprise::Job, type: :job do
-  # https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html
-  # #method-i-retry_on
   describe '#perform' do
     let(:dossier) { create(:dossier, :with_entreprise) }
 
@@ -13,15 +11,14 @@ RSpec.describe APIEntreprise::Job, type: :job do
       let(:types_de_champ_public) { [{ type: :siret }] }
       let(:dossier) { create(:dossier, procedure:) }
 
-      it "retries 25 times" do
+      it "re-raises so sidekiq can retry" do
         champ = dossier.champs.first
         champ.update!(value: '12345678901234')
 
         etablissement = create(:etablissement, champ:)
 
-        assert_performed_jobs(25) do
-          ErrorJob.perform_later(:service_unavailable, etablissement) rescue StandardError
-        end
+        expect { ErrorJob.perform_now(:service_unavailable, etablissement) }
+          .to raise_error(APIEntreprise::API::Error::ServiceUnavailable)
 
         expect(champ.reload.value).not_to be_nil
       end


### PR DESCRIPTION
Applique `use_sidekiq_retry` sur `APIEntreprise::Job` pour basculer les 12 sous-classes en une fois sur les retries natifs Sidekiq (même approche que la migration de `Cron::CronJob`). Le `discard_on RecordNotFound` du parent et le `rescue_from(BadFormatRequest)` de `ExercicesJob` sont préservés — `use_sidekiq_retry` ne retire que le handler `StandardError`. Spec `job_spec` mise à jour : `assert_performed_jobs(25)` → `raise_error`, les retries Sidekiq n'étant pas testables via l'adapter ActiveJob.