### PR TITLE
ETQ usager, mon export PDF reflète la hiérarchie de mes sections

### DIFF
--- a/app/models/concerns/dossier_sections_concern.rb
+++ b/app/models/concerns/dossier_sections_concern.rb
@@ -27,10 +27,10 @@ module DossierSectionsConcern
     types_de_champ = header.private? ? revision.types_de_champ_private : revision.types_de_champ_public
     counters = []
 
-    types_de_champ.each do |tdc|
-      next if !tdc.header_section?
-      next if !project_champ(tdc).visible?
-
+    types_de_champ
+      .filter(&:header_section?)
+      .filter { project_champ(it).visible? }
+      .each do |tdc|
       level = tdc.level_for_revision(revision)
 
       # drop counter with a higher level

--- a/app/models/concerns/dossier_sections_concern.rb
+++ b/app/models/concerns/dossier_sections_concern.rb
@@ -28,12 +28,6 @@ module DossierSectionsConcern
     counters = []
 
     types_de_champ.each do |tdc|
-      if tdc.repetition?
-        index_in_repetition = revision.children_of(tdc).find_index { _1.stable_id == header.stable_id }
-        return "#{counters.first || 1}.#{index_in_repetition + 1}" if index_in_repetition
-        next
-      end
-
       next if !tdc.header_section?
       next if !project_champ(tdc).visible?
 

--- a/app/models/concerns/dossier_sections_concern.rb
+++ b/app/models/concerns/dossier_sections_concern.rb
@@ -40,8 +40,8 @@ module DossierSectionsConcern
       # increase current counter
       counters[level - 1] = (counters[level - 1] || 0) + 1
 
-      # in case of missing level, fill any skipped ancestor level with 1
-      (0...level).each { |i| counters[i] ||= 1 }
+      # in case of missing level (nil), fill it with 1
+      counters.map! { it || 1 }
 
       return counters.join('.') if tdc.stable_id == header.stable_id
     end

--- a/app/models/concerns/dossier_sections_concern.rb
+++ b/app/models/concerns/dossier_sections_concern.rb
@@ -23,28 +23,36 @@ module DossierSectionsConcern
     sections_for(type_de_champ)&.none? { _1.libelle =~ /^\d/ }
   end
 
-  def index_for_section_header(type_de_champ)
-    types_de_champ = type_de_champ.private? ? revision.types_de_champ_private : revision.types_de_champ_public
+  def index_for_section_header(header)
+    types_de_champ = header.private? ? revision.types_de_champ_private : revision.types_de_champ_public
     counters = []
 
     types_de_champ.each do |tdc|
       if tdc.repetition?
-        index_in_repetition = revision.children_of(tdc).find_index { _1.stable_id == type_de_champ.stable_id }
+        index_in_repetition = revision.children_of(tdc).find_index { _1.stable_id == header.stable_id }
         return "#{counters.first || 1}.#{index_in_repetition + 1}" if index_in_repetition
         next
       end
 
-      next unless tdc.header_section?
-      next unless project_champ(tdc).visible?
+      next if !tdc.header_section?
+      next if !project_champ(tdc).visible?
 
       level = tdc.level_for_revision(revision)
+
+      # drop counter with a higher level
+      # ex: counters = [1,2,2], new header of level 2, drop last
       counters = counters.first(level)
+
+      # increase current counter
       counters[level - 1] = (counters[level - 1] || 0) + 1
+
+      # in case of missing level, fill any skipped ancestor level with 1
       (0...level).each { |i| counters[i] ||= 1 }
 
-      return counters.join('.') if tdc.stable_id == type_de_champ.stable_id
+      return counters.join('.') if tdc.stable_id == header.stable_id
     end
 
-    counters.join('.')
+    # invisible header: no number
+    nil
   end
 end

