### PR TITLE
ETQ usager, je peux déposer un dossier même si la vérification du Siret est temporairement indisponible

### DIFF
--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -60,8 +60,6 @@ module Dsfr
           { state: :info, text: t('.siret.fetched_with_capital', raison_sociale_or_name: displayable_raison_sociale_or_name(@champ.etablissement), forme_juridique: @champ.etablissement.entreprise_forme_juridique, capital_sociale: pretty_currency(@champ.etablissement.entreprise_capital_social)) }
         elsif @champ.etablissement && @champ.etablissement.entreprise_capital_social.blank?
           { state: :info, text: t('.siret.fetched', raison_sociale_or_name: displayable_raison_sociale_or_name(@champ.etablissement), forme_juridique: @champ.etablissement.entreprise_forme_juridique) }
-        elsif @champ.external_error?
-          { state: :warning, text: t('.siret.error', value: pretty_siret(@champ.external_id)) }
         elsif @champ.pending?
           { state: :info, text: t('.siret.pending', value: pretty_siret(@champ.external_id)) }
         end

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
@@ -8,7 +8,6 @@ en:
     pending: "Search in progress for SIRET %{value}…"
     fetched_with_capital: "%{raison_sociale_or_name} %{forme_juridique} with a share capital of %{capital_sociale}"
     fetched: "%{raison_sociale_or_name} %{forme_juridique}"
-    error: "An error occurred while retrieving SIRET information."
   referentiel:
     not_configured: "This field has not been configured by the administrator yet."
     fetching: "Search in progress."

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
@@ -8,7 +8,6 @@ fr:
     pending: "Recherche en cours pour le SIRET %{value}…"
     fetched_with_capital: "%{raison_sociale_or_name} %{forme_juridique} au capital social de %{capital_sociale}"
     fetched: "%{raison_sociale_or_name} %{forme_juridique}"
-    error: "Une erreur est survenue lors de la récupération des informations SIRET."
   referentiel:
     not_configured: "Ce champ n’est pas encore configuré par l’administrateur."
     fetching: "Recherche en cours."

--- a/app/components/editable_champ/siret_component/siret_component.html.haml
+++ b/app/components/editable_champ/siret_component/siret_component.html.haml
@@ -1,1 +1,4 @@
 = @form.text_field(:external_id, input_opts(value: pretty_siret(@champ.external_id), id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, data: { controller: 'format', format: 'siret' }, required: @champ.required?, class: "width-33-desktop"))
+
+- if @champ.external_data_status_message.present?
+  %p.fr-info-text{ role: 'status' }= t("shared.champs.external_data.#{@champ.external_data_status_message}")

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -34,6 +34,12 @@ class Champ < ApplicationRecord
     false
   end
 
+  # Overridable extension point. Override to true in a champ subclass to opt into
+  # lenient external data validation
+  def lenient_external_data_validation?
+    false
+  end
+
   def type_de_champ
     @type_de_champ ||= dossier.revision
       .types_de_champ

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -28,6 +28,12 @@ class Champ < ApplicationRecord
   # look like it was edited. Revert blank-equivalent JSON columns before saving.
   before_save :nullify_blank_json_columns
 
+  # Overridable extension point. Return true on a champ to restore the historical
+  # blocking behavior of ExternalDataChampValidator.
+  def external_data_required_for_conditions?
+    false
+  end
+
   def type_de_champ
     @type_de_champ ||= dossier.revision
       .types_de_champ

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -9,6 +9,10 @@ class Champs::SiretChamp < Champ
     true
   end
 
+  def lenient_external_data_validation?
+    true
+  end
+
   def focusable_input_id(attribute = :value)
     [input_id, :value].compact.join('-')
   end

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -35,13 +35,13 @@ class Champs::SiretChamp < Champ
   def fetch_external_data
     case APIEntrepriseService.create_etablissement_with_fallback(self, external_id.delete(" "), dossier.user&.id)
     in Success(etablissement) if etablissement.as_degraded_mode?
-      Failure(retryable: true, error: StandardError.new("API Entreprise: degraded mode"), code: 503)
+      Failure(retryable: true, error: StandardError.new("API Entreprise: degraded mode"), code: 503, kind: :technical_error)
     in Success(etablissement)
       Success(etablissement:, value: external_id)
     in Failure(type: :not_found, **)
-      Failure(retryable: false, error: StandardError.new('NotFound'), code: 404)
+      Failure(retryable: false, error: StandardError.new('NotFound'), code: 404, kind: :not_found)
     in Failure(type:, code:, retryable:, **)
