### PR TITLE
ETQ instructeur, la liste des dossiers ne plante plus avec une colonne de référentiel à l'en-tête numérique

### DIFF
--- a/app/models/columns/json_path_column.rb
+++ b/app/models/columns/json_path_column.rb
@@ -48,7 +48,7 @@ class Columns::JSONPathColumn < Columns::ChampColumn
     parts << %(@ >= "#{start_date}") if start_date
     parts << %(@ <= "#{end_date}") if end_date
 
-    condition = sanitize_sql(%{champs.value_json @? '#{jsonpath} ? (#{parts.join(' && ')})'})
+    condition = sanitize_sql(%{champs.value_json @? '#{jsonpath_for_sql} ? (#{parts.join(' && ')})'})
 
     targeted_dossiers(dossiers, condition).ids
   end
@@ -63,10 +63,10 @@ class Columns::JSONPathColumn < Columns::ChampColumn
 
       return dossiers.ids if integers.empty?
 
-      condition = sanitize_sql(%{champs.value_json @? '#{jsonpath} ? (#{integers.map { |i| "@ == #{i}" }.join(" || ")})'})
+      condition = sanitize_sql(%{champs.value_json @? '#{jsonpath_for_sql} ? (#{integers.map { |i| "@ == #{i}" }.join(" || ")})'})
     else
       value = quote_string(search_terms.join('|'))
-      condition = sanitize_sql(%{champs.value_json @? '#{jsonpath} ? (@ like_regex "#{value}" flag "i")'})
+      condition = sanitize_sql(%{champs.value_json @? '#{jsonpath_for_sql} ? (@ like_regex "#{value}" flag "i")'})
     end
 
     targeted_dossiers(dossiers, condition).ids
@@ -78,6 +78,14 @@ class Columns::JSONPathColumn < Columns::ChampColumn
     else
       raise
     end
+  end
+
+  # PostgreSQL's jsonpath parser rejects bare numeric member accessors (e.g. `$.row.4`),
+  # typically a référentiel column whose header is a number, so those segments are
+  # double-quoted (`$.row."4"`). Other segments are left as-is, keeping existing jsonpaths
+  # unchanged. The Ruby JsonPath gem used in #typed_value keeps the original dot notation.
+  def jsonpath_for_sql
+    @jsonpath_for_sql ||= jsonpath.split('.').map { _1.match?(/\A\d/) ? "\"#{_1}\"" : _1 }.join('.')
   end
 
   def column_id = "type_de_champ/#{stable_id}-#{jsonpath}"

--- a/spec/models/columns/json_path_column_spec.rb
+++ b/spec/models/columns/json_path_column_spec.rb
@@ -41,6 +41,24 @@ describe Columns::JSONPathColumn do
       end
     end
 
+    context 'with a numeric jsonpath key (e.g. a referentiel column whose header is a number)' do
+      let(:jsonpath) { '$.referentiel.data.row.4' }
+
+      subject { column.filtered_ids(Dossier.all, { operator: 'match', value: ['Lyon'] }) }
+
+      context 'when champ has value_json matching' do
+        before { champ.update(value_json: { referentiel: { data: { row: { '4' => 'Lyon' } } } }) }
+
+        it { is_expected.to eq([dossier.id]) }
+      end
+
+      context 'when champ has value_json not matching' do
+        before { champ.update(value_json: { referentiel: { data: { row: { '4' => 'Paris' } } } }) }
+
+        it { is_expected.to eq([]) }
+      end
+    end
+
     context 'with avanced search using special characters' do
       let(:jsonpath) { '$.city_name' }
 


### PR DESCRIPTION
## Problème

Quand une démarche utilise une liste déroulante avancée (référentiel) dont l'en-tête de colonne est un nombre (ex. `4`), le chemin jsonpath généré pour le filtrage devient `$.referentiel.data.row.4`. PostgreSQL interprète `.4` comme un nombre et lève une `PG::SyntaxError`, ce qui renvoie une 500 sur la liste des dossiers de l'instructeur.

## Correctif

Construction d'un jsonpath compatible PostgreSQL pour les requêtes `@?` en double-quotant les segments de clé qui ne sont pas des accesseurs valides (`$.row."4"`). La notation pointée d'origine est conservée pour la gem Ruby `JsonPath` (`#typed_value`), les deux parseurs ne s'accordant pas sur le quoting. Les jsonpaths existants (identifiants, index de tableau, wildcards) restent inchangés.


Vérifié avec ce type de csv quand on filtre sur la colonne "4" :  
```csv
Ville;4;Population
Lyon;Zone A;522969
Paris;Zone B;2133111
Marseille;Zone C;873076
Bordeaux;Zone D;259809
```

Fix https://demarches-simplifiees.sentry.io/issues/7511104180/
https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_db574471-b003-420f-afc8-00720aa22ec1/