### PR TITLE
Tech: limiter la portée du prefill_token au flux d'inscription d'un nouveau compte

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -28,7 +28,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     # all Devise code.
     # So instead we use a per-request global variable.
     CurrentConfirmation.procedure_after_confirmation = @procedure
-    CurrentConfirmation.prefill_token = @prefill_token
 
     # Handle existing user trying to sign up again
     existing_user = user_email_param.present? ? User.find_by(email: user_email_param) : nil
@@ -40,6 +39,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
       end
       return redirect_to after_inactive_sign_up_path_for(existing_user)
     end
+
+    # Only carry the prefill_token for a genuine new account: here the person
+    # submitting the form is the one creating and confirming the account.
+    # For an existing (unconfirmed) account, the submitter is not authenticated
+    # as the owner, so an attacker-supplied prefill_token must not be injected
+    # into the owner's confirmation email.
+    CurrentConfirmation.prefill_token = @prefill_token
 
     super do
       resource.update_preferred_domain(Current.host) if resource.valid?

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -115,6 +115,26 @@ describe Users::RegistrationsController, type: :controller do
           expect(decrypted_email).to eq(user[:email])
         end
       end
+
+      context 'and a prefill_token is present in the stored procedure context' do
+        let(:confirmed_at) { nil }
+        let(:procedure) { create(:procedure, :published) }
+
+        before do
+          controller.store_location_for(:user, commencer_path(path: procedure.path, prefill_token: 'attacker-token'))
+        end
+
+        it 'does not propagate the prefill_token to the existing user confirmation email' do
+          captured_token = :unset
+          allow_any_instance_of(User).to receive(:resend_confirmation_instructions) do
+            captured_token = CurrentConfirmation.prefill_token
+          end
+
+          subject
+
+          expect(captured_token).to be_nil
+        end
+      end
     end
 
     context 'when the email param is sent as a non-scalar value' do


### PR DESCRIPTION
Le `prefill_token` n'est désormais transmis au flux de confirmation que lors de la création d'un nouveau compte, où la personne qui soumet le formulaire est aussi celle qui crée et confirmera le compte.

Pour un compte existant non confirmé, le soumetteur n'est pas authentifié comme propriétaire : le token issu du contexte stocké en session n'est plus relayé dans l'e-mail de confirmation envoyé au propriétaire.

Le parcours de pré-remplissage nominal (nouveau compte) est inchangé.

## Rattachement du dossier pour un compte déjà existant

- **Compte déjà confirmé** : parcours inchangé. L'usager ouvre le lien de pré-remplissage, clique « J'ai déjà un compte » (ou est déjà connecté) ; le `prefill_token` est conservé via la location stockée et le dossier orphelin est rattaché au retour sur `commencer`.
- **Compte existant non confirmé** : il confirme d'abord son compte (via l'e-mail de confirmation reçu à l'inscription, qui n'a pas besoin du token), puis rouvre le lien de pré-remplissage une fois connecté → le dossier est rattaché. Le rattachement reste possible, il demande simplement de rouvrir le lien plutôt que de s'appuyer sur l'e-mail de confirmation de compte.