### PR TITLE
[ETQ instructeur] Amélioration des batch operations : messages d'erreur et UX de l'alerte

### DIFF
--- a/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
@@ -1,7 +1,7 @@
 .batch-alert-component{ data: should_refresh? ? { controller: "turbo-poll", turbo_poll_url_value: polling_batch_operation_instructeur_procedure_path(@procedure, batch: @batch), turbo_poll_interval_value: 2_000 } : {} }
-  .fr-mb-5v
+  .fr-mb-5v{ data: @batch.finished_at.present? ? { turbo_force: "browser" } : {} }
     - if @batch.finished_at.present?
-      = render Dsfr::AlertComponent.new(title: t(".title.finish"), state: (@batch.errors? ? :warning : :success), heading_level: 'h2', extra_class_names: 'fr-my-2w') do |c|
+      = render Dsfr::AlertComponent.new(title: t(".title.finish"), state: (@batch.errors? ? :warning : :success), heading_level: 'h2', extra_class_names: 'fr-my-2w', data: { controller: "auto-remove", auto_remove_delay_value: 5000 }) do |c|
         - c.with_body do
           %p
             = t(".#{batch.operation}.finish.text_success", count: @batch.total_count, success_count: @batch.success_count)

--- a/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
+++ b/app/components/dossiers/batch_alert_component/batch_alert_component.html.haml
@@ -1,10 +1,16 @@
 .batch-alert-component{ data: should_refresh? ? { controller: "turbo-poll", turbo_poll_url_value: polling_batch_operation_instructeur_procedure_path(@procedure, batch: @batch), turbo_poll_interval_value: 2_000 } : {} }
   .fr-mb-5v{ data: @batch.finished_at.present? ? { turbo_force: "browser" } : {} }
     - if @batch.finished_at.present?
-      = render Dsfr::AlertComponent.new(title: t(".title.finish"), state: (@batch.errors? ? :warning : :success), heading_level: 'h2', extra_class_names: 'fr-my-2w', data: { controller: "auto-remove", auto_remove_delay_value: 5000 }) do |c|
+      = render Dsfr::AlertComponent.new(title: t(".title.finish"), state: (@batch.errors? ? :warning : :success),heading_level: 'h2', extra_class_names: 'fr-my-2w', closable: @batch.errors?, data: @batch.errors? ? { controller: "element-remove" } : { controller: "auto-remove", auto_remove_delay_value: 5000 }) do |c|
         - c.with_body do
           %p
             = t(".#{batch.operation}.finish.text_success", count: @batch.total_count, success_count: @batch.success_count)
+
+          - if @batch.error_messages.present?
+            - @batch.error_messages.each do |message|
+              %p.fr-text--sm.fr-text-mention--grey
+                = message
+
     - else
       = render Dsfr::AlertComponent.new(title: t(".title.in_progress"), state: :info, heading_level: 'h2', extra_class_names: 'fr-my-2w') do |c|
         - c.with_body do

--- a/app/components/dossiers/batch_operation_component.rb
+++ b/app/components/dossiers/batch_operation_component.rb
@@ -8,26 +8,37 @@ class Dossiers::BatchOperationComponent < ApplicationComponent
     @procedure = procedure
   end
 
