### PR TITLE
ETQ usager, meilleure saisie et affichage du champ « lien vers un autre dossier »

### DIFF
--- a/app/assets/stylesheets/combobox.scss
+++ b/app/assets/stylesheets/combobox.scss
@@ -1,5 +1,8 @@
-.fr-label + .fr-ds-combobox {
+.fr-label + .fr-ds-combobox,
+.fr-label + react-fragment > .fr-ds-combobox {
   // same as .fr-label + .fr-input
+  // the combobox can be wrapped in a <react-fragment> (display: block),
+  // which breaks the `.fr-label + .fr-ds-combobox` adjacency
   margin-top: 0.5rem;
 }
 

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -129,7 +129,7 @@ module Dsfr
                                          hidden_at: l(dossier.hidden_by_user_at.to_date)),
             }
           else
-            { state: :info, text: dossier.text_summary }
+            { state: :info, text: helpers.dossier_link_summary(dossier, @champ.dossier.user) }
           end
         end
       when TypeDeChamp.type_champs[:referentiel]

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -152,20 +152,20 @@ module Dsfr
         if @champ.pending?
           { state: :info, text: t('.pj.info') }
         elsif @champ.external_error?
-          { state: :warning, text: t('.pj.error') }
+          { state: :warning, text: t('.pj.error_html') }
         elsif @champ.justificatif_domicile?
           justif = @champ.ocr_result
           if justif&.two_ddoc
             { state: :valid, text: t('.pj.justif_domicile.valid_html', beneficiary: justif.beneficiary, address: justif.label, issue_date: l(justif.issue_date)) }
           else
-            { state: :warning, text: t('.pj.justif_domicile.warning') }
+            { state: :warning, text: t('.pj.justif_domicile.warning_html') }
           end
         elsif @champ.avis_impot?
           avis = @champ.ocr_result
           if avis&.two_ddoc
             { state: :valid, text: t('.pj.avis_impot.valid_html', declarant: avis.declarant_1, reference: avis.reference_avis, annee: avis.annee_des_revenus) }
           else
-            { state: :warning, text: t('.pj.avis_impot.warning') }
+            { state: :warning, text: t('.pj.avis_impot.warning_html') }
           end
         else
           value_json = @champ.value_json
@@ -173,9 +173,9 @@ module Dsfr
           bank_name = value_json&.dig('rib', 'bank_name')
 
           if iban.nil?
-            { state: :warning, text: t('.pj.warning') }
+            { state: :warning, text: t('.pj.warning_html') }
           else
-            text = bank_name.present? ? t('.pj.valid_with_bank', iban:, bank_name:) : t('.pj.valid', iban:)
+            text = bank_name.present? ? t('.pj.valid_with_bank_html', iban:, bank_name:) : t('.pj.valid', iban:)
             { state: :valid, text: }
           end
         end

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -128,8 +128,10 @@ module Dsfr
                                          procedure_libelle: dossier.procedure.libelle,
                                          hidden_at: l(dossier.hidden_by_user_at.to_date)),
             }
-          else
+          elsif !dossier.brouillon?
             { state: :info, text: helpers.dossier_link_summary(dossier, @champ.dossier.user) }
+          else
+            { state: :info, text: dossier.text_summary }
           end
         end
       when TypeDeChamp.type_champs[:referentiel]

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
@@ -24,13 +24,13 @@ en:
   prefilled: "Prefilled data."
   pj:
     info: "The file content will be analyzed …"
-    warning: "Our system could not identify the IBAN number.<br>Please check your document, or ignore this message if you are confident about your file."
+    warning_html: "Our system could not identify the IBAN number.<br>Please check your document, or ignore this message if you are confident about your file."
     valid: "Our system identified the IBAN %{iban}"
-    valid_with_bank: "Our system identified the IBAN %{iban} - <b>%{bank_name}</b>"
-    error: "An error occurred while parsing your document.<br>Ignore this message if you are confident about your file."
+    valid_with_bank_html: "Our system identified the IBAN %{iban} - <b>%{bank_name}</b>"
+    error_html: "An error occurred while parsing your document.<br>Ignore this message if you are confident about your file."
     justif_domicile:
-      warning: "We were unable to verify the address contained in the supporting document.<br>Ignore this message if you are confident your file is correct."
+      warning_html: "We were unable to verify the address contained in the supporting document.<br>Ignore this message if you are confident your file is correct."
       valid_html: "Proof of residence in the name of <strong>%{beneficiary}</strong> (<strong>%{address}</strong>), issued on <strong>%{issue_date}</strong>."
     avis_impot:
-      warning: "We were unable to read the information in the tax notice.<br>Ignore this message if you are confident your file is correct."
+      warning_html: "We were unable to read the information in the tax notice.<br>Ignore this message if you are confident your file is correct."
       valid_html: "Tax notice in the name of <strong>%{declarant}</strong> (reference <strong>%{reference}</strong>), income year <strong>%{annee}</strong>."

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
@@ -24,14 +24,14 @@ fr:
   prefilled: "Donnée remplie automatiquement."
   pj:
     info: "Contenu du fichier en cours d’analyse…"
-    warning: "Notre système n’a pas pu identifier le numéro IBAN.<br>Vérifiez votre document ou ne tenez pas compte de ce message si vous êtes sûr(e) de votre fichier."
+    warning_html: "Notre système n’a pas pu identifier le numéro IBAN.<br>Vérifiez votre document ou ne tenez pas compte de ce message si vous êtes sûr(e) de votre fichier."
     valid: "Notre système a identifié l’IBAN %{iban}"
-    valid_with_bank: "Notre système a identifié l’IBAN %{iban} - <b>%{bank_name}</b>"
-    error: "Une erreur est survenue lors de l’analyse de votre document.<br>Ne tenez pas compte de ce message si vous êtes sûr(e) de votre fichier."
+    valid_with_bank_html: "Notre système a identifié l’IBAN %{iban} - <b>%{bank_name}</b>"
+    error_html: "Une erreur est survenue lors de l’analyse de votre document.<br>Ne tenez pas compte de ce message si vous êtes sûr(e) de votre fichier."
     justif_domicile:
-      warning: "Nous n’avons pas pu vérifier l’adresse contenue dans le justificatif.<br>Ignorez ce message si vous êtes sûr(e) de votre fichier."
+      warning_html: "Nous n’avons pas pu vérifier l’adresse contenue dans le justificatif.<br>Ignorez ce message si vous êtes sûr(e) de votre fichier."
       valid_html: "Justificatif de domicile au nom de <strong>%{beneficiary}</strong> (<strong>%{address}</strong>), émis le <strong>%{issue_date}</strong>."
     avis_impot:
-      warning: "Nous n’avons pas pu lire les informations de l’avis d’impôt.<br>Ignorez ce message si vous êtes sûr(e) de votre fichier."
+      warning_html: "Nous n’avons pas pu lire les informations de l’avis d’impôt.<br>Ignorez ce message si vous êtes sûr(e) de votre fichier."
       valid_html: "Avis d’impôt au nom de <strong>%{declarant}</strong> (référence <strong>%{reference}</strong>), revenus <strong>%{annee}</strong>."
 

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.html.haml
@@ -10,7 +10,7 @@
         = @error_full_messages.to_sentence
     - elsif status_announcement?
       %p.fr-message{ class: "fr-message--#{statut_message[:state]}" }
-        %span= sanitize(statut_message[:text])
+        %span= statut_message[:text]
 
     - if prefilled?
       %p.fr-message.fr-message--info= sanitize(t('.prefilled'))

--- a/app/components/editable_champ/champ_label_content_component.rb
+++ b/app/components/editable_champ/champ_label_content_component.rb
@@ -54,6 +54,8 @@ class EditableChamp::ChampLabelContentComponent < ApplicationComponent
         number_hints
       elsif @champ.textarea?
         text_hints
+      elsif @champ.dossier_link?
+        dossier_link_hints
       else
         []
       end
@@ -66,6 +68,13 @@ class EditableChamp::ChampLabelContentComponent < ApplicationComponent
   end
 
   private
+
+  # The dossier_link hint depends on its input mode: a select prompt when the
+  # field is limited to some procedures, the free-text format otherwise.
+  def dossier_link_hints
+    key = @champ.type_de_champ.procedures_limit? ? :select : :free
+    [I18n.t("activerecord.attributes.champs/dossier_link_champ.hints.#{key}", application_name: APPLICATION_NAME)]
+  end
 
   def formatted_champ_hints
     if @champ.formatted_simple?

--- a/app/components/editable_champ/champ_label_content_component.rb
+++ b/app/components/editable_champ/champ_label_content_component.rb
@@ -69,10 +69,10 @@ class EditableChamp::ChampLabelContentComponent < ApplicationComponent
 
   private
 
-  # The dossier_link hint depends on its input mode: a select prompt when the
-  # field is limited to some procedures, the free-text format otherwise.
+  # The dossier_link hint depends on its actual input mode: a select prompt when the
+  # user picks among their dossiers, the free-text format otherwise.
   def dossier_link_hints
