### PR TITLE
Tech: fix N+1 sur instructeurs et contact_information dans GroupeInstructeursController

### DIFF
--- a/app/components/procedure/groupes_management_component.rb
+++ b/app/components/procedure/groupes_management_component.rb
@@ -28,6 +28,6 @@ class Procedure::GroupesManagementComponent < ApplicationComponent
   end
 
   def any_custom_contact_information?
-    @procedure.groupe_instructeurs.joins(:contact_information).exists?
+    @any_custom_contact_information ||= @procedure.groupe_instructeurs.joins(:contact_information).exists?
   end
 end

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -454,7 +454,7 @@ module Administrateurs
     end
 
     def export_groupe_instructeurs
-      groupe_instructeurs = procedure.groupe_instructeurs
+      groupe_instructeurs = procedure.groupe_instructeurs.includes(instructeurs: :user)
 
       data = CSV.generate(headers: true) do |csv|
         column_names = ["Groupe", "Email"]
@@ -620,6 +620,7 @@ module Administrateurs
       end
 
       groupes
+        .includes(:contact_information)
         .page(params[:page])
         .per(ITEMS_PER_PAGE)
     end


### PR DESCRIPTION
# Probleme

N+1 detecte par analyse statique du controller et confirme par trace SQL (enrichissement des fixtures a 3+ records par association).

**Donnees de production** (depuis `.skill-context.json` / [Skylight](https://oss.skylight.io/app/applications/auuzqe8XhJIx/recent/6h/endpoints)) :

| Endpoint | RPM | P95 | Score |
|----------|-----|-----|-------|
| `GroupeInstructeursController#import` | 0 | 75ms | 19 |
| `GroupeInstructeursController#create_simple_routing` | 0 | 75ms | 7 |
| `GroupeInstructeursController#add_instructeurs` | 0 | 75ms | 6 |
| `GroupeInstructeursController#index` | 0 | 60ms | 2 |
| `GroupeInstructeursController#export_groupe_instructeurs` | 0 | 75ms | 1 |

RPM tres faible (admin-only controller), mais le N+1 impacte les administrateurs gerant des procedures avec de nombreux groupes instructeurs. Le fix est peu risque et ameliore l'experience admin.

**Triage** : 3 patterns PROD (call stack dans `app/`) identifies par trace SQL. Prosopite n'a pas leve d'erreur (probablement a cause de la normalisation des requetes avec JOIN), mais les traces SQL montrent clairement les queries repetees.

# Solution

Skill [`/n1-query-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/n1-query-fix/SKILL.md)

### Patterns corriges (PROD uniquement)

| Association | Table | Strategy | Call site (app/) |
|-------------|-------|----------|------------------|
| `instructeurs` (via `assign_tos`) + `user` | instructeurs, users | `includes(instructeurs: :user)` dans l'action | `app/controllers/administrateurs/groupe_instructeurs_controller.rb:457` (`export_groupe_instructeurs`) |
| `contact_information` | contact_informations | `includes(:contact_information)` dans `paginated_groupe_instructeurs` | `app/controllers/administrateurs/groupe_instructeurs_controller.rb:622` (index view) |
| `any_custom_contact_information?` | contact_informations | memoization (`||=`) | `app/components/procedure/groupes_management_component.rb:31` (called in loop) |

### Patterns non corriges (counts)

Les N+1 sur `gi.instructeurs.count` et `gi.dossiers.visible_by_administration.size` dans la vue index sont des COUNT queries individuelles. Les fixer necessite soit un counter cache soit un changement d'approche (subquery/window function). Impact faible car ce sont des COUNT rapides sur des index.

### Validation

- [x] Tests passes (88 examples, 0 failures)
- [x] Rubocop OK (0 offenses)
- [x] Seuls des fichiers app/ sont commites

Generated with [Claude Code](https://claude.com/claude-code)