### PR TITLE
fix: GroupeInstructeur#add - race condition sur les insertions concurrentes

### DIFF
--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -36,10 +36,9 @@ class GroupeInstructeur < ApplicationRecord
 
   def add(instructeur)
     return if instructeur.nil?
-    return if in?(instructeur.groupe_instructeurs)
 
-    instructeur.assign_to.create(groupe_instructeur: self)
-    DossierNotification.refresh_notifications_new_instructeur_for_dossiers(self, instructeur)
+    assign_to = instructeur.assign_to.create_or_find_by(groupe_instructeur: self)
+    DossierNotification.refresh_notifications_new_instructeur_for_dossiers(self, instructeur) if assign_to.previously_new_record?
   end
 
   def remove(instructeur)

--- a/spec/models/groupe_instructeur_spec.rb
+++ b/spec/models/groupe_instructeur_spec.rb
@@ -73,6 +73,21 @@ describe GroupeInstructeur, type: :model do
         expect(DossierNotification.all.map(&:notification_type)).to match_array(['dossier_depose', 'dossier_modifie'])
       end
     end
+
+    context "when the assign_to already exists in the database (race condition)" do
+      before { create(:assign_to, groupe_instructeur: another_groupe_instructeur, instructeur:) }
+
+      it "does not raise an error" do
+        # Simulate the race condition window: the guard passed before the concurrent insert
+        allow(another_groupe_instructeur).to receive(:in?).and_return(false)
+        expect { another_groupe_instructeur.add(instructeur) }.not_to raise_error
+      end
+
+      it "does not create a duplicate assign_to record" do
+        allow(another_groupe_instructeur).to receive(:in?).and_return(false)
+        expect { another_groupe_instructeur.add(instructeur) }.not_to change(AssignTo, :count)
+      end
+    end
   end
 
   describe "#remove" do


### PR DESCRIPTION
## Problème

Lors de l'ajout d'un instructeur à tous les groupes, il arrive que `GroupeInstructeur#add` lève une erreur `PG::UniqueViolation` sur la contrainte `unique_couple_groupe_instructeur_instructeur`. cf https://demarches-simplifiees.sentry.io/issues/7472872339/

La méthode avait une race condition TOCTOU : la vérification d'existence et l'INSERT n'étaient pas atomiques. Deux requêtes concurrentes (double-clic, retry réseau, deux admins sur la même procédure) pouvaient toutes deux passer le guard, puis toutes deux tenter d'insérer le même couple `(groupe_instructeur_id, instructeur_id)`.


## Correction

Remplacement du pattern check+create non-atomique par `create_or_find_by`, qui tente l'INSERT en premier et fait un SELECT en cas de violation de contrainte unique. `previously_new_record?` garantit que `DossierNotification` n'est déclenché que si l'enregistrement a réellement été créé.