### PR TITLE
ETQ admin, harmonise les couleurs des badges de statut des tuiles

### DIFF
--- a/app/components/procedure/card/accuse_lecture_component/accuse_lecture_component.html.haml
+++ b/app/components/procedure/card/accuse_lecture_component/accuse_lecture_component.html.haml
@@ -4,7 +4,7 @@
       - if @procedure.accuse_lecture.present?
         %p.fr-badge.fr-badge--success Activé
       - else
-        %p.fr-badge.fr-badge--info Désactivé
+        %p.fr-badge Désactivé
       %div
         %h3.fr-h6.fr-mt-10v= t('.title')
         %p.fr-tile-subtitle= t('.subtitle')

--- a/app/components/procedure/card/ineligibilite_dossier_component/ineligibilite_dossier_component.html.haml
+++ b/app/components/procedure/card/ineligibilite_dossier_component/ineligibilite_dossier_component.html.haml
@@ -2,7 +2,7 @@
   = link_to edit_admin_procedure_ineligibilite_rules_path(@procedure), class: 'fr-tile fr-enlarge-link' do
     .fr-tile__body.flex.column.align-center.justify-between
       - if !ready?
-        %p.fr-badge.fr-badge= t('.state.pending')
+        %p.fr-badge= t('.state.pending')
       - elsif error?
         %p.fr-badge.fr-badge--error À modifier
       - else

--- a/app/components/procedure/card/labels_component/labels_component.html.haml
+++ b/app/components/procedure/card/labels_component/labels_component.html.haml
@@ -8,7 +8,7 @@
           .line-count.fr-my-1w
             %p.fr-tag= @procedure.labels.size
       - else
-        %p.fr-badge--info
+        %p.fr-badge.fr-badge--info
           À configurer
 
       %h3.fr-h6

--- a/app/components/procedure/card/zones_component/zones_component.html.haml
+++ b/app/components/procedure/card/zones_component/zones_component.html.haml
@@ -4,7 +4,7 @@
       - if @procedure.zones.size >= 1
         %p.fr-badge.fr-badge--success Validé
       - else
-        %p.fr-badge.fr-badge--info À faire
+        %p.fr-badge.fr-badge--warning À faire
       %div
         %h3.fr-h6.fr-mt-10v= t('.title')
         %p.fr-tile-subtitle= t('.subtitle')


### PR DESCRIPTION
Sur la page de gestion d'une démarche (`/admin/procedures/:id`), certains badges de statut ne suivaient pas la convention de couleurs DSFR commune aux tuiles.

- **Accusé de lecture** : « Désactivé » passe du bleu (`fr-badge--info`) au gris neutre, comme les autres tuiles désactivées.
- **Zones** : « À faire » passe du bleu à l'orange (`fr-badge--warning`), cohérent avec les autres « À faire ».
- **Labels** : ajout de la classe de base `fr-badge` manquante (le badge perdait son padding/forme).
- **Inéligibilité** : suppression d'une classe `fr-badge` dupliquée.

Ref #13279