### PR TITLE
Tech: rate limiting hybride API Entreprise + backfill etablissements partiels

### DIFF
--- a/app/jobs/api_entreprise/job.rb
+++ b/app/jobs/api_entreprise/job.rb
@@ -11,6 +11,15 @@ class APIEntreprise::Job < ApplicationJob
   # (it can happen through EtablissementUpdateJob for instance), ignore the job
   discard_on ActiveRecord::RecordNotFound
 
+  # If rate limited, re-enqueue with delay and free the worker immediately.
+  before_perform do
+    if APIEntreprise::RateLimiter.throttled?
+      wait = APIEntreprise::RateLimiter.wait_duration
+      self.class.set(wait: wait.seconds).perform_later(*arguments)
+      throw :abort
+    end
+  end
+
   def log_job_exception(exception)
     if etablissement.present?
       if etablissement.dossier.present?
@@ -40,6 +49,9 @@ class APIEntreprise::Job < ApplicationJob
       yield params
     in Success
       nil
+    in Failure(retryable: true, type: :rate_limited, code:, **)
+      wait = APIEntreprise::RateLimiter.wait_duration(api_pool)
+      self.class.set(wait: wait.seconds).perform_later(*arguments)
     in Failure(retryable: true, type:, code:, raw_response:, **)
       raise StandardError, format_error(type, code, raw_response)
     in Failure(retryable: false, type:, code:, **)

--- a/app/jobs/api_entreprise/job.rb
+++ b/app/jobs/api_entreprise/job.rb
@@ -7,15 +7,26 @@ class APIEntreprise::Job < ApplicationJob
 
   use_sidekiq_retry
 
+  # Rate limit pool per job class (matches API Entreprise pools).
+  # Jobs not listed here default to DEFAULT_POOL (250).
+  POOL_BY_JOB = {
+    'AttestationFiscaleJob' => 5,
+    'EffectifsJob' => 50,
+    'EffectifsAnnuelsJob' => 50,
+    'AttestationSocialeJob' => 100,
+  }.freeze
+
   # If by the time the job runs the Etablissement has been deleted
   # (it can happen through EtablissementUpdateJob for instance), ignore the job
   discard_on ActiveRecord::RecordNotFound
 
-  # If rate limited, re-enqueue with delay and free the worker immediately.
+  # If rate limited for this pool, re-enqueue with delay and free the worker immediately.
   before_perform do
-    if APIEntreprise::RateLimiter.throttled?
-      wait = APIEntreprise::RateLimiter.wait_duration
-      self.class.set(wait: wait.seconds).perform_later(*arguments)
+    pool = api_pool
+    if APIEntreprise::RateLimiter.throttled?(pool)
+      wait = APIEntreprise::RateLimiter.wait_duration(pool)
+      jitter = rand(0..wait)
+      self.class.set(wait: (wait + jitter).seconds).perform_later(*arguments)
       throw :abort
     end
   end
@@ -60,6 +71,11 @@ class APIEntreprise::Job < ApplicationJob
     else
       raise "Unexpected adapter result: #{result.inspect}"
     end
+  end
+
+  # Pool derived from job class name via POOL_BY_JOB.
+  def api_pool
+    POOL_BY_JOB.fetch(self.class.name.demodulize, APIEntreprise::API::DEFAULT_POOL)
   end
 
   private

--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -16,6 +16,17 @@ class APIEntreprise::API
   BILANS_BDF_RESOURCE_NAME = "v3/banque_de_france/unites_legales/%{id}/bilans"
   PRIVILEGES_RESOURCE_NAME = "privileges"
 
+  # Rate limit pools (req/min) — keyed by ratelimit-limit header value.
+  # Endpoints not listed here default to DEFAULT_POOL (250).
+  POOL_BY_RESOURCE = {
+    ATTESTATION_FISCALE_RESOURCE_NAME => 5,
+    EFFECTIFS_RESOURCE_NAME => 50,
+    EFFECTIFS_ANNUELS_RESOURCE_NAME => 50,
+    ATTESTATION_SOCIALE_RESOURCE_NAME => 100,
+  }.freeze
+  DEFAULT_POOL = 250
+  POOL_BY_PREFIX = POOL_BY_RESOURCE.transform_keys { |k| k.split('%').first }.freeze
+
   TIMEOUT = 20
 
   attr_reader :procedure
@@ -96,24 +107,24 @@ class APIEntreprise::API
 
   def call_with_siret(resource_name, siret_or_siren, user_id: nil)
     url = make_url(resource_name, siret_or_siren)
-
     params = build_params(user_id, siret_or_siren)
+    pool = pool_for(resource_name)
 
-    call(url, params)
+    call(url, params, pool:)
   end
 
-  def call(url, params = nil)
+  def call(url, params = nil, pool: DEFAULT_POOL)
     return Failure(type: :token_missing, code: 401, retryable: false, raw_response: nil) if token_missing?
     return Failure(type: :token_expired, code: 401, retryable: false, raw_response: nil) if token_expired?
 
-    APIEntreprise::RateLimiter.consume!
+    APIEntreprise::RateLimiter.consume!(pool)
 
     case client.call(url:, params:, headers: { 'Authorization' => "Bearer #{token.jwt_token}" }, timeout: TIMEOUT)
     in Success(body:, response:)
-      APIEntreprise::RateLimiter.calibrate!(response) if rand < 0.1
+      APIEntreprise::RateLimiter.calibrate!(response, pool) if rand < 0.1
       Success(body)
     in Failure(type: :http, code:, error:)
-      APIEntreprise::RateLimiter.calibrate!(error.try(:response)) if code == 429
+      APIEntreprise::RateLimiter.calibrate!(error.try(:response), pool) if code == 429
       classify_http_error(code, error.try(:response))
     in Failure(type:, code:, retryable:, error:)
       Failure(type:, code:, retryable:, raw_response: error.try(:response))
@@ -190,6 +201,13 @@ class APIEntreprise::API
       recipient: recipient_for(siret_or_siren),
       non_diffusables: true,
     }
+  end
+
+  def pool_for(resource_name)
+    POOL_BY_PREFIX.each do |prefix, pool|
+      return pool if resource_name.start_with?(prefix)
+    end
+    DEFAULT_POOL
   end
 
   def token_missing? = token.nil? || token.jwt_token.blank?

--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -17,7 +17,6 @@ class APIEntreprise::API
   PRIVILEGES_RESOURCE_NAME = "privileges"
 
   TIMEOUT = 20
-  DEFAULT_API_ENTREPRISE_DELAY = 0.0
 
   attr_reader :procedure
   attr_accessor :token
@@ -107,12 +106,14 @@ class APIEntreprise::API
     return Failure(type: :token_missing, code: 401, retryable: false, raw_response: nil) if token_missing?
     return Failure(type: :token_expired, code: 401, retryable: false, raw_response: nil) if token_expired?
 
-    sleep api_entreprise_delay if api_entreprise_delay != 0.0
+    APIEntreprise::RateLimiter.consume!
 
     case client.call(url:, params:, headers: { 'Authorization' => "Bearer #{token.jwt_token}" }, timeout: TIMEOUT)
     in Success(body:, response:)
