### PR TITLE
refactor(columns): pass procedure_id to TypeDeChamp#columns and add #column lookup

### DIFF
--- a/app/components/export_template/champs_component.rb
+++ b/app/components/export_template/champs_component.rb
@@ -37,7 +37,7 @@ class ExportTemplate::ChampsComponent < ApplicationComponent
 
   def tdc_to_columns(type_de_champ)
     prefix = type_de_champ.repetition? ? "Bloc répétable" : nil
-    type_de_champ.columns(procedure: export_template.procedure, prefix:).map do |column|
+    type_de_champ.columns(procedure_id: export_template.procedure.id, prefix:).map do |column|
       ExportedColumn.new(column:,
                          libelle: historical_libelle(column))
     end

--- a/app/graphql/types/champ_type.rb
+++ b/app/graphql/types/champ_type.rb
@@ -20,7 +20,7 @@ module Types
       if object.repetition?
         []
       else
-        object.type_de_champ.columns(procedure: object.procedure)
+        object.type_de_champ.columns(procedure_id: object.procedure.id)
       end
     end
 

--- a/app/models/concerns/addressable_column_concern.rb
+++ b/app/models/concerns/addressable_column_concern.rb
@@ -3,7 +3,7 @@
 module AddressableColumnConcern
   extend ActiveSupport::Concern
 
