### PR TITLE
ETQ Instructeur utilisant un lecteur d'écran, je veux que la présence de notification soit mieux annoncée

### DIFF
--- a/app/components/instructeurs/procedure_counters_component/procedure_counters_component.en.yml
+++ b/app/components/instructeurs/procedure_counters_component/procedure_counters_component.en.yml
@@ -1,4 +1,4 @@
 ---
 fr:
-  notifications: Notifications
-  notifications_details: Notifications details
+  notifications: "presence of one or more unread notifications"
+  notifications_details: "Notifications details"

--- a/app/components/instructeurs/procedure_counters_component/procedure_counters_component.fr.yml
+++ b/app/components/instructeurs/procedure_counters_component/procedure_counters_component.fr.yml
@@ -1,4 +1,4 @@
 ---
 fr:
-  notifications: Notifications
-  notifications_details: Détails des notifications
+  notifications: "présence d’une ou plusieurs notifications non lues"
+  notifications_details: "Détails des notifications"

--- a/app/components/instructeurs/procedure_summary_component/procedure_summary_component.html.erb
+++ b/app/components/instructeurs/procedure_summary_component/procedure_summary_component.html.erb
@@ -223,7 +223,6 @@
       "
     >
       <%= link_to(instructeur_procedure_path(p, statut: 'traites')) do %>
-
         <div class="center fr-text--bold">
           <span id="procedure-<%= p.id %>-termines-count">
             <%= placeholder_span %>

--- a/app/components/instructeurs/procedure_summary_component/procedure_summary_component.html.erb
+++ b/app/components/instructeurs/procedure_summary_component/procedure_summary_component.html.erb
@@ -181,8 +181,6 @@
       "
     >
       <%= link_to instructeur_procedure_path(p, statut: 'a-suivre') do %>
-        <span id="procedure-<%= p.id %>-a-suivre-notification"></span>
-
         <div class="center fr-text--bold">
           <span id="procedure-<%= p.id %>-a-suivre-count">
             <%= placeholder_span %>
@@ -192,6 +190,8 @@
         <div class="center fr-text--sm">
           <%= t('instructeurs.dossiers.labels.to_follow') %>
         </div>
+
+        <span id="procedure-<%= p.id %>-a-suivre-notification"></span>
       <% end %>
     </li>
 
@@ -202,8 +202,6 @@
       "
     >
       <%= link_to(instructeur_procedure_path(p, statut: 'suivis')) do %>
-        <span id="procedure-<%= p.id %>-suivis-notification"></span>
-
         <div class="center fr-text--bold">
           <span id="procedure-<%= p.id %>-followed-count">
             <%= placeholder_span %>
@@ -213,6 +211,8 @@
         <div class="center fr-text--sm">
           <%= t('instructeurs.dossiers.labels.followed') %>
         </div>
+
+        <span id="procedure-<%= p.id %>-suivis-notification"></span>
       <% end %>
     </li>
 
@@ -223,7 +223,6 @@
       "
     >
       <%= link_to(instructeur_procedure_path(p, statut: 'traites')) do %>
-        <span id="procedure-<%= p.id %>-traites-notification"></span>
 
         <div class="center fr-text--bold">
           <span id="procedure-<%= p.id %>-termines-count">
@@ -234,6 +233,8 @@
         <div class="center fr-text--sm">
           <%= t('instructeurs.dossiers.labels.processed') %>
         </div>
+
+        <span id="procedure-<%= p.id %>-traites-notification"></span>
       <% end %>
     </li>
 

--- a/app/views/experts/avis/index.html.haml
+++ b/app/views/experts/avis/index.html.haml
@@ -15,13 +15,13 @@
         %li.fr-btn.fr-btn--tertiary.flex.justify-center.fr-enlarge-link
           = link_to(procedure_expert_avis_index_path(p, statut: Instructeurs::AvisController::A_DONNER_STATUS)) do
             - without_answer_count = procedure_avis.select { _1.answer.nil? }.reject{ _1.dossier.termine?}.size
-            - if without_answer_count > 0
-              %span.notifications
-                %span.fr-sr-only= "notification"
             .center.fr-text--bold.fr-text--sm
               = without_answer_count
             .center.fr-text--xs
               = t(".to_give", count: without_answer_count)
