### PR TITLE
ETQ usager, permettre le mode dégradé en cas de rate limit 429 API Entreprise

### DIFF
--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -47,6 +47,8 @@ class APIEntrepriseService
     # Returns Failure(type:, code:, retryable:, raw_response:) on non-recoverable errors
     def create_etablissement_with_fallback(dossier_or_champ, siret, user_id = nil)
       case create_etablissement(dossier_or_champ, siret, user_id)
+      in Failure(type: :rate_limited, retryable: true, **)
+        Success(create_etablissement_as_degraded_mode(dossier_or_champ, siret, user_id))
       in Failure(retryable: true, **) => failure if degraded_mode?(failure.failure, target: :insee)
         Success(create_etablissement_as_degraded_mode(dossier_or_champ, siret, user_id))
       in result

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -160,6 +160,20 @@ describe APIEntrepriseService do
       end
     end
 
+    context 'when API returns 429 (rate limited)' do
+      before do
+        stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)
+          .to_return(body: '{"errors":[]}', status: 429)
+      end
+
+      it 'falls back to degraded mode without checking ping' do
+        expect(APIEntrepriseService).not_to receive(:api_insee_up?)
+        expect(subject).to be_success
+        expect(subject.value!.siret).to eq(siret)
+        expect(subject.value!).to be_as_degraded_mode
+      end
+    end
+
     context 'when API returns 451' do
       before do
         stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)


### PR DESCRIPTION
## Summary
- Une erreur 429 (rate limited) de l'API Entreprise signifie que l'API fonctionne mais qu'on a dépassé notre quota
- Le ping de santé retourne "ok" dans ce cas, donc `degraded_mode?` retournait `false` et l'usager voyait une erreur bloquante
- On match désormais directement le `Failure(type: :rate_limited)` pour basculer en mode dégradé sans vérifier le ping

## Test plan
- [x] Vérifier que `create_etablissement_with_fallback` retourne un `Success` en mode dégradé quand l'API retourne 429
- [x] Vérifier que `api_insee_up?` n'est pas appelé sur une 429
- [x] Vérifier que les autres comportements (503 + ping down, 451, 404) ne sont pas impactés

🤖 Generated with [Claude Code](https://claude.com/claude-code)