### PR TITLE
ETQ opérateur, ajout d'une task qui (re)génère l'attestation d'un dossier

### DIFF
--- a/app/tasks/maintenance/regenerate_attestation_task.rb
+++ b/app/tasks/maintenance/regenerate_attestation_task.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class RegenerateAttestationTask < MaintenanceTasks::Task
+    # Régénère l'attestation de dossiers, par exemple
+    # si le PDF a été enregistré en base
+    # mais dont l'upload vers l'object storage a échoué
+    # (Excon::Error::ServiceUnavailable 503, issue Sentry RAILS-KR7).
+    #
+    # L'attestation existante (record + blob/attachment cassé) est supprimée,
+    # puis régénérée via AttestationPdfGenerationJob.
+    #
+    # **Attention**:
+    #   utilise la dernière version de l'attestation,
+    #   pas nécessairement celle en vigueur au moment
+    #   où le dossier a été traité!
+    #
+    # dossier_ids : liste d'ids séparés par des virgules et/ou espaces.
+
+    attribute :dossier_ids, :string
+    validates :dossier_ids, presence: true
+
+    def collection
+      Dossier.where(id: parsed_dossier_ids)
+    end
+
+    def process(dossier)
+      dossier.attestation&.destroy!
+      AttestationPdfGenerationJob.perform_later(dossier)
+    end
+
+    def count
+      collection.count
+    end
+
+    private
+
+    def parsed_dossier_ids
+      dossier_ids.to_s.split(/[\s,]+/).map(&:to_i).reject(&:zero?)
+    end
+  end
+end

--- a/spec/tasks/maintenance/regenerate_attestation_task_spec.rb
+++ b/spec/tasks/maintenance/regenerate_attestation_task_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe RegenerateAttestationTask do
+    describe "#collection" do
+      let!(:dossier1) { create(:dossier) }
+      let!(:dossier2) { create(:dossier) }
+
+      it "targets the dossiers matching the comma/space separated ids" do
+        task = described_class.new
+        task.dossier_ids = " #{dossier1.id}, #{dossier2.id} "
+        expect(task.collection).to contain_exactly(dossier1, dossier2)
+      end
+    end
+
+    describe "#process" do
+      let(:dossier) { create(:dossier, :accepte) }
+      let!(:broken_attestation) { create(:attestation, dossier:) }
+
+      it "destroys the broken attestation and enqueues a regeneration job" do
+        expect { described_class.new.process(dossier) }
+          .to have_enqueued_job(AttestationPdfGenerationJob).with(dossier)
+          .and change { Attestation.exists?(broken_attestation.id) }.from(true).to(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
On a quelques dizaines de dossiers pour lequel on a généré l'attestation, tout est enregistré en base sauf que [l'upload du blob sur le storage a échoué](https://demarches-simplifiees.sentry.io/issues/7488839783/)

Conséquence: l'usager ne peut pas télécharger l'attestation que le storage n'a pas et voit une erreur 404.

Cette task permet de les regénérer à la demande. Dans une autre PR on va corriger le pb à la source pour pas que le dossier croit que l'attestation existe si celle-ci n'a pas été uploadée.

(cf ticket au support que je retrouve pas)