### PR TITLE
Tech: circuit breaker par provider API Entreprise via les ping routes officielles

### DIFF
--- a/app/jobs/api_entreprise/job.rb
+++ b/app/jobs/api_entreprise/job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class APIEntreprise::Job < ApplicationJob
+  class RetryableError < StandardError; end
+
   include Dry::Monads[:result]
 
   queue_as :default
@@ -16,18 +18,39 @@ class APIEntreprise::Job < ApplicationJob
     'AttestationSocialeJob' => 100,
   }.freeze
 
+  # Maps each job to its API Entreprise provider ping key.
+  # Used by before_perform to skip jobs when provider is down.
+  # See https://entreprise.api.gouv.fr/developpeurs#surveillance-etat-fournisseurs
+  PING_KEY_BY_JOB = {
+    'EtablissementJob' => APIEntreprise::HealthChecker::PROVIDERS[:insee_sirene],
+    'EntrepriseJob' => APIEntreprise::HealthChecker::PROVIDERS[:insee_sirene],
+    'ExtraitKbisJob' => APIEntreprise::HealthChecker::PROVIDERS[:infogreffe_rcs],
+    'TvaJob' => APIEntreprise::HealthChecker::PROVIDERS[:european_commission_tva],
+    'AssociationJob' => APIEntreprise::HealthChecker::PROVIDERS[:djepva_association],
+    'ExercicesJob' => APIEntreprise::HealthChecker::PROVIDERS[:dgfip_chiffre_affaires],
+    'EffectifsJob' => APIEntreprise::HealthChecker::PROVIDERS[:gip_mds_effectifs],
+    'EffectifsAnnuelsJob' => APIEntreprise::HealthChecker::PROVIDERS[:gip_mds_effectifs],
+    'AttestationSocialeJob' => APIEntreprise::HealthChecker::PROVIDERS[:urssaf_attestation_sociale],
+    'AttestationFiscaleJob' => APIEntreprise::HealthChecker::PROVIDERS[:dgfip_attestation_fiscale],
+    'BilansBdfJob' => APIEntreprise::HealthChecker::PROVIDERS[:banque_de_france_bilans],
+    'ServiceJob' => APIEntreprise::HealthChecker::PROVIDERS[:insee_sirene],
+  }.freeze
+
   # If by the time the job runs the Etablissement has been deleted
   # (it can happen through EtablissementUpdateJob for instance), ignore the job
   discard_on ActiveRecord::RecordNotFound
 
-  # If rate limited for this pool, re-enqueue with delay and free the worker immediately.
+  # Skip job if provider is known to be down, then check rate limit.
+  # Health check first (cheap Redis read), rate limiter second.
   before_perform do
+    ping_key = ping_key_for_job
+    if ping_key && !APIEntreprise::HealthChecker.provider_up?(ping_key)
+      raise RetryableError, "Provider #{ping_key} is down, retrying later"
+    end
+
     pool = api_pool
     if APIEntreprise::RateLimiter.throttled?(pool)
-      wait = APIEntreprise::RateLimiter.wait_duration(pool)
-      jitter = rand(0..wait)
-      self.class.set(wait: (wait + jitter).seconds).perform_later(*arguments)
-      throw :abort
+      raise RetryableError, "Rate limited on pool #{pool}, retrying later"
     end
   end
 
@@ -61,8 +84,7 @@ class APIEntreprise::Job < ApplicationJob
     in Success
       nil
     in Failure(retryable: true, type: :rate_limited, code:, **)
-      wait = APIEntreprise::RateLimiter.wait_duration(api_pool)
-      self.class.set(wait: wait.seconds).perform_later(*arguments)
+      raise RetryableError, "Rate limited on pool #{api_pool}, retrying later"
     in Failure(retryable: true, type:, code:, raw_response:, **)
       raise StandardError, format_error(type, code, raw_response)
     in Failure(retryable: false, type:, code:, **)
@@ -76,6 +98,12 @@ class APIEntreprise::Job < ApplicationJob
   # Pool derived from job class name via POOL_BY_JOB.
   def api_pool
     POOL_BY_JOB.fetch(self.class.name.demodulize, APIEntreprise::API::DEFAULT_POOL)
+  end
+
+  # Ping key derived from job class name via PING_KEY_BY_JOB.
+  # Returns nil for unknown jobs (fail-open).
+  def ping_key_for_job
+    PING_KEY_BY_JOB[self.class.name.demodulize]
   end
 
   private

