### PR TITLE
ETQ admin, je peux insérer des sauts de ligne dans l'éditeur d'attestation v2

### DIFF
--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -45,6 +45,7 @@ module Administrateurs
           ['Liste numérotée', 'orderedList', 'list-ordered'],
         ],
         [
+          ['Saut de ligne', 'hardBreak', 'corner-down-left-line'],
           ['Saut de page', 'pageBreak', 'page-separator'],
         ],
         [

--- a/app/javascript/shared/tiptap/actions.ts
+++ b/app/javascript/shared/tiptap/actions.ts
@@ -107,6 +107,14 @@ const EDITOR_ACTIONS: Record<string, (editor: Editor) => EditorAction> = {
     isActive: () => false,
     isDisabled: () => !editor.can().chain().focus().redo().run()
   }),
+  hardBreak: (editor) => ({
+    run: () => editor.chain().focus().setHardBreak().run(),
+    isActive: () => false,
+    isDisabled: () =>
+      editor.isActive('title') ||
+      editor.isActive('header') ||
+      editor.isActive('footer')
+  }),
   link: (editor) => ({
     run: () => {
       // Link action is handled directly by the controller's menuButton method

--- a/app/javascript/shared/tiptap/editor.ts
+++ b/app/javascript/shared/tiptap/editor.ts
@@ -18,6 +18,7 @@ import Mention from '@tiptap/extension-mention';
 import Typography from '@tiptap/extension-typography';
 import Heading from '@tiptap/extension-heading';
 import Link from '@tiptap/extension-link';
+import HardBreak from '@tiptap/extension-hard-break';
 
 import {
   Editor,
@@ -114,6 +115,9 @@ function getEditorOptions(
         break;
       case 'title':
         extensions.push(Header, HeaderColumn, Title);
+        break;
+      case 'hardBreak':
+        extensions.push(HardBreak);
         break;
       case 'link':
         extensions.push(

--- a/app/services/tiptap_service.rb
+++ b/app/services/tiptap_service.rb
@@ -91,6 +91,8 @@ class TiptapService
       "<dt#{class_list(rest[:attrs])}>#{children(content, substitutions, level + 1)}</dt>"
     in type: 'descriptionDetails', content:
       "<dd>#{children(content, substitutions, level + 1)}</dd>"
+    in type: 'hardBreak'
+      "<br><br>"
     in type: 'text', text:, **rest
       escaped = ERB::Util.html_escape(text)
       if rest[:marks].present?

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@tiptap/extension-bullet-list": "^2.2.4",
         "@tiptap/extension-document": "^2.2.4",
         "@tiptap/extension-gapcursor": "^2.2.4",
+        "@tiptap/extension-hard-break": "^2.2.4",
         "@tiptap/extension-heading": "^2.2.4",
         "@tiptap/extension-highlight": "^2.2.4",
         "@tiptap/extension-history": "^2.2.4",
@@ -557,6 +558,8 @@
     "@tiptap/extension-document": ["@tiptap/extension-document@2.2.4", "", { "peerDependencies": { "@tiptap/core": "^2.0.0" } }, "sha512-z+05xGK0OFoXV1GL+/8bzcZuWMdMA3+EKwk5c+iziG60VZcvGTF7jBRsZidlu9Oaj0cDwWHCeeo6L9SgSh6i2A=="],
 
     "@tiptap/extension-gapcursor": ["@tiptap/extension-gapcursor@2.2.4", "", { "peerDependencies": { "@tiptap/core": "^2.0.0", "@tiptap/pm": "^2.0.0" } }, "sha512-Y6htT/RDSqkQ1UwG2Ia+rNVRvxrKPOs3RbqKHPaWr3vbFWwhHyKhMCvi/FqfI3d5pViVHOZQ7jhb5hT/a0BmNw=="],
+
+    "@tiptap/extension-hard-break": ["@tiptap/extension-hard-break@2.2.4", "", { "peerDependencies": { "@tiptap/core": "^2.0.0" } }, "sha512-FPvS57GcqHIeLbPKGJa3gnH30Xw+YB1PXXnAWG2MpnMtc2Vtj1l5xaYYBZB+ADdXLAlU0YMbKhFLQO4+pg1Isg=="],
 
     "@tiptap/extension-heading": ["@tiptap/extension-heading@2.2.4", "", { "peerDependencies": { "@tiptap/core": "^2.0.0" } }, "sha512-gkq7Ns2FcrOCRq7Q+VRYt5saMt2R9g4REAtWy/jEevJ5UV5vA2AiGnYDmxwAkHutoYU0sAUkjqx37wE0wpamNw=="],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tiptap/extension-bullet-list": "^2.2.4",
     "@tiptap/extension-document": "^2.2.4",
     "@tiptap/extension-gapcursor": "^2.2.4",
+    "@tiptap/extension-hard-break": "^2.2.4",
     "@tiptap/extension-heading": "^2.2.4",
     "@tiptap/extension-highlight": "^2.2.4",
     "@tiptap/extension-history": "^2.2.4",

--- a/spec/services/tiptap_service_spec.rb
+++ b/spec/services/tiptap_service_spec.rb
@@ -202,6 +202,38 @@ RSpec.describe TiptapService do
       end
     end
 
+    context 'hard break' do
+      let(:json) do
+        {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'Première ligne',
+                },
+                {
+                  type: 'hardBreak',
+                },
+                {
+                  type: 'text',
+                  text: 'Seconde ligne',
+                },
+              ],
+            },
+          ],
+        }
+      end
+
+      it 'renders a blank line' do
+        expect(described_class.new.to_html(json, {})).to eq(
+          '<p class="body-start">Première ligne<br><br>Seconde ligne</p>'
+        )
+      end
+    end
+
     context 'link mark' do
       let(:json) do
         {


### PR DESCRIPTION
## Contexte

L'éditeur d'attestation v2 ne permettait pas d'insérer de saut de ligne.
La touche Entrée crée un nouveau paragraphe. Mais comme on supprime les paragraphes vides, ça ne permet pas de faire des sauts de ligne.

## Changements

- Ajout de l'extension Tiptap [HardBreak](https://tiptap.dev/docs/editor/extensions/nodes/hard-break) à l'éditeur d'attestation v2 : saut de ligne via **Shift+Entrée** ou le nouveau bouton « Saut de ligne » de la barre d'outils.
- Dans le PDF généré, un saut de ligne est rendu comme une ligne vide (`<br><br>`).

## Capture d'écran

<img width="1662" height="832" alt="Capture d’écran 2026-06-10 à 21 59 03" src="https://github.com/user-attachments/assets/a9714381-9841-4ab2-87b4-7b971d25c120" />
