### PR TITLE
ETQ super-admin, je peux de nouveau utiliser des actions personnalisées qui font un POST/PATCH/…

### DIFF
--- a/app/views/manager/administrateurs/show.html.erb
+++ b/app/views/manager/administrateurs/show.html.erb
@@ -33,7 +33,7 @@
 
   <div>
     <% if page.resource.invitation_expired? %>
-      <%= link_to "renvoyer l’invitation", reinvite_manager_administrateur_path(page.resource), method: :post, class: "button" %>
+      <%= button_to "renvoyer l’invitation", reinvite_manager_administrateur_path(page.resource), method: :post, class: "button" %>
     <% end %>
 
     <%= button_to t("administrate.actions.destroy"), delete_manager_administrateur_path(page.resource), method: :delete, disabled: !page.resource.can_be_deleted?, class: "button button--danger", data: { turbo_confirm: "Confirmez-vous la suppression de l’administrateur ?" }, title: page.resource.can_be_deleted? ? "Supprimer" : "Cet administrateur a des démarches dont il est le seul admin et ne peut être supprimé" %>

--- a/app/views/manager/application/_navigation.html.erb
+++ b/app/views/manager/application/_navigation.html.erb
@@ -8,7 +8,7 @@
 %>
 
 <nav class="navigation" role="navigation">
-  <%= link_to "Se déconnecter", destroy_super_admin_session_path, method: :delete, class: "navigation__link" %>
+  <%= button_to "Se déconnecter", destroy_super_admin_session_path, method: :delete, class: "navigation__link" %>
 
   <hr>
 

--- a/app/views/manager/dossiers/show.html.erb
+++ b/app/views/manager/dossiers/show.html.erb
@@ -42,7 +42,7 @@
   <div>
     <% if dossier.transfer&.from_support %>
       <%= t('views.users.dossiers.transfers.sender_demande_en_cours_from_support_html', id: dossier.id, email: dossier.transfer.email) %>
-      <%= link_to t('views.users.dossiers.transfers.revoke_html'), transfer_destroy_manager_dossier_path(dossier), class: 'fr-link', method: :delete %>
+      <%= button_to t('views.users.dossiers.transfers.revoke_html'), transfer_destroy_manager_dossier_path(dossier), class: 'fr-link', method: :delete %>
     <% end %>
   </div>
 

--- a/app/views/manager/gestionnaires/_collection_item_actions.html.erb
+++ b/app/views/manager/gestionnaires/_collection_item_actions.html.erb
@@ -10,12 +10,12 @@
 
 <% if existing_action?(collection_presenter.resource_name, :destroy) %>
   <td>
-    <%= link_to(
+    <%= button_to(
     t("administrate.actions.destroy"),
     [namespace, resource],
     class: "text-color-red",
     method: :delete,
-    data: { confirm: t("administrate.actions.confirm") }
+    data: { turbo_confirm: t("administrate.actions.confirm") }
   ) if accessible_action?(resource, :destroy) %>
   </td>
 <% end %>

--- a/app/views/manager/gestionnaires/show.html.erb
+++ b/app/views/manager/gestionnaires/show.html.erb
@@ -34,7 +34,7 @@
     method: :delete,
     disabled: !page.resource.can_be_deleted?,
     class: "button button--danger",
-    data: { confirm: "Confirmez-vous la suppression du gestionnaire ?" },
+    data: { turbo_confirm: "Confirmez-vous la suppression du gestionnaire ?" },
     title: page.resource.can_be_deleted? ? "Supprimer" : "Ce gestionnaire ne peut etre supprimé car il est le seul gestionnaire d’un groupe racine") %>
   </div>
 </header>

