### PR TITLE
ETQ Instructeur utilisant un lecteur d'écran, je veux que les boutons ouvrant une modale soit indiqués comme tels

### DIFF
--- a/app/components/instructeurs/procedures_dossiers_synthese_button_component/procedures_dossiers_synthese_button_component.html.erb
+++ b/app/components/instructeurs/procedures_dossiers_synthese_button_component/procedures_dossiers_synthese_button_component.html.erb
@@ -4,6 +4,7 @@
     fr-icon-information-line
   "
   aria-controls="synthese-modal"
+  aria-haspopup="dialog"
   data-fr-opened="false"
   turbo-frame="synthese-modal"
   data-action="lazy-modal#load"

--- a/app/components/instructeurs/tabs_explanations_component/tabs_explanations_component.html.haml
+++ b/app/components/instructeurs/tabs_explanations_component/tabs_explanations_component.html.haml
@@ -1,5 +1,5 @@
 - if render_button?
-  %button{ aria: {controls: 'modal-tabs-explanations' }, data: {'fr-opened': "false" }, class: 'fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-question-line fr-ml-2v' }
+  %button{ aria: {controls: 'modal-tabs-explanations', haspopup: 'dialog'}, data: {'fr-opened': "false" }, class: 'fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-question-line fr-ml-2v' }
     = t('.modal.title')
 
 - if render_dialog?


### PR DESCRIPTION
Ajout de l'attribut `aria-haspopup="dialog"` sur les boutons ouvrant une modale.

# Après
<img width="1405" height="358" alt="" src="https://github.com/user-attachments/assets/e1a10f96-9ee5-48e5-ad4f-3ff78e5bc6cc" />


# Avant
<img width="1400" height="407" alt="" src="https://github.com/user-attachments/assets/0b991f88-49c3-48d4-9dcc-1c53cd3102ff" />