-  def operations_for_dossier(dossier)
-    case dossier.state
-    when Dossier.states.fetch(:en_construction)
-      [
-        BatchOperation.operations.fetch(:passer_en_instruction), BatchOperation.operations.fetch(:repousser_expiration), BatchOperation.operations.fetch(:create_avis),
-        BatchOperation.operations.fetch(:restaurer_repousser_expiration),
-      ]
-    when Dossier.states.fetch(:en_instruction)
-      [
-        BatchOperation.operations.fetch(:accepter), BatchOperation.operations.fetch(:refuser),
-        BatchOperation.operations.fetch(:classer_sans_suite), BatchOperation.operations.fetch(:repasser_en_construction), BatchOperation.operations.fetch(:create_avis),
-      ]
-    when Dossier.states.fetch(:accepte), Dossier.states.fetch(:refuse), Dossier.states.fetch(:sans_suite)
-      [
-        BatchOperation.operations.fetch(:archiver), BatchOperation.operations.fetch(:desarchiver), BatchOperation.operations.fetch(:supprimer),
-        BatchOperation.operations.fetch(:repousser_expiration), restore_operation_for(dossier),
-      ]
+  def operations_for_dossier(dossier, current_instructeur)
+    allowed_operations =
+      case dossier.state
+      when Dossier.states.fetch(:en_construction)
+        [
+          BatchOperation.operations.fetch(:passer_en_instruction), BatchOperation.operations.fetch(:repousser_expiration), BatchOperation.operations.fetch(:create_avis),
+          BatchOperation.operations.fetch(:restaurer_repousser_expiration),
+        ]
+      when Dossier.states.fetch(:en_instruction)
+        [
+          BatchOperation.operations.fetch(:accepter), BatchOperation.operations.fetch(:refuser),
+          BatchOperation.operations.fetch(:classer_sans_suite), BatchOperation.operations.fetch(:repasser_en_construction), BatchOperation.operations.fetch(:create_avis),
+        ]
+      when Dossier.states.fetch(:accepte), Dossier.states.fetch(:refuse), Dossier.states.fetch(:sans_suite)
+        [
+          BatchOperation.operations.fetch(:archiver), BatchOperation.operations.fetch(:desarchiver), BatchOperation.operations.fetch(:supprimer),
+          BatchOperation.operations.fetch(:repousser_expiration), restore_operation_for(dossier),
+        ]
+      else
+        []
+      end.append(BatchOperation.operations.fetch(:create_commentaire))
+
+    allowed_operations + follow_operations_for(dossier, current_instructeur)
+  end
+
+  def follow_operations_for(dossier, current_instructeur)
+    if current_instructeur.follow?(dossier)
+      [BatchOperation.operations.fetch(:unfollow)]
     else
-      []
-    end.append(BatchOperation.operations.fetch(:follow), BatchOperation.operations.fetch(:unfollow), BatchOperation.operations.fetch(:create_commentaire))
+      [BatchOperation.operations.fetch(:follow)]
+    end
   end
 
   private

--- a/app/components/dsfr/alert_component.rb
+++ b/app/components/dsfr/alert_component.rb
@@ -6,7 +6,7 @@ class Dsfr::AlertComponent < ApplicationComponent
 
   attr_reader :state, :title, :size, :block, :extra_class_names, :heading_level, :data
 
-  def initialize(state:, title: '', with_prefix: true, size: '', extra_class_names: nil, heading_level: 'h3', data: {})
+  def initialize(state:, title: '', with_prefix: true, size: '', extra_class_names: nil, heading_level: 'h3', data: {}, closable: false)
     @state = state
     @title = title
     @with_prefix = with_prefix
@@ -15,6 +15,7 @@ class Dsfr::AlertComponent < ApplicationComponent
     @extra_class_names = extra_class_names
     @heading_level = heading_level
     @data = data
+    @closable = closable
   end
 
   def prefix_for_state
@@ -36,5 +37,9 @@ class Dsfr::AlertComponent < ApplicationComponent
       "fr-alert--sm" => size == :sm,
       extra_class_names => true
     )
+  end
+
+  def closable?
+    !!@closable
   end
 end

--- a/app/components/dsfr/alert_component.rb
+++ b/app/components/dsfr/alert_component.rb
@@ -4,9 +4,9 @@
 class Dsfr::AlertComponent < ApplicationComponent
   renders_one :body
 
-  attr_reader :state, :title, :size, :block, :extra_class_names, :heading_level
+  attr_reader :state, :title, :size, :block, :extra_class_names, :heading_level, :data
 
-  def initialize(state:, title: '', with_prefix: true, size: '', extra_class_names: nil, heading_level: 'h3')
+  def initialize(state:, title: '', with_prefix: true, size: '', extra_class_names: nil, heading_level: 'h3', data: {})
     @state = state
     @title = title
     @with_prefix = with_prefix
@@ -14,6 +14,7 @@ class Dsfr::AlertComponent < ApplicationComponent
     @block = block
     @extra_class_names = extra_class_names
     @heading_level = heading_level
+    @data = data
   end
 
   def prefix_for_state

--- a/app/components/dsfr/alert_component/alert_component.html.haml
+++ b/app/components/dsfr/alert_component/alert_component.html.haml
@@ -1,4 +1,4 @@
-%div{ class: alert_class(state) }
+%div{ class: alert_class(state), data: data }
   - if size != :sm && (title.present? || prefix_for_state.present?)
     = content_tag(heading_level, class: 'fr-alert__title') do
       = "#{prefix_for_state}#{title}"

--- a/app/components/dsfr/alert_component/alert_component.html.haml
+++ b/app/components/dsfr/alert_component/alert_component.html.haml
@@ -3,3 +3,6 @@
     = content_tag(heading_level, class: 'fr-alert__title') do
       = "#{prefix_for_state}#{title}"
   = body
