### PR TITLE
ETQ instructeur, on me propose de contacter l'admin ou le service d'une démarche quand je clique sur un dossier lié inaccessible

### DIFF
--- a/app/assets/stylesheets/demande.scss
+++ b/app/assets/stylesheets/demande.scss
@@ -31,6 +31,11 @@
     }
   }
 
+  // Pour un dossier lié, seuls les noms (démarche, organisme) sont en gras (balises strong).
+  .champ-content.dossier_link {
+    font-weight: normal;
+  }
+
   .champ-blank {
     font-weight: normal;
     font-style: italic;

--- a/app/components/dossiers/no_access_to_dossier_component.rb
+++ b/app/components/dossiers/no_access_to_dossier_component.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Affiche le numéro d'un dossier lié auquel l'instructeur n'a pas accès,
+# sous forme de lien déclenchant une modale DSFR.
+# - S'il existe des administrateurs de la démarche partageant le domaine email
+#   de l'instructeur, leurs adresses sont proposées en lien mailto pour qu'il
+#   leur demande l'accès.
+# - Sinon, la modale invite à contacter le service en charge de la démarche et
+#   affiche ses coordonnées, sans exposer aucune adresse d'administrateur.
+class Dossiers::NoAccessToDossierComponent < ApplicationComponent
+  def initialize(dossier, instructeur)
+    @dossier = dossier
+    @instructeur = instructeur
+    @procedure = dossier.procedure
+  end
+
+  private
+
+  attr_reader :dossier, :instructeur, :procedure
+
+  def procedure_name = procedure.libelle
+
+  def service = procedure.service
+
+  def administrateurs_emails
+    @administrateurs_emails ||= begin
+      domain = email_domain(instructeur.email)
+
+      procedure.administrateurs
+        .map(&:email)
+        .filter { email_domain(it) == domain }
+    end
+  end
+
+  def email_domain(email)
+    email.split("@").last.downcase
+  end
+
+  def modal_id
+    "modal-no-access-to-dossier-#{dossier.id}"
+  end
+end

--- a/app/components/dossiers/no_access_to_dossier_component/no_access_to_dossier_component.en.yml
+++ b/app/components/dossiers/no_access_to_dossier_component/no_access_to_dossier_component.en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  link: "File nº %{id}"
+  title: "You don't have access to this file"
+  content_html: "To access this file, you should <strong>contact one of the administrators</strong> of the procedure « %{procedure_name} » and ask them to <strong>add you as an instructor</strong>:"
+  no_matching_admin_html: "Contact the department in charge of the procedure « %{procedure_name} » to take the necessary steps if you need to access this file:"

--- a/app/components/dossiers/no_access_to_dossier_component/no_access_to_dossier_component.fr.yml
+++ b/app/components/dossiers/no_access_to_dossier_component/no_access_to_dossier_component.fr.yml
@@ -1,0 +1,6 @@
+---
+fr:
+  link: 'Dossier n° %{id}'
+  title: 'Vous n’avez pas accès à ce dossier'
+  content_html: 'Pour consulter ce dossier, vous devez <strong>contacter l’un des administrateurs</strong> de la démarche « %{procedure_name} » pour lui demander de <strong>vous ajouter comme instructeur</strong> :'
+  no_matching_admin_html: 'Contactez le service en charge de la démarche « %{procedure_name} » pour vous nommer instructeur si vous devez accéder à ce dossier :'

--- a/app/components/dossiers/no_access_to_dossier_component/no_access_to_dossier_component.html.erb
+++ b/app/components/dossiers/no_access_to_dossier_component/no_access_to_dossier_component.html.erb
@@ -1,0 +1,65 @@
+<%= link_to(t(".link", id: dossier.id), "##{modal_id}",
+      class: "fr-link fr-icon-external-link-line fr-link--icon-right",
+      aria: { controls: modal_id, haspopup: "dialog" },
+      data: { "fr-opened": "false" }) %>
+
+<dialog
+  id="<%= modal_id %>"
+  class="fr-modal"
+  role="dialog"
+  aria-labelledby="<%= modal_id %>-title"
+>
+  <div class="fr-container fr-container--fluid fr-container-md">
+    <div class="fr-grid-row fr-grid-row--center">
+      <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
+        <div class="fr-modal__body">
+          <div class="fr-modal__header">
+            <button
+              class="fr-btn--close fr-btn"
+              aria-controls="<%= modal_id %>"
+              title="<%= t("utils.modal_close_alt") %>"
+            >
+              <%= t("utils.modal_close") %>
+            </button>
+          </div>
+
+          <div class="fr-modal__content">
+            <h1 id="<%= modal_id %>-title" class="fr-modal__title">
+              <span
+                class="fr-icon-arrow-right-line fr-icon--lg"
+                aria-hidden="true"
+              ></span>
+
+              <%= t(".title") %>
+            </h1>
+
+            <%= render Dsfr::AlertComponent.new(state: :warning, heading_level: "p") do |alert| %>
+              <% alert.with_body do %>
+                <% if administrateurs_emails.any? %>
+                  <p class="fr-text">
+                    <%= t(".content_html", procedure_name:) %>
+                  </p>
+                  <ul>
+                    <% administrateurs_emails.each do |email| %>
+                      <li>
+                        <%= mail_to(email, email, target: "_blank", rel: "noopener", class: "fr-link fr-icon-external-link-line fr-link--icon-right") %>
+                      </li>
+                    <% end %>
+                  </ul>
+                <% else %>
+                  <p class="fr-text">
+                    <%= t(".no_matching_admin_html", procedure_name:) %>
+                  </p>
+                  <% if service.present? %>
+                    <p class="fr-text--bold fr-mb-1w"><%= service.nom %></p>
+                    <%= render Procedure::ServiceListContactComponent.new(service_or_contact_information: service, dossier: nil) %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</dialog>

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -745,25 +745,24 @@ class Dossier < ApplicationRecord
   end
 
   def text_summary
-    if brouillon?
-      parts = [
-        "Dossier en brouillon répondant à la démarche ",
-        procedure.libelle,
-        " gérée par l’organisme ",
-        procedure.organisation_name,
-      ]
+    text_summary_segments.map { _1[:text] }.join
+  end
+
+  # Segments du résumé, avec emphasis: true sur les noms (démarche, organisme)
+  # pour permettre une mise en forme partielle dans les vues.
+  def text_summary_segments
+    intro = if brouillon?
+      "Dossier en brouillon répondant à la démarche "
     else
-      parts = [
-        "Dossier déposé le ",
-        depose_at.strftime("%d/%m/%Y"),
-        " sur la démarche ",
-        procedure.libelle,
-        " gérée par l’organisme ",
-        procedure.organisation_name,
-      ]
+      "Dossier déposé le #{depose_at.strftime("%d/%m/%Y")} sur la démarche "
     end
 
-    parts.join
+    [
+      { text: intro },
+      { text: procedure.libelle, emphasis: true },
+      { text: " gérée par l’organisme " },
+      { text: procedure.organisation_name, emphasis: true },
+    ]
   end
 
   def avis_for_expert(expert)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -745,24 +745,12 @@ class Dossier < ApplicationRecord
   end
 
   def text_summary
-    text_summary_segments.map { _1[:text] }.join
-  end
-
-  # Segments du résumé, avec emphasis: true sur les noms (démarche, organisme)
-  # pour permettre une mise en forme partielle dans les vues.
-  def text_summary_segments
-    intro = if brouillon?
-      "Dossier en brouillon répondant à la démarche "
-    else
-      "Dossier déposé le #{depose_at.strftime("%d/%m/%Y")} sur la démarche "
-    end
-
-    [
-      { text: intro },
-      { text: procedure.libelle, emphasis: true },
-      { text: " gérée par l’organisme " },
-      { text: procedure.organisation_name, emphasis: true },
-    ]
+    I18n.t(
+      "dossiers.text_summary.#{brouillon? ? :brouillon : :depose}",
+      date: depose_at && I18n.l(depose_at.to_date, format: :short),
+      procedure: procedure.libelle,
+      organisme: procedure.organisation_name
+    )
   end
 
   def avis_for_expert(expert)

--- a/app/views/shared/champs/dossier_link/_show.html.haml
+++ b/app/views/shared/champs/dossier_link/_show.html.haml
@@ -27,6 +27,6 @@
     - else
       %p Dossier n° #{dossier.id}
     .copy-zone
-      %p= safe_join(dossier.text_summary_segments.map { it[:emphasis] ? tag.strong(it[:text]) : it[:text] })
+      %p= t("dossiers.text_summary.#{dossier.brouillon? ? :brouillon : :depose}_html", date: dossier.depose_at && l(dossier.depose_at.to_date, format: :short), procedure: tag.strong(dossier.procedure.libelle), organisme: tag.strong(dossier.procedure.organisation_name))
 - else
   %p Pas de dossier associé

--- a/app/views/shared/champs/dossier_link/_show.html.haml
+++ b/app/views/shared/champs/dossier_link/_show.html.haml
@@ -22,9 +22,10 @@
     - path = dossier_linked_path(current_instructeur || current_user, dossier)
     - if path.present?
       %p= link_to("Dossier n° #{dossier.id}", path, target: '_blank', rel: 'noopener')
+    - elsif current_instructeur
+      = render Dossiers::NoAccessToDossierComponent.new(dossier, current_instructeur)
     - else
       %p Dossier n° #{dossier.id}
-    %br
     .copy-zone
       %p= sanitize(dossier.text_summary)
 - else

--- a/app/views/shared/champs/dossier_link/_show.html.haml
+++ b/app/views/shared/champs/dossier_link/_show.html.haml
@@ -27,6 +27,6 @@
     - else
       %p Dossier n° #{dossier.id}
     .copy-zone
-      %p= sanitize(dossier.text_summary)
+      %p= safe_join(dossier.text_summary_segments.map { it[:emphasis] ? tag.strong(it[:text]) : it[:text] })
 - else
   %p Pas de dossier associé

--- a/config/locales/models/dossier/en.yml
+++ b/config/locales/models/dossier/en.yml
@@ -1,4 +1,10 @@
 en:
+  dossiers:
+    text_summary:
+      brouillon: "Draft file for the procedure %{procedure} managed by %{organisme}"
+      brouillon_html: "Draft file for the procedure %{procedure} managed by %{organisme}"
+      depose: "File submitted on %{date} for the procedure %{procedure} managed by %{organisme}"
+      depose_html: "File submitted on %{date} for the procedure %{procedure} managed by %{organisme}"
   activerecord:
     models:
       dossier:

--- a/config/locales/models/dossier/fr.yml
+++ b/config/locales/models/dossier/fr.yml
@@ -1,4 +1,10 @@
 fr:
+  dossiers:
+    text_summary:
+      brouillon: "Dossier en brouillon répondant à la démarche %{procedure} gérée par l’organisme %{organisme}"
+      brouillon_html: "Dossier en brouillon répondant à la démarche %{procedure} gérée par l’organisme %{organisme}"
+      depose: "Dossier déposé le %{date} sur la démarche %{procedure} gérée par l’organisme %{organisme}"
+      depose_html: "Dossier déposé le %{date} sur la démarche %{procedure} gérée par l’organisme %{organisme}"
   activerecord:
     models:
       dossier:

--- a/spec/components/dossiers/no_access_to_dossier_component_spec.rb
+++ b/spec/components/dossiers/no_access_to_dossier_component_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe Dossiers::NoAccessToDossierComponent, type: :component do
+  let(:instructeur) { create(:instructeur, email: instructeur_email) }
+  let(:instructeur_email) { "agent@inst.com" }
+  let(:procedure) { create(:procedure) }
+  let(:dossier) { create(:dossier, procedure:) }
+
+  subject { render_inline(described_class.new(dossier, instructeur)) }
+
+  it "renders the dossier number as the modal trigger link" do
+    expect(subject).to have_link("Dossier n° #{dossier.id}", href: "#modal-no-access-to-dossier-#{dossier.id}")
+  end
+
+  it "renders the modal title" do
+    expect(subject).to have_text("Vous n’avez pas accès à ce dossier")
+  end
+
+  context "when an administrateur shares the instructeur email domain" do
+    let(:instructeur_email) { "agent@shared-domain.gouv.fr" }
+    let(:matching_admin) { create(:administrateur, email: "boss@SHARED-domain.gouv.fr") }
+    let(:other_admin) { create(:administrateur, email: "chief@elsewhere.com") }
+    let(:procedure) { create(:procedure, administrateurs: [matching_admin, other_admin]) }
+    let(:dossier) { create(:dossier, procedure:) }
+
+    it "lists only the matching administrateur email (case-insensitive domain)" do
+      expect(subject).to have_link(matching_admin.email, href: "mailto:#{matching_admin.email}")
+      expect(subject).to have_no_link(href: "mailto:#{other_admin.email}")
+    end
+
+    it "names the procedure in the modal content" do
+      expect(subject).to have_text(procedure.libelle)
+    end
+  end
+
+  context "when no administrateur shares the instructeur email domain" do
+    let(:instructeur_email) { "agent@other-domain.gouv.fr" }
+    let(:procedure) { create(:procedure, :with_service) }
+    let(:dossier) { create(:dossier, procedure:) }
+
+    it "exposes no administrateur email" do
+      procedure.administrateurs.each do |admin|
+        expect(subject).to have_no_link(href: "mailto:#{admin.email}")
+      end
+    end
+
+    it "invites to contact the service and shows its contact info" do
+      expect(subject).to have_text("Contactez le service en charge de la démarche")
+      expect(subject).to have_text(procedure.service.nom)
+      expect(subject).to have_link(procedure.service.email, href: "mailto:#{procedure.service.email}")
+    end
+  end
+end

--- a/spec/system/instructeurs/dossier_link_no_access_spec.rb
+++ b/spec/system/instructeurs/dossier_link_no_access_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe 'Instructeur viewing a linked dossier they cannot access:', js: true do
+  let(:instructeur) { create(:instructeur) }
+  let(:other_procedure) { create(:procedure, :published) }
+  let(:linked_dossier) { create(:dossier, :en_construction, procedure: other_procedure) }
+  let(:procedure) { create(:procedure, :published, instructeurs: [instructeur], types_de_champ_public: [{ type: :dossier_link }]) }
+  let(:dossier) { create(:dossier, :en_instruction, procedure:) }
+
+  before do
+    dossier.champs.find { _1.is_a?(Champs::DossierLinkChamp) }.update(value: linked_dossier.id)
+    login_as(instructeur.user, scope: :user)
+    visit instructeur_dossier_path(procedure, dossier)
+  end
+
+  # Le contenu de la modale (emails admin / service) est couvert par
+  # Dossiers::NoAccessToDossierComponent ; on vérifie ici l'intégration :
+  # le champ inaccessible rend le composant et la modale s'ouvre au clic.
+  scenario 'the dossier number link opens the modal explaining the lack of access' do
+    modal_id = "modal-no-access-to-dossier-#{linked_dossier.id}"
+
+    expect(page).to have_selector("##{modal_id}", visible: false)
+    click_on "Dossier n° #{linked_dossier.id}"
+
+    expect(page).to have_selector("##{modal_id}", visible: true)
+    within "##{modal_id}" do
+      expect(page).to have_text("Vous n’avez pas accès à ce dossier")
+    end
+  end
+end

--- a/spec/views/shared/dossiers/_champs.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_champs.html.haml_spec.rb
@@ -42,7 +42,7 @@ describe 'shared/dossiers/champs', type: :view do
       expect(subject).to have_css(".header-section")
       expect(subject).to include(champ2.libelle)
 
-      expect(subject).to include(dossier.text_summary)
+      expect(subject).to have_text(dossier.text_summary)
 
       expect(subject).to include(champ5.libelle)
       expect(subject).to include(champ5.value)
@@ -83,8 +83,14 @@ describe 'shared/dossiers/champs', type: :view do
 
     it "renders the no-access modal trigger" do
       is_expected.to have_link("Dossier n° #{dossier.id}", href: "#modal-no-access-to-dossier-#{dossier.id}")
-      is_expected.to have_text("Vous n'avez pas accès à ce dossier")
-      is_expected.to include(dossier.text_summary)
+      is_expected.to have_text("Vous n’avez pas accès à ce dossier")
+      is_expected.to have_text(dossier.text_summary)
+    end
+
+    it "emphasizes only the procedure and organisme names in the summary" do
+      is_expected.to have_css("strong", text: dossier.procedure.libelle)
+      is_expected.to have_css("strong", text: dossier.procedure.organisation_name)
+      is_expected.to have_no_css("strong", text: "Dossier déposé le")
     end
   end
 

--- a/spec/views/shared/dossiers/_champs.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_champs.html.haml_spec.rb
@@ -81,9 +81,9 @@ describe 'shared/dossiers/champs', type: :view do
       dossier.champs.first.update(value: dossier.id)
     end
 
-    it do
-      is_expected.not_to have_link("Dossier n° #{dossier.id}")
-      is_expected.to include("Dossier n° #{dossier.id}")
+    it "renders the no-access modal trigger" do
+      is_expected.to have_link("Dossier n° #{dossier.id}", href: "#modal-no-access-to-dossier-#{dossier.id}")
+      is_expected.to have_text("Vous n'avez pas accès à ce dossier")
       is_expected.to include(dossier.text_summary)
     end
   end


### PR DESCRIPTION
Extraction de la partie instructeur de la PR #11840 (dont les parties admin/usager sont déjà en production), adaptées aux maquettes fournies dans l'issue #11540
Closes #11540 

ETQ instructeur, quand un dossier référence un autre dossier via un champ « lien vers un dossier » :

- le numéro du dossier lié devient un **lien** cliquable ;
- si le dossier lié appartient à une démarche que j'instruis, je l'ouvre directement (nouvel onglet) ;
- sinon, une **modale** s'ouvre :
  - si un administrateur de la démarche partage mon domaine de messagerie, son ou ses adresses e-mail me sont proposées en lien `mailto:` afin de lui demander l'accès ;
  - sinon, la modale m'invite à contacter le **service** en charge de la démarche et affiche ses coordonnées (nom, e-mail, téléphone), sans exposer d'adresse d'administrateur.



<img width="846" height="159" alt="Capture d’écran 2026-06-08 à 18 18 33" src="https://github.com/user-attachments/assets/f7f30bb1-0bf6-410a-b504-446523d02336" />
<img width="1030" height="713" alt="Capture d’écran 2026-06-08 à 18 51 25" src="https://github.com/user-attachments/assets/2eb80d6e-9fb3-4d97-93cf-f3987de22736" />
<img width="1129" height="645" alt="Capture d’écran 2026-06-17 à 10 34 03" src="https://github.com/user-attachments/assets/ae171c02-0fe3-46db-9b5f-71915164723f" />
