### PR TITLE
fix: Erreur 500 sur /profil — guard nav_bar_profile sans request context

### DIFF
--- a/app/controllers/users/profil_controller.rb
+++ b/app/controllers/users/profil_controller.rb
@@ -10,6 +10,8 @@ module Users
     before_action :find_transfers, only: [:show]
 
     def nav_bar_profile
+      return super if request.blank? # Controller introspection does not contain params/request, see NavBarProfileConcern
+
       context = params[:context]&.to_sym
       return context if ALLOWED_NAV_BAR_PROFILES.include?(context)
       fallback_nav_bar_profile.presence || :user

--- a/spec/controllers/users/profil_controller_spec.rb
+++ b/spec/controllers/users/profil_controller_spec.rb
@@ -45,6 +45,13 @@ describe Users::ProfilController, type: :controller do
         expect(controller.nav_bar_profile).to eq(:user)
       end
     end
+
+    context 'when called without a request (controller introspection by NavBarProfileConcern)' do
+      it 'does not raise and returns a valid profile' do
+        bare_controller = Users::ProfilController.new
+        expect { bare_controller.nav_bar_profile }.not_to raise_error
+      end
+    end
   end
 
   describe 'GET #show' do


### PR DESCRIPTION
## Problème

Erreur 500 sur `https://demarche.numerique.gouv.fr/profil` introduite par le commit c47fb44.
cf Sentry https://demarches-simplifiees.sentry.io/issues/7494841126/
L'erreur est rescue ici `app/controllers/concerns/nav_bar_profile_concern.rb:36` donc la page est rendue normalement à l'usager mais ça fait du bruit dans Sentry.

`NavBarProfileConcern#nav_bar_profile_from_referrer` instancie un contrôleur « nu » (sans request) pour détecter le profil nav depuis le HTTP referer. Quand le referer est `/profil`, il crée `Users::ProfilController.new` et appelle `nav_bar_profile` dessus. La nouvelle implémentation accédait à `params`, qui appelle `request.filtered_parameters` sur un `request` nil → `NoMethodError` → 500.

## Correction

Ajout de `return super if request.blank?` en tête de `nav_bar_profile` dans `ProfilController`. Ce guard est **identique à celui déjà présent** dans `RechercheController` pou la même raison :

```ruby
# app/controllers/recherche_controller.rb:17
return super if request.blank? # Controller introspection does not contains params/request, see NavBarProfileConcern
```