### PR TITLE
[WIP] Tech: drop colonne en_construction_close_to_expiration_notice_sent_at

### DIFF
--- a/app/jobs/reset_expiring_dossiers_job.rb
+++ b/app/jobs/reset_expiring_dossiers_job.rb
@@ -11,7 +11,6 @@ class ResetExpiringDossiersJob < ApplicationJob
           DossierNotification.destroy_notifications_by_dossier_and_type(dossier, :dossier_expirant)
           DossierNotification.destroy_notifications_by_dossier_and_type(dossier, :dossier_suppression) if dossier.hidden_by_expired?
           dossier.update(brouillon_close_to_expiration_notice_sent_at: nil,
-                        en_construction_close_to_expiration_notice_sent_at: nil,
                         termine_close_to_expiration_notice_sent_at: nil,
                         hidden_by_expired_at: nil)
         end

--- a/app/models/concerns/dossier_state_concern.rb
+++ b/app/models/concerns/dossier_state_concern.rb
@@ -61,7 +61,6 @@ module DossierStateConcern
     instructeur = h[:instructeur]
     instructeur.follow(self)
 
-    self.en_construction_close_to_expiration_notice_sent_at = nil
     self.conservation_extension = 0.days
     self.en_instruction_at = self.traitements
       .passer_en_instruction(instructeur: instructeur)
@@ -93,7 +92,6 @@ module DossierStateConcern
   end
 
   def after_passer_automatiquement_en_instruction
-    self.en_construction_close_to_expiration_notice_sent_at = nil
     self.conservation_extension = 0.days
     self.en_instruction_at = traitements.passer_en_instruction.processed_at
     self.expired_at = expiration_date
@@ -125,7 +123,6 @@ module DossierStateConcern
 
     create_missing_traitemets
 
-    self.en_construction_close_to_expiration_notice_sent_at = nil
     self.conservation_extension = 0.days
     self.en_construction_at = self.traitements
       .passer_en_construction(instructeur: instructeur)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -505,7 +505,6 @@ class Dossier < ApplicationRecord
   def expiration_started?
     [
       brouillon_close_to_expiration_notice_sent_at,
-      en_construction_close_to_expiration_notice_sent_at,
       termine_close_to_expiration_notice_sent_at,
     ].any?(&:present?)
   end
@@ -679,8 +678,6 @@ class Dossier < ApplicationRecord
   def after_notification_expiration_date
     if brouillon? && brouillon_close_to_expiration_notice_sent_at.present?
       brouillon_close_to_expiration_notice_sent_at + Expired::REMAINING_WEEKS_BEFORE_EXPIRATION.weeks
-    elsif en_construction? && en_construction_close_to_expiration_notice_sent_at.present?
-      en_construction_close_to_expiration_notice_sent_at + Expired::REMAINING_WEEKS_BEFORE_EXPIRATION.weeks
     elsif termine? && termine_close_to_expiration_notice_sent_at.present?
       termine_close_to_expiration_notice_sent_at + Expired::REMAINING_WEEKS_BEFORE_EXPIRATION.weeks
     end
@@ -701,7 +698,6 @@ class Dossier < ApplicationRecord
   def extend_conservation(conservation_extension)
     update(conservation_extension: self.conservation_extension + conservation_extension,
       brouillon_close_to_expiration_notice_sent_at: nil,
-      en_construction_close_to_expiration_notice_sent_at: nil,
       termine_close_to_expiration_notice_sent_at: nil)
     update_expired_at
     DossierNotification.destroy_notifications_by_dossier_and_type(self, :dossier_expirant)

--- a/db/migrate/20260601101322_drop_en_construction_close_to_expiration_notice_sent_at_from_dossiers.rb
+++ b/db/migrate/20260601101322_drop_en_construction_close_to_expiration_notice_sent_at_from_dossiers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DropEnConstructionCloseToExpirationNoticeSentAtFromDossiers < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      remove_column :dossiers, :en_construction_close_to_expiration_notice_sent_at, :datetime, precision: nil
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_21_105001) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_01_101322) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "postgis"
-  disable_extension "postgis_tiger_geocoder"
   enable_extension "sslinfo"
   enable_extension "unaccent"
 
@@ -403,6 +401,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_21_105001) do
     t.bigint "batch_operation_id", null: false
     t.datetime "created_at", null: false
     t.bigint "dossier_id", null: false
+    t.string "error_message"
     t.string "state", default: "pending", null: false
     t.datetime "updated_at", null: false
     t.index ["batch_operation_id"], name: "index_dossier_batch_operations_on_batch_operation_id"
@@ -514,7 +513,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_21_105001) do
     t.bigint "dossier_transfer_id"
     t.bigint "editing_fork_origin_id"
     t.datetime "en_construction_at", precision: nil