--- a/app/views/manager/groupe_gestionnaires/_collection_gestionnaires.html.erb
+++ b/app/views/manager/groupe_gestionnaires/_collection_gestionnaires.html.erb
@@ -65,7 +65,7 @@
               <%= button_to 'Retirer',
           { action: :remove_gestionnaire, id: page.resource.id },
           { method: :delete,
-            data: { confirm: t("administrate.actions.confirm") },
+            data: { turbo_confirm: t("administrate.actions.confirm") },
             params: { gestionnaire: { id: resource.id }},
             class: 'fr-btn fr-btn--secondary' } %>
             </td>

--- a/app/views/manager/groupe_gestionnaires/show.html.erb
+++ b/app/views/manager/groupe_gestionnaires/show.html.erb
@@ -28,12 +28,12 @@
       class: "button",
     ) if accessible_action?(page.resource, :edit) %>
 
-    <%= link_to(
+    <%= button_to(
       t("administrate.actions.destroy"),
       [namespace, page.resource],
       class: "button button--danger",
       method: :delete,
-      data: { confirm: t("administrate.actions.confirm") }
+      data: { turbo_confirm: t("administrate.actions.confirm") }
     ) if accessible_action?(page.resource, :destroy) %>
   </div>
 </header>

--- a/app/views/manager/instructeurs/show.html.erb
+++ b/app/views/manager/instructeurs/show.html.erb
@@ -30,7 +30,7 @@
       class: "button",
     ) if accessible_action?(page.resource, :edit) %>
 