--- a/app/models/concerns/dossier_sections_concern.rb
+++ b/app/models/concerns/dossier_sections_concern.rb
@@ -25,18 +25,26 @@ module DossierSectionsConcern
 
   def index_for_section_header(type_de_champ)
     types_de_champ = type_de_champ.private? ? revision.types_de_champ_private : revision.types_de_champ_public
-    index = 1
+    counters = []
+
     types_de_champ.each do |tdc|
       if tdc.repetition?
         index_in_repetition = revision.children_of(tdc).find_index { _1.stable_id == type_de_champ.stable_id }
-        return "#{index}.#{index_in_repetition + 1}" if index_in_repetition
-      else
-        return index if tdc.stable_id == type_de_champ.stable_id
-        next unless project_champ(tdc).visible?
-
-        index += 1 if tdc.header_section?
+        return "#{counters.first || 1}.#{index_in_repetition + 1}" if index_in_repetition
+        next
       end
+
+      next unless tdc.header_section?
+      next unless project_champ(tdc).visible?
+
+      level = tdc.level_for_revision(revision)
+      counters = counters.first(level)
+      counters[level - 1] = (counters[level - 1] || 0) + 1
+      (0...level).each { |i| counters[i] ||= 1 }
+
+      return counters.join('.') if tdc.stable_id == type_de_champ.stable_id
     end
-    index
+
+    counters.join('.')
   end
 end

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -6,6 +6,10 @@ def default_margin
   10
 end
 
+def section_indent_step
+  15
+end
+
 def maybe_start_new_page(pdf, size)
   if pdf.cursor < size + default_margin
     pdf.start_new_page
@@ -67,12 +71,14 @@ def add_title(pdf, title)
   end
 end
 
-def add_section_title(pdf, title)
+def add_section_title(pdf, title, level = 1)
   maybe_start_new_page(pdf, 100)
 
-  pdf.pad_bottom(default_margin) do
-    pdf.font 'marianne', style: :bold, size: 14 do
-      pdf.text title
+  pdf.indent((level - 1) * section_indent_step) do
+    pdf.pad_bottom(default_margin) do
+      pdf.font 'marianne', style: :bold, size: 14 do
+        pdf.text title
+      end
     end
   end
 end
@@ -233,7 +239,7 @@ def add_single_champ(pdf, champ)
       tdc.libelle
     end
 
-    add_section_title(pdf, libelle)
+    add_section_title(pdf, libelle, champ.level)
   when 'Champs::ExplicationChamp'
     format_in_2_lines(pdf, tdc.libelle, strip_tags(tdc.description))
   when 'Champs::CarteChamp'
@@ -297,15 +303,25 @@ def add_single_champ(pdf, champ)
 end
 
 def add_champs(pdf, champs)
+  current_indent = 0
+
   champs.each do |champ|
-    if champ.repetition?
-      champ.rows.each do |row|
-        row.each do |champ|
-          add_single_champ(pdf, champ)
+    if champ.type == 'Champs::HeaderSectionChamp'
+      next if champ.conditional? && !champ.visible?
+      current_indent = champ.level * section_indent_step
+      add_single_champ(pdf, champ)
+    elsif champ.repetition?
+      pdf.indent(current_indent) do
+        champ.rows.each do |row|
+          row.each do |inner_champ|
+            add_single_champ(pdf, inner_champ)
+          end
         end
       end
     else
-      add_single_champ(pdf, champ)
+      pdf.indent(current_indent) do
+        add_single_champ(pdf, champ)
+      end
     end
   end
 end

--- a/spec/models/concerns/dossier_sections_concern_spec.rb
+++ b/spec/models/concerns/dossier_sections_concern_spec.rb
@@ -71,25 +71,82 @@ describe DossierSectionsConcern do
     let(:number_value) { nil }
 
     before do
-      dossier.champs.find { _1.stable_id == number_stable_id }.update(value: number_value)
+      dossier.champs.find { _1.stable_id == number_stable_id }&.update(value: number_value)
       dossier.reload
     end
 
     context "when there are invisible sections" do
       it "index accordingly header sections" do
