### PR TITLE
ETQ Instructeur utilisant un lecteur d'écran, je veux que l'ordre du code HTML de la synthèse des dossiers soit cohérent

### DIFF
--- a/app/views/instructeurs/procedures/synthese.html.erb
+++ b/app/views/instructeurs/procedures/synthese.html.erb
@@ -2,12 +2,12 @@
   <dl class="fr-badges-group">
     <% @counters.all_dossiers_counts.each do |tab_key, dossier_count| %>
       <% if dossier_count.positive? %>
-        <div class="fr-badge flex column">
-          <dt class="fr-cell--numeric">
-            <%= number_with_html_delimiter(dossier_count) %>
-          </dt>
+        <div class="fr-badge flex column-reverse">
+          <dt><%= i18n_tab_from_status(tab_key) %></dt>
 
-          <dd><%= i18n_tab_from_status(tab_key) %></dd>
+          <dd class="fr-cell--numeric">
+            <%= number_with_html_delimiter(dossier_count) %>
+          </dd>
         </div>
       <% end %>
     <% end %>

--- a/spec/views/instructeur/procedures/synthese.html.erb_spec.rb
+++ b/spec/views/instructeur/procedures/synthese.html.erb_spec.rb
@@ -22,12 +22,12 @@ describe 'instructeurs/procedures/synthese', type: :view do
   end
 
   it do
-    is_expected.to match(/2.+à suivre/m)
+    is_expected.to match(/à suivre.+2/m)
     is_expected.not_to have_text('suivis par moi')
-    is_expected.to match(/1.+traité/m)
-    is_expected.to match(/3.+au total/m)
-    is_expected.to match(/1.+expirant/m)
-    is_expected.to match(/4.+à archiver/m)
-    is_expected.to match(/2.+corbeille/m)
+    is_expected.to match(/traité.+1/m)
+    is_expected.to match(/au total.+3/m)
+    is_expected.to match(/expirant.+1/m)
+    is_expected.to match(/à archiver.+4/m)
+    is_expected.to match(/corbeille.+2/m)
   end
 end


### PR DESCRIPTION
Fix #13162

Identifie les libellés en tant que terme en lieu et place de leur valeur.

# Après
<img width="1146" height="747" alt="" src="https://github.com/user-attachments/assets/2714554f-5cd2-41ca-a037-ca00505ea045" />

# Avant

<img width="1142" height="682" alt="" src="https://github.com/user-attachments/assets/6d2233c8-7582-4d23-8a29-8f54efb8fdd2" />