+  - if closable?
+    %button.fr-btn--close.fr-btn{ title: t('utils.modal_close'), data: { action: "element-remove#remove" } }
+      = t('utils.modal_close')

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -608,13 +608,13 @@ module Instructeurs
 
     def aasm_error_message(exception, target_state:)
       if exception.originating_state == target_state
-        "Le dossier est déjà #{dossier_display_state(target_state, lower: true)}."
+        t('instructeurs.dossiers.aasm_error_originating_state', state: dossier_display_state(target_state, lower: true))
       elsif exception.failures.include?(:can_terminer?) && dossier.any_etablissement_as_degraded_mode?
-        "Les données relatives au SIRET de ce dossier n’ont pas pu encore être vérifiées : il n’est pas possible de le passer en #{dossier_display_state(target_state, lower: true)}."
+        t('instructeurs.dossiers.aasm_error_etablissement_as_degraded_mode', state: dossier_display_state(target_state, lower: true))
       elsif exception.failures.include?(:can_terminer?) && !dossier.champs_private_valid?
         t('instructeurs.dossiers.aasm_error_annotations', url: annotations_privees_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]), state: dossier_display_state(target_state, lower: true))
       else
-        "Le dossier est en ce moment #{dossier_display_state(exception.originating_state, lower: true)} : il n’est pas possible de le passer #{dossier_display_state(target_state, lower: true)}."
+        t('instructeurs.dossiers.aasm_error_other', originating_state: dossier_display_state(exception.originating_state, lower: true), target_state: dossier_display_state(target_state, lower: true))
       end
     end
 

--- a/app/javascript/controllers/auto_remove_controller.ts
+++ b/app/javascript/controllers/auto_remove_controller.ts
@@ -1,0 +1,10 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+  static values = { delay: { type: Number, default: 5000 } };
+  declare delayValue: number;
+
+  connect() {
+    setTimeout(() => this.element.remove(), this.delayValue);
+  }
+}

--- a/app/jobs/batch_operation_process_one_job.rb
+++ b/app/jobs/batch_operation_process_one_job.rb
@@ -9,11 +9,16 @@ class BatchOperationProcessOneJob < ApplicationJob
     begin
       ActiveRecord::Base.transaction do
         batch_operation.process_one(dossier)
-        batch_operation.track_processed_dossier(true, dossier)
+        batch_operation.track_processed_dossier(true, dossier, nil)
       end
     rescue => error
       ActiveRecord::Base.transaction do
-        batch_operation.track_processed_dossier(false, dossier)
+        error_message = if error.is_a?(AASM::InvalidTransition)
+          batch_operation_aasm_error_message(error, dossier)
+        else
+          error.message
+        end
+        batch_operation.track_processed_dossier(false, dossier, error_message)
       end
       raise error
     ensure
@@ -22,5 +27,35 @@ class BatchOperationProcessOneJob < ApplicationJob
   rescue ActiveRecord::RecordNotFound
     dossier.update_column(:batch_operation_id, nil)
     batch_operation.finalize_if_complete!
+  end
+
+  private
+
+  TARGET_STATES = {
+    'accepter' => 'accepte',
+    'refuser' => 'refuse',
+    'classer_sans_suite' => 'sans_suite',
+    'passer_en_instruction' => 'en_instruction',
+    'repasser_en_construction' => 'en_construction',
+  }.freeze
+
+  # Same logic as DossiersController#aasm_error_message, without URL (background job context)
+  def batch_operation_aasm_error_message(exception, dossier)
+    target_state = TARGET_STATES.fetch(exception.event_name.to_s, exception.originating_state)
+    if exception.originating_state == target_state
+      I18n.t('instructeurs.dossiers.aasm_error_originating_state', state: dossier_display_state(target_state))
+    elsif exception.failures.include?(:can_terminer?) && dossier.any_etablissement_as_degraded_mode?
+      I18n.t('instructeurs.dossiers.aasm_error_etablissement_as_degraded_mode', state: dossier_display_state(target_state))
+    elsif exception.failures.include?(:can_terminer?) && !dossier.champs_private_valid?
+      I18n.t('instructeurs.dossiers.aasm_error_annotations_no_url', state: dossier_display_state(target_state))
+    else
+      I18n.t('instructeurs.dossiers.aasm_error_other', originating_state: dossier_display_state(exception.originating_state), target_state: dossier_display_state(target_state))
+    end
+  end
+
+  # Simplified version of DossierHelper#dossier_display_state
+  def dossier_display_state(state, lower: true)
+    display_state = Dossier.human_attribute_name("state.#{state}")
+    lower ? display_state.downcase : display_state
   end
 end

