### PR TITLE
Correctif: ETQ usager, pouvoir déposer les modifications quand une option de liste déroulante multiple a été supprimée

### DIFF
--- a/app/components/editable_champ/multiple_drop_down_list_component.rb
+++ b/app/components/editable_champ/multiple_drop_down_list_component.rb
@@ -17,7 +17,7 @@ class EditableChamp::MultipleDropDownListComponent < EditableChamp::EditableCham
       class: 'fr-mt-1w',
       name: @form.field_name(:value, multiple: true),
       placeholder: t('views.components.multiple_combobox'),
-      value: @champ.selected_options,
+      value: @champ.selected_options.intersection(items.map(&:last)),
       items:,
       ariaLabelledbyPrefix: aria_labelledby_prefix,
       labelId: input_label_id(@champ)

--- a/spec/system/users/dropdown_rebase_spec.rb
+++ b/spec/system/users/dropdown_rebase_spec.rb
@@ -28,7 +28,7 @@ describe 'Multiple dropdown after rebase removes an option', js: true do
     dossier.reload
   end
 
-  scenario 'user selects a valid option but submission fails because removed option persists' do
+  scenario 'user selects a valid option and submission succeeds (removed option is filtered out)' do
     login_as(user, scope: :user)
     visit modifier_dossier_path(dossier)
 
@@ -40,7 +40,12 @@ describe 'Multiple dropdown after rebase removes an option', js: true do
 
     click_on 'Déposer les modifications'
 
-    # BUG: validation error because "Bravo" is still in the champ value
-    expect(page).to have_content('« Zonage(s) » doit être dans les options proposées')
+    # No validation error: removed option "Bravo" was filtered out by the component
+    expect(page).to have_content('Votre dossier est déposé')
+    expect(page).not_to have_content('« Zonage(s) » doit être dans les options proposées')
+
+    # After submit, champ value contains only valid options: "Bravo" was dropped, "Alpha" was added
+    champ = dossier.reload.project_champs_public.find { _1.stable_id == stable_id }
+    expect(champ.selected_options).to match_array(["Alpha", "Charlie"])
   end
 end

--- a/spec/system/users/dropdown_rebase_spec.rb
+++ b/spec/system/users/dropdown_rebase_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+describe 'Multiple dropdown after rebase removes an option', js: true do
+  include ActiveJob::TestHelper
+
+  let(:user) { create(:user) }
+  # >5 options so it renders as React MultipleSelect, not checkboxes
+  let(:options) { ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf"] }
+  let(:procedure) do
+    create(:procedure, :published, :for_individual, types_de_champ_public: [
+      { type: :multiple_drop_down_list, libelle: 'Zonage(s)', drop_down_options: options, mandatory: true }
+    ])
+  end
+  let(:dossier) { create(:dossier, :en_construction, :with_individual, user:, procedure:) }
+  let(:stable_id) { procedure.active_revision.types_de_champ_public.first.stable_id }
+
+  before do
+    # User had selected "Bravo" and "Charlie" before submitting
+    champ = dossier.champs.find { _1.stable_id == stable_id }
+    champ.update_columns(value: '["Bravo","Charlie"]')
+
+    # Admin removes "Bravo" from options and publishes
+    tdc = procedure.draft_revision.types_de_champ.find { _1.stable_id == stable_id }
+    tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(tdc)
+    tdc_to_update.update(drop_down_options: ["Alpha", "Charlie", "Delta", "Echo", "Foxtrot", "Golf"])
+    procedure.publish_revision!(procedure.administrateurs.first)
+    perform_enqueued_jobs
+    dossier.reload
+  end
+
+  scenario 'user selects a valid option but submission fails because removed option persists' do
+    login_as(user, scope: :user)
+    visit modifier_dossier_path(dossier)
+
+    # User tries to update their selection by adding "Alpha"
+    select_autocomplete('Zonage(s)', 'Alpha')
+
+    # Wait for autosave
+    expect(page).to have_css('.autosave-status.succeeded', visible: true)
+
+    click_on 'Déposer les modifications'
+
+    # BUG: validation error because "Bravo" is still in the champ value
+    expect(page).to have_content('« Zonage(s) » doit être dans les options proposées')
+  end
+end

--- a/spec/system/users/dropdown_rebase_spec.rb
+++ b/spec/system/users/dropdown_rebase_spec.rb
@@ -8,7 +8,7 @@ describe 'Multiple dropdown after rebase removes an option', js: true do
   let(:options) { ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf"] }
   let(:procedure) do
     create(:procedure, :published, :for_individual, types_de_champ_public: [
-      { type: :multiple_drop_down_list, libelle: 'Zonage(s)', drop_down_options: options, mandatory: true }
+      { type: :multiple_drop_down_list, libelle: 'Zonage(s)', drop_down_options: options, mandatory: true },
     ])
   end
   let(:dossier) { create(:dossier, :en_construction, :with_individual, user:, procedure:) }


### PR DESCRIPTION
mm: https://mattermost.incubateur.net/betagouv/pl/oxxut98iqpgmunk4h9gnpjy5xa
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_9047fa97-963f-46ca-9f00-15ca0924b86e/

# Problème

Quand un admin supprime une option d'un champ « choix multiple » (>5 options, rendu React MultipleSelect) et publie une nouvelle revision, le rebase met à jour la revision du dossier mais ne nettoie pas la valeur du champ. L'ancienne option supprimée reste dans `selected_options`.

Au moment où l'usager tente de déposer ses modifications, le composant React envoie la valeur obsolète via des hidden inputs, et la validation bloque avec « doit être dans les options proposées » — même si l'usager a sélectionné une option valide.

Le problème ne se manifeste pas avec ≤5 options (rendu checkboxes) car les checkboxes ne sont générées que pour les options existantes.

# Solution

Filtrer les `selected_options` par intersection avec les options actuelles dans `MultipleDropDownListComponent#react_props`, avant de passer la valeur au composant React. Les options supprimées sont silencieusement retirées de la sélection initiale.

Generated with [Claude Code](https://claude.com/claude-code)