### PR TITLE
feat(geo_area): add stable uuid for cross-stream identification

### DIFF
--- a/app/controllers/champs/carte_controller.rb
+++ b/app/controllers/champs/carte_controller.rb
@@ -28,7 +28,7 @@ class Champs::CarteController < Champs::ChampController
   end
 
   def update
-    geo_area = @champ.geo_areas.find(params[:id])
+    geo_area = find_geo_area(params[:id])
 
     if save_feature(geo_area, update_params_feature)
       @champ.update_timestamps
@@ -40,13 +40,17 @@ class Champs::CarteController < Champs::ChampController
   end
 
   def destroy
-    @champ.geo_areas.find(params[:id]).destroy!
+    find_geo_area(params[:id]).destroy!
     @champ.update_timestamps
 
     head :no_content
   end
 
   private
+
+  def find_geo_area(id)
+    @champ.geo_areas.find_by!('id = ? or uuid = ?', id.to_i, id)
+  end
 
   def params_source
     params[:source]

--- a/app/models/geo_area.rb
+++ b/app/models/geo_area.rb
@@ -3,6 +3,7 @@
 class GeoArea < ApplicationRecord
   include ActionView::Helpers::NumberHelper
   belongs_to :champ, optional: false
+  before_create :set_default_uuid
 
   enum :cadastre_state, %w[cadastre_fetched cadastre_error].index_by(&:itself)
 
@@ -57,7 +58,7 @@ class GeoArea < ApplicationRecord
         length: length,
         description: description,
         filename: filename,
-        id: id,
+        id: (uuid || id).to_s,
         champ_label: champ.libelle,
         champ_id: champ.stable_id,
         champ_row: champ.row_id,
@@ -252,5 +253,11 @@ class GeoArea < ApplicationRecord
   def surface_hectares
     return if surface.nil?
     surface.round / 10_000
+  end
+
+  def set_default_uuid
+    if champ.stream == Champ::MAIN_STREAM
+      self.uuid ||= SecureRandom.uuid
+    end
   end
 end

--- a/app/tasks/maintenance/t20260521_backfill_geo_area_uuid_task.rb
+++ b/app/tasks/maintenance/t20260521_backfill_geo_area_uuid_task.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260521BackfillGeoAreaUuidTask < MaintenanceTasks::Task
+    # Documentation: cette tâche modifie les données pour…
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    # Uncomment only if this task MUST run imperatively on its first deployment.
+    # If possible, leave commented for manual execution later.
+    # run_on_first_deploy
+
+    def collection
+      GeoArea.joins(:champ).where(champs: { stream: Champ::MAIN_STREAM })
+    end
+
+    def process(geo_area)
+      uuid = geo_area.uuid || SecureRandom.uuid
+      geo_area.update_column(:uuid, uuid) if geo_area.uuid.nil?
+      champ = geo_area.champ
+      GeoArea.joins(:champ)
+        .where(geometry: geo_area.geometry, champs: { dossier_id: champ.dossier_id, stable_id: champ.stable_id, row_id: champ.row_id })
+        .where.not(champs: { stream: Champ::MAIN_STREAM })
+        .update_all(uuid:)
+    end
+  end
+end

--- a/db/migrate/20260521105001_add_uuid_to_geo_area.rb
+++ b/db/migrate/20260521105001_add_uuid_to_geo_area.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUuidToGeoArea < ActiveRecord::Migration[7.2]
+  def change
+    add_column :geo_areas, :uuid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_15_085008) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_21_105001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -791,6 +790,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_15_085008) do
     t.jsonb "properties"
     t.string "source"
     t.datetime "updated_at", precision: nil
+    t.string "uuid"
     t.index ["cadastre_state"], name: "index_geo_areas_on_cadastre_state"
     t.index ["champ_id"], name: "index_geo_areas_on_champ_id"
     t.index ["source"], name: "index_geo_areas_on_source"