-    key = @champ.type_de_champ.procedures_limit? ? :select : :free
+    key = @champ.selectable? ? :select : :free
     [I18n.t("activerecord.attributes.champs/dossier_link_champ.hints.#{key}", application_name: APPLICATION_NAME)]
   end
 

--- a/app/components/editable_champ/dossier_link_component.rb
+++ b/app/components/editable_champ/dossier_link_component.rb
@@ -1,7 +1,92 @@
 # frozen_string_literal: true
 
 class EditableChamp::DossierLinkComponent < EditableChamp::EditableChampBaseComponent
+  COMBOBOX_THRESHOLD = 20
+
   def dsfr_input_classname
-    'fr-input'
+    limited? ? 'fr-select' : 'fr-input'
+  end
+
+  def limited?
+    @champ.type_de_champ.procedures_limit? && allowed_procedures.any?
+  end
+
+  def render_combobox?
+    total_dossiers >= COMBOBOX_THRESHOLD
+  end
+
+  def grouped_select_options
+    grouped_dossiers.map do |procedure, dossiers|
+      options = if dossiers.empty?
+        [[t('.no_dossier_in_procedure'), '', { disabled: true }]]
+      else
+        dossiers.map { |dossier| [option_label(dossier), dossier.id.to_s] }
+      end
+
+      [t('.procedure_group', libelle: procedure.libelle), options]
+    end
+  end
+
+  def combobox_react_props
+    {
+      id: @champ.focusable_input_id,
+      name: @form.field_name(:value),
+      sections: combobox_sections,
+      selected_key: @champ.value.presence,
+      placeholder: t('.select_placeholder'),
+      is_required: @champ.required?,
+      'aria-describedby': select_aria_describedby,
+    }.compact
+  end
+
+  def select_class_names
+    class_names('width-100': contains_long_option?, 'fr-select': true)
+  end
+
+  def select_aria_describedby
+    describedby = []
+    describedby << @champ.describedby_id if @champ.description.present?
+    describedby << @champ.error_id(:value) if errors_on_attribute?
+    describedby.presence&.join(' ')
+  end
+
+  private
+
+  def combobox_sections
+    grouped_dossiers.map do |procedure, dossiers|
+      {
+        label: t('.procedure_section', libelle: procedure.libelle),
+        items: dossiers.map { |dossier| { label: option_label(dossier), value: dossier.id.to_s } },
+      }
+    end
+  end
+
+  def allowed_procedures
+    @allowed_procedures ||= begin
+      ids = @champ.type_de_champ.dossier_link_procedure_ids
+      Procedure.where(id: ids).index_by(&:id).values_at(*ids).compact
+    end
+  end
+
+  def grouped_dossiers
+    @grouped_dossiers ||= allowed_procedures.index_with do |procedure|
+      procedure.dossiers
+        .visible_by_user_or_administration
+        .where(user_id: @champ.dossier.user_id, state: Dossier::SOUMIS)
+        .where.not(id: @champ.dossier_id)
+        .order(depose_at: :desc)
+    end
+  end
+
+  def total_dossiers
+    grouped_dossiers.sum { |_procedure, dossiers| dossiers.size }
+  end
+
+  def contains_long_option?
+    grouped_dossiers.any? { |procedure, _dossiers| procedure.libelle.size > 100 }
+  end
+
+  def option_label(dossier)
+    t('.option', id: dossier.id, date: l(dossier.depose_at.to_date))
   end
 end

--- a/app/components/editable_champ/dossier_link_component.rb
+++ b/app/components/editable_champ/dossier_link_component.rb
@@ -35,6 +35,8 @@ class EditableChamp::DossierLinkComponent < EditableChamp::EditableChampBaseComp
       selected_key: @champ.value.presence,
       placeholder: t('.select_placeholder'),
       is_required: @champ.required?,
+      labelId: input_label_id(@champ),
+      ariaLabelledbyPrefix: aria_labelledby_prefix,
       'aria-describedby': select_aria_describedby,
     }.compact
   end

--- a/app/components/editable_champ/dossier_link_component.rb
+++ b/app/components/editable_champ/dossier_link_component.rb
@@ -8,7 +8,7 @@ class EditableChamp::DossierLinkComponent < EditableChamp::EditableChampBaseComp
   end
 
   def limited?
-    @champ.type_de_champ.procedures_limit? && allowed_procedures.any?
+    @champ.selectable?
   end
 
   def render_combobox?
@@ -61,21 +61,8 @@ class EditableChamp::DossierLinkComponent < EditableChamp::EditableChampBaseComp
     end
   end
 
-  def allowed_procedures
-    @allowed_procedures ||= begin
-      ids = @champ.type_de_champ.dossier_link_procedure_ids
-      Procedure.where(id: ids).index_by(&:id).values_at(*ids).compact
-    end
-  end
-
   def grouped_dossiers
-    @grouped_dossiers ||= allowed_procedures.index_with do |procedure|
-      procedure.dossiers
-        .visible_by_user_or_administration
-        .where(user_id: @champ.dossier.user_id, state: Dossier::SOUMIS)
-        .where.not(id: @champ.dossier_id)
-        .order(depose_at: :desc)
-    end
+    @champ.linkable_dossiers_by_procedure
   end
 
   def total_dossiers
@@ -83,7 +70,7 @@ class EditableChamp::DossierLinkComponent < EditableChamp::EditableChampBaseComp
   end
 
   def contains_long_option?
-    grouped_dossiers.any? { |procedure, _dossiers| procedure.libelle.size > 100 }
+    @champ.linkable_procedures.any? { |procedure| procedure.libelle.size > 100 }
   end
 
   def option_label(dossier)

--- a/app/components/editable_champ/dossier_link_component.rb
+++ b/app/components/editable_champ/dossier_link_component.rb
@@ -76,6 +76,10 @@ class EditableChamp::DossierLinkComponent < EditableChamp::EditableChampBaseComp
   end
 
   def option_label(dossier)
-    t('.option', id: dossier.id, date: l(dossier.depose_at.to_date))
+    if dossier.expired?
+      t('.option_expired', id: dossier.id, date: l(dossier.depose_on), expired_date: l(dossier.expired_on))
+    else
+      t('.option', id: dossier.id, date: l(dossier.depose_on))
+    end
   end
 end

--- a/app/components/editable_champ/dossier_link_component.rb
+++ b/app/components/editable_champ/dossier_link_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EditableChamp::DossierLinkComponent < EditableChamp::EditableChampBaseComponent
-  COMBOBOX_THRESHOLD = 20
+  THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE = 20
 
   def dsfr_input_classname
     limited? ? 'fr-select' : 'fr-input'
@@ -11,8 +11,8 @@ class EditableChamp::DossierLinkComponent < EditableChamp::EditableChampBaseComp
     @champ.selectable?
   end
 
-  def render_combobox?
-    total_dossiers >= COMBOBOX_THRESHOLD
+  def render_as_autocomplete?
+    total_dossiers >= THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE
   end
 
   def grouped_select_options
@@ -23,19 +23,21 @@ class EditableChamp::DossierLinkComponent < EditableChamp::EditableChampBaseComp
         dossiers.map { |dossier| [option_label(dossier), dossier.id.to_s] }
       end
 
-      [t('.procedure_section', libelle: procedure.libelle), options]
+      [section_label(procedure), options]
     end
   end
 
-  def combobox_react_props
+  def select_react_props
     {
-      id: @champ.focusable_input_id,
+      class_name: 'fr-mt-1w',
+      trigger_id: @champ.focusable_input_id,
       name: @form.field_name(:value),
-      sections: combobox_sections,
-      selected_key: @champ.value.presence,
+      sections: select_sections,
+      disabled_keys:,
+      value: @champ.value.presence,
       placeholder: t('.select_placeholder'),
       is_required: @champ.required?,
-      labelId: input_label_id(@champ),
+      label_id: input_label_id(@champ),
       ariaLabelledbyPrefix: aria_labelledby_prefix,
       'aria-describedby': select_aria_describedby,
     }.compact
@@ -54,14 +56,25 @@ class EditableChamp::DossierLinkComponent < EditableChamp::EditableChampBaseComp
 
   private
 
-  def combobox_sections
+  # A procedure without any dossier still gets a section, holding a single item explaining
+  # why: its key is disabled so it can be read but never selected.
+  def select_sections
     grouped_dossiers.map do |procedure, dossiers|
-      {
-        label: t('.procedure_section', libelle: procedure.libelle),
-        items: dossiers.map { |dossier| { label: option_label(dossier), value: dossier.id.to_s } },
-      }
+      items = if dossiers.empty?
+        [{ label: t('.no_dossier_in_procedure'), value: empty_procedure_key(procedure) }]
+      else
+        dossiers.map { { label: option_label(it), value: it.id.to_s } }
+      end
+
+      { label: section_label(procedure), items: }
     end
   end
+
+  def disabled_keys
+    grouped_dossiers.filter_map { |procedure, dossiers| empty_procedure_key(procedure) if dossiers.empty? }
+  end
+
+  def empty_procedure_key(procedure) = "no-dossier-#{procedure.id}"
 
   def grouped_dossiers
     @champ.linkable_dossiers_by_procedure
