### PR TITLE
ETQ instructeur, on m’indique si un dossier a été déposé par un usager ProConnecté

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -240,6 +240,7 @@ module Users
       if @dossier.errors.blank? && @dossier.can_passer_en_construction?
         begin
           @dossier.submitted_with_france_connect = current_user.loged_in_with_france_connect.present?
+          @dossier.submitted_with_pro_connect = logged_in_with_pro_connect?
           @dossier.passer_en_construction!
           redirect_to merci_dossier_path(@dossier)
           return
@@ -284,6 +285,7 @@ module Users
 
       if dossier.errors.blank? && dossier.can_passer_en_construction?
         dossier.submitted_with_france_connect = current_user.loged_in_with_france_connect.present?
+        dossier.submitted_with_pro_connect = logged_in_with_pro_connect?
         dossier.usager_submit_en_construction!
 
         redirect_to dossier_path(dossier)

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -293,6 +293,14 @@ module DossierHelper
     end
   end
 
+  def pro_connect_informations(user_information)
+    if user_information.full_name.empty?
+      t("shared.dossiers.pro_connect_informations.details_no_name")
+    else
+      t("shared.dossiers.pro_connect_informations.details", name: user_information.full_name)
+    end
+  end
+
   def clean_string_for_pdf(str)
     str
       &.tr("\r", "\n")

--- a/app/models/concerns/columns_concern.rb
+++ b/app/models/concerns/columns_concern.rb
@@ -58,6 +58,7 @@ module ColumnsConcern
     columns.concat([dossier_accuse_lecture_agreement_at_column]) if accuse_lecture?
     columns.concat([groupe_instructeurs_id_column, followers_instructeurs_email_column])
     columns.concat([dossier_labels_column])
+    columns.concat(dossier_submitted_with_identity_provider_columns)
 
     # ensure the columns exist in main list
     # otherwise, they will be found by the find_column method
@@ -146,6 +147,11 @@ module ColumnsConcern
 
   def dossier_labels_column = dossier_col(table: 'dossier_labels', column: 'label_id', type: :enum, options_for_select: labels.map { [_1.name, _1.id] })
 
+  def dossier_submitted_with_identity_provider_columns
+    ['submitted_with_france_connect', 'submitted_with_pro_connect']
+      .map { |column| dossier_col(table: 'self', column:, type: :boolean, options_for_select: Champs::YesNoChamp.options) }
+  end
+
   def traitements_email_column = dossier_col(table: 'traitements', column: 'instructeur_email', filterable: true, displayable: false)
 
   def procedure_chorus_columns
@@ -178,6 +184,7 @@ module ColumnsConcern
     columns.concat([dossier_accuse_lecture_agreement_at_column]) if accuse_lecture?
     columns.concat(sva_svr_columns(for_export: false)) if sva_svr_enabled?
     columns.concat(dossier_non_displayable_dates_columns)
+    columns.concat(dossier_submitted_with_identity_provider_columns)
     columns.concat([Columns::ReadAgreementColumn.new(procedure_id: id)]) if accuse_lecture?
     columns
   end
@@ -212,7 +219,7 @@ module ColumnsConcern
     @individual_columns
       .concat ['nom', 'prenom'].map { |column| dossier_col(table: 'individual', column:) }
       .concat ['mandataire_last_name', 'mandataire_first_name'].map { |column| dossier_col(table: 'self', column:) }
-      .concat ['for_tiers', 'submitted_with_france_connect'].map { |column| dossier_col(table: 'self', column:, type: :boolean, options_for_select: Champs::YesNoChamp.options) }
+      .concat ['for_tiers'].map { |column| dossier_col(table: 'self', column:, type: :boolean, options_for_select: Champs::YesNoChamp.options) }
   end
 
   def moral_columns

--- a/app/models/pro_connect_information.rb
+++ b/app/models/pro_connect_information.rb
@@ -4,4 +4,8 @@ class ProConnectInformation < ApplicationRecord
   self.table_name = 'agent_connect_informations'
 
   belongs_to :user
+
+  def full_name
+    "#{given_name} #{usual_name}".strip
+  end
 end

--- a/app/views/shared/dossiers/_demande.html.erb
+++ b/app/views/shared/dossiers/_demande.html.erb
@@ -73,6 +73,10 @@
     <%= render partial: "shared/dossiers/france_connect_informations_notice", locals: { user_information: dossier.user.france_connect_informations.first } %>
   <% end %>
 
