### PR TITLE
Tech: élague les jobs cron orphelins dans Redis au déploiement

### DIFF
--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -3,7 +3,9 @@
 namespace :jobs do
   desc 'Schedule all schedulable cron jobs'
   task schedule: :environment do
-    schedulable_jobs.each(&:schedule)
+    jobs = schedulable_jobs
+    jobs.each(&:schedule)
+    prune_orphaned_cron_jobs(jobs)
   end
 
   desc 'Display schedule for all schedulable cron jobs'
@@ -15,5 +17,16 @@ namespace :jobs do
     glob = Rails.root.join('app', 'jobs', '**', '*_job.rb')
     Dir.glob(glob).each { |f| require f }
     Cron::CronJob.descendants.filter(&:schedulable?)
+  end
+
+  # Remove cron schedules left in Redis after their job class was deleted or
+  # renamed. sidekiq-cron's own `destroy_removed_jobs` only considers jobs with
+  # source == "schedule", but ours are created via `Sidekiq::Cron::Job.create`
+  # (source == "dynamic"), so we prune by comparing against the known classes.
+  def prune_orphaned_cron_jobs(jobs)
+    known_classes = jobs.map(&:name).to_set
+    Sidekiq::Cron::Job.all.each do |cron_job| # rubocop:disable Rails/FindEach -- not an ActiveRecord relation
+      cron_job.destroy unless known_classes.include?(cron_job.klass)
+    end
   end
 end

--- a/spec/lib/tasks/jobs_spec.rb
+++ b/spec/lib/tasks/jobs_spec.rb
@@ -3,8 +3,36 @@
 describe 'jobs' do
   describe 'schedule' do
     subject { Rake::Task['jobs:schedule'].invoke }
+
+    after(:each) { Rake::Task['jobs:schedule'].reenable }
+
     it 'runs' do
       expect { subject }.not_to raise_error
+    end
+
+    context 'when an orphaned cron job remains in Redis' do
+      let(:known_class) { Cron::ExpiredDossiersBrouillonDeletionJob.name }
+      let(:orphan_class) { 'Cron::ThisJobNoLongerExistsJob' }
+
+      before do
+        Sidekiq::Cron::Job.create(name: known_class, cron: '0 0 * * *', class: known_class)
+        Sidekiq::Cron::Job.create(name: orphan_class, cron: '0 0 * * *', class: orphan_class)
+      end
+
+      after do
+        Sidekiq::Cron::Job.destroy(known_class)
+        Sidekiq::Cron::Job.destroy(orphan_class)
+      end
+
+      it 'destroys cron jobs whose class is no longer schedulable' do
+        expect { subject }.to change { Sidekiq::Cron::Job.find(orphan_class) }.to(nil)
+      end
+
+      it 'keeps cron jobs whose class is still schedulable' do
+        subject
+
+        expect(Sidekiq::Cron::Job.find(known_class)).to be_present
+      end
     end
   end
 end


### PR DESCRIPTION
Quand une sous-classe de `Cron::CronJob` est supprimée ou renommée, son entrée sidekiq-cron reste dans Redis et continue d'enfiler un job vers une constante qui n'existe plus → `NameError` à chaque tick.

Sentry : [RAILS-JZ8](https://demarches-simplifiees.sentry.io/issues/RAILS-JZ8)

`jobs:schedule` ne faisait qu'ajouter des schedules, jamais retirer les obsolètes. Le `destroy_removed_jobs` natif de sidekiq-cron ne prune que les jobs avec `source == "schedule"`, or les nôtres sont créés via `Sidekiq::Cron::Job.create` (`source == "dynamic"`) : il les ignore. On élague donc en comparant les crons présents dans Redis aux classes schedulables connues.

`jobs:schedule` tournant à chaque déploiement, c'est auto-réparateur : les orphelins existants disparaissent au prochain deploy, sans action manuelle.