### PR TITLE
[UI] Fix et améliorations UI 

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -309,3 +309,8 @@ input[type='radio'] {
 .fr-tabs {
   box-shadow: none;
 }
+
+// Réduit le margin droit du toggle lorsqu'il n'y a pas de label associé
+.fr-toggle.fr-toggle--no-label label::before {
+  margin-right: 0.5rem;
+}

--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -304,3 +304,8 @@ input[type='radio'] {
     flex-basis: 100%;
   }
 }
+
+// Supprime l'ombre du composant fr-tabs pour que l'onglet actif s'affiche sans ombre
+.fr-tabs {
+  box-shadow: none;
+}

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -232,6 +232,7 @@
 
   .fr-label .fr-hint-text,
   .fr-label + .fr-hint-text {
+    margin-top: 0.25rem;
     clear: right;
     // Évite (en version mobile) que les premiers mots de l’aide
     // ne remontent en vis à vis de l’encart
@@ -264,9 +265,18 @@
     margin-top: 0.5rem;
   }
 
-  .fr-fieldset__legend .fr-hint-text {
-    // les messages d’aide se trouvant dans une légende ont le même espacement que ceux se trouvant dans un label
-    margin-top: 0.25rem;
+  .fr-fieldset__legend:has(+ .fr-hint-text) {
+    padding-bottom: 0; // supprime le padding quand suivi d'un hint externe
+  }
+
+  .fr-fieldset__legend + .fr-hint-text {
+    font-weight: 400;
+    margin-top: 0.5rem;
+    padding-bottom: 1rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+    margin-left: -0.25rem; // même décalage que le legend
+    margin-right: -0.25rem;
   }
 
   input[type='password'],

--- a/app/components/dossiers/notified_toggle_component/notified_toggle_component.html.erb
+++ b/app/components/dossiers/notified_toggle_component/notified_toggle_component.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: [:instructeur, @procedure_presentation],
   data: { controller: 'autosubmit' } do %>
-  <div class="fr-toggle">
+  <div class="fr-toggle fr-toggle--no-label">
     <%= hidden_field_tag 'sorted_column[id]', @procedure.notifications_column.id %>
     <%= hidden_field_tag 'sorted_column[order]', 'asc', id: nil %>
 

--- a/app/components/dsfr/toggle_component.rb
+++ b/app/components/dsfr/toggle_component.rb
@@ -54,4 +54,8 @@ class Dsfr::ToggleComponent < ApplicationComponent
       { 'fr-js-toggle-status-label': true }
     end
   end
+
+  def no_label_class
+    "fr-toggle--no-label" if !toggle_labels
+  end
 end

--- a/app/components/dsfr/toggle_component/toggle_component.html.haml
+++ b/app/components/dsfr/toggle_component/toggle_component.html.haml
@@ -1,4 +1,4 @@
-%div{ class: "fr-toggle #{extra_class_names}" }
+%div{ class: "fr-toggle #{no_label_class} #{extra_class_names}" }
   = @form.check_box target, check_box_options
   = @form.label target, title || html_title&.html_safe, label_options
 

--- a/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
+++ b/app/components/editable_champ/champ_label_component/champ_label_component.html.haml
@@ -9,6 +9,6 @@
   - if @champ.type_de_champ.referentiel? && @champ.type_de_champ&.referentiel&.hint&.present?
     .fr-hint-text{ id: @champ.describedby_id }= t('.referentiel', hint: @champ.type_de_champ.referentiel.hint)
 - elsif @champ.legend_label?
-  %legend.fr-fieldset__legend.fr-text--regular.fr-pb-1w{ id: champ_fieldset_legend_id(@champ) }= render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at, row_number: @row_number
+  %legend.fr-fieldset__legend.fr-text--regular{ id: champ_fieldset_legend_id(@champ) }= render EditableChamp::ChampLabelContentComponent.new form: @form, champ: @champ, seen_at: @seen_at, row_number: @row_number
   - if @champ.description.present?
-    .fr-hint-text.fr-mt-n1w.fr-mb-1w.fr-pl-1w.width-100{ id: @champ.describedby_id }= render SimpleFormatComponent.new(@champ.description, allow_a: true)
+    .fr-hint-text{ id: @champ.describedby_id }= render SimpleFormatComponent.new(@champ.description, allow_a: true)

--- a/app/components/instructeurs/column_picker_component/column_picker_component.html.haml
+++ b/app/components/instructeurs/column_picker_component/column_picker_component.html.haml
@@ -3,7 +3,7 @@
     = render ReactComponent.new "Select/MultipleSelect", items: @displayable_columns_for_select, value: @displayable_columns_selected, name: 'displayed_columns[]', 'aria-label': 'Colonne à afficher', class_name: "fr-mb-2v"
 
   - if instructeur_is_admin?
-    .fr-pb-2w
+    .fr-my-2w
       = render Dsfr::ToggleComponent.new(form: f,
         target: :admin_default_procedure_presentation_active_virtual,
         title: 'Appliquer cette personnalisation pour tous les instructeurs de la démarche',

--- a/app/components/instructeurs/customize_filters_component/customize_filters_component.html.erb
+++ b/app/components/instructeurs/customize_filters_component/customize_filters_component.html.erb
@@ -51,7 +51,7 @@
       <%= form_with url: refresh_filters_instructeur_procedure_presentation_path(@procedure_presentation), id: "toggle-apply-all-tabs-form", data: { turbo: true, turbo_force: :server, controller: 'autosubmit' } do |form| %>
         <%= filters_in_hidden_inputs(form, "toggle-apply-all-tabs-form", include_apply_to_all_tabs: false) %>
 
-        <div class="fr-toggle fr-mt-2w">
+        <div class="fr-toggle fr-mt-2w fr-toggle--no-label">
           <%= form.check_box :apply_to_all_tabs, class: 'fr-toggle__input', id: "toggle-apply-all-tabs-form-input", checked: @apply_to_all_tabs %>
 
           <%= form.label :apply_to_all_tabs, t('.apply_to_all_tabs_label'), class: 'fr-toggle__label', for: "toggle-apply-all-tabs-form-input" %>

--- a/app/components/instructeurs/editable_filters_component/editable_filters_component.html.erb
+++ b/app/components/instructeurs/editable_filters_component/editable_filters_component.html.erb
@@ -1,8 +1,13 @@
 <section id="<%= id %>">
-  <div class="fr-background-alt--grey flex flex-gap-2 column fr-my-2w fr-p-3w">
-    <div class="flex flex-gap-2">
+  <div
+    class="
+      fr-background-alt--grey flex flex-gap-2 column fr-my-2w fr-px-2w
+      fr-py-3v
+    "
+  >
+    <div class="flex flex-gap-2 align-center">
       <div class="flex flex-1">
-        <p class="fr-h6 fr-mb-0"><%= t('.search_filter_dossiers') %></p>
+        <p class="fr-text--bold fr-mb-0"><%= t('.search_filter_dossiers') %></p>
       </div>
 
       <div class="flex">

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
@@ -91,7 +91,7 @@
 
             <% if type_de_champ.explication? %>
               <div class="cell fr-mt-2w">
-                <div class="fr-toggle">
+                <div class="fr-toggle fr-toggle--no-label">
                   <%= form.check_box :collapsible_explanation_enabled, id: dom_id(type_de_champ, :collapsible_explanation_enabled), class: 'fr-toggle__input' %>
                   <%= form.label :collapsible_explanation_enabled, "Afficher un texte complémentaire affichable au clic", for: dom_id(type_de_champ, :collapsible_explanation_enabled), class: 'fr-toggle__label fr-label' %>
                 </div>
@@ -99,7 +99,7 @@
                 <% if form.object.collapsible_explanation_enabled? %>
                   <div class="cell fr-mt-1w">
                     <%= form.label :collapsible_explanation_text, for: dom_id(type_de_champ, :collapsible_explanation_text) do %>
-                      <%= "Texte complémentaire" %>
+                      Texte complémentaire
                     <% end %>
 
                     <%= form.text_area :collapsible_explanation_text, class: "fr-input small-margin small", id: dom_id(type_de_champ, :collapsible_explanation_text) %>
@@ -166,7 +166,7 @@
               <% else %>
                 <div class="fr-hr fr-mt-2w"></div>
                 <div class="cell" data-controller="hide-target">
-                  <div class="fr-toggle <%= class_names('fr-mb-2w': form.object.pj_limit_formats?) %>">
+                  <div class="fr-toggle fr-toggle--no-label <%= class_names('fr-mb-2w': form.object.pj_limit_formats?) %>">
                     <%= form.check_box :pj_limit_formats,
                       id: dom_id(type_de_champ, :pj_limit_formats),
                       class: 'fr-toggle__input',
@@ -225,7 +225,7 @@
               <% if !type_de_champ.titre_identite? %>
                 <div class="fr-hr fr-mt-2w"></div>
                 <div class="cell">
-                  <div class="fr-toggle">
+                  <div class="fr-toggle fr-toggle--no-label">
                     <%= form.check_box :pj_auto_purge, id: dom_id(type_de_champ, :pj_auto_purge), class: 'fr-toggle__input' %>
                     <%= form.label :pj_auto_purge, t('.auto_purge_label'), for: dom_id(type_de_champ, :pj_auto_purge), class: 'fr-toggle__label fr-label' %>
                   </div>
@@ -277,14 +277,14 @@
                     Format accepté
                   </legend>
 
-                  <div class="fr-toggle">
+                  <div class="fr-toggle fr-toggle--no-label">
                     <%= form.check_box :positive_number, id: dom_id(type_de_champ, :positive_number), class: 'fr-toggle__input' %>
                     <%= form.label :positive_number, "Ce nombre doit être positif", for: dom_id(type_de_champ, :positive_number), class: 'fr-toggle__label fr-label' %>
                   </div>
                 </div>
 
                 <div class="cell fr-mt-2w">
-                  <div class="fr-toggle">
+                  <div class="fr-toggle fr-toggle--no-label">
                     <%= form.check_box :range_number, id: dom_id(type_de_champ, :range_number), class: 'fr-toggle__input' %>
                     <%= form.label :range_number, "Ce nombre doit être compris entre des valeurs limites", for: dom_id(type_de_champ, :range_number), class: 'fr-toggle__label fr-label' %>
                   </div>
@@ -326,7 +326,7 @@
                   </legend>
 
                   <% if type_de_champ.date? %>
-                    <div class="fr-toggle">
+                    <div class="fr-toggle fr-toggle--no-label">
                       <%= form.check_box :birthdate, id: dom_id(type_de_champ, :birthdate), class: 'fr-toggle__input' %>
                       <%= form.label :birthdate, "Ce champ est une date de naissance", for: dom_id(type_de_champ, :birthdate), class: 'fr-toggle__label fr-label' %>
                     </div>
@@ -337,7 +337,7 @@
                   <% end %>
 
                   <% if type_de_champ.date? && form.object.birthdate? %>
-                    <div class="fr-toggle fr-mt-2w">
+                    <div class="fr-toggle fr-mt-2w fr-toggle--no-label">
                       <%= form.check_box :prefill_with_france_connect_information, { id: dom_id(type_de_champ, :prefill_with_france_connect_information), class: 'fr-toggle__input', disabled: prefill_with_france_connect_information_locked_by_sibling? } %>
                       <%= form.label :prefill_with_france_connect_information, "Préremplir avec la date de naissance FranceConnect", for: dom_id(type_de_champ, :prefill_with_france_connect_information), class: 'fr-toggle__label fr-label' %>
                     </div>
@@ -357,11 +357,11 @@
                   <% end %>
 
                   <% if !form.object.birthdate? %>
-                    <div class="fr-toggle fr-mt-2w">
+                    <div class="fr-toggle fr-mt-2w fr-toggle--no-label">
                       <%= form.check_box :date_in_past, id: dom_id(type_de_champ, :date_in_past), class: 'fr-toggle__input' %>
                       <%= form.label :date_in_past, "Cette date doit être dans le passé", for: dom_id(type_de_champ, :date_in_past), class: 'fr-toggle__label fr-label' %>
                     </div>
-                    <div class="fr-toggle fr-mt-2w">
+                    <div class="fr-toggle fr-mt-2w fr-toggle--no-label">
                       <%= form.check_box :range_date, id: dom_id(type_de_champ, :range_date), class: 'fr-toggle__input' %>
                       <%= form.label :range_date, "Cette date doit être comprise entre des dates limites", for: dom_id(type_de_champ, :range_date), class: 'fr-toggle__label fr-label' %>
                     </div>
@@ -631,7 +631,7 @@
           <%= tag.span(safe_join(["utilisé pour", link_to('l’eligibilité des dossiers', edit_admin_procedure_ineligibilite_rules_path(revision.procedure_id))], "\n")) %>
         <% else %>
           <% if coordinate.prefilled_by_type_de_champ %>
-            <span><%= "Champ prérempli (référentiel)" %></span>
+            <span>Champ prérempli (référentiel)</span>
           <% end %>
           <%= button_to type_de_champ_path, class: 'fr-btn fr-btn--tertiary-no-outline fr-icon-delete-line', title: "Supprimer le champ", method: :delete, form: { data: { turbo_confirm: } } do %>
             <span class="fr-sr-only">Supprimer</span>


### PR DESCRIPTION
**Petites améliorations UI**
- Retire l'ombre parasite sur l'onglet actif du composant `fr-tabs`
- Corrige l'espacement du hint-text quand la description est en dehors du label/legend (suite PR a11y)
- Réduit la taille du bloc des filtres instructeur
- Réduit la marge droite du toggle DSFR quand il n'y a pas de label de statut associé (`fr-toggle--no-label`)

**APRÈS**
<img width="1346" height="521" alt="Capture d’écran 2026-06-01 à 11 28 17" src="https://github.com/user-attachments/assets/97147cbb-5659-4ee5-81bf-6e569f5d1b3c" />
**AVANT**
<img width="1360" height="536" alt="Capture d’écran 2026-06-01 à 15 17 09" src="https://github.com/user-attachments/assets/86543da8-7e90-4b43-9957-535a7eee405c" />

