### PR TITLE
Tech: fix N+1 sur show et publication dans Administrateurs::ProceduresController

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -67,7 +67,12 @@ module Administrateurs
     def show
       @procedure = current_administrateur
         .procedures
+        .with_attached_logo
+        .with_attached_notice
+        .with_attached_deliberation
         .includes(
+          :published_dossier_submitted_message,
+          :draft_dossier_submitted_message,
           published_revision: {
             revision_types_de_champ: { type_de_champ: { piece_justificative_template_attachment: :blob } },
           },
@@ -306,6 +311,9 @@ module Administrateurs
       @procedure = current_administrateur
         .procedures
         .with_active_revision
+        .with_attached_logo
+        .with_attached_notice
+        .with_attached_deliberation
         .find(params[:procedure_id])
 
       if @procedure.auto_archive_on && !@procedure.auto_archive_on.future?


### PR DESCRIPTION
# Probleme

N+1 detecte par [Prosopite](https://github.com/charkost/prosopite) (scan des tests avec fixtures enrichies, 3+ records, render_views) et confirme par analyse statique du controller.

**Donnees de production** (depuis `.skill-context.json` / [Skylight](https://oss.skylight.io/app/applications/auuzqe8XhJIx/recent/6h/endpoints)) :

| Endpoint | RPM | P95 | Score |
|----------|-----|-----|-------|
| `Administrateurs::ProceduresController#show` | 0.3 | 3042ms | 1 |
| `Administrateurs::ProceduresController#clone` | 0.0 | 243ms | 8 |
| `Administrateurs::ProceduresController#archive` | 0.0 | 48ms | 7 |
| `Administrateurs::ProceduresController#publish` | 0.0 | 374ms | 6 |

Le `show` est l'endpoint avec le plus de trafic (RPM 0.3) et le P95 le plus eleve (3042ms).
L'impact est modere en termes de RPM mais les N+1 contribuent a la lenteur du P95.

**Triage Prosopite** : 2 patterns PROD (call stack dans `app/`) / Flipper N+1 ignores (cache en production).

# Solution

Skill [`/n1-query-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/n1-query-fix/SKILL.md)

### Patterns corriges (PROD uniquement)

| Association | Table | Strategy | Call site (app/) |
|-------------|-------|----------|------------------|
| `logo`, `notice`, `deliberation` | active_storage_attachments | `with_attached_*` dans show et publication | `app/controllers/administrateurs/procedures_controller.rb:88` (validate), `app/components/procedure/errors_summary.rb:27` |
| `published_dossier_submitted_message`, `draft_dossier_submitted_message` | dossier_submitted_messages | `includes` dans show | `app/models/procedure.rb:85` via `app/views/administrateurs/procedures/show.html.haml:108` |

**Details :**

1. **`active_storage_attachments` N+1 sur show et publication** : `validate(:publication)` et le rendu des card components accedent aux attachments `logo`, `notice`, `deliberation` de la procedure sans preload. Corrige en ajoutant `.with_attached_logo.with_attached_notice.with_attached_deliberation`.

2. **`dossier_submitted_messages` N+1 sur show** : Le composant `DossierSubmittedMessageComponent` appelle `active_dossier_submitted_message` qui charge `published_dossier_submitted_message || draft_dossier_submitted_message` (2 has_one :through). Corrige en ajoutant `includes(:published_dossier_submitted_message, :draft_dossier_submitted_message)`.

### Patterns ignores

- **Flipper** (`flipper_features`, `flipper_gates`) : N+1 structurel de Flipper (feature flags). En production, Flipper utilise un adapteur avec cache, ces queries n'existent pas.

### Validation

- [x] Tests passes (126 examples, 0 failures)
- [x] Rubocop OK
- [x] Seuls des fichiers app/ sont commites

Generated with [Claude Code](https://claude.com/claude-code)