+      APIEntreprise::RateLimiter.calibrate!(response) if rand < 0.1
       Success(body)
     in Failure(type: :http, code:, error:)
+      APIEntreprise::RateLimiter.calibrate!(error.try(:response)) if code == 429
       classify_http_error(code, error.try(:response))
     in Failure(type:, code:, retryable:, error:)
       Failure(type:, code:, retryable:, raw_response: error.try(:response))
@@ -189,10 +190,6 @@ class APIEntreprise::API
       recipient: recipient_for(siret_or_siren),
       non_diffusables: true,
     }
-  end
-
-  def api_entreprise_delay
-    ENV.fetch("API_ENTREPRISE_DELAY", DEFAULT_API_ENTREPRISE_DELAY).to_f
   end
 
   def token_missing? = token.nil? || token.jwt_token.blank?

--- a/app/lib/api_entreprise/rate_limiter.rb
+++ b/app/lib/api_entreprise/rate_limiter.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Shared rate limiter for API Entreprise (250 req/min).
+#
+# Hybrid approach: Redis DECR for proactive counting + server headers for calibration.
+#
+#   consume!    — DECR before each HTTP call (API#call)
+#   calibrate!  — SET from RateLimit-* headers (~10% of 200s, 100% of 429s)
+#   throttled?  — read-only check (Job#before_perform, BackfillNaf2025Task#throttle_on)
+#
+# Flow:
+#   1. Job#before_perform checks throttled? → if true, re-enqueue + free worker
+#   2. API#call calls consume! (atomic DECR)
+#   3. API#call calls calibrate! on response (recalibrates from server truth)
+#   4. BackfillNaf2025Task#throttle_on checks throttled? → pauses if remaining < 200
+#
+# Redis keys auto-expire (TTL = reset window), so no stale state after window ends.
+module APIEntreprise::RateLimiter
+  REMAINING_KEY = "api_entreprise:rate_limit:remaining"
+  RESET_KEY = "api_entreprise:rate_limit:reset"
+  def self.throttled?
+    remaining = Kredis.redis.get(REMAINING_KEY)
+    remaining.present? && remaining.to_i <= 0
+  end
+
+  # Called by API#call before each HTTP request.
+  # Atomically decrements the remaining counter.
+  # Returns without blocking — callers decide what to do when throttled.
+  def self.consume!
+    remaining = Kredis.redis.get(REMAINING_KEY)
+    return if remaining.nil? # not yet calibrated, let it through
+
+    Kredis.redis.decr(REMAINING_KEY)
+  end
+
+  # Called by API#call after receiving a response.
+  # Recalibrates Redis from server-provided RateLimit-* headers.
+  # Called on every 429, and ~10% of 200s to let DECR do its job.
+  def self.calibrate!(response)
+    headers = response&.try(:headers)
+    return if headers.nil?
+
+    remaining = headers['RateLimit-Remaining']
+    reset = headers['RateLimit-Reset']
+    return if remaining.nil? || reset.nil?
+
+    ttl = [reset.to_i - Time.current.to_i, 1].max
+    Kredis.redis.set(REMAINING_KEY, remaining.to_i, ex: ttl)
+    Kredis.redis.set(RESET_KEY, reset.to_i, ex: ttl) if remaining.to_i <= 0
+  end
+
+  # Seconds until the rate limit window resets.
+  # Used by Job#before_perform to schedule re-enqueue delay.
+  def self.wait_duration
+    reset_at = Kredis.redis.get(RESET_KEY)&.to_i
+    return 2 if reset_at.nil? || reset_at == 0
+
+    [reset_at - Time.current.to_i, 2].max
+  end
+end

--- a/app/lib/api_entreprise/rate_limiter.rb
+++ b/app/lib/api_entreprise/rate_limiter.rb
@@ -1,58 +1,63 @@
 # frozen_string_literal: true
 
-# Shared rate limiter for API Entreprise (250 req/min).
+# Shared rate limiter for API Entreprise — per-pool.
+#
+# API Entreprise enforces rate limits by pool (identified by ratelimit-limit header):
+#   - 250 req/min: most JSON endpoints (insee, dgfip/chiffres_affaires, infogreffe, etc.)
+#   -  100 req/min: urssaf/attestation_vigilance
+#   -   50 req/min: gip_mds/effectifs
+#   -    5 req/min: dgfip/attestation_fiscale
 #
 # Hybrid approach: Redis DECR for proactive counting + server headers for calibration.
 #
-#   consume!    — DECR before each HTTP call (API#call)
-#   calibrate!  — SET from RateLimit-* headers (~10% of 200s, 100% of 429s)
-#   throttled?  — read-only check (Job#before_perform, BackfillNaf2025Task#throttle_on)
+#   consume!(pool)    — DECR before each HTTP call (API#call)
+#   calibrate!(response, pool) — SET from RateLimit-* headers (~10% of 200s, 100% of 429s)
+#   throttled?(pool)  — read-only check (Job#before_perform, BackfillTask#throttle_on)
 #
-# Flow:
-#   1. Job#before_perform checks throttled? → if true, re-enqueue + free worker
-#   2. API#call calls consume! (atomic DECR)
-#   3. API#call calls calibrate! on response (recalibrates from server truth)
-#   4. BackfillNaf2025Task#throttle_on checks throttled? → pauses if remaining < 200
-#
-# Redis keys auto-expire (TTL = reset window), so no stale state after window ends.
+# Redis keys: api_entreprise:rate_limit:{remaining|reset}:{pool}
+# Keys auto-expire (TTL = reset window), so no stale state after window ends.
 module APIEntreprise::RateLimiter
-  REMAINING_KEY = "api_entreprise:rate_limit:remaining"
-  RESET_KEY = "api_entreprise:rate_limit:reset"
-  def self.throttled?
-    remaining = Kredis.redis.get(REMAINING_KEY)
-    remaining.present? && remaining.to_i <= 0
+  KEY_PREFIX = "api_entreprise:rate_limit"
+
+  def self.remaining_key(pool) = "#{KEY_PREFIX}:remaining:#{pool}"
+  def self.reset_key(pool) = "#{KEY_PREFIX}:reset:#{pool}"
+
+  def self.throttled?(pool)
+    r = remaining(pool)
+    r.present? && r <= 0
   end
 
-  # Called by API#call before each HTTP request.
-  # Atomically decrements the remaining counter.
-  # Returns without blocking — callers decide what to do when throttled.
-  def self.consume!
-    remaining = Kredis.redis.get(REMAINING_KEY)
-    return if remaining.nil? # not yet calibrated, let it through
-
-    Kredis.redis.decr(REMAINING_KEY)
+  def self.remaining(pool)
+    Kredis.redis.get(remaining_key(pool))&.to_i
   end
 
-  # Called by API#call after receiving a response.
-  # Recalibrates Redis from server-provided RateLimit-* headers.
-  # Called on every 429, and ~10% of 200s to let DECR do its job.
-  def self.calibrate!(response)
+  def self.consume!(pool)
+    return if remaining(pool).nil?
+
+    Kredis.redis.decr(remaining_key(pool))
+  end
+
+  def self.calibrate!(response, pool)
     headers = response&.try(:headers)
     return if headers.nil?
 