-      Failure(retryable:, error: StandardError.new("API Entreprise: #{type}"), code:)
+      Failure(retryable:, error: StandardError.new("API Entreprise: #{type}"), code:, kind: :technical_error)
     end
   end
 
@@ -49,9 +49,12 @@ class Champs::SiretChamp < Champ
     etablissement.present? ? etablissement.search_terms : [value]
   end
 
-  def save_additional_job_exception(exception, code)
+  # kind: defaults to :technical_error. Reason: this method is
+  # invoked from infrastructure exception catches in jobs (timeouts, transport
+  # errors), which are technical by nature. Callers can still override.
+  def save_additional_job_exception(exception, code, kind: :technical_error)
     exceptions = fetch_external_data_exceptions || []
-    exceptions << ExternalDataException.new(error: exception.inspect, code:)
+    exceptions << ExternalDataException.new(error: exception.inspect, code:, kind:)
     update_columns(fetch_external_data_exceptions: exceptions)
   end
 

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -72,6 +72,9 @@ class Champs::SiretChamp < Champ
     return if external_id.blank?
     return if etablissement.present?
     return if pending?
+    # Blocking on external_error is ExternalDataChampValidator's job (kind-aware);
+    # this validation only covers the synchronous idle/format-check path.
+    return if external_error?
 
     validator = ActiveModel::Validations::SiretValidator.new(attributes: { value: true })
 

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -95,13 +95,17 @@ module ChampExternalDataConcern
       in Success(hash)
         update_external_data!(hash)
         external_data_fetched!
-      in Failure(retryable: true, error:, code:)
-        save_external_error(error, code)
+      in Failure(retryable: true, error:, code:, **rest)
+        save_external_error(error, code, rest[:kind])
         retry!
         raise RetryableFetchError.new(error)
-      in Failure(retryable: false, error:, code:)
-        save_external_error(error, code)
+      in Failure(retryable: false, error:, code:, **rest)
+        save_external_error(error, code, rest[:kind])
         Sentry.capture_exception(error) if code != 404
+        external_data_error!
+      in Failure(retryable: false, error:)
+        save_external_error(error, nil)
+        Sentry.capture_exception(error)
         external_data_error!
       end
     elsif result.present?
@@ -114,9 +118,9 @@ module ChampExternalDataConcern
     update!(hash.merge(fetch_external_data_exceptions: []))
   end
 
-  def save_external_error(error, code)
+  def save_external_error(error, code, kind = nil)
     exceptions = fetch_external_data_exceptions || []
-    exceptions << ExternalDataException.new(error: error.inspect, code:)
+    exceptions << ExternalDataException.new(error: error.inspect, code:, kind:)
     update_columns(fetch_external_data_exceptions: exceptions)
   end
 

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -68,6 +68,13 @@ module ChampExternalDataConcern
   def done? = fetched? || external_error?
   def external_data_not_found? = external_error? && fetch_external_data_exceptions.last.not_found?
 
+  def external_data_status_message
+    return nil if external_data_required_for_conditions?
+    return :technical_error if external_error? && !external_data_not_found?
+
+    nil
+  end
+
   def has_async_external_data? = false
 
   def external_data_needed_for_validation? = has_async_external_data?

--- a/app/models/external_data_exception.rb
+++ b/app/models/external_data_exception.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class ExternalDataException
-  attr_accessor :error, :code
+  KINDS = [:not_found, :technical_error].freeze
 
-  def initialize(error:, code:)
+  attr_accessor :error, :code, :kind
+
+  def initialize(error:, code:, kind: nil)
     @error = error
     @code = code
+    @kind = kind
   end
 
   def not_found?
-    code == 404
+    kind == :not_found || code == 404
   end
 end

--- a/app/models/types_de_champ/siret_type_de_champ.rb
+++ b/app/models/types_de_champ/siret_type_de_champ.rb
@@ -7,7 +7,10 @@ class TypesDeChamp::SiretTypeDeChamp < TypesDeChamp::TypeDeChampBase
     FILL_DURATION_MEDIUM
   end
 
-  def champ_blank_or_invalid?(champ) = Siret.new(siret: champ.value).invalid?
+  # A syntactically valid external_id is enough to satisfy the mandatory
+  # check while the async fetch is pending or failed non-blockingly:
+  # the actual blocking decision belongs to ExternalDataChampValidator.
+  def champ_blank_or_invalid?(champ) = Siret.new(siret: champ.external_id).invalid?
 
   def columns(procedure_id:, displayable: true, prefix: nil)
     super