--- a/app/models/batch_operation.rb
+++ b/app/models/batch_operation.rb
@@ -138,12 +138,13 @@ class BatchOperation < ApplicationRecord
     end
   end
 
-  def track_processed_dossier(success, dossier)
+  def track_processed_dossier(success, dossier, error_message)
     dossiers.delete(dossier)
 
     if success
       dossier_operation(dossier).done!
     else
+      dossier_operation(dossier).update!(error_message:)
       dossier_operation(dossier).fail!
     end
   end
@@ -222,7 +223,27 @@ class BatchOperation < ApplicationRecord
     end
   end
 
+  def error_messages
+    dossier_operations.error
+      .group_by(&:error_message)
+      .map { |message, operations| format_error_message(message, operations) }
+  end
+
   private
+
+  def format_error_message(message, operations)
+    ids = operations.map(&:dossier_id)
+    I18n.t('views.instructeurs.dossiers.batch_operation.error_message',
+           count: ids.size,
+           ids: format_ids(ids),
+           message: message)
+  end
+
+  def format_ids(ids)
+    first_five_ids = ids.first(5).to_sentence
+    return first_five_ids if ids.size <= 5
+    "#{first_five_ids} #{I18n.t('views.instructeurs.dossiers.batch_operation.and_more', count: ids.size - 5)}"
+  end
 
   def dossier_operation(dossier)
     dossier_operations.find_by!(dossier:)

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -103,7 +103,7 @@
                                   data: { "fr-row-select" => "true" }
                               - else
                                 = check_box_tag "batch_operation[dossier_ids][]", dossier.id, false,
-                                    data: { batch_operation_target: "input", action: "batch-operation#onCheckOne", operations: batch_operation_component.operations_for_dossier(dossier).join(','), "fr-row-select" => "true" },
+                                    data: { batch_operation_target: "input", action: "batch-operation#onCheckOne", operations: batch_operation_component.operations_for_dossier(dossier, current_instructeur).join(','), "fr-row-select" => "true" },
                                     form: dom_id(BatchOperation.new), id: dom_id(BatchOperation.new, "checkbox_#{dossier.id}"),
                                     aria: { label: t('views.instructeurs.dossiers.batch_operation.enabled', dossier_id: dossier.id) }
                               = label_tag dom_id(BatchOperation.new, "checkbox_#{dossier.id}"), "Sélectionner le dossier #{dossier.id}", class: 'fr-label'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1016,7 +1016,11 @@ en:
         close_to_expiration: expiring
         to_archive: to archive
         trash: trash
+      aasm_error_originating_state: The folder is already %{state}.
+      aasm_error_etablissement_as_degraded_mode: "The SIRET data for this folder could not yet be verified: it is not possible to change it to %{state}."
+      aasm_error_annotations_no_url: The private annotations are not filled in correctly; it is not possible to change the file to %{state}.
       aasm_error_annotations: The private annotations are not filled in correctly; it is not possible to change the file to %{state}. <a href="%{url}">Edit annotations</a>.
+      aasm_error_other: "The folder is currently %{originating_state}: it is not possible to change it to %{target_state}."
       alert_error_annotations: The private annotations were not filled out correctly and are necessary to make a decision on the file.
       alert_error_annotations_link: Complete the private annotations
       alert_unspecified_attestation_champs: 'Please note, the following values have not been entered but are necessary to send a valid certificate:'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -458,6 +458,12 @@ fr:
         batch_operation:
           enabled: "Ajouter le dossier %{dossier_id} à la sélection pour un traitement de masse"
           disabled: "Impossible d’ajouter le dossier %{dossier_id} à la selection car il est déjà dans un traitement de masse"
+          and_more:
+            one: "(et %{count} autre)"
+            other: "(et %{count} autres)"
+          error_message:
+            one: "Dossier %{ids} : %{message}"
+            other: "Dossiers %{ids} : %{message}"
         show_deleted_dossiers: Historique des dossiers supprimés
         customize: Personnaliser le tableau
         passer_en_instruction: Passer en instruction
@@ -1017,7 +1023,11 @@ fr:
         close_to_expiration: expirants
         to_archive: à archiver
         trash: corbeille
