### PR TITLE
Tech: bump administrate 0.20 → 1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'activestorage-openstack'
 gem 'active_storage_validations'
 gem 'addressable'
 gem 'administrate'
-gem 'administrate-field-enum' # Allow using Field::Enum in administrate
 gem 'after_commit_everywhere'
 gem 'ancestry'
 gem 'anchored'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,16 +111,11 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    administrate (0.20.1)
-      actionpack (>= 6.0, < 8.0)
-      actionview (>= 6.0, < 8.0)
-      activerecord (>= 6.0, < 8.0)
-      jquery-rails (~> 4.6.0)
+    administrate (1.0.0)
+      actionpack (>= 6.0, < 9.0)
+      actionview (>= 6.0, < 9.0)
+      activerecord (>= 6.0, < 9.0)
       kaminari (~> 1.2.2)
-      sassc-rails (~> 2.1)
-      selectize-rails (~> 0.6)
-    administrate-field-enum (0.0.9)
-      administrate (~> 0.12)
     aes_key_wrap (1.1.0)
     after_commit_everywhere (1.6.0)
       activerecord (>= 4.2)
@@ -406,10 +401,6 @@ GEM
       reline (>= 0.4.2)
     job-iteration (1.13.1)
       activejob (>= 7.0)
-    jquery-rails (4.6.0)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (2.19.2)
     json-jwt (1.17.0)
       activesupport (>= 4.2)
@@ -811,7 +802,6 @@ GEM
       sprockets-rails
       tilt
     securerandom (0.4.1)
-    selectize-rails (0.12.6)
     selenium-devtools (0.148.0)
       selenium-webdriver (~> 4.2)
     selenium-webdriver (4.44.0)
@@ -1008,7 +998,6 @@ DEPENDENCIES
   activestorage-openstack
   addressable
   administrate
-  administrate-field-enum
   after_commit_everywhere
   ancestry
   anchored

--- a/app/dashboards/dossier_dashboard.rb
+++ b/app/dashboards/dossier_dashboard.rb
@@ -12,7 +12,7 @@ class DossierDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number.with_options(searchable: true),
     procedure: Field::HasOne,
-    state: Field::Enum,
+    state: EnumField,
     user: Field::BelongsTo,
     text_summary: Field::String.with_options(searchable: false),
     created_at: Field::DateTime,

--- a/app/dashboards/email_event_dashboard.rb
+++ b/app/dashboards/email_event_dashboard.rb
@@ -7,8 +7,8 @@ class EmailEventDashboard < Administrate::BaseDashboard
     id: Field::Number,
     to: Field::String,
     subject: Field::String,
-    method: Field::Enum,
-    status: Field::Enum,
+    method: EnumField,
+    status: EnumField,
     processed_at: Field::DateTime.with_options(format: "%F %T"),
   }
   COLLECTION_ATTRIBUTES = [:id, :to, :subject, :method, :status, :processed_at].freeze

--- a/app/dashboards/safe_mailer_dashboard.rb
+++ b/app/dashboards/safe_mailer_dashboard.rb
@@ -13,7 +13,7 @@ class SafeMailerDashboard < Administrate::BaseDashboard
     id: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    forced_delivery_method: Field::Enum,
+    forced_delivery_method: EnumField,
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/fields/enum_field.rb
+++ b/app/fields/enum_field.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "administrate/field/base"
+
+# Vendored from the unmaintained administrate-field-enum gem (0.0.9), which pins
+# administrate ~> 0.12 and blocked the upgrade to administrate 1.0.
+# Renders an enum attribute as a humanized (optionally I18n-translated) value,
+# and as a <select> on forms.
+class EnumField < Administrate::Field::Base
+  def to_s
+    data.humanize unless data.nil?
+  end
+
+  def html_options
+    options[:html] || {}
+  end
+end

--- a/app/views/fields/enum_field/_form.html.erb
+++ b/app/views/fields/enum_field/_form.html.erb
@@ -1,0 +1,15 @@
+<div class="field-unit__label"><%= f.label field.attribute %></div>
+
+<div class="field-unit__field">
+  <%= f.select(
+        field.attribute,
+        options_for_select(
+          f.object.class.public_send(field.attribute.to_s.pluralize).map do |k, _v|
+            [I18n.t("activerecord.attributes.#{f.object.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{k}", default: k.humanize), k]
+          end,
+          f.object.public_send(field.attribute.to_s)
+        ),
+        { include_blank: false },
+        field.html_options
+      ) %>
+</div>

--- a/app/views/fields/enum_field/_index.html.erb
+++ b/app/views/fields/enum_field/_index.html.erb
@@ -1,0 +1,1 @@
+<%= I18n.t("activerecord.attributes.#{field.resource.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{field.data}", default: field.to_s) %>

--- a/app/views/fields/enum_field/_show.html.erb
+++ b/app/views/fields/enum_field/_show.html.erb
@@ -1,0 +1,1 @@
+<%= I18n.t("activerecord.attributes.#{field.resource.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{field.data}", default: field.to_s) %>

--- a/app/views/manager/application/index.html.erb
+++ b/app/views/manager/application/index.html.erb
@@ -28,6 +28,7 @@
     search_term: search_term,
     page: page,
     show_search_bar: show_search_bar,
+    filters: filters,
   ) %>
 
 <section class="main-content__body main-content__body--flush">

--- a/app/views/manager/dossiers/index.html.erb
+++ b/app/views/manager/dossiers/index.html.erb
@@ -28,6 +28,7 @@
     search_term: search_term,
     page: page,
     show_search_bar: show_search_bar,
+    filters: filters,
   ) %>
 
 <%- if @deleted_dossier.present? %>


### PR DESCRIPTION
Bump `administrate` 0.20 → 1.0, préparatoire à Rails 8 (la 0.20 plafonne ses dépendances Rails à `< 8.0`.)

- Le gem `administrate-field-enum` (non maintenue) bloquait le bump. Son `Field::Enum` est vendorisé en `EnumField` (`app/fields/`), comportement identique (valeur humanisée/I18n en index/show, `<select>` en form).
- administrate 1.0 bundle ses propres assets compilés (ne tire plus `jquery-rails` / `selectize-rails`, aucun usage ailleurs).
- Les deux templates d'index surchargés transmettent le nouveau local `filters` au partial `index_header`.
- plus besoin de `jquery` 🎉 

Vérifié sur l'espace Manager : dashboards safe_mailer / email_event / dossier (EnumField en index/show/form), recherche, tri, pagination et champs custom.