### PR TITLE
ETQ admin, je ne peux pas publier une liste de choix vide dans une répétition

### DIFF
--- a/app/validators/types_de_champ/no_empty_drop_down_validator.rb
+++ b/app/validators/types_de_champ/no_empty_drop_down_validator.rb
@@ -2,12 +2,19 @@
 
 class TypesDeChamp::NoEmptyDropDownValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
-    types_de_champ.filter(&:any_drop_down_list?).each do |drop_down|
-      validate_drop_down_not_empty(procedure, attribute, drop_down)
-    end
+    types_de_champ
+      .flat_map { with_children(procedure, it) }
+      .filter(&:any_drop_down_list?)
+      .each { validate_drop_down_not_empty(procedure, attribute, it) }
   end
 
   private
+
+  def with_children(procedure, type_de_champ)
+    return [type_de_champ] unless type_de_champ.repetition?
+
+    [type_de_champ, *procedure.draft_revision.children_of(type_de_champ)]
+  end
 
   def validate_drop_down_not_empty(procedure, attribute, drop_down)
     if (drop_down.drop_down_list? || drop_down.multiple_drop_down_list?) && drop_down.drop_down_advanced? && drop_down.referentiel.blank?

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -601,6 +601,34 @@ describe Procedure do
           expect(procedure.errors.messages_for(:draft_types_de_champ_public)).not_to include(invalid_drop_down_error_message)
         end
 
+        it 'validates that no drop-down nested in a repetition is empty' do
+          types_de_champ_public = [{ type: :repetition, libelle: 'Bloc', children: [{ type: :multiple_drop_down_list, libelle: 'Choix imbriqué' }] }]
+          procedure = create(:procedure, types_de_champ_public:, types_de_champ_private: [])
+
+          repetition = procedure.draft_revision.types_de_champ.find(&:repetition?)
+          nested_drop_down = procedure.draft_revision.children_of(repetition).find(&:any_drop_down_list?)
+
+          nested_drop_down.update!(drop_down_options: [])
+          procedure.reload.validate(:publication)
+          expect(procedure.errors.messages_for(:draft_types_de_champ_public)).to include(invalid_drop_down_error_message)
+
+          nested_drop_down.update!(drop_down_options: ["un", "deux"])
+          procedure.reload.validate(:publication)
+          expect(procedure.errors.messages_for(:draft_types_de_champ_public)).not_to include(invalid_drop_down_error_message)
+        end
+
+        it 'validates that no private drop-down nested in a repetition is empty' do
+          types_de_champ_private = [{ type: :repetition, libelle: 'Bloc privé', children: [{ type: :drop_down_list, libelle: 'Choix imbriqué privé' }] }]
+          procedure = create(:procedure, types_de_champ_public: [], types_de_champ_private:)
+
+          repetition = procedure.draft_revision.types_de_champ.find(&:repetition?)
+          nested_drop_down = procedure.draft_revision.children_of(repetition).find(&:any_drop_down_list?)
+
+          nested_drop_down.update!(drop_down_options: [])
+          procedure.reload.validate(:publication)
+          expect(procedure.errors.messages_for(:draft_types_de_champ_private)).to include(invalid_drop_down_error_message)
+        end
+
         context 'validates formatted champ character rules' do
           let(:types_de_champ_private) { [] }
           let(:formatted_mode) { "simple" }


### PR DESCRIPTION
La validation `NoEmptyDropDownValidator` empêchait déjà de publier une liste de
choix sans option, mais seulement au premier niveau : `types_de_champ_public` /
`_private` filtrent sur `root?`, donc une liste imbriquée dans un bloc répétable
échappait à la validation. Elle pouvait être publiée vide et provoquait un 500
dans `Champs::RepetitionController#add` (cf #13154, remonté via Sentry).

Le validateur descend désormais dans les enfants des répétitions (via
`draft_revision.children_of`, comme `NoEmptyBlockValidator`) avant de filtrer les
listes de choix. Aucun changement pour les champs de premier niveau.

Tests de non-régression ajoutés (liste imbriquée vide, en public et en privé).