### PR TITLE
Tech: retour à rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source 'https://gem.coop'
+source 'https://rubygems.org'
 
 gem 'rails', '~> 7.2.3' # allows update to security fixes at any time
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
       sidekiq (~> 7.0)
 
 GEM
-  remote: https://gem.coop/
+  remote: https://rubygems.org/
   specs:
     aasm (5.5.2)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
gem.coop n'est actuellement pas assez fiable