### PR TITLE
ETQ admin, je n'ai plus la fonction souligner dans les éditeurs d'attestation

### DIFF
--- a/app/components/tiptap_editor_component.html.erb
+++ b/app/components/tiptap_editor_component.html.erb
@@ -24,17 +24,6 @@
       >
         Italique
       </button>
-
-      <button
-        class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-underline"
-        type="button"
-        title="Souligné"
-        data-action="click->tiptap#menuButton"
-        data-tiptap-target="button"
-        data-tiptap-action="underline"
-      >
-        Souligné
-      </button>
     </div>
 
     <div class="flex flex-gap-1">

--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -33,7 +33,6 @@ module Administrateurs
         [
           ['Gras', 'bold', 'bold'],
           ['Italic', 'italic', 'italic'],
-          ['Souligner', 'underline', 'underline'],
         ],
         [
           ['Titre', 'title', :hidden], # only for "title" section, without any action possible

--- a/app/javascript/shared/tiptap/nodes.ts
+++ b/app/javascript/shared/tiptap/nodes.ts
@@ -10,7 +10,7 @@ export const Title = Node.create({
   name: 'title',
   content: 'inline*',
   defining: true,
-  marks: 'italic underline',
+  marks: 'italic',
 
   parseHTML() {
     return [{ tag: `h1`, attrs: { level: 1 } }];

--- a/app/tasks/maintenance/t20260615_strip_underline_marks_from_tiptap_bodies_task.rb
+++ b/app/tasks/maintenance/t20260615_strip_underline_marks_from_tiptap_bodies_task.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260615StripUnderlineMarksFromTiptapBodiesTask < MaintenanceTasks::Task
+    # PR #13293 removed the underline button from the attestation editors, so the
+    # Tiptap `Underline` extension is no longer loaded. Opening an attestation
+    # whose stored json_body still contains an underline mark would then crash the
+    # editor: ProseMirror raises "Unknown mark type: underline" while parsing the
+    # JSON content, leaving the editor unmounted.
+    #
+    # This task strips every "underline" mark from the stored json_body of both
+    # editors (attestation v2 and "attestation de dépôt").
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    # Must run during the deploy that ships PR #13293, otherwise admins could open
+    # an underlined attestation with the new (underline-less) editor and crash it.
+    run_on_first_deploy
+
+    def collection
+      AttestationTemplate.where(contains_underline_mark).order(:id).to_a +
+        DossierSubmittedMessage.where(contains_underline_mark).order(:id).to_a
+    end
+
+    def process(record)
+      cleaned = strip_underline_marks(record.json_body)
+      record.update_column(:json_body, cleaned) if cleaned != record.json_body
+    end
+
+    def count
+      collection.size
+    end
+
+    private
+
+    def contains_underline_mark
+      ["json_body::text LIKE ?", '%"underline"%']
+    end
+
+    def strip_underline_marks(node)
+      case node
+      when Array
+        node.map { strip_underline_marks(_1) }
+      when Hash
+        node.each_with_object({}) do |(key, value), result|
+          if key == "marks" && value.is_a?(Array)
+            kept = value.reject { _1.is_a?(Hash) && _1["type"] == "underline" }
+            result[key] = kept if kept.any?
+          else
+            result[key] = strip_underline_marks(value)
+          end
+        end
+      else
+        node
+      end
+    end
+  end
+end

--- a/spec/components/tiptap_editor_component_spec.rb
+++ b/spec/components/tiptap_editor_component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe TiptapEditorComponent, type: :component do
+  let(:dossier_submitted_message) { build(:dossier_submitted_message) }
+  let(:form) do
+    ActionView::Helpers::FormBuilder.new(:dossier_submitted_message, dossier_submitted_message, vc_test_controller.view_context, {})
+  end
+
+  subject(:rendered) { render_inline(described_class.new(form:, field_name: :tiptap_body)) }
+
+  it "renders the formatting toolbar without an underline button" do
+    expect(rendered).to have_button("Gras")
+    expect(rendered).to have_button("Italique")
+    expect(rendered).not_to have_button("Souligné")
+    expect(rendered.to_html).not_to include('data-tiptap-action="underline"')
+  end
+end

--- a/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
@@ -148,6 +148,13 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
           expect(response.body).to have_button("Publier")
           expect(response.body).not_to have_link("Réinitialiser les modifications")
         end
+
+        it 'renders the editor toolbar without an underline button' do
+          subject
+          expect(response.body).to have_button("Gras")
+          expect(response.body).not_to have_button("Souligner")
+          expect(response.body).not_to include('data-tiptap-action="underline"')
+        end
       end
 
       context 'if an attestation template already exist on v1' do

--- a/spec/tasks/maintenance/t20260615_strip_underline_marks_from_tiptap_bodies_task_spec.rb
+++ b/spec/tasks/maintenance/t20260615_strip_underline_marks_from_tiptap_bodies_task_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260615StripUnderlineMarksFromTiptapBodiesTask do
+    def body_with_marks(marks)
+      {
+        "type" => "doc",
+        "content" => [
+          {
+            "type" => "title",
+            "content" => [{ "type" => "text", "text" => "Titre", "marks" => marks }],
+          },
+        ],
+      }
+    end
+
+    describe "#process" do
+      it "removes the underline mark while keeping other marks" do
+        attestation = create(:attestation_template, :v2,
+          json_body: body_with_marks([{ "type" => "bold" }, { "type" => "underline" }, { "type" => "italic" }]))
+
+        described_class.process(attestation)
+
+        text_node = attestation.reload.json_body.dig("content", 0, "content", 0)
+        expect(text_node["marks"]).to eq([{ "type" => "bold" }, { "type" => "italic" }])
+      end
+
+      it "drops the marks key entirely when underline was the only mark" do
+        attestation = create(:attestation_template, :v2,
+          json_body: body_with_marks([{ "type" => "underline" }]))
+
+        described_class.process(attestation)
+
+        text_node = attestation.reload.json_body.dig("content", 0, "content", 0)
+        expect(text_node).not_to have_key("marks")
+      end
+
+      it "also cleans dossier submitted messages" do
+        message = create(:dossier_submitted_message,
+          json_body: body_with_marks([{ "type" => "underline" }]))
+
+        described_class.process(message)
+
+        text_node = message.reload.json_body.dig("content", 0, "content", 0)
+        expect(text_node).not_to have_key("marks")
+      end
+    end
+
+    describe "#collection" do
+      it "only includes records whose json_body contains an underline mark" do
+        with_underline = create(:attestation_template, :v2,
+          json_body: body_with_marks([{ "type" => "underline" }]))
+        without_underline = create(:attestation_template, :v2,
+          json_body: body_with_marks([{ "type" => "italic" }]))
+
+        collection = described_class.collection
+
+        expect(collection).to include(with_underline)
+        expect(collection).not_to include(without_underline)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Pourquoi

Le soulignement n'est pas une bonne pratique d'accessibilité (confusion possible avec un lien). On retire donc cette mise en forme des éditeurs d'attestation.

## Ce que fait la PR

Supprime le bouton **Souligner** et son raccourci clavier (`Ctrl/Cmd+U`) de :
- l'éditeur d'attestation v2 ;
- l'éditeur de l'attestation de dépôt.

L'extension Tiptap `Underline` n'est chargée que si un bouton `data-tiptap-action="underline"` existe dans la barre d'outils : retirer le bouton désactive donc à la fois le bouton et le raccourci, sans modifier le JS.

Une Maintenance task lancée au déploiement enlève le style souligné des attestations V2 et des attestations de dépôt.