### PR TITLE
Tech: Simplification du code de la liste procedure-stats

### DIFF
--- a/app/components/instructeurs/procedure_summary_component/procedure_summary_component.html.erb
+++ b/app/components/instructeurs/procedure_summary_component/procedure_summary_component.html.erb
@@ -174,12 +174,7 @@
   </nav>
 
   <ul class="procedure-stats flex fr-background-alt--grey justify-around wrap fr-p-1w">
-    <li
-      class="
-        fr-btn fr-btn--tertiary-no-outline flex justify-center
-        fr-my-1w
-      "
-    >
+    <li class="fr-btn fr-btn--tertiary-no-outline flex justify-center fr-my-1w">
       <%= link_to(instructeur_procedure_path(p, statut: 'a-suivre'), class: 'center') do %>
         <span id="procedure-<%= p.id %>-a-suivre-count" class="fr-text--bold">
           <%= placeholder_span %>
@@ -193,12 +188,7 @@
       <% end %>
     </li>
 
-    <li
-      class="
-        fr-btn fr-btn--tertiary-no-outline flex justify-center
-        fr-my-1w
-      "
-    >
+    <li class="fr-btn fr-btn--tertiary-no-outline flex justify-center fr-my-1w">
       <%= link_to(instructeur_procedure_path(p, statut: 'suivis'), class: 'center') do %>
         <span id="procedure-<%= p.id %>-followed-count" class="fr-text--bold">
           <%= placeholder_span %>
@@ -212,12 +202,7 @@
       <% end %>
     </li>
 
-    <li
-      class="
-        fr-btn fr-btn--tertiary-no-outline flex justify-center
-        fr-my-1w
-      "
-    >
+    <li class="fr-btn fr-btn--tertiary-no-outline flex justify-center fr-my-1w">
       <%= link_to(instructeur_procedure_path(p, statut: 'traites'), class: 'center') do %>
         <span id="procedure-<%= p.id %>-termines-count" class="fr-text--bold">
           <%= placeholder_span %>
@@ -231,12 +216,7 @@
       <% end %>
     </li>
 
-    <li
-      class="
-        fr-btn fr-btn--tertiary-no-outline flex justify-center
-        fr-my-1w
-      "
-    >
+    <li class="fr-btn fr-btn--tertiary-no-outline flex justify-center fr-my-1w">
       <%= link_to(instructeur_procedure_path(p, statut: 'tous'), class: 'center') do %>
         <span id="procedure-<%= p.id %>-dossier-count" class="fr-text--bold">
           <%= placeholder_span %>
@@ -249,12 +229,7 @@
     </li>
 
     <% if p.procedure_expires_when_termine_enabled %>
-      <li
-        class="
-          fr-btn fr-btn--tertiary-no-outline flex justify-center
-          fr-my-1w
-        "
-      >
+      <li class="fr-btn fr-btn--tertiary-no-outline flex justify-center fr-my-1w">
         <%= link_to(instructeur_procedure_path(p, statut: 'expirant'), class: 'center') do %>
           <span class="fr-icon-timer-line fr-icon--sm fr-text--bold"></span>
 
@@ -269,12 +244,7 @@
       </li>
     <% end %>
 
-    <li
-      class="
-        fr-btn fr-btn--tertiary-no-outline flex justify-center
-        fr-my-1w
-      "
-    >
+    <li class="fr-btn fr-btn--tertiary-no-outline flex justify-center fr-my-1w">
       <%= link_to(instructeur_procedure_path(p, statut: 'archives'), class: 'center') do %>
         <span class="fr-icon-folder-2-line fr-icon--sm fr-text--bold"></span>
 
@@ -288,12 +258,7 @@
       <% end %>
     </li>
 
-    <li
-      class="
-        fr-btn fr-btn--tertiary-no-outline flex justify-center
-        fr-my-1w
-      "
-    >
+    <li class="fr-btn fr-btn--tertiary-no-outline flex justify-center fr-my-1w">
       <%= link_to(instructeur_procedure_path(p, statut: 'supprimes'), class: 'center') do %>
         <span class="fr-icon-delete-line fr-icon--sm fr-text--bold"></span>
 

