### PR TITLE
ETQ usager, la génération d'attestation est fiabilisée face à l'indisponibilité du service de stockage

### DIFF
--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -87,15 +87,20 @@ class AttestationTemplate < ApplicationRecord
     # Guard against race condition: dossier state may have changed during PDF generation
     return unless dossier.reload.accepte? || dossier.refuse?
 
-    attestation = Attestation.new(dossier:)
-    attestation.title = replace_tags(title, dossier, escape: false) if version == 1
-    attestation.pdf.attach(
+    # Upload the file before creating the attestation: if the upload fails,
+    # nothing is persisted, so a retry of the job regenerates the attestation
+    # instead of leaving one pointing to a missing file.
+    blob = ActiveStorage::Blob.create_and_upload!(
       io: StringIO.new(pdf_data),
       filename: "attestation-dossier-#{dossier.id}.pdf",
       content_type: 'application/pdf',
       # we don't want to run virus scanner on this file
       metadata: { virus_scan_result: ActiveStorage::VirusScanner::SAFE }
     )
+
+    attestation = Attestation.new(dossier:)
+    attestation.title = replace_tags(title, dossier, escape: false) if version == 1
+    attestation.pdf.attach(blob)
     attestation.save!
   end
 

--- a/spec/models/attestation_template_spec.rb
+++ b/spec/models/attestation_template_spec.rb
@@ -154,6 +154,25 @@ describe AttestationTemplate, type: :model do
       end
     end
 
+    context 'when the pdf upload fails' do
+      let(:attestation_template) do
+        build(:attestation_template, title: 'title', body: 'body')
+      end
+
+      before do
+        allow(ActiveStorage::Blob.service).to receive(:upload).and_raise('503 Service Unavailable')
+      end
+
+      it 'raises and does not persist the attestation nor its attachment' do
+        expect { attestation_template.generate_attestation_for(dossier) }
+          .to raise_error('503 Service Unavailable')
+          .and not_change { Attestation.count }
+          .and not_change { ActiveStorage::Attachment.count }
+
+        expect(dossier.reload.attestation).to be_nil
+      end
+    end
+
     context 'attestation v2' do
       let(:attestation_template) do
         build(:attestation_template, :v2, :with_files, label_logo: "Ministère des specs")


### PR DESCRIPTION
On a des périodes où le stockage est down et [renvoie des erreurs 503](https://demarches-simplifiees.sentry.io/issues/7488839783/) lors de l'upload d'attestation. 

Avant cette PR, l'attestation (blob + attachment) était enregistré en base, et le retry du job suite à l'échec de l'upload était NOOP (on ne force pas la re-génération d'une attestation existante). Conséquence, les usagers voient un lien en 404.


Maintenant, on upload avant d'attacher le blob, donc si l'upload échoue, le retry du job fera ce qu'on attend de lui.

Pendant de https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/13269 qui rattrape les attestations en erreur.