-  def addressable_columns(procedure:, displayable: true, prefix: nil, deprecated_columns: false, only: nil)
+  def addressable_columns(procedure_id:, displayable: true, prefix: nil, deprecated_columns: false, only: nil)
     column_specs = [
       [:postal_code, "Code postal (5 chiffres)", '$.postal_code', :text, [], displayable, true],
       [:city_name, "Commune", '$.city_name', :text, [], displayable, true],
@@ -20,7 +20,7 @@ module AddressableColumnConcern
 
     column_specs.map do |(_key, label, jsonpath, type, options_for_select, column_displayable, column_filterable)|
       Columns::JSONPathColumn.new(
-        procedure_id: procedure.id,
+        procedure_id:,
         stable_id:,
         tdc_type: type_champ,
         label: "#{libelle_with_prefix(prefix)} – #{label}",

--- a/app/models/concerns/columns_concern.rb
+++ b/app/models/concerns/columns_concern.rb
@@ -125,11 +125,11 @@ module ColumnsConcern
   end
 
   def form_filterable_columns
-    all_revisions_types_de_champ.public_only.flat_map { _1.columns(procedure: self) }.filter(&:filterable)
+    all_revisions_types_de_champ.public_only.flat_map { _1.columns(procedure_id: id) }.filter(&:filterable)
   end
 
   def annotation_privees_filterable_columns
-    all_revisions_types_de_champ.private_only.flat_map { _1.columns(procedure: self) }.filter(&:filterable)
+    all_revisions_types_de_champ.private_only.flat_map { _1.columns(procedure_id: id) }.filter(&:filterable)
   end
 
   private
@@ -233,7 +233,7 @@ module ColumnsConcern
   end
 
   def types_de_champ_columns
-    all_revisions_types_de_champ.flat_map { _1.columns(procedure: self) }
+    all_revisions_types_de_champ.flat_map { _1.columns(procedure_id: id) }
   end
 
   def dossier_col(**args) = Columns::DossierColumn.new(**(args.merge(procedure_id: id)))

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -90,10 +90,9 @@ class Procedure < ApplicationRecord
   end
 
   def all_revisions_types_de_champ(parent: nil, with_header_section: false)
-    types_de_champ_scope = with_header_section ? TypeDeChamp.with_header_section : TypeDeChamp.fillable
     if brouillon?
       if parent.nil?
-        types_de_champ_scope
+        (with_header_section ? TypeDeChamp.with_header_section : TypeDeChamp.fillable)
           .joins(:revision_types_de_champ)
           .where(revision_types_de_champ: { revision_id: draft_revision_id, parent_id: nil })
           .order(:private, :position)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -175,7 +175,7 @@ class TypeDeChamp < ApplicationRecord
 
   belongs_to :referentiel, optional: true, inverse_of: :types_de_champ
 
-  delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, :info_columns, to: :dynamic_type
+  delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, :column, :info_columns, to: :dynamic_type
 
   class WithIndifferentAccess
     def self.load(options)

--- a/app/models/types_de_champ/address_type_de_champ.rb
+++ b/app/models/types_de_champ/address_type_de_champ.rb
@@ -46,9 +46,9 @@ class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     end
   end
 
-  def columns(procedure:, displayable: true, prefix: nil)
+  def columns(procedure_id:, displayable: true, prefix: nil)
     super
-      .concat(addressable_columns(procedure:, displayable:, prefix:, deprecated_columns: true))
+      .concat(addressable_columns(procedure_id:, displayable:, prefix:, deprecated_columns: true))
   end
 
   def info_columns(procedure:)

--- a/app/models/types_de_champ/carte_type_de_champ.rb
+++ b/app/models/types_de_champ/carte_type_de_champ.rb
@@ -31,7 +31,7 @@ class TypesDeChamp::CarteTypeDeChamp < TypesDeChamp::TypeDeChampBase
 
   def champ_blank?(champ) = champ.geo_areas.blank?
 
-  def columns(procedure:, displayable: true, prefix: nil)
+  def columns(procedure_id:, displayable: true, prefix: nil)
     []
   end
 end

--- a/app/models/types_de_champ/commune_type_de_champ.rb
+++ b/app/models/types_de_champ/commune_type_de_champ.rb
@@ -29,9 +29,9 @@ class TypesDeChamp::CommuneTypeDeChamp < TypesDeChamp::TypeDeChampBase
     champ.code_postal? ? "#{champ.name} (#{champ.code_postal})" : champ.name
   end
 
-  def columns(procedure:, displayable: true, prefix: nil)
-    addressable_columns(procedure:, displayable:, prefix:)
-      .concat(legacy_columns(procedure:, prefix:))
+  def columns(procedure_id:, displayable: true, prefix: nil)
+    addressable_columns(procedure_id:, displayable:, prefix:)
+      .concat(legacy_columns(procedure_id:, prefix:))
   end
 
   def info_columns(procedure:)
@@ -42,10 +42,10 @@ class TypesDeChamp::CommuneTypeDeChamp < TypesDeChamp::TypeDeChampBase
 
   # Anciennes colonnes conservées pour rester résolvables par les
   # ProcedurePresentation / exports / colonnes graphql persistées avant la bascule sur AddressableColumnConcern.
-  def legacy_columns(procedure:, prefix:)
+  def legacy_columns(procedure_id:, prefix:)
     [
       Columns::ChampColumn.new(
-        procedure_id: procedure.id,
+        procedure_id:,
         stable_id:,
         tdc_type: type_champ,
         label: libelle_with_prefix(prefix),
@@ -61,7 +61,7 @@ class TypesDeChamp::CommuneTypeDeChamp < TypesDeChamp::TypeDeChampBase
       ['département', '$.code_departement', :number],
     ].map do |(label, jsonpath, type)|
       Columns::JSONPathColumn.new(
-        procedure_id: procedure.id,
+        procedure_id:,
         stable_id:,
         tdc_type: type_champ,
         label: "#{libelle_with_prefix(prefix)} - #{label}",

--- a/app/models/types_de_champ/departement_type_de_champ.rb
+++ b/app/models/types_de_champ/departement_type_de_champ.rb
@@ -3,9 +3,9 @@
 class TypesDeChamp::DepartementTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   include AddressableColumnConcern
 
-  def columns(procedure:, displayable: true, prefix: nil)
-    addressable_columns(procedure:, displayable:, prefix:, only: [:department_code, :region_code])
-      .concat(legacy_columns(procedure:, prefix:))
+  def columns(procedure_id:, displayable: true, prefix: nil)
+    addressable_columns(procedure_id:, displayable:, prefix:, only: [:department_code, :region_code])
+      .concat(legacy_columns(procedure_id:, prefix:))
   end
 
   def filter_to_human(filter_value)
@@ -51,10 +51,10 @@ class TypesDeChamp::DepartementTypeDeChamp < TypesDeChamp::TextTypeDeChamp
 
   # ChampColumn par défaut conservé pour rester résolvable par les ProcedurePresentation /
   # exports / colonnes graphql persistées avant la bascule sur AddressableColumnConcern.
-  def legacy_columns(procedure:, prefix:)
+  def legacy_columns(procedure_id:, prefix:)
     [
       Columns::ChampColumn.new(
-        procedure_id: procedure.id,
+        procedure_id:,
         stable_id:,
         tdc_type: type_champ,
         label: libelle_with_prefix(prefix),

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -26,12 +26,12 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBase
     end
   end
 
-  def columns(procedure:, displayable: true, prefix: nil)
+  def columns(procedure_id:, displayable: true, prefix: nil)
     if drop_down_advanced?
       referentiel_columns = if referentiel.present?
         referentiel.headers_with_path.map do |(header, path)|
           Columns::JSONPathColumn.new(
-            procedure_id: procedure.id,
+            procedure_id:,
             stable_id:,
             tdc_type: type_champ,
             label: "#{libelle_with_prefix(prefix)} – Référentiel #{header}",

--- a/app/models/types_de_champ/epci_type_de_champ.rb
+++ b/app/models/types_de_champ/epci_type_de_champ.rb
@@ -3,8 +3,8 @@
 class TypesDeChamp::EpciTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   include AddressableColumnConcern
 
-  def columns(procedure:, displayable: true, prefix: nil)
-    super.concat(addressable_columns(procedure:, displayable:, prefix:, only: [:department_code, :region_code]))
+  def columns(procedure_id:, displayable: true, prefix: nil)
+    super.concat(addressable_columns(procedure_id:, displayable:, prefix:, only: [:department_code, :region_code]))
   end
 
   def champ_value_for_export(champ, path = :value)

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -66,10 +66,10 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
       (has_secondary_options_for_primary?(champ) && secondary_value(champ).blank?)
   end
 
-  def columns(procedure:, displayable: true, prefix: nil)
+  def columns(procedure_id:, displayable: true, prefix: nil)
     [
       Columns::LinkedDropDownColumn.new(
-        procedure_id: procedure.id,
+        procedure_id:,
         label: libelle_with_prefix(prefix),
         stable_id:,
         tdc_type: type_champ,
@@ -79,7 +79,7 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
         mandatory: mandatory?
       ),
       Columns::LinkedDropDownColumn.new(
-        procedure_id: procedure.id,
+        procedure_id:,
         stable_id:,
         tdc_type: type_champ,
         label: "#{libelle_with_prefix(prefix)} (Primaire)",
@@ -90,7 +90,7 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
         mandatory: mandatory?
       ),
       Columns::LinkedDropDownColumn.new(
-        procedure_id: procedure.id,
+        procedure_id:,
         stable_id:,
         tdc_type: type_champ,
         label: "#{libelle_with_prefix(prefix)} (Secondaire)",

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -17,11 +17,11 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampB
     ChampPresentations::MultipleDropDownListPresentation.new(selected_options(champ))
   end
 
-  def columns(procedure:, displayable: true, prefix: nil)
+  def columns(procedure_id:, displayable: true, prefix: nil)
     if drop_down_advanced?
       referentiel.present? ? referentiel.headers_with_path.map do |(header, path)|
         Columns::MultipleDropDownColumn.new(
-          procedure_id: procedure.id,
+          procedure_id:,
           stable_id:,
           tdc_type: type_champ,
           label: "#{libelle_with_prefix(prefix)} – Référentiel #{header}",

--- a/app/models/types_de_champ/piece_justificative_type_de_champ.rb
+++ b/app/models/types_de_champ/piece_justificative_type_de_champ.rb
@@ -31,12 +31,12 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBas
 
   def champ_blank?(champ) = champ.piece_justificative_file.blank?
 
-  def columns(procedure:, displayable: true, prefix: nil)
+  def columns(procedure_id:, displayable: true, prefix: nil)
     cs = []
 
     if !titre_identite?
       cs << Columns::AttachedManyColumn.new(
-        procedure_id: procedure.id,
+        procedure_id:,
         stable_id:,
         tdc_type: type_champ,
         label: libelle_with_prefix(prefix),
@@ -55,7 +55,7 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBas
         ['Nom de la Banque', '$.rib.bank_name'],
       ].map do |label, jsonpath|
         Columns::JSONPathColumn.new(
-         procedure_id: procedure.id,
+         procedure_id:,
          stable_id:,
          tdc_type: type_champ,
          label: "#{libelle_with_prefix(prefix)} – #{label}",
@@ -71,7 +71,7 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBas
         .map do |attr, type|
         jsonpath = "$.#{attr}"
         Columns::JSONPathColumn.new(
-          procedure_id: procedure.id,
+          procedure_id:,
           stable_id:,
           tdc_type: type_champ,
           label: "#{libelle_with_prefix(prefix)} – #{attr}",
@@ -84,7 +84,7 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBas
     elsif titre_identite?
       cs += [
         Columns::TitreIdentiteColumn.new(
-          procedure_id: procedure.id,
+          procedure_id:,
           stable_id:,
           tdc_type: type_champ,
           label: "#{libelle_with_prefix(prefix)} – filled",

--- a/app/models/types_de_champ/quotient_familial_type_de_champ.rb
+++ b/app/models/types_de_champ/quotient_familial_type_de_champ.rb
@@ -14,10 +14,10 @@ class TypesDeChamp::QuotientFamilialTypeDeChamp < TypesDeChamp::TypeDeChampBase
     end
   end
 
-  def columns(procedure:, displayable: true, prefix: nil)
+  def columns(procedure_id:, displayable: true, prefix: nil)
     Columns::QuotientFamilialColumn::QUOTIENT_FAMILIAL_COLUMNS.map do |label, jsonpath, type|
       Columns::QuotientFamilialColumn.new(
-        procedure_id: procedure.id,
+        procedure_id:,
         stable_id:,
         tdc_type: type_champ,
         label: "#{libelle_with_prefix(prefix)} – #{label}",

--- a/app/models/types_de_champ/region_type_de_champ.rb
+++ b/app/models/types_de_champ/region_type_de_champ.rb
@@ -3,9 +3,9 @@
 class TypesDeChamp::RegionTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   include AddressableColumnConcern
 
-  def columns(procedure:, displayable: true, prefix: nil)
-    addressable_columns(procedure:, displayable:, prefix:, only: [:region_code])
-      .concat(legacy_columns(procedure:, prefix:))
+  def columns(procedure_id:, displayable: true, prefix: nil)
+    addressable_columns(procedure_id:, displayable:, prefix:, only: [:region_code])
+      .concat(legacy_columns(procedure_id:, prefix:))
   end
 
   def filter_to_human(filter_value)
@@ -38,10 +38,10 @@ class TypesDeChamp::RegionTypeDeChamp < TypesDeChamp::TextTypeDeChamp
 
   # ChampColumn par défaut conservé pour rester résolvable par les ProcedurePresentation /
   # exports / colonnes graphql persistées avant la bascule sur AddressableColumnConcern.
-  def legacy_columns(procedure:, prefix:)
+  def legacy_columns(procedure_id:, prefix:)
     [
       Columns::ChampColumn.new(
-        procedure_id: procedure.id,
+        procedure_id:,
         stable_id:,
         tdc_type: type_champ,
         label: libelle_with_prefix(prefix),

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -25,12 +25,12 @@ class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
     ActiveStorage::Filename.new(str.delete('[]*?')).sanitized
   end
 
-  def columns(procedure:, displayable: nil, prefix: nil)
+  def columns(procedure_id:, displayable: true, prefix: nil)
     prefix = prefix.present? ? "(#{prefix} #{libelle})" : libelle
 
-    procedure
+    Procedure.find(procedure_id)
       .all_revisions_types_de_champ(parent: @type_de_champ)
-      .flat_map { _1.columns(procedure:, displayable: false, prefix:) }
+      .flat_map { _1.columns(procedure_id:, displayable: false, prefix:) }
   end
 
   def champ_blank?(champ) = champ.dossier.repetition_row_ids(@type_de_champ).blank?

--- a/app/models/types_de_champ/rna_type_de_champ.rb
+++ b/app/models/types_de_champ/rna_type_de_champ.rb
@@ -21,15 +21,15 @@ class TypesDeChamp::RNATypeDeChamp < TypesDeChamp::TypeDeChampBase
     column_labels
   end
 
-  def columns(procedure:, displayable: true, prefix: nil)
+  def columns(procedure_id:, displayable: true, prefix: nil)
     i18n_scope = [:activerecord, :attributes, :procedure_presentation, :fields, :etablissement]
 
     super
-      .concat(addressable_columns(procedure:, displayable:, prefix:, deprecated_columns: true))
+      .concat(addressable_columns(procedure_id:, displayable:, prefix:, deprecated_columns: true))
       .concat(
         Etablissement::EXPORTABLE_ASSOCIATION_COLUMNS.map do |(column, attributes)|
           Columns::JSONPathColumn.new(
-            procedure_id: procedure.id,
+            procedure_id:,
             stable_id:,
             tdc_type: type_champ,
             label: [prefix, libelle, I18n.t(column, scope: i18n_scope)].compact.join(' – '),
@@ -43,7 +43,7 @@ class TypesDeChamp::RNATypeDeChamp < TypesDeChamp::TypeDeChampBase
       )
       .concat([
         Columns::JSONPathColumn.new(
-          procedure_id: procedure.id,
+          procedure_id:,
           stable_id:,
           tdc_type: type_champ,
           label: "#{libelle_with_prefix(prefix)} – Titre au répertoire national des associations",

--- a/app/models/types_de_champ/rnf_type_de_champ.rb
+++ b/app/models/types_de_champ/rnf_type_de_champ.rb
@@ -35,12 +35,12 @@ class TypesDeChamp::RNFTypeDeChamp < TypesDeChamp::TextTypeDeChamp
 
   def champ_blank?(champ) = champ.external_id.blank?
 
-  def columns(procedure:, displayable: true, prefix: nil)
+  def columns(procedure_id:, displayable: true, prefix: nil)
     super
-      .concat(addressable_columns(procedure:, displayable:, prefix:, deprecated_columns: true))
+      .concat(addressable_columns(procedure_id:, displayable:, prefix:, deprecated_columns: true))
       .concat([
         Columns::JSONPathColumn.new(
-          procedure_id: procedure.id,
+          procedure_id:,
           stable_id:,
           tdc_type: type_champ,
           label: "#{libelle_with_prefix(prefix)} – Titre au répertoire national des fondations ",

--- a/app/models/types_de_champ/siret_type_de_champ.rb
+++ b/app/models/types_de_champ/siret_type_de_champ.rb
@@ -9,10 +9,10 @@ class TypesDeChamp::SiretTypeDeChamp < TypesDeChamp::TypeDeChampBase
 
   def champ_blank_or_invalid?(champ) = Siret.new(siret: champ.value).invalid?
 
-  def columns(procedure:, displayable: true, prefix: nil)
+  def columns(procedure_id:, displayable: true, prefix: nil)
     super
-      .concat(etablissement_columns(procedure:, displayable:, prefix:))
-      .concat(addressable_columns(procedure:, displayable:, prefix:, deprecated_columns: true))
+      .concat(etablissement_columns(procedure_id:, displayable:, prefix:))
+      .concat(addressable_columns(procedure_id:, displayable:, prefix:, deprecated_columns: true))
   end
 
   def info_columns(procedure:)
@@ -29,12 +29,12 @@ class TypesDeChamp::SiretTypeDeChamp < TypesDeChamp::TypeDeChampBase
 
   private
 
-  def etablissement_columns(procedure:, displayable:, prefix:)
+  def etablissement_columns(procedure_id:, displayable:, prefix:)
     i18n_scope = [:activerecord, :attributes, :procedure_presentation, :fields, :etablissement]
 
     Etablissement::DISPLAYABLE_COLUMNS.map do |(column, attributes)|
       Columns::JSONPathColumn.new(
-        procedure_id: procedure.id,
+        procedure_id:,
         stable_id:,
         tdc_type: type_champ,
         label: [prefix, libelle, I18n.t(column, scope: i18n_scope)].compact.join(' – '),

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -95,11 +95,11 @@ class TypesDeChamp::TypeDeChampBase
   def champ_blank?(champ) = champ.value.blank?
   def champ_blank_or_invalid?(champ) = champ_blank?(champ)
 
-  def columns(procedure:, displayable: true, prefix: nil)
+  def columns(procedure_id:, displayable: true, prefix: nil)
     if fillable?
       [
         Columns::ChampColumn.new(
-          procedure_id: procedure.id,
+          procedure_id:,
           stable_id:,
           tdc_type: type_champ,
           label: libelle_with_prefix(prefix),
@@ -119,9 +119,13 @@ class TypesDeChamp::TypeDeChampBase
     # Example: "Commune - code postal" => "code postal"
     regex_prefix = /^#{Regexp.escape(libelle)}[^\p{L}]+/
 
-    columns(procedure:).filter_map do |column|
+    columns(procedure_id: procedure.id).filter_map do |column|
       column.label.sub(regex_prefix, '')
     end
+  end
+
+  def column(column_id)
+    columns(procedure_id: nil).find { it.h_id[:column_id] == column_id }
   end
 
   private

--- a/spec/models/columns/champ_column_spec.rb
+++ b/spec/models/columns/champ_column_spec.rb
@@ -51,7 +51,7 @@ describe Columns::ChampColumn do
         expect_type_de_champ_values('piece_justificative', be_an_instance_of(Array))
         type_de_champ = types_de_champ.find(&:titre_identite?)
         champ = dossier.send(:filled_champ, type_de_champ)
-        columns = type_de_champ.columns(procedure:)
+        columns = type_de_champ.columns(procedure_id: procedure.id)
         expect(columns.map { _1.value(champ) }).to be_an_instance_of(Array)
         expect_type_de_champ_values('cojo', eq([nil]))
         expect_type_de_champ_values('formatted', eq([nil]))
@@ -607,7 +607,7 @@ describe Columns::ChampColumn do
   def expect_type_de_champ_values(type, assertion)
     type_de_champ = types_de_champ.find { _1.type_champ == type }
     champ = dossier.send(:filled_champ, type_de_champ)
-    columns = type_de_champ.columns(procedure:)
+    columns = type_de_champ.columns(procedure_id: procedure.id)
     expect(columns.map { _1.value(champ) }).to assertion
   end
 

--- a/spec/models/export_template_tabular_spec.rb
+++ b/spec/models/export_template_tabular_spec.rb
@@ -128,7 +128,7 @@ describe ExportTemplate do
 
   describe 'columns_for_stable_id' do
     before do
-      export_template.exported_columns = procedure.published_revision.types_de_champ.first.columns(procedure: procedure).map do |column|
+      export_template.exported_columns = procedure.published_revision.types_de_champ.first.columns(procedure_id: procedure.id).map do |column|
         ExportedColumn.new(libelle: column.label, column:)
       end
     end

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -292,6 +292,54 @@ describe TypeDeChamp do
     end
   end
 
+  describe '#column' do
+    context 'with a fillable type de champ' do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text, libelle: 'Mon texte' }]) }
+      let(:type_de_champ) { procedure.active_revision.types_de_champ.first }
+
+      it 'returns the column matching the given column_id' do
+        column = type_de_champ.column("type_de_champ/#{type_de_champ.stable_id}")
+
+        expect(column).to be_a(Columns::ChampColumn)
+        expect(column.label).to eq('Mon texte')
+        expect(column.h_id[:column_id]).to eq("type_de_champ/#{type_de_champ.stable_id}")
+      end
+
+      it 'returns nil when no column matches' do
+        expect(type_de_champ.column('type_de_champ/unknown')).to be_nil
+      end
+    end
+
+    context 'with an addressable type de champ exposing several columns' do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :communes, libelle: 'Ma commune' }]) }
+      let(:type_de_champ) { procedure.active_revision.types_de_champ.first }
+
+      it 'returns the jsonpath column matching the given column_id' do
+        column = type_de_champ.column("type_de_champ/#{type_de_champ.stable_id}-$.postal_code")
+
+        expect(column).to be_a(Columns::JSONPathColumn)
+        expect(column.jsonpath).to eq('$.postal_code')
+      end
+
+      it 'resolves legacy (non displayable) columns too' do
+        column = type_de_champ.column("type_de_champ/#{type_de_champ.stable_id}-$.code_postal")
+
+        expect(column).to be_a(Columns::JSONPathColumn)
+        expect(column.jsonpath).to eq('$.code_postal')
+        expect(column.displayable).to be(false)
+      end
+    end
+
+    context 'with a non fillable type de champ' do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :header_section, libelle: 'Titre' }]) }
+      let(:type_de_champ) { procedure.active_revision.types_de_champ.first }
+
+      it 'returns nil since it exposes no column' do
+        expect(type_de_champ.column("type_de_champ/#{type_de_champ.stable_id}")).to be_nil
+      end
+    end
+  end
+
   describe '#public_only' do
     let(:procedure) { create(:procedure, :with_type_de_champ, :with_type_de_champ_private) }
 

--- a/spec/models/types_de_champ/address_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/address_type_de_champ_spec.rb
@@ -4,7 +4,7 @@ describe TypesDeChamp::AddressTypeDeChamp do
   describe '#columns' do
     let(:procedure) { create(:procedure, types_de_champ_public: [libelle: 'addr', type: 'address']) }
     let(:address_tdc) { procedure.active_revision.types_de_champ.first }
-    let(:columns) { address_tdc.columns(procedure:) }
+    let(:columns) { address_tdc.columns(procedure_id: procedure.id) }
 
     it '' do
       expected_columns = [

--- a/spec/models/types_de_champ/commune_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/commune_type_de_champ_spec.rb
@@ -7,7 +7,7 @@ describe TypesDeChamp::CommuneTypeDeChamp do
   describe '#columns' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :communes, libelle: 'Ma commune' }]) }
     let(:tdc) { procedure.active_revision.types_de_champ.first }
-    let(:jsonpath_columns) { tdc.columns(procedure:).grep(Columns::JSONPathColumn) }
+    let(:jsonpath_columns) { tdc.columns(procedure_id: procedure.id).grep(Columns::JSONPathColumn) }
 
     it 'exposes the addressable columns as displayable and filterable' do
       addressable = jsonpath_columns.filter(&:displayable)

--- a/spec/models/types_de_champ/departement_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/departement_type_de_champ_spec.rb
@@ -4,7 +4,7 @@ describe TypesDeChamp::DepartementTypeDeChamp do
   describe '#columns' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :departements, libelle: 'Mon département' }]) }
     let(:tdc) { procedure.active_revision.types_de_champ.first }
-    let(:jsonpath_columns) { tdc.columns(procedure:).grep(Columns::JSONPathColumn) }
+    let(:jsonpath_columns) { tdc.columns(procedure_id: procedure.id).grep(Columns::JSONPathColumn) }
 
     it 'exposes only department_code and region_code addressable columns' do
       expect(jsonpath_columns.map(&:jsonpath)).to contain_exactly('$.department_code', '$.region_code')

--- a/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
@@ -6,7 +6,7 @@ describe TypesDeChamp::DropDownListTypeDeChamp do
     let(:types_de_champ_public) { [{ type: :drop_down_list, referentiel:, drop_down_mode: }] }
     let(:referentiel) { create(:csv_referentiel, :with_items) }
     let(:dropdown_list_tdc) { procedure.active_revision.types_de_champ.first }
-    subject { dropdown_list_tdc.columns(procedure:) }
+    subject { dropdown_list_tdc.columns(procedure_id: procedure.id) }
 
     context 'when drop_down_mode is advanced (referentiel)' do
       let(:drop_down_mode) { 'advanced' }

--- a/spec/models/types_de_champ/epci_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/epci_type_de_champ_spec.rb
@@ -4,7 +4,7 @@ describe TypesDeChamp::EpciTypeDeChamp do
   describe '#columns' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :epci, libelle: 'Mon EPCI' }]) }
     let(:tdc) { procedure.active_revision.types_de_champ.first }
-    let(:jsonpath_columns) { tdc.columns(procedure:).grep(Columns::JSONPathColumn) }
+    let(:jsonpath_columns) { tdc.columns(procedure_id: procedure.id).grep(Columns::JSONPathColumn) }
 
     it 'exposes only department_code and region_code addressable columns' do
       expect(jsonpath_columns.map(&:jsonpath)).to contain_exactly('$.department_code', '$.region_code')

--- a/spec/models/types_de_champ/multiple_drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/multiple_drop_down_list_type_de_champ_spec.rb
@@ -9,7 +9,7 @@ describe TypesDeChamp::MultipleDropDownListTypeDeChamp do
     let(:multiple_dropdown_list_tdc) { procedure.active_revision.types_de_champ.first }
 
     it 'returns one column per referentiel header in advanced mode' do
-      columns = multiple_dropdown_list_tdc.columns(procedure:)
+      columns = multiple_dropdown_list_tdc.columns(procedure_id: procedure.id)
 
       expect(columns.size).to eq(3)
       expect(columns).to all(be_an_instance_of(Columns::MultipleDropDownColumn))

--- a/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
@@ -6,7 +6,7 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
 
     it 'adds RIB columns' do
       tdc = create(:type_de_champ_piece_justificative, procedure:, nature: 'rib')
-      cols = tdc.dynamic_type.columns(procedure:, displayable: true)
+      cols = tdc.dynamic_type.columns(procedure_id: procedure.id, displayable: true)
       labels = cols.map(&:label)
       expect(labels.any? { _1.include?('Titulaire') }).to be true
       expect(labels.any? { _1.include?('IBAN') }).to be true

--- a/spec/models/types_de_champ/quotient_familial_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/quotient_familial_type_de_champ_spec.rb
@@ -47,7 +47,7 @@ describe TypesDeChamp::QuotientFamilialTypeDeChamp do
   describe '#columns' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :quotient_familial, libelle: 'qf' }]) }
     let(:tdc_quotient_familial) { procedure.active_revision.types_de_champ.first }
