### PR TITLE
Tech: renforce la validation des imports CSV

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -401,12 +401,11 @@ module Administrateurs
     end
 
     def import
-      if !CSV_ACCEPTED_CONTENT_TYPES.include?(csv_file.content_type) && !CSV_ACCEPTED_CONTENT_TYPES.include?(marcel_content_type)
+      case validate_csv_upload(csv_file)
+      when :not_csv
         flash[:alert] = "Importation impossible : veuillez importer un fichier CSV"
-
-      elsif csv_file.size > CSV_MAX_SIZE
+      when :too_large
         flash[:alert] = "Importation impossible : le poids du fichier est supérieur à #{number_to_human_size(CSV_MAX_SIZE)}"
-
       else
         csv_content = parse_csv(csv_file)
 
@@ -501,9 +500,10 @@ module Administrateurs
     end
 
     def import_contact_informations
-      if !CSV_ACCEPTED_CONTENT_TYPES.include?(csv_file.content_type) && !CSV_ACCEPTED_CONTENT_TYPES.include?(marcel_content_type)
+      case validate_csv_upload(csv_file)
+      when :not_csv
         flash[:alert] = "Importation impossible : veuillez importer un fichier CSV"
-      elsif csv_file.size > CSV_MAX_SIZE
+      when :too_large
         flash[:alert] = "Importation impossible : le poids du fichier est supérieur à #{number_to_human_size(CSV_MAX_SIZE)}"
       else
         csv_content = parse_csv(csv_file)
@@ -640,10 +640,6 @@ module Administrateurs
 
     def csv_file
       params[:csv_file]
-    end
-
-    def marcel_content_type
-      Marcel::MimeType.for(csv_file.read, name: csv_file.original_filename, declared_type: csv_file.content_type)
     end
 
     def instructeurs_self_management_enabled_params

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -146,8 +146,12 @@ module Administrateurs
     end
 
     def import_referentiel
-      return flash[:alert] = "Importation impossible : veuillez importer un fichier CSV" unless csv_file?
-      return flash[:alert] = "Importation impossible : le poids du fichier est supérieur à #{number_to_human_size(CSV_MAX_SIZE)}" if referentiel_file.size > CSV_MAX_SIZE
+      case validate_csv_upload(referentiel_file)
+      when :not_csv
+        return flash[:alert] = "Importation impossible : veuillez importer un fichier CSV"
+      when :too_large
+        return flash[:alert] = "Importation impossible : le poids du fichier est supérieur à #{number_to_human_size(CSV_MAX_SIZE)}"
+      end
 
       type_de_champ = draft.find_and_ensure_exclusive_use(params[:stable_id])
       csv_content = parse_csv(referentiel_file, keep_original_headers: true)
@@ -278,10 +282,6 @@ module Administrateurs
 
     def referentiel_file
       params["referentiel_file"]
-    end
-
-    def marcel_content_type
-      Marcel::MimeType.for(referentiel_file.read, name: referentiel_file.original_filename, declared_type: referentiel_file.content_type)
     end
   end
 end

--- a/app/controllers/concerns/csv_parsing_concern.rb
+++ b/app/controllers/concerns/csv_parsing_concern.rb
@@ -8,13 +8,21 @@ module CsvParsingConcern
   CSV_ACCEPTED_CONTENT_TYPES = [
     "text/csv",
     "application/vnd.ms-excel",
-  ]
+  ].freeze
+
+  def validate_csv_upload(file)
+    return :too_large if file.size > CSV_MAX_SIZE
+    return :not_csv unless CSV_ACCEPTED_CONTENT_TYPES.include?(sniff_content_type(file))
+    :ok
+  end
 
   private
 