-    <%= link_to 'Réinviter', reinvite_manager_instructeur_path(instructeur), method: :post, class: 'button' %>
+    <%= button_to 'Réinviter', reinvite_manager_instructeur_path(instructeur), method: :post, class: 'button' %>
 
     <%= button_to("Supprimer",
                   delete_manager_instructeur_path(page.resource),

--- a/app/views/manager/procedures/show.html.erb
+++ b/app/views/manager/procedures/show.html.erb
@@ -39,19 +39,19 @@
     <%= link_to 'Aperçu', apercu_admin_procedure_path(procedure), class: 'button' %>
 
     <% if !procedure.whitelisted? %>
-      <%= link_to 'Whitelister', whitelist_manager_procedure_path(procedure), method: :post, class: 'button' %>
+      <%= button_to 'Whitelister', whitelist_manager_procedure_path(procedure), method: :post, class: 'button' %>
     <% end %>
 
     <% if procedure.hidden_as_template? %>
-      <%= link_to 'Autoriser l’affichage dans les modèles', unhide_as_template_manager_procedure_path(procedure), method: :post, class: 'button' %>
+      <%= button_to 'Autoriser l’affichage dans les modèles', unhide_as_template_manager_procedure_path(procedure), method: :post, class: 'button' %>
     <% else %>
-      <%= link_to 'Masquer l’affichage dans la liste de "Toutes les démarches"', hide_as_template_manager_procedure_path(procedure), method: :post, class: 'button' %>
+      <%= button_to 'Masquer l’affichage dans la liste de "Toutes les démarches"', hide_as_template_manager_procedure_path(procedure), method: :post, class: 'button' %>
     <% end %>
 
     <% if procedure.can_be_deleted_by_manager? %>
-      <%= link_to 'Supprimer la démarche', discard_manager_procedure_path(procedure), method: :post, class: 'button button--danger', data: { confirm: "Confirmez-vous la suppression de la démarche ?" } %>
+      <%= button_to 'Supprimer la démarche', discard_manager_procedure_path(procedure), method: :post, class: 'button button--danger', data: { turbo_confirm: "Confirmez-vous la suppression de la démarche ?" } %>
     <% elsif procedure.discarded? %>
-      <%= link_to 'Restaurer la démarche', restore_manager_procedure_path(procedure), method: :post, class: 'button', data: { confirm: "Confirmez-vous la restauration de la démarche ?" } %>
+      <%= button_to 'Restaurer la démarche', restore_manager_procedure_path(procedure), method: :post, class: 'button', data: { turbo_confirm: "Confirmez-vous la restauration de la démarche ?" } %>
     <% end %>
   </div>
 </header>
@@ -96,7 +96,7 @@
                   ou
                   <%= link_to("ETQ instructeur", instructeur_procedure_path(procedure), **external_link_attributes) %>.
                 </p>
-                <%= link_to 'Me retirer de cette démarche', delete_administrateur_manager_procedure_path(procedure), method: :put, class: 'button' %>
+                <%= button_to 'Me retirer de cette démarche', delete_administrateur_manager_procedure_path(procedure), method: :put, class: 'button' %>
               <% else %>
                 <%= form_tag(add_administrateur_and_instructeur_manager_procedure_path(procedure), style: 'margin-top: 1rem;') do %>
                   <button>

--- a/app/views/manager/users/emails.html.erb
+++ b/app/views/manager/users/emails.html.erb
@@ -140,7 +140,7 @@ Bien cordialement</pre>
     <p>
       <strong>Ce compte n’est pas activé</strong>
       . Vous pouvez lui
-      <%= link_to('renvoyer l’email de confirmation', [:resend_confirmation_instructions, namespace, :user], method: :post, class: 'button') %>
+      <%= button_to('renvoyer l’email de confirmation', [:resend_confirmation_instructions, namespace, :user], method: :post, class: 'button') %>
       , puis un email.
       <button
         class="btn btn-secondary btn-small"
@@ -164,7 +164,7 @@ Cordialement</pre>
 
   <p>
     <strong>Mot de passe perdu ?</strong> Vous pouvez
-    <%= link_to('renvoyer l’email de réinitialisation', [:resend_reset_password_instructions, namespace, :user], method: :post, class: 'button') %>
+    <%= button_to('renvoyer l’email de réinitialisation', [:resend_reset_password_instructions, namespace, :user], method: :post, class: 'button') %>
     
     <small>Attention au téléscopage: cet email invalide les liens des emails similaires précédents.</small>
   </p>
@@ -176,7 +176,7 @@ Cordialement</pre>
       chez Brevo?
     </strong>
     Vous pouvez le
-    <%= link_to('débloquer', manager_user_unblock_email_path(@user), method: :put, class: 'button') %>
+    <%= button_to('débloquer', manager_user_unblock_email_path(@user), method: :put, class: 'button') %>
     puis lui envoyer
     <button
       class="btn btn-secondary btn-small"

--- a/app/views/manager/users/show.html.erb
+++ b/app/views/manager/users/show.html.erb
@@ -31,9 +31,9 @@
 
   <div class="buttons">
     <% if user.unverified_email? %>
-      <%= link_to(
+      <%= button_to(
         "Débloquer mails",
-        [:unblock_mails, namespace, page.resource], 
+        [:unblock_mails, namespace, page.resource],
         method: :post,
         class: "button") %>
     <% end %>
@@ -61,7 +61,7 @@
                   title: page.resource.can_be_deleted? ? "Supprimer" : "Cet utilisateur ne peut être supprimé. Il a des dossiers dont l’instruction a commencé ou il est administrateur ou instructeur") %>
 
     <% if !user.confirmed? %>
-      <%= link_to('Renvoyer l’email de confirmation', [:resend_confirmation_instructions, namespace, page.resource], method: :post, class: 'button') %>
+      <%= button_to('Renvoyer l’email de confirmation', [:resend_confirmation_instructions, namespace, page.resource], method: :post, class: 'button') %>
     <% end %>
   </div>
 </header>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -24,48 +24,21 @@
       "note": ""
     },
     {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "2a921e7bd4cf2de55bf58db10d05d316c4355c639c72c2cd4d7488cbc78a39d8",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/columns/json_path_column.rb",
-      "line": 32,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "dossiers.with_type_de_champ(stable_id).where(\"champs.value_json @? '#{jsonpath} ? (@ like_regex \\\"#{quote_string(search_terms.join(\"|\"))}\\\" flag \\\"i\\\")'\")",
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.2.3.1 ends on 2026-08-09",
+      "file": "Gemfile.lock",
+      "line": 640,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
       "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Columns::JSONPathColumn",
-        "method": "filtered_ids_for_values"
-      },
-      "user_input": "jsonpath",
+      "location": null,
+      "user_input": null,
       "confidence": "Weak",
       "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "317cf1145a84f666b0bb0297ad0af6700717540a20b537d323416c95e2ef3fd1",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/tasks/maintenance/t20251112backfill_champ_siret_external_state_with_etablissement_but_no_value_or_external_id_task.rb",
