### PR TITLE
Nommage : remplace "fin de dépôt" par "page de confirmation de dépôt"

### DIFF
--- a/app/components/procedure/card/dossier_submitted_message_component/dossier_submitted_message_component.fr.yml
+++ b/app/components/procedure/card/dossier_submitted_message_component/dossier_submitted_message_component.fr.yml
@@ -1,3 +1,3 @@
 ---
 fr:
-  title: Fin de dépôt
+  sub_title: Orienter l’usager suite au dépôt de son dossier

--- a/app/components/procedure/card/dossier_submitted_message_component/dossier_submitted_message_component.html.haml
+++ b/app/components/procedure/card/dossier_submitted_message_component/dossier_submitted_message_component.html.haml
@@ -6,6 +6,6 @@
       - else
         %p.fr-badge.fr-badge--info À configurer
       %div
-        %h3.fr-h6.fr-mt-10v= t('.title')
-        %p.fr-tile-subtitle Orienter l’usager suite à l’envoi de son dossier
+        %h3.fr-h6.fr-mt-10v= t('shared.dossier_submitted_message.title')
+        %p.fr-tile-subtitle= t('.sub_title')
       %p.fr-btn.fr-btn--tertiary= t('views.shared.actions.edit')

--- a/app/controllers/administrateurs/dossier_submitted_messages_controller.rb
+++ b/app/controllers/administrateurs/dossier_submitted_messages_controller.rb
@@ -12,9 +12,9 @@ module Administrateurs
       @dossier_submitted_message = build_dossier_submitted_message(dossier_submitted_message_params)
 
       if @dossier_submitted_message.save
-        redirect_to admin_procedure_path(@procedure), flash: { notice: "Les informations de fin de dépot ont bien été sauvegardées." }
+        redirect_to admin_procedure_path(@procedure), flash: { notice: "Les informations de la page de confirmation de dépôt ont bien été sauvegardées." }
       else
-        flash.alert = "Impossible de sauvegarder les informations de fin de dépot, veuillez ré-essayer."
+        flash.alert = "Impossible de sauvegarder les informations de la page de confirmation de dépôt, veuillez ré-essayer."
         render :edit, status: 400
       end
     end
@@ -22,9 +22,9 @@ module Administrateurs
     def create
       @dossier_submitted_message = build_dossier_submitted_message(dossier_submitted_message_params)
       if @dossier_submitted_message.save
-        redirect_to admin_procedure_path(@procedure), flash: { notice: "Les informations de fin de dépot ont bien été sauvegardées." }
+        redirect_to admin_procedure_path(@procedure), flash: { notice: "Les informations de la page de confirmation de dépôt ont bien été sauvegardées." }
       else
-        flash.alert = "Impossible de sauvegarder les informations de \"fin de dépot\", veuillez ré-essayer."
+        flash.alert = "Impossible de sauvegarder les informations de la page de confirmation de dépôt, veuillez ré-essayer."
         render :edit, status: 400
       end
     end

--- a/app/views/administrateurs/dossier_submitted_messages/edit.html.erb
+++ b/app/views/administrateurs/dossier_submitted_messages/edit.html.erb
@@ -1,11 +1,11 @@
-<% content_for(:title, "Message de fin") %>
+<% content_for(:title, t('shared.dossier_submitted_message.title')) %>
 <% content_for(:root_class, 'scroll-margins-for-sticky-footer') %>
 <% render_procedure_sticky_title(@procedure) %>
 
 <%= render partial: 'shared/breadcrumbs_section',
   locals: { steps: [[admin_procedures_back_label(@procedure), admin_procedures_back_path(@procedure)],
                     [@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)],
-                    ['Fin de dépôt']] } %>
+                    [t('shared.dossier_submitted_message.title')]] } %>
 
 <%= form_with model: @dossier_submitted_message, url: admin_procedure_dossier_submitted_message_path(@procedure) do |f| %>
   <div class="fr-container fr-my-4w">
@@ -19,7 +19,9 @@
             class="fr-fieldset__legend"
             id="edit-dossier-submitted-message"
           >
-            <h1 class="fr-h2">Fin de dépôt</h1>
+            <h1 class="fr-h2">
+              <%= t('shared.dossier_submitted_message.title') %>
+            </h1>
 
             <p class="fr-text--regular">
               Personnalisez le message affiché à l’usager après le dépôt de son

--- a/app/views/administrateurs/procedures/clone_settings.html.erb
+++ b/app/views/administrateurs/procedures/clone_settings.html.erb
@@ -261,7 +261,7 @@
               <%= fco.check_box 'dossier_submitted_message', checked: true %>
 
               <%= fco.label 'dossier_submitted_message', class: "fr-label" do %>
