### PR TITLE
ETQ Opérateur, je peux désactiver le TvaJob via un feature flag (api_entreprise_tva_job)

### DIFF
--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -74,6 +74,7 @@ class APIEntrepriseService
         APIEntreprise::EffectifsJob, APIEntreprise::EffectifsAnnuelsJob, APIEntreprise::AttestationSocialeJob,
         APIEntreprise::BilansBdfJob,
       ]
+      jobs << APIEntreprise::TvaJob if Flipper.enabled?(:api_entreprise_tva_job)
       if etablissement.as_degraded_mode?
         jobs << APIEntreprise::EtablissementJob
       end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -7,13 +7,15 @@
 require 'flipper/adapters/active_record'
 require 'flipper/adapters/active_support_cache_store'
 
-def setup_features(features)
+def setup_features(features, enabled_by_default: [])
   existing = Flipper.preload_all.map { _1.name.to_sym }
   missing = features - existing
 
   missing.each do |feature|
     # Feature is disabled by default
     Flipper.add(feature.to_s)
+    # Enable on creation only: subsequent boots won't override an operator's choice
+    Flipper.enable(feature) if enabled_by_default.include?(feature)
   end
 end
 
@@ -36,6 +38,7 @@ features = [
   :llm_nightly_improve_procedure,
   :ami_notifications,
   :column_conditions,
+  :api_entreprise_tva_job,
 ]
 
 def database_exists?
@@ -57,7 +60,7 @@ end
 
 ActiveSupport.on_load(:active_record) do
   if database_exists? && ActiveRecord::Base.connection.data_source_exists?('flipper_features')
-    setup_features(features)
+    setup_features(features, enabled_by_default: [:api_entreprise_tva_job])
   end
 end
 

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -45,6 +45,22 @@ describe APIEntrepriseService do
       end
 
       it_behaves_like 'schedule fetch of all etablissement params'
+
+      context 'when api_entreprise_tva_job feature is enabled' do
+        before { Flipper.enable(:api_entreprise_tva_job) }
+
+        it 'should enqueue TvaJob' do
+          expect { subject }.to have_enqueued_job(APIEntreprise::TvaJob)
+        end
+      end
+
+      context 'when api_entreprise_tva_job feature is disabled' do
+        before { Flipper.disable(:api_entreprise_tva_job) }
+
+        it 'should not enqueue TvaJob' do
+          expect { subject }.not_to have_enqueued_job(APIEntreprise::TvaJob)
+        end
+      end
     end
 
     context 'when etablissement api down' do


### PR DESCRIPTION
La PR #13264 a retiré `APIEntreprise::TvaJob` de la liste des jobs enqueués, car
l'endpoint TVA de l'API Entreprise est trop souvent down (~44 % d'uptime sur
3 mois). Mais le code est réutilisé par d'autres opérateurs qui, eux, veulent
garder la récupération TVA.

Cette PR remet l'enqueue du TvaJob derrière un feature flag `api_entreprise_tva_job` :

- **enabled par défaut** pour toutes les instances (seed enabled à la création du flag) ;
- désactivable **uniquement chez nous** (demarche.numerique) via l'UI Flipper (`/manager/features`), sans impacter les autres opérateurs.

Le mécanisme `enabled_by_default` de `setup_features` n'active le flag qu'à sa création : les boots suivants ne réécrasent pas le choix d'un opérateur.