### PR TITLE
ETQ Usager/Instruction, allège la vue d'un dossier en retirant la ligne indiquant une non expiration en instruction

### DIFF
--- a/app/views/instructeurs/dossiers/_expiration_banner.html.haml
+++ b/app/views/instructeurs/dossiers/_expiration_banner.html.haml
@@ -20,7 +20,3 @@
         - c.with_bottom do
           = button_to repousser_expiration_instructeur_dossier_path(dossier.procedure, dossier), class: 'fr-btn', id: 'test-instructeur-repousser-expiration' do
             = t('instructeurs.dossiers.header.banner.button_delay_expiration', count: dossier.procedure.duree_conservation_dossiers_dans_ds)
-
-- elsif dossier.en_instruction? && dossier.procedure.procedure_expires_when_termine_enabled
-  %p.expires_at_en_instruction.fr-text--sm
-    = t("shared.dossiers.header.expires_at.en_instruction")

--- a/app/views/users/dossiers/_expiration_banner.html.haml
+++ b/app/views/users/dossiers/_expiration_banner.html.haml
@@ -18,7 +18,3 @@
         - c.with_bottom do
           = button_to users_dossier_repousser_expiration_path(dossier), class: 'fr-btn', id: 'test-user-repousser-expiration' do
             = t('users.dossiers.header.banner.button_delay_expiration', count: dossier.procedure.duree_conservation_dossiers_dans_ds)
-
-- elsif dossier.en_instruction? && dossier.procedure.procedure_expires_when_termine_enabled
-  %p.expires_at_en_instruction.fr-text--sm
-    = t("shared.dossiers.header.expires_at.en_instruction")

--- a/spec/views/instructeur/dossiers/_expiration_banner.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/_expiration_banner.html.haml_spec.rb
@@ -53,16 +53,6 @@ describe 'instructeur/dossiers/expiration_banner', type: :view do
       end
     end
 
-    context 'with dossier.en_instruction?' do
-      let(:state) { :en_instruction }
-      let(:attributes) { {} }
-
-      it 'render estimated expiration date' do
-        expect(subject).to have_selector('p.expires_at_en_instruction',
-                                         text: I18n.t("shared.dossiers.header.expires_at.#{i18n_key_state}"))
-      end
-    end
-
     context 'with dossier.en_processed_at?' do
       let(:state) { :accepte }
       let(:attributes) { {} }

--- a/spec/views/users/dossiers/_expiration_banner.html.haml_spec.rb
+++ b/spec/views/users/dossiers/_expiration_banner.html.haml_spec.rb
@@ -66,16 +66,6 @@ describe 'users/dossiers/expiration_banner', type: :view do
       end
     end
 
-    context 'with dossier.en_instruction?' do
-      let(:state) { :en_instruction }
-      let(:attributes) { {} }
-
-      it 'render estimated expiration date' do
-        expect(subject).to have_selector('p.expires_at_en_instruction',
-                                         text: I18n.t("shared.dossiers.header.expires_at.#{i18n_key_state}"))
-      end
-    end
-
     context 'with dossier.en_processed_at?' do
       let(:state) { :accepte }
       let(:attributes) { {} }


### PR DESCRIPTION
on parle de ces lignes la :

<img width="2492" height="662" alt="Screenshot 2026-06-04 at 18-04-11 Suivi de votre dossier · Dossier 24577053 (old and new pjs) · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/a9a65daf-f963-40c5-af69-867768bc9dcb" />
<img width="2496" height="432" alt="Screenshot 2026-06-04 at 18-00-57 Demande · Dossier n° 24577053 (m p) · demarche numerique gouv fr" src="https://github.com/user-attachments/assets/43a9fc51-1e73-438c-84f5-69bb28d30820" />
