### PR TITLE
Correctif: ETQ usager, pouvoir modifier/supprimer les polygones carte en construction

### DIFF
--- a/app/controllers/champs/carte_controller.rb
+++ b/app/controllers/champs/carte_controller.rb
@@ -28,19 +28,23 @@ class Champs::CarteController < Champs::ChampController
   end
 
   def update
-    geo_area = @champ.geo_areas.find(params[:id])
+    geo_area = find_geo_area(params[:id])
 
     if save_feature(geo_area, update_params_feature)
       @champ.update_timestamps
       FetchCadastreRealGeometryJob.perform_later(geo_area) if geo_area.cadastre?
-      head :no_content
+      if @source_id_used
+        render json: { geo_area_id: geo_area.id }, status: :ok
+      else
+        head :no_content
+      end
     else
       render json: { errors: geo_area.errors.full_messages }, status: :unprocessable_content
     end
   end
 
   def destroy
-    @champ.geo_areas.find(params[:id]).destroy!
+    find_geo_area(params[:id]).destroy!
     @champ.update_timestamps
 
     head :no_content
@@ -86,6 +90,16 @@ class Champs::CarteController < Champs::ChampController
       geo_area.properties.merge!(feature[:properties])
     end
     geo_area.save
+  end
+
+  def find_geo_area(id)
+    @champ.geo_areas.find_by(id:) || find_geo_area_by_source_id(id)
+  end
+
+  def find_geo_area_by_source_id(id)
+    geo_area = @champ.geo_areas.find_by!("properties->>'source_id' = ?", id.to_s)
+    @source_id_used = true
+    geo_area
   end
 
   def ensure_legitimate_access

--- a/app/javascript/components/MapEditor/hooks.ts
+++ b/app/javascript/components/MapEditor/hooks.ts
@@ -143,10 +143,25 @@ export function useFeatureCollection(
         for (const feature of features) {
           const id = feature.properties?.id;
           if (id) {
-            await httpRequest(endpointWithId(url, id), {
+            const result = await httpRequest(endpointWithId(url, id), {
               method: 'patch',
               json: { feature }
-            }).json();
+            }).json<{ geo_area_id?: number } | null>();
+            if (result?.geo_area_id) {
+              const newId = result.geo_area_id;
+              fire(document, 'map:internal:draw:setId', {
+                lid: String(id),
+                id: String(newId)
+              });
+              setFeatureCollection(({ features }) => ({
+                type: 'FeatureCollection',
+                features: features.map((f) =>
+                  f.properties?.id == id
+                    ? { ...f, properties: { ...f.properties, id: newId } }
+                    : f
+                )
+              }));
+            }
           } else {
             const data = await httpRequest(url, {
               method: 'post',
@@ -171,7 +186,14 @@ export function useFeatureCollection(
         onError('Le polygone dessiné n’est pas valide.');
       }
     },
-    [url, refreshFeatureList, updateFeatureCollection, addFeatures, onError]
+    [
+      url,
+      refreshFeatureList,
+      updateFeatureCollection,
+      setFeatureCollection,
+      addFeatures,
+      onError
+    ]
   );
 
   const deleteFeatures = useCallback<DeleteFeatures>(

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -310,7 +310,11 @@ class Champ < ApplicationRecord
     self.data = champ.data
     self.external_state = champ.external_state
 
-    self.geo_areas = champ.geo_areas.map(&:dup)
+    self.geo_areas = champ.geo_areas.map do |ga|
+      duped = ga.dup
+      duped.properties = duped.properties.merge('source_id' => ga.id)
+      duped
+    end
 
     ClonePiecesJustificativesService.clone_attachments(champ, self)
 

--- a/spec/controllers/champs/carte_controller_en_construction_spec.rb
+++ b/spec/controllers/champs/carte_controller_en_construction_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+describe Champs::CarteController, type: :controller do
+  let(:user) { create(:user) }
+  let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :carte }]) }
+  let(:dossier) { create(:dossier, user: user, procedure: procedure) }
+  let(:champ) { dossier.champs.first }
+  let(:feature) { attributes_for(:geo_area, :polygon) }
+  let!(:geo_area) { create(:geo_area, :selection_utilisateur, :polygon, champ: champ) }
+
+  before do
+    sign_in user
+    request.accept = "application/json"
+    request.content_type = "application/json"
+  end
+
+  context 'when dossier is en_construction' do
+    before do
+      champ.geo_areas.reset
+      dossier.passer_en_construction!
+    end
+
+    describe 'DELETE #destroy' do
+      it 'finds the cloned geo_area by source_id and deletes it' do
+        expect {
+          delete :destroy, params: {
+            dossier_id: champ.dossier_id,
+            stable_id: champ.stable_id,
+            id: geo_area.id,
+          }
+        }.to change { GeoArea.count }.by(0) # +1 clone, -1 delete = net 0
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    describe 'PATCH #update' do
+      it 'finds the cloned geo_area by source_id and returns the new id' do
+        patch :update, params: {
+          dossier_id: champ.dossier_id,
+          stable_id: champ.stable_id,
+          id: geo_area.id,
+          feature: feature,
+        }
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body['geo_area_id']).to be_present
+        expect(body['geo_area_id']).not_to eq(geo_area.id)
+      end
+    end
+
+    describe 'POST #create' do
+      it 'creates a new geo_area on the buffer champ' do
+        expect {
+          post :create, params: {
+            dossier_id: champ.dossier_id,
+            stable_id: champ.stable_id,
+            feature: feature,
+            source: GeoArea.sources.fetch(:selection_utilisateur),
+          }
+        }.to change { GeoArea.count }.by(2) # 1 clone + 1 new
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body['feature']).to be_present
+      end
+    end
+
+    describe 'self-healing across multiple operations' do
+      let!(:geo_area2) { create(:geo_area, :selection_utilisateur, :polygon, champ: champ) }
+
+      before { champ.geo_areas.reset }
+
+      it 'each operation resolves its own ID via source_id' do
+        # First: delete geo_area by source_id
+        delete :destroy, params: {
+          dossier_id: champ.dossier_id,
+          stable_id: champ.stable_id,
+          id: geo_area.id,
+        }
+        expect(response).to have_http_status(:no_content)
+
+        # Second: update geo_area2 by source_id, get new id back
+        patch :update, params: {
+          dossier_id: champ.dossier_id,
+          stable_id: champ.stable_id,
+          id: geo_area2.id,
+          feature: feature,
+        }
+        expect(response).to have_http_status(:ok)
+        new_id = response.parsed_body['geo_area_id']
+
+        # Third: use the new id directly
+        patch :update, params: {
+          dossier_id: champ.dossier_id,
+          stable_id: champ.stable_id,
+          id: new_id,
+          feature: feature,
+        }
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+  end
+
+  context 'when dossier is brouillon' do
+    describe 'DELETE #destroy' do
+      it 'deletes directly' do
+        expect {
+          delete :destroy, params: {
+            dossier_id: champ.dossier_id,
+            stable_id: champ.stable_id,
+            id: geo_area.id,
+          }
+        }.to change { GeoArea.count }.by(-1)
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    describe 'PATCH #update' do
+      it 'updates directly' do
+        patch :update, params: {
+          dossier_id: champ.dossier_id,
+          stable_id: champ.stable_id,
+          id: geo_area.id,
+          feature: feature,
+        }
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    describe 'POST #create' do
+      it 'creates a new geo_area' do
+        expect {
+          post :create, params: {
+            dossier_id: champ.dossier_id,
+            stable_id: champ.stable_id,
+            feature: feature,
+            source: GeoArea.sources.fetch(:selection_utilisateur),
+          }
+        }.to change { GeoArea.count }.by(1)
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body['feature']).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
crisp: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_013fcfb7-2c32-4840-a704-8b8f604578a4/