+  <% if dossier.submitted_with_pro_connect? && dossier.user.last_pro_connect_information.present? && current_user.instructeur? && !current_user.owns_or_invite?(dossier) %>
+    <%= render partial: "shared/dossiers/pro_connect_informations_notice", locals: { user_information: dossier.user.last_pro_connect_information } %>
+  <% end %>
+
   <dl class="fr-pl-0">
     <%= render partial: "shared/dossiers/user_infos", locals: { user_deleted: dossier.user_deleted?, email: dossier.user_email_for(:display), for_tiers: dossier.for_tiers?, beneficiaire_mail: dossier.for_tiers? ? dossier.individual.email : ""} %>
 

--- a/app/views/shared/dossiers/_edit.html.erb
+++ b/app/views/shared/dossiers/_edit.html.erb
@@ -4,6 +4,12 @@
   <% end %>
 <% end %>
 
+<% if dossier.submitted_with_pro_connect? && dossier.user.last_pro_connect_information.present? && current_user.instructeur? && !current_user.owns_or_invite?(dossier) %>
+  <% content_for(:notice_info) do %>
+    <%= render partial: "shared/dossiers/pro_connect_informations_notice", locals: { user_information: dossier.user.last_pro_connect_information } %>
+  <% end %>
+<% end %>
+
 <div class="dossier-edit fr-container counter-start-header-section">
   <%= render partial: "shared/dossiers/submit_is_over", locals: { dossier: } %>
   <%= render NestedForms::FormOwnerComponent.new %>

--- a/app/views/shared/dossiers/_pro_connect_informations_notice.html.haml
+++ b/app/views/shared/dossiers/_pro_connect_informations_notice.html.haml
@@ -1,0 +1,3 @@
+= render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: 'fr-my-2v') do |c|
+  - c.with_body do
+    %p= pro_connect_informations(user_information)

--- a/config/locales/models/procedure_presentation/en.yml
+++ b/config/locales/models/procedure_presentation/en.yml
@@ -24,7 +24,8 @@ en:
             svr_decision_before: SVR decision date before
             user_from_france_connect?: "France connecté ?"
             for_tiers: "For tiers"
-            submitted_with_france_connect: "FranceConnect authentication"
+            submitted_with_france_connect: "Submitted with FranceConnect"
+            submitted_with_pro_connect: "Submitted with ProConnect"
             mandataire_last_name: "Tier last name"
             mandataire_first_name: "Tier first name"
             accuse_lecture_agreement_at: 'Read receipt'

--- a/config/locales/models/procedure_presentation/fr.yml
+++ b/config/locales/models/procedure_presentation/fr.yml
@@ -24,7 +24,8 @@ fr:
             svr_decision_before: Date décision SVR avant
             user_from_france_connect?: "France connecté ?"
             for_tiers: "Dépôt pour un tiers"
-            submitted_with_france_connect: "Authentification FranceConnect"
+            submitted_with_france_connect: "Déposé avec FranceConnect"
+            submitted_with_pro_connect: "Déposé avec ProConnect"
             mandataire_last_name: "Nom [Identité du mandataire]"
             mandataire_first_name: "Prénom [Identité du mandataire]"
             archived: 'Archivé'

--- a/config/locales/shared.en.yml
+++ b/config/locales/shared.en.yml
@@ -8,6 +8,9 @@ en:
       france_connect_informations:
         details_no_name: "The file was submitted by a FranceConnect authenticated account."
         details: "The file was submitted by the account of %{name}, authenticated by FranceConnect."
+      pro_connect_informations:
+        details_no_name: "The file was submitted by a ProConnect authenticated account."
+        details: "The file was submitted by the account of %{name}, authenticated by ProConnect."
       motivation:
         refused_by_svr: "The service handling your file was unable to process it within the time limit set by the Silence Vaut Rejet law."
       header:

--- a/config/locales/shared.fr.yml
+++ b/config/locales/shared.fr.yml
@@ -8,6 +8,9 @@ fr:
       france_connect_informations:
         details_no_name: "Le dossier a été déposé par un compte authentifié par FranceConnect."
         details: "Le dossier a été déposé par le compte de %{name}, authentifié par FranceConnect."