--- a/app/jobs/cron/api_entreprise_health_check_job.rb
+++ b/app/jobs/cron/api_entreprise_health_check_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Cron::APIEntrepriseHealthCheckJob < Cron::CronJob
+  self.schedule_expression = "every 2 minutes"
+
+  def perform
+    APIEntreprise::HealthChecker.refresh_all!
+  end
+end

--- a/app/lib/api_entreprise/health_checker.rb
+++ b/app/lib/api_entreprise/health_checker.rb
@@ -14,7 +14,7 @@ module APIEntreprise::HealthChecker
     dgfip_attestation_fiscale: 'dgfip/attestation_fiscale',
     gip_mds_effectifs: 'gip_mds/effectifs',
     urssaf_attestation_sociale: 'urssaf/attestation_sociale',
-    banque_de_france_bilans: 'banque_de_france/bilans'
+    banque_de_france_bilans: 'banque_de_france/bilans',
   }.freeze
 
   # ok = provider works correctly

--- a/app/lib/api_entreprise/health_checker.rb
+++ b/app/lib/api_entreprise/health_checker.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module APIEntreprise::HealthChecker
+  PING_BASE_URL = "#{API_ENTREPRISE_URL}/ping"
+  CACHE_KEY_PREFIX = "api_entreprise:health"
+  CACHE_TTL = 5.minutes
+
+  PROVIDERS = {
+    insee_sirene: 'insee/sirene',
+    infogreffe_rcs: 'infogreffe/rcs',
+    european_commission_tva: 'european_commission/numero_tva',
+    djepva_association: 'djepva/api-association',
+    dgfip_chiffre_affaires: 'dgfip/chiffre_affaires',
+    dgfip_attestation_fiscale: 'dgfip/attestation_fiscale',
+    gip_mds_effectifs: 'gip_mds/effectifs',
+    urssaf_attestation_sociale: 'urssaf/attestation_sociale',
+    banque_de_france_bilans: 'banque_de_france/bilans'
+  }.freeze
+
+  # ok = provider works correctly
+  # unknown = insufficient data to determine status (HTTP 200, fail-open by design)
+  UP_STATUSES = %w[ok unknown].freeze
+
+  def self.provider_up?(provider)
+    ping_key = provider.is_a?(Symbol) ? PROVIDERS.fetch(provider) : provider
+    status = cached_status(ping_key)
+    return true if status.nil? # fail-open: cache empty or Redis down
+    status.in?(UP_STATUSES)
+  end
+
+  def self.refresh_all!
+    hydra = Typhoeus::Hydra.new
+    PROVIDERS.each_value do |key|
+      request = Typhoeus::Request.new("#{PING_BASE_URL}/#{key}", timeout: 5)
+      request.on_complete { |response| store_response(key, response) }
+      hydra.queue(request)
+    end
+    hydra.run
+  end
+
+  def self.cached_status(ping_key)
+    Kredis.redis.get(cache_key(ping_key))
+  end
+
+  def self.cache_key(ping_key)
+    "#{CACHE_KEY_PREFIX}:#{ping_key}"
+  end
+
+  def self.store_response(ping_key, response)
+    status = JSON.parse(response.body)['status']
+    Kredis.redis.set(cache_key(ping_key), status, ex: CACHE_TTL.to_i)
+    status
+  rescue JSON::ParserError => e
+    Rails.logger.error("HealthChecker: JSON parse error for #{ping_key}: #{e.message}")
+    Sentry.capture_exception(e)
+    nil
+  rescue => e
+    Rails.logger.error("HealthChecker: refresh failed for #{ping_key}: #{e.class} #{e.message}")
+    Sentry.capture_exception(e)
+    nil
+  end
+end

--- a/app/models/concerns/rna_champ_association_fetchable_concern.rb
+++ b/app/models/concerns/rna_champ_association_fetchable_concern.rb
@@ -10,7 +10,7 @@ module RNAChampAssociationFetchableConcern
     in Success(data)
       update_external_data!(data: data.presence, value:)
       true
-    in Failure(retryable: true, **) => result if APIEntrepriseService.degraded_mode?(result.failure, target: :djepva)
+    in Failure(retryable: true, **) => result if !APIEntreprise::HealthChecker.provider_up?(:djepva_association)
       update_external_data!(data: nil, value:)
       errors.add(:value, :network_error)
       false

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -47,9 +47,9 @@ class APIEntrepriseService
     # Returns Failure(type:, code:, retryable:, raw_response:) on non-recoverable errors
     def create_etablissement_with_fallback(dossier_or_champ, siret, user_id = nil)
       case create_etablissement(dossier_or_champ, siret, user_id)
