### PR TITLE
ETQ admin, fix lien cliquable dans les attestations d'acceptation v2

### DIFF
--- a/app/views/administrateurs/attestation_template_v2s/show.html.erb
+++ b/app/views/administrateurs/attestation_template_v2s/show.html.erb
@@ -33,7 +33,7 @@
     <%- end -%>
 
     <div class="main">
-      <%= sanitize(@body, attributes: %w[class style], tags: Rails.configuration.action_view.sanitized_allowed_tags + %w[header]) %>
+      <%= sanitize(@body, attributes: %w[class style href target rel], tags: Rails.configuration.action_view.sanitized_allowed_tags + %w[header a]) %>
 
       <%- if @signature&.attached? -%>
         <div class="signature">

--- a/spec/views/administrateurs/attestation_template_v2s/show.html.erb_spec.rb
+++ b/spec/views/administrateurs/attestation_template_v2s/show.html.erb_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe 'administrateurs/attestation_template_v2s/show', type: :view do
+  let(:attestation_template) do
+    build_stubbed(:attestation_template, :v2, official_layout: false, footer: nil, label_direction: nil)
+  end
+
+  before do
+    assign(:attestation_template, attestation_template)
+    assign(:signature, nil)
+  end
+
+  context "quand le corps contient un lien Tiptap" do
+    let(:body_with_link) do
+      '<p><a href="https://demarche.numerique.gouv.fr/commencer/dossier-inscription-en-ligne-des-escadrilles-air-jeunesse-2026" target="_blank" rel="noopener noreferrer">https://demarche.numerique.gouv.fr/commencer/dossier-inscription-en-ligne-des-escadrilles-air-jeunesse-2026</a></p>'
+    end
+
+    before { assign(:body, body_with_link) }
+
+    it "conserve la balise <a href> pour que Weasyprint génère une annotation de lien PDF correcte" do
+      render
+      expect(rendered).to include('href="https://demarche.numerique.gouv.fr/commencer/dossier-inscription-en-ligne-des-escadrilles-air-jeunesse-2026"')
+    end
+  end
+end


### PR DESCRIPTION
## Problème

Les URLs saisies comme liens dans l'éditeur Tiptap des attestations v2 apparaissaient avec un `href` incorrect dans le PDF généré. En cas de retour à la ligne sur un trait d'union, le visionneur PDF de Chrome supprimait le tiret du `href` auto-détecté — sans affecter le texte affiché.

**Exemple :** `...escadrilles-air-jeunesse-2026` s'affichait correctement mais le lien pointait vers `...escadrilles-airjeunesse-2026`.

## Cause racine

Le sanitizer Rails supprimait les balises `<a>` avant l'envoi du HTML à Weasyprint. Sans annotation de lien dans le PDF, Chrome devait auto-détecter l'URL dans le texte brut, et traitait par erreur le tiret en fin de ligne comme un trait d'union de césure typographique.

## Correction

Autoriser les balises `<a>` (avec `href`, `target`, `rel`) dans le `sanitize` de la vue PDF. Weasyprint embarque désormais une vraie annotation de lien avec le `href` correct — Chrome l'utilise directement sans auto-détection.

Le sanitizer Loofah bloque toujours les `href` dangereux (`javascript:`, etc.).

## Plan de test
- [ ] Créer une attestation v2 avec une URL longue comportant des tirets
- [ ] Générer le PDF et vérifier que le lien cliquable pointe vers la bonne URL
- [ ] Vérifier qu'un `href` avec `javascript:` est bien supprimé par le sanitizer

🤖 Generated with [Claude Code](https://claude.com/claude-code)