### PR TITLE
ETQ instructeur, adresse cohérente entre exports, interface, PDF et API

### DIFF
--- a/app/models/columns/address_column.rb
+++ b/app/models/columns/address_column.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Columns::AddressColumn < Columns::ChampColumn
+  private
+
+  # The raw `value` column is not guaranteed to match the canonical address
+  # label stored in `value_json` (eg. BAN addresses). The PDF, the UI and the
+  # API all display `address_label`, so exports and dossiers lists must too.
+  # Fallback to the raw value for champs of another type (eg. after a rebase).
+  def string_value(champ) = champ.respond_to?(:address_label) ? champ.address_label : super
+end

--- a/app/models/types_de_champ/address_type_de_champ.rb
+++ b/app/models/types_de_champ/address_type_de_champ.rb
@@ -47,8 +47,17 @@ class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   end
 
   def columns(procedure_id:, displayable: true, prefix: nil)
-    super
-      .concat(addressable_columns(procedure_id:, displayable:, prefix:, deprecated_columns: true))
+    [
+      Columns::AddressColumn.new(
+        procedure_id:,
+        stable_id:,
+        tdc_type: type_champ,
+        label: libelle_with_prefix(prefix),
+        type: TypeDeChamp.column_type(type_champ),
+        displayable:,
+        mandatory: mandatory?
+      ),
+    ].concat(addressable_columns(procedure_id:, displayable:, prefix:, deprecated_columns: true))
   end
 
   def info_columns(procedure:)

--- a/spec/models/columns/champ_column_spec.rb
+++ b/spec/models/columns/champ_column_spec.rb
@@ -12,7 +12,7 @@ describe Columns::ChampColumn do
         expect_type_de_champ_values('civilite', eq(["M."]))
         expect_type_de_champ_values('email', eq(['yoda@beta.gouv.fr']))
         expect_type_de_champ_values('phone', eq(['0666666666']))
-        expect_type_de_champ_values('address', eq(["2 rue des Démarches", "38000", "grenoble", "38", "84", "Auvergne-Rhones-Alpes"]))
+        expect_type_de_champ_values('address', eq(["2 rue des Démarches grenoble (38100)", "38000", "grenoble", "38", "84", "Auvergne-Rhones-Alpes"]))
         expect_type_de_champ_values('communes', eq(["60580", "Coye-la-Forêt", "60", "32", "Coye-la-Forêt", "60580", "60"]))
         expect_type_de_champ_values('departements', eq(["01", "84", "01"]))
         expect_type_de_champ_values('regions', eq(['01', '01']))

--- a/spec/models/types_de_champ/address_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/address_type_de_champ_spec.rb
@@ -19,6 +19,26 @@ describe TypesDeChamp::AddressTypeDeChamp do
       expect(columns.map(&:label)).to match_array(expected_columns)
     end
 
+    describe 'main value column' do
+      let(:main_column) { columns.find { _1.label == 'addr' } }
+      let(:champ) do
+        Champs::AddressChamp.new(
+          type_de_champ: address_tdc,
+          value: '2 rue des Démarches',
+          value_json: {
+            'label' => '2 rue des Démarches grenoble (38100)',
+            'city_code' => '38100',
+            'street_address' => '2 rue des Démarches',
+            'country_code' => 'FR',
+          }
+        )
+      end
+
+      it 'returns the canonical address label, like the PDF and the UI (not the raw value)' do
+        expect(main_column.value(champ)).to eq('2 rue des Démarches grenoble (38100)')
+      end
+    end
+
     context 'legacy region_name column (kept for backward compat)' do
       let(:legacy_column) { columns.find { _1.is_a?(Columns::JSONPathColumn) && _1.jsonpath == '$.region_name' } }
 


### PR DESCRIPTION
## Problème

Pour les champs adresse, la valeur affichée dans les **exports template** et dans le **tableau des dossiers** (côté instructeur) provenait de la colonne SQL brute `champs.value`, alors que le PDF, l'interface et l'API utilisent `address_label` (`value_json['label']`, avec repli sur `value`).

Pour les adresses BAN, ces deux valeurs peuvent différer (`value` = saisie brute, `value_json['label']` = libellé canonique), d'où une adresse incohérente entre l'export et le PDF.

https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_6bf9701c-9e20-4ce1-80e0-de302b9b0041/

## Correctif

Introduction de `Columns::AddressColumn` (sur le modèle de `Columns::LinkedDropDownColumn`) qui expose `address_label` comme valeur, alignant exports et liste sur le PDF, l'interface et l'API.

- Le filtrage SQL continue d'utiliser la colonne `value` (inchangé).
- Le `column_id` est inchangé → les présentations et gabarits d'export enregistrés continuent de se résoudre sans migration.

## À noter (API GraphQL)

`champ.columns` expose un champ `value` par colonne. Pour un champ adresse, la colonne principale renvoie désormais `address_label` au lieu de la valeur brute. C'est une mise en cohérence : le champ `string_value` de l'API renvoyait déjà ce libellé.
