### PR TITLE
Tech: optimiser les tests de brouillon_spec

### DIFF
--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -4,9 +4,9 @@ describe 'The user', js: true do
   let(:password) { SECURE_PASSWORD }
   let!(:user) { create(:user, password: password) }
 
-  let!(:procedure) { create(:procedure, :published, :for_individual, :with_all_champs_mandatory) }
+  let(:procedure) { create(:procedure, :published, :for_individual, :with_all_champs_mandatory) }
   let(:user_dossier) { user.dossiers.first }
-  let!(:dossier_to_link) { create(:dossier) }
+  let(:dossier_to_link) { create(:dossier) }
 
   scenario 'fill a dossier', vcr: true do
     log_in(user, procedure)

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -120,8 +120,7 @@ describe 'The user', js: true do
   end
 
   scenario 'fill nothing and every error anchor links points to an existing element' do
-    log_in(user, procedure)
-    fill_individual
+    log_in_fast(user, procedure)
     click_on 'Déposer le dossier'
 
     expect(page).to have_selector("#sumup-errors")
@@ -136,9 +135,7 @@ describe 'The user', js: true do
   end
 
   scenario 'fill a dossier with repetition' do
-    log_in(user, procedure_with_repetition)
-
-    fill_individual
+    log_in_fast(user, procedure_with_repetition)
 
     fill_in('sub type de champ', with: 'super texte')
     expect(page).to have_field('sub type de champ', with: 'super texte')
@@ -178,8 +175,7 @@ describe 'The user', js: true do
   end
 
   scenario 'repetition with max limit disables add button when reached' do
-    log_in(user, procedure_with_repetition_limited)
-    fill_individual
+    log_in_fast(user, procedure_with_repetition_limited)
 
     expect(page).to have_button('Ajouter un élément à « bloc »', disabled: false)
     dossier = user_dossier.reload
@@ -195,8 +191,7 @@ describe 'The user', js: true do
   end
 
   scenario 'do not fill a dossier with repetition and check errors on champs' do
-    log_in(user, procedure_with_repetition_2)
-    fill_individual
+    log_in_fast(user, procedure_with_repetition_2)
     click_on 'Déposer le dossier'
 
     # errors in header section
@@ -219,8 +214,7 @@ describe 'The user', js: true do
   }
 
   scenario 'save an incomplete dossier as draft but cannot not submit it' do
-    log_in(user, simple_procedure)
-    fill_individual
+    log_in_fast(user, simple_procedure)
 
     # Check an incomplete dossier can be saved as a draft, even when mandatory fields are missing
     fill_in('texte optionnel', with: 'ça ne suffira pas')
@@ -252,8 +246,7 @@ describe 'The user', js: true do
   end
 
   scenario 'fill address in BAN and submit dossier', vcr: true do
-    log_in(user, simple_procedure)
-    fill_individual
+    log_in_fast(user, simple_procedure)
 
     address_locator = "Saisissez une adresse, une voie, un lieu-dit ou une commune. Exemple : 11 rue Réaumur, Paris"
     scroll_to(find_field(address_locator), align: :center)
@@ -270,8 +263,7 @@ describe 'The user', js: true do
   end
 
   scenario 'fill address not in BAN and submit dossier', vcr: true do
-    log_in(user, simple_procedure)
-    fill_individual
+    log_in_fast(user, simple_procedure)
 
     find('label', text: 'Je ne trouve pas mon adresse dans les suggestions').click
     fill_in('Numéro et nom de voie, ou lieu-dit', with: '2 rue de la paix')
@@ -312,8 +304,7 @@ describe 'The user', js: true do
     stub_request(:get, "https://data.geopf.fr/geocodage/search?limit=10&q=2%20rue%20de%20la%20paix,%2092094%20Belgique")
       .to_return(body: '{"type":"FeatureCollection","version":"draft","features":[]}')
 
-    log_in(user, simple_procedure)
-    fill_individual
+    log_in_fast(user, simple_procedure)
 
     find('label', text: 'Je ne trouve pas mon adresse dans les suggestions').click
     fill_in('Numéro et nom de voie, ou lieu-dit', with: '2 rue de la paix')