--- a/app/components/instructeurs/procedure_summary_component/procedure_summary_component.html.erb
+++ b/app/components/instructeurs/procedure_summary_component/procedure_summary_component.html.erb
@@ -177,7 +177,7 @@
     <li
       class="
         fr-btn fr-btn--tertiary-no-outline flex justify-center
-        fr-enlarge-link fr-my-1w
+        fr-my-1w
       "
     >
       <%= link_to instructeur_procedure_path(p, statut: 'a-suivre') do %>
@@ -198,7 +198,7 @@
     <li
       class="
         fr-btn fr-btn--tertiary-no-outline flex justify-center
-        fr-enlarge-link fr-my-1w
+        fr-my-1w
       "
     >
       <%= link_to(instructeur_procedure_path(p, statut: 'suivis')) do %>
@@ -219,7 +219,7 @@
     <li
       class="
         fr-btn fr-btn--tertiary-no-outline flex justify-center
-        fr-enlarge-link fr-my-1w
+        fr-my-1w
       "
     >
       <%= link_to(instructeur_procedure_path(p, statut: 'traites')) do %>
@@ -240,7 +240,7 @@
     <li
       class="
         fr-btn fr-btn--tertiary-no-outline flex justify-center
-        fr-enlarge-link fr-my-1w
+        fr-my-1w
       "
     >
       <%= link_to(instructeur_procedure_path(p, statut: 'tous')) do %>
@@ -260,7 +260,7 @@
       <li
         class="
           fr-btn fr-btn--tertiary-no-outline flex justify-center
-          fr-enlarge-link fr-my-1w
+          fr-my-1w
         "
       >
         <%= link_to(instructeur_procedure_path(p, statut: 'expirant')) do %>
@@ -282,7 +282,7 @@
     <li
       class="
         fr-btn fr-btn--tertiary-no-outline flex justify-center
-        fr-enlarge-link fr-my-1w
+        fr-my-1w
       "
     >
       <%= link_to(instructeur_procedure_path(p, statut: 'archives')) do %>
@@ -303,7 +303,7 @@
     <li
       class="
         fr-btn fr-btn--tertiary-no-outline flex justify-center
-        fr-enlarge-link fr-my-1w
+        fr-my-1w
       "
     >
       <%= link_to(instructeur_procedure_path(p, statut: 'supprimes')) do %>

--- a/app/components/instructeurs/procedure_summary_component/procedure_summary_component.html.erb
+++ b/app/components/instructeurs/procedure_summary_component/procedure_summary_component.html.erb
@@ -180,14 +180,12 @@
         fr-my-1w
       "
     >
-      <%= link_to instructeur_procedure_path(p, statut: 'a-suivre') do %>
-        <div class="center fr-text--bold">
-          <span id="procedure-<%= p.id %>-a-suivre-count">
-            <%= placeholder_span %>
-          </span>
-        </div>
+      <%= link_to(instructeur_procedure_path(p, statut: 'a-suivre'), class: 'center') do %>
+        <span id="procedure-<%= p.id %>-a-suivre-count" class="fr-text--bold">
+          <%= placeholder_span %>
+        </span>
 
-        <div class="center fr-text--sm">
+        <div class="fr-text--sm">
           <%= t('instructeurs.dossiers.labels.to_follow') %>
         </div>
 
@@ -201,14 +199,12 @@
         fr-my-1w
       "
     >
-      <%= link_to(instructeur_procedure_path(p, statut: 'suivis')) do %>
-        <div class="center fr-text--bold">
-          <span id="procedure-<%= p.id %>-followed-count">
-            <%= placeholder_span %>
-          </span>
-        </div>
+      <%= link_to(instructeur_procedure_path(p, statut: 'suivis'), class: 'center') do %>
+        <span id="procedure-<%= p.id %>-followed-count" class="fr-text--bold">
+          <%= placeholder_span %>
+        </span>
 
