### PR TITLE
ETQ admin, je peux ajouter un saut de page dans l'éditeur d'attestation v2

### DIFF
--- a/app/assets/stylesheets/attestation.scss
+++ b/app/assets/stylesheets/attestation.scss
@@ -35,6 +35,10 @@
   }
 }
 
+.page-break {
+  break-before: page;
+}
+
 #attestation {
   @media screen {
     .a4-container {

--- a/app/assets/stylesheets/icons.scss
+++ b/app/assets/stylesheets/icons.scss
@@ -246,6 +246,14 @@
     }
   }
 
+  &-page-separator {
+    &:before,
+    &:after {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M17 21V17H7V21H5V16C5 15.4477 5.44772 15 6 15H18C18.5523 15 19 15.4477 19 16V21H17ZM7 3V7H17V3H19V8C19 8.55228 18.5523 9 18 9H6C5.44772 9 5 8.55228 5 8V3H7ZM2 9L6 12L2 15V9ZM22 9V15L18 12L22 9Z'%3E%3C/path%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M17 21V17H7V21H5V16C5 15.4477 5.44772 15 6 15H18C18.5523 15 19 15.4477 19 16V21H17ZM7 3V7H17V3H19V8C19 8.55228 18.5523 9 18 9H6C5.44772 9 5 8.55228 5 8V3H7ZM2 9L6 12L2 15V9ZM22 9V15L18 12L22 9Z'%3E%3C/path%3E%3C/svg%3E");
+    }
+  }
+
   &-pdf-2-line {
     &:before,
     &:after {

--- a/app/assets/stylesheets/tiptap.scss
+++ b/app/assets/stylesheets/tiptap.scss
@@ -45,6 +45,29 @@
   }
 }
 
+.tiptap .page-break {
+  position: relative;
+  height: 0;
+  margin: $default-spacer 0;
+  border-top: 2px dashed var(--border-default-grey);
+
+  &::before {
+    content: 'Saut de page';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    padding: 0 0.5rem;
+    background: var(--background-default-grey);
+    font-size: 0.75rem;
+    color: var(--text-mention-grey);
+  }
+
+  &.ProseMirror-selectednode {
+    border-top-color: var(--border-active-blue-france);
+  }
+}
+
 // Modal link editor footer: override DSFR button group width
 // to allow justify-between layout with split buttons
 #tiptap-link-modal .fr-modal__footer .fr-btns-group {

--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -45,6 +45,9 @@ module Administrateurs
           ['Liste numérotée', 'orderedList', 'list-ordered'],
         ],
         [
+          ['Saut de page', 'pageBreak', 'page-separator'],
+        ],
+        [
           ['Aligner à gauche', 'left', 'align-left'],
           ['Aligner au centre', 'center', 'align-center'],
           ['Aligner à droite', 'right', 'align-right'],

--- a/app/javascript/shared/tiptap/actions.ts
+++ b/app/javascript/shared/tiptap/actions.ts
@@ -113,6 +113,15 @@ const EDITOR_ACTIONS: Record<string, (editor: Editor) => EditorAction> = {
     },
     isActive: () => editor.isActive('link'),
     isDisabled: () => false
+  }),
+  pageBreak: (editor) => ({
+    run: () =>
+      editor.chain().focus().insertContent({ type: 'pageBreak' }).run(),
+    isActive: () => false,
+    isDisabled: () =>
+      editor.isActive('title') ||
+      editor.isActive('header') ||
+      editor.isActive('footer')
   })
 };
 

--- a/app/javascript/shared/tiptap/editor.ts
+++ b/app/javascript/shared/tiptap/editor.ts
@@ -27,7 +27,13 @@ import {
   type Extensions
 } from '@tiptap/core';
 
-import { DocumentWithHeader, Title, Header, HeaderColumn } from './nodes';
+import {
+  DocumentWithHeader,
+  Title,
+  Header,
+  HeaderColumn,
+  PageBreak
+} from './nodes';
 import { createSuggestionMenu, type TagSchema } from './tags';
 
 const SingleLineDocument = Document.extend({
@@ -119,6 +125,9 @@ function getEditorOptions(
             }
           })
         );