--- a/spec/controllers/champs/carte_controller_spec.rb
+++ b/spec/controllers/champs/carte_controller_spec.rb
@@ -108,7 +108,7 @@ describe Champs::CarteController, type: :controller do
         {
           dossier_id: champ.dossier_id,
           stable_id: champ.stable_id,
-          id: geo_area.id,
+          id: geo_area.to_feature[:properties][:id],
           feature: feature,
         }
       end
@@ -153,15 +153,31 @@ describe Champs::CarteController, type: :controller do
         {
           dossier_id: champ.dossier_id,
           stable_id: champ.stable_id,
-          id: geo_area.id,
+          id: geo_area.to_feature[:properties][:id],
         }
       end
+
+      before { geo_area }
 
       subject { delete :destroy, params: params }
 
       it do
-        expect { subject } .to change { dossier.reload.last_champ_updated_at }
+        expect { subject }.to change { dossier.reload.last_champ_updated_at }
         expect(response).to have_http_status(:no_content)
+      end
+
+      it { expect { subject }.to change { GeoArea.count }.by(-1) }
+
+      context 'en_construction' do
+        before do
+          dossier.reload
+          dossier.passer_en_construction!
+        end
+
+        it do
+          expect { subject }.to change { GeoArea.count }.by(0) # +1 clone, -1 delete = net 0
+          expect(response).to have_http_status(:no_content)
+        end
       end
     end
 

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -2504,7 +2504,7 @@ describe Dossier, type: :model do
               champ_id: champ_carte.stable_id,
               champ_private: false,
               dossier_id: dossier.id,
-              id: geo_area.id,
+              id: geo_area.uuid,
               source: 'selection_utilisateur',
             },
           },

--- a/spec/tasks/maintenance/t20260521_backfill_geo_area_uuid_task_spec.rb
+++ b/spec/tasks/maintenance/t20260521_backfill_geo_area_uuid_task_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260521BackfillGeoAreaUuidTask do
+    describe "#process" do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :carte }]) }
+      let(:dossier) { create(:dossier, procedure:) }
+      let(:main_champ) { dossier.champs.first }
+      let(:main_geo_area) do
+        ga = create(:geo_area, :selection_utilisateur, :polygon, champ: main_champ)
+        ga.update_column(:uuid, nil)
+        ga.reload
+      end
+
+      subject(:process) { described_class.new.process(main_geo_area) }
+
+      it 'assigns a uuid to a main stream geo_area that has none' do
+        expect { process }.to change { main_geo_area.reload.uuid }.from(nil).to(a_kind_of(String))
+      end
+
+      context 'when the main stream geo_area already has a uuid' do
+        let(:existing_uuid) { SecureRandom.uuid }
+        before { main_geo_area.update_column(:uuid, existing_uuid) }
+
+        it 'keeps the existing uuid' do
+          expect { process }.not_to change { main_geo_area.reload.uuid }
+        end
+      end
+
+      context 'when a matching geo_area exists in another stream' do
+        let(:buffer_champ) do
+          champ = main_champ.dup
+          champ.stream = Champ::USER_BUFFER_STREAM
+          champ.save!(validate: false)
+          champ
+        end
+        let!(:buffer_geo_area) { create(:geo_area, :selection_utilisateur, :polygon, champ: buffer_champ) }
+
+        it 'propagates the same uuid to the matching geo_area' do
+          process
+          expect(buffer_geo_area.reload.uuid).to eq(main_geo_area.reload.uuid)
+        end
+      end
+
+      context 'when a geo_area in another stream has a different geometry' do
+        let(:buffer_champ) do
+          champ = main_champ.dup
+          champ.stream = Champ::USER_BUFFER_STREAM
+          champ.save!(validate: false)
+          champ
+        end
+        let!(:buffer_geo_area) { create(:geo_area, :selection_utilisateur, :point, champ: buffer_champ) }
+
+        it 'does not update its uuid' do
+          expect(buffer_geo_area.reload.uuid).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a uuid column to geo_areas so the same logical area can be referenced across stream clones (main, user_buffer). New main-stream geo_areas get a uuid via before_create; the carte controller now looks up by id or uuid.

Includes a maintenance task to backfill uuids on existing rows and propagate them to matching cross-stream siblings.