### PR TITLE
Tech: extraire les textes en dur de DegradedIdentiteEntrepriseComponent vers i18n

### DIFF
--- a/app/components/dossiers/degraded_identite_entreprise_component.rb
+++ b/app/components/dossiers/degraded_identite_entreprise_component.rb
@@ -9,7 +9,7 @@ class Dossiers::DegradedIdentiteEntrepriseComponent < ApplicationComponent
   end
 
   def call
-    source = 'Annuaire des Entreprises'
+    source = t('.source')
     header = safe_join([
       render(insee_down),
       render(Dossiers::AnnuaireEntrepriseLinkComponent.new(

--- a/app/components/dossiers/degraded_identite_entreprise_component/degraded_identite_entreprise_component.en.yml
+++ b/app/components/dossiers/degraded_identite_entreprise_component/degraded_identite_entreprise_component.en.yml
@@ -1,3 +1,4 @@
 ---
 en:
+  source: Business Directory
   dossier_blocked: It is not possible to accept or reject a file without this step.

--- a/app/components/dossiers/degraded_identite_entreprise_component/degraded_identite_entreprise_component.fr.yml
+++ b/app/components/dossiers/degraded_identite_entreprise_component/degraded_identite_entreprise_component.fr.yml
@@ -1,3 +1,4 @@
 ---
 fr:
+  source: Annuaire des Entreprises
   dossier_blocked: Il nʼest pas possible dʼaccepter ou de refuser un dossier sans cette étape.


### PR DESCRIPTION
# Probleme

Texte francais en dur dans `app/components/dossiers/degraded_identite_entreprise_component.rb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 1 cle i18n vers les fichiers sidecar du composant.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `.source` | "Annuaire des Entreprises" | "Business Directory" |

### Validation visuelle — IDENTIQUE

Screenshots avant/apres disponibles dans `tmp/DegradedIdentiteEntrepriseComponent/`.

**Avant :**
`tmp/DegradedIdentiteEntrepriseComponent/before-1.png`

**Apres :**
`tmp/DegradedIdentiteEntrepriseComponent/after-1.png`

**Couverture :**
- localhost:3220/rails/view_components/dossiers/degraded_identite_entreprise_component/default — preview ViewComponent

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante
- [x] Apostrophes typographiques verifiees
- [x] Rubocop OK
- [x] Screenshots avant/apres identiques

Generated with [Claude Code](https://claude.com/claude-code)