### PR TITLE
Tech: bloquer les accès résiduels d'un expert à un avis révoqué

### DIFF
--- a/app/controllers/instructeurs/commentaires_controller.rb
+++ b/app/controllers/instructeurs/commentaires_controller.rb
@@ -50,7 +50,7 @@ module Instructeurs
       @dossier ||= begin
         dossier_id = params[:dossier_id]
         found = current_instructeur&.dossiers&.visible_by_administration&.find_by(id: dossier_id)
-        found ||= current_expert&.avis&.find_by(dossier_id:)&.dossier
+        found ||= current_expert&.avis&.not_revoked&.find_by(dossier_id:)&.dossier
         found || raise(ActiveRecord::RecordNotFound)
       end
     end

--- a/app/controllers/recherche_controller.rb
+++ b/app/controllers/recherche_controller.rb
@@ -35,7 +35,7 @@ class RechercheController < ApplicationController
       .matching_dossiers(current_instructeur&.dossiers, @search_terms, with_annotation: true)
 
     expert_dossier_ids = DossierSearchService
-      .matching_dossiers(current_expert&.dossiers, @search_terms)
+      .matching_dossiers(current_expert&.dossiers_from_not_revoked_avis, @search_terms)
 
     matching_dossiers_ids = (@instructeur_dossiers_ids + expert_dossier_ids).uniq
 

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -14,6 +14,11 @@ class Expert < ApplicationRecord
     user.email
   end
 
+  # Dossiers the expert can currently access, excluding those whose avis has been revoked.
+  def dossiers_from_not_revoked_avis
+    Dossier.where(id: avis.not_revoked.select(:dossier_id))
+  end
+
   def self.by_email(email)
     Expert.eager_load(:user).find_by(users: { email: email })
   end

--- a/spec/controllers/instructeurs/commentaires_controller_spec.rb
+++ b/spec/controllers/instructeurs/commentaires_controller_spec.rb
@@ -159,6 +159,17 @@ describe Instructeurs::CommentairesController, type: :controller do
           expect(subject.body).to include('Votre message a été supprimé')
         end
       end
+
+      context 'when the expert avis has been revoked' do
+        let!(:avis) { create(:avis, dossier:, experts_procedure:, claimant: instructeur, revoked_at: 1.day.ago) }
+        let!(:commentaire) { create(:commentaire, expert: expert, dossier: dossier) }
+        subject { delete :destroy, params: { dossier_id: dossier.id, procedure_id: procedure.id, id: commentaire.id, statut: 'a-suivre' }, format: :turbo_stream }
+
+        it 'returns 404 and does not delete the commentaire' do
+          expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+          expect(commentaire.reload).not_to be_discarded
+        end
+      end
     end
   end
 end

--- a/spec/controllers/recherche_controller_spec.rb
+++ b/spec/controllers/recherche_controller_spec.rb
@@ -42,6 +42,18 @@ describe RechercheController, type: :controller do
         end
       end
 
+      context 'when the expert avis on the dossier has been revoked' do
+        let(:user) { avis.experts_procedure.expert.user }
+        let(:query) { dossier_with_expert.id }
+
+        before { avis.update!(revoked_at: 1.day.ago) }
+
+        it 'does not return the dossier' do
+          is_expected.to have_http_status(200)
+          expect(assigns(:projected_dossiers)).to be_empty
+        end
+      end
+
       context 'when instructeur do not own the dossier' do
         let(:dossier2) { create(:dossier, :en_construction) }
         let(:query) { dossier2.id }


### PR DESCRIPTION
Un expert dont l'avis a été révoqué (`revoked_at` posé) conservait deux accès résiduels au dossier, faute de filtre `not_revoked` lors de la résolution de l'accès :

- **Messagerie** : `Instructeurs::CommentairesController#destroy` lui permettait de supprimer ses propres commentaires, ce qui vide le message **et purge ses pièces jointes**.
- **Recherche** : `RechercheController#index` faisait encore remonter le dossier dans les résultats (libellé de la démarche + email de l'usager).

Correctifs :
- Ajout de `.not_revoked` à la résolution du dossier dans `CommentairesController` (aligné sur le `check_if_avis_revoked` de `Experts::AvisController`).
- Nouvelle méthode `Expert#dossiers_from_not_revoked_avis`, utilisée par la recherche (seul consommateur non protégé de `Expert#dossiers`).

Chaque faille est couverte par un test de non-régression écrit d'abord en échec.