### PR TITLE
ETQ usager, message d'erreur explicite des listes déroulantes liées

### DIFF
--- a/app/components/dossiers/errors_full_messages_component.rb
+++ b/app/components/dossiers/errors_full_messages_component.rb
@@ -29,7 +29,8 @@ class Dossiers::ErrorsFullMessagesComponent < ApplicationComponent
   end
 
   def model_libelle(model)
-    parent_prefix(model) + row_number_prefix(model) + model.libelle.truncate(200)
+    libelle = model.try(:libelle_for_error) || model.libelle
+    parent_prefix(model) + row_number_prefix(model) + libelle.truncate(200)
   end
 
   def parent_prefix(model)

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -44,7 +44,7 @@ module Dsfr
     end
 
     def libelle
-      @row_number.present? ? "[#{@row_number}] #{@champ.libelle}" : @champ.libelle
+      @row_number.present? ? "[#{@row_number}] #{@champ.libelle_for_error}" : @champ.libelle_for_error
     end
 
     def statut_message

--- a/app/components/editable_champ/linked_drop_down_list_component.rb
+++ b/app/components/editable_champ/linked_drop_down_list_component.rb
@@ -1,28 +1,6 @@
 # frozen_string_literal: true
 
 class EditableChamp::LinkedDropDownListComponent < EditableChamp::EditableChampBaseComponent
-  delegate :primary_value, :secondary_value, to: :@champ
-  # small trick here.
-  # linked dropdown champ is a compound input. one input for primary, one for secondary.
-  # focusable error does not point to the same input depending of the stage of the input.
-  # if no primary selected, focusable error points to primary input which is named 'value'
-  # if a primary is selected, focusable error points to secondary input which is now named 'value' (and primary input is now named 'primary_value')
-  def focusable_primary_value_input_id
-    if primary_value.blank?
-      @champ.focusable_input_id(:value) # must be focusable when no primary is selected
-    else
-      @champ.focusable_input_id(:primary_value) # otherwise, use same as error name
-    end
-  end
-
-  def focusable_secondary_value_input_id
-    if primary_value.present?
-      @champ.focusable_input_id(:value)
-    else
-      @champ.focusable_input_id(:not_visible_do_not_care)
-    end
-  end
-
   def dsfr_champ_container
     :div
   end

--- a/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
@@ -1,13 +1,13 @@
 .fr-fieldset__element.fr-mb-0.fr-pl-0
-  %div{ class: class_names("fr-select-group", "fr-select-group--error": primary_value.blank?) }
+  %div{ class: class_names("fr-select-group", "fr-select-group--error": @champ.errors.include?(:value)) }
     = render EditableChamp::ChampLabelComponent.new form: @form, champ: @champ, seen_at: @seen_at
 
     = @form.select :primary_value, @champ.primary_options, select_options, required: @champ.required?, class: 'fr-select fr-mb-3v', id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, translate: 'no'
 
 - if @champ.has_secondary_options_for_primary?
   .fr-fieldset__element.fr-pl-0
-    %div{ class: class_names("fr-select-group", "fr-select-group--error": primary_value.present? && secondary_value.blank?) }
-      = @form.label :secondary_value, for: "#{@champ.focusable_input_id}-secondary", class: 'fr-label' do
+    %div{ class: class_names("fr-select-group", "fr-select-group--error": @champ.errors.include?(:secondary_value)) }
+      = @form.label :secondary_value, for: @champ.focusable_input_id(:secondary_value), class: 'fr-label' do
         = @champ.drop_down_secondary_libelle.presence || t("shared.champs.linked_drop_down_list.secondary_default_libelle")
         - if @champ.public?
           - if @champ.mandatory?
@@ -15,6 +15,6 @@
       - if @champ.drop_down_secondary_description.present?
         .fr-hint-text.fr-mb-1w{ id: "#{@champ.describedby_id}-secondary" }
           = render SimpleFormatComponent.new(@champ.drop_down_secondary_description, allow_a: true)