--- a/app/types/external_data_exception_type.rb
+++ b/app/types/external_data_exception_type.rb
@@ -2,21 +2,29 @@
 
 class ExternalDataExceptionType < ActiveRecord::Type::Value
   # value can come from:
-  # setter: ExternalDataException or { error:, code: } (Hash),
-  # from db: { reason:, code: } (Hash) (legacy) or { error:, code: } (Hash)
+  # setter: ExternalDataException or { error:, code:, kind?: } (Hash),
+  # from db: { reason:, code: } (Hash, legacy pre error) or
+  #          { error:, code: } (Hash, legacy pre kind) or
+  #          { error:, code:, kind: } (Hash, current shape — kind may be nil)
   def cast(value)
     case value
     in NilClass
       nil
     in ExternalDataException
       value
+    in { error: String => error, code: Integer => code, kind: } => h
+      ExternalDataException.new(error:, code:, kind: cast_kind(h[:kind]))
     in { error: String => error, code: Integer => code }
-      ExternalDataException.new(error:, code:)
+      ExternalDataException.new(error:, code:, kind: nil)
     in { reason: String => error, code: Integer => code }
-      ExternalDataException.new(error:, code:)
+      ExternalDataException.new(error:, code:, kind: nil)
     in String => json_string
       h = JSON.parse(json_string, symbolize_names: true) rescue { reason: json_string, code: nil }
-      ExternalDataException.new(error: h[:error] || h[:reason], code: h[:code])
+      ExternalDataException.new(
+        error: h[:error] || h[:reason],
+        code: h[:code],
+        kind: cast_kind(h[:kind])
+      )
     else
       raise ArgumentError, "Invalid value for ExternalDataException casting: #{value}"
     end
@@ -31,12 +39,17 @@ class ExternalDataExceptionType < ActiveRecord::Type::Value
     in NilClass
       nil
     in ExternalDataException
-      JSON.generate({
-        code: value.code,
-        error: value.error,
-      })
+      JSON.generate({ code: value.code, error: value.error, kind: value.kind })
     else
       raise ArgumentError, "Invalid value for ExternalDataException serialization: #{value}"
     end
+  end
+
+  private
+
+  def cast_kind(raw)
+    return nil if raw.nil?
+    sym = raw.to_sym
+    ExternalDataException::KINDS.include?(sym) ? sym : nil
   end
 end

--- a/app/validators/external_data_champ_validator.rb
+++ b/app/validators/external_data_champ_validator.rb
@@ -3,22 +3,40 @@
 class ExternalDataChampValidator < ActiveModel::Validator
   # Required checks are delegated to check_mandatory_and_visible_champs_public.
   def validate(record)
-    if record.pending?
-      # User filled the field, but background job is still running.
-      record.errors.add(:external_id, :api_response_pending)
-    elsif record.external_error?
-      # User filled the field, but background job failed.
-      record.errors.add(:external_id, error_key_for_api_response_code(record))
+    if record.lenient_external_data_validation? && !record.external_data_required_for_conditions?
+      lenient_validate(record)
+    else
+      legacy_validate(record)
     end
   end
 
   private
 
-  def error_key_for_api_response_code(record)
-    first_exception = record.fetch_external_data_exceptions&.first
-    return :code_unknown if first_exception.nil?
+  # Historical behavior: any pending or external_error blocks submission.
+  # Used when another field's logic condition depends on this champ's value_json.
+  def legacy_validate(record)
+    if record.pending?
+      # User filled the field, but background job is still running.
+      record.errors.add(:external_id, :api_response_pending)
+    elsif record.external_error?
+      # User filled the field, but background job failed.
+      record.errors.add(:external_id, error_key_for(record, record.fetch_external_data_exceptions&.first))
+    end
+  end
 
-    http_status = first_exception.code
+  # Lenient behavior: only a not-found result (kind :not_found, or a legacy 404)
+  # blocks submission. Pending and technical errors let the user submit.
+  # Exceptions accumulate across retries: only the most recent one is conclusive.
+  def lenient_validate(record)
+    return unless record.external_data_not_found?
+
+    record.errors.add(:value, error_key_for(record, record.fetch_external_data_exceptions.last))
+  end
+
+  def error_key_for(record, exception)
+    return :code_unknown if exception.nil?
+
+    http_status = exception.code
     error_key = :"code_#{http_status}"
 
     if http_status && translation_exists_for?(error_key, record)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -94,6 +94,7 @@ search:
 ## Consider these keys used:
 ignore_unused:
   - 'errors.format'
