### PR TITLE
Tech: migrer PendingCorrectionCheckboxComponent de HAML vers ERB

### DIFF
--- a/app/components/dossiers/pending_correction_checkbox_component/pending_correction_checkbox_component.html.erb
+++ b/app/components/dossiers/pending_correction_checkbox_component/pending_correction_checkbox_component.html.erb
@@ -1,0 +1,18 @@
+<div class="fr-checkbox-group fr-my-3w <%= class_names('fr-checkbox-group--error' => error?) %>">
+  <%= check_box_tag field_name(:dossier, :pending_correction), '1', false, form: 'form-submit-en-construction', required: true, aria: check_box_aria_attributes %>
+
+  <label class="fr-label" for="dossier_pending_correction">
+    <%= t('.confirm_label') %>
+    <%= render EditableChamp::AsteriskMandatoryComponent.new %>
+  </label>
+
+  <% if error? -%>
+    <div
+      id="dossier_pending_correction_error_messages"
+      class="fr-messages-group"
+      aria-live="assertlive"
+    >
+      <p class="fr-message fr-message--error"><%= error_message %></p>
+    </div>
+  <% end -%>
+</div>

--- a/app/components/dossiers/pending_correction_checkbox_component/pending_correction_checkbox_component.html.haml
+++ b/app/components/dossiers/pending_correction_checkbox_component/pending_correction_checkbox_component.html.haml
@@ -1,9 +1,0 @@
-.fr-checkbox-group.fr-my-3w{ class: class_names("fr-checkbox-group--error" => error?) }
-  = check_box_tag field_name(:dossier, :pending_correction), "1", false, form: "form-submit-en-construction", required: true, aria: check_box_aria_attributes
-  %label.fr-label{ for: :dossier_pending_correction }
-    = t('.confirm_label')
-    = render EditableChamp::AsteriskMandatoryComponent.new
-
-  - if error?
-    #dossier_pending_correction_error_messages.fr-messages-group{ aria: { live: "assertlive" } }
-      %p.fr-message.fr-message--error= error_message

--- a/spec/components/previews/dossiers/pending_correction_checkbox_component_preview.rb
+++ b/spec/components/previews/dossiers/pending_correction_checkbox_component_preview.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Dossiers::PendingCorrectionCheckboxComponentPreview < ViewComponent::Preview
+  def default
+    dossier = Dossier.en_construction.first
+    component = Dossiers::PendingCorrectionCheckboxComponent.new(dossier:)
+    component.define_singleton_method(:render?) { true }
+    render(component)
+  end
+
+  def with_error
+    dossier = Dossier.en_construction.first
+    dossier.errors.add(:pending_correction, :blank)
+    component = Dossiers::PendingCorrectionCheckboxComponent.new(dossier:)
+    component.define_singleton_method(:render?) { true }
+    render(component)
+  end
+end


### PR DESCRIPTION
# Probleme

On migre HAML → ERB. C'est lent, pénible, et c'est une charge mentale.

# Solution

Skill [`/haml-migration`](https://github.com/mfo/night-shift/blob/main/.claude/skills/haml-migration/SKILL.md)

### PendingCorrectionCheckboxComponent — ✅ identique au byte

**Validation :** formatter herb ✅, tests ✅ (4 examples, 0 failures), apostrophes ✅

**Avant (default) :**
![haml](https://gist.githubusercontent.com/mfo/4dfbb999ea386943d5e6f0568d9d5a10/raw/haml-usage1-component-1.png)

**Après (default) :**
![erb](https://gist.githubusercontent.com/mfo/4dfbb999ea386943d5e6f0568d9d5a10/raw/erb-usage1-component-1.png)

**Avant (error) :**
![haml](https://gist.githubusercontent.com/mfo/4dfbb999ea386943d5e6f0568d9d5a10/raw/haml-usage2-component-1.png)

**Après (error) :**
![erb](https://gist.githubusercontent.com/mfo/4dfbb999ea386943d5e6f0568d9d5a10/raw/erb-usage2-component-1.png)

**Couverture visuelle (1/1 utilisations) :**
- ✅ `localhost:3210/rails/view_components/dossiers/pending_correction_checkbox_component/default` — état normal (preview)
- ✅ `localhost:3210/rails/view_components/dossiers/pending_correction_checkbox_component/with_error` — état erreur (preview)
- ⏭️ `localhost:3210/dossiers/:id/modifier` — page réelle, nécessite procédure SVA + correction en attente (non disponible en dev DB)

[Voir tous les screenshots](https://gist.github.com/mfo/4dfbb999ea386943d5e6f0568d9d5a10)

Generated with [Claude Code](https://claude.com/claude-code)