@@ -73,6 +86,10 @@ class EditableChamp::DossierLinkComponent < EditableChamp::EditableChampBaseComp
 
   def contains_long_option?
     @champ.linkable_procedures.any? { |procedure| procedure.libelle.size > 100 }
+  end
+
+  def section_label(procedure)
+    t('.procedure_section', libelle: procedure.libelle)
   end
 
   def option_label(dossier)

--- a/app/components/editable_champ/dossier_link_component.rb
+++ b/app/components/editable_champ/dossier_link_component.rb
@@ -23,7 +23,7 @@ class EditableChamp::DossierLinkComponent < EditableChamp::EditableChampBaseComp
         dossiers.map { |dossier| [option_label(dossier), dossier.id.to_s] }
       end
 
-      [t('.procedure_group', libelle: procedure.libelle), options]
+      [t('.procedure_section', libelle: procedure.libelle), options]
     end
   end
 

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.en.yml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.en.yml
@@ -1,0 +1,8 @@
+---
+en:
+  not_found: This file is unknown
+  procedure_group: '--- Procedure "%{libelle}" ---'
+  procedure_section: 'Procedure “%{libelle}”'
+  option: 'No. %{id} - submitted on %{date}'
+  no_dossier_in_procedure: You have not submitted any file for this procedure.
+  select_placeholder: Select a file

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.en.yml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.en.yml
@@ -1,7 +1,6 @@
 ---
 en:
   not_found: This file is unknown
-  procedure_group: '--- Procedure "%{libelle}" ---'
   procedure_section: 'Procedure “%{libelle}”'
   option: 'No. %{id} - submitted on %{date}'
   no_dossier_in_procedure: You have not submitted any file for this procedure.

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.en.yml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.en.yml
@@ -3,5 +3,6 @@ en:
   not_found: This file is unknown
   procedure_section: 'Procedure “%{libelle}”'
   option: 'No. %{id} - submitted on %{date}'
+  option_expired: 'No. %{id} - submitted on %{date}, expired on %{expired_date}'
   no_dossier_in_procedure: You have not submitted any file for this procedure.
   select_placeholder: Select a file

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.en.yml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.en.yml
@@ -1,6 +1,5 @@
 ---
 en:
-  not_found: This file is unknown
   procedure_section: 'Procedure “%{libelle}”'
   option: 'No. %{id} - submitted on %{date}'
   option_expired: 'No. %{id} - submitted on %{date}, expired on %{expired_date}'

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.fr.yml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.fr.yml
@@ -1,0 +1,8 @@
+---
+fr:
+  not_found: Ce dossier est inconnu
+  procedure_group: '--- Démarche "%{libelle}" ---'
+  procedure_section: Démarche « %{libelle} »
+  option: N° %{id} - déposé le %{date}
+  no_dossier_in_procedure: Vous n’avez déposé aucun dossier sur cette démarche.
+  select_placeholder: Sélectionnez un dossier

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.fr.yml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.fr.yml
@@ -1,7 +1,6 @@
 ---
 fr:
   not_found: Ce dossier est inconnu
-  procedure_group: '--- Démarche "%{libelle}" ---'
   procedure_section: Démarche « %{libelle} »
   option: N° %{id} - déposé le %{date}
   no_dossier_in_procedure: Vous n’avez déposé aucun dossier sur cette démarche.

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.fr.yml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.fr.yml
@@ -1,6 +1,5 @@
 ---
 fr:
-  not_found: Ce dossier est inconnu
   procedure_section: Démarche « %{libelle} »
   option: N° %{id} - déposé le %{date}
   option_expired: N° %{id} - déposé le %{date}, expiré le %{expired_date}

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.fr.yml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.fr.yml
@@ -3,5 +3,6 @@ fr:
   not_found: Ce dossier est inconnu
   procedure_section: Démarche « %{libelle} »
   option: N° %{id} - déposé le %{date}
+  option_expired: N° %{id} - déposé le %{date}, expiré le %{expired_date}
   no_dossier_in_procedure: Vous n’avez déposé aucun dossier sur cette démarche.
   select_placeholder: Sélectionnez un dossier

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.html.erb
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.html.erb
@@ -1,1 +1,18 @@
-<%= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, inputmode: :numeric, min: 1, pattern: "[0-9]{1,12}", autocomplete: 'off', required: @champ.required?, class: "width-33-desktop")) %>
+<% if limited? %>
+  <% if render_combobox? %>
+    <react-fragment class="flex-1">
+      <%= render ReactComponent.new("ComboBox/SingleComboBox", **combobox_react_props) %>
+    </react-fragment>
+  <% else %>
+    <%= @form.select :value,
+          grouped_options_for_select(grouped_select_options, @champ.value),
+          { include_blank: t(".select_placeholder") },
+          { required: @champ.required?,
+            id: @champ.focusable_input_id,
+            class: select_class_names,
+            aria: { **labelledby_id_attr, describedby: select_aria_describedby },
+            translate: "no" } %>
+  <% end %>
+<% else %>
+  <%= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, inputmode: :numeric, min: 1, pattern: "[0-9]{1,12}", autocomplete: 'off', required: @champ.required?, class: "width-33-desktop")) %>
+<% end %>

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.html.erb
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.html.erb
@@ -1,7 +1,7 @@
 <% if limited? %>
-  <% if render_combobox? %>
-    <react-fragment class="flex-1">
-      <%= render ReactComponent.new("ComboBox/SingleComboBox", **combobox_react_props) %>
+  <% if render_as_autocomplete? %>
+    <react-fragment>
+      <%= render ReactComponent.new("Select/SingleSelect", **select_react_props) %>
     </react-fragment>
   <% else %>
     <%= @form.select :value,

--- a/app/components/types_de_champ_editor/champ_component/champ_component.en.yml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.en.yml
@@ -28,7 +28,7 @@ en:
   start_date_label: "start date"
   end_date_label: "end date"
   procedures_limit_label: "Limit to specific procedures"
-  procedures_limit_notice: "Only dossiers submitted by the user themselves will be proposed"
+  procedures_limit_notice_html: "Only dossiers <strong>submitted by the user themselves</strong> will be proposed (their “draft” and “deleted” dossiers will not be proposed)."
   limit_repetitions_legend: "Limit the number of items"
   limit_repetitions_label: "Limit the number of items the user can add"
   min_repetitions_label: "Minimum number of items"

--- a/app/components/types_de_champ_editor/champ_component/champ_component.en.yml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.en.yml
@@ -28,7 +28,7 @@ en:
   start_date_label: "start date"
   end_date_label: "end date"
   procedures_limit_label: "Limit to specific procedures"
-  procedures_limit_notice_html: "Only dossiers <strong>submitted by the user themselves</strong> will be proposed (their “draft” and “deleted” dossiers will not be proposed)."
+  procedures_limit_notice_html: "Only dossiers <strong>submitted by the user themselves</strong> will be proposed, including their expired dossiers (their “drafts” and the ones they deleted will not be proposed)."
   limit_repetitions_legend: "Limit the number of items"
   limit_repetitions_label: "Limit the number of items the user can add"
   min_repetitions_label: "Minimum number of items"

--- a/app/components/types_de_champ_editor/champ_component/champ_component.fr.yml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.fr.yml
@@ -29,7 +29,7 @@ fr:
   start_date_label: "date de début"
   end_date_label: "date de fin"
   procedures_limit_label: "Limiter à certaines démarches"
-  procedures_limit_notice_html: "Seuls les dossiers <strong>déposés par l’usager lui-même</strong> seront proposés (ses dossiers « brouillon » et « supprimés » ne lui seront pas proposés)."
+  procedures_limit_notice_html: "Seuls les dossiers <strong>déposés par l’usager lui-même</strong> seront proposés, y compris ses dossiers expirés (ses « brouillon » et ceux qu’il a supprimés ne le seront pas)."
   limit_repetitions_legend: "Limiter le nombre d’éléments"
   limit_repetitions_label: "Limiter le nombre d’éléments que l’usager peut ajouter"
   min_repetitions_label: "Nombre d’éléments minimum"

--- a/app/components/types_de_champ_editor/champ_component/champ_component.fr.yml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.fr.yml
@@ -29,7 +29,7 @@ fr:
   start_date_label: "date de début"
   end_date_label: "date de fin"
   procedures_limit_label: "Limiter à certaines démarches"
-  procedures_limit_notice: "Seuls les dossiers déposés par l’usager lui-même seront proposés"
+  procedures_limit_notice_html: "Seuls les dossiers <strong>déposés par l’usager lui-même</strong> seront proposés (ses dossiers « brouillon » et « supprimés » ne lui seront pas proposés)."
   limit_repetitions_legend: "Limiter le nombre d’éléments"
   limit_repetitions_label: "Limiter le nombre d’éléments que l’usager peut ajouter"
   min_repetitions_label: "Nombre d’éléments minimum"

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
@@ -180,13 +180,13 @@
                       <%= form.check_box :prefill_with_france_connect_information, { id: dom_id(type_de_champ, :prefill_with_france_connect_information), class: 'fr-toggle__input', disabled: prefill_with_france_connect_information_locked_by_sibling? } %>
                       <%= form.label :prefill_with_france_connect_information, t(".prefill_fc_birthdate_label"), for: dom_id(type_de_champ, :prefill_with_france_connect_information), class: "fr-toggle__label fr-label" %>
                     </div>