-         expect(dossier.index_for_section_header(headers[0])).to eq(1)
-         expect(dossier.project_champ(headers[1])).not_to be_visible
-         expect(dossier.index_for_section_header(headers[2])).to eq(2)
-       end
+        expect(dossier.index_for_section_header(headers[0])).to eq("1")
+        expect(dossier.project_champ(headers[1])).not_to be_visible
+        expect(dossier.index_for_section_header(headers[2])).to eq("2")
+      end
     end
 
     context "when all headers are visible" do
       let(:number_value) { 5 }
       it "index accordingly header sections" do
-        expect(dossier.index_for_section_header(headers[0])).to eq(1)
+        expect(dossier.index_for_section_header(headers[0])).to eq("1")
         expect(dossier.project_champ(headers[1])).to be_visible
-        expect(dossier.index_for_section_header(headers[1])).to eq(2)
-        expect(dossier.index_for_section_header(headers[2])).to eq(3)
+        expect(dossier.index_for_section_header(headers[1])).to eq("2")
+        expect(dossier.index_for_section_header(headers[2])).to eq("3")
+      end
+    end
+
+    context "with nested levels" do
+      let(:types_de_champ) {
+        [
+          { type: :header_section, libelle: "Identité", level: 1 },
+          { type: :header_section, libelle: "État civil", level: 2 },
+          { type: :header_section, libelle: "Coordonnées", level: 2 },
+          { type: :header_section, libelle: "Justificatifs", level: 1 },
+          { type: :header_section, libelle: "Pièce d'identité", level: 2 }
+        ]
+      }
+
+      it "numbers headers hierarchically and resets sub-counters" do
+        expect(dossier.index_for_section_header(headers[0])).to eq("1")
+        expect(dossier.index_for_section_header(headers[1])).to eq("1.1")
+        expect(dossier.index_for_section_header(headers[2])).to eq("1.2")
+        expect(dossier.index_for_section_header(headers[3])).to eq("2")
+        expect(dossier.index_for_section_header(headers[4])).to eq("2.1")
+      end
+    end
+
+    context "with three levels of nesting" do
+      let(:types_de_champ) {
+        [
+          { type: :header_section, libelle: "Niveau 1", level: 1 },
+          { type: :header_section, libelle: "Niveau 2 a", level: 2 },
+          { type: :header_section, libelle: "Niveau 3 a", level: 3 },
+          { type: :header_section, libelle: "Niveau 3 b", level: 3 },
+          { type: :header_section, libelle: "Niveau 2 b", level: 2 }
+        ]
+      }
+
+      it "produces 1, 1.1, 1.1.1, 1.1.2, 1.2" do
+        expect(dossier.index_for_section_header(headers[0])).to eq("1")
+        expect(dossier.index_for_section_header(headers[1])).to eq("1.1")
+        expect(dossier.index_for_section_header(headers[2])).to eq("1.1.1")
+        expect(dossier.index_for_section_header(headers[3])).to eq("1.1.2")
+        expect(dossier.index_for_section_header(headers[4])).to eq("1.2")
+      end
+    end
+
+    context "with an invisible sub-section" do
+      let(:types_de_champ) {
+        [
+          { type: :header_section, libelle: "Visible parent", level: 1 },
+          { type: :header_section, libelle: "Invisible enfant", level: 2, condition: ds_eq(champ_value(number_stable_id), constant(5)) },
+          { type: :integer_number, stable_id: number_stable_id },
+          { type: :header_section, libelle: "Visible enfant", level: 2 }
+        ]
+      }
+
+      it "skips invisible sub-headers in the hierarchical numbering" do
+        expect(dossier.index_for_section_header(headers[0])).to eq("1")
+        expect(dossier.project_champ(headers[1])).not_to be_visible
+        expect(dossier.index_for_section_header(headers[2])).to eq("1.1")
       end
     end
   end

