### PR TITLE
Tech: optimiser les tests de api_referentiel_spec

### DIFF
--- a/spec/system/administrateurs/api_referentiel_spec.rb
+++ b/spec/system/administrateurs/api_referentiel_spec.rb
@@ -24,34 +24,24 @@ describe 'Referentiel API:' do
 
     before { visit champs_admin_procedure_path(procedure) }
 
-    scenario 'Setup as admin, fails with invalid url (tiptap)', js: true do
+    scenario 'Setup as admin, invalid url validation and auth checkbox state', js: true do
       click_on('Configurer le champ')
+      expect(page).to have_unchecked_field("Ajouter une méthode d’authentification")
 
       fill_in_tiptap_url('http://google.com')
 
-      expect(page).to have_content('Seuls les domaines se terminant par .gouv.fr sont automatiquement autorisés')
-      expect(page).to have_content('doit commencer par https://')
-      expect(page).to have_content('doit contenir au moins un paramètre dynamique (tag)')
-      expect(page).to have_content('doit être autorisée par notre équipe.')
+      aggregate_failures 'invalid url errors' do
+        expect(page).to have_content('Seuls les domaines se terminant par .gouv.fr sont automatiquement autorisés')
+        expect(page).to have_content('doit commencer par https://')
+        expect(page).to have_content('doit contenir au moins un paramètre dynamique (tag)')
+        expect(page).to have_content('doit être autorisée par notre équipe.')
+      end
+      expect(page).to have_unchecked_field("Ajouter une méthode d’authentification")
 
       fill_in_tiptap_url('https://rnb-api.beta.gouv.fr/api/alpha/buildings/')
       insert_tiptap_tag("Valeur saisie par l’usager", insert_after: '/')
 
       expect(page).to have_content('Attention si vous appelez une API qui renvoie de la donnée personnelle, vous devez en informer votre DPO.')
-    end
-
-    scenario 'Setup as admin, back/forth auth does not changes preselected option', js: true do
-      visit champs_admin_procedure_path(procedure)
-      click_on('Configurer le champ')
-      expect(page).to have_unchecked_field("Ajouter une méthode d’authentification")
-
-      fill_in_tiptap_url('http://google.com')
-
-      expect(page).to have_content('Seuls les domaines se terminant par .gouv.fr sont automatiquement autorisés')
-      expect(page).to have_content('doit commencer par https://')
-      expect(page).to have_content('doit contenir au moins un paramètre dynamique (tag)')
-      expect(page).to have_content('doit être autorisée par notre équipe.')
-      expect(page).to have_unchecked_field("Ajouter une méthode d’authentification")
     end
   end
 

--- a/spec/system/administrateurs/api_referentiel_spec.rb
+++ b/spec/system/administrateurs/api_referentiel_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 describe 'Referentiel API:' do
-  let(:zone) { create(:zone) }
-  let(:user) { create(:user) }
-  let(:administrateur) { create(:administrateur, user:) }
-  let(:instructeur) { administrateur.instructeur }
-  let(:service) { create(:service, administrateur:) }
+  let_it_be(:zone) { create(:zone) }
+  let_it_be(:user) { create(:user) }
+  let_it_be(:administrateur) { create(:administrateur, user:) }
+  let_it_be(:instructeur) { administrateur.instructeur }
+  let_it_be(:service) { create(:service, administrateur:) }
   let!(:procedure) { create(:procedure, :for_individual, types_de_champ_public:, types_de_champ_private:, zones: [zone], service:, administrateurs: [administrateur], instructeurs: [instructeur]) }
   let(:referentiel_stable_id) { 21 }
   let(:prefill_text_stable_id) { 42 }


### PR DESCRIPTION
# Probleme

Tests lents dans `spec/system/administrateurs/api_referentiel_spec.rb` — temps baseline : 45.21s (mediane locale, 3 runs).

# Solution

Skill [`/test-optimization`](https://github.com/mfo/night-shift/blob/main/.claude/skills/test-optimization/SKILL.md)

### Techniques appliquees

| Technique | Avant | Apres | Gain |
|-----------|-------|-------|------|
| T08: let_it_be (zone, user, admin, service) | 45.21s | 37.86s | -16.3% |
| S02: merge edge case scenarios | 37.86s | 34.18s | -9.7% |

**Resultat final : 45.21s -> 34.18s (gain total 24.4%)**

### Techniques tentees sans succes

| Technique | Raison |
|-----------|--------|
| S03: publish programmatique | `procedure.publish!` ne produit pas le meme etat que le flux UI (5/6 tests rouges) |
| T09: aggregate_failures | Chaque context n'a qu'un seul scenario — pas de setup repetitif a eliminer |
| T01: create -> build | Non applicable aux system specs (besoin de vrais records DB) |
| T10: let! -> let | Seul `procedure` est `let!`, utilise par tous les tests |

### Details des commits

1. **T08 — let_it_be** : `zone`, `user`, `administrateur`, `instructeur`, `service` sont read-only dans les 7 scenarios. Convertis de `let`/`let!` a `let_it_be` pour les creer une seule fois au lieu de 7x (~30 INSERTs economises).

2. **S02 — merge edge cases** : Les deux scenarios edge case (invalid url + auth checkbox) partageaient le meme setup et visitaient la meme page. Fusionnes en un seul scenario avec `aggregate_failures`, eliminant 1 login + 1 creation procedure + 1 navigation (~3.7s).

Generated with [Claude Code](https://claude.com/claude-code)