+      aasm_error_originating_state: Le dossier est déjà %{state}.
+      aasm_error_etablissement_as_degraded_mode: "Les données relatives au SIRET de ce dossier n’ont pas pu encore être vérifiées : il n’est pas possible de le passer en %{state}."
+      aasm_error_annotations_no_url: Les annotations privées ne sont pas remplis correctement, il n’est pas possible de passer le dossier en %{state}.
       aasm_error_annotations: Les annotations privées ne sont pas remplis correctement, il n’est pas possible de passer le dossier en %{state}. <a href="%{url}">Modifier les annotations</a>.
+      aasm_error_other: "Le dossier est en ce moment %{originating_state} : il n’est pas possible de le passer %{target_state}."
       alert_error_annotations: Les annotations privées n’ont pas été correctement renseignées. Elles sont indispensables à l’instruction du dossier.
       alert_error_annotations_link: Compléter les annotations privées
       alert_unspecified_attestation_champs: 'Attention, les valeurs suivantes n’ont pas été renseignées mais sont nécessaires pour pouvoir envoyer une attestation valide :'

--- a/db/migrate/20260519131906_add_message_error_to_dossier_batch_operations.rb
+++ b/db/migrate/20260519131906_add_message_error_to_dossier_batch_operations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMessageErrorToDossierBatchOperations < ActiveRecord::Migration[7.2]
+  def change
+    add_column :dossier_batch_operations, :error_message, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -403,6 +403,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_21_105001) do
     t.bigint "batch_operation_id", null: false
     t.datetime "created_at", null: false
     t.bigint "dossier_id", null: false
+    t.string "error_message"
     t.string "state", default: "pending", null: false
     t.datetime "updated_at", null: false
     t.index ["batch_operation_id"], name: "index_dossier_batch_operations_on_batch_operation_id"

--- a/spec/components/dossiers/batch_alert_component_spec.rb
+++ b/spec/components/dossiers/batch_alert_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
     let!(:batch_operation) { create(:batch_operation, operation: :archiver, dossiers: [dossier, dossier_2], instructeur: instructeur) }
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -41,8 +41,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
@@ -57,8 +57,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and fail' do
       before {
-        batch_operation.track_processed_dossier(false, dossier)
-        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.track_processed_dossier(false, dossier, nil)
+        batch_operation.track_processed_dossier(true, dossier_2, nil)
         batch_operation.finalize_if_complete!
         batch_operation.reload
       }
@@ -89,7 +89,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
     let!(:batch_operation) { create(:batch_operation, operation: :desarchiver, dossiers: [dossier, dossier_2], instructeur: instructeur) }
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -103,8 +103,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
@@ -119,8 +119,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and fail' do
       before {
-        batch_operation.track_processed_dossier(false, dossier)
-        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.track_processed_dossier(false, dossier, nil)
+        batch_operation.track_processed_dossier(true, dossier_2, nil)
         batch_operation.finalize_if_complete!
         batch_operation.reload
       }
@@ -152,7 +152,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -165,8 +165,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
@@ -181,8 +181,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and fail' do
       before {
-        batch_operation.track_processed_dossier(false, dossier)
-        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.track_processed_dossier(false, dossier, nil)
+        batch_operation.track_processed_dossier(true, dossier_2, nil)
         batch_operation.finalize_if_complete!
         batch_operation.reload
       }
@@ -213,7 +213,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
     let!(:batch_operation) { create(:batch_operation, operation: :repousser_expiration, dossiers: [dossier, dossier_2], instructeur: instructeur) }
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -227,8 +227,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
@@ -243,8 +243,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and fail' do
       before {
-        batch_operation.track_processed_dossier(false, dossier)
-        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.track_processed_dossier(false, dossier, nil)
+        batch_operation.track_processed_dossier(true, dossier_2, nil)
         batch_operation.finalize_if_complete!
         batch_operation.reload
       }
@@ -276,7 +276,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -289,14 +289,15 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
 
       it do
         is_expected.to have_selector('.fr-alert--success')
+        is_expected.not_to have_selector('button.fr-btn--close')
         is_expected.to have_text("L’action de masse est terminée")
         is_expected.to have_text("2 dossiers ont été acceptés")
         expect(batch_operation.seen_at).to eq(nil)
@@ -305,14 +306,15 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and fail' do
       before {
-        batch_operation.track_processed_dossier(false, dossier)
-        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.track_processed_dossier(false, dossier, nil)
+        batch_operation.track_processed_dossier(true, dossier_2, nil)
         batch_operation.finalize_if_complete!
         batch_operation.reload
       }
 
       it do
         is_expected.to have_selector('.fr-alert--warning')
