### PR TITLE
Tech: extract update_annotations dans DossierEditConcern

### DIFF
--- a/app/controllers/concerns/dossier_edit_concern.rb
+++ b/app/controllers/concerns/dossier_edit_concern.rb
@@ -5,39 +5,74 @@ module DossierEditConcern
 
   private
 
-  def update_dossier_and_compute_errors
-    public_id, champ_attributes = champs_public_attributes_params.to_h.first
-    champ = dossier.public_champ_for_update(public_id, updated_by: current_user.email)
-    if champ.referentiel? && champ.autocomplete?
-      champ_attributes = champ_attributes.merge(params.require(:dossier).require(:champs_public_attributes).require(public_id).permit(:data).to_h)
-    end
-    champ.assign_attributes(champ_attributes)
+  def update_champ_and_compute_errors(scope:)
+    champ = find_and_prepare_champ(scope:)
     champ_changed = champ.changed_for_autosave?
 
-    # We save the dossier without validating fields, and if it is successful and the client
-    # requests it, we ask for field validation errors.
-    if Dossier.no_touching { champ.save }
-      if champ_changed
-        champ.update_timestamps if dossier.brouillon?
+    saved = save_champ(champ, champ_changed, scope)
 
-        if champ.has_async_external_data?
-          champ.reset_external_data!
-          champ.fetch_later! if champ.may_fetch_later?
-        end
+    if saved && champ_changed
+      champ.update_timestamps if scope == :private || dossier.brouillon?
+      refresh_external_data(champ)
+      scope == :public ? after_public_champ_saved(champ) : after_private_champ_saved
+    end
 
-        if champ.used_by_routing_rules? && dossier.brouillon?
-          @update_contact_information = true
-          RoutingEngine.compute(dossier)
-        end
-      end
+    validate_champ(champ, saved, scope)
+  end
 
-      if params[:validate].present? && !champ.pending?
-        dossier.validate(:champs_public_value)
-      end
+  def find_and_prepare_champ(scope:)
+    param_key = :"champs_#{scope}_attributes"
+    public_id, champ_attributes = champs_attributes_params(scope).to_h.first
+    champ = dossier.send(:"#{scope}_champ_for_update", public_id, updated_by: current_user.email)
+
+    if champ.referentiel? && champ.autocomplete?
+      champ_attributes = champ_attributes.merge(params.require(:dossier).require(param_key).require(public_id).permit(:data).to_h)
+    end
+    champ.assign_attributes(champ_attributes)
+    champ
+  end
+
+  def save_champ(champ, champ_changed, scope)
+    if scope == :public
+      Dossier.no_touching { champ.save }
+    else
+      champ_changed && champ.save
     end
   end
 
-  def champs_public_params
+  def after_public_champ_saved(champ)
+    if champ.used_by_routing_rules? && dossier.brouillon?
+      @update_contact_information = true
+      RoutingEngine.compute(dossier)
+    end
+  end
+
+  def after_private_champ_saved
+    dossier.index_search_terms_later
+    DossierNotification.create_notification(dossier, :annotation_instructeur, except_instructeur: current_instructeur) if !dossier.brouillon?
+  end
+
+  def validate_champ(champ, saved, scope)
+    validation_context = :"champs_#{scope}_value"
+    should_validate = if scope == :public
+      saved && params[:validate].present? && !champ.pending?
+    else
+      !champ.pending?
+    end
+    dossier.validate(validation_context) if should_validate
+  end
+
+  def refresh_external_data(champ)
+    if champ.has_async_external_data?
+      champ.reset_external_data!
+      champ.fetch_later! if champ.may_fetch_later?
+    end
+  end
+
+  # Strong attributes do not support records (indexed hash); they only support hashes with
+  # static keys. We create a static hash based on the available keys.
+  def champs_attributes_params(scope)
+    param_key = :"champs_#{scope}_attributes"
     champ_attributes = [
       :id,
       :value,
@@ -57,17 +92,11 @@ module DossierEditConcern
       :country_code,
       :commune_code,
       :postal_code,
-      :preview_state,
+      (:preview_state if scope == :public),
       value: [],
-    ]
-    # Strong attributes do not support records (indexed hash); they only support hashes with
-    # static keys. We create a static hash based on the available keys.
-    public_ids = params.dig(:dossier, :champs_public_attributes)&.keys || []
-    champs_public_attributes = public_ids.index_with { champ_attributes }
-    params.require(:dossier).permit(champs_public_attributes:)
-  end
-
-  def champs_public_attributes_params
-    champs_public_params.fetch(:champs_public_attributes)
+    ].compact
+    public_ids = params.dig(:dossier, param_key)&.keys || []
+    champs_attributes = public_ids.index_with { champ_attributes }
+    params.require(:dossier).permit(param_key => champs_attributes).fetch(param_key)
   end
 end

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -8,6 +8,7 @@ module Instructeurs
     include AvisCreationConcern
     include TurboChampsConcern
     include InstructeurConcern
