### PR TITLE
Tech: calibrer le rate limiter API Entreprise sur chaque reponse HTTP

### DIFF
--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -117,16 +117,15 @@ class APIEntreprise::API
     return Failure(type: :token_missing, code: 401, retryable: false, raw_response: nil) if token_missing?
     return Failure(type: :token_expired, code: 401, retryable: false, raw_response: nil) if token_expired?
 
-    APIEntreprise::RateLimiter.consume!(pool)
-
     case client.call(url:, params:, headers: { 'Authorization' => "Bearer #{token.jwt_token}" }, timeout: TIMEOUT)
     in Success(body:, response:)
-      APIEntreprise::RateLimiter.calibrate!(response, pool) if rand < 0.1
+      APIEntreprise::RateLimiter.calibrate!(response, pool)
       Success(body)
     in Failure(type: :http, code:, error:)
-      APIEntreprise::RateLimiter.calibrate!(error.try(:response), pool) if code == 429
+      APIEntreprise::RateLimiter.calibrate!(error.try(:response), pool)
       classify_http_error(code, error.try(:response))
     in Failure(type:, code:, retryable:, error:)
+      APIEntreprise::RateLimiter.calibrate!(error.try(:response), pool)
       Failure(type:, code:, retryable:, raw_response: error.try(:response))
     end
   end

--- a/app/lib/api_entreprise/rate_limiter.rb
+++ b/app/lib/api_entreprise/rate_limiter.rb
@@ -8,11 +8,10 @@
 #   -   50 req/min: gip_mds/effectifs
 #   -    5 req/min: dgfip/attestation_fiscale
 #
-# Hybrid approach: Redis DECR for proactive counting + server headers for calibration.
+# Server-driven approach: every HTTP response calibrates the local state from RateLimit-* headers.
 #
-#   consume!(pool)    — DECR before each HTTP call (API#call)
-#   calibrate!(response, pool) — SET from RateLimit-* headers (~10% of 200s, 100% of 429s)
-#   throttled?(pool)  — read-only check (Job#before_perform, BackfillTask#throttle_on)
+#   calibrate!(response, pool) — SET remaining/reset from RateLimit-* headers (every response)
+#   throttled?(pool)           — read-only check (Job#before_perform, BackfillTask#throttle_on)
 #
 # Redis keys: api_entreprise:rate_limit:{remaining|reset}:{pool}
 # Keys auto-expire (TTL = reset window), so no stale state after window ends.
@@ -29,12 +28,6 @@ module APIEntreprise::RateLimiter
 
   def self.remaining(pool)
     Kredis.redis.get(remaining_key(pool))&.to_i
-  end
-
-  def self.consume!(pool)
-    return if remaining(pool).nil?
-
-    Kredis.redis.decr(remaining_key(pool))
   end
 
   def self.calibrate!(response, pool)

--- a/spec/lib/api_entreprise/api_spec.rb
+++ b/spec/lib/api_entreprise/api_spec.rb
@@ -470,8 +470,7 @@ describe APIEntreprise::API do
       context 'when API returns 200 with RateLimit headers' do
         let(:status) { 200 }
 
-        it 'stores remaining in Redis when calibration triggers (reset not stored when remaining > 0)' do
-          allow_any_instance_of(described_class).to receive(:rand).and_return(0.05) # force calibration
+        it 'stores remaining in Redis (reset not stored when remaining > 0)' do
           described_class.new(procedure_id).entreprise(siren)
 
           expect(Kredis.redis.get(APIEntreprise::RateLimiter.remaining_key(pool)).to_i).to eq(47)
@@ -479,18 +478,10 @@ describe APIEntreprise::API do
         end
 
         it 'sets TTL on Redis keys' do
-          allow_any_instance_of(described_class).to receive(:rand).and_return(0.05)
           described_class.new(procedure_id).entreprise(siren)
 
           ttl = Kredis.redis.ttl(APIEntreprise::RateLimiter.remaining_key(pool))
           expect(ttl).to be_between(1, 30)
-        end
-
-        it 'skips calibration ~90% of the time' do
-          allow_any_instance_of(described_class).to receive(:rand).and_return(0.5)
-          described_class.new(procedure_id).entreprise(siren)
-
-          expect(Kredis.redis.get(APIEntreprise::RateLimiter.remaining_key(pool))).to be_nil
         end
       end
 
@@ -510,46 +501,11 @@ describe APIEntreprise::API do
         let(:body) { '{"errors":[{"code":"00429","title":"Trop de requêtes"}]}' }
         let(:rate_limit_headers) { { 'RateLimit-Remaining' => '0', 'RateLimit-Reset' => reset_timestamp.to_s } }
 