-  def csv_file?
-    CSV_ACCEPTED_CONTENT_TYPES.include?(referentiel_file.content_type) ||
-      CSV_ACCEPTED_CONTENT_TYPES.include?(marcel_content_type)
+  def sniff_content_type(file)
+    io = file.tempfile.tap(&:rewind)
+    Marcel::MimeType.for(io, name: file.original_filename, declared_type: file.content_type)
+  ensure
+    file.tempfile&.rewind
   end
 
   def parse_csv(file, strings_as_keys: true, keep_original_headers: false, convert_values_to_numeric: false)

--- a/app/controllers/manager/procedures_controller.rb
+++ b/app/controllers/manager/procedures_controller.rb
@@ -2,6 +2,7 @@
 
 module Manager
   class ProceduresController < Manager::ApplicationController
+    include ActiveSupport::NumberHelper
     include CsvParsingConcern
 
     #
@@ -147,33 +148,35 @@ module Manager
     end
 
     def import_tags
-      if !CSV_ACCEPTED_CONTENT_TYPES.include?(tags_csv_file.content_type) && !CSV_ACCEPTED_CONTENT_TYPES.include?(marcel_content_type)
+      case validate_csv_upload(tags_csv_file)
+      when :not_csv
         flash[:alert] = "Importation impossible : veuillez importer un fichier CSV"
-
-      elsif tags_csv_file.size > CSV_MAX_SIZE
+        return redirect_to manager_administrateurs_path
+      when :too_large
         flash[:alert] = "Importation impossible : le poids du fichier est supérieur à #{number_to_human_size(CSV_MAX_SIZE)}"
-
-      else
-        procedure_tags = csv_parse(tags_csv_file).map { |r| r.to_h.slice('demarche', 'tag') }
-
-        invalid_ids = []
-        procedure_tags.each do |procedure_tag|
-          procedure = Procedure.find_by(id: procedure_tag['demarche'])
-          tags = procedure_tag["tag"].split(',').map(&:strip).map(&:capitalize)
-
-          if procedure.nil?
-            invalid_ids << procedure_tag['demarche']
-            next
-          end
-
-          tags.each do |tag|
-            procedure.tags.push(tag)
-          end
-          procedure.save
-        end
+        return redirect_to manager_administrateurs_path
       end
-      message =  "Import des tags terminé."
-      message += " Ces démarches n’existent pas : #{invalid_ids.to_sentence}" if invalid_ids.any?
+
+      procedure_tags = parse_csv(tags_csv_file).map { |r| r.to_h.slice('demarche', 'tag') }
+      invalid_ids = []
+
+      procedure_tags.each do |procedure_tag|
+        procedure = Procedure.find_by(id: procedure_tag['demarche'])
+        tags = procedure_tag["tag"].split(',').map(&:strip).map(&:capitalize)
+
+        if procedure.nil?
+          invalid_ids << procedure_tag['demarche']
+          next
+        end
+
+        tags.each do |tag|
+          procedure.tags.push(tag)
+        end
+        procedure.save
+      end
+
+      message = "Import des tags terminé."
+      message += " Ces démarches n'existent pas : #{invalid_ids.to_sentence}" if invalid_ids.any?
       flash.notice = message
       redirect_to manager_administrateurs_path
     end
@@ -210,10 +213,6 @@ module Manager
 
     def tags_csv_file
       params[:tags_csv_file]
-    end
-
-    def marcel_content_type
-      Marcel::MimeType.for(tags_csv_file.read, name: tags_csv_file.original_filename, declared_type: tags_csv_file.content_type)
     end
 
     def unfiltered_list?

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -697,6 +697,16 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         end
       end
 
+      context 'when a binary file is uploaded with a spoofed text/csv content type' do
+        let(:csv_file) { fixture_file_upload('spec/fixtures/files/french-flag.gif', 'text/csv') }
+
+        before { subject }
+
+        it 'rejects the file based on sniffed content type, not declared content type' do
+          expect(flash.alert).to eq("Importation impossible : veuillez importer un fichier CSV")
+        end
+      end
+
       context 'when the headers are wrong' do
         let(:csv_file) { fixture_file_upload('spec/fixtures/files/invalid-group-file.csv', 'text/csv') }
 