-                    <% if prefill_with_france_connect_information_locked_by_sibling? %>
-                      <p class="fr-hint-text">
+                    <p class="fr-hint-text">
+                      <% if prefill_with_france_connect_information_locked_by_sibling? %>
                         <%= t(".prefill_fc_locked_hint") %>
-                      </p>
-                    <% else %>
-                      <p class="fr-hint-text"><%= t(".prefill_fc_hint") %></p>
-                    <% end %>
+                      <% else %>
+                        <%= t(".prefill_fc_hint") %>
+                      <% end %>
+                    </p>
                   <% end %>
 
                   <% if !form.object.birthdate? %>
@@ -244,8 +244,8 @@
                       <div class="fr-container">
                         <div class="fr-notice__body">
                           <p>
-                            <span class="fr-notice__title fr-text--sm fr-mr-0">
-                              <%= t(".procedures_limit_notice") %>
+                            <span class="fr-notice__desc fr-text--sm fr-mr-0">
+                              <%= t(".procedures_limit_notice_html") %>
                             </span>
                           </p>
                         </div>

--- a/app/components/types_de_champ_editor/dossier_link_champ_component.rb
+++ b/app/components/types_de_champ_editor/dossier_link_champ_component.rb
@@ -14,6 +14,9 @@ class TypesDeChampEditor::DossierLinkChampComponent < TypesDeChampEditor::BaseCh
       name: @form.field_name(:dossier_link_procedure_ids, multiple: true),
       selected_keys: @type_de_champ.dossier_link_procedure_ids.map(&:to_s),
       'aria-label': "Liste des démarches",
+      # Les libellés de démarches contiennent des espaces (et parfois des `,`/`;`) ;
+      # sans cela le séparateur par défaut `/\s|,|;/` empêche de saisir une espace dans la recherche.
+      value_separator: false,
     }
   end
 

--- a/app/helpers/dossier_link_helper.rb
+++ b/app/helpers/dossier_link_helper.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
 module DossierLinkHelper
+  def dossier_link_summary(dossier, user)
+    path = dossier_linked_path(user, dossier)
+    numero = "N° #{dossier.id}"
+    # No `fr-link` class: it forces font-size 1rem and adds an external-link icon,
+    # which looks oversized inside the 0.75rem `.fr-message`. A plain link inherits
+    # the surrounding text size, consistent with the rest of the summary.
+    numero = link_to(numero, path, target: '_blank', rel: 'noopener') if path.present?
+
+    t('shared.champs.dossier_link.summary_html',
+      numero:,
+      date: l(dossier.depose_at.to_date),
+      libelle: tag.strong(dossier.procedure.libelle),
+      organisme: tag.strong(dossier.procedure.organisation_name))
+  end
+
   def dossier_linked_path(user, dossier)
     if user.is_a?(Instructeur)
       if user.groupe_instructeurs.include?(dossier.groupe_instructeur)