-        <div class="center fr-text--sm">
+        <div class="fr-text--sm">
           <%= t('instructeurs.dossiers.labels.followed') %>
         </div>
 
@@ -222,14 +218,12 @@
         fr-my-1w
       "
     >
-      <%= link_to(instructeur_procedure_path(p, statut: 'traites')) do %>
-        <div class="center fr-text--bold">
-          <span id="procedure-<%= p.id %>-termines-count">
-            <%= placeholder_span %>
-          </span>
-        </div>
+      <%= link_to(instructeur_procedure_path(p, statut: 'traites'), class: 'center') do %>
+        <span id="procedure-<%= p.id %>-termines-count" class="fr-text--bold">
+          <%= placeholder_span %>
+        </span>
 
-        <div class="center fr-text--sm">
+        <div class="fr-text--sm">
           <%= t('instructeurs.dossiers.labels.processed') %>
         </div>
 
@@ -243,14 +237,12 @@
         fr-my-1w
       "
     >
-      <%= link_to(instructeur_procedure_path(p, statut: 'tous')) do %>
-        <div class="center fr-text--bold">
-          <span id="procedure-<%= p.id %>-dossier-count">
-            <%= placeholder_span %>
-          </span>
-        </div>
+      <%= link_to(instructeur_procedure_path(p, statut: 'tous'), class: 'center') do %>
+        <span id="procedure-<%= p.id %>-dossier-count" class="fr-text--bold">
+          <%= placeholder_span %>
+        </span>
 
-        <div class="center fr-text--sm">
+        <div class="fr-text--sm">
           <%= t('instructeurs.dossiers.labels.total') %>
         </div>
       <% end %>
@@ -263,12 +255,10 @@
           fr-my-1w
         "
       >
-        <%= link_to(instructeur_procedure_path(p, statut: 'expirant')) do %>
-          <div class="center fr-text--bold">
-            <span class="fr-icon-timer-line fr-icon--sm"></span>
-          </div>
+        <%= link_to(instructeur_procedure_path(p, statut: 'expirant'), class: 'center') do %>
+          <span class="fr-icon-timer-line fr-icon--sm fr-text--bold"></span>
 
-          <div class="center fr-text--sm">
+          <div class="fr-text--sm">
             <%= t('instructeurs.dossiers.labels.close_to_expiration') %>
 
             <span id="procedure-<%= p.id %>-expirant-count">
@@ -285,12 +275,10 @@
         fr-my-1w
       "
     >
-      <%= link_to(instructeur_procedure_path(p, statut: 'archives')) do %>
-        <div class="center fr-text--bold">
-          <span class="fr-icon-folder-2-line fr-icon--sm"></span>
-        </div>
+      <%= link_to(instructeur_procedure_path(p, statut: 'archives'), class: 'center') do %>
+        <span class="fr-icon-folder-2-line fr-icon--sm fr-text--bold"></span>
 
-        <div class="center fr-text--sm">
+        <div class="fr-text--sm">
           <%= t('instructeurs.dossiers.labels.to_archive') %>
 
           <span id="procedure-<%= p.id %>-archives-count">
@@ -306,12 +294,10 @@
         fr-my-1w
       "
     >
-      <%= link_to(instructeur_procedure_path(p, statut: 'supprimes')) do %>
-        <div class="center fr-text--bold">
-          <span class="fr-icon-delete-line fr-icon--sm"></span>
-        </div>
+      <%= link_to(instructeur_procedure_path(p, statut: 'supprimes'), class: 'center') do %>
+        <span class="fr-icon-delete-line fr-icon--sm fr-text--bold"></span>
 
-        <div class="center fr-text--sm">
+        <div class="fr-text--sm">
           <%= t('instructeurs.dossiers.labels.trash') %>
 
           <span id="procedure-<%= p.id %>-supprimes-count">

--- a/app/views/experts/avis/index.html.haml
+++ b/app/views/experts/avis/index.html.haml
@@ -12,7 +12,7 @@
       = procedure_badge(p)
 
       %ul.procedure-stats.flex.wrap.flex-gap-1.fr-my-2w