-    remaining = headers['RateLimit-Remaining']
-    reset = headers['RateLimit-Reset']
+    remaining = headers['RateLimit-Remaining'] || headers['ratelimit-remaining']
+    reset = headers['RateLimit-Reset'] || headers['ratelimit-reset']
     return if remaining.nil? || reset.nil?
 
+    server_limit = headers['RateLimit-Limit'] || headers['ratelimit-limit']
+    if server_limit && server_limit.to_i != pool
+      Rails.logger.warn("APIEntreprise::RateLimiter pool mismatch: expected=#{pool} server=#{server_limit}")
+    end
+
+    # RateLimit-Reset is a Unix timestamp (UTC epoch seconds), same as Time.current.to_i — timezone-safe.
     ttl = [reset.to_i - Time.current.to_i, 1].max
-    Kredis.redis.set(REMAINING_KEY, remaining.to_i, ex: ttl)
-    Kredis.redis.set(RESET_KEY, reset.to_i, ex: ttl) if remaining.to_i <= 0
+    Kredis.redis.set(remaining_key(pool), remaining.to_i, ex: ttl)
+    Kredis.redis.set(reset_key(pool), reset.to_i, ex: ttl) if remaining.to_i <= 0
   end
 
-  # Seconds until the rate limit window resets.
-  # Used by Job#before_perform to schedule re-enqueue delay.
-  def self.wait_duration
-    reset_at = Kredis.redis.get(RESET_KEY)&.to_i
+  def self.wait_duration(pool)
+    reset_at = Kredis.redis.get(reset_key(pool))&.to_i
     return 2 if reset_at.nil? || reset_at == 0
 
     [reset_at - Time.current.to_i, 2].max

--- a/app/tasks/maintenance/t20260522_backfill_partial_etablissements_task.rb
+++ b/app/tasks/maintenance/t20260522_backfill_partial_etablissements_task.rb
@@ -13,10 +13,11 @@ module Maintenance
     # Reserve quota for normal traffic — backfill pauses when < 200 remaining.
     # Jobs get the full 0-200 range, backfill only uses the 200+ surplus.
     BACKFILL_REMAINING_THRESHOLD = 200
+    BACKFILL_POOL = APIEntreprise::API::DEFAULT_POOL # etablissement endpoint = pool 250
 
     throttle_on(backoff: 1.minute) do
-      remaining = Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY)
-      remaining.present? && remaining.to_i < BACKFILL_REMAINING_THRESHOLD
+      remaining = APIEntreprise::RateLimiter.remaining(BACKFILL_POOL)
+      remaining.present? && remaining < BACKFILL_REMAINING_THRESHOLD
     end
 
     def collection

--- a/app/tasks/maintenance/t20260522_backfill_partial_etablissements_task.rb
+++ b/app/tasks/maintenance/t20260522_backfill_partial_etablissements_task.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260522BackfillPartialEtablissementsTask < MaintenanceTasks::Task
+    # Re-fetch etablissements that have partial data due to 429s silently
+    # swallowed as 404s in the pre-monads era (see PR #13101).
+    # Uses entreprise_siren IS NULL as marker: any properly fetched
+    # etablissement has entreprise_siren populated.
+
+    include RunnableOnDeployConcern
+    include Dry::Monads[:result]
+
+    # Reserve quota for normal traffic — backfill pauses when < 200 remaining.
+    # Jobs get the full 0-200 range, backfill only uses the 200+ surplus.
+    BACKFILL_REMAINING_THRESHOLD = 200
+
+    throttle_on(backoff: 1.minute) do
+      remaining = Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY)
+      remaining.present? && remaining.to_i < BACKFILL_REMAINING_THRESHOLD
+    end
+
+    def collection
+      Etablissement
+        .where(entreprise_siren: nil)
+        .where.not(siret: nil)
+        .includes(dossier: :procedure, champ: { dossier: :procedure })
+    end
+
+    def process(etablissement)
+      procedure_id = etablissement.dossier&.procedure&.id || etablissement.champ&.dossier&.procedure&.id
+      return if procedure_id.nil?
+
+      result = APIEntreprise::EtablissementAdapter.new(etablissement.siret, procedure_id).to_params
+
+      case result
+      in Success(params) if params.present?
+        etablissement.update_columns(params)
+      else
+        nil
+      end
+    rescue => e
+      Rails.logger.error("T20260522BackfillPartialEtablissementsTask: #{etablissement.id}: #{e.message}")
+      Sentry.capture_exception(e, extra: { etablissement_id: etablissement.id })
+    end
+
+    def count
+      collection.count
+    end
+  end
+end

--- a/spec/jobs/api_entreprise/job_spec.rb
+++ b/spec/jobs/api_entreprise/job_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
-include ActiveJob::TestHelper
-
 RSpec.describe APIEntreprise::Job, type: :job do
+  include ActiveJob::TestHelper
+  before do
+    Kredis.redis.del(APIEntreprise::RateLimiter::REMAINING_KEY, APIEntreprise::RateLimiter::RESET_KEY)
+  end
+
   describe '#perform' do
     let(:dossier) { create(:dossier, :with_entreprise) }
 
@@ -21,6 +24,47 @@ RSpec.describe APIEntreprise::Job, type: :job do
           .to raise_error(StandardError, /API Entreprise error/)
 
         expect(champ.reload.value).not_to be_nil
+      end
+    end
+  end
+
+  describe 'before_perform rate limit check' do
+    context 'when not throttled' do
+      before { allow(APIEntreprise::RateLimiter).to receive(:throttled?).and_return(false) }
+
+      it 'runs the job normally' do
+        dossier = create(:dossier, :with_entreprise)
+        etablissement = dossier.etablissement
+
+        expect { ErrorJob.perform_now(etablissement) }.to raise_error(StandardError, /API Entreprise error/)
+      end
+    end
+
+    context 'when throttled' do
+      before do
+        allow(APIEntreprise::RateLimiter).to receive(:throttled?).and_return(true)
+        allow(APIEntreprise::RateLimiter).to receive(:wait_duration).and_return(15)
+      end
+
+      it 're-enqueues the job with delay and aborts' do
+        dossier = create(:dossier, :with_entreprise)
+        etablissement = dossier.etablissement
+
+        expect(ErrorJob).to receive(:set).with(wait: 15.seconds).and_return(ErrorJob)
+        expect(ErrorJob).to receive(:perform_later).with(etablissement)
+
+        ErrorJob.perform_now(etablissement)
+      end
+
+      it 'does not execute the job body' do
+        dossier = create(:dossier, :with_entreprise)
+        etablissement = dossier.etablissement
+
+        allow(ErrorJob).to receive(:set).and_return(ErrorJob)
+        allow(ErrorJob).to receive(:perform_later)
+
+        # If the job body ran, it would raise — no raise means abort worked
+        expect { ErrorJob.perform_now(etablissement) }.not_to raise_error
       end
     end
   end
@@ -76,6 +120,26 @@ RSpec.describe APIEntreprise::Job, type: :job do
       it 'raises a StandardError with diagnostic message' do
         expect { job.send(:with_adapter, adapter) { |_| } }
           .to raise_error(StandardError, /API Entreprise error: type=token code=401/)