-    t.datetime "en_construction_close_to_expiration_notice_sent_at", precision: nil
     t.datetime "en_instruction_at", precision: nil
     t.datetime "expired_at"
     t.boolean "for_procedure_preview", default: false, null: false
@@ -1011,9 +1009,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_21_105001) do
     t.datetime "created_at", precision: nil
     t.boolean "customized", default: false, null: false
     t.jsonb "displayed_columns", default: [], null: false, array: true
-    t.jsonb "displayed_fields", default: [{"label"=>"Demandeur", "table"=>"user", "column"=>"email"}], null: false
+    t.jsonb "displayed_fields", default: [{"label" => "Demandeur", "table" => "user", "column" => "email"}], null: false
     t.jsonb "expirant_filters", default: [], null: false, array: true
-    t.jsonb "filters", default: {"tous"=>[], "suivis"=>[], "traites"=>[], "a-suivre"=>[], "archives"=>[], "expirant"=>[], "supprimes"=>[]}, null: false
+    t.jsonb "filters", default: {"tous" => [], "suivis" => [], "traites" => [], "a-suivre" => [], "archives" => [], "expirant" => [], "supprimes" => []}, null: false
     t.boolean "filters_expanded", default: true, null: false
     t.jsonb "sort", default: {"order" => "desc", "table" => "notifications", "column" => "notifications"}, null: false
     t.jsonb "sorted_column"

--- a/spec/jobs/reset_expiring_dossiers_job_spec.rb
+++ b/spec/jobs/reset_expiring_dossiers_job_spec.rb
@@ -9,7 +9,6 @@ describe ResetExpiringDossiersJob do
   let(:procedure) { create(:procedure, duree_conservation_dossiers_dans_ds:) }
 
   let!(:expiring_dossier_brouillon) { create(:dossier, :brouillon, procedure: procedure, brouillon_close_to_expiration_notice_sent_at: duree_conservation_dossiers_dans_ds.months.ago) }
-  let!(:expiring_dossier_en_construction) { create(:dossier, :en_construction, procedure: procedure, en_construction_close_to_expiration_notice_sent_at: duree_conservation_dossiers_dans_ds.months.ago) }
   let!(:expiring_dossier_termine) { create(:dossier, :accepte, procedure: procedure, termine_close_to_expiration_notice_sent_at: duree_conservation_dossiers_dans_ds.months.ago) }
   let!(:automatic_expiring_dossier) { create(:dossier, :accepte, procedure:, termine_close_to_expiration_notice_sent_at: 3.weeks.ago, hidden_by_expired_at: 1.week.ago) }
   let!(:not_expiring_dossier) { create(:dossier, :accepte, procedure:, processed_at: 1.month.ago) }
@@ -19,18 +18,15 @@ describe ResetExpiringDossiersJob do
       subject
 
       expect(expiring_dossier_brouillon.reload.brouillon_close_to_expiration_notice_sent_at).to eq(nil)
-      expect(expiring_dossier_en_construction.reload.en_construction_close_to_expiration_notice_sent_at).to eq(nil)
       expect(expiring_dossier_termine.reload.termine_close_to_expiration_notice_sent_at).to eq(nil)
       expect(expiring_dossier_brouillon.expired_at).to be_within(1.hour).of(2.months.from_now)
-      expect(expiring_dossier_en_construction.expired_at).to be_nil
       expect(expiring_dossier_termine.expired_at).to be_within(1.hour).of(2.months.from_now)
       expect(automatic_expiring_dossier.reload.hidden_by_expired_at).to eq(nil)
       expect(not_expiring_dossier.reload.expired_at).to be_within(1.hour).of(1.month.from_now)
     end
 
     it 'destroys dossier_expirant notification' do
-      notif_expirant_dossier_en_construction = create(:dossier_notification, dossier: expiring_dossier_en_construction, notification_type: :dossier_expirant)
-      notif_expirant_dossier_termine = create(:dossier_notification, dossier: expiring_dossier_termine, notification_type: :dossier_expirant)
+      create(:dossier_notification, dossier: expiring_dossier_termine, notification_type: :dossier_expirant)
 
       subject
 

--- a/spec/models/concerns/dossier_clone_concern_spec.rb
+++ b/spec/models/concerns/dossier_clone_concern_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe DossierCloneConcern do
       expect(new_dossier.deleted_user_email_never_send).to be_nil
       expect(new_dossier.depose_at).to be_nil
       expect(new_dossier.en_construction_at).to be_nil
