### PR TITLE
ETQ admin, corrige l'erreur 500 à la suppression d'un groupe instructeur avec tableau de bord par défaut

### DIFF
--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -37,6 +37,7 @@ class ProcedurePresentation < ApplicationRecord
 
   before_create { self.displayed_columns = procedure.default_displayed_columns }
   before_create :set_default_filters
+  before_destroy :unset_admin_default_on_procedure
 
   validates_associated :displayed_columns, :sorted_column, :a_suivre_filters, :suivis_filters,
     :traites_filters, :tous_filters, :supprimes_filters, :expirant_filters, :archives_filters
@@ -120,5 +121,14 @@ class ProcedurePresentation < ApplicationRecord
     else
       displayed_columns
     end
+  end
+
+  def unset_admin_default_on_procedure
+    Procedure
+      .where(admin_default_procedure_presentation_id: id)
+      .update_all(
+        admin_default_procedure_presentation_active: false,
+        admin_default_procedure_presentation_id: nil
+      )
   end
 end

--- a/spec/models/groupe_instructeur_spec.rb
+++ b/spec/models/groupe_instructeur_spec.rb
@@ -196,6 +196,27 @@ describe GroupeInstructeur, type: :model do
         expect { second_group.destroy! }.not_to raise_error
       end
     end
+
+    context 'when an instructeur of the group has set the admin default procedure presentation' do
+      let(:second_group) { create(:groupe_instructeur, procedure:) }
+      let(:second_instructeur) { create(:instructeur) }
+      let(:assign_to_in_second_group) { create(:assign_to, instructeur: second_instructeur, procedure:, groupe_instructeur: second_group) }
+      let!(:procedure_presentation) { create(:procedure_presentation, assign_to: assign_to_in_second_group) }
+
+      before do
+        procedure.update!(
+          admin_default_procedure_presentation_active: true,
+          admin_default_procedure_presentation_id: procedure_presentation.id
+        )
+      end
+
+      it 'destroys without foreign key error and clears the admin default on procedure' do
+        expect { second_group.destroy! }.not_to raise_error
+        procedure.reload
+        expect(procedure.admin_default_procedure_presentation_id).to be_nil
+        expect(procedure.admin_default_procedure_presentation_active).to be(false)
+      end
+    end
   end
 
   describe 'routing rule validity' do


### PR DESCRIPTION
## Contexte

Lors de la suppression d'un `GroupeInstructeur`, la cascade vers les `AssignTo` puis leurs `ProcedurePresentation` échouait avec `PG::ForeignKeyViolation` quand l'une de ces présentations était paramétrée comme tableau de bord par défaut de la démarche (`procedure.admin_default_procedure_presentation_id`).

La FK `fk_rails_ad02727fd3` (ajoutée en mars) bloque la suppression et l'admin reçoit une 500.

## Fix

`before_destroy` sur `ProcedurePresentation` qui nullifie `admin_default_procedure_presentation_id` et désactive `admin_default_procedure_presentation_active` sur la démarche avant la suppression.

Closes #13004
Fixes [RAILS-KRC](https://demarches-simplifiees.sentry.io/issues/7488976766/)