### PR TITLE
Tech: API Entreprise, considérer un ping en timeout comme provider indisponible

### DIFF
--- a/app/lib/api_entreprise/health_checker.rb
+++ b/app/lib/api_entreprise/health_checker.rb
@@ -47,7 +47,17 @@ module APIEntreprise::HealthChecker
   end
 
   def self.store_response(ping_key, response)
-    status = JSON.parse(response.body)['status']
+    status =
+      if response.timed_out? || response.code.zero? || response.body.blank?
+        # No usable response (timeout, connection error): on_complete is still
+        # invoked by Typhoeus with an empty body. Treat the provider as down (the
+        # same outage shows up sometimes as a 502 bad_gateway, sometimes as a
+        # timeout) so the circuit breaker reschedules jobs. Fail-safe: jobs only retry.
+        'no_response'
+      else
+        JSON.parse(response.body)['status']
+      end
+
     Kredis.redis.set(cache_key(ping_key), status, ex: CACHE_TTL.to_i)
     status
   rescue JSON::ParserError => e

--- a/spec/lib/api_entreprise/health_checker_spec.rb
+++ b/spec/lib/api_entreprise/health_checker_spec.rb
@@ -72,15 +72,21 @@ RSpec.describe APIEntreprise::HealthChecker do
         stub_request(:get, "#{described_class::PING_BASE_URL}/insee/sirene").to_timeout
       end
 
-      it 'captures exception in Sentry' do
-        expect(Sentry).to receive(:capture_exception)
+      it 'marks the provider as down' do
         described_class.refresh_all!
+        expect(described_class.provider_up?('insee/sirene')).to be false
+      end
+    end
+
+    context 'when a provider returns an empty body' do
+      before do
+        stub_request(:get, "#{described_class::PING_BASE_URL}/insee/sirene")
+          .to_return(status: 200, body: '')
       end
 
-      it 'does not overwrite existing cache for that provider' do
-        cache_status('insee/sirene', 'ok')
+      it 'marks the provider as down' do
         described_class.refresh_all!
-        expect(described_class.cached_status('insee/sirene')).to eq('ok')
+        expect(described_class.provider_up?('insee/sirene')).to be false
       end
     end
 


### PR DESCRIPTION
## Contexte

Le health-check `APIEntreprise::HealthChecker` ping chaque provider de l'API Entreprise. [On a constaté](https://demarches-simplifiees.sentry.io/issues/7513481575/) qu'un provider en panne (ex. `european_commission/numero_tva`) répond de façon intermittente, tantôt en `502 {"status":"bad_gateway"}`, tantôt en **timeout** (body vide).

Sur timeout, Typhoeus invoque quand même `on_complete` avec un body vide, donc `JSON.parse("")` levait une `JSON::ParserError` remontée à Sentry à chaque occurrence (~600 events de bruit), alors que la même panne était par ailleurs correctement détectée via le 502. La conséquence est qu'on ne considère pas l'endpiont comme en panne, est ça provoque alors [les erreurs en cascade qu'on connaît](https://demarches-simplifiees.sentry.io/issues/7494851855/).

## Changement

Un timeout / absence de réponse est désormais traité comme un statut `no_response` (provider down), pour que le disjoncteur reporte les jobs concernés (`RetryableError`) — fail-safe, les jobs sont simplement retentés.

Le parsing JSON réellement invalide (anomalie côté API) continue d'être capturé.