### PR TITLE
Tech: corriger une erreur 500 sur la fiche admin d'une démarche close dont la remplaçante est discardée

### DIFF
--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -72,10 +72,15 @@
         %p
           Les dossiers en cours peuvent être instruits, mais aucun nouveau dossier ne peut plus être déposé.
         - if @procedure.closing_reason == 'internal_procedure'
-          - new_procedure = Procedure.find_by(id: @procedure.replaced_by_procedure_id)
+          - new_procedure = @procedure.replaced_by_procedure
           %p
-            = "Cette démarche est remplacée par une autre démarche dans #{Current.application_name} :"
-            = link_to(new_procedure.libelle, admin_procedure_path(new_procedure))
+            - if new_procedure&.kept?
+              = "Cette démarche est remplacée par une autre démarche dans #{Current.application_name} :"
+              = link_to(new_procedure.libelle, admin_procedure_path(new_procedure))
+            - elsif new_procedure
+              = "Cette démarche était remplacée par « #{new_procedure.libelle} », démarche qui n'est plus disponible."
+            - else
+              = "Cette démarche était remplacée par une démarche qui n'est plus disponible."
         - if @procedure.closing_reason == 'other'
           %p
             = "Plus d’informations dans la #{link_to('page de fermeture', closing_details_path(@procedure.path))}, visible par les usagers."

--- a/spec/views/administrateurs/procedures/show.html.haml_spec.rb
+++ b/spec/views/administrateurs/procedures/show.html.haml_spec.rb
@@ -65,6 +65,51 @@ describe 'administrateurs/procedures/show', type: :view do
     end
   end
 
+  describe 'procedure is closed with internal_procedure replacement' do
+    let(:replacement) { create(:procedure, :published, libelle: 'Démarche de remplacement') }
+
+    before do
+      procedure.publish!(procedure.administrateurs.first)
+      procedure.update!(closing_reason: 'internal_procedure', replaced_by_procedure_id: replacement.id)
+      procedure.close!
+      procedure.reload
+    end
+
+    context 'when the replacement procedure is kept' do
+      before { render }
+
+      it 'renders the libelle and a link to the replacement procedure' do
+        expect(rendered).to have_content('Cette démarche est remplacée par une autre démarche')
+        expect(rendered).to have_link('Démarche de remplacement', href: admin_procedure_path(replacement))
+      end
+    end
+
+    context 'when the replacement procedure is discarded' do
+      before do
+        replacement.discard!
+        render
+      end
+
+      it 'renders the libelle without a link and a fallback message' do
+        expect(rendered).to have_content('Démarche de remplacement')
+        expect(rendered).to have_content("n'est plus disponible")
+        expect(rendered).not_to have_link('Démarche de remplacement')
+      end
+    end
+
+    context 'when the replaced_by_procedure_id points to a missing procedure' do
+      before do
+        procedure.update_column(:replaced_by_procedure_id, Procedure.maximum(:id).to_i + 1_000)
+        render
+      end
+
+      it 'renders a fallback message and does not crash' do
+        expect(rendered).to have_content("Cette démarche était remplacée par une démarche qui n'est plus disponible.")
+        expect(rendered).not_to have_content('Cette démarche est remplacée par une autre démarche')
+      end
+    end
+  end
+
   describe 'procedure with expiration disabled' do
     let(:procedure) { create(:procedure, procedure_expires_when_termine_enabled: true) }
     before do


### PR DESCRIPTION
## Contexte

Quand une démarche est close avec `closing_reason='internal_procedure'` et que la démarche remplaçante a été discardée (ou détruite) ensuite, `GET /admin/procedures/:id` retourne un 500. La fiche admin devient inaccessible : plus de gestion des cartes (présentation, zones, champs), plus de publication ni de réinitialisation possibles.

Issue Sentry préproduction #73468 (release `2.5.93`), priorité High, état Escalating. 22 events, 3 utilisateurs touchés sur une heure.

## Cause

[`app/views/administrateurs/procedures/show.html.haml`](app/views/administrateurs/procedures/show.html.haml) résout la démarche remplaçante via `Procedure.find_by(id: @procedure.replaced_by_procedure_id)`. Le `default_scope :kept` de `Procedure` masque la cible discardée, `find_by` retourne `nil`, et le rendu lève `NoMethodError` sur `nil.libelle` (ou `UrlGenerationError` sur `admin_procedure_path(nil)` selon la variante locale).

`replaced_by_procedure_id` n'est pas nullifié au discard (le `dependent: :nullify` du `has_many :replaced_procedures` ne joue que sur `destroy`).

## Correctif

Passer par l'association `belongs_to :replaced_by_procedure, -> { with_discarded }` (déjà déclarée sur le modèle) et brancher le rendu sur l'état réel de la cible :

* **kept** : libellé et lien vers la fiche admin de la remplaçante.
* **discardée non purgée** : libellé sans lien, message « n'est plus disponible ».
* **introuvable** (purgée ou orpheline) : message générique de remplacement.

Le lien n'est pas exposé pour une cible discardée car `Administrateurs::ProceduresController#show` charge via `current_administrateur.procedures.find(...)`, soumis au `default_scope :kept` : un clic donnerait un 404.

## Tests

Trois cas ajoutés dans [`spec/views/administrateurs/procedures/show.html.haml_spec.rb`](spec/views/administrateurs/procedures/show.html.haml_spec.rb), un par branche. Validation A/B : sans le correctif, les cas « discardée » et « introuvable » échouent ; avec le correctif, les trois passent.

## Hors scope

Discussion à ouvrir séparément : faut-il nullifier `replaced_by_procedure_id` au discard de la cible ? Décision produit qui touche aussi les vues usagers (`_dossiers_list.html.erb`, `_dossier_actions.html.haml`).

## Screenshots Sentry

<img width="2000" height="1690" alt="image" src="https://github.com/user-attachments/assets/59cb4d03-62a4-4b43-8d00-661b6c905a9a" />

<img width="1381" height="2000" alt="image" src="https://github.com/user-attachments/assets/f4bd4918-525b-4195-86fa-13399cb0ecc4" />