-      in Failure(type: :rate_limited, retryable: true, **)
+      in Failure(type: :rate_limited, **)
         Success(create_etablissement_as_degraded_mode(dossier_or_champ, siret, user_id))
-      in Failure(retryable: true, **) => failure if degraded_mode?(failure.failure, target: :insee)
+      in Failure(retryable: true, **) if !APIEntreprise::HealthChecker.provider_up?(:insee_sirene)
         Success(create_etablissement_as_degraded_mode(dossier_or_champ, siret, user_id))
       in result
         result
@@ -90,34 +90,6 @@ class APIEntrepriseService
         level: :error,
         extra: extra.merge(code: failure[:code], raw_body: failure[:raw_response]&.body&.truncate(1000))
       )
-    end
-
-    def degraded_mode?(failure, target: :insee)
-      return false unless failure[:retryable]
-      target == :insee ? !api_insee_up? : !api_djepva_up?
-    end
-
-    # See: https://entreprise.api.gouv.fr/developpeurs#surveillance-etat-fournisseurs
-    def api_insee_up?
-      api_up?("https://entreprise.api.gouv.fr/ping/insee/sirene")
-    end
-
-    def api_djepva_up?
-      api_up?("https://entreprise.api.gouv.fr/ping/djepva/api-association")
-    end
-
-    private
-
-    def api_up?(url)
-      response = Typhoeus.get(url, timeout: 1)
-      if response.success?
-        JSON.parse(response.body).fetch('status') == 'ok'
-      else
-        false
-      end
-    rescue => e
-      Sentry.capture_exception(e)
-      false
     end
   end
 end

--- a/spec/controllers/champs/rna_controller_spec.rb
+++ b/spec/controllers/champs/rna_controller_spec.rb
@@ -113,7 +113,7 @@ describe Champs::RNAController, type: :controller do
         let(:body) { File.read('spec/fixtures/files/api_entreprise/associations.json') }
 
         before do
-          expect(APIEntrepriseService).to receive(:api_djepva_up?).and_return(false)
+          allow(APIEntreprise::HealthChecker).to receive(:provider_up?).with(:djepva_association).and_return(false)
         end
 
         subject! { get :show, params: params, format: :turbo_stream }

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -434,7 +434,7 @@ describe Users::DossiersController, type: :controller do
     let(:api_etablissement_status) { 200 }
     let(:api_etablissement_body) { Rails.root.join('spec/fixtures/files/api_entreprise/etablissements.json').read }
     let(:token_expired) { false }
-    let(:api_insee_status_response) { nil }
+    let(:provider_up) { true }
 
     before do
       sign_in(user)
@@ -443,11 +443,7 @@ describe Users::DossiersController, type: :controller do
       allow_any_instance_of(APIEntrepriseToken).to receive(:roles)
         .and_return(["attestations_fiscales", "attestations_sociales", "bilans_entreprise_bdf"])
       allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(token_expired)
-
-      if api_insee_status_response
-        stub_request(:get, "https://entreprise.api.gouv.fr/ping/insee/sirene")
-          .to_return(body: api_insee_status_response)
-      end
+      allow(APIEntreprise::HealthChecker).to receive(:provider_up?).with(:insee_sirene).and_return(provider_up)
       travel_to(2.minutes.ago)
     end
 
@@ -492,14 +488,13 @@ describe Users::DossiersController, type: :controller do
 
       context 'When API-Entreprise is ponctually down' do
         let(:api_etablissement_status) { 502 }
-        let(:api_insee_status_response) { Rails.root.join('spec/fixtures/files/api_entreprise/ping.json').read }
 
         it_behaves_like 'the request fails with an error', I18n.t('errors.messages.siret.network_error')
       end
 
       context 'When API-Entreprise is globally down' do
         let(:api_etablissement_status) { 502 }
-        let(:api_insee_status_response) { Rails.root.join('spec/fixtures/files/api_entreprise/ping.json').read.gsub('ok', 'HASISSUES') }
+        let(:provider_up) { false }
 
         it "create an etablissement only with SIRET as degraded mode" do
           dossier.reload
