### PR TITLE
ETQ Opérateur, on arrête les jobs relatif aux informations sur la tva (APIEntreprise::TvaJob)

### DIFF
--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -69,7 +69,7 @@ class APIEntrepriseService
 
     def perform_later_fetch_jobs(etablissement, procedure_id, user_id, wait: nil)
       jobs = [
-        APIEntreprise::ExtraitKbisJob, APIEntreprise::TvaJob,
+        APIEntreprise::ExtraitKbisJob,
         APIEntreprise::AssociationJob, APIEntreprise::ExercicesJob,
         APIEntreprise::EffectifsJob, APIEntreprise::EffectifsAnnuelsJob, APIEntreprise::AttestationSocialeJob,
         APIEntreprise::BilansBdfJob,

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -3,7 +3,7 @@
 describe APIEntrepriseService do
   shared_examples 'schedule fetch of all etablissement params' do
     [
-      APIEntreprise::ExtraitKbisJob, APIEntreprise::TvaJob,
+      APIEntreprise::ExtraitKbisJob,
       APIEntreprise::AssociationJob, APIEntreprise::ExercicesJob,
       APIEntreprise::EffectifsJob, APIEntreprise::EffectifsAnnuelsJob, APIEntreprise::AttestationSocialeJob,
       APIEntreprise::BilansBdfJob,


### PR DESCRIPTION
Beaucoup trop d'erreur et de retry, le endpoint étant clairement down pendant trop longtemps voir

voir https://status.entreprise.api.gouv.fr/

ici 44% de uptime sur 3 mois.