### PR TITLE
Tech: migre les demandes 2fa ProConnect en utilisant les nouveaux mots clés

### DIFF
--- a/app/services/pro_connect_service.rb
+++ b/app/services/pro_connect_service.rb
@@ -31,8 +31,11 @@ class ProConnectService
       claims[:id_token][:acr] = {
         essential: true,
         values: [
-          "eidas2", # login / pwd + 2FA
-          "eidas3", # physical card with PIN + certificates
+          "eidas0-mfa", # Identité : Faible ou déclarative, Auth: MFA (auto-géré), Orga: Modération ou déclaratif
+          "eidas1-mfa", # Identité : Faible, Auth: MFA (auto-géré), Orga: Modération ou plus
+          "eidas2",     # Identité : Substantielle, Auth: MFA (géré par l'organisation), Orga: Lien certifié par une source officielle
+          "eidas3",     # Identité : Élevée, Auth: MFA matérielle (géré par l'organisation), Orga: Lien certifié par une source officielle
+          # deprecated claims to be removed after 18/06/2026
           "https://proconnect.gouv.fr/assurance/self-asserted-2fa", # declarative identity + 2FA
           "https://proconnect.gouv.fr/assurance/consistency-checked-2fa", # verified identity + 2FA
         ],

--- a/spec/services/pro_connect_service_spec.rb
+++ b/spec/services/pro_connect_service_spec.rb
@@ -46,6 +46,8 @@ describe ProConnectService do
 
       it 'includes various acr values in the authorization uri' do
         uri, _state, _nonce = subject
+        expect(uri).to include('eidas0-mfa')
+        expect(uri).to include('eidas1-mfa')
         expect(uri).to include('eidas2')
         expect(uri).to include('eidas3')
         expect(uri).to include('self-asserted-2fa')


### PR DESCRIPTION
Vu avec Raphael, doit être mep avant le 18 juin.