@@ -828,6 +838,16 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
 
         it 'validates file format and displays a flash alert' do
           expect(flash.alert).to be_present
+          expect(flash.alert).to eq("Importation impossible : veuillez importer un fichier CSV")
+        end
+      end
+
+      context 'when a binary file is uploaded with a spoofed text/csv content type' do
+        let(:csv_file) { fixture_file_upload('spec/fixtures/files/french-flag.gif', 'text/csv') }
+
+        before { subject }
+
+        it 'rejects the file based on sniffed content type, not declared content type' do
           expect(flash.alert).to eq("Importation impossible : veuillez importer un fichier CSV")
         end
       end
@@ -1016,6 +1036,15 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       it 'shows an error message' do
         subject
         expect(flash[:alert]).to include('colonnes')
+      end
+    end
+
+    context 'when a binary file is uploaded with a spoofed text/csv content type' do
+      let(:csv_file) { fixture_file_upload('spec/fixtures/files/french-flag.gif', 'text/csv') }
+
+      it 'rejects the file based on sniffed content type, not declared content type' do
+        subject
+        expect(flash[:alert]).to eq("Importation impossible : veuillez importer un fichier CSV")
       end
     end
   end

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -197,6 +197,17 @@ describe Administrateurs::TypesDeChampController, type: :controller do
         end
       end
 
+      context 'when a binary file is uploaded with a spoofed text/csv content type' do
+        let(:referentiel_file) { fixture_file_upload('spec/fixtures/files/french-flag.gif', 'text/csv') }
+
+        before { subject }
+
+        it 'rejects the file based on sniffed content type, not declared content type' do
+          expect(flash.alert).to eq("Importation impossible : veuillez importer un fichier CSV")
+          expect(Referentiel.count).to eq(0)
+        end
+      end
+
       context 'when the csv file has a bom' do
         let(:referentiel_file) { fixture_file_upload('spec/fixtures/files/modele-import-referentiel-with-bom.csv', 'text/csv') }
 

--- a/spec/controllers/concerns/csv_parsing_concern_spec.rb
+++ b/spec/controllers/concerns/csv_parsing_concern_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+describe CsvParsingConcern, type: :controller do
+  controller(ApplicationController) do
+    include CsvParsingConcern
+  end
+
+  describe '#validate_csv_upload' do
+    subject { controller.validate_csv_upload(file) }
+
+    context 'when file is a valid CSV under the size limit' do
+      let(:file) { fixture_file_upload('spec/fixtures/files/modele-import-referentiel.csv', 'text/csv') }
+
+      it { is_expected.to eq(:ok) }
+    end
+
+    context 'when file exceeds max size' do
+      let(:file) { fixture_file_upload('spec/fixtures/files/modele-import-referentiel.csv', 'text/csv') }
+
+      before { allow(file).to receive(:size).and_return(CsvParsingConcern::CSV_MAX_SIZE + 1) }
+
+      it { is_expected.to eq(:too_large) }
+
+      it 'does not sniff the content type' do
+        expect(Marcel::MimeType).not_to receive(:for)
+        subject
+      end
+    end
+
+    context 'when a binary file is uploaded with text/csv declared content type' do
+      let(:file) { fixture_file_upload('spec/fixtures/files/french-flag.gif', 'text/csv') }
+
+      it { is_expected.to eq(:not_csv) }
+    end
+
+    context 'when a valid CSV is uploaded with application/vnd.ms-excel declared content type' do
+      let(:file) { fixture_file_upload('spec/fixtures/files/modele-import-referentiel.csv', 'application/vnd.ms-excel') }
+
+      it { is_expected.to eq(:ok) }
+    end
+  end
+end

--- a/spec/controllers/manager/procedures_controller_spec.rb
+++ b/spec/controllers/manager/procedures_controller_spec.rb
@@ -203,4 +203,58 @@ describe Manager::ProceduresController, type: :controller do
       end
     end
   end