--- a/app/javascript/components/Select.tsx
+++ b/app/javascript/components/Select.tsx
@@ -20,7 +20,7 @@ import type {
 import { useState, useMemo, useRef, useCallback, type Key } from 'react';
 import { flushSync } from 'react-dom';
 import * as s from 'superstruct';
-import { Plural } from '@lingui/react/macro';
+import { Plural, useLingui } from '@lingui/react/macro';
 
 import './react-aria/components/Select.css';
 import { SearchField } from './react-aria/components/SearchField';
@@ -69,6 +69,7 @@ function Select<M extends SelectionMode = 'single'>({
   id: _id, // eslint-disable-line @typescript-eslint/no-unused-vars -- intentionally discarded to prevent AriaSelect from putting it on a hidden <select>
   ...props
 }: SelectProps<M>) {
+  const { t } = useLingui();
   const { contains } = useFilter({ sensitivity: 'base', numeric: true });
   const filter = useCallback<AutocompleteFilter>(
     (textValue, inputValue, node) => {
@@ -118,7 +119,12 @@ function Select<M extends SelectionMode = 'single'>({
         style={{ display: 'flex', flexDirection: 'column' }}
       >
         <Autocomplete<Item> filter={filter}>
-          <SearchField autoFocus style={{ margin: 4 }} />
+          <SearchField
+            autoFocus
+            aria-label={t`Rechercher dans la liste`}
+            placeholder={t`Rechercher`}
+            style={{ margin: 4 }}
+          />
           <Virtualizer layout={ListLayout}>
             <SelectListBox items={sections ? undefined : items}>
               {sections ? (
@@ -170,6 +176,7 @@ function MultipleSelectValue({
   selectedLabels?: { one: string; other: string };
 }) {
   const selectButtonRef = useRef<HTMLButtonElement>(null);
+  const { t } = useLingui();
   return (
     <SelectValue<Item>>
       {({ selectedItems, state, defaultChildren }) => (
@@ -199,7 +206,7 @@ function MultipleSelectValue({
                 }
               }}
               fallbackFocusRef={selectButtonRef}
-              aria-label="Sélection"
+              aria-label={t`Sélection`}
             />
           )}
         </>

--- a/app/javascript/components/SelectSections.test.tsx
+++ b/app/javascript/components/SelectSections.test.tsx
@@ -46,8 +46,15 @@ const sections: Section[] = [
       { label: "Ministère de l'Intérieur", value: 'interieur' },
       { label: 'Ministère de la Justice', value: 'justice' }
     ]
+  },
+  {
+    label: 'Ambassades',
+    items: [{ label: 'Aucun organisme disponible', value: 'ambassades-vide' }]
   }
 ];
+
+// une section peut n'avoir qu'un item explicatif, rendu non sélectionnable
+const disabledKeys = ['ambassades-vide'];
 
 function SelectWithSections() {
   const [value, setValue] = useState<string | null>(null);
@@ -58,6 +65,7 @@ function SelectWithSections() {
       aria-label="Organisme"
       selectionMode="single"
       value={value}
+      disabledKeys={disabledKeys}
       onChange={(key: Key | null) => setValue(key ? String(key) : null)}
     >
       <Button className="fr-select">
@@ -140,5 +148,21 @@ suite('Select avec sections', () => {
       page.getByRole('option', { name: 'Préfecture du Rhône' })
     );
     await expect.element(button).toHaveTextContent('Préfecture du Rhône');
+  });
+
+  test('affiche un item désactivé sans permettre de le sélectionner', async () => {
+    root.render(<SelectWithSections />);
+
+    const button = page.getByRole('button', { name: 'Organisme' });
+    await userEvent.click(button);
+
+    // l'item est lisible, annoncé désactivé, et donc hors de portée du clic
+    const disabledOption = page.getByRole('option', {
+      name: 'Aucun organisme disponible'
+    });
+    await expect.element(disabledOption).toBeVisible();
+    await expect
+      .element(disabledOption)
+      .toHaveAttribute('aria-disabled', 'true');
   });
 });

--- a/app/javascript/components/react-aria/components/ListBox.css
+++ b/app/javascript/components/react-aria/components/ListBox.css
@@ -16,14 +16,19 @@
   }
 }
 
+/* A group heading, not a label: a band that caps the options it announces.
+   The list is virtualized (each row is absolutely positioned on its own), so
+   nothing can frame a whole group — the band is what ties the heading to what
+   follows, and the space above it is what separates one group from the next. */
 .dropdown-section-header {
-  padding: calc((2rem - 1lh) / 2) 0.75rem;
-  margin-inline: 0.25rem;
-  font-size: 0.75rem;
+  padding: 0.375rem 0.75rem;
+  margin: 0.75rem 0.25rem 0.25rem;
+  font-size: 0.875rem;
   font-weight: bold;
-  color: var(--text-color-placeholder);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  color: var(--text-color-heading);
+  background: var(--heading-background);
+  border-radius: 0.25rem;
+  text-wrap: pretty;
 }
 
 .dropdown-item {

--- a/app/javascript/components/react-aria/components/theme.css
+++ b/app/javascript/components/react-aria/components/theme.css
@@ -3,6 +3,8 @@
 .fr-ds-select_multiple,
 .select-popover {
   --text-color: var(--text-label-grey);
+  --text-color-heading: var(--text-title-grey);
+  --heading-background: var(--background-alt-grey);
   --text-color-placeholder: var(--text-mention-grey);
   --text-color-disabled: var(--text-disabled-grey);
   --border-color: var(--border-default-grey);

--- a/app/javascript/components/react-aria/props.ts
+++ b/app/javascript/components/react-aria/props.ts
@@ -125,6 +125,7 @@ const SelectProps = s.partial(
     labelId: s.string(),
     ariaLabelledbyPrefix: s.string(),
     alwaysShowKey: s.string(),
+    disabledKeys: s.array(s.string()),
     emptyHint: s.optional(s.string()),
     selectedLabels: s.object({ one: s.string(), other: s.string() })
   })

--- a/app/javascript/locales/en/messages.po
+++ b/app/javascript/locales/en/messages.po
@@ -14,18 +14,25 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: selectedItems.length
-#: app/javascript/components/Select.tsx:103
+#: app/javascript/components/Select.tsx:187
 msgid "{0, plural, =0 {{defaultChildren}} one {1 choix sélectionné} other {# "
 "choix sélectionnés}}"
 msgstr "{0, plural, =0 {{defaultChildren}} one {1 item selected} other {# items "
 "selected}}"
 
-#: app/javascript/components/Select.tsx:115
+#: app/javascript/components/Select.tsx:125
+msgid "Rechercher"
+msgstr "Search"
+
+#: app/javascript/components/Select.tsx:124
+msgid "Rechercher dans la liste"
+msgstr "Search the list"
+
+#: app/javascript/components/Select.tsx:209
 msgid "Sélection"
 msgstr "Selection"
 
 #. placeholder {0}: item.label
-#: app/javascript/components/ComboBox.tsx:341
-#: app/javascript/components/Select.tsx:124
+#: app/javascript/components/react-aria/components/TagGroup.tsx:36
 msgid "Supprimer {0}"
 msgstr "Delete {0}"

--- a/app/javascript/locales/fr/messages.po
+++ b/app/javascript/locales/fr/messages.po
@@ -14,18 +14,25 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: selectedItems.length
-#: app/javascript/components/Select.tsx:103
+#: app/javascript/components/Select.tsx:187
 msgid "{0, plural, =0 {{defaultChildren}} one {1 choix sélectionné} other {# "
 "choix sélectionnés}}"
 msgstr "{0, plural, =0 {{defaultChildren}} one {1 choix sélectionné} other {# "
 "choix sélectionnés}}"
 
-#: app/javascript/components/Select.tsx:115
+#: app/javascript/components/Select.tsx:125
+msgid "Rechercher"
+msgstr "Rechercher"
+
+#: app/javascript/components/Select.tsx:124
+msgid "Rechercher dans la liste"
+msgstr "Rechercher dans la liste"
+
+#: app/javascript/components/Select.tsx:209
 msgid "Sélection"
 msgstr "Sélection"
 
 #. placeholder {0}: item.label
-#: app/javascript/components/ComboBox.tsx:341
-#: app/javascript/components/Select.tsx:124
+#: app/javascript/components/react-aria/components/TagGroup.tsx:36
 msgid "Supprimer {0}"
 msgstr "Supprimer {0}"

--- a/app/models/champs/dossier_link_champ.rb
+++ b/app/models/champs/dossier_link_champ.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class Champs::DossierLinkChamp < ChampData
+  # A linkable dossier, normalized from either a still-present Dossier or a purged
+  # DeletedDossier. `id` is always the original dossier number (the option value).
+  LinkableDossier = Data.define(:id, :procedure_id, :depose_on, :expired_on) do
+    def expired? = expired_on.present?
+  end
+
   validates_with DossierLinkValidator, if: -> { should_validate_in_current_context? && value.present? }
 
   # The (still existing) procedures the field is restricted to, in the admin-configured order.
@@ -12,14 +18,17 @@ class Champs::DossierLinkChamp < ChampData
   end
 
   # The user's submitted dossiers on those procedures, grouped by procedure (newest first).
+  # We offer exactly what the user still sees in their own dossier list (Dossier.visible_by_user),
+  # so dossiers they deleted themselves stay excluded. Expired dossiers are added back so the user
+  # can still link to them, whether they are still soft-deleted (Dossier#hidden_by_expired_at) or
+  # already purged (DeletedDossier, reason: :expired).
+  # Cost is constant: two grouped queries, regardless of the number of procedures.
   def linkable_dossiers_by_procedure
-    @linkable_dossiers_by_procedure ||= linkable_procedures.index_with do |procedure|
-      procedure.dossiers
-        .visible_by_user_or_administration
-        .where(user_id: dossier.user_id, state: Dossier::SOUMIS)
-        .where.not(id: dossier_id)
-        .order(depose_at: :desc)
-        .to_a
+    @linkable_dossiers_by_procedure ||= begin
+      by_procedure = linkable_dossiers.group_by(&:procedure_id)
+      linkable_procedures.index_with do |procedure|
+        by_procedure.fetch(procedure.id, []).sort_by(&:depose_on).reverse
+      end
     end
   end
 
@@ -28,5 +37,38 @@ class Champs::DossierLinkChamp < ChampData
   # keep free input so the user can still type a number (e.g. a since-deleted dossier).
   def selectable?
     type_de_champ.procedures_limit? && linkable_dossiers_by_procedure.values.any?(&:present?)
+  end
+
+  private
+
+  def linkable_dossiers
+    active_linkable_dossiers + deleted_linkable_dossiers
+  end
+
+  def linkable_procedure_ids
+    linkable_procedures.map(&:id)
+  end
+
+  # Still-present dossiers (visible or soft-expired) across all allowed procedures, in one query.
+  # Scoped through the owner's association so we can only ever reach this user's own dossiers.
+  def active_linkable_dossiers
+    dossier.user.dossiers
+      .joins(:revision)
+      .where(procedure_revisions: { procedure_id: linkable_procedure_ids })
+      .merge(Dossier.visible_by_user.or(Dossier.hidden_by_expired))
+      .where(state: Dossier::SOUMIS)
+      .where.not(id: dossier_id)
+      .pluck('procedure_revisions.procedure_id', 'dossiers.id', 'dossiers.depose_at', 'dossiers.hidden_by_expired_at')
+      .map { |procedure_id, id, depose_at, expired_at| LinkableDossier.new(id:, procedure_id:, depose_on: depose_at.to_date, expired_on: expired_at&.to_date) }
+  end
+
+  # Purged dossiers removed for expiration across all allowed procedures, in one query.
+  # Scoped through the owner's association so we can only ever reach this user's own dossiers.
+  def deleted_linkable_dossiers
+    dossier.user.deleted_dossiers
+      .where(procedure_id: linkable_procedure_ids, reason: :expired)
+      .where.not(dossier_id: dossier_id)
+      .pluck(:procedure_id, :dossier_id, :depose_at, :deleted_at)
+      .map { |procedure_id, id, depose_at, deleted_at| LinkableDossier.new(id:, procedure_id:, depose_on: depose_at, expired_on: deleted_at.to_date) }
   end
 end

--- a/app/models/champs/dossier_link_champ.rb
+++ b/app/models/champs/dossier_link_champ.rb
@@ -2,4 +2,31 @@
 
 class Champs::DossierLinkChamp < ChampData
   validates_with DossierLinkValidator, if: -> { should_validate_in_current_context? && value.present? }
+
+  # The (still existing) procedures the field is restricted to, in the admin-configured order.
+  def linkable_procedures
+    @linkable_procedures ||= begin
+      ids = type_de_champ.dossier_link_procedure_ids
+      Procedure.where(id: ids).index_by(&:id).values_at(*ids).compact
+    end
+  end
+
+  # The user's submitted dossiers on those procedures, grouped by procedure (newest first).
+  def linkable_dossiers_by_procedure
+    @linkable_dossiers_by_procedure ||= linkable_procedures.index_with do |procedure|
+      procedure.dossiers
+        .visible_by_user_or_administration
+        .where(user_id: dossier.user_id, state: Dossier::SOUMIS)
+        .where.not(id: dossier_id)
+        .order(depose_at: :desc)
+        .to_a
+    end
+  end
+
+  # Offer a select/combobox (rather than free input) only when the field is limited
+  # to procedures AND the user actually has at least one dossier to pick. Otherwise we
+  # keep free input so the user can still type a number (e.g. a since-deleted dossier).
+  def selectable?
+    type_de_champ.procedures_limit? && linkable_dossiers_by_procedure.values.any?(&:present?)
+  end
 end

--- a/app/views/shared/champs/dossier_link/_show.html.haml
+++ b/app/views/shared/champs/dossier_link/_show.html.haml
@@ -18,6 +18,9 @@
     %br
     .copy-zone
       %p= t('shared.champs.dossier_link.hidden', depose_at: l(dossier.depose_at.to_date), procedure_libelle: dossier.procedure.libelle, hidden_at: l(hidden_at.to_date))
+  - elsif !dossier.brouillon?
+    .copy-zone
+      %p= dossier_link_summary(dossier, current_instructeur || current_user)
   - else
     - path = dossier_linked_path(current_instructeur || current_user, dossier)
     - if path.present?

--- a/app/views/shared/champs/dossier_link/_show.html.haml
+++ b/app/views/shared/champs/dossier_link/_show.html.haml
@@ -2,6 +2,7 @@
 - deleted_dossier = dossier.nil? ? DeletedDossier.includes(:procedure).find_by(dossier_id: champ.to_s) : nil
 - profile = controller.try(:nav_bar_profile)
 - hidden_at = dossier && ((profile == :user && dossier.hidden_by_user_at) || (profile == :instructeur && dossier.hidden_by_administration_at))
+- instructeur_without_access = dossier.present? && current_instructeur.present? && dossier_linked_path(current_instructeur, dossier).blank?
 - if deleted_dossier
   %p Dossier n° #{champ}
   %br
@@ -18,7 +19,7 @@
     %br
     .copy-zone
       %p= t('shared.champs.dossier_link.hidden', depose_at: l(dossier.depose_at.to_date), procedure_libelle: dossier.procedure.libelle, hidden_at: l(hidden_at.to_date))
-  - elsif !dossier.brouillon?
+  - elsif !dossier.brouillon? && !instructeur_without_access
     .copy-zone
       %p= dossier_link_summary(dossier, current_instructeur || current_user)
   - else

--- a/config/locales/models/champs/dossier_link_champ/en.yml
+++ b/config/locales/models/champs/dossier_link_champ/en.yml
@@ -3,7 +3,8 @@ en:
     attributes:
       champs/dossier_link_champ:
         hints:
-          value: "Expected format: A %{application_name} file number"
+          free: "Expected format: A %{application_name} file number"
+          select: "Select the number of a file you submitted on %{application_name}"
 
     errors:
       models:

--- a/config/locales/models/champs/dossier_link_champ/fr.yml
+++ b/config/locales/models/champs/dossier_link_champ/fr.yml
@@ -3,7 +3,8 @@ fr:
     attributes:
       champs/dossier_link_champ:
         hints:
-          value: "Format attendu : Un numéro de dossier déposé sur %{application_name}"
+          free: "Format attendu : Un numéro de dossier déposé sur %{application_name}"
+          select: "Sélectionnez le numéro d’un dossier que vous avez déposé sur %{application_name}"
 
     errors:
       models:

--- a/config/locales/views/shared/champs/dossier_link/en.yml
+++ b/config/locales/views/shared/champs/dossier_link/en.yml
@@ -6,3 +6,4 @@ en:
         hidden: "File submitted on %{depose_at} for the procedure “%{procedure_libelle}” but deleted on %{hidden_at}"
         expired: "File submitted on %{depose_at} for the procedure “%{procedure_libelle}” but expired on %{expired_at}"
         deleted: "The file referenced at submission for the procedure “%{procedure_libelle}” no longer exists"
+        summary_html: "File %{numero} - submitted on %{date} for the procedure %{libelle} managed by %{organisme}"

--- a/config/locales/views/shared/champs/dossier_link/fr.yml
+++ b/config/locales/views/shared/champs/dossier_link/fr.yml
@@ -6,3 +6,4 @@ fr:
         hidden: "Dossier déposé le %{depose_at} sur la démarche « %{procedure_libelle} » mais supprimé le %{hidden_at}"
         expired: "Dossier déposé le %{depose_at} sur la démarche « %{procedure_libelle} » mais expiré le %{expired_at}"
         deleted: "Le dossier renseigné lors du dépôt sur la démarche « %{procedure_libelle} » n’existe plus"
+        summary_html: "Dossier %{numero} - déposé le %{date} sur la démarche %{libelle} gérée par l’organisme %{organisme}"

--- a/spec/components/editable_champ/dossier_link_component_spec.rb
+++ b/spec/components/editable_champ/dossier_link_component_spec.rb
@@ -128,22 +128,38 @@ describe EditableChamp::DossierLinkComponent, type: :component do
       end
     end
 
-    context 'with at least the combobox threshold of dossiers' do
-      before do
-        stub_const("#{described_class}::COMBOBOX_THRESHOLD", 1)
-        create(:dossier, :en_construction, procedure: linked_procedure, user:)
-      end
+    context 'with at least the autocomplete threshold of dossiers' do
+      let!(:user_dossier) { create(:dossier, :en_construction, procedure: linked_procedure, user:) }
 
-      it 'renders a searchable combobox grouped by procedure without separators' do
+      before { stub_const("#{described_class}::THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE", 1) }
+
+      it 'renders a filterable react select grouped by procedure' do
         render
 
-        expect(page).to have_css('react-component[name="ComboBox/SingleComboBox"]')
+        expect(page).to have_css('react-component[name="Select/SingleSelect"]')
         expect(page).not_to have_css('select')
 
         props = JSON.parse(page.find('react-component')['props'])
         expect(props['sections'].first['label']).to eq('Démarche « Démarche A »')
-        # the combobox input gets its accessible name from the field label
-        expect(props['labelId']).to be_present
+        expect(props['sections'].first['items'].map { it['value'] }).to eq([user_dossier.id.to_s])
+        # the select trigger gets its accessible name from the field label
+        expect(props['label_id']).to be_present
+      end
+
+      context 'when the user has no dossier on another allowed procedure' do
+        let(:empty_procedure) { create(:procedure, libelle: 'Démarche B') }
+
+        before { tdc.update!(procedures_limit: '1', dossier_link_procedure_ids: [linked_procedure.id, empty_procedure.id]) }
+
+        it 'renders an unselectable item for the procedure without any dossier' do
+          render
+
+          props = JSON.parse(page.find('react-component')['props'])
+          empty_section = props['sections'].last
+          expect(empty_section['label']).to eq('Démarche « Démarche B »')
+          expect(empty_section['items'].map { it['label'] }).to eq(['Vous n’avez déposé aucun dossier sur cette démarche.'])
+          expect(props['disabled_keys']).to eq(empty_section['items'].map { it['value'] })
+        end
       end
     end
 

--- a/spec/components/editable_champ/dossier_link_component_spec.rb
+++ b/spec/components/editable_champ/dossier_link_component_spec.rb
@@ -35,13 +35,28 @@ describe EditableChamp::DossierLinkComponent, type: :component do
       end
     end
 
-    context 'when the admin limited the field to some procedures' do
-      before { tdc.update!(procedures_limit: '1', dossier_link_procedure_ids: [create(:procedure).id]) }
+    context 'when the admin limited the field and the user has a dossier to propose' do
+      let(:linked_procedure) { create(:procedure) }
+
+      before do
+        tdc.update!(procedures_limit: '1', dossier_link_procedure_ids: [linked_procedure.id])
+        create(:dossier, :en_construction, procedure: linked_procedure, user:)
+      end
 
       it 'invites the user to select a dossier' do
         render
 
         expect(page).to have_text('Sélectionnez le numéro')
+      end
+    end
+
+    context 'when the admin limited the field but the user has no dossier to propose' do
+      before { tdc.update!(procedures_limit: '1', dossier_link_procedure_ids: [create(:procedure).id]) }
+
+      it 'keeps the free-text format hint' do
+        render
+
+        expect(page).to have_text('Format attendu')
       end
     end
   end
@@ -66,11 +81,27 @@ describe EditableChamp::DossierLinkComponent, type: :component do
       end
     end
 
-    context 'when the user has no dossier on an allowed procedure' do
-      it 'renders a disabled option explaining there is no dossier' do
+    context 'when the user has no dossier to propose on any allowed procedure' do
+      it 'falls back to the free numeric text input' do
         render
 
-        expect(page).to have_css('select optgroup[label*="Démarche A"] option[disabled]', text: 'Vous n’avez déposé aucun dossier sur cette démarche.')
+        expect(page).to have_css('input[type="text"]')
+        expect(page).not_to have_css('select')
+      end
+    end
+
+    context 'when the user has a dossier on one allowed procedure but not another' do
+      let(:empty_procedure) { create(:procedure, libelle: 'Démarche B') }
+
+      before do
+        tdc.update!(procedures_limit: '1', dossier_link_procedure_ids: [linked_procedure.id, empty_procedure.id])
+        create(:dossier, :en_construction, procedure: linked_procedure, user:)
+      end
+
+      it 'renders a disabled option for the procedure without any dossier' do
+        render
+
+        expect(page).to have_css('select optgroup[label*="Démarche B"] option[disabled]', text: 'Vous n’avez déposé aucun dossier sur cette démarche.')
       end
     end
 
@@ -93,12 +124,14 @@ describe EditableChamp::DossierLinkComponent, type: :component do
 
     context 'when the current dossier itself belongs to an allowed procedure' do
       let(:dossier) { create(:dossier, :en_construction, procedure:) }
+      let!(:sibling_dossier) { create(:dossier, :en_construction, procedure:, user:) }
 
       before { tdc.update!(procedures_limit: '1', dossier_link_procedure_ids: [procedure.id]) }
 
       it 'does not offer the current dossier as a link target' do
         render
 
+        expect(page).to have_css("select option[value='#{sibling_dossier.id}']")
         expect(page).not_to have_css("select option[value='#{dossier.id}']")
       end
     end

--- a/spec/components/editable_champ/dossier_link_component_spec.rb
+++ b/spec/components/editable_champ/dossier_link_component_spec.rb
@@ -119,6 +119,8 @@ describe EditableChamp::DossierLinkComponent, type: :component do
 
         props = JSON.parse(page.find('react-component')['props'])
         expect(props['sections'].first['label']).to eq('Démarche « Démarche A »')
+        # the combobox input gets its accessible name from the field label
+        expect(props['labelId']).to be_present
       end
     end
 

--- a/spec/components/editable_champ/dossier_link_component_spec.rb
+++ b/spec/components/editable_champ/dossier_link_component_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+describe EditableChamp::DossierLinkComponent, type: :component do
+  let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :dossier_link }]) }
+  let(:dossier) { create(:dossier, procedure:) }
+  let(:user) { dossier.user }
+  let(:tdc) { procedure.active_revision.type_de_champs.first }
+  let(:champ) { dossier.champs.first }
+
+  subject(:render) do
+    component = nil
+    ActionView::Base.empty.form_for(champ, url: '/') do |form|
+      component = EditableChamp::EditableChampComponent.new(champ:, form:)
+    end
+
+    render_inline(component)
+  end
+
+  context 'when the admin did not limit procedures' do
+    it 'renders a free numeric text input' do
+      render
+
+      expect(page).to have_css('input[type="text"]')
+      expect(page).not_to have_css('select')
+      expect(page).not_to have_css('react-component')
+    end
+  end
+
+  describe 'the field hint' do
+    context 'when the admin did not limit procedures' do
+      it 'invites the user to type a dossier number' do
+        render
+
+        expect(page).to have_text('Format attendu')
+      end
+    end
+
+    context 'when the admin limited the field to some procedures' do
+      before { tdc.update!(procedures_limit: '1', dossier_link_procedure_ids: [create(:procedure).id]) }
+
+      it 'invites the user to select a dossier' do
+        render
+
+        expect(page).to have_text('Sélectionnez le numéro')
+      end
+    end
+  end
+
+  context 'when the admin limited the field to some procedures' do
+    let(:linked_procedure) { create(:procedure, libelle: 'Démarche A') }
+
+    before { tdc.update!(procedures_limit: '1', dossier_link_procedure_ids: [linked_procedure.id]) }
+
+    context 'with fewer than 20 dossiers submitted by the user' do
+      let!(:user_dossier) { create(:dossier, :en_construction, procedure: linked_procedure, user:) }
+      let!(:other_user_dossier) { create(:dossier, :en_construction, procedure: linked_procedure) }
+      let!(:brouillon) { create(:dossier, procedure: linked_procedure, user:) }
+
+      it 'renders a grouped select with only the dossiers submitted by the user' do
+        render
+
+        expect(page).to have_css('select optgroup[label*="Démarche A"]')
+        expect(page).to have_css("select option[value='#{user_dossier.id}']")
+        expect(page).not_to have_css("select option[value='#{other_user_dossier.id}']")
+        expect(page).not_to have_css("select option[value='#{brouillon.id}']")
+      end
+    end
+
+    context 'when the user has no dossier on an allowed procedure' do
+      it 'renders a disabled option explaining there is no dossier' do
+        render
+
+        expect(page).to have_css('select optgroup[label*="Démarche A"] option[disabled]', text: 'Vous n’avez déposé aucun dossier sur cette démarche.')
+      end
+    end
+
+    context 'with at least the combobox threshold of dossiers' do
+      before do
+        stub_const("#{described_class}::COMBOBOX_THRESHOLD", 1)
+        create(:dossier, :en_construction, procedure: linked_procedure, user:)
+      end
+
+      it 'renders a searchable combobox grouped by procedure without separators' do
+        render
+
+        expect(page).to have_css('react-component[name="ComboBox/SingleComboBox"]')
+        expect(page).not_to have_css('select')
+
+        props = JSON.parse(page.find('react-component')['props'])
+        expect(props['sections'].first['label']).to eq('Démarche « Démarche A »')
+      end
+    end
+
+    context 'when the current dossier itself belongs to an allowed procedure' do
+      let(:dossier) { create(:dossier, :en_construction, procedure:) }
+
+      before { tdc.update!(procedures_limit: '1', dossier_link_procedure_ids: [procedure.id]) }
+
+      it 'does not offer the current dossier as a link target' do
+        render
+
+        expect(page).not_to have_css("select option[value='#{dossier.id}']")
+      end
+    end
+  end
+end

--- a/spec/components/editable_champ/dossier_link_component_spec.rb
+++ b/spec/components/editable_champ/dossier_link_component_spec.rb
@@ -81,6 +81,29 @@ describe EditableChamp::DossierLinkComponent, type: :component do
       end
     end
 
+    context 'with an expired dossier submitted by the user' do
+      let!(:expired_dossier) { create(:dossier, :en_construction, :hidden_by_expired, procedure: linked_procedure, user:) }
+
+      it 'offers it with an option label mentioning its expiration date' do
+        render
+
+        expect(page).to have_css("select option[value='#{expired_dossier.id}']", text: /expiré le/)
+      end
+    end
+
+    context 'with an expired dossier already purged (DeletedDossier)' do
+      let!(:purged_dossier) do
+        create(:deleted_dossier, reason: :expired, user_id: user.id, procedure: linked_procedure,
+                                 dossier_id: 99_999, depose_at: 3.days.ago.to_date)
+      end
+
+      it 'offers it with an option label mentioning its expiration date' do
+        render
+
+        expect(page).to have_css("select option[value='#{purged_dossier.dossier_id}']", text: /expiré le/)
+      end
+    end
+
     context 'when the user has no dossier to propose on any allowed procedure' do
       it 'falls back to the free numeric text input' do
         render

--- a/spec/components/input_status_message_component_spec.rb
+++ b/spec/components/input_status_message_component_spec.rb
@@ -89,8 +89,20 @@ RSpec.describe Dsfr::InputStatusMessageComponent, type: :component do
       end
 
       context "when a dossier is found" do
-        it "renders the dossier information" do
+        it "renders the dossier information with the procedure emphasized" do
           expect(subject).to have_css(".fr-message--info", text: /Dossier/)
+          expect(subject).to have_css(".fr-message--info strong", text: linked_dossier.procedure.libelle)
+          # wrapped in a single span so the flex `.fr-message` keeps the spacing
+          expect(subject).to have_css(".fr-message--info > span", text: /Dossier/)
+        end
+
+        context "when the user owns the linked dossier" do
+          let(:linked_dossier) { create(:dossier, :en_construction, user: dossier.user) }
+
+          it "links to the dossier in a new tab" do
+            expect(subject).to have_link("N° #{linked_dossier.id}", href: "/dossiers/#{linked_dossier.id}")
+            expect(subject).to have_css("a[href='/dossiers/#{linked_dossier.id}'][target='_blank'][rel='noopener']")
+          end
         end
       end
 

--- a/spec/components/input_status_message_component_spec.rb
+++ b/spec/components/input_status_message_component_spec.rb
@@ -118,6 +118,15 @@ RSpec.describe Dsfr::InputStatusMessageComponent, type: :component do
           )
         end
       end
