### PR TITLE
ETQ gestionnaire, je veux des tableaux correctement formattées

### DIFF
--- a/app/views/administrateurs/groupe_gestionnaire/commentaires.html.haml
+++ b/app/views/administrateurs/groupe_gestionnaire/commentaires.html.haml
@@ -3,7 +3,8 @@
                     ['Messagerie']] }
 
 .fr-container
-  %h1 Messagerie de « #{@groupe_gestionnaire.name} »
+  %h1.fr-h2 Messagerie de « #{@groupe_gestionnaire.name} »
+
   .messagerie
     - if current_administrateur.commentaire_groupe_gestionnaires.where(groupe_gestionnaire: @groupe_gestionnaire).present?
       %ol.messages-list{ data: { controller: 'scroll-to' } }

--- a/app/views/gestionnaires/groupe_gestionnaire_administrateurs/index.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaire_administrateurs/index.html.haml
@@ -3,19 +3,23 @@
   locals: { steps: [["#{@groupe_gestionnaire.name.truncate_words(10)}", gestionnaire_groupe_gestionnaire_path(@groupe_gestionnaire)],
                     ['Administrateurs']] }
 
-.container
-  %h1 Gérer les administrateurs de « #{@groupe_gestionnaire.name} »
+.fr-container
+  %h1.fr-h2 Gérer les administrateurs de « #{@groupe_gestionnaire.name} »
 
-  %table.table
-    %thead
-      %tr
-        %th= 'Adresse électronique'
-        %th= 'Enregistré le'
-        %th= 'État'
-        %th
-        %th
-    %tbody#administrateurs
-      = render(GroupeGestionnaire::GroupeGestionnaireAdministrateurs::AdministrateurComponent.with_collection(@groupe_gestionnaire.administrateurs.order('users.email'), groupe_gestionnaire: @groupe_gestionnaire))
+  .fr-table
+    .fr-table__wrapper
+      .fr-table__container
+        .fr-table__content
+          %table
+            %thead
+              %tr
+                %th= 'Adresse électronique'
+                %th= 'Enregistré le'
+                %th= 'État'
+                %th
+                %th
+            %tbody#administrateurs
+              = render(GroupeGestionnaire::GroupeGestionnaireAdministrateurs::AdministrateurComponent.with_collection(@groupe_gestionnaire.administrateurs.order('users.email'), groupe_gestionnaire: @groupe_gestionnaire))
 
   .fr-mt-4w
     = render 'add_administrateur_form', groupe_gestionnaire: @groupe_gestionnaire

--- a/app/views/gestionnaires/groupe_gestionnaire_children/index.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaire_children/index.html.haml
@@ -3,8 +3,8 @@
   locals: { steps: [["#{@groupe_gestionnaire.name.truncate_words(10)}", gestionnaire_groupe_gestionnaire_path(@groupe_gestionnaire)],
                     ['Groupes enfants']] }
 
-.container
-  %h1 Gérer les groupes enfants de « #{@groupe_gestionnaire.name} »
+.fr-container
+  %h1.fr-h2 Gérer les groupes enfants de « #{@groupe_gestionnaire.name} »
 
   .fr-mt-4w
     = link_to 'Afficher l’arborescence', tree_structure_gestionnaire_groupe_gestionnaire_path(@groupe_gestionnaire)
@@ -12,10 +12,14 @@
   .fr-mt-4w
     = render 'add_child_form', groupe_gestionnaire: @groupe_gestionnaire
 
-  %table.table
-    %thead
-      %tr
-        %th= 'Nom'
-        %th= 'Enregistré le'
-    %tbody#children
-      = render(GroupeGestionnaire::GroupeGestionnaireChildren::ChildComponent.with_collection(@groupe_gestionnaire.children.order(:name), groupe_gestionnaire: @groupe_gestionnaire))
+  .fr-table
+    .fr-table__wrapper
+      .fr-table__container
+        .fr-table__content
+          %table
+            %thead
+              %tr
+                %th= 'Nom'
+                %th= 'Enregistré le'
+            %tbody#children
+              = render(GroupeGestionnaire::GroupeGestionnaireChildren::ChildComponent.with_collection(@groupe_gestionnaire.children.order(:name), groupe_gestionnaire: @groupe_gestionnaire))

