### PR TITLE
Tech: désactiver l'accélération C de smarter_csv (crash SIGILL)

### DIFF
--- a/app/controllers/concerns/csv_parsing_concern.rb
+++ b/app/controllers/concerns/csv_parsing_concern.rb
@@ -39,7 +39,11 @@ module CsvParsingConcern
           tempfile.path,
           strings_as_keys:,
           keep_original_headers:,
-          convert_values_to_numeric:
+          convert_values_to_numeric:,
+          # smarter_csv 1.17.x's accelerated C parser crashes with a SIGILL
+          # ([BUG] Illegal instruction in new_parse_context_c) on x86_64 under
+          # certain heap states. Use the pure-Ruby parser to avoid the native crash.
+          acceleration: false
         )
       rescue *[CSV::MalformedCSVError, SmarterCSV::NoColSepDetected, ArgumentError]
         []


### PR DESCRIPTION
## Problème

Le parseur C accéléré de `smarter_csv` 1.17.1 (activé par défaut via `acceleration: true`) provoque un crash natif de l'interpréteur Ruby sur x86_64 :

```
smarter_csv-1.17.1/lib/smarter_csv/reader.rb:242: [BUG] Illegal instruction
... new_parse_context_c
```

Le crash (SIGILL, `core dumped`) survient au premier appel à `CsvParsingConcern#parse_csv` dans un worker, indépendamment de l'appelant (`groupe_instructeurs#import`, `instructeurs_import_service`, `manager/procedures#import_tags`) et indépendamment de YJIT (reproduit avec `RUBY_YJIT_ENABLE=0`). Il s'agit d'une corruption mémoire native dont le parseur C est la victime.

## Correctif

On force le parseur Ruby pur (`acceleration: false`) dans le seul point d'entrée CSV de l'application. Cela évite l'extension C défaillante et protège aussi la production (un import CSV ne doit pas pouvoir faire crasher un worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)