### PR TITLE
ETQ usager, améliore l'accessibilité de la zone de dépôt de pièce jointe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ yarn-debug.log*
 /config/initializers/config.local.rb
 /coverage
 
+# Vitest browser-mode artifacts (failure screenshots, run attachments)
+__screenshots__/
+/.vitest-attachments
+
 # Local Netlify folder
 .netlify
 

--- a/app/assets/stylesheets/attachment.scss
+++ b/app/assets/stylesheets/attachment.scss
@@ -94,7 +94,9 @@ ul[data-file-input-reset-target='fileList'] {
 .attachment-drop-zone {
   .attachment-drop-area {
     width: 100%;
-    border: 2px dashed var(--border-default-grey);
+    // --border-contrast-grey keeps a >=3:1 contrast with the zone background
+    // in both light and dark themes (RGAA 3.3); --border-default-grey was 1.36:1.
+    border: 2px dashed var(--border-contrast-grey);
     border-radius: 0.25rem;
     cursor: pointer;
     text-align: center;

--- a/app/components/attachment/attachment_row_component/attachment_row_component.html.erb
+++ b/app/components/attachment/attachment_row_component/attachment_row_component.html.erb
@@ -20,7 +20,7 @@
 
       <% if user_can_destroy? %>
         <p class="fr-mb-0">
-          <%= render NestedForms::OwnedButtonComponent.new(formaction: destroy_attachment_path, http_method: :delete, opt: {class: "fr-btn fr-btn--tertiary fr-btn--sm", title: t(".delete_file_title", filename: attachment.filename)}) do %>
+          <%= render NestedForms::OwnedButtonComponent.new(formaction: destroy_attachment_path, http_method: :delete, opt: {class: "fr-btn fr-btn--tertiary fr-btn--sm", title: t(".delete_file_title", filename: attachment.filename), data: {attachment_delete_button: true}}) do %>
             <span class="fr-icon--sm fr-icon-delete-line fr-mr-1w"></span>
             <%= t('.delete_file') %>
 

--- a/app/components/attachment/file_field_component.rb
+++ b/app/components/attachment/file_field_component.rb
@@ -121,7 +121,8 @@ class Attachment::FileFieldComponent < ApplicationComponent
       max: @max,
       current_count: @current_count,
       hidden: @hidden,
-      id: @input_id
+      id: @input_id,
+      keyboard_focusable: @drop_zone != :integrated
     )
   end
 

--- a/app/components/attachment/file_field_component.rb
+++ b/app/components/attachment/file_field_component.rb
@@ -88,6 +88,19 @@ class Attachment::FileFieldComponent < ApplicationComponent
     "#{champ.focusable_input_id}-hint"
   end
 
+  def drop_zone_labelledby_id
+    return nil if champ.nil?
+    helpers.input_label_id(champ)
+  end
+
+  def drop_zone_describedby_ids
+    return nil if champ.nil?
+
+    ids = [describedby_hint_id]
+    ids << champ.describedby_id if champ.description.present?
+    ids.compact.join(' ').presence
+  end
+
   def error_wrapper_id
     champ.present? ? "attachment-error-#{champ.public_id}" : "attachment-error-generic"
   end

--- a/app/components/attachment/file_field_component/file_field_component.html.erb
+++ b/app/components/attachment/file_field_component/file_field_component.html.erb
@@ -36,13 +36,9 @@
               <%= t('.or') %>
             </p>
 
-            <button
-              class="fr-btn fr-btn--secondary fr-btn--sm"
-              type="button"
-              tabindex="-1"
-            >
+            <span class="fr-btn fr-btn--secondary fr-btn--sm">
               <%= t('.button_label', count: @max) %>
-            </button>
+            </span>
           </div>
 
           <%= render file_input_component %>

--- a/app/components/attachment/file_field_component/file_field_component.html.erb
+++ b/app/components/attachment/file_field_component/file_field_component.html.erb
@@ -20,7 +20,14 @@
             class="attachment-drop-area fr-p-2w"
             role="button"
             tabindex="0"
-            aria-label="<%= t('.drop_zone_aria_label') %>"
+            <% if drop_zone_labelledby_id %>
+              aria-labelledby="<%= drop_zone_labelledby_id %>"
+            <% else %>
+              aria-label="<%= t('.drop_zone_aria_label') %>"
+            <% end %>
+            <% if drop_zone_describedby_ids %>
+              aria-describedby="<%= drop_zone_describedby_ids %>"
+            <% end %>
             data-action="click->drop-target#openFilePicker keydown.enter->drop-target#openFilePicker keydown.space->drop-target#openFilePicker"
           >
             <span

--- a/app/components/attachment/file_input_component.rb
+++ b/app/components/attachment/file_input_component.rb
@@ -10,12 +10,13 @@ class Attachment::FileInputComponent < ApplicationComponent
   delegate :champ, :direct_upload, :aria_labelledby,
            :parent_hint_id, :form_object_name, :attached_file, to: :context
 
-  def initialize(context:, max: nil, current_count: 0, hidden: false, id: nil)
+  def initialize(context:, max: nil, current_count: 0, hidden: false, id: nil, keyboard_focusable: true)
     @context = context
     @max = max
     @current_count = current_count
     @hidden = hidden
     @input_id = id
+    @keyboard_focusable = keyboard_focusable
   end
 
   # Automatically deduce from ActiveStorage type
@@ -67,6 +68,9 @@ class Attachment::FileInputComponent < ApplicationComponent
     options.merge!(accept.present? ? { accept: } : {})
     options[:multiple] = true if as_multiple?
     options[:disabled] = true if @max && @current_count >= @max
+    # Inside an integrated drop zone the role="button" zone is the keyboard
+    # target; keep this input out of the tab order to avoid a redundant stop.
+    options[:tabindex] = -1 unless @keyboard_focusable
 
     options
   end

--- a/app/components/attachment/file_input_component/file_input_component.html.erb
+++ b/app/components/attachment/file_input_component/file_input_component.html.erb
@@ -1,6 +1,6 @@
 <%= file_field_tag(field_name_or_default, **file_field_options) %>
 
-<% if champ.blank? %>
+<% if champ.nil? %>
   <div
     class="fr-sr-only"
     id="<%= final_input_id %>-aria-live"

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -6,12 +6,19 @@ module Dsfr
     delegate :type_de_champ, to: :@champ
     delegate :prefilled?, to: :@champ
 
-    def initialize(champ_component:, champ:, row_number: nil)
-      @errors_on_attribute = champ_component.errors_on_attribute?
-      @error_full_messages = champ_component.error_full_messages
-      @error_id = champ.error_id(champ_component.attribute)
+    def initialize(champ:, champ_component: nil, row_number: nil, as_announcement: false)
+      @errors_on_attribute = champ_component&.errors_on_attribute?
+      @error_full_messages = champ_component&.error_full_messages || []
+      @error_id = champ_component ? champ.error_id(champ_component.attribute) : nil
       @champ = champ
       @row_number = row_number
+      @as_announcement = as_announcement
+    end
+
+    # True when there is a status message worth announcing (excludes validation
+    # errors and the static "prefilled" notice, which are not live updates).
+    def status_announcement?
+      statutable? && statut_message.present?
     end
 
     def statutable?
@@ -53,6 +60,12 @@ module Dsfr
     end
 
     def statut_message
+      @statut_message ||= compute_statut_message
+    end
+
+    private
+
+    def compute_statut_message
       case @champ.type_de_champ.type_champ
       when TypeDeChamp.type_champs[:siret]
         # TODO: use fetched? after T20251029backfillChampSiretExternalStateTask
@@ -151,8 +164,6 @@ module Dsfr
         end
       end
     end
-
-    private
 
     def displayable_raison_sociale_or_name(etablissement)
       if etablissement.diffusable_commercialement

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -15,8 +15,9 @@ module Dsfr
       @as_announcement = as_announcement
     end
 
-    # True when there is a status message worth announcing (excludes validation
-    # errors and the static "prefilled" notice, which are not live updates).
+    # True when the champ has an external/async status message to surface.
+    # Validation errors and the static "prefilled" notice are handled separately
+    # (they are not produced by statut_message).
     def status_announcement?
       statutable? && statut_message.present?
     end

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -1,12 +1,16 @@
-.fr-messages-group{ id: @error_id, aria: { live: :assertive } }
-  - if @error_full_messages.size > 0
-    %p{ class: class_names('fr-message' => true, "fr-message--#{@errors_on_attribute ? 'error' : 'valid'}" => true) }
-      = "« #{libelle} » "
+- if @as_announcement
+  - if status_announcement?
+    = sanitize(statut_message[:text])
+- else
+  .fr-messages-group{ id: @error_id, aria: { live: :assertive } }
+    - if @error_full_messages.size > 0
+      %p{ class: class_names('fr-message' => true, "fr-message--#{@errors_on_attribute ? 'error' : 'valid'}" => true) }
+        = "« #{libelle} » "
 
-      = @error_full_messages.to_sentence
-  - elsif statutable? && statut_message.present?
-    %p.fr-message{ class: "fr-message--#{statut_message[:state]}" }
-      %span= sanitize(statut_message[:text])
+        = @error_full_messages.to_sentence
+    - elsif statutable? && statut_message.present?
+      %p.fr-message{ class: "fr-message--#{statut_message[:state]}" }
+        %span= sanitize(statut_message[:text])
 
-  - if prefilled?
-    %p.fr-message.fr-message--info= sanitize(t('.prefilled'))
+    - if prefilled?
+      %p.fr-message.fr-message--info= sanitize(t('.prefilled'))

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -8,7 +8,7 @@
         = "« #{libelle} » "
 
         = @error_full_messages.to_sentence
-    - elsif statutable? && statut_message.present?
+    - elsif status_announcement?
       %p.fr-message{ class: "fr-message--#{statut_message[:state]}" }
         %span= sanitize(statut_message[:text])
 

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -2,7 +2,7 @@
   - if status_announcement?
     = sanitize(statut_message[:text])
 - else
-  .fr-messages-group{ id: @error_id, aria: { live: :assertive } }
+  .fr-messages-group{ id: @error_id, aria: { live: (@error_full_messages.size > 0 ? :assertive : nil) } }
     - if @error_full_messages.size > 0
       %p{ class: class_names('fr-message' => true, "fr-message--#{@errors_on_attribute ? 'error' : 'valid'}" => true) }
         = "« #{libelle} » "

--- a/app/components/editable_champ/section_component/section_component.html.haml
+++ b/app/components/editable_champ/section_component/section_component.html.haml
@@ -9,7 +9,7 @@
         - else
           = fields_for champ.input_name, champ do |form|
             = render EditableChamp::EditableChampComponent.new form:, champ:, row_number: @row_number
-          - if champ.piece_justificative?
+          - if champ.status_announceable?
             .fr-sr-only{ id: "#{champ.focusable_input_id}-aria-live", role: 'status', 'aria-live': 'polite', 'aria-atomic': 'true' }
 - else
   - if header_section
@@ -21,5 +21,5 @@
     - else
       = fields_for champ.input_name, champ do |form|
         = render EditableChamp::EditableChampComponent.new form:, champ:, row_number: @row_number
-      - if champ.piece_justificative?
+      - if champ.status_announceable?
         .fr-sr-only{ id: "#{champ.focusable_input_id}-aria-live", role: 'status', 'aria-live': 'polite', 'aria-atomic': 'true' }

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -345,6 +345,7 @@ module Users
 
     # polling url for champ
     def champ
+      @polling = true
       @dossier = dossier_with_champs(pj_template: false)
       type_de_champ = dossier.find_type_de_champ_by_stable_id(params[:stable_id], :public)
       champ = dossier.project_champ(type_de_champ, row_id: params[:row_id])

--- a/app/javascript/shared/activestorage/progress-bar.test.ts
+++ b/app/javascript/shared/activestorage/progress-bar.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
+
+import ProgressBar from './progress-bar';
+
+const ID = 'test-id';
+
+function setupDom() {
+  document.body.innerHTML = `
+    <template id="progress-bar-template">
+      <div class="direct-upload">
+        <div class="direct-upload__progress"></div>
+        <slot name="filename"></slot>
+      </div>
+    </template>
+    <div class="attachment-field">
+      <input type="file" />
+      <div data-progress-container></div>
+    </div>
+  `;
+  return document.querySelector<HTMLInputElement>('input')!;
+}
+
+function progressBarElement() {
+  return document.querySelector(`#direct-upload-${ID}`);
+}
+
+suite('ProgressBar minimum display time', () => {
+  let input: HTMLInputElement;
+
+  beforeEach(() => {
+    input = setupDom();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  test('keeps the progress bar visible for at least 1.5s when the upload finishes sooner', () => {
+    const file = new File(['x'], 'doc.pdf');
+    const bar = new ProgressBar(input, ID, file);
+    expect(progressBarElement()).not.toBeNull();
+
+    // Upload finished almost immediately
+    bar.destroy();
+    expect(progressBarElement()).not.toBeNull();
+
+    vi.advanceTimersByTime(1499);
+    expect(progressBarElement()).not.toBeNull();
+
+    vi.advanceTimersByTime(1);
+    expect(progressBarElement()).toBeNull();
+  });
+
+  test('removes the progress bar immediately when it has already been visible for 1.5s', () => {
+    const file = new File(['x'], 'doc.pdf');
+    const bar = new ProgressBar(input, ID, file);
+
+    vi.advanceTimersByTime(1500);
+    bar.destroy();
+
+    expect(progressBarElement()).toBeNull();
+  });
+});

--- a/app/javascript/shared/activestorage/progress-bar.ts
+++ b/app/javascript/shared/activestorage/progress-bar.ts
@@ -4,6 +4,11 @@ const PENDING_CLASS = 'direct-upload--pending';
 const ERROR_CLASS = 'direct-upload--error';
 const COMPLETE_CLASS = 'direct-upload--complete';
 
+// Minimum time the progress bar stays visible once shown, so a fast upload
+// (small file or fast connection) doesn't make it flash by too quickly to be
+// perceived — including by assistive technologies. See #13104.
+const MIN_DISPLAY_MS = 1500;
+
 /**
   ProgressBar is and utility class responsible for
   rendering upload progress bar. It is used to handle
@@ -100,10 +105,18 @@ export default class ProgressBar {
   }
 
   id: string;
+  #minDisplayElapsed = false;
+  #removalRequested = false;
 
   constructor(input: HTMLInputElement, id: string, file: File) {
     ProgressBar.init(input, id, file);
     this.id = id;
+    setTimeout(() => {
+      this.#minDisplayElapsed = true;
+      if (this.#removalRequested) {
+        this.#removeElement();
+      }
+    }, MIN_DISPLAY_MS);
   }
 
   start() {
@@ -123,6 +136,14 @@ export default class ProgressBar {
   }
 
   destroy() {
+    if (this.#minDisplayElapsed) {
+      this.#removeElement();
+    } else {
+      this.#removalRequested = true;
+    }
+  }
+
+  #removeElement() {
     const element = getDirectUploadElement(this.id);
     element?.remove();
   }

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -114,6 +114,13 @@ class Champ < ApplicationRecord
     !private?
   end
 
+  # Champs that can surface an external/async status message (rendered by
+  # Dsfr::InputStatusMessageComponent) and therefore need a persistent
+  # live region to announce it to screen readers.
+  def status_announceable?
+    siret? || rna? || referentiel? || dossier_link? || piece_justificative?
+  end
+
   def prefilled_from_france_connect_information?
     data&.dig("prefilled_from_france_connect_information") == true
   end

--- a/app/views/champs/piece_justificative/show.turbo_stream.erb
+++ b/app/views/champs/piece_justificative/show.turbo_stream.erb
@@ -5,9 +5,7 @@
 <% end %>
 
 <% last_attached_file = @champ.piece_justificative_file.attachments.last %>
+
 <% if last_attached_file %>
   <%= turbo_stream.focus_all "#persisted_row_attachment_#{last_attached_file.id} [data-attachment-delete-button]" %>
-  <% if last_attached_file.virus_scanner.pending? %>
-    <%= turbo_stream.update "#{@champ.focusable_input_id}-aria-live", t('activerecord.models.attachment.antivirus_pending') %>
-  <% end %>
 <% end %>

--- a/app/views/champs/piece_justificative/show.turbo_stream.erb
+++ b/app/views/champs/piece_justificative/show.turbo_stream.erb
@@ -6,7 +6,7 @@
 
 <% last_attached_file = @champ.piece_justificative_file.attachments.last %>
 <% if last_attached_file %>
-  <%= turbo_stream.focus_all "#persisted_row_attachment_#{last_attached_file.id} .attachment-filename a" %>
+  <%= turbo_stream.focus_all "#persisted_row_attachment_#{last_attached_file.id} [data-attachment-delete-button]" %>
   <% if last_attached_file.virus_scanner.pending? %>
     <%= turbo_stream.update "#{@champ.focusable_input_id}-aria-live", t('activerecord.models.attachment.antivirus_pending') %>
   <% end %>

--- a/app/views/shared/dossiers/_update_all.turbo_stream.erb
+++ b/app/views/shared/dossiers/_update_all.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'shared/dossiers/update_champs', locals: { to_show: @to_show, to_hide: @to_hide, to_update: @to_update } %>
+<%= render partial: 'shared/dossiers/update_champs', locals: { to_show: @to_show, to_hide: @to_hide, to_update: @to_update, polling: @polling } %>
 <%= render partial: 'shared/dossiers/update_footer', locals: { dossier: @dossier } %>
 
 <% if params[:validate].present? %>

--- a/app/views/shared/dossiers/_update_champ.turbo_stream.erb
+++ b/app/views/shared/dossiers/_update_champ.turbo_stream.erb
@@ -9,16 +9,13 @@
     <% end %>
   <% end %>
 
-  <%# Announce the champ status (and any caller-provided notice, e.g. antivirus scan) %>
-  <%# into the champ's persistent sr-only live region, which is never recreated by %>
-  <%# the replace above. See EditableChamp::SectionComponent. %>
+  <%# Announce the champ status into its persistent sr-only live region, which is %>
+  <%# never recreated by the replace above. See EditableChamp::SectionComponent. %>
   <% polling = local_assigns.fetch(:polling, false) %>
-  <% extra_announcement = local_assigns.fetch(:extra_announcement, nil) %>
-  <% if full && !(polling && champ.pending?) %>
-    <% status = render(Dsfr::InputStatusMessageComponent.new(champ:, as_announcement: true)) if champ.status_announceable? %>
-    <% parts = [extra_announcement, status].select { it.to_s.strip.present? } %>
-    <% if parts.any? %>
-      <%= turbo_stream.update "#{champ.focusable_input_id}-aria-live" do %><%= safe_join(parts, ' ') %><% end %>
+  <% if full && champ.status_announceable? && !(polling && champ.pending?) %>
+    <% status = render(Dsfr::InputStatusMessageComponent.new(champ:, as_announcement: true)) %>
+    <% if status.to_s.strip.present? %>
+      <%= turbo_stream.update "#{champ.focusable_input_id}-aria-live" do %><%= status %><% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/dossiers/_update_champ.turbo_stream.erb
+++ b/app/views/shared/dossiers/_update_champ.turbo_stream.erb
@@ -8,4 +8,19 @@
       <%= render EditableChamp::ChampLabelContentComponent.new champ:, form: %>
     <% end %>
   <% end %>
+
+  <%# Announce the champ status (and any caller-provided notice, e.g. antivirus scan) %>
+  <%# into the champ's persistent sr-only live region, which is never recreated by %>
+  <%# the replace above. See EditableChamp::SectionComponent. %>
+  <% polling = local_assigns.fetch(:polling, false) %>
+  <% extra_announcement = local_assigns.fetch(:extra_announcement, nil) %>
+  <% if full && (champ.status_announceable? || extra_announcement.present?) && !(polling && champ.pending?) %>
+    <% status = render(Dsfr::InputStatusMessageComponent.new(champ:, as_announcement: true)) %>
+    <% parts = [] %>
+    <% parts << extra_announcement if extra_announcement.present? %>
+    <% parts << status if status.to_s.strip.present? %>
+    <% if parts.any? %>
+      <%= turbo_stream.update "#{champ.focusable_input_id}-aria-live" do %><%= safe_join(parts, ' ') %><% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/shared/dossiers/_update_champ.turbo_stream.erb
+++ b/app/views/shared/dossiers/_update_champ.turbo_stream.erb
@@ -14,11 +14,9 @@
   <%# the replace above. See EditableChamp::SectionComponent. %>
   <% polling = local_assigns.fetch(:polling, false) %>
   <% extra_announcement = local_assigns.fetch(:extra_announcement, nil) %>
-  <% if full && (champ.status_announceable? || extra_announcement.present?) && !(polling && champ.pending?) %>
-    <% status = render(Dsfr::InputStatusMessageComponent.new(champ:, as_announcement: true)) %>
-    <% parts = [] %>
-    <% parts << extra_announcement if extra_announcement.present? %>
-    <% parts << status if status.to_s.strip.present? %>
+  <% if full && !(polling && champ.pending?) %>
+    <% status = render(Dsfr::InputStatusMessageComponent.new(champ:, as_announcement: true)) if champ.status_announceable? %>
+    <% parts = [extra_announcement, status].select { it.to_s.strip.present? } %>
     <% if parts.any? %>
       <%= turbo_stream.update "#{champ.focusable_input_id}-aria-live" do %><%= safe_join(parts, ' ') %><% end %>
     <% end %>

--- a/app/views/shared/dossiers/_update_champs.turbo_stream.erb
+++ b/app/views/shared/dossiers/_update_champs.turbo_stream.erb
@@ -4,8 +4,9 @@
 <% if to_hide.present? %>
   <%= turbo_stream.hide_all(to_hide) %>
 <% end %>
+<% polling = local_assigns.fetch(:polling, false) %>
 <% to_update.each do |champ| %>
-  <%= render partial: 'shared/dossiers/update_champ', locals: { full: champ.refresh_after_update?, champ: } %>
+  <%= render partial: 'shared/dossiers/update_champ', locals: { full: champ.refresh_after_update?, champ:, polling: } %>
 <% end %>
 
 <%= turbo_stream.remove_all(".editable-champ + .spinner-removable") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -729,7 +729,6 @@ en:
       attachment:
         successfully_deleted_with_anchor: 'The attachment (%{attachment}) has been deleted. You can now <a href="#%{champ}">add another</a>.'
         successfully_deleted_without_anchor: 'The attachment (%{attachment}) has been deleted.'
-        antivirus_pending: 'Antivirus scanning in progress…'
 
     attributes:
       default_attributes: &default_attributes

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -739,7 +739,6 @@ fr:
       attachment:
         successfully_deleted_with_anchor: 'La pièce jointe (%{attachment}) a bien été supprimée. Vous pouvez en <a href="#%{champ}">ajouter une autre</a>.'
         successfully_deleted_without_anchor: 'La pièce jointe (%{attachment}) a bien été supprimée.'
-        antivirus_pending: 'Analyse antivirus en cours…'
 
     attributes:
       default_attributes: &default_attributes

--- a/spec/components/attachment/file_field_component_spec.rb
+++ b/spec/components/attachment/file_field_component_spec.rb
@@ -106,6 +106,29 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
     end
   end
 
+  describe 'drop zone file input tab order (issue #13104)' do
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champs.first }
+    let(:context) { Attachment::Context.new(champ:) }
+
+    context 'with an integrated drop zone' do
+      subject { render_inline(described_class.new(context:, drop_zone: :integrated)).to_html }
+
+      it 'takes the file input out of the tab order (the drop zone button is the keyboard target)' do
+        expect(subject).to have_selector('input[type="file"][tabindex="-1"]')
+      end
+    end
+
+    context 'without a drop zone' do
+      subject { render_inline(described_class.new(context:, drop_zone: :none)).to_html }
+
+      it 'keeps the file input keyboard-focusable' do
+        expect(subject).to have_no_selector('input[type="file"][tabindex]')
+      end
+    end
+  end
+
   describe 'format indication hints' do
     subject { render_inline(described_class.new(context:, drop_zone: :integrated)).to_html }
 

--- a/spec/components/attachment/file_field_component_spec.rb
+++ b/spec/components/attachment/file_field_component_spec.rb
@@ -86,6 +86,26 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
     end
   end
 
+  describe 'drop zone accessible name (issue #13104)' do
+    include ChampAriaLabelledbyHelper
+
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champs.first }
+    let(:context) { Attachment::Context.new(champ:) }
+
+    let(:drop_area) { render_inline(described_class.new(context:, drop_zone: :integrated)).at_css('.attachment-drop-area') }
+
+    it 'names the drop zone via the field label instead of a generic aria-label' do
+      expect(drop_area['aria-label']).to be_nil
+      expect(drop_area['aria-labelledby']).to eq(input_label_id(champ))
+    end
+
+    it 'describes the drop zone via the format/size hints' do
+      expect(drop_area['aria-describedby']).to include("#{champ.focusable_input_id}-hint")
+    end
+  end
+
   describe 'format indication hints' do
     subject { render_inline(described_class.new(context:, drop_zone: :integrated)).to_html }
 

--- a/spec/components/attachment/file_input_component_spec.rb
+++ b/spec/components/attachment/file_input_component_spec.rb
@@ -58,6 +58,26 @@ RSpec.describe Attachment::FileInputComponent, type: :component do
     end
   end
 
+  describe 'aria-live status region' do
+    context 'when there is no champ (e.g. has_one_attached like a logo)' do
+      let(:procedure) { create(:procedure) }
+      let(:context) { Attachment::Context.new(attached_file: procedure.logo) }
+      let(:component) { described_class.new(context:) }
+
+      it 'renders its own polite live region' do
+        expect(subject).to have_selector('[role="status"][aria-live="polite"]')
+      end
+    end
+
+    context 'when there is a champ' do
+      # SectionComponent already renders one live region per champ; rendering a
+      # second one here would duplicate the #champ-…-input-value-aria-live id.
+      it 'does not render a live region' do
+        expect(subject).not_to have_selector('[role="status"][aria-live="polite"]')
+      end
+    end
+  end
+
   context 'piece justificative nature titre_identite' do
     let(:types_de_champ_public) { [{ type: :piece_justificative, nature: 'titre_identite' }] }
 

--- a/spec/components/attachment/file_input_component_spec.rb
+++ b/spec/components/attachment/file_input_component_spec.rb
@@ -50,6 +50,22 @@ RSpec.describe Attachment::FileInputComponent, type: :component do
     end
   end
 
+  describe 'keyboard_focusable (issue #13104)' do
+    context 'when keyboard_focusable: false (input wrapped in a drop zone)' do
+      let(:kwargs) { { keyboard_focusable: false } }
+
+      it 'takes the input out of the tab order with tabindex=-1' do
+        expect(subject).to have_selector('input[type="file"][tabindex="-1"]')
+      end
+    end
+
+    context 'by default' do
+      it 'leaves the input keyboard-focusable (no tabindex)' do
+        expect(subject).to have_no_selector('input[type="file"][tabindex]')
+      end
+    end
+  end
+
   describe 'custom id for remote drop zones' do
     let(:kwargs) { { id: 'custom-file-123' } }
 

--- a/spec/components/dsfr/input_status_message_component_spec.rb
+++ b/spec/components/dsfr/input_status_message_component_spec.rb
@@ -24,4 +24,26 @@ describe Dsfr::InputStatusMessageComponent, type: :component do
       end
     end
   end
+
+  describe 'visible mode aria-live' do
+    let(:no_error_component) { double('champ_component', errors_on_attribute?: false, error_full_messages: [], attribute: :value) }
+    let(:error_component) { double('champ_component', errors_on_attribute?: true, error_full_messages: ['est invalide'], attribute: :value) }
+
+    context 'with a status message and no validation error' do
+      before { champ.update_column(:external_state, :waiting_for_job) }
+
+      it 'drops aria-live (the sr-only region announces the status instead)' do
+        render_inline(described_class.new(champ:, champ_component: no_error_component))
+        expect(page).to have_css('.fr-messages-group')
+        expect(page).not_to have_css('.fr-messages-group[aria-live]')
+      end
+    end
+
+    context 'with a validation error' do
+      it 'keeps aria-live="assertive" for the error' do
+        render_inline(described_class.new(champ:, champ_component: error_component))
+        expect(page).to have_css('.fr-messages-group[aria-live="assertive"]')
+      end
+    end
+  end
 end

--- a/spec/components/dsfr/input_status_message_component_spec.rb
+++ b/spec/components/dsfr/input_status_message_component_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe Dsfr::InputStatusMessageComponent, type: :component do
+  let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: 'rib' }]) }
+  let(:dossier) { create(:dossier, procedure:) }
+  let(:champ) { dossier.champs.first }
+
+  describe 'announcement mode' do
+    context 'when the RIB analysis is pending' do
+      before { champ.update_column(:external_state, :waiting_for_job) }
+
+      it 'renders only the status text (no .fr-messages-group wrapper)' do
+        render_inline(described_class.new(champ:, as_announcement: true))
+        expect(page).to have_text('Contenu du fichier en cours')
+        expect(page).not_to have_css('.fr-messages-group')
+      end
+    end
+
+    context 'when the champ is idle (no status to announce)' do
+      it 'renders nothing' do
+        render_inline(described_class.new(champ:, as_announcement: true))
+        expect(page).not_to have_text('Contenu du fichier')
+        expect(page).not_to have_css('.fr-messages-group')
+      end
+    end
+  end
+end

--- a/spec/components/editable_champ/section_component_spec.rb
+++ b/spec/components/editable_champ/section_component_spec.rb
@@ -116,6 +116,25 @@ describe EditableChamp::SectionComponent, type: :component do
     end
   end
 
+  context 'persistent live region for status-bearing champs' do
+    context 'with a SIRET champ' do
+      let(:types_de_champ_public) { [{ type: :siret }] }
+
+      it 'renders a persistent sr-only polite live region' do
+        champ = dossier.project_champs_public.first
+        expect(page).to have_css("##{champ.focusable_input_id}-aria-live.fr-sr-only[aria-live='polite']", visible: :all)
+      end
+    end
+
+    context 'with a plain text champ' do
+      let(:types_de_champ_public) { [{ type: :text }] }
+
+      it 'does not render a live region' do
+        expect(page).not_to have_css(".fr-sr-only[aria-live='polite']", visible: :all)
+      end
+    end
+  end
+
   context 'with complex markup structure' do
     def check_fieldset_structure(fieldset)
       expect(fieldset[:class]).to include('fr-fieldset')

--- a/spec/controllers/champs/piece_justificative_controller_spec.rb
+++ b/spec/controllers/champs/piece_justificative_controller_spec.rb
@@ -149,6 +149,11 @@ describe Champs::PieceJustificativeController, type: :controller do
         attachment = champ.reload.piece_justificative_file.attachments.last
         expect(response.body).to include(%(<turbo-stream action="focus" targets="#persisted_row_attachment_#{attachment.id} [data-attachment-delete-button]">))
       end
+
+      it 'does not push any aria-live announcement after upload (no visual equivalent)' do
+        subject
+        expect(response.body).not_to include(%(<turbo-stream action="update" target="#{champ.focusable_input_id}-aria-live">))
+      end
     end
 
     context 'when the file is invalid' do

--- a/spec/controllers/champs/piece_justificative_controller_spec.rb
+++ b/spec/controllers/champs/piece_justificative_controller_spec.rb
@@ -141,6 +141,16 @@ describe Champs::PieceJustificativeController, type: :controller do
       end
     end
 
+    context 'accessibility feedback after a successful upload (#13104)' do
+      let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
+
+      it 'emits a focus action targeting the delete link of the newly added attachment' do
+        subject
+        attachment = champ.reload.piece_justificative_file.attachments.last
+        expect(response.body).to include(%(<turbo-stream action="focus" targets="#persisted_row_attachment_#{attachment.id} [data-attachment-delete-button]">))
+      end
+    end
+
     context 'when the file is invalid' do
       let(:file) { fixture_file_upload('spec/fixtures/files/invalid_file_format.json', 'bad/bad') }
 

--- a/spec/controllers/champs/piece_justificative_controller_spec.rb
+++ b/spec/controllers/champs/piece_justificative_controller_spec.rb
@@ -150,9 +150,31 @@ describe Champs::PieceJustificativeController, type: :controller do
         expect(response.body).to include(%(<turbo-stream action="focus" targets="#persisted_row_attachment_#{attachment.id} [data-attachment-delete-button]">))
       end
 
-      it 'does not push any aria-live announcement after upload (no visual equivalent)' do
+      it 'does not push any aria-live announcement for a plain PJ (no visual equivalent)' do
         subject
         expect(response.body).not_to include(%(<turbo-stream action="update" target="#{champ.focusable_input_id}-aria-live">))
+      end
+    end
+
+    context 'when the champ is a RIB whose content analysis is pending (#13104)' do
+      let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative, nature: 'rib' }]) }
+      let(:dossier) { create(:dossier, user: user, procedure: procedure) }
+      let(:champ) { dossier.project_champs_public.first }
+      let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
+
+      before do
+        allow_any_instance_of(Champs::PieceJustificativeChamp).to receive(:has_async_external_data?).and_return(true)
+        allow_any_instance_of(Champs::PieceJustificativeChamp).to receive(:fetch_later!)
+        allow_any_instance_of(Champs::PieceJustificativeChamp).to receive(:idle?).and_return(false)
+        allow_any_instance_of(Champs::PieceJustificativeChamp).to receive(:pending?).and_return(true)
+      end
+
+      it 'announces the OCR status inside the champ’s persistent live region' do
+        subject
+        doc = Nokogiri::HTML5.fragment(response.body)
+        region = doc.css(%(turbo-stream[action="update"][target="#{champ.focusable_input_id}-aria-live"]))
+        expect(region).to be_present
+        expect(region.text).to include('Contenu du fichier en cours')
       end
     end
 

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -2423,6 +2423,35 @@ describe Users::DossiersController, type: :controller do
       end
     end
 
+    context 'live announcement of a RIB status (polling anti-spam)' do
+      render_views
+      let(:types_de_champ_public) { [{ type: :piece_justificative, nature: 'rib', stable_id: }] }
+      let(:champ) { dossier.project_champs_public.first }
+      let(:region_id) { "#{champ.focusable_input_id}-aria-live" }
+
+      def announced_region(body)
+        Nokogiri::HTML5.fragment(body).css(%(turbo-stream[action="update"][target="#{region_id}"]))
+      end
+
+      context 'while the analysis is still pending' do
+        before { dossier.champs.first.update_column(:external_state, :waiting_for_job) }
+
+        it 'does not re-announce the pending status on a poll' do
+          subject
+          expect(announced_region(response.body)).to be_empty
+        end
+      end
+
+      context 'when the analysis has completed' do
+        before { dossier.champs.first.update_columns(external_state: :fetched, value_json: { 'rib' => { 'iban' => 'FR7612345' } }) }
+
+        it 'announces the result on the poll that observes completion' do
+          subject
+          expect(announced_region(response.body).text).to include('FR7612345')
+        end
+      end
+    end
+
     context 'when champ is pollable' do
       let(:referentiel) { create(:api_referentiel, :exact_match) }
       let(:types_de_champ_public) { [{ type: :referentiel, referentiel:, stable_id: }] }

--- a/spec/system/users/piece_justificative_drag_drop_spec.rb
+++ b/spec/system/users/piece_justificative_drag_drop_spec.rb
@@ -45,10 +45,12 @@ describe 'Piece justificative drag and drop', js: true do
         expect(page).to have_text('Faites glisser et déposez vos fichiers ici')
         expect(page).to have_css('.fr-btn--secondary', text: 'Choisir des fichiers')
 
-        # Accessibilité ARIA
+        # Accessibilité ARIA : la zone est reliée au label et aux hints du champ (#13104)
         expect(drop_area['role']).to eq('button')
         expect(drop_area['tabindex']).to eq('0')
-        expect(drop_area['aria-label']).to include('Zone de glisser-déposer')
+        expect(drop_area['aria-label']).to be_nil
+        expect(find_by_id(drop_area['aria-labelledby']).text).to include('Document')
+        expect(find_by_id(drop_area['aria-describedby'].split.first).text).to include('Taille maximale par fichier')
         expect(page).to have_selector('[data-attachment-error][aria-live="assertive"]')
       end
     end

--- a/spec/system/users/piece_justificative_drag_drop_spec.rb
+++ b/spec/system/users/piece_justificative_drag_drop_spec.rb
@@ -94,6 +94,31 @@ describe 'Piece justificative drag and drop', js: true do
         expect(page).to have_text('Formats acceptés : .pdf, .doc, .docx, .jpg, .jpeg, .png')
       end
     end
+
+    scenario 'announces the RIB analysis status in the persistent live region after upload (#13104)' do
+      procedure_rib = create(:procedure, :published, :for_individual, types_de_champ_public: [{ type: :piece_justificative, libelle: 'RIB', nature: 'rib' }])
+      login_as(user, scope: :user)
+      visit commencer_path(path: procedure_rib.path)
+      click_on 'Commencer la démarche'
+      fill_individual
+
+      # Capture the persistent live region id before upload: a RIB is single-file,
+      # so the labelled input disappears once a file is attached.
+      file_input = find_field('RIB', visible: :all)
+      live_region_selector = "##{file_input[:id]}-aria-live"
+
+      attach_file('RIB', Rails.root.join('spec/fixtures/files/file.pdf'))
+      expect(page).to have_text('file.pdf')
+
+      # The status is announced into the champ's persistent sr-only live region
+      # (which survives the turbo_stream.replace), not into the recreated champ.
+      expect(page).to have_css(
+        live_region_selector,
+        text: 'Contenu du fichier en cours',
+        visible: :all,
+        wait: 5
+      )
+    end
   end
 
   context 'client-side validation and error handling' do

--- a/spec/system/users/piece_justificative_drag_drop_spec.rb
+++ b/spec/system/users/piece_justificative_drag_drop_spec.rb
@@ -43,7 +43,7 @@ describe 'Piece justificative drag and drop', js: true do
 
         # Textes et boutons (PJ uses MultipleComponent with default max=10, so plural)
         expect(page).to have_text('Faites glisser et déposez vos fichiers ici')
-        expect(page).to have_button('Choisir des fichiers')
+        expect(page).to have_css('.fr-btn--secondary', text: 'Choisir des fichiers')
 
         # Accessibilité ARIA
         expect(drop_area['role']).to eq('button')
@@ -242,7 +242,7 @@ describe 'Piece justificative drag and drop', js: true do
 
         # Drop zone should STILL be visible (max not reached)
         expect(page).to have_css('.attachment-drop-zone')
-        expect(page).to have_button('Choisir des fichiers')
+        expect(page).to have_css('.fr-btn--secondary', text: 'Choisir des fichiers')
 
         # Upload second file
         attach_file('All types', Rails.root.join('spec/fixtures/files/white.png'))
@@ -253,7 +253,7 @@ describe 'Piece justificative drag and drop', js: true do
 
         # Drop zone should still be visible after deletion
         expect(page).to have_css('.attachment-drop-zone')
-        expect(page).to have_button('Choisir des fichiers')
+        expect(page).to have_css('.fr-btn--secondary', text: 'Choisir des fichiers')
 
         # Upload third file
         attach_file('All types', Rails.root.join('spec/fixtures/files/black.png'))


### PR DESCRIPTION
Correctifs d'accessibilité de la zone de glisser-déposer, suite à #13104.

- **Validité du code** : la zone (`role="button"`) contenait un vrai `<button>` imbriqué (HTML invalide, double cible interactive). Le bouton interne devient un `<span>` stylé — apparence DSFR identique, une seule cible interactive.
- **Redondance d'information** : un champ pièce justificative vide produisait deux éléments partageant le même id `#champ-…-input-value-aria-live`. La zone live propre au `FileInputComponent` est désormais limitée au cas sans champ (logo, pièces de procédure) ; pour un champ, c'est le `SectionComponent` qui fournit l'unique zone.
- **Visibilité de la zone** : la bordure pointillée passe de `--border-default-grey` (contraste 1.36:1) à `--border-contrast-grey` (~5:1 en thème clair et sombre), conforme au critère RGAA 3.3.
- **Intitulé de la zone** : la zone n'a plus d'`aria-label` générique. Elle est reliée au label du champ (`aria-labelledby`) et à ses indications — formats, taille, pièce attendue — (`aria-describedby`), pour que les technologies d'assistance annoncent de quelle pièce il s'agit.
- **Retour de succès du transfert** : après un ajout, le focus est déplacé sur le lien de suppression de la pièce ajoutée (« Supprimer le fichier *nom* »), repère clair même en présence de plusieurs blocs. Le message aria-live « Analyse antivirus en cours… » est supprimé : il n'avait aucun équivalent visuel dans la zone d'édition (l'indicateur antivirus du récap, lui, reste inchangé).
- **Progression du transfert** (première itération) : la barre de progression reste affichée au moins 1,5 s une fois apparue, pour qu'un upload rapide (petit fichier ou bonne connexion) ne la fasse pas clignoter trop vite.