### PR TITLE
ETQ usager, vocalisation des messages de statut de champ

### DIFF
--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -15,8 +15,9 @@ module Dsfr
       @as_announcement = as_announcement
     end
 
-    # True when there is a status message worth announcing (excludes validation
-    # errors and the static "prefilled" notice, which are not live updates).
+    # True when the champ has an external/async status message to surface.
+    # Validation errors and the static "prefilled" notice are handled separately
+    # (they are not produced by statut_message).
     def status_announcement?
       statutable? && statut_message.present?
     end

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -6,12 +6,19 @@ module Dsfr
     delegate :type_de_champ, to: :@champ
     delegate :prefilled?, to: :@champ
 
-    def initialize(champ_component:, champ:, row_number: nil)
-      @errors_on_attribute = champ_component.errors_on_attribute?
-      @error_full_messages = champ_component.error_full_messages
-      @error_id = champ.error_id(champ_component.attribute)
+    def initialize(champ:, champ_component: nil, row_number: nil, as_announcement: false)
+      @errors_on_attribute = champ_component&.errors_on_attribute?
+      @error_full_messages = champ_component&.error_full_messages || []
+      @error_id = champ_component ? champ.error_id(champ_component.attribute) : nil
       @champ = champ
       @row_number = row_number
+      @as_announcement = as_announcement
+    end
+
+    # True when there is a status message worth announcing (excludes validation
+    # errors and the static "prefilled" notice, which are not live updates).
+    def status_announcement?
+      statutable? && statut_message.present?
     end
 
     def statutable?
@@ -48,6 +55,12 @@ module Dsfr
     end
 
     def statut_message
+      @statut_message ||= compute_statut_message
+    end
+
+    private
+
+    def compute_statut_message
       case @champ.type_de_champ.type_champ
       when TypeDeChamp.type_champs[:siret]
         # TODO: use fetched? after T20251029backfillChampSiretExternalStateTask
@@ -118,8 +131,6 @@ module Dsfr
         end
       end
     end
-
-    private
 
     def displayable_raison_sociale_or_name(etablissement)
       if etablissement.diffusable_commercialement

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -2,7 +2,7 @@
   - if status_announcement?
     = sanitize(statut_message[:text])
 - else
-  .fr-messages-group{ id: @error_id, aria: { live: :assertive } }
+  .fr-messages-group{ id: @error_id, aria: { live: (@error_full_messages.size > 0 ? :assertive : nil) } }
     - if @error_full_messages.size > 0
       %p{ class: class_names('fr-message' => true, "fr-message--#{@errors_on_attribute ? 'error' : 'valid'}" => true) }
         = "« #{libelle} » "

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -1,11 +1,15 @@
-.fr-messages-group{ id: @error_id, aria: { live: :assertive } }
-  - if @error_full_messages.size > 0
-    %p{ class: class_names('fr-message' => true, "fr-message--#{@errors_on_attribute ? 'error' : 'valid'}" => true) }
-      = "« #{libelle} » "
+- if @as_announcement
+  - if status_announcement?
+    = sanitize(statut_message[:text])
+- else
+  .fr-messages-group{ id: @error_id, aria: { live: :assertive } }
+    - if @error_full_messages.size > 0
+      %p{ class: class_names('fr-message' => true, "fr-message--#{@errors_on_attribute ? 'error' : 'valid'}" => true) }
+        = "« #{libelle} » "
 
-      = @error_full_messages.to_sentence
-  - elsif statutable? && statut_message.present?
-    %p.fr-message{ class: "fr-message--#{statut_message[:state]}" }= sanitize(statut_message[:text])
+        = @error_full_messages.to_sentence
+    - elsif statutable? && statut_message.present?
+      %p.fr-message{ class: "fr-message--#{statut_message[:state]}" }= sanitize(statut_message[:text])
 
-  - if prefilled?
-    %p.fr-message.fr-message--info= sanitize(t('.prefilled'))
+    - if prefilled?
+      %p.fr-message.fr-message--info= sanitize(t('.prefilled'))

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -8,7 +8,7 @@
         = "« #{libelle} » "
 
         = @error_full_messages.to_sentence
