### PR TITLE
Tech: extraire les textes en dur de CommuneComponent vers i18n

### DIFF
--- a/app/components/dossiers/commune_component.rb
+++ b/app/components/dossiers/commune_component.rb
@@ -32,6 +32,6 @@ class Dossiers::CommuneComponent < ApplicationComponent
   end
 
   def source
-    "référentiels géographiques nationaux"
+    t('.source')
   end
 end

--- a/app/components/dossiers/commune_component/commune_component.en.yml
+++ b/app/components/dossiers/commune_component/commune_component.en.yml
@@ -1,3 +1,4 @@
 en:
   municipality: Municipality
   insee_code: INSEE Code
+  source: national geographic repositories

--- a/app/components/dossiers/commune_component/commune_component.fr.yml
+++ b/app/components/dossiers/commune_component/commune_component.fr.yml
@@ -1,3 +1,4 @@
 fr:
   municipality: Commune
   insee_code: Code INSEE
+  source: référentiels géographiques nationaux


### PR DESCRIPTION
# Probleme

Texte français en dur dans `app/components/dossiers/commune_component.rb` — bloque l'internationalisation et l'accessibilité (les lecteurs d'écran dépendent des traductions structurées).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 1 clé i18n vers les fichiers sidecar du composant.

### Clés extraites

| Clé | FR | EN |
|-----|----|----|
| `.source` | "référentiels géographiques nationaux" | "national geographic repositories" |

### Validation visuelle — SKIPPED

⏭️ Dev server runs on a different worktree (`commentaire_list_component`), cannot render this component.

### Validation technique

- [x] Chaque `t()` a sa clé YAML correspondante (FR + EN)
- [x] Apostrophes typographiques vérifiées
- [x] Pas de spec existante pour ce composant
- [x] Rubocop OK

Generated with [Claude Code](https://claude.com/claude-code)