### PR TITLE
ETQ usager, je peux ajouter une ligne à une répétition contenant un choix multiple sans options

### DIFF
--- a/app/models/champs/multiple_drop_down_list_champ.rb
+++ b/app/models/champs/multiple_drop_down_list_champ.rb
@@ -36,7 +36,7 @@ class Champs::MultipleDropDownListChamp < Champ
   end
 
   def checkbox_id(value)
-    "#{input_id}-#{Digest::MD5.hexdigest(value)}"
+    "#{input_id}-#{Digest::MD5.hexdigest(value.to_s)}"
   end
 
   def checkbox_label_id(value)

--- a/spec/models/champs/multiple_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/multiple_drop_down_list_champ_spec.rb
@@ -66,4 +66,15 @@ describe Champs::MultipleDropDownListChamp do
     let(:value) { ["val1", "val2"] }
     it { expect(champ.type_de_champ.champ_value_for_tag(champ).to_s).to eq("val1, val2") }
   end
+
+  describe "#focusable_input_id" do
+    context "when drop_down_options is empty" do
+      before { champ.type_de_champ.update_column(:options, {}) }
+
+      it "does not raise" do
+        expect(champ.drop_down_options).to be_empty
+        expect { champ.focusable_input_id }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/7489350649/?project=1429550

## Summary

- `Champs::RepetitionController#add` plantait en 500 (`TypeError: no implicit conversion of nil into String`) quand la répétition commençait par un champ « choix multiple » sans option configurée.
- `MultipleDropDownListChamp#checkbox_id` appelait `Digest::MD5.hexdigest(value)` avec `value = drop_down_options.first`, qui vaut `nil` quand la liste est vide.
- Correction d'une ligne : ajout de `.to_s`, alignant le comportement sur `DropDownListChamp#radio_id` (déjà protégé).
- Test de régression ajouté.