### PR TITLE
ETQ Opérateur, je veux que les blobs supprimés soient ignorés par les jobs

### DIFF
--- a/app/jobs/create_representations_job.rb
+++ b/app/jobs/create_representations_job.rb
@@ -5,6 +5,7 @@ class CreateRepresentationsJob < ApplicationJob
 
   queue_as :ultra_low
 
+  discard_on ActiveJob::DeserializationError
   discard_on ActiveRecord::RecordNotFound
   discard_on ActiveStorage::FileNotFoundError
   discard_on ActiveRecord::InvalidForeignKey

--- a/app/jobs/delayed_purge_job.rb
+++ b/app/jobs/delayed_purge_job.rb
@@ -21,6 +21,7 @@ class DelayedPurgeJob < ApplicationJob
   retry_on Excon::Error::TooManyRequests, wait: 10.minutes, attempts: MAX_ATTEMPTS_JOBS
 
   # can discard
+  discard_on ActiveJob::DeserializationError
   discard_on ActiveRecord::RecordNotFound
 
   def self.openstack?


### PR DESCRIPTION
En ce moment, `CreateRepresentationsJob` et `DelayedPurgeJob` lèvent une exception `ActiveJob::DeserializationError` lorsque le blob concerné a déjà été supprimé par ailleurs. Le job se retrouve donc en erreur dans Sidekiq, qui va ré-essayer périodiquement avant d'échouer.

On veut plutôt que ces jobs soient retirés de la queue si le blob n'existe plus.