### PR TITLE
Tech: restreindre les modèles d'export à la procédure de l'URL

### DIFF
--- a/app/controllers/instructeurs/export_templates_controller.rb
+++ b/app/controllers/instructeurs/export_templates_controller.rb
@@ -88,7 +88,7 @@ module Instructeurs
     end
 
     def set_export_template
-      @export_template = current_instructeur.export_templates.find(params[:id])
+      @export_template = ExportTemplate.where(groupe_instructeur: @groupe_instructeurs).find(params[:id])
     end
 
     def ensure_legitimate_groupe_instructeur

--- a/spec/controllers/instructeurs/export_templates_controller_spec.rb
+++ b/spec/controllers/instructeurs/export_templates_controller_spec.rb
@@ -158,6 +158,15 @@ describe Instructeurs::ExportTemplatesController, type: :controller do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+
+    context "with export_template belonging to another procedure of the current instructeur" do
+      let(:other_procedure) { create(:procedure, instructeurs: [instructeur]) }
+      let(:export_template) { create(:export_template, groupe_instructeur: other_procedure.defaut_groupe_instructeur) }
+
+      it 'raise exception' do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 
   describe '#update' do
@@ -197,6 +206,16 @@ describe Instructeurs::ExportTemplatesController, type: :controller do
         subject
         expect(export_template.export_pdf.template_json).not_to eq(item_params(text: "exPort_")["template"])
         expect(flash.alert).to be_present
+      end
+    end
+
+    context "with export_template belonging to another procedure of the current instructeur" do
+      let(:other_procedure) { create(:procedure, instructeurs: [instructeur]) }
+      let(:export_template) { create(:export_template, groupe_instructeur: other_procedure.defaut_groupe_instructeur) }
+
+      it 'does not move the export template into the URL procedure' do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(export_template.reload.groupe_instructeur).to eq(other_procedure.defaut_groupe_instructeur)
       end
     end
 
@@ -240,6 +259,17 @@ describe Instructeurs::ExportTemplatesController, type: :controller do
         subject
         expect(response).to redirect_to(export_templates_instructeur_procedure_path(procedure))
         expect(flash.notice).to eq "Le modèle d’export Mon export a bien été supprimé"
+      end
+    end
+
+    context "with export_template belonging to another procedure of the current instructeur" do
+      let(:other_procedure) { create(:procedure, instructeurs: [instructeur]) }
+      let(:export_template) { create(:export_template, groupe_instructeur: other_procedure.defaut_groupe_instructeur) }
+
+      it 'does not destroy the export template of the other procedure' do
+        export_template
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(ExportTemplate.exists?(export_template.id)).to be(true)
       end
     end
   end


### PR DESCRIPTION
`Instructeurs::ExportTemplatesController#set_export_template` récupérait le modèle via `current_instructeur.export_templates`, association `through: :groupe_instructeurs` qui couvre **tous** les groupes de l'instructeur, sans lien avec la procédure de l'URL.

Conséquence : un instructeur affecté à deux procédures pouvait, via l'URL d'une procédure A, atteindre le modèle d'export d'une procédure B — le lire (`edit`), le déplacer/partager vers un de ses groupes (`update` avec `groupe_instructeur_id` + `shared`) ou le supprimer (`destroy`).

La résolution est désormais scopée à `@groupe_instructeurs` (= `current_instructeur.groupe_instructeurs.where(procedure: @procedure)`), ce qui garantit à la fois l'appartenance de l'instructeur **et** le lien avec la procédure de l'URL. Un modèle d'une autre procédure lève `ActiveRecord::RecordNotFound`.

Specs de non-régression ajoutées sur `edit`, `update` et `destroy`.