### PR TITLE
Tech: fix N+1 sur add_instructeurs dans GroupeInstructeursController

### DIFF
--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -123,19 +123,37 @@ class DossierNotification < ApplicationRecord
   end
 
   def self.refresh_notifications_new_instructeur_for_dossiers(groupe_instructeur, instructeur)
-    instructeur_preferences = instructeur_preferences(instructeur, groupe_instructeur.procedure)
+    refresh_notifications_new_instructeurs_for_groupe(groupe_instructeur, [instructeur])
+  end
 
-    notification_types_to_refresh = notification_types.keys.map(&:to_sym).filter do |notification_type|
-      instructeur_preferences[notification_type] == 'all'
-    end
-
-    notification_types_to_refresh.concat(NON_CUSTOMISABLE_TYPE)
+  def self.refresh_notifications_new_instructeurs_for_groupe(groupe_instructeur, instructeurs)
+    return if instructeurs.empty?
 
     dossiers = groupe_instructeur.dossiers.state_not_brouillon
+    return if dossiers.blank?
 
-    notification_types_to_refresh.each do |notification_type|
-      dossiers_to_notify = dossiers_to_notify(dossiers, notification_type, instructeur.id)
-      create_notifications_by_type_for_instructeur_dossiers(dossiers_to_notify, notification_type, instructeur.id) if dossiers_to_notify.any?
+    instructeur_ids = instructeurs.map(&:id)
+    preferences_by_id = InstructeursProcedure
+      .where(instructeur_id: instructeur_ids, procedure_id: groupe_instructeur.procedure_id)
+      .index_by(&:instructeur_id)
+
+    cached_dossiers_to_notify = {}
+    all_type_keys = notification_types.keys.map(&:to_sym)
+
+    instructeurs.each do |instructeur|
+      prefs = preferences_by_id[instructeur.id]&.notification_preferences || InstructeursProcedure::DEFAULT_NOTIFICATIONS_PREFERENCES
+
+      types_to_refresh = all_type_keys.filter { prefs[_1] == 'all' }
+      types_to_refresh.concat(NON_CUSTOMISABLE_TYPE)
+
+      types_to_refresh.each do |type|
+        result = if type == :message
+          dossiers_to_notify(dossiers, type, instructeur.id)
+        else
+          cached_dossiers_to_notify[type] ||= dossiers_to_notify(dossiers, type, instructeur.id).load
+        end
+        create_notifications_by_type_for_instructeur_dossiers(result, type, instructeur.id) if result.any?
+      end
     end
   end
 

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -73,7 +73,10 @@ class GroupeInstructeur < ApplicationRecord
 
     # We dont't want to assign a user to a groupe_instructeur if they are already assigned to it
     instructeurs_to_add -= instructeurs
-    instructeurs_to_add.each { add(_1) }
+    instructeurs_to_add.compact!
+
+    new_instructeurs = instructeurs_to_add.filter { |instructeur| instructeur.assign_to.create_or_find_by(groupe_instructeur: self).previously_new_record? }
+    DossierNotification.refresh_notifications_new_instructeurs_for_groupe(self, new_instructeurs)
 
     [instructeurs_to_add, invalid_emails]
   end


### PR DESCRIPTION
# Probleme

N+1 detecte par [Prosopite](https://github.com/charkost/prosopite) (scan des tests enrichis) et confirme par [Skylight](https://www.skylight.io/) (production).

**Donnees de production** (depuis `.skill-context.json` / [Skylight](https://oss.skylight.io/app/applications/auuzqe8XhJIx/recent/6h/endpoints)) :

| Endpoint | RPM | P95 | N+1 failures |
|----------|-----|-----|--------------|
| `Instructeurs::GroupeInstructeursController#add_instructeurs` | 0.0 | 283ms | 5 |

> Note : RPM tres faible (0.0). Le fix vaut le coup car (1) la complexite est faible, (2) le pattern N+1 est lineaire en nombre d'instructeurs ajoutes (potentiellement ~10-20 en batch), et (3) le code devient plus lisible avec le batch explicite.

**Triage Prosopite** : 5 patterns PROD (call stack dans `app/`) / 5 patterns TEST ignores (`Procedure#toggle_routing` en setup).

# Solution

Skill [`/n1-query-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/n1-query-fix/SKILL.md)

### Patterns corriges (PROD uniquement)

| Association / Query | Table | Strategy | Call site (app/) |
|---------------------|-------|----------|------------------|
| `in?(instructeur.groupe_instructeurs)` | groupe_instructeurs via assign_tos | Skip redundant check (already deduped by `-= instructeurs`) | `app/models/groupe_instructeur.rb:39` |
| `InstructeursProcedure.find_by` | instructeurs_procedures | Batch preload with `.where().index_by()` | `app/models/dossier_notification.rb:382` |
| `dossiers_to_notify` (dossier_depose, dossier_expirant, dossier_suppression) | dossiers | Cache group-level queries with `.load` across instructeurs | `app/models/dossier_notification.rb:138` |

### Patterns non corriges (justification)

| Pattern | Raison |
|---------|--------|
| `User.create_or_promote_to_instructeur` (users lookup per email) | Creation sequentielle inherente — chaque user doit etre trouve/cree individuellement |
| `user.instructeur` (instructeur load per user) | Suite de la creation — `user.instructeur` apres `create_or_promote_to_instructeur` |

### Implementation

1. **`GroupeInstructeur#add_instructeurs`** : Remplace `instructeurs_to_add.each { add(_1) }` par des operations inlinees :
   - `compact!` + creation directe des `assign_to`
   - Appel unique a `DossierNotification.refresh_notifications_new_instructeurs_for_groupe`

2. **`DossierNotification.refresh_notifications_new_instructeurs_for_groupe`** (nouvelle methode batch) :
   - Precharge les preferences de tous les instructeurs en une seule requete
   - Early-return si le groupe n'a aucun dossier (evite toutes les queries suivantes)
   - Cache les resultats `dossiers_to_notify` pour les types group-level (tous sauf `:message`)
   - Reduction : de O(N * T) a O(T) queries pour les types group-level (N = instructeurs, T = notification types)

### Validation

- [x] Tests passes (18 specs controller + 22 specs model GroupeInstructeur + 34 specs model DossierNotification)
- [x] Rubocop OK
- [x] Seuls des fichiers app/ sont commites

Generated with [Claude Code](https://claude.com/claude-code)