--- a/app/views/gestionnaires/groupe_gestionnaire_commentaires/_list_commentaires.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaire_commentaires/_list_commentaires.html.haml
@@ -1,8 +1,12 @@
-%table.fr-table.width-100.fr-mt-6v
-  %thead
-    %tr
-      %th= 'Adresse électronique'
-      %th= 'Dernier message'
-      %th
-  %tbody#commentaires
-    = render(GroupeGestionnaire::GroupeGestionnaireListCommentaires::CommentaireComponent.with_collection(commentaires, groupe_gestionnaire: groupe_gestionnaire))
+.fr-table
+  .fr-table__wrapper
+    .fr-table__container
+      .fr-table__content
+        %table
+          %thead
+            %tr
+              %th= 'Adresse électronique'
+              %th= 'Dernier message'
+              %th
+          %tbody#commentaires
+            = render(GroupeGestionnaire::GroupeGestionnaireListCommentaires::CommentaireComponent.with_collection(commentaires, groupe_gestionnaire: groupe_gestionnaire))

--- a/app/views/gestionnaires/groupe_gestionnaire_commentaires/index.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaire_commentaires/index.html.haml
@@ -2,8 +2,8 @@
   locals: { steps: [["#{@groupe_gestionnaire.name.truncate_words(10)}", gestionnaire_groupe_gestionnaire_path(@groupe_gestionnaire)],
                     ["Messagerie"]] }
 
-.container
-  %h1 Messagerie de « #{@groupe_gestionnaire.name} »
+.fr-container
+  %h1.fr-h2 Messagerie de « #{@groupe_gestionnaire.name} »
 
   = render partial: 'list_commentaires', locals: { commentaires: @commentaires, groupe_gestionnaire: @groupe_gestionnaire }
 
@@ -16,14 +16,18 @@
     - if @commentaires_parent_group.present?
       = render partial: 'list_commentaires', locals: { commentaires: @commentaires_parent_group, groupe_gestionnaire: @groupe_gestionnaire }
     - else
-      %table.fr-table.width-100.fr-mt-6v
-        %thead
-          %tr
-            %th= 'Adresse électronique'
-            %th= 'Dernier message'
-            %th
-          %tr
-            %td= "Messages avec le groupe gestionnaire parent"
-            %td
-            %td
-              = link_to 'Voir', parent_groupe_gestionnaire_gestionnaire_groupe_gestionnaire_commentaires_path(@groupe_gestionnaire), class: 'fr-btn'
+      .fr-table
+        .fr-table__wrapper
+          .fr-table__container
+            .fr-table__content
+              %table
+                %thead
+                  %tr
+                    %th= 'Adresse électronique'
+                    %th= 'Dernier message'
+                    %th
+                  %tr
+                    %td= "Messages avec le groupe gestionnaire parent"
+                    %td
+                    %td
+                      = link_to 'Voir', parent_groupe_gestionnaire_gestionnaire_groupe_gestionnaire_commentaires_path(@groupe_gestionnaire), class: 'fr-btn'

--- a/app/views/gestionnaires/groupe_gestionnaire_gestionnaires/index.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaire_gestionnaires/index.html.haml
@@ -3,18 +3,22 @@
   locals: { steps: [["#{@groupe_gestionnaire.name.truncate_words(10)}", gestionnaire_groupe_gestionnaire_path(@groupe_gestionnaire)],
                     ['Gestionnaires']] }
 
-.container
-  %h1 Gérer les gestionnaires de « #{@groupe_gestionnaire.name} »
+.fr-container
+  %h1.fr-h2 Gérer les gestionnaires de « #{@groupe_gestionnaire.name} »
 
-  %table.table
-    %thead
-      %tr
-        %th= 'Adresse électronique'
-        %th= 'Enregistré le'
-        %th= 'État'
-        %th
-    %tbody#gestionnaires
-      = render(GroupeGestionnaire::GroupeGestionnaireGestionnaires::GestionnaireComponent.with_collection(@groupe_gestionnaire.gestionnaires.order('users.email'), groupe_gestionnaire: @groupe_gestionnaire))
+  .fr-table
+    .fr-table__wrapper
+      .fr-table__container
+        .fr-table__content
+          %table
+            %thead
+              %tr
+                %th= 'Adresse électronique'
+                %th= 'Enregistré le'
+                %th= 'État'
+                %th
+            %tbody#gestionnaires
+              = render(GroupeGestionnaire::GroupeGestionnaireGestionnaires::GestionnaireComponent.with_collection(@groupe_gestionnaire.gestionnaires.order('users.email'), groupe_gestionnaire: @groupe_gestionnaire))
 
   .fr-mt-4w
     = render 'add_gestionnaire_form', groupe_gestionnaire: @groupe_gestionnaire