-    - elsif statutable? && statut_message.present?
+    - elsif status_announcement?
       %p.fr-message{ class: "fr-message--#{statut_message[:state]}" }= sanitize(statut_message[:text])
 
     - if prefilled?

--- a/app/components/editable_champ/section_component/section_component.html.haml
+++ b/app/components/editable_champ/section_component/section_component.html.haml
@@ -9,7 +9,7 @@
         - else
           = fields_for champ.input_name, champ do |form|
             = render EditableChamp::EditableChampComponent.new form:, champ:, row_number: @row_number
-          - if champ.piece_justificative?
+          - if champ.status_announceable?
             .fr-sr-only{ id: "#{champ.focusable_input_id}-aria-live", role: 'status', 'aria-live': 'polite', 'aria-atomic': 'true' }
 - else
   - if header_section
@@ -21,5 +21,5 @@
     - else
       = fields_for champ.input_name, champ do |form|
         = render EditableChamp::EditableChampComponent.new form:, champ:, row_number: @row_number
-      - if champ.piece_justificative?
+      - if champ.status_announceable?
         .fr-sr-only{ id: "#{champ.focusable_input_id}-aria-live", role: 'status', 'aria-live': 'polite', 'aria-atomic': 'true' }

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -376,6 +376,7 @@ module Users
 
     # polling url for champ
     def champ
+      @polling = true
       @dossier = dossier_with_champs(pj_template: false)
       type_de_champ = dossier.find_type_de_champ_by_stable_id(params[:stable_id], :public)
       champ = dossier.project_champ(type_de_champ, row_id: params[:row_id])

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -105,6 +105,13 @@ class Champ < ApplicationRecord
     !private?
   end
 
+  # Champs that can surface an external/async status message (rendered by
+  # Dsfr::InputStatusMessageComponent) and therefore need a persistent
+  # live region to announce it to screen readers.
+  def status_announceable?
+    siret? || rna? || referentiel? || dossier_link? || piece_justificative?
+  end
+
   def prefilled_from_france_connect_information?
     data&.dig("prefilled_from_france_connect_information") == true
   end

--- a/app/views/shared/dossiers/_update_champ.turbo_stream.erb
+++ b/app/views/shared/dossiers/_update_champ.turbo_stream.erb
@@ -9,16 +9,13 @@
     <% end %>
   <% end %>
 
-  <%# Announce the champ status (and any caller-provided notice, e.g. antivirus scan) %>
-  <%# into the champ's persistent sr-only live region, which is never recreated by %>
-  <%# the replace above. See EditableChamp::SectionComponent. %>
+  <%# Announce the champ status into its persistent sr-only live region, which is %>
+  <%# never recreated by the replace above. See EditableChamp::SectionComponent. %>
   <% polling = local_assigns.fetch(:polling, false) %>
-  <% extra_announcement = local_assigns.fetch(:extra_announcement, nil) %>
-  <% if full && !(polling && champ.pending?) %>
-    <% status = render(Dsfr::InputStatusMessageComponent.new(champ:, as_announcement: true)) if champ.status_announceable? %>
-    <% parts = [extra_announcement, status].select { it.to_s.strip.present? } %>
-    <% if parts.any? %>
-      <%= turbo_stream.update "#{champ.focusable_input_id}-aria-live" do %><%= safe_join(parts, ' ') %><% end %>
+  <% if full && champ.status_announceable? && !(polling && champ.pending?) %>
+    <% status = render(Dsfr::InputStatusMessageComponent.new(champ:, as_announcement: true)) %>
+    <% if status.to_s.strip.present? %>
+      <%= turbo_stream.update "#{champ.focusable_input_id}-aria-live" do %><%= status %><% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/dossiers/_update_champ.turbo_stream.erb
+++ b/app/views/shared/dossiers/_update_champ.turbo_stream.erb
@@ -8,4 +8,19 @@
       <%= render EditableChamp::ChampLabelContentComponent.new champ:, form: %>
     <% end %>
   <% end %>