+  - 'shared.champs.external_data.*' # dynamic key: t("shared.champs.external_data.#{external_data_status_message}")
   - 'user_mailer.*.subject'
   - 'activerecord.models.*'
   - 'activerecord.attributes.*'

--- a/config/locales/shared.en.yml
+++ b/config/locales/shared.en.yml
@@ -28,6 +28,8 @@ en:
       move_down: Move down
 
     champs:
+      external_data:
+        technical_error: "Automatic verification is temporarily unavailable. You can continue submitting; the information will be retrieved as soon as possible."
       drop_down_list:
         other: Enter another option
         other_label: Enter your option

--- a/config/locales/shared.fr.yml
+++ b/config/locales/shared.fr.yml
@@ -30,6 +30,8 @@ fr:
       move_down: Déplacer vers le bas
 
     champs:
+      external_data:
+        technical_error: "La vérification automatique est temporairement indisponible. Vous pouvez poursuivre le dépôt ; les informations seront récupérées dès que possible."
       rna:
         association:
           data_fetched: "Ce RNA correspond à : %{title}, %{address}"

--- a/spec/components/input_status_message_component_spec.rb
+++ b/spec/components/input_status_message_component_spec.rb
@@ -240,6 +240,21 @@ RSpec.describe Dsfr::InputStatusMessageComponent, type: :component do
         end
       end
 
+      context "when external fetch failed with a technical error (non-blocking)" do
+        before do
+          champ.update!(etablissement: nil)
+          champ.update_columns(
+            external_id: '80879023200025',
+            external_state: 'external_error',
+            fetch_external_data_exceptions: [ExternalDataException.new(error: 'API down', code: 503, kind: :technical_error)]
+          )
+        end
+
+        it "does not render a warning message (the non-blocking info banner already covers it)" do
+          expect(subject).not_to have_css(".fr-message--warning")
+        end
+      end
+
       context "when etablissement is non-diffusible (diffusable_commercialement: false)" do
         before do
           etablissement = create(:etablissement, :non_diffusable, entreprise_raison_sociale: "SECRET EI", entreprise_forme_juridique: "Entrepreneur individuel")

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -642,4 +642,10 @@ describe Champ do
       expect(target_champ.external_state).to eq('fetched')
     end
   end
+
+  describe '#external_data_required_for_conditions?' do
+    it 'returns false by default' do
+      expect(Champs::TextChamp.new.external_data_required_for_conditions?).to be(false)
+    end
+  end
 end

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -85,6 +85,42 @@ describe Champs::SiretChamp do
     end
   end
 
+  describe '#mandatory_blank?' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret, mandatory: true }]) }
+    let(:external_id) { "12345678901245" }
+
+    context 'when the fetch is pending' do
+      before { champ.update_columns(external_state: 'waiting_for_job') }
+
+      it 'is not mandatory_blank (a syntactically valid SIRET is enough while pending)' do
+        expect(champ.mandatory_blank?).to be false
+      end
+    end
+
+    context 'when the fetch failed with a technical error' do
+      let(:exception) { ExternalDataException.new(error: 'API down', code: 503, kind: :technical_error) }
+
+      before do
+        champ.update_columns(
+          external_state: 'external_error',
+          fetch_external_data_exceptions: [exception]
+        )
+      end
+
+      it 'is not mandatory_blank (a syntactically valid SIRET is enough despite the technical error)' do
+        expect(champ.mandatory_blank?).to be false
+      end
+    end
+
+    context 'when the format is invalid' do
+      let(:external_id) { "12345" }
+
+      it 'is mandatory_blank' do
+        expect(champ.mandatory_blank?).to be true
+      end
+    end
+  end
+
   describe '.fetch_external_data' do
     let(:api_etablissement_status) { 200 }
     let(:api_etablissement_body) { File.read('spec/fixtures/files/api_entreprise/etablissements.json') }

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -46,8 +46,8 @@ describe Champs::SiretChamp do
 
       before { champ.update_columns(external_state: 'waiting_for_job') }
 
-      it 'adds a pending error on external_id' do
-        expect(subject.errors[:external_id]).to include(I18n.t('activerecord.errors.messages.api_response_pending'))
+      it 'does not block submission (pending is non-blocking)' do
+        expect(subject).to be_valid
       end
     end
 
@@ -62,9 +62,9 @@ describe Champs::SiretChamp do
         )
       end
 