-                <%= t('administrateurs.procedures.clone.dossier_submitted_message') %>
+                <%= t('shared.dossier_submitted_message.title') %>
 
                 <div class="fr-hint-text">
                   <%= t('administrateurs.procedures.clone.dossier_submitted_message_hint', message: @procedure.active_revision.dossier_submitted_message&.message_on_submit_by_usager) %>

--- a/config/locales/shared.en.yml
+++ b/config/locales/shared.en.yml
@@ -18,6 +18,8 @@ en:
           accepte: "Expires on %{date} (%{duree_conservation_totale} months after this file was processed)"
           refuse: "Expires on %{date} (%{duree_conservation_totale} months after this file was processed)"
           sans_suite: "Expires on %{date} (%{duree_conservation_totale} months after this file was processed)"
+    dossier_submitted_message:
+      title: Submission confirmation page
     order_positions:
       move_up: Move up
       move_down: Move down

--- a/config/locales/shared.fr.yml
+++ b/config/locales/shared.fr.yml
@@ -19,6 +19,8 @@ fr:
           refuse: "Expirera le %{date}  (%{duree_conservation_totale} mois après le traitement du dossier)"
           sans_suite: "Expirera le %{date} (%{duree_conservation_totale} mois après le traitement dossier)"
 
+    dossier_submitted_message:
+      title: Page de confirmation de dépôt
 
     order_positions:
       move_up: Déplacer vers le haut

--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -128,7 +128,6 @@ en:
         ineligibilite_hint: Enabled
         monavis_embed: MonAvis button
         monavis_embed_hint: "Code generated on MonAvis website : %{code}"
-        dossier_submitted_message: End of submission
         dossier_submitted_message_hint: "(Custom message) %{message}"
         accuse_lecture: Acknowledgment of receipt of the decision
         accuse_lecture_hint: Enabled

--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -128,7 +128,6 @@ fr:
         ineligibilite_hint: Activée
         monavis_embed: Bouton « MonAvis »
         monavis_embed_hint: "Code généré sur le site MonAvis : %{code}"
-        dossier_submitted_message: Fin de dépôt
         dossier_submitted_message_hint: "(Message personnalisé) %{message}"
         accuse_lecture: Accusé de lecture de la décision
         accuse_lecture_hint: Activé

--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -117,13 +117,13 @@ namespace :stats do
     sva_svr_procedures = base_scope.where.not(sva_svr: [nil, {}])
     add_procedure_stat(stats, "SVA/SVR activé", sva_svr_procedures, total_procedures, total_dossiers_all_procedures)
 
-    # 9. Personnalisation du message fin de dépôt
+    # 9. Personnalisation de la page de confirmation de dépôt
     ApplicationRecord.transaction do
       ApplicationRecord.connection.execute("SET LOCAL statement_timeout = '10min'")
       custom_message_procedures = base_scope.joins(:dossier_submitted_messages)
         .where.not(dossier_submitted_messages: { message_on_submit_by_usager: [nil, ''] })
         .distinct
-      add_procedure_stat(stats, "Message fin de dépôt personnalisé", custom_message_procedures, total_procedures, total_dossiers_all_procedures)
+      add_procedure_stat(stats, "Message de confirmation de dépôt personnalisé", custom_message_procedures, total_procedures, total_dossiers_all_procedures)
     end
 
     # 10. API entreprise avec jeton personnalisé

--- a/spec/system/administrateurs/dossier_submitted_message_spec.rb
+++ b/spec/system/administrateurs/dossier_submitted_message_spec.rb
@@ -47,7 +47,7 @@ describe 'As an administateur i can setup a DossierSubmittedMessage', js: true d
     end
 
     click_on 'Enregistrer'
-    expect(page).to have_content("Les informations de fin de dépot ont bien été sauvegardées.")
+    expect(page).to have_content("Les informations de la page de confirmation de dépôt ont bien été sauvegardées.")
     expect(procedure.dossier_submitted_messages.last.json_body["content"].to_s).to include("super important")
   end
 end


### PR DESCRIPTION
L'expression "fin de dépôt" est remplacée par "page de confirmation de dépôt" : 
- Dans l'écran de gestion d'une démarche (le texte de la tuile est adapté aussi)
<img width="2804" height="1744" alt="Capture d’écran 2026-06-15 à 17 10 13" src="https://github.com/user-attachments/assets/1a2645a1-6d8c-4441-9ba3-73120c82d1bd" />

- Dans la page de personnalisation du message affiché au dépôt du dossier (le title de l'onglet passe de "Message de fin" à "Confirmation de dépôt")
<img width="2794" height="1632" alt="Capture d’écran 2026-06-15 à 17 08 01" src="https://github.com/user-attachments/assets/9dadce3c-54e6-466d-b993-2d3255e5f333" />

- Dans la page de configuration du clonage d'une démarche

<img width="2804" height="1744" alt="Capture d’écran 2026-06-15 à 17 08 39" src="https://github.com/user-attachments/assets/59c4d247-8f30-40e9-b952-deb092b7eedc" />