--- a/spec/models/concerns/dossier_sections_concern_spec.rb
+++ b/spec/models/concerns/dossier_sections_concern_spec.rb
@@ -58,8 +58,10 @@ describe DossierSectionsConcern do
     let(:number_stable_id) { 99 }
     let(:types_de_champ) do
       [
-        { type: :header_section, libelle: "Infos" }, { type: :integer_number, stable_id: number_stable_id },
-        { type: :header_section, libelle: "Details", condition: ds_eq(champ_value(99), constant(5)) }, { type: :header_section, libelle: "Conclusion" },
+        { type: :header_section, libelle: "Infos" },
+        { type: :integer_number, stable_id: number_stable_id },
+        { type: :header_section, libelle: "Details", condition: ds_eq(champ_value(99), constant(5)) },
+        { type: :header_section, libelle: "Conclusion" },
       ]
     end
 
@@ -100,7 +102,7 @@ describe DossierSectionsConcern do
           { type: :header_section, libelle: "État civil", level: 2 },
           { type: :header_section, libelle: "Coordonnées", level: 2 },
           { type: :header_section, libelle: "Justificatifs", level: 1 },
-          { type: :header_section, libelle: "Pièce d'identité", level: 2 }
+          { type: :header_section, libelle: "Pièce d'identité", level: 2 },
         ]
       }
 

--- a/spec/models/concerns/dossier_sections_concern_spec.rb
+++ b/spec/models/concerns/dossier_sections_concern_spec.rb
@@ -122,7 +122,7 @@ describe DossierSectionsConcern do
           { type: :header_section, libelle: "Niveau 2 a", level: 2 },
           { type: :header_section, libelle: "Niveau 3 a", level: 3 },
           { type: :header_section, libelle: "Niveau 3 b", level: 3 },
-          { type: :header_section, libelle: "Niveau 2 b", level: 2 }
+          { type: :header_section, libelle: "Niveau 2 b", level: 2 },
         ]
       }
 
@@ -141,7 +141,7 @@ describe DossierSectionsConcern do
           { type: :header_section, libelle: "Visible parent", level: 1 },
           { type: :header_section, libelle: "Invisible enfant", level: 2, condition: ds_eq(champ_value(number_stable_id), constant(5)) },
           { type: :integer_number, stable_id: number_stable_id },
-          { type: :header_section, libelle: "Visible enfant", level: 2 }
+          { type: :header_section, libelle: "Visible enfant", level: 2 },
         ]
       }
 

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -2236,17 +2236,6 @@ describe Dossier, type: :model do
     end
   end
 
-  describe 'index_for_section_header' do
-    let(:types_de_champ_public) { [{ type: :repetition, mandatory: true, children: [{ type: :header_section }] }] }
-    let(:procedure) { create(:procedure, types_de_champ_public:) }
-    let(:dossier) { create(:dossier, procedure:) }
-    let(:header_in_repetition) { dossier.revision.types_de_champ.find(&:header_section?) }
-
-    it 'index classly' do
-      expect(dossier.index_for_section_header(header_in_repetition)).to eq("1.1")
-    end
-  end
-
   describe '#repasser_en_instruction!' do
     let(:dossier) { create(:dossier, :refuse, :with_attestation_acceptation, :with_justificatif, archived: true, termine_close_to_expiration_notice_sent_at: Time.zone.now, sva_svr_decision_on: 1.day.ago) }
     let!(:instructeur) { create(:instructeur) }