-      it 'adds the external error on external_id only' do
-        expect(subject.errors[:external_id]).to include(I18n.t('activerecord.errors.messages.code_404'))
-        expect(subject.errors[:value]).to be_empty
+      it 'adds the external error on value only' do
+        expect(subject.errors[:value]).to include(I18n.t('activerecord.errors.messages.code_404'))
+        expect(subject.errors[:external_id]).to be_empty
       end
     end
   end

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -53,7 +53,7 @@ describe Champs::SiretChamp do
 
     context 'when external fetch failed' do
       let(:external_id) { "12345678901245" }
-      let(:exception) { ExternalDataException.new(error: 'Not retryable', code: 404) }
+      let(:exception) { ExternalDataException.new(error: 'Not retryable', code: 404, kind: :not_found) }
 
       before do
         champ.update_columns(
@@ -145,6 +145,50 @@ describe Champs::SiretChamp do
       it "fetches the entreprise raison sociale" do
         fetch_external_data
         expect(champ.reload.etablissement.entreprise_raison_sociale).to eq("DIRECTION INTERMINISTERIELLE DU NUMERIQUE")
+      end
+    end
+  end
+
+  describe '#fetch_external_data (kind classification)' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champs.first }
+    before { champ.update_column(:external_id, '12345678901234') }
+
+    context 'when API returns not_found' do
+      before do
+        allow(APIEntrepriseService).to receive(:create_etablissement_with_fallback)
+          .and_return(Dry::Monads::Failure(type: :not_found, code: 404, retryable: false))
+      end
+
+      it 'wraps as kind: :not_found' do
+        result = champ.fetch_external_data
+        expect(result).to be_failure
+        expect(result.failure[:kind]).to eq(:not_found)
+        expect(result.failure[:code]).to eq(404)
+      end
+    end
+
+    context 'when API returns a generic technical failure' do
+      before do
+        allow(APIEntrepriseService).to receive(:create_etablissement_with_fallback)
+          .and_return(Dry::Monads::Failure(type: :network, code: 503, retryable: true))
+      end
+
+      it 'wraps as kind: :technical_error' do
+        expect(champ.fetch_external_data.failure[:kind]).to eq(:technical_error)
+      end
+    end
+
+    context 'when API returns Success in degraded mode' do
+      let(:etablissement) { instance_double(Etablissement, as_degraded_mode?: true) }
+      before do
+        allow(APIEntrepriseService).to receive(:create_etablissement_with_fallback)
+          .and_return(Dry::Monads::Success(etablissement))
+      end
+
+      it 'wraps degraded mode as kind: :technical_error' do
+        expect(champ.fetch_external_data.failure[:kind]).to eq(:technical_error)
       end
     end
   end

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -47,7 +47,7 @@ describe Champs::SiretChamp do
       before { champ.update_columns(external_state: 'waiting_for_job') }
 
       it 'does not block submission (pending is non-blocking)' do
-        expect(subject).to be_valid
+        expect(subject.errors).to be_empty
       end
     end
 
@@ -65,6 +65,22 @@ describe Champs::SiretChamp do
       it 'adds the external error on value only' do
         expect(subject.errors[:value]).to include(I18n.t('activerecord.errors.messages.code_404'))
         expect(subject.errors[:external_id]).to be_empty
+      end
+    end
+
+    context 'when external fetch failed with a technical error' do
+      let(:external_id) { "12345678901245" }
+      let(:exception) { ExternalDataException.new(error: 'API down', code: 503, kind: :technical_error) }
+
+      before do
+        champ.update_columns(
+          external_state: 'external_error',
+          fetch_external_data_exceptions: [exception]
+        )
+      end
+
+      it 'does not block submission (technical error is non-blocking)' do
+        expect(subject.errors).to be_empty
       end
     end
   end

--- a/spec/models/concerns/champ_external_data_concern_spec.rb
+++ b/spec/models/concerns/champ_external_data_concern_spec.rb
@@ -9,8 +9,72 @@ RSpec.describe ChampExternalDataConcern do
     let(:champ) { dossier.champs.first }
     context "add execption to the log" do
       it do
-        champ.send(:save_external_error, double(inspect: 'PAN'), 404)
+        champ.send(:save_external_error, double(inspect: 'PAN'), 404, :not_found)
         expect { champ.reload }.not_to raise_error
