### PR TITLE
Fix : ETQ admin dans l'éditeur d'attestation v2, le retour à la ligne fonctionne même sans texte après le curseur

### DIFF
--- a/spec/system/administrateurs/procedure_attestation_template_spec.rb
+++ b/spec/system/administrateurs/procedure_attestation_template_spec.rb
@@ -177,6 +177,31 @@ describe 'As an administrateur, I want to manage the procedure’s attestation',
       expect(page).to have_text(/La nouvelle version de l’attestation/)
     end
 
+    scenario 'pressing Enter with no text after the cursor creates a new paragraph' do
+      visit edit_admin_procedure_attestation_template_v2_path(procedure, attestation_kind: :acceptation)
+      expect(page).to have_css('#editor .ProseMirror')
+
+      editor = find('#editor .ProseMirror')
+      editor.click
+
+      # Place the caret at the very end of the document, so there is no text
+      # after it when Enter is pressed.
+      page.execute_script(<<~JS)
+        const el = document.querySelector('#editor .ProseMirror');
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        range.collapse(false);
+        const selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(range);
+      JS
+
+      editor.send_keys('Hello', :enter, 'World')
+
+      expect(page).to have_css('#editor .ProseMirror p', exact_text: 'World')
+      expect(page).to have_no_css('#editor .ProseMirror p', text: 'HelloWorld')
+    end
+
     context "tag in error" do
       before do
         tdc = procedure.active_revision.add_type_de_champ(type_champ: :integer_number, libelle: 'age')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,17 @@ logger.warn = (msg, options) => {
 };
 
 export default defineConfig({
-  resolve: { alias: { '@utils': '/shared/utils.ts' } },
+  resolve: {
+    alias: { '@utils': '/shared/utils.ts' },
+    dedupe: [
+      'prosemirror-model',
+      'prosemirror-state',
+      'prosemirror-view',
+      'prosemirror-transform',
+      'prosemirror-keymap',
+      'prosemirror-commands'
+    ]
+  },
   build: { sourcemap: true, assetsInlineLimit: 0 },
   customLogger: logger,
   css: {


### PR DESCRIPTION
## Problème

Dans l'éditeur d'attestation v2 (TipTap), appuyer sur **Entrée** ne créait aucun saut de ligne lorsqu'il n'y avait **pas de texte après le curseur** (typiquement en fin de paragraphe). La console affichait une `RangeError : multiple versions of prosemirror-model were loaded `.
cf [ce retour au support](https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_27e5204a-2809-4e7b-b5eb-140e203fd418/)

## Cause

Le pré-bundling de dépendances de Vite (`optimizeDeps`) incluait `prosemirror-model` dans plusieurs chunks optimisés (via `@tiptap/core` et `@tiptap/pm` / `prosemirror-state`), produisant **deux classes `Fragment` distinctes**. Les vérifications `instanceof` inter-instances échouaient, ce qui cassait `splitBlock` au moment de construire un nouveau paragraphe vide.

## Correctif

- `resolve.dedupe` dans `vite.config.ts` pour forcer une instance unique des paquets prosemirror.
- System spec de non-régression couvrant l'appui sur Entrée en position finale vide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)