-      = @form.select :secondary_value, @champ.secondary_options[@champ.primary_value], select_options, required: @champ.required?, class: 'fr-select', id: "#{@champ.focusable_input_id}-secondary", aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id}-secondary" }, translate: 'no', data: { turbo_force: :server }
+      = @form.select :secondary_value, @champ.secondary_options[@champ.primary_value], select_options, required: @champ.required?, class: 'fr-select', id: @champ.focusable_input_id(:secondary_value), aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id}-secondary #{@champ.error_id(:value)}" }, translate: 'no', data: { turbo_force: :server }
 - else
   = @form.hidden_field :secondary_value, value: ''

--- a/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
@@ -8,7 +8,7 @@
   .fr-fieldset__element.fr-pl-0
     %div{ class: class_names("fr-select-group", "fr-select-group--error": primary_value.present? && secondary_value.blank?) }
       = @form.label :secondary_value, for: "#{@champ.focusable_input_id}-secondary", class: 'fr-label' do
-        = @champ.drop_down_secondary_libelle.presence || "Valeur secondaire dépendant de la première"
+        = @champ.drop_down_secondary_libelle.presence || t("shared.champs.linked_drop_down_list.secondary_default_libelle")
         - if @champ.public?
           - if @champ.mandatory?
             = render EditableChamp::AsteriskMandatoryComponent.new

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -141,6 +141,10 @@ class Champ < ApplicationRecord
     type_de_champ.mandatory_blank?(self)
   end
 
+  def libelle_for_error
+    libelle
+  end
+
   def blank?
     # FIXME: temporary fix to avoid breaking validation
     in_dossier_revision? ? type_de_champ.champ_blank?(self) : value.blank?

--- a/app/models/champs/linked_drop_down_list_champ.rb
+++ b/app/models/champs/linked_drop_down_list_champ.rb
@@ -45,6 +45,14 @@ class Champs::LinkedDropDownListChamp < Champ
     primary_value.present? && secondary_options[primary_value]&.any?(&:present?)
   end
 
+  def libelle_for_error
+    if primary_value.blank?
+      libelle
+    else
+      drop_down_secondary_libelle.presence || I18n.t('shared.champs.linked_drop_down_list.secondary_default_libelle')
+    end
+  end
+
   private
 
   def pack_value(primary, secondary)

--- a/app/models/champs/linked_drop_down_list_champ.rb
+++ b/app/models/champs/linked_drop_down_list_champ.rb
@@ -53,6 +53,19 @@ class Champs::LinkedDropDownListChamp < Champ
     end
   end
 
+  # Validate each sub-input independently so the error targets the right select,
+  # like AddressChamp does for its sub-fields. The primary is the main value
+  # (anchored on :value); only the secondary needs its own attribute.
+  def validate_completed
+    return if !mandatory?
+
+    if primary_value.blank?
+      errors.add(:value, :missing)
+    elsif has_secondary_options_for_primary? && secondary_value.blank?
+      errors.add(:secondary_value, :missing)
+    end
+  end
+
   private
 
   def pack_value(primary, secondary)

--- a/app/models/concerns/dossier_validate_concern.rb
+++ b/app/models/concerns/dossier_validate_concern.rb
@@ -19,7 +19,7 @@ module DossierValidateConcern
 
   def check_mandatory_and_visible_champs_for(collection)
     collection.filter(&:visible?).each do |champ|
-      if champ.mandatory_blank? && !champ.address?
+      if champ.mandatory_blank? && !champ.respond_to?(:validate_completed)
         error = champ.errors.add(:value, :missing)
         errors.import(error)
       end
@@ -27,7 +27,7 @@ module DossierValidateConcern
       if champ.repetition?
         champ.rows.each do |champs|
           champs.filter(&:visible?).each do |champ|
