### PR TITLE
ETQ admin, conserve l'authentification au re-clonage d'un référentiel API

### DIFF
--- a/app/controllers/administrateurs/referentiels_controller.rb
+++ b/app/controllers/administrateurs/referentiels_controller.rb
@@ -20,7 +20,7 @@ module Administrateurs
     end
 
     def create
-      handle_referentiel_save(@type_de_champ.build_referentiel(referentiel_params))
+      handle_referentiel_save(@type_de_champ.build_referentiel(referentiel_params_with_carried_credentials))
     end
 
     def update
@@ -136,6 +136,23 @@ module Administrateurs
                 test_data_tiptap: {})
     rescue ActionController::ParameterMissing
       {}
+    end
+
+    # When cloning an existing referentiel, the auth inputs are rendered as `disabled`
+    # to hide the secret, so the browser does not submit them. We carry the existing
+    # authentication_data over from the source so credentials are not lost on save.
+    def referentiel_params_with_carried_credentials
+      attrs = referentiel_params.to_h
+      source_id = params.dig(:referentiel, :referentiel_id).presence
+      return attrs if source_id.blank?
+
+      source = @type_de_champ.referentiel
+      return attrs if source.nil? || source.id != source_id.to_i
+
+      if attrs[:authentication_method] == 'header_token' && attrs[:authentication_data].blank?
+        attrs[:authentication_data] = source.authentication_data
+      end
+      attrs
     end
 
     def retrieve_type_de_champ

--- a/spec/controllers/administrateurs/referentiels_controller_spec.rb
+++ b/spec/controllers/administrateurs/referentiels_controller_spec.rb
@@ -199,6 +199,51 @@ describe Administrateurs::ReferentielsController, type: :controller do
         end
       end
     end
+
+    context 'cloning an existing referentiel whose auth fields were rendered disabled' do
+      let(:type_de_champ) { procedure.draft_revision.types_de_champ.first }
+      let(:original_authentication_data) { { 'header' => 'Authorization', 'value' => 'Bearer secret-token' } }
+      let!(:existing_referentiel) do
+        create(:api_referentiel, :exact_match,
+               types_de_champ: [type_de_champ],
+               authentication_method: 'header_token',
+               authentication_data: original_authentication_data)
+      end
+      let(:url_tiptap_json) do
+        {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "text", text: "https://rnb-api.beta.gouv.fr/api/alpha/buildings/" },
+                { type: "mention", attrs: { id: "{query}", label: "Valeur saisie par l'usager" } },
+              ],
+            },
+          ],
+        }
+      end
+      let(:referentiel_params) do
+        {
+          type: 'Referentiels::APIReferentiel',
+          mode: 'exact_match',
+          url_tiptap: url_tiptap_json.to_json,
+          hint: 'Identifiant unique du bâtiment dans le RNB',
+          test_data_tiptap: { "{query}" => "PG46YY6YWCX8" },
+          authentication_method: 'header_token',
+          referentiel_id: existing_referentiel.id.to_s,
+        }
+      end
+
+      it 'carries over authentication_data from the source referentiel' do
+        post :create, params: { commit: 'Étape suivante', procedure_id: procedure.id, stable_id:, referentiel: referentiel_params }, format: :turbo_stream
+
+        new_referentiel = type_de_champ.reload.referentiel
+        expect(new_referentiel).to be_present
+        expect(new_referentiel.authentication_method).to eq('header_token')
+        expect(new_referentiel.authentication_data.with_indifferent_access).to eq(original_authentication_data.with_indifferent_access)
+      end
+    end
   end
 
   describe '#create with tiptap' do


### PR DESCRIPTION
Quand on revient configurer un champ API référentiel d'une démarche publiée (URL `?referentiel_id=X`), les inputs d'authentification sont rendus `disabled` pour ne pas ré-afficher le secret. Les navigateurs n'envoyant pas les champs `disabled`, le `create` côté serveur sauvegardait un nouveau référentiel sans `authentication_data` → 403 à l'appel suivant de l'API.

Le `create` recopie désormais l'`authentication_data` depuis le référentiel source quand `authentication_method=header_token` et que le formulaire ne l'a pas re-soumise, avec la même garde IDOR que `build_or_clone_by_id_params`.

### Le bug :
<img width="1222" height="609" alt="Capture d’écran 2026-05-20 à 11 04 19" src="https://github.com/user-attachments/assets/79b4b1ed-c405-4834-8fc2-60646e62c43f" />
Puis
<img width="940" height="631" alt="Capture d’écran 2026-05-20 à 11 04 29" src="https://github.com/user-attachments/assets/1b87592d-9934-4196-9382-7568f58bad9c" />