-        it 'always calibrates on 429 (broadcast stop signal)' do
+        it 'calibrates remaining to 0 and stores reset timestamp' do
           described_class.new(procedure_id).entreprise(siren)
 
           expect(Kredis.redis.get(APIEntreprise::RateLimiter.remaining_key(pool)).to_i).to eq(0)
           expect(Kredis.redis.get(APIEntreprise::RateLimiter.reset_key(pool)).to_i).to eq(reset_timestamp)
-        end
-      end
-    end
-
-    describe 'RateLimiter.consume! decrements counter' do
-      before do
-        stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v3\/insee\/sirene\/unites_legales\/#{siren}/)
-          .to_return(body:, status: 200)
-      end
-
-      context 'when Redis has no rate limit state' do
-        it 'skips decrement and makes the call' do
-          expect { described_class.new(procedure_id).entreprise(siren) }.not_to raise_error
-        end
-      end
-
-      context 'when remaining > 0' do
-        before do
-          Kredis.redis.set(APIEntreprise::RateLimiter.remaining_key(pool), 10, ex: 60)
-        end
-
-        it 'decrements remaining' do
-          described_class.new(procedure_id).entreprise(siren)
-          expect(Kredis.redis.get(APIEntreprise::RateLimiter.remaining_key(pool)).to_i).to eq(9)
-        end
-      end
-
-      context 'when remaining = 0' do
-        before do
-          Kredis.redis.set(APIEntreprise::RateLimiter.remaining_key(pool), 0, ex: 60)
-        end
-
-        it 'decrements to negative (caller handles throttling)' do
-          described_class.new(procedure_id).entreprise(siren)
-          expect(Kredis.redis.get(APIEntreprise::RateLimiter.remaining_key(pool)).to_i).to eq(-1)
         end
       end
     end

--- a/spec/lib/api_entreprise/rate_limiter_spec.rb
+++ b/spec/lib/api_entreprise/rate_limiter_spec.rb
@@ -57,46 +57,6 @@ describe APIEntreprise::RateLimiter do
     end
   end
 
-  describe '.consume!' do
-    context 'when Redis has no state (not yet calibrated)' do
-      it 'does nothing' do
-        expect { described_class.consume!(pool) }.not_to raise_error
-        expect(Kredis.redis.get(described_class.remaining_key(pool))).to be_nil
-      end
-    end
-
-    context 'when remaining is set' do
-      before { Kredis.redis.set(described_class.remaining_key(pool), 5, ex: 60) }
-
-      it 'decrements the counter' do
-        described_class.consume!(pool)
-        expect(Kredis.redis.get(described_class.remaining_key(pool)).to_i).to eq(4)
-      end
-
-      it 'is safe under concurrent calls' do
-        3.times { described_class.consume!(pool) }
-        expect(Kredis.redis.get(described_class.remaining_key(pool)).to_i).to eq(2)
-      end
-    end
-
-    context 'does not affect other pools' do
-      before do
-        Kredis.redis.set(described_class.remaining_key(250), 10, ex: 60)
-        Kredis.redis.set(described_class.remaining_key(50), 5, ex: 60)
-      end
-
-      after do
-        Kredis.redis.del(described_class.remaining_key(250), described_class.remaining_key(50))
-      end
-
-      it 'decrements only the specified pool' do
-        described_class.consume!(250)
-        expect(Kredis.redis.get(described_class.remaining_key(250)).to_i).to eq(9)
-        expect(Kredis.redis.get(described_class.remaining_key(50)).to_i).to eq(5)
-      end
-    end
-  end
-
   describe '.calibrate!' do
     let(:reset_timestamp) { Time.current.to_i + 30 }
 


### PR DESCRIPTION
# Probleme

Le rate limiter API Entreprise utilisait `consume!` pour decrementer un compteur Redis **avant** chaque appel HTTP. La calibration (sync avec les headers serveur `RateLimit-*`) ne se faisait que sur ~10% des 200 et sur les 429.

Consequence : sur les erreurs serveur (502/503/504), le compteur local etait decremente mais jamais recalibre. Une serie de 502 (fournisseur de donnees down) faisait deriver le compteur vers 0, declenchant un throttle local alors que le serveur avait encore de la capacite.

# Solution

- Suppression de `consume!` (decrement optimiste devenu inutile)
- Calibration systematique sur **chaque** reponse HTTP (Success, Failure HTTP, Failure timeout/reseau)
- `calibrate!` gere deja les reponses sans headers (`early return`), donc zero risque sur les reponses sans `RateLimit-*`

Le rate limiter devient purement server-driven : la source de verite est toujours les headers de la gateway API Entreprise, pas un compteur local.

Generated with [Claude Code](https://claude.com/claude-code)