+      end
+    end
+
+    it 'persists kind on the exception' do
+      champ.send(:save_external_error, StandardError.new('boom'), 503, :technical_error)
+      expect(champ.reload.fetch_external_data_exceptions.first.kind).to eq(:technical_error)
+    end
+  end
+
+  describe '#handle_result' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champs.first }
+
+    context 'with Failure(:not_found)' do
+      it 'persists an exception with kind: :not_found' do
+        allow(champ).to receive(:ready_for_external_call?).and_return(true)
+        champ.fetch_later!
+
+        result = Failure(retryable: false, error: StandardError.new('NotFound'), code: 404, kind: :not_found)
+        allow(champ).to receive(:fetch_external_data).and_return(result)
+        champ.fetch!
+
+        expect(champ.reload.fetch_external_data_exceptions.first.kind).to eq(:not_found)
+      end
+    end
+
+    context 'with Failure(:technical_error, retryable: true)' do
+      it 'persists an exception with kind: :technical_error and raises RetryableFetchError' do
+        allow(champ).to receive(:ready_for_external_call?).and_return(true)
+        champ.fetch_later!
+
+        result = Failure(retryable: true, error: StandardError.new('boom'), code: 503, kind: :technical_error)
+        allow(champ).to receive(:fetch_external_data).and_return(result)
+
+        expect { champ.fetch! }.to raise_error(RetryableFetchError)
+        expect(champ.reload).to be_waiting_for_job
+        expect(champ.fetch_external_data_exceptions.first.kind).to eq(:technical_error)
+      end
+    end
+
+    context 'with Failure without kind (legacy service — API::Client::Error or un-migrated service)' do
+      it 'persists nil kind for non-retryable failure with code' do
+        allow(champ).to receive(:ready_for_external_call?).and_return(true)
+        champ.fetch_later!
+
+        result = Failure(retryable: false, error: StandardError.new('some error'), code: 503)
+        allow(champ).to receive(:fetch_external_data).and_return(result)
+        champ.fetch!
+
+        expect(champ.reload).to be_external_error
+        expect(champ.fetch_external_data_exceptions.first.kind).to be_nil
+      end
+
+      it 'persists nil kind for non-retryable failure without code' do
+        allow(champ).to receive(:ready_for_external_call?).and_return(true)
+        champ.fetch_later!
+
+        result = Failure(retryable: false, error: StandardError.new('not configured'))
+        allow(champ).to receive(:fetch_external_data).and_return(result)
+        champ.fetch!
+
+        expect(champ.reload).to be_external_error
+        expect(champ.fetch_external_data_exceptions.first.kind).to be_nil
       end
     end
   end
@@ -125,7 +189,7 @@ RSpec.describe ChampExternalDataConcern do
         allow(champ).to receive(:ready_for_external_call?).and_return(true)
         champ.fetch_later!
 
-        failure = Failure(retryable: false, error: Exception.new('nop'), code:)
+        failure = Failure(retryable: false, error: Exception.new('nop'), code:, kind: :technical_error)
         allow(champ).to receive(:fetch_external_data).and_return(failure)
         allow(Sentry).to receive(:capture_exception)
         champ.fetch!
@@ -152,7 +216,7 @@ RSpec.describe ChampExternalDataConcern do
         allow(champ).to receive(:ready_for_external_call?).and_return(true)
         champ.fetch_later!
 
-        failure = Failure(retryable: true, error: Exception.new('nop'), code: 404)
+        failure = Failure(retryable: true, error: Exception.new('nop'), code: 404, kind: :technical_error)
         allow(champ).to receive(:fetch_external_data).and_return(failure)
       end
 

--- a/spec/models/concerns/champ_external_data_concern_spec.rb
+++ b/spec/models/concerns/champ_external_data_concern_spec.rb
@@ -111,6 +111,55 @@ RSpec.describe ChampExternalDataConcern do
     end
   end
 
+  describe '#external_data_status_message' do
+    let(:champ) { Champs::SiretChamp.new }
+
+    it 'returns nil when fetched' do
+      allow(champ).to receive_messages(pending?: false, external_error?: false)
+      expect(champ.external_data_status_message).to be_nil
+    end
+
+    it 'returns nil when pending (message already handled by InputStatusMessageComponent)' do
+      allow(champ).to receive_messages(pending?: true, external_error?: false, external_data_required_for_conditions?: false)
+      expect(champ.external_data_status_message).to be_nil
+    end
+
+    it 'returns :technical_error on external_error with non-not_found kind' do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        external_data_required_for_conditions?: false,
+        fetch_external_data_exceptions: [ExternalDataException.new(error: 'x', code: 503, kind: :technical_error)]
+      )
+      expect(champ.external_data_status_message).to eq(:technical_error)
+    end
+
+    it 'returns nil on :not_found (handled by the validation error)' do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        external_data_required_for_conditions?: false,
+        fetch_external_data_exceptions: [ExternalDataException.new(error: 'x', code: 404, kind: :not_found)]
+      )
+      expect(champ.external_data_status_message).to be_nil
+    end
+
+    it 'returns nil when a technical retry was followed by a :not_found (exceptions accumulate)' do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        external_data_required_for_conditions?: false,
+        fetch_external_data_exceptions: [
+          ExternalDataException.new(error: 'boom', code: 503, kind: :technical_error),
+          ExternalDataException.new(error: 'NF', code: 404, kind: :not_found),
+        ]
+      )
+      expect(champ.external_data_status_message).to be_nil
+    end
+
+    it 'returns nil when external_data_required_for_conditions? is true' do
+      allow(champ).to receive_messages(external_data_required_for_conditions?: true)
+      expect(champ.external_data_status_message).to be_nil
+    end
+  end
+
   describe 'the state machine' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
     let(:dossier) { create(:dossier, procedure:) }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -2062,7 +2062,7 @@ describe Dossier, type: :model do
       let(:champ_siret) { dossier.champs.first }
 
       before do
