### PR TITLE
Tech: extraire les textes en dur de ChampsRowsShowComponent vers i18n

### DIFF
--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.en.yml
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.en.yml
@@ -1,5 +1,6 @@
 ---
 en:
+  repetition_heading: "%{libelle} %{row_number}:"
   blank: 'empty'
   blank_attachment: 'document not supplied'
   blank_optional: 'empty (optional)'

--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.fr.yml
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.fr.yml
@@ -1,5 +1,6 @@
 ---
 fr:
+  repetition_heading: "%{libelle} %{row_number} :"
   blank: 'non saisi'
   blank_attachment: 'pièce justificative non saisie'
   blank_optional: 'non saisi (facultatif)'

--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
@@ -3,7 +3,7 @@
     <% types_de_champ = champ.dossier.revision.children_of(champ.type_de_champ) %>
     <% champ.row_ids.each.with_index(1) do |row_id, row_number| %>
       <div class="fr-background-alt--grey fr-p-2w fr-my-3w fr-ml-2w champ-repetition">
-        <%= tag.send(repetition_heading_tag, "#{champ.libelle} #{row_number} :", class: "fr-h6 fr-text--bold") %>
+        <%= tag.send(repetition_heading_tag, t(".repetition_heading", libelle: champ.libelle, row_number: row_number), class: "fr-h6 fr-text--bold") %>
         <%= render ViewableChamp::SectionComponent.new(dossier: champ.dossier, types_de_champ:, row_id:, demande_seen_at: seen_at, profile:) %>
       </div>
     <% end %>


### PR DESCRIPTION
# Probleme

Texte francais en dur dans `app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.haml` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 1 cle i18n vers les fichiers sidecar du composant.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `.repetition_heading` | `"%{libelle} %{row_number} :"` | `"%{libelle} %{row_number}:"` |

### Validation visuelle

⏭️ Pas de screenshot — aucun serveur de dev disponible sur ce worktree (port 3220 pointe vers un autre worktree). Pas de preview ViewComponent disponible.

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante (FR et EN)
- [x] Apostrophes typographiques verifiees (`lint:apostrophe:fix` OK)
- [x] Tests passes (2 examples, 0 failures)
- [x] Rendu identique : meme texte produit, seule la source change (lazy lookup i18n)

Generated with [Claude Code](https://claude.com/claude-code)