+        is_expected.to have_selector('button.fr-btn--close')
         is_expected.to have_text("L’action de masse est terminée")
         is_expected.to have_text("1/2 dossiers ont été acceptés")
         expect(batch_operation.seen_at).to eq(nil)
@@ -321,6 +323,20 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
       it 'on next render "seen_at" is set to avoid rendering alert' do
         render_inline(described_class.new(batch: batch_operation, procedure:)).to_html
         expect(batch_operation.seen_at).not_to eq(nil)
+      end
+    end
+
+    context 'finished with error messages' do
+      before {
+        batch_operation.track_processed_dossier(false, dossier, "Les annotations privées ne sont pas remplis correctement")
+        batch_operation.track_processed_dossier(true, dossier_2, nil)
+        batch_operation.finalize_if_complete!
+        batch_operation.reload
+      }
+
+      it do
+        is_expected.to have_selector('.fr-alert--warning')
+        is_expected.to have_text("Dossier #{dossier.id} : Les annotations privées ne sont pas remplis correctement")
       end
     end
   end
@@ -338,7 +354,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -351,8 +367,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
@@ -379,7 +395,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -392,8 +408,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
@@ -420,7 +436,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -433,8 +449,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
@@ -449,8 +465,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and fail' do
       before {
-        batch_operation.track_processed_dossier(false, dossier)
-        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.track_processed_dossier(false, dossier, nil)
+        batch_operation.track_processed_dossier(true, dossier_2, nil)
         batch_operation.finalize_if_complete!
         batch_operation.reload
       }
@@ -482,7 +498,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -495,8 +511,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
@@ -511,8 +527,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and fail' do
       before {
-        batch_operation.track_processed_dossier(false, dossier)
-        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.track_processed_dossier(false, dossier, nil)
+        batch_operation.track_processed_dossier(true, dossier_2, nil)
         batch_operation.finalize_if_complete!
         batch_operation.reload
       }
@@ -544,7 +560,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -557,8 +573,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
@@ -573,8 +589,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and fail' do
       before {
-        batch_operation.track_processed_dossier(false, dossier)
-        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.track_processed_dossier(false, dossier, nil)
+        batch_operation.track_processed_dossier(true, dossier_2, nil)
         batch_operation.finalize_if_complete!
         batch_operation.reload
       }
@@ -606,7 +622,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -619,8 +635,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
@@ -635,8 +651,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and fail' do
       before {
-        batch_operation.track_processed_dossier(false, dossier)
-        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.track_processed_dossier(false, dossier, nil)
+        batch_operation.track_processed_dossier(true, dossier_2, nil)
         batch_operation.finalize_if_complete!
         batch_operation.reload
       }
@@ -668,7 +684,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -681,8 +697,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
@@ -697,8 +713,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and fail' do
       before {
-        batch_operation.track_processed_dossier(false, dossier)
-        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.track_processed_dossier(false, dossier, nil)
+        batch_operation.track_processed_dossier(true, dossier_2, nil)
         batch_operation.finalize_if_complete!
         batch_operation.reload
       }
@@ -730,7 +746,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -743,8 +759,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
@@ -759,8 +775,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and fail' do
       before {
-        batch_operation.track_processed_dossier(false, dossier)
-        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.track_processed_dossier(false, dossier, nil)
+        batch_operation.track_processed_dossier(true, dossier_2, nil)
         batch_operation.finalize_if_complete!
         batch_operation.reload
       }
@@ -792,7 +808,7 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'in_progress' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
+         batch_operation.track_processed_dossier(true, dossier, nil)
          batch_operation.reload
        }
 
@@ -805,8 +821,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and success' do
       before {
-         batch_operation.track_processed_dossier(true, dossier)
-         batch_operation.track_processed_dossier(true, dossier_2)
+         batch_operation.track_processed_dossier(true, dossier, nil)
+         batch_operation.track_processed_dossier(true, dossier_2, nil)
          batch_operation.finalize_if_complete!
          batch_operation.reload
        }
@@ -821,8 +837,8 @@ RSpec.describe Dossiers::BatchAlertComponent, type: :component do
 
     context 'finished and fail' do
       before {
-        batch_operation.track_processed_dossier(false, dossier)
-        batch_operation.track_processed_dossier(true, dossier_2)
+        batch_operation.track_processed_dossier(false, dossier, nil)
+        batch_operation.track_processed_dossier(true, dossier_2, nil)
         batch_operation.finalize_if_complete!
         batch_operation.reload
       }