-        champ_siret.update(value: '44011762001530')
+        champ_siret.update(external_id: '44011762001530', value: '44011762001530', etablissement: build(:etablissement, siret: '44011762001530'))
       end
 
       it 'should not have errors' do
@@ -2071,7 +2071,7 @@ describe Dossier, type: :model do
 
       context "and invalid SIRET" do
         before do
-          champ_siret.update(value: "1234")
+          champ_siret.update(external_id: "1234", value: "1234")
           dossier.reload
         end
 

--- a/spec/models/external_data_exception_spec.rb
+++ b/spec/models/external_data_exception_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExternalDataException do
+  describe '#initialize' do
+    it 'defaults kind to nil' do
+      ex = described_class.new(error: 'boom', code: 500)
+      expect(ex.kind).to be_nil
+    end
+
+    it 'accepts :not_found' do
+      ex = described_class.new(error: 'boom', code: 404, kind: :not_found)
+      expect(ex.kind).to eq(:not_found)
+    end
+
+    it 'accepts :technical_error' do
+      ex = described_class.new(error: 'boom', code: 503, kind: :technical_error)
+      expect(ex.kind).to eq(:technical_error)
+    end
+  end
+
+  describe 'KINDS' do
+    it { expect(described_class::KINDS).to contain_exactly(:not_found, :technical_error) }
+  end
+
+  describe '#not_found?' do
+    it 'is true when code is 404 (legacy exceptions without kind)' do
+      expect(described_class.new(error: 'boom', code: 404).not_found?).to be_truthy
+    end
+
+    it 'is true when kind is :not_found even without a 404 code' do
+      expect(described_class.new(error: 'boom', code: nil, kind: :not_found).not_found?).to be_truthy
+    end
+
+    it 'is false for a technical error' do
+      expect(described_class.new(error: 'boom', code: 503, kind: :technical_error).not_found?).to be_falsey
+    end
+  end
+end

--- a/spec/types/external_data_exception_type_spec.rb
+++ b/spec/types/external_data_exception_type_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExternalDataExceptionType do
+  let(:type) { described_class.new }
+
+  describe '#cast' do
+    it 'returns nil for nil' do
+      expect(type.cast(nil)).to be_nil
+    end
+
+    it 'parses a legacy JSON string without kind' do
+      json = '{"code":500,"error":"boom"}'
+      result = type.cast(json)
+      expect(result.error).to eq('boom')
+      expect(result.code).to eq(500)
+      expect(result.kind).to be_nil
+    end
+
+    it 'parses a JSON string with kind' do
+      json = '{"code":404,"error":"NotFound","kind":"not_found"}'
+      result = type.cast(json)
+      expect(result.kind).to eq(:not_found)
+    end
+
+    it 'parses a hash with kind symbol' do
+      result = type.cast(error: 'x', code: 503, kind: :technical_error)
+      expect(result.kind).to eq(:technical_error)
+    end
+
+    it 'parses a legacy hash without kind' do
+      result = type.cast(error: 'x', code: 503)
+      expect(result.kind).to be_nil
+    end
+
+    it 'parses a hash with kind: nil explicitly' do
+      result = type.cast(error: 'x', code: 503, kind: nil)
+      expect(result.kind).to be_nil
+    end
+  end
+
+  describe '#serialize' do
+    it 'serializes kind' do
+      ex = ExternalDataException.new(error: 'x', code: 404, kind: :not_found)
+      expect(JSON.parse(type.serialize(ex))).to eq('code' => 404, 'error' => 'x', 'kind' => 'not_found')
+    end
+  end
+end