# Problème

Sur les dossiers en construction (ex: procédures "label bas carbone"), les usagers ne peuvent pas modifier ni supprimer les polygones sur le champ carte. Les erreurs affichées sont :
- "le polygone n'a pas pu être supprimé"

https://github.com/user-attachments/assets/1e21287b-98e1-4c4f-9f30-7cd199912905


- "le polygone tracé n'est pas valide"

https://github.com/user-attachments/assets/4e1d064f-251e-4752-8ab0-fe908b4a2055



**Root cause** : le mécanisme de buffer stream crée un champ buffer avec des geo_areas clonées (nouveaux IDs en base). Mais la page est rendue avec les IDs du main stream. Quand le frontend envoie un PATCH/DELETE avec l'ancien ID, le contrôleur cherche sur le buffer champ → `RecordNotFound`.

# Solution

Approche **self-heal par opération** :

1. **`clone_value_from`** stocke un `source_id` dans les properties des geo_areas clonées, traçant l'ID d'origine
2. **`find_geo_area`** dans le contrôleur carte cherche d'abord par ID direct, puis fallback sur `source_id` via JSONB query
3. **`update`** retourne le nouvel `geo_area_id` quand le fallback est utilisé → le frontend met à jour l'ID de CE feature via `map:internal:draw:setId`
4. **`delete`** fonctionne directement (le feature est supprimé côté frontend, pas besoin de remap)
5. Chaque opération successive se corrige individuellement — pas de mapping global

update:
https://github.com/user-attachments/assets/30381683-8c6b-479a-b843-e9ecdc496fe0

destroy:
https://github.com/user-attachments/assets/91be393d-2ccb-46e2-8e8d-da934b13ebcd




### Pourquoi cette approche ?

- Pas de couplage entre `modifier` et le type de champ carte (vs créer le buffer eagerly au chargement de page)
- Pas de mapping global ni de synchronisation JS complexe
- Compatible avec le buffer stream existant (isolation usager/instructeur préservée)

Generated with [Claude Code](https://claude.com/claude-code)