### PR TITLE
Tech: corrige une erreur `NoMethodError includes on PaginatableArray` dans `groupe_instructeurs_controller`

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -615,12 +615,13 @@ module Administrateurs
         procedure.groupe_instructeurs
       end
 
+      groupes = groupes.includes(:contact_information)
+
       if params[:filter] == '1'
         groupes = Kaminari.paginate_array(groupes.filter(&:routing_to_configure?))
       end
 
       groupes
-        .includes(:contact_information)
         .page(params[:page])
         .per(ITEMS_PER_PAGE)
     end

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -35,6 +35,12 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
             expect(assigns(:groupes_instructeurs)).to match_array([gi_1_2])
           end
         end
+
+        context 'when filtering groups to configure' do
+          let(:params) { { procedure_id: procedure.id, filter: '1' } }
+
+          it { expect(response).to have_http_status(:ok) }
+        end
       end
     end
   end


### PR DESCRIPTION
## Résumé

- Un `.includes(:contact_information)` appelé sur un `Kaminari.paginate_array(...)` dans `paginated_groupe_instructeurs` levait une `NoMethodError` lorsque le paramètre `filter=1` était utilisé sur la page index des groupes instructeurs
- On déplace ce `.includes` pour l'appeler sur l'objet ActiveRecord 
- Ajout d'un test de non-régression sur l'action `#index` avec `filter=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)