### PR TITLE
Tech: réduit MAX_CHAMPS_PER_BATCH des exports (140k → 40k) contre les timeouts

### DIFF
--- a/app/models/dossier_preloader.rb
+++ b/app/models/dossier_preloader.rb
@@ -2,7 +2,13 @@
 
 class DossierPreloader
   DEFAULT_BATCH_SIZE = 2000
-  MAX_CHAMPS_PER_BATCH = 140_000
+  # Plafonne le nombre de champs chargés par batch dans `load_dossiers`.
+  # Le `SELECT` champs remonte les lignes du heap + détoaste les `value_json`
+  # côté serveur : son temps croît avec le nombre de lignes. 140k saturait
+  # le statement_timeout (60s) sur les grosses démarches (PG::QueryCanceled).
+  # 40k ramène ce SELECT à ~6-8s sur les démarches les plus lourdes, soit une
+  # large marge sous contention. Voir la PR pour les mesures.
+  MAX_CHAMPS_PER_BATCH = 40_000
 
   def initialize(dossiers, includes_for_champ: [], includes_for_etablissement: [])
     @dossiers = dossiers


### PR DESCRIPTION
## Contexte

Recrudescence de `PG::QueryCanceled` (statement_timeout 60s) dans `ExportJob` (Sentry `RAILS-KPS`). Le timeout tombe sur le `SELECT` champs par batch de `DossierPreloader#load_dossiers`. En prod, le temps médian d'un `ExportJob` est déjà ~50s (Skylight), donc les grosses démarches franchissent régulièrement les 60s, et chaque export en échec rejoue jusqu'à 25× (amplification des occurrences).

`MAX_CHAMPS_PER_BATCH = 140_000` datait d'avant les `value_json` et la généralisation des grosses démarches à répétitions. Ce `SELECT` remonte les lignes du heap **et PG détoaste (reconstitue) les `value_json`** : son temps croît avec le nombre de lignes chargées.

## Mesures (prod)

temps du `SELECT` champs d'un batch, selon le plafond de champs :

| démarche | champs/batch  | 140k | 60k | **40k** | 25k |
|---|---|---|---|---|---|
| 83996 | 135 885 | 25,0s | 9,5s | **6,0s** | 3,7s |
| 25897 | 103 493 | 37,1s | 10,6s | **7,5s** | 4,3s |
| 68862 | 90 936 | 14,4s | 5,9s | **3,0s** | 2,6s |

La décomposition montre que le coût est ~entièrement la requête champs (attachments/blobs < 2s) et qu'il est proportionnel au nombre de lignes — donc découper ne crée pas de travail supplémentaire sur ce poste.

## Changement

`MAX_CHAMPS_PER_BATCH` : `140_000 → 40_000`.

- Ramène le `SELECT` le plus lourd à ~6-8s, soit une large marge sous contention.
- N'affecte que les démarches ≥ 2000 dossiers (en dessous, le sizer court-circuite). Le coût total par export reste stable (même volume de champs, juste plus de batches plus petits).

Fix https://demarches-simplifiees.sentry.io/issues/7469364106/ + tickets au support