### PR TITLE
ETQ usager, corrige l'affichage des formats de fichier acceptés

### DIFF
--- a/app/javascript/controllers/autosave_controller.ts
+++ b/app/javascript/controllers/autosave_controller.ts
@@ -7,6 +7,7 @@ import {
   FAILURE_CLIENT,
   FileUploadError
 } from '../shared/activestorage/file-upload-error';
+import { parseAcceptForDisplay } from '../shared/accept-format';
 import {
   hideAttachmentError,
   showAttachmentError
@@ -313,126 +314,6 @@ export class AutosaveController extends ApplicationController {
     showAttachmentError(input, uniqueErrors);
   }
 
-  /**
-   * Parse l'attribut accept pour générer un label lisible
-   * Extrait les extensions et catégories MIME directement depuis accept
-   * @example ".pdf,.docx,image/*" → "PDF, DOCX, images"
-   */
-  private parseAcceptForDisplay(accept: string): string {
-    const acceptedFormats = accept
-      .split(',')
-      .map((format) => format.trim().toLowerCase());
-
-    const displayItems: string[] = [];
-
-    for (const format of acceptedFormats) {
-      if (format.startsWith('.')) {
-        const ext = format.substring(1).toUpperCase();
-        if (!displayItems.includes(ext)) {
-          displayItems.push(ext);
-        }
-      } else if (format.includes('/*')) {
-        const category = format.split('/')[0];
-        const label = this.getFormatFamilyLabel(category);
-        if (!displayItems.includes(label)) {
-          displayItems.push(label);
-        }
-      } else {
-        const label = this.getMimeTypeLabel(format);
-        if (label && !displayItems.includes(label)) {
-          displayItems.push(label);
-        }
-      }
-    }
-
-    // Si aucune extension/wildcard/MIME type reconnu, message générique
-    if (displayItems.length === 0) {
-      return 'certains formats spécifiques';
-    }
-
-    return displayItems.join(', ');
-  }
-
-  /**
-   * Retourne le label correspondant à une famille de formats
-   * Basé sur FORMAT_FAMILY_EXAMPLES de config/initializers/authorized_content_types.rb
-   */
-  private getFormatFamilyLabel(mimeCategory: string): string {
-    const formatFamilyLabels: Record<string, string> = {
-      // Correspond à FORMAT_FAMILY_EXAMPLES[:image_scan]
-      image: '.jpg, .jpeg, .png',
-      // Correspond à FORMAT_FAMILY_EXAMPLES[:video]
-      video: '.mp4, .mov, .avi, .wmv',
-      // Correspond à FORMAT_FAMILY_EXAMPLES[:audio]
-      audio: '.mp3, .wav, .aac, .m4a',
-      // Correspond à FORMAT_FAMILY_EXAMPLES[:document_texte] (partiel)
-      application: '.pdf, .doc, .docx, .odt, .txt',
-      // Correspond à FORMAT_FAMILY_EXAMPLES[:donnees] (partiel)
-      text: '.xml, .json, .txt, .csv'
-    };
-
-    return formatFamilyLabels[mimeCategory] || mimeCategory;
-  }
-
-  /**
-   * Convertit un MIME type exact vers son label correspondant de FORMAT_FAMILY_EXAMPLES
-   * Mapping basé sur FORMAT_FAMILIES (config/initializers/authorized_content_types.rb)
-   */
-  private getMimeTypeLabel(mimeType: string): string | null {
-    // Mapping des MIME types utilisés dans FORMAT_FAMILIES vers leurs labels
-    const mimeToFamilyLabel: Record<string, string> = {
-      // image_scan → '.jpg, .jpeg, .png'
-      'image/jpeg': '.jpg, .jpeg, .png',
-      'image/png': '.jpg, .jpeg, .png',
-
-      // document_texte → '.pdf, .doc, .docx, .odt, .txt'
-      'application/pdf': '.pdf, .doc, .docx, .odt, .txt',
-      'application/x-pdf': '.pdf, .doc, .docx, .odt, .txt',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
-        '.pdf, .doc, .docx, .odt, .txt',
-      'application/vnd.oasis.opendocument.text':
-        '.pdf, .doc, .docx, .odt, .txt',
-      'application/msword': '.pdf, .doc, .docx, .odt, .txt',
-      'text/plain': '.pdf, .doc, .docx, .odt, .txt',
-
-      // tableur → '.xls, .xlsx, .ods, .csv'
-      'application/vnd.ms-excel': '.xls, .xlsx, .ods, .csv',
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
-        '.xls, .xlsx, .ods, .csv',
-      'application/vnd.oasis.opendocument.spreadsheet':
-        '.xls, .xlsx, .ods, .csv',
-      'text/csv': '.xls, .xlsx, .ods, .csv',
-
-      // presentation → '.ppt, .pptx, .odp'
-      'application/vnd.openxmlformats-officedocument.presentationml.presentation':
-        '.ppt, .pptx, .odp',
-      'application/vnd.ms-powerpoint': '.ppt, .pptx, .odp',
-
-      // audio → '.mp3, .wav, .aac, .m4a'
-      'audio/mpeg': '.mp3, .wav, .aac, .m4a',
-      'audio/mp4': '.mp3, .wav, .aac, .m4a',
-      'audio/x-m4a': '.mp3, .wav, .aac, .m4a',
-      'audio/aac': '.mp3, .wav, .aac, .m4a',
-      'audio/x-wav': '.mp3, .wav, .aac, .m4a',
-
-      // video → '.mp4, .mov, .avi, .wmv'
-      'video/mp4': '.mp4, .mov, .avi, .wmv',
-      'video/quicktime': '.mp4, .mov, .avi, .wmv',
-      'video/3gpp': '.mp4, .mov, .avi, .wmv',
-      'video/x-ms-wm': '.mp4, .mov, .avi, .wmv',
-
-      // archive → '.zip, .rar, .7z, .gz'
-      'application/zip': '.zip, .rar, .7z, .gz',
-      'application/x-zip-compressed': '.zip, .rar, .7z, .gz',
-      'application/x-7z-compressed': '.zip, .rar, .7z, .gz',
-      'application/vnd.rar': '.zip, .rar, .7z, .gz',
-      'application/x-rar': '.zip, .rar, .7z, .gz',
-      'application/gzip': '.zip, .rar, .7z, .gz'
-    };
-
-    return mimeToFamilyLabel[mimeType] || null;
-  }
-
   private checkFileFormat(input: HTMLInputElement, file: File): string | null {
     const accept = input.accept;
     if (!accept) return null;
@@ -457,7 +338,7 @@ export class AutosaveController extends ApplicationController {
 
     if (!isAccepted) {
       // Parser accept directement pour construire le message d'erreur
-      const formatsLabel = this.parseAcceptForDisplay(accept);
+      const formatsLabel = parseAcceptForDisplay(accept);
       return `Les formats de fichier acceptés sont :&nbsp;<strong>${formatsLabel}</strong>.`;
     }
 

--- a/app/javascript/shared/accept-format.test.ts
+++ b/app/javascript/shared/accept-format.test.ts
@@ -1,0 +1,45 @@
+import { suite, test, expect } from 'vitest';
+
+import { parseAcceptForDisplay } from './accept-format';
+
+suite('@accept-format', () => {
+  suite('parseAcceptForDisplay', () => {
+    test('returns uppercase extensions for a .ext-only accept', () => {
+      expect(parseAcceptForDisplay('.pdf, .docx')).toBe('PDF, DOCX');
+    });
+
+    test('returns a family label for a wildcard MIME category', () => {
+      expect(parseAcceptForDisplay('image/*')).toBe('.jpg, .jpeg, .png');
+    });
+
+    test('falls back to a generic label when nothing is recognised', () => {
+      expect(parseAcceptForDisplay('')).toBe('certains formats spécifiques');
+    });
+
+    test('does not emit an extension twice when accept mixes MIME types and their .ext', () => {
+      const accept = 'application/pdf, image/jpeg, .pdf, .jpeg';
+
+      const result = parseAcceptForDisplay(accept);
+
+      // Chaque extension ne doit apparaître qu'une fois (peu importe la casse,
+      // peu importe la présence d'un point initial). On extrait toutes les
+      // extensions du résultat et on vérifie l'absence de doublons.
+      const extensions = result
+        .split(',')
+        .map((token) => token.trim().replace(/^\./, '').toLowerCase());
+      const duplicates = extensions.filter(
+        (ext, index) => extensions.indexOf(ext) !== index
+      );
+
+      expect(duplicates).toEqual([]);
+    });
+
+    test('keeps an extension that is not covered by any family label', () => {
+      // .acidcsa est ajouté côté Ruby à côté de application/octet-stream :
+      // aucun mapping family ne le couvre, il doit donc rester dans le rendu.
+      const accept = 'application/pdf, .pdf, .acidcsa';
+
+      expect(parseAcceptForDisplay(accept)).toContain('ACIDCSA');
+    });
+  });
+});

--- a/app/javascript/shared/accept-format.test.ts
+++ b/app/javascript/shared/accept-format.test.ts
@@ -4,8 +4,8 @@ import { parseAcceptForDisplay } from './accept-format';
 
 suite('@accept-format', () => {
   suite('parseAcceptForDisplay', () => {
-    test('returns uppercase extensions for a .ext-only accept', () => {
-      expect(parseAcceptForDisplay('.pdf, .docx')).toBe('PDF, DOCX');
+    test('returns lowercase dotted extensions for a .ext-only accept', () => {
+      expect(parseAcceptForDisplay('.pdf, .docx')).toBe('.pdf, .docx');
     });
 
     test('returns a family label for a wildcard MIME category', () => {
@@ -39,7 +39,7 @@ suite('@accept-format', () => {
       // aucun mapping family ne le couvre, il doit donc rester dans le rendu.
       const accept = 'application/pdf, .pdf, .acidcsa';
 
-      expect(parseAcceptForDisplay(accept)).toContain('ACIDCSA');
+      expect(parseAcceptForDisplay(accept)).toContain('.acidcsa');
     });
   });
 });

--- a/app/javascript/shared/accept-format.ts
+++ b/app/javascript/shared/accept-format.ts
@@ -1,0 +1,159 @@
+/**
+ * Helpers pour générer un libellé lisible à partir d'un attribut HTML `accept`.
+ *
+ * L'attribut `accept` côté Ruby (Attachment::Validation#content_types_with_extensions)
+ * concatène volontairement MIME types ET extensions (.ext) pour la compatibilité
+ * navigateur. Ces helpers s'occupent de produire un texte unique pour l'utilisateur
+ * sans dupliquer chaque extension (une fois via label famille, une fois via .ext).
+ */
+
+/**
+ * Retourne le label d'une famille de formats à partir d'une catégorie MIME (image, video, …).
+ * Basé sur FORMAT_FAMILY_EXAMPLES de config/initializers/authorized_content_types.rb
+ */
+function getFormatFamilyLabel(mimeCategory: string): string {
+  const formatFamilyLabels: Record<string, string> = {
+    // Correspond à FORMAT_FAMILY_EXAMPLES[:image_scan]
+    image: '.jpg, .jpeg, .png',
+    // Correspond à FORMAT_FAMILY_EXAMPLES[:video]
+    video: '.mp4, .mov, .avi, .wmv',
+    // Correspond à FORMAT_FAMILY_EXAMPLES[:audio]
+    audio: '.mp3, .wav, .aac, .m4a',
+    // Correspond à FORMAT_FAMILY_EXAMPLES[:document_texte] (partiel)
+    application: '.pdf, .doc, .docx, .odt, .txt',
+    // Correspond à FORMAT_FAMILY_EXAMPLES[:donnees] (partiel)
+    text: '.xml, .json, .txt, .csv'
+  };
+
+  return formatFamilyLabels[mimeCategory] || mimeCategory;
+}
+
+/**
+ * Convertit un MIME type exact vers son label famille.
+ * Mapping basé sur FORMAT_FAMILIES (config/initializers/authorized_content_types.rb)
+ */
+function getMimeTypeLabel(mimeType: string): string | null {
+  // Mapping des MIME types utilisés dans FORMAT_FAMILIES vers leurs labels
+  const mimeToFamilyLabel: Record<string, string> = {
+    // image_scan → '.jpg, .jpeg, .png'
+    'image/jpeg': '.jpg, .jpeg, .png',
+    'image/png': '.jpg, .jpeg, .png',
+
+    // document_texte → '.pdf, .doc, .docx, .odt, .txt'
+    'application/pdf': '.pdf, .doc, .docx, .odt, .txt',
+    'application/x-pdf': '.pdf, .doc, .docx, .odt, .txt',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+      '.pdf, .doc, .docx, .odt, .txt',
+    'application/vnd.oasis.opendocument.text': '.pdf, .doc, .docx, .odt, .txt',
+    'application/msword': '.pdf, .doc, .docx, .odt, .txt',
+    'text/plain': '.pdf, .doc, .docx, .odt, .txt',
+
+    // tableur → '.xls, .xlsx, .ods, .csv'
+    'application/vnd.ms-excel': '.xls, .xlsx, .ods, .csv',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+      '.xls, .xlsx, .ods, .csv',
+    'application/vnd.oasis.opendocument.spreadsheet': '.xls, .xlsx, .ods, .csv',
+    'text/csv': '.xls, .xlsx, .ods, .csv',
+
+    // presentation → '.ppt, .pptx, .odp'
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation':
+      '.ppt, .pptx, .odp',
+    'application/vnd.ms-powerpoint': '.ppt, .pptx, .odp',
+
+    // audio → '.mp3, .wav, .aac, .m4a'
+    'audio/mpeg': '.mp3, .wav, .aac, .m4a',
+    'audio/mp4': '.mp3, .wav, .aac, .m4a',
+    'audio/x-m4a': '.mp3, .wav, .aac, .m4a',
+    'audio/aac': '.mp3, .wav, .aac, .m4a',
+    'audio/x-wav': '.mp3, .wav, .aac, .m4a',
+
+    // video → '.mp4, .mov, .avi, .wmv'
+    'video/mp4': '.mp4, .mov, .avi, .wmv',
+    'video/quicktime': '.mp4, .mov, .avi, .wmv',
+    'video/3gpp': '.mp4, .mov, .avi, .wmv',
+    'video/x-ms-wm': '.mp4, .mov, .avi, .wmv',
+
+    // archive → '.zip, .rar, .7z, .gz'
+    'application/zip': '.zip, .rar, .7z, .gz',
+    'application/x-zip-compressed': '.zip, .rar, .7z, .gz',
+    'application/x-7z-compressed': '.zip, .rar, .7z, .gz',
+    'application/vnd.rar': '.zip, .rar, .7z, .gz',
+    'application/x-rar': '.zip, .rar, .7z, .gz',
+    'application/gzip': '.zip, .rar, .7z, .gz'
+  };
+
+  return mimeToFamilyLabel[mimeType] || null;
+}
+
+/**
+ * Extrait les extensions (sans point, en minuscules) d'un label famille
+ * du type ".pdf, .doc, .docx".
+ */
+function extensionsFromLabel(label: string): string[] {
+  return label
+    .split(',')
+    .map((token) => token.trim().replace(/^\./, '').toLowerCase())
+    .filter((ext) => ext.length > 0);
+}
+
+/**
+ * Parse l'attribut accept pour générer un label lisible.
+ *
+ * L'attribut accept produit côté Ruby contient à la fois les MIME types
+ * et leurs extensions (.ext). Pour éviter d'afficher chaque extension deux
+ * fois, on émet d'abord les labels famille (issus des MIME types), puis on
+ * n'ajoute que les .ext qui ne sont couvertes par aucun label.
+ *
+ * @example ".pdf, .docx" → "PDF, DOCX"
+ * @example "image/*" → ".jpg, .jpeg, .png"
+ * @example "application/pdf, .pdf" → ".pdf, .doc, .docx, .odt, .txt"
+ */
+export function parseAcceptForDisplay(accept: string): string {
+  const acceptedFormats = accept
+    .split(',')
+    .map((format) => format.trim().toLowerCase())
+    .filter((format) => format.length > 0);
+
+  const familyLabels: string[] = [];
+  const coveredExtensions = new Set<string>();
+  const standaloneExtensions: string[] = [];
+
+  for (const format of acceptedFormats) {
+    if (format.startsWith('.')) {
+      const ext = format.substring(1);
+      if (ext.length > 0 && !standaloneExtensions.includes(ext)) {
+        standaloneExtensions.push(ext);
+      }
+    } else if (format.includes('/*')) {
+      const category = format.split('/')[0];
+      const label = getFormatFamilyLabel(category);
+      if (!familyLabels.includes(label)) {
+        familyLabels.push(label);
+        for (const ext of extensionsFromLabel(label)) {
+          coveredExtensions.add(ext);
+        }
+      }
+    } else {
+      const label = getMimeTypeLabel(format);
+      if (label && !familyLabels.includes(label)) {
+        familyLabels.push(label);
+        for (const ext of extensionsFromLabel(label)) {
+          coveredExtensions.add(ext);
+        }
+      }
+    }
+  }
+
+  const uncoveredExtensions = standaloneExtensions
+    .filter((ext) => !coveredExtensions.has(ext))
+    .map((ext) => ext.toUpperCase());
+
+  const displayItems = [...familyLabels, ...uncoveredExtensions];
+
+  // Si aucune extension/wildcard/MIME type reconnu, message générique
+  if (displayItems.length === 0) {
+    return 'certains formats spécifiques';
+  }
+
+  return displayItems.join(', ');
+}

--- a/app/javascript/shared/accept-format.ts
+++ b/app/javascript/shared/accept-format.ts
@@ -104,7 +104,7 @@ function extensionsFromLabel(label: string): string[] {
  * fois, on émet d'abord les labels famille (issus des MIME types), puis on
  * n'ajoute que les .ext qui ne sont couvertes par aucun label.
  *
- * @example ".pdf, .docx" → "PDF, DOCX"
+ * @example ".pdf, .docx" → ".pdf, .docx"
  * @example "image/*" → ".jpg, .jpeg, .png"
  * @example "application/pdf, .pdf" → ".pdf, .doc, .docx, .odt, .txt"
  */
@@ -146,7 +146,7 @@ export function parseAcceptForDisplay(accept: string): string {
 
   const uncoveredExtensions = standaloneExtensions
     .filter((ext) => !coveredExtensions.has(ext))
-    .map((ext) => ext.toUpperCase());
+    .map((ext) => `.${ext}`);
 
   const displayItems = [...familyLabels, ...uncoveredExtensions];
 

--- a/config/initializers/authorized_content_types.rb
+++ b/config/initializers/authorized_content_types.rb
@@ -78,6 +78,7 @@ AUTHORIZED_CONTENT_TYPES = PROCESSABLE_TYPES + AUTHORIZED_SPREADSHEET_TYPES + [
   'application/msword', # text x 30167
   'text/plain', # text x 24477
   'text/markdown', # text .md
+  'text/x-markdown', # text .md (variante legacy renvoyée par certains navigateurs/OS)
   'application/vnd.openxmlformats-officedocument.presentationml.presentation', # text x 3231
   'application/rtf', # text x 1438
   'application/vnd.apple.pages', # text x 609
@@ -112,6 +113,7 @@ FORMAT_FAMILIES = {
     'application/msword',
     'text/plain',
     'text/markdown',
+    'text/x-markdown',
     'application/rtf',
     'application/vnd.apple.pages',
   ],

--- a/spec/models/champs/piece_justificative_champ_spec.rb
+++ b/spec/models/champs/piece_justificative_champ_spec.rb
@@ -29,6 +29,13 @@ describe Champs::PieceJustificativeChamp do
         expect(champ.errors[:piece_justificative_file]).to be_present
       end
 
+      it "accepts a markdown file declared as the legacy text/x-markdown content type" do
+        champ.piece_justificative_file.purge
+        champ.piece_justificative_file.attach(io: StringIO.new('# titre'), filename: 'notes.md', content_type: 'text/x-markdown')
+
+        expect(champ.valid?(:champs_public_value)).to be true
+      end
+
       it "does not validate public PJ when validating private context" do
         champ.piece_justificative_file.attach(
           io: StringIO.new('x'),
@@ -121,6 +128,12 @@ describe Champs::PieceJustificativeChamp do
         champ.piece_justificative_file.attach(io: StringIO.new('x'), filename: 'arc.zip', content_type: 'application/zip')
         expect(champ.valid?(:champs_public_value)).to be false
         expect(champ.errors[:piece_justificative_file]).to be_present
+      end
+
+      it 'accepts markdown declared as the legacy text/x-markdown content type' do
+        champ.piece_justificative_file.purge
+        champ.piece_justificative_file.attach(io: StringIO.new('# titre'), filename: 'notes.md', content_type: 'text/x-markdown')
+        expect(champ.valid?(:champs_public_value)).to be true
       end
     end
 


### PR DESCRIPTION
Essentiellement un refacto avec extraction d'un module JS. Au dépôt d'une pièce justificative dans un format non autorisé, le message « Les formats de fichier acceptés sont… » affichait certaines extensions en double (une fois via le libellé de famille, une fois via l'extension `.ext` ce qui créé de la confusion).

- Déduplication des extensions dans le message d'erreur côté client.
- Harmonisation des extensions en minuscules avec le point (`.ext`).
- Extraction de la logique d'affichage dans un module partagé `accept-format.ts` + tests
- Sur le chemin acceptation du content type legacy `text/x-markdown` (renvoyé par certains navigateurs/OS pour les fichiers `.md`).
<img width="1233" height="307" alt="Capture d’écran 2026-05-28 à 16 48 41" src="https://github.com/user-attachments/assets/c8ea1b4d-5419-4867-adca-bb4595d8a373" />


## AVANT
<img width="1233" height="326" alt="Capture d’écran 2026-05-28 à 18 10 42" src="https://github.com/user-attachments/assets/f511e79f-3d32-47f3-b7a7-63912f29459b" />