-      expect(new_dossier.en_construction_close_to_expiration_notice_sent_at).to be_nil
       expect(new_dossier.en_instruction_at).to be_nil
       expect(new_dossier.for_procedure_preview).to be_falsey
       expect(new_dossier.groupe_instructeur_updated_at).to be_nil

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -232,7 +232,6 @@ describe Dossier, type: :model do
     end
 
     it "has not expired" do
-      dossier.update_column(:en_construction_close_to_expiration_notice_sent_at, 1.month.ago)
       expect(dossier.has_expired?).to be(false)
     end
 
@@ -1594,7 +1593,7 @@ describe Dossier, type: :model do
   end
 
   describe '#passer_en_instruction!' do
-    let(:dossier) { create(:dossier, :en_construction, en_construction_close_to_expiration_notice_sent_at: Time.zone.now) }
+    let(:dossier) { create(:dossier, :en_construction) }
     let(:last_operation) { dossier.dossier_operation_logs.last }
     let(:operation_serialized) { last_operation.data }
     let(:instructeur) { create(:instructeur) }
@@ -1607,7 +1606,6 @@ describe Dossier, type: :model do
 
       expect(dossier.state).to eq('en_instruction')
       expect(dossier.followers_instructeurs).to include(instructeur)
-      expect(dossier.en_construction_close_to_expiration_notice_sent_at).to be_nil
       expect(last_operation.operation).to eq('passer_en_instruction')
       expect(last_operation.automatic_operation?).to be_falsey
       expect(operation_serialized['operation']).to eq('passer_en_instruction')
@@ -1635,7 +1633,7 @@ describe Dossier, type: :model do
     let(:instructeur) { create(:instructeur) }
 
     context "via procedure declarative en instruction" do
-      let(:dossier) { create(:dossier, :en_construction, :with_declarative_en_instruction, en_construction_close_to_expiration_notice_sent_at: Time.zone.now) }
+      let(:dossier) { create(:dossier, :en_construction, :with_declarative_en_instruction) }
 
       subject do
         dossier.process_declarative!
@@ -1644,7 +1642,6 @@ describe Dossier, type: :model do
 
       it 'passes dossier en instruction' do
         expect(subject.followers_instructeurs).not_to include(instructeur)
-        expect(subject.en_construction_close_to_expiration_notice_sent_at).to be_nil
         expect(subject.declarative_triggered_at).to be_within(1.second).of(Time.current)
         expect(last_operation.operation).to eq('passer_en_instruction')
         expect(last_operation.automatic_operation?).to be_truthy

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1723,13 +1723,11 @@ describe Procedure do
     let(:duree_conservation_dossiers_dans_ds) { 2 }
     let(:procedure) { create(:procedure, duree_conservation_dossiers_dans_ds:) }
     let(:expiring_dossier_brouillon) { create(:dossier, :brouillon, procedure: procedure, brouillon_close_to_expiration_notice_sent_at: duree_conservation_dossiers_dans_ds.months.ago) }
-    let(:expiring_dossier_en_construction) { create(:dossier, :en_construction, procedure: procedure, en_construction_close_to_expiration_notice_sent_at: duree_conservation_dossiers_dans_ds.months.ago) }
     let(:expiring_dossier_en_termine) { create(:dossier, :accepte, procedure: procedure, termine_close_to_expiration_notice_sent_at: duree_conservation_dossiers_dans_ds.months.ago) }
     let(:not_expiring_dossie) { create(:dossier, :accepte, procedure: procedure, created_at: duree_conservation_dossiers_dans_ds.months.ago) }
     before do
       procedure
       expiring_dossier_brouillon
-      expiring_dossier_en_construction
       expiring_dossier_en_termine
       not_expiring_dossie
     end


### PR DESCRIPTION
Suite de #13212.

## Contexte

Dans #13212, la colonne `en_construction_close_to_expiration_notice_sent_at` est marquée `ignored_columns` (plus aucune lecture/écriture dans le code applicatif). Cette PR finalise le nettoyage en supprimant la colonne et en retirant l'entrée `ignored_columns` devenue inutile.

## Changements

- `chore(db)` : migration `remove_column :dossiers, :en_construction_close_to_expiration_notice_sent_at` (`safety_assured` — aucune référence applicative depuis #13212).
- `refactor(dossier)` : retrait de l'entrée `ignored_columns` correspondante.

## Pré-requis avant merge

- [ ] PR #13212 mergée et déployée en prod (tous les pods doivent ignorer la colonne avant que la migration tourne)
- [ ] `Maintenance::T20260528ResetEnConstructionExpirationTask` exécutée
- [ ] `Maintenance::T20260601NullifyEnConstructionExpiredAtTask` exécutée
- [ ] Rebase de cette branche sur `main` (actuellement basée sur `dossier_en_construction_cannot_expire`)

Ref #13178