-            if champ.address?
+            if champ.respond_to?(:validate_completed)
               champ.validate_completed
               champ.errors.each { errors.import(it) }
             elsif champ.mandatory_blank?
@@ -36,7 +36,7 @@ module DossierValidateConcern
             end
           end
         end
-      elsif champ.address?
+      elsif champ.respond_to?(:validate_completed)
         champ.validate_completed
         champ.errors.each { errors.import(it) }
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1136,6 +1136,9 @@ en:
         Thus, you will receive an answer to your request within %{delay} of submitting your complete file.
         For example, if you submit your application today, you will receive a reply no later than %{date}.
         If your file is incomplete, this date may be postponed until submitting a completed file.
+    champs:
+      linked_drop_down_list:
+        secondary_default_libelle: "Secondary value depending on the first"
   editable_champ:
     repetition_component:
       deleted: "[%{row_number}] %{libelle} deleted"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1196,6 +1196,9 @@ fr:
         Ainsi, vous recevrez une réponse à votre demande dans les %{delay} après avoir déposé votre dossier complet.
         Par exemple, si vous déposez votre dossier aujourd’hui, vous aurez une réponse au plus tard le %{date}.
         Si votre dossier est incomplet, cette date pourrait être repoussée jusqu’à la soumission d’un dossier complété.
+    champs:
+      linked_drop_down_list:
+        secondary_default_libelle: "Valeur secondaire dépendant de la première"
   editable_champ:
     repetition_component:
       deleted: '[%{row_number}] %{libelle} supprimé'

--- a/config/locales/models/champs/champs.en.yml
+++ b/config/locales/models/champs/champs.en.yml
@@ -8,3 +8,6 @@ en:
               format: '%{message}'
               missing: must be filled
               invalid_regexp: '%{expression_reguliere_error_message}'
+            secondary_value:
+              format: '%{message}'
+              missing: must be filled

--- a/config/locales/models/champs/champs.fr.yml
+++ b/config/locales/models/champs/champs.fr.yml
@@ -8,3 +8,6 @@ fr:
               format: '%{message}'
               missing: doit être rempli
               invalid_regexp: '%{expression_reguliere_error_message}'
+            secondary_value:
+              format: '%{message}'
+              missing: doit être rempli

--- a/spec/components/dossiers/errors_full_messages_component_spec.rb
+++ b/spec/components/dossiers/errors_full_messages_component_spec.rb
@@ -113,17 +113,18 @@ RSpec.describe Dossiers::ErrorsFullMessagesComponent, type: :component do
         end
 
         context 'when the primary value is blank' do
-          it 'shows the primary libelle' do
-            expect(subject).to have_text('Ville')
+          it 'shows the primary libelle and links to the primary select' do
+            expect(subject).to have_link('Ville', href: "##{champ.focusable_input_id(:value)}")
           end
         end
 
         context 'when the primary value is set but the secondary is blank' do
           before { champ.update!(value: JSON.generate(['Primary 1', ''])) }
 