+      end
+    end
+
+    context 'when adapter returns Failure with rate_limited' do
+      before do
+        allow(adapter).to receive(:to_params)
+          .and_return(Dry::Monads::Failure(type: :rate_limited, code: 429, retryable: true, raw_response: nil))
+      end
+
+      it 're-enqueues the job with wait from RateLimiter.wait_duration' do
+        allow(APIEntreprise::RateLimiter).to receive(:wait_duration).and_return(20)
+        expect(described_class).to receive(:set).with(wait: 20.seconds).and_return(described_class)
+        expect(described_class).to receive(:perform_later)
+        job.send(:with_adapter, adapter) { |_| }
+      end
+
+      it 'does not raise' do
+        allow(described_class).to receive(:set).and_return(described_class)
+        allow(described_class).to receive(:perform_later)
+        expect { job.send(:with_adapter, adapter) { |_| } }.not_to raise_error
       end
     end
 

--- a/spec/jobs/api_entreprise/job_spec.rb
+++ b/spec/jobs/api_entreprise/job_spec.rb
@@ -3,7 +3,9 @@
 RSpec.describe APIEntreprise::Job, type: :job do
   include ActiveJob::TestHelper
   before do
-    Kredis.redis.del(APIEntreprise::RateLimiter::REMAINING_KEY, APIEntreprise::RateLimiter::RESET_KEY)
+    [5, 50, 100, 250].each do |pool|
+      Kredis.redis.del(APIEntreprise::RateLimiter.remaining_key(pool), APIEntreprise::RateLimiter.reset_key(pool))
+    end
   end
 
   describe '#perform' do
@@ -29,8 +31,10 @@ RSpec.describe APIEntreprise::Job, type: :job do
   end
 
   describe 'before_perform rate limit check' do
+    let(:pool) { APIEntreprise::API::DEFAULT_POOL }
+
     context 'when not throttled' do
-      before { allow(APIEntreprise::RateLimiter).to receive(:throttled?).and_return(false) }
+      before { allow(APIEntreprise::RateLimiter).to receive(:throttled?).with(pool).and_return(false) }
 
       it 'runs the job normally' do
         dossier = create(:dossier, :with_entreprise)
@@ -42,15 +46,15 @@ RSpec.describe APIEntreprise::Job, type: :job do
 
     context 'when throttled' do
       before do
-        allow(APIEntreprise::RateLimiter).to receive(:throttled?).and_return(true)
-        allow(APIEntreprise::RateLimiter).to receive(:wait_duration).and_return(15)
+        allow(APIEntreprise::RateLimiter).to receive(:throttled?).with(pool).and_return(true)
+        allow(APIEntreprise::RateLimiter).to receive(:wait_duration).with(pool).and_return(15)
       end
 
       it 're-enqueues the job with delay and aborts' do
         dossier = create(:dossier, :with_entreprise)
         etablissement = dossier.etablissement
 
-        expect(ErrorJob).to receive(:set).with(wait: 15.seconds).and_return(ErrorJob)
+        expect(ErrorJob).to receive(:set).with(wait: a_value_between(15.seconds, 30.seconds)).and_return(ErrorJob)
         expect(ErrorJob).to receive(:perform_later).with(etablissement)
 
         ErrorJob.perform_now(etablissement)
@@ -66,6 +70,27 @@ RSpec.describe APIEntreprise::Job, type: :job do
         # If the job body ran, it would raise — no raise means abort worked
         expect { ErrorJob.perform_now(etablissement) }.not_to raise_error
       end
+    end
+  end
+
+  describe '#api_pool' do
+    it 'returns the correct pool for each job class' do
+      expect(APIEntreprise::EtablissementJob.new.api_pool).to eq(250)
+      expect(APIEntreprise::EntrepriseJob.new.api_pool).to eq(250)
+      expect(APIEntreprise::ExtraitKbisJob.new.api_pool).to eq(250)
+      expect(APIEntreprise::TvaJob.new.api_pool).to eq(250)
+      expect(APIEntreprise::ExercicesJob.new.api_pool).to eq(250)
+      expect(APIEntreprise::AssociationJob.new.api_pool).to eq(250)
+      expect(APIEntreprise::BilansBdfJob.new.api_pool).to eq(250)
+      expect(APIEntreprise::ServiceJob.new.api_pool).to eq(250)
+      expect(APIEntreprise::EffectifsJob.new.api_pool).to eq(50)
+      expect(APIEntreprise::EffectifsAnnuelsJob.new.api_pool).to eq(50)
+      expect(APIEntreprise::AttestationSocialeJob.new.api_pool).to eq(100)
+      expect(APIEntreprise::AttestationFiscaleJob.new.api_pool).to eq(5)
+    end
+
+    it 'defaults to 250 for unknown job classes' do
+      expect(ErrorJob.new.api_pool).to eq(250)
     end
   end
 

--- a/spec/lib/api_entreprise/api_spec.rb
+++ b/spec/lib/api_entreprise/api_spec.rb
@@ -450,6 +450,110 @@ describe APIEntreprise::API do
     end
   end
 