--- a/spec/components/dossiers/batch_operation_component_spec.rb
+++ b/spec/components/dossiers/batch_operation_component_spec.rb
@@ -97,14 +97,15 @@ RSpec.describe Dossiers::BatchOperationComponent, type: :component do
   describe "operations_for_dossier" do
     let(:procedure) { create(:procedure) }
     let(:statut) { 'whatever' }
+    let(:instructeur) { create(:instructeur) }
 
-    subject { described_class.new(statut: statut, procedure: procedure).operations_for_dossier(dossier) }
+    subject { described_class.new(statut: statut, procedure: procedure).operations_for_dossier(dossier, instructeur) }
 
     context "when the dossier is en_construction" do
       let(:dossier) { create(:dossier, :en_construction) }
 
       it do
-        expect(subject).to match_array(["passer_en_instruction", "repousser_expiration", "create_avis", "restaurer_repousser_expiration", "follow", "unfollow", "create_commentaire"])
+        expect(subject).to match_array(["passer_en_instruction", "repousser_expiration", "create_avis", "restaurer_repousser_expiration", "follow", "create_commentaire"])
       end
     end
 
@@ -113,7 +114,7 @@ RSpec.describe Dossiers::BatchOperationComponent, type: :component do
         let(:dossier) { create(:dossier, :accepte) }
 
         it do
-          expect(subject).to match_array(["archiver", "desarchiver", "supprimer", "repousser_expiration", "restaurer", "follow", "unfollow", "create_commentaire"])
+          expect(subject).to match_array(["archiver", "desarchiver", "supprimer", "repousser_expiration", "restaurer", "follow", "create_commentaire"])
         end
       end
 
@@ -121,7 +122,7 @@ RSpec.describe Dossiers::BatchOperationComponent, type: :component do
         let(:dossier) { create(:dossier, :accepte, hidden_by_administration_at: Time.zone.now) }
 
         it do
-          expect(subject).to match_array(["archiver", "desarchiver", "supprimer", "repousser_expiration", "restaurer", "follow", "unfollow", "create_commentaire"])
+          expect(subject).to match_array(["archiver", "desarchiver", "supprimer", "repousser_expiration", "restaurer", "follow", "create_commentaire"])
         end
       end
 
@@ -129,7 +130,17 @@ RSpec.describe Dossiers::BatchOperationComponent, type: :component do
         let(:dossier) { create(:dossier, :accepte, hidden_by_expired_at: Time.zone.now) }
 
         it do
-          expect(subject).to match_array(["archiver", "desarchiver", "supprimer", "repousser_expiration", "restaurer_repousser_expiration", "follow", "unfollow", "create_commentaire"])
+          expect(subject).to match_array(["archiver", "desarchiver", "supprimer", "repousser_expiration", "restaurer_repousser_expiration", "follow", "create_commentaire"])
+        end
+      end
+
+      context "and followed by instructeur" do
+        let(:dossier) { create(:dossier, :accepte) }
+
+        before { instructeur.follow(dossier) }
+
+        it do
+          expect(subject).to match_array(["archiver", "desarchiver", "repousser_expiration", "restaurer", "supprimer", "unfollow", "create_commentaire"])
         end
       end
     end

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -226,7 +226,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
       it 'warns about the error' do
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include('Le dossier est en ce moment accepté&nbsp;: il n’est pas possible de le passer en&nbsp;instruction.')
+        expect(response.body).to include('Le dossier est en ce moment accepté : il n’est pas possible de le passer en&nbsp;instruction.')
       end
     end
 

--- a/spec/jobs/batch_operation_process_one_job_spec.rb
+++ b/spec/jobs/batch_operation_process_one_job_spec.rb
@@ -23,6 +23,7 @@ describe BatchOperationProcessOneJob, type: :job do
       expect { subject.perform_now }.to raise_error('boom')
 
       expect(batch_operation.dossier_operations.error.pluck(:dossier_id)).to eq([dossier_job.id])
+      expect(batch_operation.dossier_operations.error.first.error_message).to eq("boom")
     end
 
     it 'calls finalize_if_complete! even when process_one raises' do
@@ -341,6 +342,39 @@ describe BatchOperationProcessOneJob, type: :job do
 
         expect(batch_operation.reload.failed_dossier_ids).to eq([])
         expect(batch_operation.dossiers).not_to include(dossier_job)