--- a/spec/validators/external_data_champ_validator_spec.rb
+++ b/spec/validators/external_data_champ_validator_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExternalDataChampValidator do
+  let(:champ) { Champs::SiretChamp.new }
+  let(:validator) { described_class.new(attributes: {}) }
+
+  before { champ.errors.clear }
+
+  shared_examples 'no error added' do
+    it { expect { validator.validate(champ) }.not_to change { champ.errors.size } }
+  end
+
+  shared_examples 'adds a lenient error' do
+    it { expect { validator.validate(champ) }.to change { champ.errors[:value].size }.by(1) }
+  end
+
+  shared_examples 'adds a legacy error' do
+    it { expect { validator.validate(champ) }.to change { champ.errors[:external_id].size }.by(1) }
+  end
+
+  context 'fetched' do
+    before { allow(champ).to receive_messages(pending?: false, external_error?: false) }
+    include_examples 'no error added'
+  end
+
+  context 'pending and not required for conditions' do
+    before do
+      allow(champ).to receive_messages(pending?: true, external_error?: false, external_data_required_for_conditions?: false)
+    end
+    include_examples 'no error added'
+  end
+
+  context 'pending and required for conditions' do
+    before do
+      allow(champ).to receive_messages(pending?: true, external_error?: false, external_data_required_for_conditions?: true)
+    end
+    include_examples 'adds a legacy error'
+  end
+
+  context 'external_error :not_found and not required for conditions' do
+    before do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        external_data_required_for_conditions?: false,
+        fetch_external_data_exceptions: [ExternalDataException.new(error: 'NF', code: 404, kind: :not_found)]
+      )
+    end
+    include_examples 'adds a lenient error'
+  end
+
+  context 'external_error :technical_error and not required for conditions' do
+    before do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        external_data_required_for_conditions?: false,
+        fetch_external_data_exceptions: [ExternalDataException.new(error: 'boom', code: 503, kind: :technical_error)]
+      )
+    end
+    include_examples 'no error added'
+  end
+
+  context 'external_error :technical_error and required for conditions' do
+    before do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        external_data_required_for_conditions?: true,
+        fetch_external_data_exceptions: [ExternalDataException.new(error: 'boom', code: 503, kind: :technical_error)]
+      )
+    end
+    include_examples 'adds a legacy error'
+  end
+
+  context 'external_error with a technical retry followed by a :not_found (exceptions accumulate)' do
+    before do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        external_data_required_for_conditions?: false,
+        fetch_external_data_exceptions: [
+          ExternalDataException.new(error: 'boom', code: 503, kind: :technical_error),
+          ExternalDataException.new(error: 'NF', code: 404, kind: :not_found),
+        ]
+      )
+    end
+    include_examples 'adds a lenient error'
+
+    it 'uses the error key of the most recent exception' do
+      validator.validate(champ)
+      expect(champ.errors.map(&:type)).to include(:code_404)
+    end
+  end
+
+  context 'external_error with legacy nil kind (no condition)' do
+    before do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        external_data_required_for_conditions?: false,
+        fetch_external_data_exceptions: [ExternalDataException.new(error: 'old', code: 500, kind: nil)]
+      )
+    end
+    include_examples 'no error added'
+  end
+end


### PR DESCRIPTION
Ref #12997

## Contexte
Aujourd'hui, si l'API Entreprise est en mode dégradé ou renvoie une erreur technique au moment de la vérification du SIRET, l'usager ne peut pas déposer son dossier.

## Ce que fait cette PR
- Classifie les erreurs du champ SIRET en deux catégories : `:not_found` (SIRET inexistant, bloquant) et `:technical_error` (API indisponible, non bloquant)
- Le validateur laisse passer les erreurs techniques et les états pending pour le champ SIRET uniquement — le comportement des autres champs avec données externes est inchangé
- Affiche un message informatif non bloquant (`fr-info-text`) sous le champ quand la vérification est en cours ou temporairement indisponible

## Périmètre
Uniquement SiretChamp. Les autres champs avec données externes (RNF, RNA, référentiel…) seront traités dans des PRs à venir.

## Points d'attention pour la revue
- ExternalDataException a un nouveau champ `kind` (requis). Les exceptions legacy en base désérialisent avec kind: nil, traité comme non-bloquant dans le validateur.
- `handle_result` dans `ChampExternalDataConcern` garde des fallbacks sans `kind` pour les services pas encore migrés.
- `lenient_external_data_validation?` permet à un champ d'opter pour le comportement non-bloquant — seul SiretChamp l'active pour l'instant.