+        break;
+      case 'pageBreak':
+        extensions.push(PageBreak);
         break;
     }
   }

--- a/app/javascript/shared/tiptap/nodes.ts
+++ b/app/javascript/shared/tiptap/nodes.ts
@@ -49,3 +49,22 @@ export const HeaderColumn = Node.create({
     return ['div', mergeAttributes(HTMLAttributes, { class: 'flex-1' }), 0];
   }
 });
+
+export const PageBreak = Node.create({
+  name: 'pageBreak',
+  group: 'block',
+  atom: true,
+
+  parseHTML() {
+    return [{ tag: 'div.page-break' }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        class: 'page-break',
+        'data-page-break': ''
+      })
+    ];
+  }
+});

--- a/app/services/tiptap_service.rb
+++ b/app/services/tiptap_service.rb
@@ -52,7 +52,7 @@ class TiptapService
         "<span class='fr-tag fr-tag--sm'>#{label}</span>"
       end
     in type: 'pageBreak'
-      ''
+      ' '
     end
   end
 

--- a/app/services/tiptap_service.rb
+++ b/app/services/tiptap_service.rb
@@ -112,7 +112,7 @@ class TiptapService
         text
       end
     in type: 'pageBreak'
-      '<div class="page-break"></div>'
+      level == 0 && !@body_started ? '' : '<div class="page-break"></div>'
     in { type: type } if ["paragraph", "title", "heading"].include?(type) && !node.key?(:content)
       # noop
     else

--- a/app/services/tiptap_service.rb
+++ b/app/services/tiptap_service.rb
@@ -109,6 +109,8 @@ class TiptapService
       else
         text
       end
+    in type: 'pageBreak'
+      '<div class="page-break"></div>'
     in { type: type } if ["paragraph", "title", "heading"].include?(type) && !node.key?(:content)
       # noop
     else

--- a/app/services/tiptap_service.rb
+++ b/app/services/tiptap_service.rb
@@ -51,6 +51,8 @@ class TiptapService
       else
         "<span class='fr-tag fr-tag--sm'>#{label}</span>"
       end
+    in type: 'pageBreak'
+      ''
     end
   end
 

--- a/spec/services/tiptap_service_spec.rb
+++ b/spec/services/tiptap_service_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe TiptapService do
     context 'pageBreak node' do
       let(:substitutions) { {} }
 
-      it 'ignores pageBreak nodes' do
+      it 'renders a space between paragraphs separated by a pageBreak' do
         json = {
           type: 'doc',
           content: [
@@ -395,7 +395,7 @@ RSpec.describe TiptapService do
             { type: 'paragraph', content: [{ type: 'text', text: 'Après' }] },
           ],
         }
-        expect { described_class.new.to_texts_and_tags(json) }.not_to raise_error
+        expect(described_class.new.to_texts_and_tags(json)).to eq('Avant Après')
       end
     end
   end

--- a/spec/services/tiptap_service_spec.rb
+++ b/spec/services/tiptap_service_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe TiptapService do
         )
       end
 
-      it 'keeps body-start on the first paragraph when a pageBreak comes first' do
+      it 'does not render a page-break div when it is the first node' do
         json = {
           type: 'doc',
           content: [
@@ -287,7 +287,7 @@ RSpec.describe TiptapService do
           ],
         }
         expect(described_class.new.to_html(json)).to eq(
-          '<div class="page-break"></div><p class="body-start">Premier paragraphe</p>'
+          '<p class="body-start">Premier paragraphe</p>'
         )
       end
     end

--- a/spec/services/tiptap_service_spec.rb
+++ b/spec/services/tiptap_service_spec.rb
@@ -260,6 +260,25 @@ RSpec.describe TiptapService do
       end
     end
 