@@ -516,7 +511,6 @@ describe Users::DossiersController, type: :controller do
 
       context 'when default token has expired' do
         let(:api_etablissement_status) { 200 }
-        let(:api_insee_status_response) { Rails.root.join('spec/fixtures/files/api_entreprise/ping.json').read }
         let(:token_expired) { true }
 
         it_behaves_like 'the request fails with an error', I18n.t('errors.messages.siret.network_error')

--- a/spec/jobs/api_entreprise/job_spec.rb
+++ b/spec/jobs/api_entreprise/job_spec.rb
@@ -30,10 +30,14 @@ RSpec.describe APIEntreprise::Job, type: :job do
     end
   end
 
-  describe 'before_perform rate limit check' do
+  describe 'before_perform checks' do
     let(:pool) { APIEntreprise::API::DEFAULT_POOL }
 
-    context 'when not throttled' do
+    before do
+      allow(APIEntreprise::HealthChecker).to receive(:provider_up?).and_return(true)
+    end
+
+    context 'when provider is up and not throttled' do
       before { allow(APIEntreprise::RateLimiter).to receive(:throttled?).with(pool).and_return(false) }
 
       it 'runs the job normally' do
@@ -44,31 +48,48 @@ RSpec.describe APIEntreprise::Job, type: :job do
       end
     end
 
