### PR TITLE
ETQ usager, je suis mieux alerté si j’ai apporté des modifications à mon dossier mais ne les ai pas déposées

### DIFF
--- a/app/components/dossiers/en_construction_not_submitted_component/en_construction_not_submitted_component.html.haml
+++ b/app/components/dossiers/en_construction_not_submitted_component/en_construction_not_submitted_component.html.haml
@@ -1,8 +1,7 @@
-= render Dsfr::CalloutComponent.new(title: t(".title"), icon: "fr-fi-information-line", heading_level: 'h2') do |c|
+= render Dsfr::AlertComponent.new(title: t(".title"), state: :warning, heading_level: 'h2', extra_class_names: 'fr-mb-3w') do |c|
   - c.with_body do
     = t(".body")
 
-  - c.with_bottom do
-    %ul.fr-mt-2w.fr-btns-group.fr-btns-group--inline
-      %li= link_to t(".buttons.edit"), modifier_dossier_path(dossier), class: "fr-btn"
-      %li= button_to t(".buttons.submit"), modifier_dossier_path(dossier), class: "fr-btn fr-btn--secondary", method: :post
+    %ul.fr-mt-2w.fr-btns-group.fr-btns-group--inline.fr-btns-group--sm
+      %li= button_to t(".buttons.submit"), modifier_dossier_path(dossier), class: "fr-btn", method: :post
+      %li= link_to t(".buttons.edit"), modifier_dossier_path(dossier), class: "fr-btn fr-btn--secondary"

--- a/app/views/users/dossiers/_dossiers_list.html.erb
+++ b/app/views/users/dossiers/_dossiers_list.html.erb
@@ -118,6 +118,10 @@
         <% end %>
       <% end %>
 
+      <% if dossier.en_construction? %>
+        <%= render Dossiers::EnConstructionNotSubmittedComponent.new(dossier: dossier, user: current_user) %>
+      <% end %>
+
       <% if dossier.pending_correction? %>
         <%= render Dsfr::AlertComponent.new(state: :warning, size: :sm, extra_class_names: "fr-mb-2w") do |c| %>
           <% c.with_body do %>

--- a/app/views/users/dossiers/demande.html.haml
+++ b/app/views/users/dossiers/demande.html.haml
@@ -9,9 +9,6 @@
   .fr-container
     .fr-grid-row.fr-grid-row--center
       .fr-col-md-9
-        - if @dossier.en_construction?
-          = render Dossiers::EnConstructionNotSubmittedComponent.new(dossier: @dossier, user: current_user)
-
         = render partial: 'shared/dossiers/demande', locals: { dossier: @dossier, demande_seen_at: nil, profile: 'usager' }
 
         - if !@dossier.read_only?

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -24,6 +24,8 @@
             = link_to t('views.users.dossiers.demande.edit_dossier'), modifier_dossier_path(dossier), class: 'fr-btn fr-btn-sm fr-mt-2w fr-mt-md-0 fr-ml-md-1w',
               title: t('views.users.dossiers.demande.edit_dossier_title')
 
+    - if dossier.en_construction?
+      = render Dossiers::EnConstructionNotSubmittedComponent.new(dossier: dossier, user: current_user)
     %nav.fr-tabs{ role: 'navigation', 'aria-label': t('views.users.dossiers.dossier_menu', id: dossier.id) }
       %ul.fr-tabs__list
         = dynamic_tab_item(t('views.users.dossiers.show.header.summary_html'), dossier_path(dossier))

--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -16,11 +16,6 @@
           %li.termine{ 'aria-current': dossier.termine? ? 'true' : nil }
             = t('views.users.dossiers.show.status_overview.status_completed')
 
-  - if dossier.en_construction?
-    .fr-grid-row.fr-grid-row--center
-      .fr-col-md-10.fr-col-lg-9
-        = render Dossiers::EnConstructionNotSubmittedComponent.new(dossier: dossier, user: current_user)
-
   .fr-grid-row.fr-grid-row--center
     .fr-col-md-10.fr-col-lg-9.status-explanation
       -# brouillon does not occure


### PR DESCRIPTION
closes #13190 

> Vu avec Marlène, on n'a finalement pas mis l'alerte du navigateur car sur un evenement `beforeunload` on ne peut pas personnaliser l'alerte, et le message de l'alerte générique est plus confusante qu'autre chose.


<img width="1265" height="652" alt="Capture d’écran 2026-06-03 à 16 35 19" src="https://github.com/user-attachments/assets/3f75c518-37f4-49a4-82b5-aa85e2cbf8b2" />
