### PR TITLE
ETQ admin, je peux transformer un champ de type communes en champ de type texte

### DIFF
--- a/app/models/columns/champ_column.rb
+++ b/app/models/columns/champ_column.rb
@@ -224,6 +224,10 @@ class Columns::ChampColumn < Column
     [:multiple_drop_down_list, :text] => -> (v) { v.join(', ') },
     [:multiple_drop_down_list, :textarea] => -> (v) { v.join("\n") },
     [:multiple_drop_down_list, :formatted] => -> (v) { v.join(', ') },
+    # communes
+    [:communes, :text] => -> (v) { v },
+    [:communes, :textarea] => -> (v) { v },
+    [:communes, :formatted] => -> (v) { v },
   }
 
   def parse_boolean(value)

--- a/spec/components/types_de_champ_editor/champ_component_spec.rb
+++ b/spec/components/types_de_champ_editor/champ_component_spec.rb
@@ -146,6 +146,7 @@ describe TypesDeChampEditor::ChampComponent, type: :component do
       expect(described_class::ACCEPTED_TYPES).to include(
         "checkbox" => ["yes_no", "text", "textarea", "formatted"],
         "civilite" => ["text", "textarea", "formatted"],
+        "communes" => ["text", "textarea", "formatted"],
         "date" => ["datetime", "text", "textarea", "formatted"],
         "datetime" => ["date", "text", "textarea", "formatted"],
         "decimal_number" => ["integer_number", "text", "textarea", "formatted"],

--- a/spec/models/columns/champ_column_spec.rb
+++ b/spec/models/columns/champ_column_spec.rb
@@ -152,6 +152,22 @@ describe Columns::ChampColumn do
           expect(column('textarea').value(champ)).to eq("val1\nval2")
         end
       end
+
+      context 'from a communes' do
+        let(:champ) do
+          Champs::CommuneChamp.new(
+            value: 'Coye-la-Forêt',
+            external_id: '60172',
+            code_postal: '60580'
+          )
+        end
+
+        it do
+          expect(column('text').value(champ)).to eq('Coye-la-Forêt')
+          expect(column('textarea').value(champ)).to eq('Coye-la-Forêt')
+          expect(column('formatted').value(champ)).to eq('Coye-la-Forêt')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
cf retour au support : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_33008d90-9ea7-4d36-805f-c55ddf090bcd/

## Résumé

Le type de champ **communes** n'est utilisable que pour des communes françaises. Certains administrateurs l'utilisent pour des champs comme « commune de naissance », ce qui bloque les usagers nés à l'étranger si le champ est obligatoire.

Cette PR permet à un administrateur de transformer un champ `communes` publié en champ `texte court`, `zone de texte` ou `texte formaté`, sans avoir à supprimer et recréer le champ.

- Ajoute les casts `[:communes, :text]`, `[:communes, :textarea]` et `[:communes, :formatted]` dans `Columns::ChampColumn::CAST`
- L'éditeur de type de champ (`TypesDeChampEditor::ChampComponent`) dérive automatiquement les transitions autorisées depuis ce hash — aucune modification côté éditeur nécessaire
- Les dossiers déjà en `en_instruction` / `accepté` / `refusé` restent sur leur révision d'origine, sans impact
- Les dossiers en `brouillon` / `en_construction` sont rebasés : la valeur textuelle du nom de commune (déjà stockée dans la colonne `value`) est préservée

## Plan de test

- [ ] Créer une démarche avec un champ **Communes**, la publier
- [ ] Modifier la démarche : vérifier que les options Texte court, Zone de texte et Texte formaté sont maintenant actives dans le menu déroulant du type
- [ ] Transformer le champ en Texte court et publier la nouvelle révision
- [ ] Créer un dossier : le champ s'affiche bien comme un input texte
- [ ] (optionnel) Créer un dossier brouillon avec une commune saisie avant la transformation, vérifier que la valeur est préservée après rebase