### PR TITLE
Tech: capturer le rejet de navigator.clipboard.writeText

### DIFF
--- a/app/javascript/controllers/clipboard2_controller.ts
+++ b/app/javascript/controllers/clipboard2_controller.ts
@@ -72,11 +72,18 @@ export class Clipboard2Controller extends Controller {
     ).trim();
 
     if (document.hasFocus() && textToCopy) {
-      navigator.clipboard.writeText(textToCopy).then(() => {
-        if (button) {
-          this.setCopiedState(button);
-        }
-      });
+      navigator.clipboard
+        .writeText(textToCopy)
+        .then(() => {
+          if (button) {
+            this.setCopiedState(button);
+          }
+        })
+        .catch(() => {
+          // Intentional no-op. writeText() can reject when the browser refuses
+          // to honor the gesture (synthetic click, focus loss, permission).
+          // The badge stays in "Copy" state, so the user simply retries.
+        });
     }
   }
 


### PR DESCRIPTION
`navigator.clipboard.writeText()` peut être rejeté quand le navigateur refuse
d'honorer le geste utilisateur (clic synthétique, perte de focus, permission
refusée). Le rejet remontait en `unhandled promise rejection` et générait du
bruit dans Sentry (≈ 3 200 events sur 580 users depuis octobre).

Le badge reste en état « Copy » sur échec, donc l'utilisateur peut simplement
réessayer — pas de changement de comportement visible.

Sentry: https://demarches-simplifiees.sentry.io/issues/JAVASCRIPT-DHG