+
+  <%# Announce the champ status (and any caller-provided notice, e.g. antivirus scan) %>
+  <%# into the champ's persistent sr-only live region, which is never recreated by %>
+  <%# the replace above. See EditableChamp::SectionComponent. %>
+  <% polling = local_assigns.fetch(:polling, false) %>
+  <% extra_announcement = local_assigns.fetch(:extra_announcement, nil) %>
+  <% if full && (champ.status_announceable? || extra_announcement.present?) && !(polling && champ.pending?) %>
+    <% status = render(Dsfr::InputStatusMessageComponent.new(champ:, as_announcement: true)) %>
+    <% parts = [] %>
+    <% parts << extra_announcement if extra_announcement.present? %>
+    <% parts << status if status.to_s.strip.present? %>
+    <% if parts.any? %>
+      <%= turbo_stream.update "#{champ.focusable_input_id}-aria-live" do %><%= safe_join(parts, ' ') %><% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/shared/dossiers/_update_champ.turbo_stream.erb
+++ b/app/views/shared/dossiers/_update_champ.turbo_stream.erb
@@ -14,11 +14,9 @@
   <%# the replace above. See EditableChamp::SectionComponent. %>
   <% polling = local_assigns.fetch(:polling, false) %>
   <% extra_announcement = local_assigns.fetch(:extra_announcement, nil) %>
-  <% if full && (champ.status_announceable? || extra_announcement.present?) && !(polling && champ.pending?) %>
-    <% status = render(Dsfr::InputStatusMessageComponent.new(champ:, as_announcement: true)) %>
-    <% parts = [] %>
-    <% parts << extra_announcement if extra_announcement.present? %>
-    <% parts << status if status.to_s.strip.present? %>
+  <% if full && !(polling && champ.pending?) %>
+    <% status = render(Dsfr::InputStatusMessageComponent.new(champ:, as_announcement: true)) if champ.status_announceable? %>
+    <% parts = [extra_announcement, status].select { it.to_s.strip.present? } %>
     <% if parts.any? %>
       <%= turbo_stream.update "#{champ.focusable_input_id}-aria-live" do %><%= safe_join(parts, ' ') %><% end %>
     <% end %>

--- a/app/views/shared/dossiers/_update_champs.turbo_stream.erb
+++ b/app/views/shared/dossiers/_update_champs.turbo_stream.erb
@@ -4,8 +4,9 @@
 <% if to_hide.present? %>
   <%= turbo_stream.hide_all(to_hide) %>
 <% end %>
+<% polling = local_assigns.fetch(:polling, false) %>
 <% to_update.each do |champ| %>
-  <%= render partial: 'shared/dossiers/update_champ', locals: { full: champ.refresh_after_update?, champ: } %>
+  <%= render partial: 'shared/dossiers/update_champ', locals: { full: champ.refresh_after_update?, champ:, polling: } %>
 <% end %>
 
 <%= turbo_stream.remove_all(".editable-champ + .spinner-removable") %>

--- a/app/views/users/dossiers/update.turbo_stream.erb
+++ b/app/views/users/dossiers/update.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'shared/dossiers/update_champs', locals: { to_show: @to_show, to_hide: @to_hide, to_update: @to_update } %>
+<%= render partial: 'shared/dossiers/update_champs', locals: { to_show: @to_show, to_hide: @to_hide, to_update: @to_update, polling: @polling } %>
 <%= render partial: 'shared/dossiers/update_footer', locals: { dossier: @dossier } %>
 
 <% if params[:validate].present? %>

--- a/spec/components/dsfr/input_status_message_component_spec.rb
+++ b/spec/components/dsfr/input_status_message_component_spec.rb
@@ -24,4 +24,26 @@ describe Dsfr::InputStatusMessageComponent, type: :component do
       end
     end
   end
+
+  describe 'visible mode aria-live' do
+    let(:no_error_component) { double('champ_component', errors_on_attribute?: false, error_full_messages: [], attribute: :value) }
+    let(:error_component) { double('champ_component', errors_on_attribute?: true, error_full_messages: ['est invalide'], attribute: :value) }
+
+    context 'with a status message and no validation error' do
+      before { champ.update_column(:external_state, :waiting_for_job) }
+
+      it 'drops aria-live (the sr-only region announces the status instead)' do
+        render_inline(described_class.new(champ:, champ_component: no_error_component))
+        expect(page).to have_css('.fr-messages-group')
+        expect(page).not_to have_css('.fr-messages-group[aria-live]')
+      end
+    end
+
+    context 'with a validation error' do
+      it 'keeps aria-live="assertive" for the error' do
+        render_inline(described_class.new(champ:, champ_component: error_component))
+        expect(page).to have_css('.fr-messages-group[aria-live="assertive"]')
+      end
+    end
+  end
 end

