### PR TITLE
ETQ Usager, toute la page se connecter par ProConnect est traduite

### DIFF
--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -16,7 +16,7 @@ en:
       france_connect_login:
         # signup_pc_title: "Create an account with ProConnect"
         commencer_title: "Are you an individual?"
-        # commencer_pc_title: "Are you a professional?"
+        commencer_pc_title: "Are you a professional?"
         login_button: "Sign in with"
         help_link: What is FranceConnect?
         separator: or


### PR DESCRIPTION
**Avant**

<img width="1152" height="596" alt="Screenshot 2026-06-04 at 17-54-30 Connect with ProConnect · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/4287f3de-c630-45f4-8a6b-b169e47954e4" />

**Après**

<img width="1214" height="620" alt="Screenshot 2026-06-04 at 17-53-54 Connect with ProConnect · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/7c546fb8-a039-4918-abbb-0ba808c15e18" />
