### PR TITLE
Tech: optimiser les tests de dropdown_spec

### DIFF
--- a/spec/system/users/dropdown_spec.rb
+++ b/spec/system/users/dropdown_spec.rb
@@ -22,17 +22,12 @@ describe 'dropdown list with other option activated', js: true do
       ]
     end
 
-    scenario 'Select other option and the other input hidden must appear' do
+    scenario "Select other, fill it, then switch back saves correctly", :aggregate_failures do
       fill_individual
 
       choose I18n.t('shared.champs.drop_down_list.other'), allow_label_click: true
       expect(page).to have_selector('.drop_down_other', visible: true)
-    end
 
-    scenario "Getting back from other save the new option" do
-      fill_individual
-
-      choose I18n.t('shared.champs.drop_down_list.other'), allow_label_click: true
       fill_in(I18n.t('shared.champs.drop_down_list.other_label'), with: "My choice")
 
       wait_until { user_dossier.reload.project_champs_public.first.value == "My choice" }


### PR DESCRIPTION
# Probleme

Tests lents dans `spec/system/users/dropdown_spec.rb` — temps baseline : 31.1s (mediane locale, 3 runs).

# Solution

Skill [`/test-optimization`](https://github.com/mfo/night-shift/blob/main/.claude/skills/test-optimization/SKILL.md)

### Techniques appliquees

| Technique | Avant | Apres | Gain |
|-----------|-------|-------|------|
| S02 inline radio scenarios | 31.1s | 22.19s | -28.6% |

### Techniques evaluees sans gain

| Technique | Raison |
|-----------|--------|
| S03 pre-create dossier | Coverage drop (45.45% → 43.85%) — rollback |
| T04 let! → let (user) | Toujours utilise dans before — aucun gain |
| T08 let_it_be | 1 example par context — pas de N-1 savings |
| T01 create → build | System spec, DB records necessaires |
| S01 sleep → assertions | Pas de sleep dans ce fichier |
| T09 aggregate_failures | Deja applique dans le scenario merge |
| T06 duplicate tests | 2 scenarios distincts (radios vs select) |

**Resultat final : 31.1s → 22.19s (gain total 28.6%)**

Coverage : 45.45% → 45.45% (maintenue)

Generated with [Claude Code](https://claude.com/claude-code)