+
+      context "when the linked dossier is still a brouillon" do
+        let(:linked_dossier) { create(:dossier, :brouillon) }
+
+        it "falls back to the plain text summary without raising" do
+          expect { subject }.not_to raise_error
+          expect(subject).to have_css(".fr-message--info", text: /Dossier en brouillon/)
+        end
+      end
     end
 
     context 'with referentiel champs' do

--- a/spec/components/types_de_champ_editor/dossier_link_champ_component_spec.rb
+++ b/spec/components/types_de_champ_editor/dossier_link_champ_component_spec.rb
@@ -27,6 +27,7 @@ describe TypesDeChampEditor::DossierLinkChampComponent, type: :component do
         expect(props[:label]).to eq("Sélectionnez la ou les démarches concernées")
         expect(props[:selected_keys]).to eq([])
         expect(props[:'aria-label']).to eq("Liste des démarches")
+        expect(props[:value_separator]).to be(false)
         expect(props[:sections].map { it[:label] }).to contain_exactly('Démarches publiées', 'Démarches en test', 'Démarches closes/dépubliées')
       end
     end

--- a/spec/helpers/dossier_link_helper_spec.rb
+++ b/spec/helpers/dossier_link_helper_spec.rb
@@ -35,4 +35,30 @@ describe DossierLinkHelper do
       it { expect(helper.dossier_linked_path(user, dossier)).to eq(dossier_path(dossier)) }
     end
   end