-    context 'when throttled' do
+    context 'when provider is down' do
+      let(:ping_key) { 'insee/sirene' }
+
+      before do
+        allow_any_instance_of(ErrorJob).to receive(:ping_key_for_job).and_return(ping_key)
+        allow(APIEntreprise::HealthChecker).to receive(:provider_up?).with(ping_key).and_return(false)
+      end
+
+      it 'raises RetryableError without checking rate limit' do
+        dossier = create(:dossier, :with_entreprise)
+        etablissement = dossier.etablissement
+
+        expect(APIEntreprise::RateLimiter).not_to receive(:throttled?)
+        expect { ErrorJob.perform_now(etablissement) }
+          .to raise_error(APIEntreprise::Job::RetryableError, /Provider #{ping_key} is down/)
+      end
+    end
+
+    context 'when provider is up but throttled' do
       before do
         allow(APIEntreprise::RateLimiter).to receive(:throttled?).with(pool).and_return(true)
-        allow(APIEntreprise::RateLimiter).to receive(:wait_duration).with(pool).and_return(15)
       end
 
-      it 're-enqueues the job with delay and aborts' do
+      it 'raises RetryableError for rate limit' do
         dossier = create(:dossier, :with_entreprise)
         etablissement = dossier.etablissement
 
-        expect(ErrorJob).to receive(:set).with(wait: a_value_between(15.seconds, 30.seconds)).and_return(ErrorJob)
-        expect(ErrorJob).to receive(:perform_later).with(etablissement)
-
-        ErrorJob.perform_now(etablissement)
+        expect { ErrorJob.perform_now(etablissement) }
+          .to raise_error(APIEntreprise::Job::RetryableError, /Rate limited on pool #{pool}/)
       end
+    end
 
-      it 'does not execute the job body' do
+    context 'when job is not in PING_KEY_BY_JOB (fail-open)' do
+      it 'skips health check and proceeds' do
+        # ErrorJob is not in PING_KEY_BY_JOB, so ping_key_for_job returns nil
+        allow(APIEntreprise::RateLimiter).to receive(:throttled?).and_return(false)
+
         dossier = create(:dossier, :with_entreprise)
         etablissement = dossier.etablissement
 
-        allow(ErrorJob).to receive(:set).and_return(ErrorJob)
-        allow(ErrorJob).to receive(:perform_later)
-
-        # If the job body ran, it would raise — no raise means abort worked
-        expect { ErrorJob.perform_now(etablissement) }.not_to raise_error
+        # Job runs (raises from adapter, not from before_perform)
+        expect { ErrorJob.perform_now(etablissement) }.to raise_error(StandardError, /API Entreprise error/)
       end
     end
   end
@@ -91,6 +112,37 @@ RSpec.describe APIEntreprise::Job, type: :job do
 
     it 'defaults to 250 for unknown job classes' do
       expect(ErrorJob.new.api_pool).to eq(250)
+    end
+  end
+
+  describe '#ping_key_for_job' do
+    it 'returns the correct ping key for each job class' do
+      expect(APIEntreprise::EtablissementJob.new.ping_key_for_job).to eq('insee/sirene')
+      expect(APIEntreprise::EntrepriseJob.new.ping_key_for_job).to eq('insee/sirene')
+      expect(APIEntreprise::ExtraitKbisJob.new.ping_key_for_job).to eq('infogreffe/rcs')
+      expect(APIEntreprise::TvaJob.new.ping_key_for_job).to eq('european_commission/numero_tva')
+      expect(APIEntreprise::AssociationJob.new.ping_key_for_job).to eq('djepva/api-association')
+      expect(APIEntreprise::ExercicesJob.new.ping_key_for_job).to eq('dgfip/chiffre_affaires')
+      expect(APIEntreprise::EffectifsJob.new.ping_key_for_job).to eq('gip_mds/effectifs')
+      expect(APIEntreprise::EffectifsAnnuelsJob.new.ping_key_for_job).to eq('gip_mds/effectifs')
+      expect(APIEntreprise::AttestationSocialeJob.new.ping_key_for_job).to eq('urssaf/attestation_sociale')
+      expect(APIEntreprise::AttestationFiscaleJob.new.ping_key_for_job).to eq('dgfip/attestation_fiscale')
+      expect(APIEntreprise::BilansBdfJob.new.ping_key_for_job).to eq('banque_de_france/bilans')
+      expect(APIEntreprise::ServiceJob.new.ping_key_for_job).to eq('insee/sirene')
+    end
+
+    it 'returns nil for unknown job classes (fail-open)' do
+      expect(ErrorJob.new.ping_key_for_job).to be_nil
+    end
+  end
+
+  describe 'PING_KEY_BY_JOB completeness' do
+    it 'covers all job classes in app/jobs/api_entreprise/' do
+      job_files = Rails.root.glob('app/jobs/api_entreprise/*_job.rb')
+      job_class_names = job_files.map { |f| File.basename(f, '.rb').camelize }
+
+      mapped = described_class::PING_KEY_BY_JOB.keys
+      expect(mapped).to match_array(job_class_names)
     end
   end
 
@@ -154,17 +206,9 @@ RSpec.describe APIEntreprise::Job, type: :job do
           .and_return(Dry::Monads::Failure(type: :rate_limited, code: 429, retryable: true, raw_response: nil))
       end
 
-      it 're-enqueues the job with wait from RateLimiter.wait_duration' do
-        allow(APIEntreprise::RateLimiter).to receive(:wait_duration).and_return(20)
-        expect(described_class).to receive(:set).with(wait: 20.seconds).and_return(described_class)
-        expect(described_class).to receive(:perform_later)
-        job.send(:with_adapter, adapter) { |_| }
-      end
-
-      it 'does not raise' do
-        allow(described_class).to receive(:set).and_return(described_class)
-        allow(described_class).to receive(:perform_later)
-        expect { job.send(:with_adapter, adapter) { |_| } }.not_to raise_error
+      it 'raises RetryableError for Sidekiq exponential backoff' do
+        expect { job.send(:with_adapter, adapter) { |_| } }
+          .to raise_error(APIEntreprise::Job::RetryableError, /Rate limited on pool/)
       end
     end
 

--- a/spec/jobs/cron/api_entreprise_health_check_job_spec.rb
+++ b/spec/jobs/cron/api_entreprise_health_check_job_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe Cron::APIEntrepriseHealthCheckJob, type: :job do
+  describe '#perform' do
+    it 'refreshes all provider statuses' do
+      expect(APIEntreprise::HealthChecker).to receive(:refresh_all!)
+      described_class.perform_now
+    end
+  end
+end

--- a/spec/lib/api_entreprise/health_checker_spec.rb
+++ b/spec/lib/api_entreprise/health_checker_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe APIEntreprise::HealthChecker do
+  before do
+    APIEntreprise::HealthChecker::PROVIDERS.each_value do |key|
+      Kredis.redis.del(APIEntreprise::HealthChecker.cache_key(key))
+    end
+  end
+
+  describe '.provider_up?' do
+    let(:ping_key) { 'european_commission/numero_tva' }
+
+    context 'when status is ok' do
+      before { cache_status(ping_key, 'ok') }
+
+      it { expect(described_class.provider_up?(ping_key)).to be true }
+    end
+
+    context 'when status is unknown' do
+      before { cache_status(ping_key, 'unknown') }
+
+      it { expect(described_class.provider_up?(ping_key)).to be true }
+    end
+
+    context 'when status is bad_gateway' do
+      before { cache_status(ping_key, 'bad_gateway') }
+
+      it { expect(described_class.provider_up?(ping_key)).to be false }
+    end
+
+    context 'when status is maintenance' do
+      before { cache_status(ping_key, 'maintenance') }
+
+      it { expect(described_class.provider_up?(ping_key)).to be false }
+    end
+
+    context 'when cache is empty (fail-open)' do
+      it { expect(described_class.provider_up?(ping_key)).to be true }
+    end
+  end
+
+  describe '.refresh_all!' do
+    before do
+      APIEntreprise::HealthChecker::PROVIDERS.each_value do |key|
+        stub_request(:get, "#{described_class::PING_BASE_URL}/#{key}")
+          .to_return(status: 200, body: { status: 'ok' }.to_json)
+      end
+    end
+
+    it 'caches all provider statuses' do
+      described_class.refresh_all!
+
+      APIEntreprise::HealthChecker::PROVIDERS.each_value do |key|
+        expect(described_class.cached_status(key)).to eq('ok')
+      end
+    end
+
+    context 'when a provider returns bad_gateway' do
+      before do
+        stub_request(:get, "#{described_class::PING_BASE_URL}/insee/sirene")
+          .to_return(status: 502, body: { status: 'bad_gateway' }.to_json)
+      end
+
+      it 'caches the bad_gateway status' do
+        described_class.refresh_all!
+        expect(described_class.cached_status('insee/sirene')).to eq('bad_gateway')
+      end
+    end
+
+    context 'when a provider times out' do
+      before do
+        stub_request(:get, "#{described_class::PING_BASE_URL}/insee/sirene").to_timeout
+      end
+
+      it 'captures exception in Sentry' do
+        expect(Sentry).to receive(:capture_exception)
+        described_class.refresh_all!
+      end
+
+      it 'does not overwrite existing cache for that provider' do
+        cache_status('insee/sirene', 'ok')
+        described_class.refresh_all!
+        expect(described_class.cached_status('insee/sirene')).to eq('ok')
+      end
+    end
+
+    context 'when a provider returns invalid JSON' do
+      before do
+        stub_request(:get, "#{described_class::PING_BASE_URL}/insee/sirene")
+          .to_return(status: 200, body: 'not json')
+      end
+
+      it 'captures exception in Sentry' do
+        expect(Sentry).to receive(:capture_exception)
+        described_class.refresh_all!
+      end
+    end
+  end
+
+  private
+
+  def cache_status(ping_key, status)
+    Kredis.redis.set(described_class.cache_key(ping_key), status, ex: 300)
+  end
+end

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -94,7 +94,7 @@ describe Champs::SiretChamp do
       let(:siret) { '82161143100015' }
       let(:api_etablissement_status) { 503 }
 
-      before { expect(APIEntrepriseService).to receive(:api_insee_up?).and_return(true) }
+      before { allow(APIEntreprise::HealthChecker).to receive(:provider_up?).with(:insee_sirene).and_return(true) }
 
       it_behaves_like 'an error occured'
 
@@ -108,7 +108,7 @@ describe Champs::SiretChamp do
       let(:siret) { '82161143100015' }
       let(:api_etablissement_status) { 502 }
 
-      before { expect(APIEntrepriseService).to receive(:api_insee_up?).and_return(false) }
+      before { allow(APIEntreprise::HealthChecker).to receive(:provider_up?).with(:insee_sirene).and_return(false) }
 
       it { expect { fetch_external_data }.to change { champ.reload.etablissement } }
 

--- a/spec/models/concerns/rna_champ_association_fetchable_concern_spec.rb
+++ b/spec/models/concerns/rna_champ_association_fetchable_concern_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe RNAChampAssociationFetchableConcern do
       let(:status) { 503 }
       let(:body) { File.read('spec/fixtures/files/api_entreprise/associations.json') }
 
-      before { expect(APIEntrepriseService).to receive(:api_djepva_up?).and_return(false) }
+      before { allow(APIEntreprise::HealthChecker).to receive(:provider_up?).with(:djepva_association).and_return(false) }
 
       it_behaves_like "an association fetcher", false, :network_error, 'W595001988', nil
     end

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -137,7 +137,7 @@ describe APIEntrepriseService do
       before do
         stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)
           .to_return(body: '', status: 503)
-        allow(APIEntrepriseService).to receive(:api_insee_up?).and_return(false)
+        allow(APIEntreprise::HealthChecker).to receive(:provider_up?).with(:insee_sirene).and_return(false)
       end
 
       it 'returns Success with degraded etablissement' do
@@ -151,7 +151,7 @@ describe APIEntrepriseService do
       before do
         stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)
           .to_return(body: '', status: 503)