+  describe 'rate limiting' do
+    let(:siren) { '418166096' }
+    let(:body) { fixture_file('entreprises.json') }
+    let(:rate_limit_headers) { { 'RateLimit-Remaining' => '47', 'RateLimit-Limit' => '50', 'RateLimit-Reset' => reset_timestamp.to_s } }
+    let(:reset_timestamp) { Time.current.to_i + 30 }
+
+    before do
+      Kredis.redis.del(APIEntreprise::RateLimiter::REMAINING_KEY, APIEntreprise::RateLimiter::RESET_KEY)
+    end
+
+    describe 'RateLimiter.calibrate! via response headers' do
+      before do
+        stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v3\/insee\/sirene\/unites_legales\/#{siren}/)
+          .to_return(body:, status:, headers: rate_limit_headers)
+      end
+
+      context 'when API returns 200 with RateLimit headers' do
+        let(:status) { 200 }
+
+        it 'stores remaining in Redis when calibration triggers (reset not stored when remaining > 0)' do
+          allow_any_instance_of(described_class).to receive(:rand).and_return(0.05) # force calibration
+          described_class.new(procedure_id).entreprise(siren)
+
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY).to_i).to eq(47)
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter::RESET_KEY)).to be_nil
+        end
+
+        it 'sets TTL on Redis keys' do
+          allow_any_instance_of(described_class).to receive(:rand).and_return(0.05)
+          described_class.new(procedure_id).entreprise(siren)
+
+          ttl = Kredis.redis.ttl(APIEntreprise::RateLimiter::REMAINING_KEY)
+          expect(ttl).to be_between(1, 30)
+        end
+
+        it 'skips calibration ~90% of the time' do
+          allow_any_instance_of(described_class).to receive(:rand).and_return(0.5)
+          described_class.new(procedure_id).entreprise(siren)
+
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY)).to be_nil
+        end
+      end
+
+      context 'when API returns 200 without RateLimit headers' do
+        let(:status) { 200 }
+        let(:rate_limit_headers) { {} }
+
+        it 'does not write to Redis' do
+          described_class.new(procedure_id).entreprise(siren)
+
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY)).to be_nil
+        end
+      end
+
+      context 'when API returns 429 with RateLimit-Reset header' do
+        let(:status) { 429 }
+        let(:body) { '{"errors":[{"code":"00429","title":"Trop de requêtes"}]}' }
+        let(:rate_limit_headers) { { 'RateLimit-Remaining' => '0', 'RateLimit-Reset' => reset_timestamp.to_s } }
+
+        it 'always calibrates on 429 (broadcast stop signal)' do
+          described_class.new(procedure_id).entreprise(siren)
+
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY).to_i).to eq(0)
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter::RESET_KEY).to_i).to eq(reset_timestamp)
+        end
+      end
+    end
+
+    describe 'RateLimiter.consume! decrements counter' do
+      before do
+        stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v3\/insee\/sirene\/unites_legales\/#{siren}/)
+          .to_return(body:, status: 200)
+      end
+
+      context 'when Redis has no rate limit state' do
+        it 'skips decrement and makes the call' do
+          expect { described_class.new(procedure_id).entreprise(siren) }.not_to raise_error
+        end
+      end
+
+      context 'when remaining > 0' do
+        before do
+          Kredis.redis.set(APIEntreprise::RateLimiter::REMAINING_KEY, 10, ex: 60)
+        end
+
+        it 'decrements remaining' do
+          described_class.new(procedure_id).entreprise(siren)
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY).to_i).to eq(9)
+        end
+      end
+
+      context 'when remaining = 0' do
+        before do
+          Kredis.redis.set(APIEntreprise::RateLimiter::REMAINING_KEY, 0, ex: 60)
+        end
+
+        it 'decrements to negative (caller handles throttling)' do
+          described_class.new(procedure_id).entreprise(siren)
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY).to_i).to eq(-1)
+        end
+      end
+    end
+  end
+
   describe 'with expired token' do
     let(:siren) { '111111111' }
     subject { described_class.new(procedure_id).entreprise(siren) }

--- a/spec/lib/api_entreprise/api_spec.rb
+++ b/spec/lib/api_entreprise/api_spec.rb
@@ -453,11 +453,12 @@ describe APIEntreprise::API do
   describe 'rate limiting' do
     let(:siren) { '418166096' }
     let(:body) { fixture_file('entreprises.json') }
-    let(:rate_limit_headers) { { 'RateLimit-Remaining' => '47', 'RateLimit-Limit' => '50', 'RateLimit-Reset' => reset_timestamp.to_s } }
+    let(:pool) { APIEntreprise::API::DEFAULT_POOL }
+    let(:rate_limit_headers) { { 'RateLimit-Remaining' => '47', 'RateLimit-Limit' => pool.to_s, 'RateLimit-Reset' => reset_timestamp.to_s } }
     let(:reset_timestamp) { Time.current.to_i + 30 }
 
     before do
-      Kredis.redis.del(APIEntreprise::RateLimiter::REMAINING_KEY, APIEntreprise::RateLimiter::RESET_KEY)
+      Kredis.redis.del(APIEntreprise::RateLimiter.remaining_key(pool), APIEntreprise::RateLimiter.reset_key(pool))
     end
 
     describe 'RateLimiter.calibrate! via response headers' do
@@ -473,15 +474,15 @@ describe APIEntreprise::API do
           allow_any_instance_of(described_class).to receive(:rand).and_return(0.05) # force calibration
           described_class.new(procedure_id).entreprise(siren)
 
-          expect(Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY).to_i).to eq(47)
-          expect(Kredis.redis.get(APIEntreprise::RateLimiter::RESET_KEY)).to be_nil
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter.remaining_key(pool)).to_i).to eq(47)
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter.reset_key(pool))).to be_nil
         end
 
         it 'sets TTL on Redis keys' do
           allow_any_instance_of(described_class).to receive(:rand).and_return(0.05)
           described_class.new(procedure_id).entreprise(siren)
 
-          ttl = Kredis.redis.ttl(APIEntreprise::RateLimiter::REMAINING_KEY)
+          ttl = Kredis.redis.ttl(APIEntreprise::RateLimiter.remaining_key(pool))
           expect(ttl).to be_between(1, 30)
         end
 
@@ -489,7 +490,7 @@ describe APIEntreprise::API do
           allow_any_instance_of(described_class).to receive(:rand).and_return(0.5)
           described_class.new(procedure_id).entreprise(siren)
 
-          expect(Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY)).to be_nil
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter.remaining_key(pool))).to be_nil
         end
       end
 
@@ -500,7 +501,7 @@ describe APIEntreprise::API do
         it 'does not write to Redis' do
           described_class.new(procedure_id).entreprise(siren)
 
-          expect(Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY)).to be_nil
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter.remaining_key(pool))).to be_nil
         end
       end
 
@@ -512,8 +513,8 @@ describe APIEntreprise::API do
         it 'always calibrates on 429 (broadcast stop signal)' do
           described_class.new(procedure_id).entreprise(siren)
 
-          expect(Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY).to_i).to eq(0)
-          expect(Kredis.redis.get(APIEntreprise::RateLimiter::RESET_KEY).to_i).to eq(reset_timestamp)
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter.remaining_key(pool)).to_i).to eq(0)
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter.reset_key(pool)).to_i).to eq(reset_timestamp)
         end
       end
     end
@@ -532,23 +533,23 @@ describe APIEntreprise::API do
 
       context 'when remaining > 0' do
         before do
-          Kredis.redis.set(APIEntreprise::RateLimiter::REMAINING_KEY, 10, ex: 60)
+          Kredis.redis.set(APIEntreprise::RateLimiter.remaining_key(pool), 10, ex: 60)
         end
 
         it 'decrements remaining' do
           described_class.new(procedure_id).entreprise(siren)
-          expect(Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY).to_i).to eq(9)
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter.remaining_key(pool)).to_i).to eq(9)
         end
       end
 
       context 'when remaining = 0' do
         before do
-          Kredis.redis.set(APIEntreprise::RateLimiter::REMAINING_KEY, 0, ex: 60)
+          Kredis.redis.set(APIEntreprise::RateLimiter.remaining_key(pool), 0, ex: 60)
         end
 
         it 'decrements to negative (caller handles throttling)' do
           described_class.new(procedure_id).entreprise(siren)
-          expect(Kredis.redis.get(APIEntreprise::RateLimiter::REMAINING_KEY).to_i).to eq(-1)
+          expect(Kredis.redis.get(APIEntreprise::RateLimiter.remaining_key(pool)).to_i).to eq(-1)
         end
       end
     end

--- a/spec/lib/api_entreprise/rate_limiter_spec.rb
+++ b/spec/lib/api_entreprise/rate_limiter_spec.rb
@@ -3,38 +3,56 @@
 require 'rails_helper'
 
 describe APIEntreprise::RateLimiter do
+  let(:pool) { 250 }
+
   before do
