### PR TITLE
Tech: corrige un test flaky sur le n+1 GraphQL (fixtures dans let_it_be)

### DIFF
--- a/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe API::V2::GraphqlController do
-  let_it_be(:admin) { Administrateur.first }
+  let_it_be(:admin) { administrateurs(:default_admin) }
   let_it_be(:generated_token) { APIToken.generate(admin) }
   let(:token) { generated_token.second }
   let_it_be(:procedure) { create(:procedure, :published, :for_individual, :with_service, administrateurs: [admin], types_de_champ_public: [{}, { type: :piece_justificative }, { type: :siret }, { type: :repetition, mandatory: true, children: [{}, { type: :piece_justificative }, { type: :siret }] }]) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,10 @@ require 'simplecov' if ENV["CI"] || ENV["COVERAGE"] # see config in .simplecov f
 
 require 'test_prof/recipes/rspec/let_it_be'
 
+TestProf::BeforeAll.configure do |config|
+  config.setup_fixtures = true
+end
+
 require 'rspec/retry'
 
 SECURE_PASSWORD = '{My-$3cure-p4ssWord}'


### PR DESCRIPTION
J'ai l'impression qu'il y a un [test flaky](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/26085316205/job/76696827509) dû à l'utilisation des fixtures dans `let_it_be`, qui est similaire à `before_all` (cf. [doc test-prof](https://github.com/test-prof/test-prof/blob/master/docs/recipes/before_all.md#using-rails-fixtures-experimental)).

On active le flag `setup_fixtures`.