+
+  describe "#dossier_link_summary" do
+    let(:procedure) { create(:procedure, libelle: "Ma démarche", organisation: "Mon service") }
+    let(:dossier) { create(:dossier, :en_construction, procedure:) }
+    let(:summary) { Capybara.string(helper.dossier_link_summary(dossier, user)) }
+
+    context "when the user owns the linked dossier" do
+      let(:user) { dossier.user }
+
+      it "renders the dossier number as a link opening in a new tab and emphasizes procedure and service" do
+        expect(summary).to have_link("N° #{dossier.id}", href: dossier_path(dossier))
+        expect(summary.find_link("N° #{dossier.id}")[:target]).to eq("_blank")
+        expect(summary).to have_css("strong", text: "Ma démarche")
+        expect(summary).to have_css("strong", text: "Mon service")
+      end
+    end
+
+    context "when the user has no access to the linked dossier" do
+      let(:user) { create(:user) }
+
+      it "renders the dossier number as plain text without a link" do
+        expect(summary).to have_no_link("N° #{dossier.id}")
+        expect(summary).to have_text("N° #{dossier.id}")
+      end
+    end
+  end
 end

--- a/spec/models/champs/dossier_link_champ_spec.rb
+++ b/spec/models/champs/dossier_link_champ_spec.rb
@@ -67,6 +67,11 @@ describe Champs::DossierLinkChamp, type: :model do
       it { is_expected.to be_truthy }
     end
 