-    Kredis.redis.del(described_class::REMAINING_KEY, described_class::RESET_KEY)
+    Kredis.redis.del(described_class.remaining_key(pool), described_class.reset_key(pool))
   end
 
   describe '.throttled?' do
     context 'when Redis has no state' do
       it 'returns false' do
-        expect(described_class.throttled?).to be false
+        expect(described_class.throttled?(pool)).to be false
       end
     end
 
     context 'when remaining > 0' do
-      before { Kredis.redis.set(described_class::REMAINING_KEY, 10, ex: 60) }
+      before { Kredis.redis.set(described_class.remaining_key(pool), 10, ex: 60) }
 
       it 'returns false' do
-        expect(described_class.throttled?).to be false
+        expect(described_class.throttled?(pool)).to be false
       end
     end
 
     context 'when remaining = 0' do
-      before { Kredis.redis.set(described_class::REMAINING_KEY, 0, ex: 60) }
+      before { Kredis.redis.set(described_class.remaining_key(pool), 0, ex: 60) }
 
       it 'returns true' do
-        expect(described_class.throttled?).to be true
+        expect(described_class.throttled?(pool)).to be true
       end
     end
 
     context 'when remaining < 0 (over-decremented)' do
-      before { Kredis.redis.set(described_class::REMAINING_KEY, -3, ex: 60) }
+      before { Kredis.redis.set(described_class.remaining_key(pool), -3, ex: 60) }
 
       it 'returns true' do
-        expect(described_class.throttled?).to be true
+        expect(described_class.throttled?(pool)).to be true
+      end
+    end
+
+    context 'with different pools' do
+      before do
+        Kredis.redis.set(described_class.remaining_key(250), 10, ex: 60)
+        Kredis.redis.set(described_class.remaining_key(50), 0, ex: 60)
+      end
+
+      after do
+        Kredis.redis.del(described_class.remaining_key(250), described_class.remaining_key(50))
+      end
+
+      it 'tracks each pool independently' do
+        expect(described_class.throttled?(250)).to be false
+        expect(described_class.throttled?(50)).to be true
       end
     end
   end
@@ -42,22 +60,39 @@ describe APIEntreprise::RateLimiter do
   describe '.consume!' do
     context 'when Redis has no state (not yet calibrated)' do
       it 'does nothing' do
-        expect { described_class.consume! }.not_to raise_error
-        expect(Kredis.redis.get(described_class::REMAINING_KEY)).to be_nil
+        expect { described_class.consume!(pool) }.not_to raise_error
+        expect(Kredis.redis.get(described_class.remaining_key(pool))).to be_nil
       end
     end
 
     context 'when remaining is set' do
-      before { Kredis.redis.set(described_class::REMAINING_KEY, 5, ex: 60) }
+      before { Kredis.redis.set(described_class.remaining_key(pool), 5, ex: 60) }
 
-      it 'atomically decrements' do
-        described_class.consume!
-        expect(Kredis.redis.get(described_class::REMAINING_KEY).to_i).to eq(4)
+      it 'decrements the counter' do
+        described_class.consume!(pool)
+        expect(Kredis.redis.get(described_class.remaining_key(pool)).to_i).to eq(4)
       end
 
       it 'is safe under concurrent calls' do
-        3.times { described_class.consume! }
-        expect(Kredis.redis.get(described_class::REMAINING_KEY).to_i).to eq(2)
+        3.times { described_class.consume!(pool) }
+        expect(Kredis.redis.get(described_class.remaining_key(pool)).to_i).to eq(2)
+      end
+    end
+
+    context 'does not affect other pools' do
+      before do
+        Kredis.redis.set(described_class.remaining_key(250), 10, ex: 60)
+        Kredis.redis.set(described_class.remaining_key(50), 5, ex: 60)
+      end
+
+      after do
+        Kredis.redis.del(described_class.remaining_key(250), described_class.remaining_key(50))
+      end
+
+      it 'decrements only the specified pool' do
+        described_class.consume!(250)
+        expect(Kredis.redis.get(described_class.remaining_key(250)).to_i).to eq(9)
+        expect(Kredis.redis.get(described_class.remaining_key(50)).to_i).to eq(5)
       end
     end
   end
@@ -70,22 +105,53 @@ describe APIEntreprise::RateLimiter do
         Typhoeus::Response.new(
           effective_url: 'http://host.com/path', code: 200, body: '{}',
           return_message: 'ok', total_time: 1, connect_time: 0,
-          headers: { 'RateLimit-Remaining' => '42', 'RateLimit-Reset' => reset_timestamp.to_s }
+          headers: { 'RateLimit-Limit' => '250', 'RateLimit-Remaining' => '42', 'RateLimit-Reset' => reset_timestamp.to_s }
         )
       end
 
       it 'sets remaining in Redis but not reset (remaining > 0)' do
-        described_class.calibrate!(response)
+        described_class.calibrate!(response, pool)
 
-        expect(Kredis.redis.get(described_class::REMAINING_KEY).to_i).to eq(42)
-        expect(Kredis.redis.get(described_class::RESET_KEY)).to be_nil
+        expect(Kredis.redis.get(described_class.remaining_key(pool)).to_i).to eq(42)
+        expect(Kredis.redis.get(described_class.reset_key(pool))).to be_nil
       end
 
       it 'sets TTL based on reset timestamp' do
-        described_class.calibrate!(response)
+        described_class.calibrate!(response, pool)
 
-        ttl = Kredis.redis.ttl(described_class::REMAINING_KEY)
+        ttl = Kredis.redis.ttl(described_class.remaining_key(pool))
         expect(ttl).to be_between(1, 30)
+      end
+    end
+
+    context 'with lowercase ratelimit headers' do
+      let(:response) do
+        Typhoeus::Response.new(
+          effective_url: 'http://host.com/path', code: 200, body: '{}',
+          return_message: 'ok', total_time: 1, connect_time: 0,
+          headers: { 'ratelimit-limit' => '250', 'ratelimit-remaining' => '42', 'ratelimit-reset' => reset_timestamp.to_s }
+        )
+      end
+
+      it 'reads lowercase headers' do
+        described_class.calibrate!(response, pool)
+        expect(Kredis.redis.get(described_class.remaining_key(pool)).to_i).to eq(42)
+      end
+    end
+
+    context 'when server limit diverges from expected pool' do
+      let(:response) do
+        Typhoeus::Response.new(
+          effective_url: 'http://host.com/path', code: 200, body: '{}',
+          return_message: 'ok', total_time: 1, connect_time: 0,
+          headers: { 'RateLimit-Limit' => '100', 'RateLimit-Remaining' => '42', 'RateLimit-Reset' => reset_timestamp.to_s }
+        )
+      end
+
+      it 'logs a warning and still calibrates' do
+        expect(Rails.logger).to receive(:warn).with(/pool mismatch.*expected=250.*server=100/)
+        described_class.calibrate!(response, pool)
+        expect(Kredis.redis.get(described_class.remaining_key(pool)).to_i).to eq(42)
       end
     end
 
@@ -98,15 +164,15 @@ describe APIEntreprise::RateLimiter do
       end
 
       it 'does not write to Redis' do