--- a/spec/components/dsfr/input_status_message_component_spec.rb
+++ b/spec/components/dsfr/input_status_message_component_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe Dsfr::InputStatusMessageComponent, type: :component do
+  let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: 'rib' }]) }
+  let(:dossier) { create(:dossier, procedure:) }
+  let(:champ) { dossier.champs.first }
+
+  describe 'announcement mode' do
+    context 'when the RIB analysis is pending' do
+      before { champ.update_column(:external_state, :waiting_for_job) }
+
+      it 'renders only the status text (no .fr-messages-group wrapper)' do
+        render_inline(described_class.new(champ:, as_announcement: true))
+        expect(page).to have_text('Contenu du fichier en cours')
+        expect(page).not_to have_css('.fr-messages-group')
+      end
+    end
+
+    context 'when the champ is idle (no status to announce)' do
+      it 'renders nothing' do
+        render_inline(described_class.new(champ:, as_announcement: true))
+        expect(page).not_to have_text('Contenu du fichier')
+        expect(page).not_to have_css('.fr-messages-group')
+      end
+    end
+  end
+end

--- a/spec/components/editable_champ/section_component_spec.rb
+++ b/spec/components/editable_champ/section_component_spec.rb
@@ -116,6 +116,25 @@ describe EditableChamp::SectionComponent, type: :component do
     end
   end
 
+  context 'persistent live region for status-bearing champs' do
+    context 'with a SIRET champ' do
+      let(:types_de_champ_public) { [{ type: :siret }] }
+
+      it 'renders a persistent sr-only polite live region' do
+        champ = dossier.project_champs_public.first
+        expect(page).to have_css("##{champ.focusable_input_id}-aria-live.fr-sr-only[aria-live='polite']", visible: :all)
+      end
+    end
+
+    context 'with a plain text champ' do
+      let(:types_de_champ_public) { [{ type: :text }] }
+
+      it 'does not render a live region' do
+        expect(page).not_to have_css(".fr-sr-only[aria-live='polite']", visible: :all)
+      end
+    end
+  end
+
   context 'with complex markup structure' do
     def check_fieldset_structure(fieldset)
       expect(fieldset[:class]).to include('fr-fieldset')

--- a/spec/controllers/champs/piece_justificative_controller_spec.rb
+++ b/spec/controllers/champs/piece_justificative_controller_spec.rb
@@ -146,9 +146,31 @@ describe Champs::PieceJustificativeController, type: :controller do
         expect(response.body).to include(%(<turbo-stream action="focus" targets="#persisted_row_attachment_#{attachment.id} [data-attachment-delete-button]">))
       end
 
-      it 'does not push any aria-live announcement after upload (no visual equivalent)' do
+      it 'does not push any aria-live announcement for a plain PJ (no visual equivalent)' do
         subject
         expect(response.body).not_to include(%(<turbo-stream action="update" target="#{champ.focusable_input_id}-aria-live">))
+      end
+    end
+
+    context 'when the champ is a RIB whose content analysis is pending (#13104)' do
+      let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative, nature: 'rib' }]) }
+      let(:dossier) { create(:dossier, user: user, procedure: procedure) }
+      let(:champ) { dossier.project_champs_public.first }
+      let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
+
+      before do
+        allow_any_instance_of(Champs::PieceJustificativeChamp).to receive(:has_async_external_data?).and_return(true)
+        allow_any_instance_of(Champs::PieceJustificativeChamp).to receive(:fetch_later!)
+        allow_any_instance_of(Champs::PieceJustificativeChamp).to receive(:idle?).and_return(false)
+        allow_any_instance_of(Champs::PieceJustificativeChamp).to receive(:pending?).and_return(true)
+      end
+
+      it 'announces the OCR status inside the champ’s persistent live region' do
+        subject
+        doc = Nokogiri::HTML5.fragment(response.body)
+        region = doc.css(%(turbo-stream[action="update"][target="#{champ.focusable_input_id}-aria-live"]))
+        expect(region).to be_present
+        expect(region.text).to include('Contenu du fichier en cours')
       end
     end
 

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -2349,6 +2349,35 @@ describe Users::DossiersController, type: :controller do
       end
     end
 