-        allow(APIEntrepriseService).to receive(:api_insee_up?).and_return(true)
+        allow(APIEntreprise::HealthChecker).to receive(:provider_up?).with(:insee_sirene).and_return(true)
       end
 
       it 'returns the original Failure' do
@@ -163,11 +163,11 @@ describe APIEntrepriseService do
     context 'when API returns 429 (rate limited)' do
       before do
         stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)
-          .to_return(body: '{"errors":[]}', status: 429)
+          .to_return(body: '', status: 429)
       end
 
-      it 'falls back to degraded mode without checking ping' do
-        expect(APIEntrepriseService).not_to receive(:api_insee_up?)
+      it 'falls back to degraded mode without checking provider health' do
+        expect(APIEntreprise::HealthChecker).not_to receive(:provider_up?)
         expect(subject).to be_success
         expect(subject.value!.siret).to eq(siret)
         expect(subject.value!).to be_as_degraded_mode
@@ -211,38 +211,6 @@ describe APIEntrepriseService do
       )
 
       APIEntrepriseService.report_error(failure, siret: '123')
-    end
-  end
-
-  describe "#api_insee_up?" do
-    subject { described_class.api_insee_up? }
-    let(:body) { Rails.root.join('spec/fixtures/files/api_entreprise/ping.json').read }
-    let(:status) { 200 }
-
-    before do
-      stub_request(:get, "https://entreprise.api.gouv.fr/ping/insee/sirene")
-        .to_return(body: body, status: status)
-    end
-
-    it "returns true when api etablissement is up" do
-      expect(subject).to be_truthy
-    end
-
-    context "when api entreprise is down" do
-      let(:body) { Rails.root.join('spec/fixtures/files/api_entreprise/ping.json').read.gsub('ok', 'HASISSUES') }
-
-      it "returns false" do
-        expect(subject).to be_falsey
-      end
-    end
-
-    context "when api entreprise status is unknown" do
-      let(:body) { "" }
-      let(:status) { 0 }
-
-      it "returns nil" do
-        expect(subject).to be_falsey
-      end
     end
   end
 end