-      "line": 34,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ApplicationRecord.connection.execute(\"UPDATE champs\\nSET value = etablissements.siret,\\n    external_id = etablissements.siret\\nFROM etablissements\\nWHERE champs.etablissement_id = etablissements.id\\n  AND champs.id IN (#{batch.ids.join(\",\")})\\n  AND champs.value IS NULL\\n  AND champs.external_id IS NULL\\n  AND champs.external_state = '#{Champs::SiretChamp.external_states[:fetched]}'\\n  AND champs.type = 'Champs::SiretChamp'\\n\".squish)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Maintenance::T20251112backfillChampSiretExternalStateWithEtablissementButNoValueOrExternalIdTask",
-        "method": "process"
-      },
-      "user_input": "batch.ids.join(\",\")",
-      "confidence": "Medium",
-      "cwe_id": [
-        89
+        1104
       ],
       "note": ""
     },
@@ -99,7 +72,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/tasks/maintenance/concerns/statements_helpers_concern.rb",
-      "line": 28,
+      "line": 27,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "ApplicationRecord.connection.execute(\"SET LOCAL statement_timeout = '#{timeout}'\")",
       "render_path": null,
@@ -122,7 +95,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/users/dossiers/_merci.html.erb",
-      "line": 54,
+      "line": 77,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "current_user.dossiers.includes(:procedure).find(params[:id]).procedure.monavis_embed_html_source(\"site\")",
       "render_path": [
@@ -130,7 +103,7 @@
           "type": "controller",
           "class": "Users::DossiersController",
           "method": "merci",
-          "line": 360,
+          "line": 375,
           "file": "app/controllers/users/dossiers_controller.rb",
           "rendered": {
             "name": "users/dossiers/merci",
@@ -179,25 +152,6 @@
       "confidence": "Weak",
       "cwe_id": [
         502
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 122,
-      "fingerprint": "98b26f60d776fd41ee6f088c833725145be9aac2d7c5b33780241c273622db42",
-      "check_name": "EOLRails",
-      "message": "Support for Rails 7.1.5.2 ends on 2025-10-01",
-      "file": "Gemfile.lock",
-      "line": 642,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": [
-        1104
       ],
       "note": ""
     },
@@ -259,102 +213,13 @@
       "note": ""
     },
     {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "b270328e93526e345fa8522a94482f0c8065f0126efa56c7a648c5db6aa1de7d",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/instructeurs/procedures/show.html.haml",
-      "line": 81,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "::Haml::AttributeBuilder.build_id(true, dom_id(BatchOperation.new, :checkbox_all))",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Instructeurs::ProceduresController",
-          "method": "show",
-          "line": 207,
-          "file": "app/controllers/instructeurs/procedures_controller.rb",
-          "rendered": {
-            "name": "instructeurs/procedures/show",
-            "file": "app/views/instructeurs/procedures/show.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "instructeurs/procedures/show"
-      },
-      "user_input": "BatchOperation.new",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "c97049798ff05438dcca6f3ee1a714f2336041837411ab001a7e3caf1bfb75c8",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/layouts/mailers/_signature.html.haml",
-      "line": 9,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Current.application_name.gsub(\".\", \"&#8288;.\")",
-      "render_path": [
-        {
-          "type": "template",
-          "name": "administrateur_mailer/api_token_expiration",
-          "line": 19,
-          "file": "app/views/administrateur_mailer/api_token_expiration.haml",
-          "rendered": {
-            "name": "layouts/mailers/_signature",
-            "file": "app/views/layouts/mailers/_signature.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "layouts/mailers/_signature"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": [
-        79
-      ],
-      "note": "Current is not a model"
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "f74cfb12b3183f456594e809f222bb2723cc232aa5b8f5f7d9bd6d493c1521fb",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/notification_mailer/send_notification_for_tiers.html.haml",
-      "line": 31,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Current.application_name.gsub(\".\", \"&#8288;.\")",
-      "render_path": null,
-      "location": {
-        "type": "template",
-        "template": "notification_mailer/send_notification_for_tiers"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": [
-        79
-      ],
-      "note": "Current is not a model"
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "fc12551e83eab01e5955c73470bb1fc30b6642bd39750ba4aa9f0fe6ef4d6522",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/concerns/dossier_filtering_concern.rb",
-      "line": 46,
+      "line": 47,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "where(\"unaccent(#{DossierFilterService.sanitized_column(table, column)}) ILIKE ANY (ARRAY((SELECT unaccent(unnest(ARRAY[?])))))\", search_terms.map(&:strip).map do\n \"%#{sanitize_sql_like(_1)}%\"\n end)",
       "render_path": null,
@@ -371,5 +236,5 @@
       "note": "The table and column are escaped, which should make this safe"
     }
   ],
-  "brakeman_version": "7.1.0"
+  "brakeman_version": "8.0.4"
 }

--- a/spec/system/manager/instructeurs_spec.rb
+++ b/spec/system/manager/instructeurs_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe 'Manager instructeurs', js: true do
+  let(:super_admin) { create(:super_admin) }
+  let(:instructeur) { create(:instructeur) }
+
+  before { login_as super_admin, scope: :super_admin }
+
+  # Generic regression guard for manager action buttons: they must trigger
+  # their HTTP verb (here POST) through the browser. They used to rely on the
+  # rails-ujs `data-method` handler, which disappeared when administrate
+  # dropped jquery-rails in its 1.0 upgrade — turning every such link into a
+  # plain GET and yielding a 404. A controller spec cannot catch this because
+  # it posts to the action directly, bypassing the rendered button.
+  scenario 'reinviting an instructeur runs the action instead of a GET 404' do
+    visit manager_instructeur_path(instructeur)
+    click_on 'Réinviter'
+
+    expect(page).to have_text('Instructeur réinvité.')
+  end
+end


### PR DESCRIPTION
## Problème

https://mattermost.incubateur.net/betagouv/pl/kfbbqoedoibm58eapcpxsirmwc

Dans le manager, les boutons d'action (« Réinviter », « Whitelister », « Supprimer la démarche », « Se déconnecter », etc.) renvoyaient une **404**. Exemple signalé : `/manager/instructeurs/13/reinvite`.

## Cause

Ces boutons étaient des `link_to … method: :post/:put/:delete`, qui reposent sur le handler `data-method` de **rails-ujs**. Or l'entrypoint JS du manager (`manager.ts`) ne charge pas rails-ujs : ça fonctionnait jusqu'ici uniquement parce qu'`administrate` tirait `jquery-rails` (et donc `jquery_ujs`).

Le bump **administrate 0.20.1 → 1.0.0** (#13251) a retiré `jquery-rails`. Depuis, plus aucun handler `data-method` côté manager : le clic suit le `href` en **GET** → 404.

Le périmètre est strictement le manager : l'app principale charge `@rails/ujs` + `Rails.start()` dans `application.js`, indépendamment.

## Correctif

- Conversion de tous les `link_to … method:` du manager en `button_to` (vrais formulaires, aucun JS requis).
- Passage des `data: { confirm: }` (rails-ujs) restants en `data: { turbo_confirm: }` pour que les confirmations s'affichent à nouveau sous Turbo.
- Ajout d'un system spec sur le bouton « Réinviter », qui pilote un vrai navigateur et garde contre cette classe de régression (un controller spec ne peut pas la détecter : il poste directement sur l'action sans passer par le bouton rendu).