+    context 'when dossier is expired (auto-deleted) but belongs to an allowed procedure and to the current user' do
+      let(:value) { create(:dossier, :en_construction, :hidden_by_expired, procedure: allowed_procedure, user:).id }
+      it { is_expected.to be_truthy }
+    end
+
     context 'when dossier does not belong to an allowed procedure' do
       let(:value) { create(:dossier, :en_construction, procedure: other_procedure, user:).id }
 
@@ -152,6 +157,63 @@ describe Champs::DossierLinkChamp, type: :model do
       context 'and the user has no dossier to propose' do
         it { is_expected.to be(false) }
       end
+
+      context 'and the user only has an expired (auto-deleted) dossier' do
+        before { create(:dossier, :en_construction, :hidden_by_expired, procedure: allowed_procedure, user: dossier.user) }
+
+        it { is_expected.to be(true) }
+      end
+    end
+  end
+
+  describe '#linkable_dossiers_by_procedure' do
+    let(:allowed_procedure) { create(:procedure) }
+    let(:type_de_champ) { procedure.draft_revision.type_de_champs.first }
+    let(:user) { dossier.user }
+
+    before do
+      type_de_champ.update!(options: type_de_champ.options.merge(
+        'procedures_limit' => '1',
+        'dossier_link_procedure_ids' => [allowed_procedure.id]
+      ))
+    end
+
+    subject { champ.linkable_dossiers_by_procedure.values.flatten.map(&:id) }
+
+    context 'with an expired (soft-deleted, still present) deposited dossier' do
+      let!(:expired_dossier) { create(:dossier, :en_construction, :hidden_by_expired, procedure: allowed_procedure, user:) }
+
+      it { is_expected.to include(expired_dossier.id) }
+    end
+
+    context 'with a dossier the user deleted himself' do
+      let!(:hidden_dossier) { create(:dossier, :en_construction, :hidden_by_user, procedure: allowed_procedure, user:) }
+
+      it { is_expected.not_to include(hidden_dossier.id) }
+    end
+
+    context 'with an en_instruction dossier the user deleted himself' do
+      let!(:hidden_dossier) { create(:dossier, :en_instruction, :hidden_by_user, procedure: allowed_procedure, user:) }
+
+      it { is_expected.not_to include(hidden_dossier.id) }
+    end
+
+    context 'with a deposited dossier purged for expiration (DeletedDossier reason: expired)' do
+      let!(:deleted) do
+        create(:deleted_dossier, reason: :expired, user_id: user.id, procedure: allowed_procedure,
+                                 dossier_id: 99_999, depose_at: 3.days.ago.to_date)
+      end
+
+      it { is_expected.to include(deleted.dossier_id) }
+    end
+
+    context 'with a purged dossier deleted for another reason (DeletedDossier reason: user_request)' do
+      let!(:deleted) do
+        create(:deleted_dossier, reason: :user_request, user_id: user.id, procedure: allowed_procedure,
+                                 dossier_id: 99_998, depose_at: 3.days.ago.to_date)
+      end
+
+      it { is_expected.not_to include(deleted.dossier_id) }
     end
   end
 end

--- a/spec/models/champs/dossier_link_champ_spec.rb
+++ b/spec/models/champs/dossier_link_champ_spec.rb
@@ -124,4 +124,34 @@ describe Champs::DossierLinkChamp, type: :model do
       it { is_expected.to be_truthy }
     end
   end
+
+  describe '#selectable?' do
+    let(:allowed_procedure) { create(:procedure) }
+    let(:type_de_champ) { procedure.draft_revision.type_de_champs.first }
+
+    subject { champ.selectable? }
+
+    context 'when the field is not limited to procedures' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the field is limited' do
+      before do
+        type_de_champ.update!(options: type_de_champ.options.merge(
+          'procedures_limit' => '1',
+          'dossier_link_procedure_ids' => [allowed_procedure.id]
+        ))
+      end
+
+      context 'and the user has a submitted dossier on an allowed procedure' do
+        before { create(:dossier, :en_construction, procedure: allowed_procedure, user: dossier.user) }
+
+        it { is_expected.to be(true) }
+      end
+
+      context 'and the user has no dossier to propose' do
+        it { is_expected.to be(false) }
+      end
+    end
+  end
 end

--- a/spec/views/shared/dossiers/_champs.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_champs.html.haml_spec.rb
@@ -94,6 +94,20 @@ describe 'shared/dossiers/champs', type: :view do
     end
   end
 
+  context "with a dossier champ pointing to a deposited dossier" do
+    let(:public_type_de_champs) { [{ type: :dossier_link }] }
+    let(:linked_dossier) { create(:dossier, :en_construction) }
+
+    before do
+      dossier.champs.first.update(value: linked_dossier.id)
+    end
+
+    it "renders the enriched summary with the procedure in bold" do
+      is_expected.to have_css("strong", text: linked_dossier.procedure.libelle)
+      is_expected.to include("N° #{linked_dossier.id}")
+    end
+  end
+
   context "with a dossier_link champ but without value" do
     let(:public_type_de_champs) { [{ type: :dossier_link, mandatory: false }] }
 

--- a/spec/views/shared/dossiers/_champs.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_champs.html.haml_spec.rb
@@ -96,15 +96,26 @@ describe 'shared/dossiers/champs', type: :view do
 
   context "with a dossier champ pointing to a deposited dossier" do
     let(:public_type_de_champs) { [{ type: :dossier_link }] }
-    let(:linked_dossier) { create(:dossier, :en_construction) }
 
     before do
       dossier.champs.first.update(value: linked_dossier.id)
     end
 
-    it "renders the enriched summary with the procedure in bold" do
-      is_expected.to have_css("strong", text: linked_dossier.procedure.libelle)
-      is_expected.to include("N° #{linked_dossier.id}")
+    context "when the viewer has access to the linked dossier" do
+      let(:linked_dossier) { create(:dossier, :en_construction, procedure: create(:procedure, instructeurs: [instructeur])) }
+
+      it "renders the enriched summary with the procedure in bold" do
+        is_expected.to have_css("strong", text: linked_dossier.procedure.libelle)
+        is_expected.to include("N° #{linked_dossier.id}")
+      end
+    end
+
+    context "when the instructeur has no access to the linked dossier" do
+      let(:linked_dossier) { create(:dossier, :en_construction) }
+
+      it "renders the no-access component instead of the summary" do
+        is_expected.to have_css("#modal-no-access-to-dossier-#{linked_dossier.id}", visible: false)
+      end
     end
   end
 


### PR DESCRIPTION
Extraction de la partie qui améliore la saisie usager de la PR https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/11840  adaptées aux maquettes fournies dans l'issue https://github.com/demarche-numerique/demarche.numerique.gouv.fr/issues/11539 (Les autres aspects sont déjà en prod)

**Saisie** — quand l'administrateur limite le champ à certaines démarches, l'usager choisit parmi ses propres dossiers déposés au lieu de saisir un numéro à la main :
- liste déroulante groupée par démarche, ou select filtrable au-delà de 20 dossiers proposés ;
- sont exclus les brouillons, les dossiers supprimés et le dossier en cours ; on intègre les dossiers expirés
- une démarche sans dossier affiche une mention explicite ;
- le texte d'aide s'adapte au mode (saisie libre / sélection).

**Affichage** — sous le champ et en lecture seule :
- le numéro du dossier devient un lien (nouvel onglet) uniquement pour les dossiers déposés par l'usager lui-même, via un chemin qui vérifie l'accès ;
- le libellé de la démarche et le nom de l'organisme sont mis en gras.

**Select filtrable** — suite à la revue, le select React remplace le combobox au-delà du seuil : mêmes sections, même recherche pour retrouver un dossier par son numéro, mais aucune valeur hors liste n'est saisissable. Un ajout au composant partagé, qui profite aussi aux champs choix simple/multiples : `disabled_keys`, pour l'item non sélectionnable des démarches sans dossier.

**Admin** — dans le combobox qui limite les démarches proposées, l'espace n'était plus saisissable (interprété comme séparateur de valeurs) : on désactive ce séparateur pour ce sélecteur, la recherche multi-mots fonctionne à nouveau.

Closes #11539


<img width="997" height="720" alt="Capture d’écran 2026-06-17 à 15 47 44" src="https://github.com/user-attachments/assets/305d4053-401a-4467-96b8-f840c7e5f8df" />
<img width="1244" height="968" alt="Capture d’écran 2026-08-25 à 16 36 10" src="https://github.com/user-attachments/assets/9083ea82-139a-4257-a55c-1972f4e06855" />


<img width="1233" height="170" alt="Capture d’écran 2026-06-22 à 16 43 55" src="https://github.com/user-attachments/assets/0371286b-124b-40a6-bce2-6c0ad76bc6cb" />


