### PR TITLE
Tech: différer le report Sentry des jobs API Entreprise au 8e essai

### DIFF
--- a/app/jobs/api_entreprise/job.rb
+++ b/app/jobs/api_entreprise/job.rb
@@ -5,7 +5,7 @@ class APIEntreprise::Job < ApplicationJob
 
   queue_as :default
 
-  use_sidekiq_retry
+  use_sidekiq_retry(report_after_attempts: 8)
 
   # If by the time the job runs the Etablissement has been deleted
   # (it can happen through EtablissementUpdateJob for instance), ignore the job

--- a/app/lib/active_job/retry_on_standard_error.rb
+++ b/app/lib/active_job/retry_on_standard_error.rb
@@ -8,9 +8,15 @@ module ActiveJob::RetryOnStandardError
   class_methods do
     # Opt out of Active Job's retry_on StandardError and rely on Sidekiq's
     # native retry mechanism instead. Useful for long-running jobs where
-    def use_sidekiq_retry
+    #
+    # report_after_attempts: when set, sentry-sidekiq only reports the error
+    # once the job reaches that attempt number (see Sentry::Sidekiq::ErrorHandler
+    # reading the `attempt_threshold` job option). Keeps transient external-API
+    # failures out of Sentry until they persist across several retries.
+    def use_sidekiq_retry(report_after_attempts: nil)
       self.rescue_handlers = rescue_handlers.reject { |klass_name, _| klass_name == "StandardError" }
       sidekiq_options retry: MAX_ATTEMPTS_JOBS
+      sidekiq_options attempt_threshold: report_after_attempts if report_after_attempts
     end
   end
 

--- a/spec/jobs/api_entreprise/job_spec.rb
+++ b/spec/jobs/api_entreprise/job_spec.rb
@@ -97,6 +97,15 @@ RSpec.describe APIEntreprise::Job, type: :job do
     end
   end
 
+  describe 'sidekiq retry configuration' do
+    subject(:options) { described_class.get_sidekiq_options }
+
+    it 'defers Sentry reporting until the 8th attempt while keeping native retry' do
+      expect(options["attempt_threshold"]).to eq(8)
+      expect(options["retry"]).to eq(ActiveJob::RetryOnStandardError::MAX_ATTEMPTS_JOBS)
+    end
+  end
+
   class ErrorJob < APIEntreprise::Job
     include Dry::Monads[:result]
 


### PR DESCRIPTION
Beaucoup de bruit sur sentry depuis qu'on a rétabli les notifications dès la première erreur, cette PR permet de passer sous silence les premières erreurs temporaires des services appelés par les jobs APIEntreprise.

---

Les jobs `APIEntreprise::*` (retry natif Sidekiq, `retry: 25`) relèvent une `StandardError` sur chaque erreur transitoire fournisseur (502/503/504/429) pour déclencher le retry — que `sentry-sidekiq` capture à chaque tentative, jusqu'à 25× par job. D'où un bruit massif sur des indisponibilités passagères (RAILS-KS6 & co : dizaines de milliers d'events).

Via l'option `attempt_threshold`, Sentry ne rapporte plus qu'**au 8ᵉ essai = 7ᵉ retry Sidekiq (~42 min d'échec continu)**. À noter : `attempt_threshold` compte les *tentatives* (la 1ʳᵉ = le run initial), donc `8` correspond au 7ᵉ retry de la [table Sidekiq](https://github.com/sidekiq/sidekiq/wiki/Error-Handling). Les blips transitoires des premiers essais disparaissent, seules les pannes qui persistent remontent. Retry inchangé.