-        described_class.calibrate!(response)
-        expect(Kredis.redis.get(described_class::REMAINING_KEY)).to be_nil
+        described_class.calibrate!(response, pool)
+        expect(Kredis.redis.get(described_class.remaining_key(pool))).to be_nil
       end
     end
 
     context 'with nil response' do
       it 'does not write to Redis' do
-        described_class.calibrate!(nil)
-        expect(Kredis.redis.get(described_class::REMAINING_KEY)).to be_nil
+        described_class.calibrate!(nil, pool)
+        expect(Kredis.redis.get(described_class.remaining_key(pool))).to be_nil
       end
     end
   end
@@ -114,27 +180,27 @@ describe APIEntreprise::RateLimiter do
   describe '.wait_duration' do
     context 'when reset key is not set' do
       it 'returns 2 seconds default' do
-        expect(described_class.wait_duration).to eq(2)
+        expect(described_class.wait_duration(pool)).to eq(2)
       end
     end
 
     context 'when reset is in the future' do
       before do
-        Kredis.redis.set(described_class::RESET_KEY, Time.current.to_i + 25, ex: 60)
+        Kredis.redis.set(described_class.reset_key(pool), Time.current.to_i + 25, ex: 60)
       end
 
       it 'returns seconds until reset' do
-        expect(described_class.wait_duration).to be_between(23, 25)
+        expect(described_class.wait_duration(pool)).to be_between(23, 25)
       end
     end
 
     context 'when reset is in the past' do
       before do
-        Kredis.redis.set(described_class::RESET_KEY, Time.current.to_i - 5, ex: 60)
+        Kredis.redis.set(described_class.reset_key(pool), Time.current.to_i - 5, ex: 60)
       end
 
       it 'returns minimum of 2 seconds' do
-        expect(described_class.wait_duration).to eq(2)
+        expect(described_class.wait_duration(pool)).to eq(2)
       end
     end
   end

