### PR TITLE
Tech: extraire les textes en dur de DeletedDossiersComponent vers i18n

### DIFF
--- a/app/components/dossiers/deleted_dossiers_component/deleted_dossiers_component.en.yml
+++ b/app/components/dossiers/deleted_dossiers_component/deleted_dossiers_component.en.yml
@@ -1,7 +1,12 @@
 en:
+  title: Deleted dossiers history
   deleted_explanation: "The folders have been deleted. You can no longer recover them for the following reasons:"
   deleted_explanation_first_instructor: The user intentionally deleted their folder.
   deleted_explanation_second_instructor: The maximum retention period has expired. In accordance with GDPR regulations, the application cannot continue to host them.
   deleted_explanation_first_user: You have deleted your folder.
   deleted_explanation_second_user: The maximum retention period has expired. In accordance with GDPR regulations, the application cannot continue to host them.
   no_deleted_folders: You have no permanently deleted folders.
+  dossier_number: Dossier number
+  procedure_libelle: Procedure label
+  deletion_reason: Deletion reason
+  deletion_date: Deletion date

--- a/app/components/dossiers/deleted_dossiers_component/deleted_dossiers_component.fr.yml
+++ b/app/components/dossiers/deleted_dossiers_component/deleted_dossiers_component.fr.yml
@@ -1,7 +1,12 @@
 fr:
+  title: Historique des dossiers supprimés
   deleted_explanation: "Les dossiers ont été supprimés. Vous ne pouvez plus les récupérer pour les raisons suivantes :"
   deleted_explanation_first_instructeur: L’utilisateur a intentionnellement supprimé son dossier.
   deleted_explanation_second_instructeur: Le délai de conservation maximal a expiré. Conformément au règlement RGPD, l’application ne peut continuer à les héberger.
   deleted_explanation_first_user: Vous avez supprimé votre dossier.
   deleted_explanation_second_user: Le délai de conservation maximal a expiré. Conformément au règlement RGPD, l’application ne peut continuer à les héberger.
   no_deleted_dossiers: Vous n’avez pas de dossiers supprimés définitivement.
+  dossier_number: N° dossier
+  procedure_libelle: Libellé de la démarche
+  deletion_reason: Raison de suppression
+  deletion_date: Date de suppression

--- a/app/components/dossiers/deleted_dossiers_component/deleted_dossiers_component.html.haml
+++ b/app/components/dossiers/deleted_dossiers_component/deleted_dossiers_component.html.haml
@@ -1,7 +1,7 @@
 
 .fr-container
   %h1.fr-h4
-    Historique des dossiers supprimés
+    = t('.title')
 
 .fr-container
   - if @deleted_dossiers.present?
@@ -23,10 +23,10 @@
             %table
               %thead
                 %tr
-                  %th N° dossier
-                  %th Libellé de la démarche
-                  %th Raison de suppression
-                  %th Date de suppression
+                  %th= t('.dossier_number')
+                  %th= t('.procedure_libelle')
+                  %th= t('.deletion_reason')
+                  %th= t('.deletion_date')
               %tbody
                 - @deleted_dossiers.each do |deleted_dossier|
                   %tr


### PR DESCRIPTION
# Probleme

Textes francais en dur dans `app/components/dossiers/deleted_dossiers_component/deleted_dossiers_component.html.haml` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 5 cles i18n vers les fichiers sidecar du composant.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `.title` | "Historique des dossiers supprimes" | "Deleted dossiers history" |
| `.dossier_number` | "N° dossier" | "Dossier number" |
| `.procedure_libelle` | "Libelle de la demarche" | "Procedure label" |
| `.deletion_reason` | "Raison de suppression" | "Deletion reason" |
| `.deletion_date` | "Date de suppression" | "Deletion date" |

### Validation visuelle — IDENTIQUE

**Avant :**
![before](https://gist.githubusercontent.com/mfo/53bcf7949074903b283c6df3259a95de/raw/before-1.png)

**Apres :**
![after](https://gist.githubusercontent.com/mfo/53bcf7949074903b283c6df3259a95de/raw/after-1.png)

**Couverture :**
- :white_check_mark: `localhost:3220/deleted_dossiers` — page usager avec dossiers supprimes

[Voir tous les screenshots](https://gist.github.com/mfo/53bcf7949074903b283c6df3259a95de)

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante (FR et EN)
- [x] Apostrophes typographiques verifiees
- [x] Tests passes (spec/system/breadcrumbs_spec.rb — 10 examples, 0 failures)
- [x] Rubocop OK
- [x] Screenshots avant/apres visuellement identiques

Generated with [Claude Code](https://claude.com/claude-code)