-        %li.fr-btn.fr-btn--tertiary.flex.justify-center.fr-enlarge-link
+        %li.fr-btn.fr-btn--tertiary.flex.justify-center
           = link_to(procedure_expert_avis_index_path(p, statut: Instructeurs::AvisController::A_DONNER_STATUS)) do
             - without_answer_count = procedure_avis.select { _1.answer.nil? }.reject{ _1.dossier.termine?}.size
             .center.fr-text--bold.fr-text--sm
@@ -22,7 +22,7 @@
             - if without_answer_count > 0
               %span.notifications
                 %span.fr-sr-only= t(".notification")
-        %li.fr-btn.fr-btn--tertiary.flex.justify-center.fr-enlarge-link
+        %li.fr-btn.fr-btn--tertiary.flex.justify-center
           = link_to(procedure_expert_avis_index_path(p, statut: Instructeurs::AvisController::DONNES_STATUS)) do
             - with_answer_count = procedure_avis.select { |a| a.answer.present? }.size
             .center.fr-text--bold.fr-text--sm= with_answer_count

--- a/app/views/experts/avis/index.html.haml
+++ b/app/views/experts/avis/index.html.haml
@@ -13,18 +13,19 @@
 
       %ul.procedure-stats.flex.wrap.flex-gap-1.fr-my-2w
         %li.fr-btn.fr-btn--tertiary.flex.justify-center
-          = link_to(procedure_expert_avis_index_path(p, statut: Instructeurs::AvisController::A_DONNER_STATUS)) do
+          = link_to(procedure_expert_avis_index_path(p, statut: Instructeurs::AvisController::A_DONNER_STATUS), class: 'center') do
             - without_answer_count = procedure_avis.select { _1.answer.nil? }.reject{ _1.dossier.termine?}.size
-            .center.fr-text--bold.fr-text--sm
+            %span.fr-text--bold.fr-text--sm
               = without_answer_count
-            .center.fr-text--xs
+            .fr-text--xs
               = t(".to_give", count: without_answer_count)
             - if without_answer_count > 0
               %span.notifications
                 %span.fr-sr-only= t(".notification")
         %li.fr-btn.fr-btn--tertiary.flex.justify-center
-          = link_to(procedure_expert_avis_index_path(p, statut: Instructeurs::AvisController::DONNES_STATUS)) do
+          = link_to(procedure_expert_avis_index_path(p, statut: Instructeurs::AvisController::DONNES_STATUS), class: 'center') do
             - with_answer_count = procedure_avis.select { |a| a.answer.present? }.size
-            .center.fr-text--bold.fr-text--sm= with_answer_count
-            .center.fr-text--xs
+            %span.fr-text--bold.fr-text--sm
+              = with_answer_count
+            .fr-text--xs
               = t(".given", count: with_answer_count)


### PR DESCRIPTION
Simplification du code de la liste `procedure-stats` :
- Suppression de la classe `fr-enlarge-link` dont le style `position: relative;` est conféré par la feuille de styles.
- Factorisation de la classe `center` sur le lien parent plutôt que sur chaque enfant.
- Formattage du fichier.

# Après
<img width="1470" height="552" alt="Capture d’écran 2026-06-02 à 13 18 07" src="https://github.com/user-attachments/assets/77f4a5ea-25d3-4a8f-850a-f7a73a079084" />
<img width="1492" height="633" alt="Capture d’écran 2026-06-02 à 13 50 26" src="https://github.com/user-attachments/assets/5c5754c4-4979-4a05-8c17-7f894aae0ebd" />

# Avant
<img width="1480" height="554" alt="Capture d’écran 2026-06-02 à 13 19 24" src="https://github.com/user-attachments/assets/0e2fa886-8ebe-44f6-8bd8-84522cd66e7a" />

<img width="1487" height="668" alt="Capture d’écran 2026-06-02 à 13 50 55" src="https://github.com/user-attachments/assets/dc352c3a-3e93-436c-b322-a90da58cf57e" />