+    context 'page break node' do
+      let(:json) do
+        {
+          type: 'doc',
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'Avant' }] },
+            { type: 'pageBreak' },
+            { type: 'paragraph', content: [{ type: 'text', text: 'Après' }] },
+          ],
+        }
+      end
+
+      it 'renders a page-break div without consuming the body-start mark' do
+        expect(described_class.new.to_html(json)).to eq(
+          '<p class="body-start">Avant</p><div class="page-break"></div><p>Après</p>'
+        )
+      end
+    end
+
     context 'ordered list with custom classes' do
       let(:json) do
         {

--- a/spec/services/tiptap_service_spec.rb
+++ b/spec/services/tiptap_service_spec.rb
@@ -277,6 +277,19 @@ RSpec.describe TiptapService do
           '<p class="body-start">Avant</p><div class="page-break"></div><p>Après</p>'
         )
       end
+
+      it 'keeps body-start on the first paragraph when a pageBreak comes first' do
+        json = {
+          type: 'doc',
+          content: [
+            { type: 'pageBreak' },
+            { type: 'paragraph', content: [{ type: 'text', text: 'Premier paragraphe' }] },
+          ],
+        }
+        expect(described_class.new.to_html(json)).to eq(
+          '<div class="page-break"></div><p class="body-start">Premier paragraphe</p>'
+        )
+      end
     end
 
     context 'ordered list with custom classes' do
@@ -368,6 +381,22 @@ RSpec.describe TiptapService do
       let(:substitutions) { {} }
 
       it { is_expected.to eq('') }
+    end
+
+    context 'pageBreak node' do
+      let(:substitutions) { {} }
+
+      it 'ignores pageBreak nodes' do
+        json = {
+          type: 'doc',
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'Avant' }] },
+            { type: 'pageBreak' },
+            { type: 'paragraph', content: [{ type: 'text', text: 'Après' }] },
+          ],
+        }
+        expect { described_class.new.to_texts_and_tags(json) }.not_to raise_error
+      end
     end
   end
 end

--- a/spec/system/administrateurs/procedure_attestation_template_spec.rb
+++ b/spec/system/administrateurs/procedure_attestation_template_spec.rb
@@ -177,6 +177,20 @@ describe 'As an administrateur, I want to manage the procedure’s attestation',
       expect(page).to have_text(/La nouvelle version de l’attestation/)
     end
 
+    scenario 'inserting a page break in the v2 attestation' do
+      visit edit_admin_procedure_attestation_template_v2_path(procedure, attestation_kind: :acceptation)
+
+      expect(page).to have_css('#editor')
+
+      within('#attestation-edit') do
+        find('#editor .ProseMirror').click
+        click_on 'Saut de page'
+      end
+
+      expect(page).to have_css('#editor .page-break')
+      expect(find('input[data-tiptap-target="input"]', visible: false).value).to include('pageBreak')
+    end
+
     context "tag in error" do
       before do
         tdc = procedure.active_revision.add_type_de_champ(type_champ: :integer_number, libelle: 'age')


### PR DESCRIPTION
## Contexte

Un administrateur dont l'attestation v2 fait 12 pages souhaitait soigner sa mise en page avec des sauts de page. Cf [ce retour au support](https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_27e5204a-2809-4e7b-b5eb-140e203fd418/). L'éditeur ne proposait aucune fonctionnalité de ce type.

## Ce que fait cette PR

Ajoute un bouton **« Saut de page »** à la barre d'outils de l'éditeur d'attestation v2. L'admin clique pour insérer un saut, matérialisé dans l'éditeur par un séparateur pointillé étiqueté, et appliqué comme véritable saut de page dans le PDF généré (WeasyPrint).

## Fonctionnement

- Nouveau nœud TipTap `pageBreak`, sérialisé `{ "type": "pageBreak" }`.
- Conversion serveur (`TiptapService`) en `<div class="page-break"></div>`.
- CSS `break-before: page` dans la feuille PDF ; rendu visuel dans l'éditeur ; icône custom ajoutée via la convention data-URI existante de `icons.scss`.

## Capture d'écran


https://github.com/user-attachments/assets/0a3be4a0-8d4d-4f46-91dd-d3c9df8a3a74