+    include DossierEditConcern
     include ActionController::Streaming
     include BilansBdfConcern
     include Zipline
@@ -367,31 +368,11 @@ module Instructeurs
     end
 
     def update_annotations
-      public_id, annotation_attributes = champs_private_attributes_params.to_h.first
-      annotation = dossier.private_champ_for_update(public_id, updated_by: current_user.email)
-      if annotation.referentiel? && annotation.autocomplete?
-        annotation_attributes = annotation_attributes.merge(params.require(:dossier).require(:champs_private_attributes).require(public_id).permit(:data).to_h)
-      end
-      annotation.assign_attributes(annotation_attributes)
-      annotation_changed = annotation.changed_for_autosave?
-
-      if annotation_changed && annotation.save
-        annotation.update_timestamps
-
-        if annotation.has_async_external_data?
-          annotation.reset_external_data!
-          annotation.fetch_later! if annotation.may_fetch_later?
-        end
-
-        dossier.index_search_terms_later
-        DossierNotification.create_notification(dossier, :annotation_instructeur, except_instructeur: current_instructeur) if !dossier.brouillon?
-      end
-
-      dossier.validate(:champs_private_value) if !annotation.pending?
+      update_champ_and_compute_errors(scope: :private)
 
       respond_to do |format|
         format.turbo_stream do
-          @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_private_attributes_params, dossier.project_champs_private_all)
+          @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_attributes_params(:private), dossier.project_champs_private_all)
         end
       end
     end
@@ -554,39 +535,6 @@ module Instructeurs
 
     def commentaire_params
       params.require(:commentaire).permit(:body, piece_jointe: [])
-    end
-
-    def champs_private_params
-      champ_attributes = [
-        :id,
-        :value,
-        :value_other,
-        :external_id,
-        :code,
-        :primary_value,
-        :secondary_value,
-        :piece_justificative_file,
-        :code_departement,
-        :accreditation_number,
-        :accreditation_birthdate,
-        :address,
-        :not_in_ban,
-        :street_address,
-        :city_name,
-        :country_code,
-        :commune_code,
-        :postal_code,
-        value: [],
-      ]
-      # Strong attributes do not support records (indexed hash); they only support hashes with
-      # static keys. We create a static hash based on the available keys.
-      public_ids = params.dig(:dossier, :champs_private_attributes)&.keys || []
-      champs_private_attributes = public_ids.index_with { champ_attributes }
-      params.require(:dossier).permit(champs_private_attributes:)
-    end
-
-    def champs_private_attributes_params
-      champs_private_params.fetch(:champs_private_attributes)
     end
 
     def mark_demande_as_read

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -360,11 +360,11 @@ module Users
 
     def update
       @dossier = dossier_with_champs(pj_template: false)
-      update_dossier_and_compute_errors
+      update_champ_and_compute_errors(scope: :public)
 
       respond_to do |format|
         format.turbo_stream do
-          @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_public_attributes_params, dossier.project_champs_public_all)
+          @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_attributes_params(:public), dossier.project_champs_public_all)
           render :update, layout: false
         end
       end


### PR DESCRIPTION
## Summary

- Extrait la logique de mutation d'annotation de `Instructeurs::DossiersController#update_annotations` dans `DossierEditConcern`
- API unifiée `update_champ_and_compute_errors(scope:)` pour public (usager) et private (instructeur)
- Factorise les strong params dupliqués (`champs_public_params` / `champs_private_params`) en un seul `champs_attributes_params(scope)`
- Supprime ~55 lignes de code dupliqué dans le contrôleur instructeur

Refactoring pur, zéro changement de comportement. Prépare l'ajout de guards cross-cutting (ex: champ pré-rempli read-only) qui s'appliqueront automatiquement aux deux chemins.

## Test plan

- [ ] Specs instructeur `update_annotations` passent (10 examples)
- [ ] Specs usager `update` passent (75 examples)
- [ ] CI verte

🤖 Generated with [Claude Code](https://claude.com/claude-code)