### PR TITLE
Tech: drop colonne en_construction_close_to_expiration_notice_sent_at

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Dossier < ApplicationRecord
-  self.ignored_columns += [:search_terms, :private_search_terms, :editing_fork_origin_id, :last_champ_piece_jointe_updated_at, :en_construction_close_to_expiration_notice_sent_at]
+  self.ignored_columns += [:search_terms, :private_search_terms, :editing_fork_origin_id, :last_champ_piece_jointe_updated_at]
 
   include DossierCloneConcern
   include DossierCorrectableConcern

--- a/db/migrate/20260601101322_drop_en_construction_close_to_expiration_notice_sent_at_from_dossiers.rb
+++ b/db/migrate/20260601101322_drop_en_construction_close_to_expiration_notice_sent_at_from_dossiers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DropEnConstructionCloseToExpirationNoticeSentAtFromDossiers < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      remove_column :dossiers, :en_construction_close_to_expiration_notice_sent_at, :datetime, precision: nil
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -524,7 +524,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_22_131426) do
     t.bigint "dossier_transfer_id"
     t.bigint "editing_fork_origin_id"
     t.datetime "en_construction_at", precision: nil
-    t.datetime "en_construction_close_to_expiration_notice_sent_at", precision: nil
     t.datetime "en_instruction_at", precision: nil
     t.datetime "expired_at"
     t.boolean "for_procedure_preview", default: false, null: false


### PR DESCRIPTION
Suite de #13212.

## Contexte

Dans #13212, la colonne `en_construction_close_to_expiration_notice_sent_at` est marquée `ignored_columns` (plus aucune lecture/écriture dans le code applicatif). Cette PR finalise le nettoyage en supprimant la colonne et en retirant l'entrée `ignored_columns` devenue inutile.

## Changements

- `chore(db)` : migration `remove_column :dossiers, :en_construction_close_to_expiration_notice_sent_at` (`safety_assured` — aucune référence applicative depuis #13212).
- `refactor(dossier)` : retrait de l'entrée `ignored_columns` correspondante.

## Pré-requis avant merge

- [x] PR #13212 mergée et déployée en prod (tous les pods doivent ignorer la colonne avant que la migration tourne)
- [x] `Maintenance::T20260528ResetEnConstructionExpirationTask` exécutée
- [x] `Maintenance::T20260601NullifyEnConstructionExpiredAtTask` exécutée
- [x] Rebase de cette branche sur `main` (actuellement basée sur `dossier_en_construction_cannot_expire`)

Ref #13178