+            - if without_answer_count > 0
+              %span.notifications
+                %span.fr-sr-only= t(".notification")
         %li.fr-btn.fr-btn--tertiary.flex.justify-center.fr-enlarge-link
           = link_to(procedure_expert_avis_index_path(p, statut: Instructeurs::AvisController::DONNES_STATUS)) do
             - with_answer_count = procedure_avis.select { |a| a.answer.present? }.size

--- a/app/views/shared/_notification_sticker.html.haml
+++ b/app/views/shared/_notification_sticker.html.haml
@@ -1,4 +1,3 @@
-%div{ id: "notification-sticker-#{label.parameterize.underscore}" }
-  - if notification
-    %span.notifications
-      %span.fr-sr-only= "notification"
+- if notification
+  %span.notifications{ id: "notification-sticker-#{label.parameterize.underscore}" }
+    %span.fr-sr-only= t('notification', scope: 'views.shared')

--- a/app/views/shared/_tab_item.html.haml
+++ b/app/views/shared/_tab_item.html.haml
@@ -1,8 +1,8 @@
 %li{ class: "relative #{(active ? 'active' : nil)}" }
-  = render partial: 'shared/notification_sticker', locals: { label:, notification: }
   = link_to(url, 'aria-current': active ? 'page' : nil, class: class_names("fr-tabs__tab", html_class) ) do
     - if badge.present?
       %span.fr-badge.fr-badge--blue-ecume.fr-mr-1w= badge
     = label
     - if small_counter.present?
       %span.fr-text--sm.fr-text--regular.fr-ml-1v= "(#{small_counter})"
+    = render partial: 'shared/notification_sticker', locals: { label:, notification: }

--- a/config/locales/views/experts/avis/en.yml
+++ b/config/locales/views/experts/avis/en.yml
@@ -3,6 +3,7 @@ en:
     avis:
       index:
         title: "Opinions"
+        notification: "presence of one or more unread notifications"
         to_give:
           zero: "opinion to give"
           one: "opinion to give"

--- a/config/locales/views/experts/avis/fr.yml
+++ b/config/locales/views/experts/avis/fr.yml
@@ -3,6 +3,7 @@ fr:
     avis:
       index:
         title: "Avis"
+        notification: "présence d’une ou plusieurs notifications non lues"
         to_give:
           zero: "avis à donner"
           one: "avis à donner"

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -1,6 +1,7 @@
 en:
   views:
     shared:
+      notification: "presence of one or more unread notifications"
       dossiers:
         identite_entreprise:
           warning_for_private_info: "The establishment SIRET %{siret} applied his right to not publish information regarding his identity. These informaiton won't be visible from instructor services."

--- a/config/locales/views/shared/fr.yml
+++ b/config/locales/views/shared/fr.yml
@@ -1,6 +1,7 @@
 fr:
   views:
     shared:
+      notification: "présence d’une ou plusieurs notifications non lues"
       dossiers:
         identite_entreprise:
           warning_for_private_info: "L’établissement SIRET %{siret} a exercé son droit à la non publication des informations relatives à son identité. Les informations ne seront donc visibles que de la part des services instructeurs."


### PR DESCRIPTION
Amélioration de l'indication de notification

# Après
<img width="1217" height="477" alt="Capture d’écran 2026-06-01 à 16 29 26" src="https://github.com/user-attachments/assets/3680fb87-345c-4d38-9b58-37d05acc5a4e" />
<img width="1119" height="570" alt="Capture d’écran 2026-06-01 à 16 34 58" src="https://github.com/user-attachments/assets/c786e5e0-74ab-4588-9f70-3b500f54d9c3" />
<img width="1233" height="492" alt="Capture d’écran 2026-06-01 à 16 38 16" src="https://github.com/user-attachments/assets/6d43c9d2-10c2-4430-a58a-5d57d175dc5d" />

# Avant
<img width="1229" height="605" alt="Capture d’écran 2026-06-01 à 16 30 04" src="https://github.com/user-attachments/assets/d1a44aea-d1c7-465b-ad78-08af0156ae2c" />
<img width="1068" height="560" alt="Capture d’écran 2026-06-01 à 16 36 38" src="https://github.com/user-attachments/assets/52a8a58c-19b4-4930-8d61-9f187d925697" />
<img width="1474" height="481" alt="Capture d’écran 2026-06-01 à 16 37 36" src="https://github.com/user-attachments/assets/3ec2588f-a81b-4f42-9835-c76e20627bc9" />