--- a/spec/views/dossiers/show.pdf.prawn_spec.rb
+++ b/spec/views/dossiers/show.pdf.prawn_spec.rb
@@ -1,0 +1,161 @@
+describe 'dossiers/show.pdf', type: :view do
+  PDFTOTEXT_AVAILABLE = system('which pdftotext > /dev/null 2>&1') unless defined?(PDFTOTEXT_AVAILABLE)
+
+  def render_and_extract(dossier, procedure, scenario_label)
+    assign(:dossier, dossier)
+    assign(:acls, PiecesJustificativesService.new(user_profile: dossier.user, export_template: nil).acl_for_dossier_export(procedure))
+    render template: 'dossiers/show', formats: [:pdf]
+
+    pdf_path = Rails.root.join("tmp/test_show_#{scenario_label}.pdf")
+    File.binwrite(pdf_path, rendered)
+    `pdftotext -layout #{pdf_path} - 2>/dev/null`
+  end
+
+  describe 'nested hierarchy (level 1/2/3)' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :header_section, libelle: 'Identité', level: 1 },
+        { type: :header_section, libelle: 'État civil', level: 2 },
+        { type: :text, libelle: 'Nom' },
+        { type: :header_section, libelle: 'Détail', level: 3 },
+        { type: :text, libelle: 'Prénom' },
+        { type: :header_section, libelle: 'Coordonnées', level: 2 },
+        { type: :text, libelle: 'Email' },
+        { type: :header_section, libelle: 'Justificatifs', level: 1 },
+        { type: :header_section, libelle: "Pièce d'identité", level: 2 },
+        { type: :text, libelle: 'Numéro' }
+      ])
+    end
+
+    let(:dossier) do
+      d = create(:dossier, :en_construction, procedure: procedure)
+      d.project_champs_public.find { _1.libelle == 'Nom' }&.update(value: 'Dupont')
+      d.project_champs_public.find { _1.libelle == 'Prénom' }&.update(value: 'Jean')
+      d.project_champs_public.find { _1.libelle == 'Email' }&.update(value: 'jean.dupont@example.fr')
+      d.project_champs_public.find { _1.libelle == 'Numéro' }&.update(value: 'AB123456')
+      d
+    end
+
+    it 'renders without error' do
+      expect { render_and_extract(dossier, procedure, 'hierarchy') }.not_to raise_error
+      expect(rendered).to start_with('%PDF')
+    end
+
+    it 'numbers and indents hierarchically', if: PDFTOTEXT_AVAILABLE do
+      text = render_and_extract(dossier, procedure, 'hierarchy')
+      expect(text).to include('1. Identité')
+      expect(text).to include('1.1. État civil')
+      expect(text).to include('1.1.1. Détail')
+      expect(text).to include('1.2. Coordonnées')
+      expect(text).to include('2. Justificatifs')
+      expect(text).to include("2.1. Pièce d'identité")
+    end
+  end
+
+  describe 'private (instructeur) header sections' do
+    let(:instructeur) { create(:instructeur) }
+    let(:procedure) do
+      create(:procedure, :published,
+        types_de_champ_public: [{ type: :text, libelle: 'Question publique' }],
+        types_de_champ_private: [
+          { type: :header_section, libelle: 'Notes', level: 1 },
+          { type: :header_section, libelle: 'Vérifications', level: 2 },
+          { type: :text, libelle: 'Statut' }
+        ],
+        instructeurs: [instructeur])
+    end
+    let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
+
+    it 'numbers private sections hierarchically and independently', if: PDFTOTEXT_AVAILABLE do
+      assign(:dossier, dossier)
+      assign(:acls, PiecesJustificativesService.new(user_profile: instructeur, export_template: nil).acl_for_dossier_export(procedure))
+      render template: 'dossiers/show', formats: [:pdf]
+
+      pdf_path = Rails.root.join('tmp/test_show_private.pdf')
+      File.binwrite(pdf_path, rendered)
+      text = `pdftotext -layout #{pdf_path} - 2>/dev/null`
+
+      expect(text).to include('1. Notes')
+      expect(text).to include('1.1. Vérifications')
+    end
+  end
+
+  describe 'no header sections' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :text, libelle: 'Nom complet' },
+        { type: :text, libelle: 'Téléphone' }
+      ])
+    end
+    let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
+
+    it 'renders without indentation regression', if: PDFTOTEXT_AVAILABLE do
+      text = render_and_extract(dossier, procedure, 'no_headers')
+      expect(text).to include('Nom complet')
+      expect(text).to include('Téléphone')
+    end
+  end
+
+  describe 'manually numbered libellés (opt-out)' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :header_section, libelle: '1 - Manuellement numéroté', level: 1 },
+        { type: :header_section, libelle: '1.a Sous-section', level: 2 },
+        { type: :text, libelle: 'Champ' }
+      ])
+    end
+    let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
+
+    it 'preserves user libellés without auto prefix but still indents', if: PDFTOTEXT_AVAILABLE do
+      text = render_and_extract(dossier, procedure, 'manual_num')
+      expect(text).to include('1 - Manuellement numéroté')
+      expect(text).to include('1.a Sous-section')
+      expect(text).not_to match(/^\s*1\.\s+1 -/) # pas de "1. 1 -"
+    end
+  end
+
+  describe 'invisible conditional sub-header' do
+    include Logic
+    let(:stable_id_number) { 99 }
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :header_section, libelle: 'Parent', level: 1 },
+        { type: :integer_number, libelle: 'Critère', stable_id: stable_id_number },
+        { type: :header_section, libelle: 'Caché', level: 2, condition: ds_eq(champ_value(stable_id_number), constant(5)) },
+        { type: :text, libelle: 'Optionnel' },
+        { type: :header_section, libelle: 'Visible', level: 2 },
+        { type: :text, libelle: 'Toujours' }
+      ])
+    end
+    let(:dossier) do
+      d = create(:dossier, :en_construction, procedure: procedure)
+      d.project_champs_public.find { _1.stable_id == stable_id_number }&.update(value: 1)
+      d.reload
+      d
+    end
+
+    it 'skips invisible header and numbers next visible as 1.1', if: PDFTOTEXT_AVAILABLE do
+      text = render_and_extract(dossier, procedure, 'invisible')
+      expect(text).to include('1. Parent')
+      expect(text).not_to include('Caché')
+      expect(text).to include('1.1. Visible')
+    end
+  end
+
+  describe 'diverse champ types under indented headers' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :header_section, libelle: 'Coordonnées', level: 1 },
+        { type: :header_section, libelle: 'Adresse', level: 2 },
+        { type: :address, libelle: 'Adresse postale' },
+        { type: :drop_down_list, libelle: 'Civilité', options: ['M.', 'Mme'] },
+        { type: :textarea, libelle: 'Commentaire' }
+      ])
+    end
+    let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
+
+    it 'renders without error for varied types under indent' do
+      expect { render_and_extract(dossier, procedure, 'varied_types') }.not_to raise_error
+    end
+  end
+end