--- a/spec/lib/api_entreprise/rate_limiter_spec.rb
+++ b/spec/lib/api_entreprise/rate_limiter_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe APIEntreprise::RateLimiter do
+  before do
+    Kredis.redis.del(described_class::REMAINING_KEY, described_class::RESET_KEY)
+  end
+
+  describe '.throttled?' do
+    context 'when Redis has no state' do
+      it 'returns false' do
+        expect(described_class.throttled?).to be false
+      end
+    end
+
+    context 'when remaining > 0' do
+      before { Kredis.redis.set(described_class::REMAINING_KEY, 10, ex: 60) }
+
+      it 'returns false' do
+        expect(described_class.throttled?).to be false
+      end
+    end
+
+    context 'when remaining = 0' do
+      before { Kredis.redis.set(described_class::REMAINING_KEY, 0, ex: 60) }
+
+      it 'returns true' do
+        expect(described_class.throttled?).to be true
+      end
+    end
+
+    context 'when remaining < 0 (over-decremented)' do
+      before { Kredis.redis.set(described_class::REMAINING_KEY, -3, ex: 60) }
+
+      it 'returns true' do
+        expect(described_class.throttled?).to be true
+      end
+    end
+  end
+
+  describe '.consume!' do
+    context 'when Redis has no state (not yet calibrated)' do
+      it 'does nothing' do
+        expect { described_class.consume! }.not_to raise_error
+        expect(Kredis.redis.get(described_class::REMAINING_KEY)).to be_nil
+      end
+    end
+
+    context 'when remaining is set' do
+      before { Kredis.redis.set(described_class::REMAINING_KEY, 5, ex: 60) }
+
+      it 'atomically decrements' do
+        described_class.consume!
+        expect(Kredis.redis.get(described_class::REMAINING_KEY).to_i).to eq(4)
+      end
+
+      it 'is safe under concurrent calls' do
+        3.times { described_class.consume! }
+        expect(Kredis.redis.get(described_class::REMAINING_KEY).to_i).to eq(2)
+      end
+    end
+  end
+
+  describe '.calibrate!' do
+    let(:reset_timestamp) { Time.current.to_i + 30 }
+
+    context 'with a response containing RateLimit headers' do
+      let(:response) do
+        Typhoeus::Response.new(
+          effective_url: 'http://host.com/path', code: 200, body: '{}',
+          return_message: 'ok', total_time: 1, connect_time: 0,
+          headers: { 'RateLimit-Remaining' => '42', 'RateLimit-Reset' => reset_timestamp.to_s }
+        )
+      end
+
+      it 'sets remaining in Redis but not reset (remaining > 0)' do
+        described_class.calibrate!(response)
+
+        expect(Kredis.redis.get(described_class::REMAINING_KEY).to_i).to eq(42)
+        expect(Kredis.redis.get(described_class::RESET_KEY)).to be_nil
+      end
+
+      it 'sets TTL based on reset timestamp' do
+        described_class.calibrate!(response)
+
+        ttl = Kredis.redis.ttl(described_class::REMAINING_KEY)
+        expect(ttl).to be_between(1, 30)
+      end
+    end
+
+    context 'with a response without RateLimit headers' do
+      let(:response) do
+        Typhoeus::Response.new(
+          effective_url: 'http://host.com/path', code: 200, body: '{}',
+          return_message: 'ok', total_time: 1, connect_time: 0, headers: ''
+        )
+      end
+
+      it 'does not write to Redis' do
+        described_class.calibrate!(response)
+        expect(Kredis.redis.get(described_class::REMAINING_KEY)).to be_nil
+      end
+    end
+
+    context 'with nil response' do
+      it 'does not write to Redis' do
+        described_class.calibrate!(nil)
+        expect(Kredis.redis.get(described_class::REMAINING_KEY)).to be_nil
+      end
+    end
+  end
+
+  describe '.wait_duration' do
+    context 'when reset key is not set' do
+      it 'returns 2 seconds default' do
+        expect(described_class.wait_duration).to eq(2)
+      end
+    end
+
+    context 'when reset is in the future' do
+      before do
+        Kredis.redis.set(described_class::RESET_KEY, Time.current.to_i + 25, ex: 60)
+      end
+
+      it 'returns seconds until reset' do
+        expect(described_class.wait_duration).to be_between(23, 25)
+      end
+    end
+
+    context 'when reset is in the past' do
+      before do
+        Kredis.redis.set(described_class::RESET_KEY, Time.current.to_i - 5, ex: 60)
+      end
+
+      it 'returns minimum of 2 seconds' do
+        expect(described_class.wait_duration).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20260522_backfill_partial_etablissements_task_spec.rb
+++ b/spec/tasks/maintenance/t20260522_backfill_partial_etablissements_task_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260522BackfillPartialEtablissementsTask do
+    let(:procedure) { create(:procedure) }
+    let(:task) { described_class.new }
+
+    def fixture_file(filename) = Rails.root.join('spec/fixtures/files/api_entreprise', filename).read
+
+    describe "#collection" do
+      let!(:partial_etablissement) do
+        e = create(:etablissement, dossier: create(:dossier, procedure:))
+        e.update_column(:entreprise_siren, nil)
+        e
+      end
+
+      let!(:complete_etablissement) do
+        create(:etablissement, dossier: create(:dossier, procedure:))
+      end
+
+      let!(:etablissement_without_siret) do
+        e = build(:etablissement, dossier: create(:dossier, procedure:), siret: nil)
+        e.save!(validate: false)
+        e.update_column(:entreprise_siren, nil)
+        e
+      end
+
+      it "includes only etablissements with nil entreprise_siren and non-nil siret" do
+        expect(task.collection).to contain_exactly(partial_etablissement)
+      end
+    end
+
+    describe "#process" do
+      let(:dossier) { create(:dossier, :en_construction, procedure:) }
+      let!(:etablissement) do
+        e = create(:etablissement, dossier:)
+        e.update_column(:entreprise_siren, nil)
+        e
+      end
+
+      before do
+        stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{etablissement.siret}/)
+          .to_return(body: fixture_file('etablissements.json'), status: 200)
+      end
+
+      it "updates all etablissement data from API response (not just naf_2025)" do
+        task.process(etablissement)
+
+        etablissement.reload
+        expect(etablissement.naf_2025).to eq("84.11")
+        expect(etablissement.libelle_naf_2025).to eq("Administration publique générale")
+        expect(etablissement.naf).to eq("8411Z")
+        expect(etablissement.entreprise_raison_sociale).to eq("DIRECTION INTERMINISTERIELLE DU NUMERIQUE")
+        expect(etablissement.entreprise_siren).to eq("130025265")
+      end
+
+      it "does not touch updated_at on etablissement or dossier" do
+        etablissement_updated_at = etablissement.reload.updated_at
+        dossier_updated_at = dossier.reload.updated_at
+
+        task.process(etablissement)
+
+        expect(etablissement.reload.updated_at).to eq(etablissement_updated_at)
+        expect(dossier.reload.updated_at).to eq(dossier_updated_at)
+      end
+
+      context "when API returns a failure" do
+        before do
+          stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{etablissement.siret}/)
+            .to_return(body: '{"errors":[{"code":"503","title":"Service unavailable"}]}', status: 503)
+        end
+
+        it "does not update and does not raise" do
+          expect { task.process(etablissement) }.not_to raise_error
+          expect(etablissement.reload.naf_2025).to be_nil
+        end
+      end
+
+      context "when an exception is raised" do
+        before do
+          allow(APIEntreprise::EtablissementAdapter).to receive(:new).and_raise(StandardError, "boom")
+        end
+
+        it "logs to Rails and reports to Sentry" do
+          expect(Rails.logger).to receive(:error).with(/T20260522BackfillPartialEtablissementsTask: #{etablissement.id}: boom/)
+          expect(Sentry).to receive(:capture_exception)
+          task.process(etablissement)
+        end
+      end
+
+      context "when etablissement has no procedure (orphan)" do
+        let!(:orphan_etablissement) do
+          e = create(:etablissement)
+          e.update_columns(dossier_id: nil, entreprise_siren: nil)
+          e
+        end
+
+        it "skips without error" do
+          expect { task.process(orphan_etablissement) }.not_to raise_error
+          expect(orphan_etablissement.reload.entreprise_siren).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Probleme

sentry: https://demarches-simplifiees.sentry.io/issues/7494851871/?environment=production&project=1429550&query=is%3Aunresolved&referrer=issue-stream
sentry: https://demarches-simplifiees.sentry.io/issues/7494851855/?environment=production&project=1429550&query=is%3Aunresolved&referrer=issue-stream

Deux problemes lies :

1. **Pas de rate limiting coordonne** — les jobs Sidekiq appellent l'API Entreprise en parallele sans coordination. Le seul mecanisme etait un `sleep` configurable par env var (`API_ENTREPRISE_DELAY`), identique pour tous les threads, sans rapport avec l'etat reel du serveur. Resultat : on se prend des 429 et des 502 "trop de requetes" des fournisseurs en amont, au point qu'on se fait blacklister.

2. **Etablissements avec donnees partielles** — avant la PR #13101 (Dry::Monads), les erreurs 429 etaient silencieusement traitees comme des 404. Les donnees d'etablissement etaient perdues sans trace. ~13k etablissements a reprendre.

# Solution

## Rate limiting hybride per-pool (`APIEntreprise::RateLimiter`)

API Entreprise applique des limites par pool (identifie par le header `RateLimit-Limit`) :
- 250 req/min : endpoints JSON classiques (insee, dgfip/chiffres_affaires, infogreffe…)
- 100 req/min : urssaf/attestation_vigilance
-  50 req/min : gip_mds/effectifs
-   5 req/min : dgfip/attestation_fiscale

4 methodes, un module partage :

| Methode | Role | Appele par |
|---------|------|------------|
| `remaining(pool)` | GET Redis — source unique pour l'etat du compteur | `throttled?`, `consume!`, `BackfillTask#throttle_on` |
| `consume!(pool)` | DECR atomique avant chaque appel HTTP (skip si pas encore calibre) | `API#call` |
| `calibrate!(response, pool)` | SET Redis depuis headers RateLimit-* (~10% des 200, 100% des 429) | `API#call` |
| `throttled?(pool)` | Read-only : remaining <= 0 ? | `Job#before_perform` |

**Pourquoi DECR + calibration probabiliste ?** Le DECR compte les requetes en vol entre deux reponses (multi-thread safe). La calibration recale sur la realite serveur sans ecraser le DECR a chaque appel. Sur un 429, calibration systematique = broadcast "stop tout le monde" via Redis.

**Zero sleep, zero worker bloque** : si throttled, le job est re-enqueue avec delay + jitter (`RateLimit-Reset`) et le worker est libere immediatement (`throw :abort`).

**Mapping pool ↔ job** : `POOL_BY_RESOURCE` dans `API` (resource_name → pool) et `POOL_BY_JOB` dans `Job` (job_class → pool) referencent les memes valeurs. `calibrate!` log un warning si le header serveur diverge du pool attendu.

## Backfill etablissements partiels (`T20260522BackfillPartialEtablissementsTask`)

- Collection : `entreprise_siren IS NULL AND siret IS NOT NULL` (marqueur de donnees partielles)
- Re-fetch complet via `EtablissementAdapter` (pas juste un champ)
- `update_columns` : pas de touch `updated_at`, pas de callbacks
- `throttle_on(backoff: 1.minute)` quand `remaining(250) < 200` — reserve le quota pour le trafic normal (backfill ne consomme que le surplus)

## Pourquoi cette approche ?

- **Pourquoi per-pool ?** API Entreprise applique des limites differentes par famille d'endpoint. Un seul compteur global bloquerait les appels a 250 req/min quand seul le pool a 5 req/min est sature.
- **Pourquoi pas juste les headers ?** Multi-thread : les headers sont reactifs (apres l'appel). DECR bloque les threads avant.
- **Pourquoi pas une limite hardcodee ?** Les headers calibrent dynamiquement — si API Entreprise change sa limite, on s'adapte.
- **Pourquoi `update_columns` ?** Backfill silencieux : pas de reindex, pas de notifications.
- **Pourquoi threshold 200/250 ?** Le backfill est basse priorite — il laisse 200 req/min aux jobs normaux et ne consomme que le surplus.

Generated with [Claude Code](https://claude.com/claude-code)