### PR TITLE
Tech: fix N+1 sur claimant, expert et attachments dans Experts::AvisController#avis_list

### DIFF
--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -67,6 +67,11 @@ module Experts
     end
 
     def avis_list
+      @avis_for_expert = @dossier
+        .avis_for_expert(current_expert)
+        .includes(:claimant, experts_procedure: :expert)
+        .with_attached_piece_justificative_file
+        .with_attached_introduction_file
     end
 
     def expert_procedure

--- a/app/views/experts/avis/avis_list.html.haml
+++ b/app/views/experts/avis/avis_list.html.haml
@@ -7,8 +7,8 @@
     .fr-col.fr-col-12.fr-col-md-3
       = render partial: 'sidemenu'
     .fr-col
-      - if @dossier.avis_for_expert(current_expert).present?
-        = render partial: 'shared/avis/list', locals: { avis: @dossier.avis_for_expert(current_expert), avis_seen_at: nil, expert_or_instructeur: current_expert }
+      - if @avis_for_expert.present?
+        = render partial: 'shared/avis/list', locals: { avis: @avis_for_expert, avis_seen_at: nil, expert_or_instructeur: current_expert }
 
       - else
         %h2.empty-text


### PR DESCRIPTION
# Probleme

N+1 detecte par [Prosopite](https://github.com/charkost/prosopite) (scan des tests avec fixtures enrichies) et confirme par analyse statique du controller.

**Donnees de production** (depuis `.skill-context.json` / [Skylight](https://oss.skylight.io/app/applications/auuzqe8XhJIx/recent/6h/endpoints)) :

| Endpoint | RPM | P95 | Score |
|----------|-----|-----|-------|
| `Experts::AvisController#with` | 0.0 | 173ms | 48 (n1_failures) |

> RPM = 0 dans le contexte Skylight, mais le score N+1 de 48 (detecte en test) indique un risque reel lors de l'utilisation.
> L'endpoint `avis_list` est utilise par les experts pour consulter les avis sur un dossier — l'impact depend du nombre d'avis par dossier.

**Triage Prosopite** : 2 patterns PROD (call stack dans `app/views/shared/avis/_list.html.haml`) / 2 patterns TEST ignores (Flipper features/gates sans call stack app/).

# Solution

Skill [`/n1-query-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/n1-query-fix/SKILL.md)

### Patterns corriges (PROD uniquement)

| Association | Table | Strategy | Call site (app/) |
|-------------|-------|----------|------------------|
| `claimant` (polymorphic) | experts | `includes(:claimant)` dans controller | `app/views/shared/avis/_list.html.haml:12` |
| `expert` (through experts_procedure) | experts + experts_procedures | `includes(experts_procedure: :expert)` dans controller | `app/views/shared/avis/_list.html.haml:28` |
| `piece_justificative_file` | active_storage_attachments | `with_attached_piece_justificative_file` dans controller | `app/views/shared/avis/_list.html.haml:57` |
| `introduction_file` | active_storage_attachments | `with_attached_introduction_file` dans controller | `app/views/shared/avis/_list.html.haml:52` |

### Bonus

La vue `avis_list.html.haml` appelait `@dossier.avis_for_expert(current_expert)` **deux fois** (une pour `present?`, une pour le `render`). Le fix precharge la collection dans le controller et la passe via `@avis_for_expert`, eliminant la requete dupliquee.

### Validation

- [x] Tests passes (66 examples, 0 failures — `spec/controllers/experts/avis_controller_spec.rb`)
- [x] Prosopite ne detecte plus les N+1 PROD apres fix
- [x] Rubocop OK
- [x] Seuls des fichiers app/ sont commites

Generated with [Claude Code](https://claude.com/claude-code)