### PR TITLE
ETQ usager, interdire l'accès d'un compte FranceConnect déjà retiré ne provoque plus d'erreur 500

### DIFF
--- a/app/controllers/users/profil_controller.rb
+++ b/app/controllers/users/profil_controller.rb
@@ -75,6 +75,8 @@ module Users
 
     def destroy_fci
       fci = current_user.france_connect_informations.find_by(id: params[:fci_id])
+      return redirect_to profil_path if fci.nil?
+
       fci.destroy!
 
       flash.notice = "Le compte FranceConnect de « #{fci.full_name} » ne peut plus accéder à vos dossiers"

--- a/spec/controllers/users/profil_controller_spec.rb
+++ b/spec/controllers/users/profil_controller_spec.rb
@@ -275,6 +275,15 @@ describe Users::ProfilController, type: :controller do
       expect(response).to redirect_to(profil_path)
     end
 
+    context 'when the fci does not exist (already deleted or unknown id)' do
+      subject { delete :destroy_fci, params: { fci_id: 'unknown' } }
+
+      it 'redirects without raising' do
+        expect { subject }.not_to raise_error
+        expect(response).to redirect_to(profil_path)
+      end
+    end
+
     context 'when the user is logged in with FranceConnect' do
       before do
         stub_const('FRANCE_CONNECT', { end_session_endpoint: 'https://logout.franceconnect.gouv.fr' })


### PR DESCRIPTION
https://demarches-simplifiees.sentry.io/issues/7445437040/?project=1429550

## Résumé

Si l'usager déclenche deux fois l'action « Interdire l'accès » sur un compte FranceConnect lié (double clic, onglet stale, etc.), `find_by(id:)` renvoie `nil` au second passage et `nil.destroy!` lève une 500.

On redirige silencieusement vers la page profil lorsque le `fci` n'existe plus.
