### PR TITLE
Tech: bump Puma 6 → 8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -609,7 +609,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (6.6.1)
+    puma (8.0.1)
       nio4r (~> 2.0)
     pundit (2.5.2)
       activesupport (>= 3.0.0)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,12 +30,15 @@ if ENV.fetch("RAILS_ENV") == "production"
   # processes).
   #
   workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+end
 
-  # Use the `preload_app!` method when specifying a `workers` number.
-  # This directive tells Puma to first boot the application and load code
-  # before forking the application. This takes advantage of Copy On Write
-  # process behavior so workers use less memory.
-  #
+# `cluster do` (Puma 8): the block is evaluated only when `workers > 0`.
+# It replaces the `if RAILS_ENV == "production"` guard for cluster-only settings
+# and keeps mode-specific config co-located.
+cluster do
+  # Load the application BEFORE forking workers. Linux's Copy-on-Write then lets
+  # workers share the parent's memory pages (gems, eager-loaded constants, ...)
+  # until they write to them, lowering the overall RAM footprint.
   preload_app!
 end
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -40,6 +40,14 @@ cluster do
   # workers share the parent's memory pages (gems, eager-loaded constants, ...)
   # until they write to them, lowering the overall RAM footprint.
   preload_app!
+
+  # On graceful shutdown (SIGTERM, deploy), Puma waits for in-flight requests
+  # to finish. If a request stalls past `worker_shutdown_timeout` (30s default)
+  # the master force-kills the worker. With `on_force: true` Puma logs a full
+  # thread backtrace ONLY in that forced case, so we get visibility on what
+  # was stuck without spamming the logs on every normal deploy. Pre-Puma 8 the
+  # equivalent option logged backtraces on every shutdown.
+  shutdown_debug on_force: true
 end
 
 # Allow puma to be restarted by `rails restart` command.


### PR DESCRIPTION
La conf `config/puma.rb` profite au passage du nouveau DSL `cluster do` introduit par Puma 8.

On adopte aussi la nouvelle option `shutdown_debug on_force: true` (Puma 8) : Puma ne dumpe désormais les backtraces de tous les threads que lorsqu'un worker doit être tué de force (timeout du shutdown gracieux dépassé), au lieu de spammer les logs à chaque arrêt normal.

## Guides d'upgrade

- [Puma 7 — Romantic Warrior](https://github.com/puma/puma/blob/master/docs/7.0-Upgrade.md)
- [Puma 8 — Into the Arena](https://github.com/puma/puma/blob/master/docs/8.0-Upgrade.md)

## Compat vérifiée

| Contrainte Puma 7/8 | État chez nous |
|---|---|
| Pas d'usage de `env['HTTP_VERSION']` (supprimé pour Rack > 3.1) | ✅ aucune occurrence |
| Aucun hook renommé (`on_worker_boot` → `before_worker_boot`, etc.) | ✅ aucun hook dans `config/puma.rb` |
| `preload_app!` devient le défaut en cluster mode | ✅ on l'active explicitement |
| Headers de réponse forcés en lowercase | ✅ `ActionDispatch::Http::Headers` est case-insensitive |

## Changements de comportement à surveiller

- **Bind par défaut `::` (IPv6)** au lieu de `0.0.0.0` — derrière nginx, normalement transparent. Si pas d'ipv6 dispo : pinner explicitement `port ENV.fetch("PORT", 3000), "0.0.0.0"`.
- **`max_keep_alive` défaut = 999** et **`persistent_timeout` = 65s** — a priori absorbé par nginx en amont.
- **`http_content_length_limit`** : un `413` sur une requête HTTP/1.1 keep-alive force désormais `connection: close`.


## Pistes d'optimisations pour plus tard
- **`max_io_threads`** + `env[\"puma.mark_as_io_bound\"]` : nouveau levier Puma 8 contre le head-of-line blocking par les requêtes très lentes (appels réseaux, token FC/PC, API Entreprise/Particulier, Simpliscore, champ rérférentiel, …). À déclencher de manière chirurgicale pour les requêtes concernées via un middleware ciblé