### PR TITLE
Tech: optimiser les tests de procedure_cloning_spec

### DIFF
--- a/spec/system/administrateurs/procedure_cloning_spec.rb
+++ b/spec/system/administrateurs/procedure_cloning_spec.rb
@@ -16,7 +16,7 @@ describe 'As an administrateur I wanna clone a procedure', js: true do
       published_at: Time.zone.now)
     login_as administrateur.user, scope: :user
   end
-  context 'Visit all admin procedures' do
+  context 'Visit all admin procedures and clone from this page' do
     let(:download_dir) { Rails.root.join('tmp/capybara') }
     let(:download_file_pattern) { download_dir.join('*.xlsx') }
 
@@ -30,6 +30,14 @@ describe 'As an administrateur I wanna clone a procedure', js: true do
                      "File download timeout! can't download procedure/all.xlsx") do
         sleep 0.1 until !Dir[download_file_pattern].empty?
       end
+
+      expect(page).to have_content(Procedure.last.libelle)
+      find('.button_to>button').click
+      click_on 'Cloner'
+      check 'Instructeurs', allow_label_click: true
+      click_on 'Cloner la démarche'
+      visit admin_procedures_path(statut: "brouillons")
+      expect(page.find_by_id('procedures')['data-item-count']).to eq('1')
     end
   end
   context 'Cloning a procedure owned by the current admin' do
@@ -69,19 +77,6 @@ describe 'As an administrateur I wanna clone a procedure', js: true do
       expect(page.find_by_id('procedures')['data-item-count']).to eq('1')
       visit admin_procedures_path(statut: "brouillons")
       expect(page.find_by_id('procedures')['data-item-count']).to eq('0')
-    end
-  end
-
-  context 'Cloning a procedure from the all procedure page' do
-    scenario do
-      visit all_admin_procedures_path
-      expect(page).to have_content(Procedure.last.libelle)
-      find('.button_to>button').click
-      click_on 'Cloner'
-      check 'Instructeurs', allow_label_click: true
-      click_on 'Cloner la démarche'
-      visit admin_procedures_path(statut: "brouillons")
-      expect(page.find_by_id('procedures')['data-item-count']).to eq('1')
     end
   end
 end

--- a/spec/system/administrateurs/procedure_cloning_spec.rb
+++ b/spec/system/administrateurs/procedure_cloning_spec.rb
@@ -82,32 +82,6 @@ describe 'As an administrateur I wanna clone a procedure', js: true do
       click_on 'Cloner la démarche'
       visit admin_procedures_path(statut: "brouillons")
       expect(page.find_by_id('procedures')['data-item-count']).to eq('1')
-      click_on Procedure.last.libelle
-      expect(page).to have_current_path(admin_procedure_path(id: Procedure.last))
-
-      # select service
-      find("#service .fr-btn").click
-      click_on "Affecter"
-
-      # select zone
-      find("#zones .fr-btn").click
-      check Zone.last.current_label, allow_label_click: true
-      click_on 'Enregistrer'
-
-      # then publish
-      find('#publish-procedure-link').click
-      expect(find_field('Lien de la démarche à diffuser aux usagers').value).to eq 'libelle-de-la-procedure-2'
-      fill_in 'Lien de la démarche à diffuser aux usagers', with: 'libelle-de-la-procedure'
-      expect(page).to have_content "Si vous publiez cette démarche, le lien ne pointera plus sur l’ancienne démarche."
-      fill_in 'Où les usagers trouveront-ils le lien vers la démarche ?', with: 'http://some.website'
-      click_on 'publish'
-
-      page.refresh
-
-      visit admin_procedures_path(statut: "archivees")
-      expect(page.find_by_id('procedures')['data-item-count']).to eq('1')
-      visit admin_procedures_path(statut: "brouillons")
-      expect(page.find_by_id('procedures')['data-item-count']).to eq('0')
     end
   end
 end


### PR DESCRIPTION
# Probleme

Tests lents dans `spec/system/administrateurs/procedure_cloning_spec.rb` — temps baseline : 29.82s (mediane locale, 3 runs).

# Solution

Skill [`/test-optimization`](https://github.com/mfo/night-shift/blob/main/.claude/skills/test-optimization/SKILL.md)

### Techniques appliquees

| Technique | Avant | Apres | Gain |
|-----------|-------|-------|------|
| S02 — trim duplicate publish flow | 29.82s | 27.05s | -9.3% |
| S02 — merge xlsx download + clone into one scenario | 27.05s | 25.03s | -7.5% |

**Resultat final : 29.82s -> 25.03s (gain total 16.1%)**

Coverage : 44.64% -> 44.64% (maintenue)

### Tentatives sans gain suffisant

| Technique | Resultat |
|-----------|----------|
| Remove redundant `page.refresh` | 0.33s gain (< 0.5s threshold) — rollback |
| T08 (let_it_be) | Not applicable — `before` block, not `let`, and modifiers unavailable |
| T04 (reduce setup) | All factory traits needed by publish scenario |
| T01 (create -> build) | Not applicable — system specs need real DB records |
| S01 (sleep -> assertions) | `sleep 0.1` loop already minimal and timeout-wrapped |
| S03 (pre-create factories) | Clone flow is the feature under test via UI |

### Details des changements

**Commit 1 — S02 trim duplicate publish flow:** Scenarios "clone from admin page" and "clone from all procedures page" had identical post-clone flows (service selection, zone selection, publish, verify archival). Removed the duplicate flow from the second scenario, keeping only the clone entry-point verification. Full publish flow already covered by first scenario.

**Commit 2 — S02 merge xlsx download + clone:** Both "xlsx download" and "clone from all procedures" scenarios visited `all_admin_procedures_path` with identical setup. Merged into one scenario that downloads the xlsx then clones from the same page, eliminating one login + procedure creation cycle.

Generated with [Claude Code](https://claude.com/claude-code)