### PR TITLE
WIP - Tech: Correction open redirect dans rdv_connections#destroy

### DIFF
--- a/app/controllers/instructeurs/rdv_connections_controller.rb
+++ b/app/controllers/instructeurs/rdv_connections_controller.rb
@@ -10,7 +10,7 @@ module Instructeurs
     def destroy
       current_instructeur.rdv_connection.destroy
       flash.notice = "Votre compte #{Current.application_name} n’est plus connecté à RDV Service Public."
-      redirect_to params[:redirect_path] || profil_path
+      redirect_to url_from(params[:redirect_path]) || profil_path
     end
   end
 end

--- a/spec/controllers/instructeurs/rdv_connections_controller_spec.rb
+++ b/spec/controllers/instructeurs/rdv_connections_controller_spec.rb
@@ -33,5 +33,23 @@ describe Instructeurs::RdvConnectionsController, type: :controller do
       expect(flash.notice).to eq("Votre compte #{APPLICATION_NAME} n’est plus connecté à RDV Service Public.")
       expect(response).to redirect_to(profil_path)
     end
+
+    context "with a valid internal redirect_path" do
+      before { delete :destroy, params: { redirect_path: "/instructeurs/procedures/1/dossiers/2/rendez_vous" } }
+
+      it { expect(response).to redirect_to("/instructeurs/procedures/1/dossiers/2/rendez_vous") }
+    end
+
+    context "with an external redirect_path (open redirect attempt)" do
+      before { delete :destroy, params: { redirect_path: "https://evil.example/login" } }
+
+      it { expect(response).to redirect_to(profil_path) }
+    end
+
+    context "with a protocol-relative redirect_path (open redirect bypass)" do
+      before { delete :destroy, params: { redirect_path: "//evil.example/login" } }
+
+      it { expect(response).to redirect_to(profil_path) }
+    end
   end
 end


### PR DESCRIPTION
## Résumé

- `params[:redirect_path]` était passé directement à `redirect_to` dans `RdvConnectionsController#destroy`, permettant à un attaquant de rediriger la victime vers un domaine externe via un lien forgé (y compris le contournement protocol-relative `//evil.example`).
- Correction : utilisation de `url_from` pour valider que la cible de redirection appartient au même hôte, avec repli sur `profil_path`.

## Exploitation

Un attaquant envoie à un instructeur authentifié :
```
DELETE /instructeurs/rdv_connections?redirect_path=//evil.example/login
```
Après déconnexion RDV, la victime atterrit sur le domaine de l'attaquant.

## Test plan

- [ ] La déconnexion RDV depuis un dossier redirige bien vers l'onglet rendez-vous du dossier
- [ ] Un `redirect_path` externe est ignoré → redirection vers `/profil`
- [ ] Un `redirect_path` protocol-relative (`//evil.example`) est ignoré → redirection vers `/profil`
- [ ] Les specs passent : `bundle exec rspec spec/controllers/instructeurs/rdv_connections_controller_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)