+    context 'live announcement of a RIB status (polling anti-spam)' do
+      render_views
+      let(:types_de_champ_public) { [{ type: :piece_justificative, nature: 'rib', stable_id: }] }
+      let(:champ) { dossier.project_champs_public.first }
+      let(:region_id) { "#{champ.focusable_input_id}-aria-live" }
+
+      def announced_region(body)
+        Nokogiri::HTML5.fragment(body).css(%(turbo-stream[action="update"][target="#{region_id}"]))
+      end
+
+      context 'while the analysis is still pending' do
+        before { dossier.champs.first.update_column(:external_state, :waiting_for_job) }
+
+        it 'does not re-announce the pending status on a poll' do
+          subject
+          expect(announced_region(response.body)).to be_empty
+        end
+      end
+
+      context 'when the analysis has completed' do
+        before { dossier.champs.first.update_columns(external_state: :fetched, value_json: { 'rib' => { 'iban' => 'FR7612345' } }) }
+
+        it 'announces the result on the poll that observes completion' do
+          subject
+          expect(announced_region(response.body).text).to include('FR7612345')
+        end
+      end
+    end
+
     context 'when champ is pollable' do
       let(:referentiel) { create(:api_referentiel, :exact_match) }
       let(:types_de_champ_public) { [{ type: :referentiel, referentiel:, stable_id: }] }

--- a/spec/system/users/piece_justificative_drag_drop_spec.rb
+++ b/spec/system/users/piece_justificative_drag_drop_spec.rb
@@ -94,6 +94,31 @@ describe 'Piece justificative drag and drop', js: true do
         expect(page).to have_text('Formats acceptés : .pdf, .doc, .docx, .jpg, .jpeg, .png')
       end
     end
+
+    scenario 'announces the RIB analysis status in the persistent live region after upload (#13104)' do
+      procedure_rib = create(:procedure, :published, :for_individual, types_de_champ_public: [{ type: :piece_justificative, libelle: 'RIB', nature: 'rib' }])
+      login_as(user, scope: :user)
+      visit commencer_path(path: procedure_rib.path)
+      click_on 'Commencer la démarche'
+      fill_individual
+
+      # Capture the persistent live region id before upload: a RIB is single-file,
+      # so the labelled input disappears once a file is attached.
+      file_input = find_field('RIB', visible: :all)
+      live_region_selector = "##{file_input[:id]}-aria-live"
+
+      attach_file('RIB', Rails.root.join('spec/fixtures/files/file.pdf'))
+      expect(page).to have_text('file.pdf')
+
+      # The status is announced into the champ's persistent sr-only live region
+      # (which survives the turbo_stream.replace), not into the recreated champ.
+      expect(page).to have_css(
+        live_region_selector,
+        text: 'Contenu du fichier en cours',
+        visible: :all,
+        wait: 5
+      )
+    end
   end
 
   context 'client-side validation and error handling' do


### PR DESCRIPTION
> Empilée sur #13245 (zone de dépôt PJ) — à merger après elle.

## Contexte

Les messages de statut des champs
(résultat d'une recherche SIRET, analyse d'un RIB, référentiel, lien dossier, RNA…)
s'affichent visuellement mais ne sont **pas vocalisés** par les lecteurs d'écran.

La région `aria-live` qui les portait était rendue **à l'intérieur** du sous-arbre
du champ, recréé à chaque mise à jour par `turbo_stream.replace`. Une région live
recréée avec son contenu déjà présent n'est pas annoncée de façon fiable : elle doit
préexister dans le DOM et voir son contenu *muter*.

## Changements

- Région `sr-only` **persistante par champ** (rendue hors du sous-arbre recréé),
  alimentée par turbo stream — pour tous les champs porteurs de statut
  (SIRET, RNA, référentiel, lien dossier, RIB).
- Le texte annoncé réutilise le composant de statut existant (pas de duplication i18n).
- Anti-spam : le message « en cours d'analyse » n'est plus réannoncé à chaque polling.
- Retrait de l'`aria-live="assertive"` redondant sur les statuts visibles
  (conservé pour les erreurs de validation).