--- a/app/views/gestionnaires/groupe_gestionnaires/index.html.haml
+++ b/app/views/gestionnaires/groupe_gestionnaires/index.html.haml
@@ -3,29 +3,33 @@
 = render partial: 'shared/breadcrumbs_section',
   locals: { steps: [['Groupes gestionnaires']] }
 
-.fr-container.procedure-admin-container
+.fr-container
+  %h1.fr-h2 Groupes gestionnaires
 
-.fr-container#groupe_gestionnaire
-  %table.fr-table.width-100.fr-mt-6v
-    %thead
-      %tr
-        %th{ scope: "col" }
-          Nom
-        %th{ scope: "col" }
-          Nombre de gestionnaires
-        %th{ scope: "col" }
-          Nombre d’administrateurs
-        %th{ scope: "col" }
-          Arborescence
+  .fr-table
+    .fr-table__wrapper
+      .fr-table__container
+        .fr-table__content
+          %table
+            %thead
+              %tr
+                %th{ scope: "col" }
+                  Nom
+                %th{ scope: "col" }
+                  Nombre de gestionnaires
+                %th{ scope: "col" }
+                  Nombre d’administrateurs
+                %th{ scope: "col" }
+                  Arborescence
 
-    %tbody
-      - @groupe_gestionnaires.order(:name).each do |groupe_gestionnaire|
-        %tr
-          %td
-            = link_to groupe_gestionnaire.name, gestionnaire_groupe_gestionnaire_path(groupe_gestionnaire)
-          %td
-            = groupe_gestionnaire.gestionnaire_ids.size
-          %td
-            = groupe_gestionnaire.administrateur_ids.size
-          %td
-            = link_to 'Voir', tree_structure_gestionnaire_groupe_gestionnaire_path(groupe_gestionnaire), class: 'fr-btn'
+            %tbody
+              - @groupe_gestionnaires.order(:name).each do |groupe_gestionnaire|
+                %tr
+                  %td
+                    = link_to groupe_gestionnaire.name, gestionnaire_groupe_gestionnaire_path(groupe_gestionnaire)
+                  %td
+                    = groupe_gestionnaire.gestionnaire_ids.size
+                  %td
+                    = groupe_gestionnaire.administrateur_ids.size
+                  %td
+                    = link_to 'Voir', tree_structure_gestionnaire_groupe_gestionnaire_path(groupe_gestionnaire), class: 'fr-btn'


### PR DESCRIPTION
Le formatage des tableaux dans les différentes pages des Gestionnaires a sauté à un moment. En mettant à jour les classes CSS et l'arborescence pour respecter le DSFR, c'est mieux.

_Tip: Le diff se lit mieux avec "Hide whitespaces"._

## Avant

| <img width="1901" height="1605" alt="Screenshot 2026-06-11 at 10-04-42 demarches adullact org" src="https://github.com/user-attachments/assets/358f2981-842c-46e2-ac5a-87ced4e8f782" /> |  <img width="1901" height="1605" alt="Screenshot 2026-06-11 at 10-16-01 demarche numerique gouv fr" src="https://github.com/user-attachments/assets/c5246c6f-3d31-408a-ab32-0c61f0c7e312" /> |
| -- | -- |

## Après

| <img width="1901" height="1605" alt="Screenshot 2026-06-11 at 10-16-13 demarche numerique gouv fr" src="https://github.com/user-attachments/assets/0460c8f8-d8bb-482e-80e5-2ded9bb87f36" /> | <img width="1914" height="1605" alt="Screenshot 2026-06-11 at 10-47-48 demarche numerique gouv fr" src="https://github.com/user-attachments/assets/bff7c651-ccff-4e62-bcb6-ecf304dc2c76" /> |
| -- | -- |