-    let(:columns) { tdc_quotient_familial.columns(procedure:) }
+    let(:columns) { tdc_quotient_familial.columns(procedure_id: procedure.id) }
 
     it 'adds QF columns' do
       expected_columns = [

--- a/spec/models/types_de_champ/region_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/region_type_de_champ_spec.rb
@@ -4,7 +4,7 @@ describe TypesDeChamp::RegionTypeDeChamp do
   describe '#columns' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :regions, libelle: 'Ma région' }]) }
     let(:tdc) { procedure.active_revision.types_de_champ.first }
-    let(:jsonpath_columns) { tdc.columns(procedure:).grep(Columns::JSONPathColumn) }
+    let(:jsonpath_columns) { tdc.columns(procedure_id: procedure.id).grep(Columns::JSONPathColumn) }
 
     it 'exposes only the region_code addressable column' do
       expect(jsonpath_columns.map(&:jsonpath)).to contain_exactly('$.region_code')

--- a/spec/models/types_de_champ/siret_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/siret_type_de_champ_spec.rb
@@ -5,7 +5,7 @@ describe TypesDeChamp::SiretTypeDeChamp do
   let(:procedure) { build(:procedure) }
 
   describe "#columns" do
-    subject(:columns) { tdc_siret.columns(procedure: procedure) }
+    subject(:columns) { tdc_siret.columns(procedure_id: procedure.id) }
 
     it "returns base column without duplicating SIRET when already in libelle" do
       expect(columns[0].label).to eq("Numéro SIRET")


### PR DESCRIPTION
Change TypeDeChamp#columns (and the addressable/typed variants) to accept
procedure_id: instead of a full procedure:, so columns can be built without
loading the procedure record. Update all callers accordingly.

Add TypeDeChamp#column(column_id), delegated to the dynamic type, which finds
a single column by its h_id column_id (procedure-independent). Covers fillable,
addressable (multi-column, incl. legacy), and non-fillable types in specs.