### PR TITLE
Tech: restreindre les autocomplétions data_sources aux utilisateurs connectés

### DIFF
--- a/app/controllers/data_sources/adresse_controller.rb
+++ b/app/controllers/data_sources/adresse_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DataSources::AdresseController < ApplicationController
+class DataSources::AdresseController < DataSources::BaseController
   def search
     query = clean_query(params[:q])
 

--- a/app/controllers/data_sources/base_controller.rb
+++ b/app/controllers/data_sources/base_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DataSources::BaseController < ApplicationController
+  before_action :authenticate_data_source_user!
+
+  private
+
+  def authenticate_data_source_user!
+    authenticate_logged_user!
+  end
+end

--- a/app/controllers/data_sources/chorus_controller.rb
+++ b/app/controllers/data_sources/chorus_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class DataSources::ChorusController < ApplicationController
-  before_action :authenticate_administrateur!
-
+class DataSources::ChorusController < DataSources::BaseController
   def search_domaine_fonct
     result = APIBretagneService.new.search_domaine_fonct(code_or_label: params[:q])
     render json: format_or_error(result:,
@@ -22,6 +20,10 @@ class DataSources::ChorusController < ApplicationController
   end
 
   private
+
+  def authenticate_data_source_user!
+    authenticate_administrateur!
+  end
 
   def format_or_error(result:, label_formatter:)
     if result.is_a?(Dry::Monads::Failure)

--- a/app/controllers/data_sources/commune_controller.rb
+++ b/app/controllers/data_sources/commune_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DataSources::CommuneController < ApplicationController
+class DataSources::CommuneController < DataSources::BaseController
   def search
     if params[:q].present? && params[:q].length > 1
       response = APIGeoService.commune_by_name_or_postal_code(params[:q])

--- a/app/controllers/data_sources/education_controller.rb
+++ b/app/controllers/data_sources/education_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DataSources::EducationController < ApplicationController
+class DataSources::EducationController < DataSources::BaseController
   def search
     if params[:q].present? && params[:q].length >= 3
       response = fetch_results

--- a/app/controllers/data_sources/referentiel_controller.rb
+++ b/app/controllers/data_sources/referentiel_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class DataSources::ReferentielController < ApplicationController
-  before_action :authenticate_user!
+class DataSources::ReferentielController < DataSources::BaseController
   before_action :mark_as_retryable, :set_dossier, :referentiel, :referentiel_service
   MIN_QUERY_LENGTH = 3
   MAX_QUERY_SIZE = 100
@@ -36,6 +35,10 @@ class DataSources::ReferentielController < ApplicationController
   end
 
   private
+
+  def authenticate_data_source_user!
+    authenticate_user!
+  end
 
   def mark_as_retryable
     @retryable = true

--- a/spec/controllers/data_sources/adresse_controller_spec.rb
+++ b/spec/controllers/data_sources/adresse_controller_spec.rb
@@ -1,6 +1,39 @@
 # frozen_string_literal: true
 
 describe DataSources::AdresseController, type: :controller do
+  describe "#search" do
+    let(:upstream_response) do
+      Typhoeus::Response.new(code: 200, body: { features: [] }.to_json, mock: true)
+    end
+
+    before { allow(Typhoeus).to receive(:get).and_return(upstream_response) }
+
+    subject(:search) { get :search, params: { q: "12 rue de la Paix" } }
+
+    context "without a signed-in user" do
+      it "redirects to the sign-in page instead of proxying the request" do
+        search
+        expect(response).to redirect_to(new_user_session_path)
+        expect(Typhoeus).not_to have_received(:get)
+      end
+    end
+
+    context "with a signed-in user" do
+      before { sign_in(create(:user)) }
+
+      it "answers with the formatted results" do
+        search
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "confines the user input to the query string of the configured address API host" do
+        search
+        expect(Typhoeus).to have_received(:get)
+          .with(start_with(API_ADRESSE_URL), hash_including(params: hash_including(q: "12 rue de la Paix")))
+      end
+    end
+  end
+
   describe "#clean_query" do
     subject(:clean_query) { controller.send(:clean_query, input) }
 

--- a/spec/controllers/data_sources/commune_controller_spec.rb
+++ b/spec/controllers/data_sources/commune_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe DataSources::CommuneController, type: :controller do
+  describe "#search" do
+    let(:upstream_response) do
+      Typhoeus::Response.new(code: 200, body: [].to_json, mock: true)
+    end
+
+    before { allow(APIGeoService).to receive(:commune_by_name_or_postal_code).and_return(upstream_response) }
+
+    subject(:search) { get :search, params: { q: "Lyon" } }
+
+    context "without a signed-in user" do
+      it "redirects to the sign-in page instead of proxying the request" do
+        search
+        expect(response).to redirect_to(new_user_session_path)
+        expect(APIGeoService).not_to have_received(:commune_by_name_or_postal_code)
+      end
+    end
+
+    context "with a signed-in user" do
+      before { sign_in(create(:user)) }
+
+      it "answers with the formatted results" do
+        search
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/controllers/data_sources/education_controller_spec.rb
+++ b/spec/controllers/data_sources/education_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe DataSources::EducationController, type: :controller do
+  describe "#search" do
+    let(:upstream_response) do
+      Typhoeus::Response.new(code: 200, body: { records: [] }.to_json, mock: true)
+    end
+
+    before { allow(Typhoeus).to receive(:get).and_return(upstream_response) }
+
+    subject(:search) { get :search, params: { q: "lycee" } }
+
+    context "without a signed-in user" do
+      it "redirects to the sign-in page instead of proxying the request" do
+        search
+        expect(response).to redirect_to(new_user_session_path)
+        expect(Typhoeus).not_to have_received(:get)
+      end
+    end
+
+    context "with a signed-in user" do
+      before { sign_in(create(:user)) }
+
+      it "answers with the formatted results" do
+        search
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Les endpoints `data_sources` (`adresse`, `commune`, `education`) héritaient de `ApplicationController` sans contrôle d'auth, alors que leurs seuls appelants sont déjà derrière un login (édition de dossier). Ils étaient donc joignables sans session, agissant comme proxy HTTP sortant non authentifié.

Introduction d'un `DataSources::BaseController` qui exige une authentification par défaut (`authenticate_logged_user!`), surchargeable pour un rôle plus strict. Les cinq contrôleurs `data_sources` en héritent désormais : un nouvel endpoint sera authentifié par défaut, sans risque d'oubli. `referentiel` et `chorus` conservent leur auth d'origine via la surcharge.