### PR TITLE
fix: restore hide-target Stimulus target in referentiel new form

### DIFF
--- a/app/components/referentiels/new_form_component/new_form_component.html.erb
+++ b/app/components/referentiels/new_form_component/new_form_component.html.erb
@@ -17,7 +17,6 @@
         <div
           id="url-tiptap"
           data-controller="tiptap"
-          data-tiptap-insert-after-tag-value=""
           data-tiptap-single-line-value="true"
         >
           <div class="fr-input-group fr-mb-3w">
@@ -74,7 +73,7 @@
         </div>
 
         <div
-          data-hide-target_target="toHide"
+          data-hide-target-target="toHide"
           class="<%= class_names('fr-hidden': !@referentiel&.authentication_by_header_token?) %>"
         >
           <%= render Dsfr::InputComponent.new(form:, attribute: "authentication_data[header]", **authentication_data_header_opts) %>


### PR DESCRIPTION
The HAML→ERB migration translated the data hash into a raw HTML attribute, leaving an underscore (data-hide-target_target) that Stimulus does not recognize, so the toHide target was never detected. Use the hyphenated data-hide-target-target and drop the redundant empty data-tiptap-insert-after-tag-value attribute (equal to the controller default), fixing both herb lint offenses.