-          it 'shows the secondary libelle' do
-            expect(subject).to have_text(
-              I18n.t('shared.champs.linked_drop_down_list.secondary_default_libelle')
+          it 'shows the secondary libelle and links to the secondary select' do
+            expect(subject).to have_link(
+              I18n.t('shared.champs.linked_drop_down_list.secondary_default_libelle'),
+              href: "##{champ.focusable_input_id(:secondary_value)}"
             )
           end
         end

--- a/spec/components/dossiers/errors_full_messages_component_spec.rb
+++ b/spec/components/dossiers/errors_full_messages_component_spec.rb
@@ -106,6 +106,29 @@ RSpec.describe Dossiers::ErrorsFullMessagesComponent, type: :component do
         end
       end
 
+      context 'when champ is linked_drop_down_list' do
+        let(:options) { ['--Primary 1--', 'Secondary 1.1', 'Secondary 1.2'] }
+        let(:types_de_champ_public) do
+          [{ type: :linked_drop_down_list, libelle: 'Ville', options:, mandatory: true }]
+        end
+
+        context 'when the primary value is blank' do
+          it 'shows the primary libelle' do
+            expect(subject).to have_text('Ville')
+          end
+        end
+
+        context 'when the primary value is set but the secondary is blank' do
+          before { champ.update!(value: JSON.generate(['Primary 1', ''])) }
+
+          it 'shows the secondary libelle' do
+            expect(subject).to have_text(
+              I18n.t('shared.champs.linked_drop_down_list.secondary_default_libelle')
+            )
+          end
+        end
+      end
+
       context 'when champ is yes_no' do
         let(:types_de_champ_public) { [{ type: :yes_no }] }
         it 'focuses on focusable_input_id' do

--- a/spec/models/champs/linked_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/linked_drop_down_list_champ_spec.rb
@@ -193,4 +193,51 @@ describe Champs::LinkedDropDownListChamp do
       end
     end
   end
+
+  describe '#validate_completed' do
+    let(:options) { ['--Primary 1--', 'Secondary 1.1', 'Secondary 1.2', '--Primary 2--'] }
+
+    subject do
+      champ.validate_completed
+      champ.errors
+    end
+
+    context 'when the champ is not mandatory' do
+      let(:mandatory) { false }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when mandatory and the primary value is blank' do
+      it 'adds a missing error on :value (the main value) only' do
+        expect(subject).to be_added(:value, :missing)
+        expect(subject).not_to be_added(:secondary_value, :missing)
+      end
+    end
+
+    context 'when mandatory, primary set and secondary blank' do
+      before { champ.primary_value = 'Primary 1' }
+
+      it 'adds a missing error on :secondary_value only' do
+        expect(subject).to be_added(:secondary_value, :missing)
+        expect(subject).not_to be_added(:primary_value, :missing)
+      end
+    end
+
+    context 'when mandatory and complete' do
+      before do
+        champ.primary_value = 'Primary 1'
+        champ.secondary_value = 'Secondary 1.1'
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when mandatory, primary set but it has no secondary options' do
+      let(:options) { ['--A--', 'Abbott', '--B--'] }
+      before { champ.primary_value = 'B' }
+
+      it { is_expected.to be_empty }
+    end
+  end
 end

--- a/spec/models/champs/linked_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/linked_drop_down_list_champ_spec.rb
@@ -118,6 +118,41 @@ describe Champs::LinkedDropDownListChamp do
     end
   end
 
+  describe '#libelle_for_error' do
+    let(:options) do
+      ['--Primary 1--', 'Secondary 1.1', 'Secondary 1.2', '--Primary 2--', 'Secondary 2.1']
+    end
+
+    context 'when the primary value is blank' do
+      it 'returns the champ libelle' do
+        expect(champ.libelle_for_error).to eq(champ.libelle)
+      end
+    end
+
+    context 'when the primary value is set but the secondary is blank' do
+      before { champ.primary_value = 'Primary 1' }
+
+      context 'without a custom secondary libelle' do
+        it 'returns the i18n default secondary libelle' do
+          expect(champ.libelle_for_error)
+            .to eq(I18n.t('shared.champs.linked_drop_down_list.secondary_default_libelle'))
+        end
+      end
+
+      context 'with a custom secondary libelle' do
+        let(:procedure) do
+          create(:procedure, types_de_champ_public: [
+            { type: :linked_drop_down_list, libelle: 'Ville', options:, secondary_libelle: 'Quartier', mandatory: true },
+          ])
+        end
+
+        it 'returns the custom secondary libelle' do
+          expect(champ.libelle_for_error).to eq('Quartier')
+        end
+      end
+    end
+  end
+
   describe '#mandatory_and_blank' do
     let(:options) { ["--Primary--", "Secondary"] }
 

--- a/spec/system/users/linked_dropdown_spec.rb
+++ b/spec/system/users/linked_dropdown_spec.rb
@@ -77,6 +77,12 @@ describe 'linked dropdown lists', js: true do
       select('Primary 1', from: 'linked dropdown')
       click_on 'Déposer le dossier'
       expect(page).to have_content('« Valeur secondaire dépendant de la première » doit être rempli')
+
+      # The error summary link and the secondary select both target the secondary input,
+      # and the secondary select is associated to the error region for screen readers.
+      champ = user_dossier.champs.first
+      expect(page).to have_link('Valeur secondaire dépendant de la première', href: "##{champ.focusable_input_id(:secondary_value)}")
+      expect(find("##{champ.focusable_input_id(:secondary_value)}")['aria-describedby']).to include(champ.error_id(:value))
     end
   end
 

--- a/spec/system/users/linked_dropdown_spec.rb
+++ b/spec/system/users/linked_dropdown_spec.rb
@@ -62,6 +62,22 @@ describe 'linked dropdown lists', js: true do
       # Secondary menu gets updated
       expect(page).to have_select("Valeur secondaire dépendant de la première", options: ['Sélectionnez', 'Secondary 1.1', 'Secondary 1.2'])
     end
+
+    scenario 'missing value error references the contextual label' do
+      log_in(user.email, password, procedure)
+
+      fill_individual
+
+      # Submit with nothing selected: error references the primary label.
+      click_on 'Déposer le dossier'
+      expect(page).to have_content('« linked dropdown » doit être rempli')
+
+      # Select a primary value, leave the secondary empty, submit again:
+      # error now references the secondary label.
+      select('Primary 1', from: 'linked dropdown')
+      click_on 'Déposer le dossier'
+      expect(page).to have_content('« Valeur secondaire dépendant de la première » doit être rempli')
+    end
   end
 
   private


### PR DESCRIPTION
Fixes #11366

Avant
<img width="1234" height="461" alt="before" src="https://github.com/user-attachments/assets/ac5c42a4-5e8d-4b2c-822c-5cf78ac614c7" />

Après
<img width="1260" height="477" alt="after" src="https://github.com/user-attachments/assets/ca16452e-7ed9-4032-9384-136e7704f24f" />



Quand une liste déroulante liée (champ avec une liste primaire et une liste secondaire dépendante) est obligatoire et non remplie, l'erreur faisait toujours référence au **premier** champ — son étiquette dans le message, et son `<select>` comme cible du lien dans le récapitulatif d'erreurs — même lorsque c'est la **seconde** liste qui n'est pas renseignée.

Désormais l'erreur cible la bonne liste, de bout en bout :
- **Libellé** : liste primaire vide → étiquette du premier champ ; primaire choisie mais secondaire vide → étiquette du second champ (ou son libellé par défaut). S'applique au message sous le champ et au récapitulatif.
- **Ancre & accessibilité** : le lien du récapitulatif amène le focus sur le bon `<select>`, et le select secondaire est associé à la zone d'erreur (`aria-describedby`) pour les lecteurs d'écran.

### Mise en œuvre
- `Champ#libelle_for_error` (par défaut `libelle`), surchargée dans `Champs::LinkedDropDownListChamp` pour choisir l'étiquette primaire/secondaire ; utilisée par le message inline et le récapitulatif.
- Validation alignée sur le pattern du champ `adresse` : `Champs::LinkedDropDownListChamp#validate_completed` émet l'erreur sur le sous-attribut réel (`:secondary_value` quand la seconde liste manque), et le hook de validation du dossier est généralisé (`respond_to?(:validate_completed)` au lieu de `champ.address?`). Id/label/aria du select secondaire alignés en conséquence ; le surlignage suit les erreurs réelles.
- Libellé de repli de la liste secondaire extrait en i18n (fr/en) ; nettoyage de code mort dans le composant.