+
+  describe '#import_tags' do
+    let(:procedure) { create(:procedure) }
+
+    subject do
+      post :import_tags, params: { id: procedure.id, tags_csv_file: csv_file }
+    end
+
+    context 'when the file is a valid CSV' do
+      let(:csv_file) { fixture_file_upload('spec/fixtures/files/import-tags.csv', 'text/csv') }
+
+      it 'redirects with a success notice' do
+        subject
+        expect(response).to redirect_to(manager_administrateurs_path)
+        expect(flash[:notice]).to include("Import des tags terminé")
+        expect(flash[:alert]).to be_nil
+      end
+    end
+
+    context 'when the file content type is not accepted' do
+      let(:csv_file) { fixture_file_upload('spec/fixtures/files/french-flag.gif', 'image/gif') }
+
+      it 'rejects the file and redirects with an alert' do
+        subject
+        expect(response).to redirect_to(manager_administrateurs_path)
+        expect(flash[:alert]).to eq("Importation impossible : veuillez importer un fichier CSV")
+        expect(flash[:notice]).to be_nil
+      end
+    end
+
+    context 'when a binary file is uploaded with a spoofed text/csv content type' do
+      let(:csv_file) { fixture_file_upload('spec/fixtures/files/french-flag.gif', 'text/csv') }
+
+      it 'rejects the file based on sniffed content type, not declared content type' do
+        subject
+        expect(response).to redirect_to(manager_administrateurs_path)
+        expect(flash[:alert]).to eq("Importation impossible : veuillez importer un fichier CSV")
+        expect(flash[:notice]).to be_nil
+      end
+    end
+
+    context 'when the file exceeds max size' do
+      let(:csv_file) { fixture_file_upload('spec/fixtures/files/import-tags.csv', 'text/csv') }
+
+      before { allow_any_instance_of(ActionDispatch::Http::UploadedFile).to receive(:size).and_return(2.megabytes) }
+
+      it 'rejects the file and redirects with an alert' do
+        subject
+        expect(response).to redirect_to(manager_administrateurs_path)
+        expect(flash[:alert]).to eq("Importation impossible : le poids du fichier est supérieur à 1 Mo")
+        expect(flash[:notice]).to be_nil
+      end
+    end
+  end
 end

--- a/spec/fixtures/files/import-tags.csv
+++ b/spec/fixtures/files/import-tags.csv
@@ -1,0 +1,2 @@
+demarche,tag
+9999999,"Tag1,Tag2"


### PR DESCRIPTION
## Contexte

Trois contrôleurs acceptaient des fichiers CSV uploadés en se fiant au `Content-Type` déclaré par le client, ce qui permettait deux classes de problèmes :

- **MIME bypass** : un fichier binaire déclaré `text/csv` passait la validation sans être analysé (le premier `include?` court-circuitait le sniff Marcel).
- **DoS mémoire** : la vérification de taille intervenait après `file.read` complet en RAM, permettant de charger un fichier volumineux avant de le rejeter.

Endpoints concernés : `import_referentiel`, `import` / `import_contact_informations` (groupe instructeurs), `import_tags` (manager).

## Changements

- Ajout de `validate_csv_upload(file)` dans `CsvParsingConcern` : vérifie la taille **avant** le sniff, puis sniff Marcel sur le `tempfile` en streaming (pas de `file.read`)
- Suppression des 4 duplications de `marcel_content_type` dans les contrôleurs
- Suppression de `csv_file?` (remplacée par `validate_csv_upload`)
- `CSV_ACCEPTED_CONTENT_TYPES` gelé (`.freeze`) ; `application/vnd.ms-excel` conservé pour compat Excel
- Correction de deux bugs latents dans `manager/procedures_controller#import_tags` : `csv_parse` → `parse_csv` (méthode inexistante) et `invalid_ids` potentiellement `nil` hors du bloc `else`
- Ajout de `include ActiveSupport::NumberHelper` manquant dans le manager controller