### PR TITLE
ETQ instructeur, n'autoriser que les labels de la démarche du dossier

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -85,10 +85,12 @@ module Instructeurs
     end
 
     def dossier_labels
-      labels = params[:label_id]&.map(&:to_i) || []
-
       @dossier = dossier
-      labels.each { |params_label| DossierLabel.find_or_create_by(dossier_id: @dossier.id, label_id: params_label) }
+
+      requested_label_ids = params[:label_id]&.map(&:to_i) || []
+      labels = @dossier.procedure.labels.where(id: requested_label_ids).pluck(:id)
+
+      labels.each { |label_id| DossierLabel.find_or_create_by(dossier_id: @dossier.id, label_id:) }
 
       all_labels = DossierLabel.where(dossier_id: @dossier.id).pluck(:label_id)
 

--- a/app/models/dossier_label.rb
+++ b/app/models/dossier_label.rb
@@ -3,4 +3,16 @@
 class DossierLabel < ApplicationRecord
   belongs_to :dossier
   belongs_to :label
+
+  validate :label_belongs_to_dossier_procedure
+
+  private
+
+  def label_belongs_to_dossier_procedure
+    return if dossier.nil? || label.nil?
+
+    if label.procedure_id != dossier.procedure&.id
+      errors.add(:label, :invalid)
+    end
+  end
 end

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -2103,6 +2103,19 @@ describe Instructeurs::DossiersController, type: :controller do
         expect(subject.body).to include('Ajouter un label')
       end
     end
+
+    context 'when a label_id belongs to another procedure' do
+      let(:other_procedure) { create(:procedure, :with_labels) }
+      let(:foreign_label) { other_procedure.labels.first }
+
+      subject(:cross_procedure_request) do
+        post :dossier_labels, params: { procedure_id: procedure.id, dossier_id: dossier.id, label_id: [foreign_label.id], statut: 'a-suivre' }, format: :turbo_stream
+      end
+
+      it 'does not assign the label from the other procedure to the dossier' do
+        expect { cross_procedure_request }.not_to change { dossier.dossier_labels.count }
+      end
+    end
   end
 
   describe '#rendez_vous' do

--- a/spec/models/dossier_label_spec.rb
+++ b/spec/models/dossier_label_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe DossierLabel do
+  let(:procedure) { create(:procedure, :with_labels) }
+  let(:dossier) { create(:dossier, procedure:) }
+
+  describe 'label_belongs_to_dossier_procedure' do
+    context 'when the label belongs to the dossier procedure' do
+      let(:label) { procedure.labels.first }
+
+      it 'is valid' do
+        expect(DossierLabel.new(dossier:, label:)).to be_valid
+      end
+    end
+
+    context 'when the label belongs to another procedure' do
+      let(:label) { create(:procedure, :with_labels).labels.first }
+
+      it 'is invalid' do
+        expect(DossierLabel.new(dossier:, label:)).not_to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
Lors de l'assignation de labels à un dossier (`Instructeurs::DossiersController#dossier_labels`), les `label_id` reçus étaient utilisés tels quels, sans vérifier qu'ils appartenaient à la démarche du dossier. Un instructeur pouvait ainsi rattacher à son dossier un label appartenant à une autre démarche.

## Changements
- Le contrôleur restreint désormais les `label_id` acceptés au périmètre `@dossier.procedure.labels` ; les ids hors périmètre sont ignorés.
- Ajout d'une validation `label_belongs_to_dossier_procedure` sur `DossierLabel`, en défense en profondeur.
- Specs de régression côté contrôleur et modèle.