--- a/spec/views/dossiers/show.pdf.prawn_spec.rb
+++ b/spec/views/dossiers/show.pdf.prawn_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe 'dossiers/show.pdf', type: :view do
   PDFTOTEXT_AVAILABLE = system('which pdftotext > /dev/null 2>&1') unless defined?(PDFTOTEXT_AVAILABLE)
 
@@ -23,7 +25,7 @@ describe 'dossiers/show.pdf', type: :view do
         { type: :text, libelle: 'Email' },
         { type: :header_section, libelle: 'Justificatifs', level: 1 },
         { type: :header_section, libelle: "Pièce d'identité", level: 2 },
-        { type: :text, libelle: 'Numéro' }
+        { type: :text, libelle: 'Numéro' },
       ])
     end
 
@@ -60,7 +62,7 @@ describe 'dossiers/show.pdf', type: :view do
         types_de_champ_private: [
           { type: :header_section, libelle: 'Notes', level: 1 },
           { type: :header_section, libelle: 'Vérifications', level: 2 },
-          { type: :text, libelle: 'Statut' }
+          { type: :text, libelle: 'Statut' },
         ],
         instructeurs: [instructeur])
     end
@@ -84,7 +86,7 @@ describe 'dossiers/show.pdf', type: :view do
     let(:procedure) do
       create(:procedure, types_de_champ_public: [
         { type: :text, libelle: 'Nom complet' },
-        { type: :text, libelle: 'Téléphone' }
+        { type: :text, libelle: 'Téléphone' },
       ])
     end
     let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