### PR DESCRIPTION
# Probleme

Certains providers API Entreprise sont down pendant plusieurs jours (ex: Commission Europeenne TVA a 55% d'uptime sur 90 jours). Les jobs Sidekiq continuent de requeter ces APIs mortes, se re-enqueue manuellement, et saturent les queues — effet boule de neige.

De plus, chaque appel a un endpoint down consomme du budget sur le rate limit du pool concerne. On brule des requetes pour rien, ce qui reduit la capacite disponible pour les providers qui fonctionnent.

Les health checks existants (`api_insee_up?`, `api_djepva_up?`) faisaient un appel HTTP synchrone a chaque invocation, ne couvraient que 2 providers sur 9, et n'etaient utilises que dans le chemin synchrone (`degraded_mode?`), pas dans les jobs.

# Solution

Circuit breaker centralise base sur les [ping routes officielles](https://entreprise.api.gouv.fr/developpeurs#surveillance-etat-fournisseurs) d'API Entreprise.

**`APIEntreprise::HealthChecker`** — module qui cache les statuts providers dans Redis (TTL 5 min). Design fail-open : si le cache est vide ou Redis down, les jobs passent normalement.

**`Cron::APIEntrepriseHealthCheckJob`** — rafraichit les 9 providers toutes les 2 minutes via les ping routes (gratuites, sans rate limit).

**`APIEntreprise::Job#before_perform`** — verifie le statut provider avant chaque job. Si le provider est down, raise `RetryableError` pour declencher le backoff exponentiel natif de Sidekiq (`retry^4 + 15 + jitter`) au lieu de re-enqueue manuel. Zero appel API, zero consommation de rate limit.

Les 12 jobs sont mappes a leur provider via `PING_KEY_BY_JOB`, avec un test de completeness qui empeche d'oublier un nouveau job.

`api_insee_up?` / `api_djepva_up?` / `api_up?` sont supprimes, remplaces par `HealthChecker.provider_up?` dans `degraded_mode?`.

Generated with [Claude Code](https://claude.com/claude-code)