+      end
+    end
+
+    context 'when operation is "accepter" and annotations privees have errors' do
+      let(:batch_operation) do
+        create(:batch_operation, :accepter,
+               options.merge(instructeur: create(:instructeur), motivation: 'motivation'))
+      end
+
+      before do
+        allow_any_instance_of(Dossier).to receive(:champs_private_valid?).and_return(false)
+        allow_any_instance_of(Dossier).to receive(:any_etablissement_as_degraded_mode?).and_return(false)
+      end
+
+      it 'stores a human readable error message' do
+        expect { subject.perform_now }.to raise_error(AASM::InvalidTransition)
+        expect(batch_operation.dossier_operations.error.first.error_message).to include("annotations privées")
+      end
+    end
+
+    context 'when operation is "accepter" and etablissement is in degraded mode' do
+      let(:batch_operation) do
+        create(:batch_operation, :accepter,
+               options.merge(instructeur: create(:instructeur), motivation: 'motivation'))
+      end
+
+      before do
+        allow_any_instance_of(Dossier).to receive(:any_etablissement_as_degraded_mode?).and_return(true)
+      end
+
+      it 'stores a human readable error message' do
+        expect { subject.perform_now }.to raise_error(AASM::InvalidTransition)
+        expect(batch_operation.dossier_operations.error.first.error_message).to include("SIRET")
       end
     end
   end

--- a/spec/models/batch_operation_spec.rb
+++ b/spec/models/batch_operation_spec.rb
@@ -92,7 +92,7 @@ describe BatchOperation, type: :model do
     let(:batch_operation) { create(:batch_operation, operation: :archiver, instructeur: instructeur, dossiers: [dossier]) }
 
     it 'unlock the dossier' do
-      expect { batch_operation.track_processed_dossier(true, dossier) }
+      expect { batch_operation.track_processed_dossier(true, dossier, nil) }
         .to change { dossier.reload.batch_operation }
         .from(batch_operation)
         .to(nil)
@@ -100,7 +100,7 @@ describe BatchOperation, type: :model do
 
     context 'when it succeed' do
       it 'pushes dossier_job id to batch_operation.success_dossier_ids' do
-        expect { batch_operation.track_processed_dossier(true, dossier) }
+        expect { batch_operation.track_processed_dossier(true, dossier, nil) }
           .to change { batch_operation.dossier_operations.success.pluck(:dossier_id) }
           .from([])
           .to([dossier.id])
@@ -110,10 +110,10 @@ describe BatchOperation, type: :model do
     context 'when it succeed after a failure' do
       let(:batch_operation) { create(:batch_operation, operation: :archiver, instructeur: instructeur, dossiers: [dossier]) }
       before do
-        batch_operation.track_processed_dossier(false, dossier)
+        batch_operation.track_processed_dossier(false, dossier, nil)
       end
       it 'remove former dossier id from failed_dossier_ids' do
-        expect { batch_operation.track_processed_dossier(true, dossier) }
+        expect { batch_operation.track_processed_dossier(true, dossier, nil) }
           .to change { batch_operation.dossier_operations.error.pluck(:dossier_id) }
           .from([dossier.id])
           .to([])
@@ -122,7 +122,7 @@ describe BatchOperation, type: :model do
 
     context 'when it fails' do
       it 'pushes dossier_job id to batch_operation.failed_dossier_ids' do
-        expect { batch_operation.track_processed_dossier(false, dossier) }
+        expect { batch_operation.track_processed_dossier(false, dossier, nil) }
           .to change { batch_operation.dossier_operations.error.pluck(:dossier_id) }
           .from([])
           .to([dossier.id])


### PR DESCRIPTION
Après plusieurs modifications de l'app, il était nécessaire d'améliorer les actions de masse :

- **Messages d'erreur** : les erreurs liées aux annotations privées obligatoires et d'autres erreurs métier sont maintenant catchées et affichées à l'instructeur à la fin du batch
- **à suivre/ne plus suivre** : l'action s'active ou se désactive comme les autres selon que l'instructeur suit déjà le dossier, depuis que cette action a été déplacée dans l'onglet "au total"
- **UX de l'alerte** : en cas de succès, l'alerte se ferme automatiquement après 5 secondes. En cas d'erreur, elle reste ouverte et l'instructeur doit la fermer manuellement, car il y a désormais des infos à lire

<img width="1365" height="775" alt="Capture d’écran 2026-05-26 à 12 09 03" src="https://github.com/user-attachments/assets/3e9cc4a8-da18-4a5a-b805-927c9aab7d91" />
