### PR TITLE
[Fix] Export ZIP illisible sous Windows

### DIFF
--- a/app/services/downloadable_file_service.rb
+++ b/app/services/downloadable_file_service.rb
@@ -17,7 +17,7 @@ class DownloadableFileService
         download_manager.download_all
 
         File.delete(zip_path) if File.exist?(zip_path)
-        system 'zip', '-0', '-r', zip_path, EXPORT_DIRNAME, chdir: tmp_dir
+        system 'zip', '-0', '-r', '-UN=UTF8', zip_path, EXPORT_DIRNAME, chdir: tmp_dir
         yield(zip_path)
       ensure
         FileUtils.remove_entry_secure(export_dir) if Dir.exist?(export_dir)

--- a/spec/services/downloadable_file_service_spec.rb
+++ b/spec/services/downloadable_file_service_spec.rb
@@ -29,7 +29,7 @@ describe DownloadableFileService do
 
     it 'creates a zip with zip utility' do
       expected_zip_path = File.join(DownloadableFileService::ARCHIVE_CREATION_DIR, "#{service.send(:zip_root_folder, archive)}.zip")
-      expect(DownloadableFileService).to receive(:system).with('zip', '-0', '-r', expected_zip_path, an_instance_of(String), chdir: an_instance_of(String))
+      expect(DownloadableFileService).to receive(:system).with('zip', '-0', '-r', '-UN=UTF8', expected_zip_path, an_instance_of(String), chdir: an_instance_of(String))
       DownloadableFileService.download_and_zip(procedure, [], filename) { |zip_path| }
     end
 


### PR DESCRIPTION
Suite à un retour Crisp https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_a7c73ccf-1a5f-466e-bb8a-e00afac79d4e/,, les exports ZIP ne s'ouvraient pas sous Windows.
On ajoute l'option -UN=UTF8 à la commande zip pour forcer l'encodage UTF-8 des noms de fichiers.

Note// Les tests du DownloadableFileService échouent en local sur Mac mais ils passent sur la CI.