### PR TITLE
Tech: verrou atomique anti double-soumission de dossier

### DIFF
--- a/app/controllers/concerns/lockable_concern.rb
+++ b/app/controllers/concerns/lockable_concern.rb
@@ -5,12 +5,14 @@ module LockableConcern
 
   def lock_action(key)
     lock = Kredis.flag(key)
-    head :locked and return if lock.marked?
+    # Atomic acquire (SET NX): only the request that actually sets the flag
+    # enters the protected section, so concurrent requests cannot both pass.
+    head :locked and return unless lock.mark(expires_in: 10.seconds, force: false)
 
-    lock.mark(expires_in: 10.seconds)
-
-    yield
-
-    lock.remove
+    begin
+      yield
+    ensure
+      lock.remove
+    end
   end
 end

--- a/spec/controllers/concerns/lockable_concern_spec.rb
+++ b/spec/controllers/concerns/lockable_concern_spec.rb
@@ -6,6 +6,7 @@ describe LockableConcern, type: :controller do
 
     def test_action
       lock_action(params.fetch(:lock_key)) do
+        raise StandardError, 'boom' if params[:raise_in_action]
         render plain: 'Action completed'
       end
     end
@@ -42,6 +43,65 @@ describe LockableConcern, type: :controller do
         sleep 0.002
 
         expect(subject).to have_http_status(:ok)
+      end
+    end
+
+    context 'when two overlapping requests reach the lock at the same time' do
+      # Minimal host for the concern so each thread drives lock_action on its own
+      # instance, without sharing controller request/response state across threads.
+      let(:host_class) do
+        Class.new do
+          include LockableConcern
+
+          attr_reader :locked_status
+
+          def head(status)
+            @locked_status = status
+          end
+        end
+      end
+
+      it 'runs the protected section only once' do
+        executions = Concurrent::AtomicFixnum.new(0)
+        start = Concurrent::CyclicBarrier.new(2)
+
+        # Force the two threads to both finish reading the lock state before
+        # either one writes it, reproducing the concurrent arrival deterministically.
+        check_barrier = Concurrent::CyclicBarrier.new(2)
+        shared_flag = Kredis.flag(lock_key)
+        allow(Kredis).to receive(:flag).with(lock_key).and_return(shared_flag)
+        allow(shared_flag).to receive(:marked?).and_wrap_original do |original|
+          result = original.call
+          check_barrier.wait(2)
+          result
+        end
+
+        protected_section = proc do
+          executions.increment
+          # Hold the lock long enough that the other request genuinely overlaps.
+          sleep 0.2
+        end
+
+        threads = Array.new(2) do
+          Thread.new do
+            host = host_class.new
+            start.wait(2)
+            host.lock_action(lock_key, &protected_section)
+          end
+        end
+        threads.each(&:join)
+
+        expect(executions.value).to eq(1)
+      end
+    end
+
+    context 'when the protected section raises' do
+      it 'releases the lock so a later request can run' do
+        expect {
+          get :test_action, params: { lock_key:, raise_in_action: true }
+        }.to raise_error(StandardError, 'boom')
+
+        expect(Kredis.flag(lock_key).marked?).to be(false)
       end
     end
   end


### PR DESCRIPTION
Le verrou qui protège `submit_en_construction` (dépôt d'un dossier par l'usager) vérifiait l'état du verrou puis le posait en deux opérations Redis distinctes : deux requêtes concurrentes pouvaient le franchir en même temps et déclencher un double dépôt (doubles traitements, notifications, e-mails). Cette action ne passant pas par la garde d'état AASM, le verrou en était la seule protection.

## Changements
- Acquisition atomique via `SET … NX` (`Kredis::Flag#mark(force: false)`) : seule la requête qui pose réellement le drapeau entre dans la section protégée.
- `yield` encadré par `begin/ensure` : le verrou est relâché même en cas d'exception, sans attendre l'expiration du TTL.
- Specs de régression ajoutées (concurrence + libération après exception).