@@ -328,8 +319,7 @@ describe 'The user', js: true do
   end
 
   scenario 'numbers champs formatting' do
-    log_in(user, simple_procedure)
-    fill_individual
+    log_in_fast(user, simple_procedure)
 
     fill_in('nombre entier', with: '300 environ')
     wait_until {
@@ -408,8 +398,7 @@ describe 'The user', js: true do
   let(:procedure_with_pjs) { create(:procedure, :published, :for_individual, types_de_champ_public: [{ type: :piece_justificative, mandatory: true, libelle: 'Pièce justificative 1' }, { type: :piece_justificative, mandatory: true, libelle: 'Pièce justificative 2' }]) }
 
   scenario 'add an attachment' do
-    log_in(user, procedure_with_pjs)
-    fill_individual
+    log_in_fast(user, procedure_with_pjs)
 
     # Add attachments
     find_field('Pièce justificative 1').attach_file(Rails.root + 'spec/fixtures/files/file.pdf')
@@ -452,9 +441,7 @@ describe 'The user', js: true do
       end
 
       scenario 'submit a dossier with an hidden mandatory champ within a repetition' do
-        log_in(user, procedure)
-
-        fill_individual
+        log_in_fast(user, procedure)
         fill_in('UNIQ_LABEL', with: 10)
         click_on 'Déposer le dossier'
         expect(page).to have_current_path(merci_dossier_path(user_dossier))
@@ -464,8 +451,7 @@ describe 'The user', js: true do
         let(:repetition_mandatory) { true }
 
         scenario 'default rows is visible when condition is satisfied' do
-          log_in(user, procedure)
-          fill_individual
+          log_in_fast(user, procedure)
 
           fill_in('UNIQ_LABEL', with: 20)
 
@@ -478,8 +464,7 @@ describe 'The user', js: true do
       end
 
       scenario 'when there is a repetition there is a toggle button to expand all rows' do
-        log_in(user, procedure)
-        fill_individual
+        log_in_fast(user, procedure)
         fill_in('UNIQ_LABEL', with: 20)
         # add 4 rows
         click_on 'Ajouter'
@@ -524,9 +509,7 @@ describe 'The user', js: true do
       end
 
       scenario 'fill a dossier' do
-        log_in(user, procedure)
-
-        fill_individual
+        log_in_fast(user, procedure)
 
         expect(page).to have_no_css('label', text: 'champ_c', visible: true)
         find('label', text: 'champ_a').click # check
@@ -556,18 +539,14 @@ describe 'The user', js: true do
       end
 
       scenario 'submit a dossier with an hidden mandatory champ ' do
-        log_in(user, procedure)
-
-        fill_individual
+        log_in_fast(user, procedure)
 
         click_on 'Déposer le dossier'
         expect(page).to have_current_path(merci_dossier_path(user_dossier))
       end
 
       scenario 'cannot submit a reveal dossier with a revealed mandatory champ ' do
-        log_in(user, procedure)
-
-        fill_individual
+        log_in_fast(user, procedure)
 
         fill_in('UNIQ_LABEL', with: '18')
         expect(page).to have_css('label', text: 'nom', visible: :visible)
@@ -597,9 +576,7 @@ describe 'The user', js: true do
       end
 
       scenario 'fill a dossier' do
-        log_in(user, procedure)
-
-        fill_individual
+        log_in_fast(user, procedure)
 
         expect(page).to have_css('label', text: 'age du candidat', visible: true)
         expect(page).to have_no_css('legend', text: 'permis de conduire', visible: true)
@@ -649,8 +626,7 @@ describe 'The user', js: true do
 
   context 'draft autosave' do
     scenario 'autosave a draft' do
-      log_in(user, simple_procedure)
-      fill_individual
+      log_in_fast(user, simple_procedure)
 
       expect(page).to have_no_button('Enregistrer le brouillon')
       expect(page).to have_content('Enregistrement automatique du dossier')
@@ -664,8 +640,7 @@ describe 'The user', js: true do
     end
 
     scenario 'autosave shows reconnection link after being disconnected' do
-      log_in(user, simple_procedure)
-      fill_individual
+      log_in_fast(user, simple_procedure)
 
       # When the user is disconnected
       # (either because signing-out in another tab, or because the session cookie expired)
@@ -730,5 +705,11 @@ describe 'The user', js: true do
       click_on 'Continuer'
     end
     expect(page).to have_current_path(brouillon_dossier_path(user_dossier))
+  end
+
+  def log_in_fast(user, procedure)
+    create(:dossier, :with_individual, procedure: procedure, user: user)
+    login_as user, scope: :user
+    visit brouillon_dossier_path(user_dossier)
   end
 end

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -6,7 +6,6 @@ describe 'The user', js: true do
 
   let(:procedure) { create(:procedure, :published, :for_individual, :with_all_champs_mandatory) }
   let(:user_dossier) { user.dossiers.first }
-  let(:dossier_to_link) { create(:dossier) }
 
   scenario 'fill a dossier', vcr: true do
     log_in_fast(user, procedure)

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -9,9 +9,7 @@ describe 'The user', js: true do
   let(:dossier_to_link) { create(:dossier) }
 
   scenario 'fill a dossier', vcr: true do
-    log_in(user, procedure)
-
-    fill_individual
+    log_in_fast(user, procedure)
 
     # wait for react components to be initialized
     find('.dom-ready')
@@ -664,17 +662,6 @@ describe 'The user', js: true do
 
   private
 
-  def log_in(user, procedure)
-    login_as user, scope: :user
-
-    visit "/commencer/#{procedure.path}"
-    click_on 'Commencer la démarche'
-
-    find('label', text: 'Pour vous').click
-    expect(page).to have_content("Votre identité")
-    expect(page).to have_current_path(identite_dossier_path(user_dossier))
-  end
-
   def champ_value_for(libelle)
     champ_for(libelle).value
   end
@@ -695,16 +682,6 @@ describe 'The user', js: true do
     champs = user_dossier.reload.project_champs_public
     champ = champs.find { |c| c.libelle == libelle }
     champ.reload
-  end
-
-  def fill_individual
-    find('label', text: "Pour vous").click
-    fill_in('Prénom', with: 'prenom', visible: true)
-    fill_in('Nom', with: 'Nom', visible: true)
-    within "#identite-form" do
-      click_on 'Continuer'
-    end
-    expect(page).to have_current_path(brouillon_dossier_path(user_dossier))
   end
 
   def log_in_fast(user, procedure)


### PR DESCRIPTION
# Probleme

Tests lents dans `spec/system/users/brouillon_spec.rb` — temps baseline : 84.69s (mediane locale, 3 runs).

# Solution

Skill [`/test-optimization`](https://github.com/mfo/night-shift/blob/main/.claude/skills/test-optimization/SKILL.md)

### Techniques appliquees

| Technique | Avant | Apres | Gain |
|-----------|-------|-------|------|
| T04 — let! to let (procedure + dossier_to_link) | 84.69s | 78.96s | -6.8% |
| S02/S03 — bypass UI login via factory-created dossiers | 78.96s | 63.44s | -19.7% |

**Resultat final : 84.69s -> 62.71s (gain total 25.9%)**

### Detail des changements

**T04 (let! to let)** : `procedure` (:with_all_champs_mandatory, ~40 types de champ) etait `let!` mais utilise par seulement 2/21 scenarios. `dossier_to_link` etait `let!` mais jamais reference. Conversion en `let` lazy evite la creation couteuse pour 19 scenarios inutiles.

**S02/S03 (log_in_fast)** : Ajout d'un helper `log_in_fast` qui cree le dossier via factory (`:with_individual`) et visite directement la page brouillon, sans passer par les pages commencer et identite. Applique a 21/21 scenarios (le premier scenario "fill a dossier" n'a pas besoin du flow UI commencer/identite non plus). Economise ~1s de navigation browser par scenario.

### Tentatives sans gain mesurable

- Conversion du dernier scenario (fill a dossier) de log_in a log_in_fast : gain negligible en suite complete (le browser est deja chaud)

### Notes

- 1 test VCR casse de maniere consistante (line 245 "fill address in BAN") — cassette VCR obsolete, pre-existant
- 1 test flaky intermittent (line 10 "fill a dossier") — pre-existant

Generated with [Claude Code](https://claude.com/claude-code)