+      pro_connect_informations:
+        details_no_name: "Le dossier a été déposé par un compte authentifié par ProConnect."
+        details: "Le dossier a été déposé par le compte de %{name}, authentifié par ProConnect."
       motivation:
         refused_by_svr: "Le service traitant n’a pas été en mesure de traiter votre demande dans le délai imparti par la règle du Silence Vaut Rejet."
       header:

--- a/db/migrate/20260608084303_add_submitted_with_pro_connect_to_dossiers.rb
+++ b/db/migrate/20260608084303_add_submitted_with_pro_connect_to_dossiers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSubmittedWithProConnectToDossiers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :dossiers, :submitted_with_pro_connect, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -558,6 +558,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_22_131426) do
     t.string "state"
     t.bigint "submitted_revision_id"
     t.boolean "submitted_with_france_connect", default: false, null: false
+    t.boolean "submitted_with_pro_connect", default: false, null: false
     t.date "sva_svr_decision_on"
     t.datetime "sva_svr_decision_triggered_at"
     t.datetime "termine_close_to_expiration_notice_sent_at", precision: nil

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -722,6 +722,26 @@ describe Users::DossiersController, type: :controller do
         expect(dossier.submitted_with_france_connect).to be false
       end
     end
+
+    context 'when user logged via pro connect' do
+      before do
+        cookies.encrypted[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME] = { value: { user_id: user.id }.to_json }
+      end
+
+      it 'sets submitted_with_pro_connect to true' do
+        subject
+        dossier.reload
+        expect(dossier.submitted_with_pro_connect).to be true
+      end
+    end
+
+    context 'when user not logged via pro connect' do
+      it 'sets submitted_with_pro_connect to false' do
+        subject
+        dossier.reload
+        expect(dossier.submitted_with_pro_connect).to be false
+      end
+    end
   end
 
   describe '#submit_en_construction (stream)' do

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -251,6 +251,26 @@ RSpec.describe DossierHelper, type: :helper do
     end
   end
 
+  describe ".pro_connect_informations" do
+    subject { pro_connect_informations(user_information) }
+
+    context "with complete pro_connect information" do
+      let(:user_information) { build(:pro_connect_information) }
+
+      it {
+        expect(subject).to have_text("Le dossier a été déposé par le compte de #{user_information.given_name} #{user_information.usual_name}, authentifié par ProConnect.")
+      }
+    end
+
+    context "with all names missing" do
+      let(:user_information) { build(:pro_connect_information, given_name: nil, usual_name: nil) }
+
+      it {
+        expect(subject).to have_text("Le dossier a été déposé par un compte authentifié par ProConnect.")
+      }
+    end
+  end
+
   describe ".tags_notification" do
     subject { tags_notification([notification]) }
 

--- a/spec/models/concerns/columns_concern_spec.rb
+++ b/spec/models/concerns/columns_concern_spec.rb
@@ -199,6 +199,16 @@ describe ColumnsConcern do
         expect(column.filterable).to be true
         expect(column.displayable).to be true
       end
+
+      it 'defines yes/no options for the submitted_with_pro_connect boolean column' do
+        column = procedure.columns.find { _1.column == 'submitted_with_pro_connect' }
+
+        expect(column).to be_present
+        expect(column.type).to eq(:boolean)
+        expect(column.options_for_select).to eq(Champs::YesNoChamp.options)
+        expect(column.filterable).to be true
+        expect(column.displayable).to be true
+      end
     end
 
     context 'when the procedure is sva' do


### PR DESCRIPTION
closes #13211 

On a laissé "France connecté ?" dans les exports pour ne pas casser les templates existants. On regroupe maintenant "Déposé avec FranceConnect" et "Déposé avec ProConnect" dans la section "informations dossier" (et non plus "usager").
Seules les colonnes "Déposé avec…" sont disponibles comme filtres et colonnes du tableau instructeur.

<img width="678" height="641" alt="Capture d’écran 2026-06-16 à 16 25 27" src="https://github.com/user-attachments/assets/4f04aabd-f4cc-4c65-ae4d-ba336d049f02" />

<img width="719" height="489" alt="Capture d’écran 2026-06-16 à 16 26 07" src="https://github.com/user-attachments/assets/f9a5efae-3c2d-47a6-9243-9ff54722b62a" />

<img width="671" height="400" alt="Capture d’écran 2026-06-16 à 16 25 14" src="https://github.com/user-attachments/assets/d1377d58-bb69-467c-a9da-18c83acf7323" />