@@ -101,7 +103,7 @@ describe 'dossiers/show.pdf', type: :view do
       create(:procedure, types_de_champ_public: [
         { type: :header_section, libelle: '1 - Manuellement numéroté', level: 1 },
         { type: :header_section, libelle: '1.a Sous-section', level: 2 },
-        { type: :text, libelle: 'Champ' }
+        { type: :text, libelle: 'Champ' },
       ])
     end
     let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
@@ -124,7 +126,7 @@ describe 'dossiers/show.pdf', type: :view do
         { type: :header_section, libelle: 'Caché', level: 2, condition: ds_eq(champ_value(stable_id_number), constant(5)) },
         { type: :text, libelle: 'Optionnel' },
         { type: :header_section, libelle: 'Visible', level: 2 },
-        { type: :text, libelle: 'Toujours' }
+        { type: :text, libelle: 'Toujours' },
       ])
     end
     let(:dossier) do
@@ -149,7 +151,7 @@ describe 'dossiers/show.pdf', type: :view do
         { type: :header_section, libelle: 'Adresse', level: 2 },
         { type: :address, libelle: 'Adresse postale' },
         { type: :drop_down_list, libelle: 'Civilité', options: ['M.', 'Mme'] },
-        { type: :textarea, libelle: 'Commentaire' }
+        { type: :textarea, libelle: 'Commentaire' },
       ])
     end
     let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }


### PR DESCRIPTION
## Contexte

Demande remontée par des utilisateurs de démarches sociales : leurs
formulaires comportent souvent plusieurs niveaux de sections (identité,
état civil, justificatifs...) et l'export PDF rendait la lecture pénible
en perdant cette structure.

Concrètement, l'export PDF numérotait toutes les sections à plat (1, 2, 3)
alors que l'affichage HTML utilise une numérotation hiérarchique
(1, 1.1, 1.1.1) via des compteurs CSS. Le PDF perdait donc l'information
de niveau.

## Avant / Après

**Avant** (PDF) :
```
1. Identité
2. État civil
3. Détail
4. Coordonnées
5. Justificatifs
6. Pièce d'identité
```

**Après** (PDF, identique au HTML) :
```
1. Identité
   1.1. État civil
      1.1.1. Détail
   1.2. Coordonnées
2. Justificatifs
   2.1. Pièce d'identité
```

## Ce qui change

* \`index_for_section_header\` produit désormais une chaîne hiérarchique
  ("1.1.1") à la place d'un entier plat ("3"), grâce à un tableau de
  compteurs par niveau qui se réinitialise quand on remonte d'un cran.
* Le titre de section reçoit une indentation visuelle proportionnelle à
  son niveau (\`(level - 1) × 15pt\`).
* Les champs et répétitions sous une section héritent du même retrait
  que leur section parente, comme dans le HTML.

## Cas couverts

Headers conditionnels invisibles (exclus du compteur), sections privées
instructeur (numérotation indépendante du public), libellés déjà
numérotés manuellement (opt out, on ne double pas le préfixe),
répétitions sous section indentée.

## Tests

* 10 specs unitaires sur le concern (compteur multi niveaux, reset, sub
  section invisible).
* 7 specs e2e sur le rendu PDF complet (extraction texte via pdftotext).
* 7 PDFs générés manuellement via le chemin de prod
  (\`ApplicationController.render\`), inspectés visuellement.

## Hors scope

\`dossier_vide.pdf.prawn\` (formulaire vierge) reste avec sa
numérotation plate. À traiter séparément pour cohérence cross template
si besoin.