### PR TITLE
Tech: résoud un problème d'accès concurrents pour l'analyse OCR

### DIFF
--- a/app/controllers/champs/piece_justificative_controller.rb
+++ b/app/controllers/champs/piece_justificative_controller.rb
@@ -34,8 +34,6 @@ class Champs::PieceJustificativeController < Champs::ChampController
     save_succeed = Attachment::PieceJustificativeService.attach_champ_pj(@champ, params[:blob_signed_id])
 
     if save_succeed
-      @champ.fetch_later! if @champ.has_async_external_data? && @champ.may_fetch_later?
-
       @champ.update_timestamps
 
       dossier = DossierPreloader.load_one(@champ.dossier, pj_template: true)

--- a/app/services/attachment/piece_justificative_service.rb
+++ b/app/services/attachment/piece_justificative_service.rb
@@ -14,6 +14,11 @@ class Attachment::PieceJustificativeService
       champ.reload(lock: true) # SELECT FOR UPDATE + clear association cache
       champ.updated_by = updated_by # keep record dirty so attach defers save to us
       champ.piece_justificative_file.attach(blob_signed_id)
+
+      # fetch_later should be called inside the transaction to avoid
+      # race condition with processor_job
+      champ.fetch_later if champ.has_async_external_data? && champ.may_fetch_later?
+
       context = champ.public? ? :champs_public_value : :champs_private_value
       champ.save(context:)
     end

--- a/spec/controllers/champs/piece_justificative_controller_spec.rb
+++ b/spec/controllers/champs/piece_justificative_controller_spec.rb
@@ -74,7 +74,6 @@ describe Champs::PieceJustificativeController, type: :controller do
 
       before do
         allow_any_instance_of(Champs::PieceJustificativeChamp).to receive(:has_async_external_data?).and_return(true)
-        expect_any_instance_of(Champs::PieceJustificativeChamp).to receive(:fetch_later!)
       end
 
       it 'attach the file' do
@@ -82,6 +81,11 @@ describe Champs::PieceJustificativeController, type: :controller do
         champ.reload
         expect(champ.piece_justificative_file.attached?).to be true
         expect(champ.piece_justificative_file[0].filename).to eq('piece_justificative_0.pdf')
+      end
+
+      it 'marks the champ waiting_for_job' do
+        subject
+        expect(champ.reload).to be_waiting_for_job
       end
 
       it 'renders the attachment template as Javascript' do
@@ -103,10 +107,10 @@ describe Champs::PieceJustificativeController, type: :controller do
         champ.update_column(:external_state, :fetched)
       end
 
-      it 'does not call fetch_later!' do
-        expect_any_instance_of(Champs::PieceJustificativeChamp).not_to receive(:fetch_later!)
+      it 'does not transition the champ out of fetched' do
         subject
         expect(response.status).to eq(200)
+        expect(champ.reload).to be_fetched
       end
     end
 

--- a/spec/services/attachment/piece_justificative_service_spec.rb
+++ b/spec/services/attachment/piece_justificative_service_spec.rb
@@ -34,5 +34,23 @@ RSpec.describe Attachment::PieceJustificativeService do
         expect(champ.reload.piece_justificative_file.count).to eq(2)
       end
     end
+
+    context 'with an OCR-compatible PJ (justificatif de domicile)' do
+      let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative, nature: 'justificatif_domicile' }]) }
+
+      it 'transitions the champ to waiting_for_job in the same transaction' do
+        described_class.attach_champ_pj(champ, blob_1.signed_id)
+
+        expect(champ.reload).to be_waiting_for_job
+      end
+    end
+
+    context 'with a non-OCR PJ' do
+      it 'leaves the champ idle' do
+        described_class.attach_champ_pj(champ, blob_1.signed_id)
+
+        expect(champ.reload).to be_idle
+      end
+    end
   end
 end


### PR DESCRIPTION
On avait un ptit soucis :

1. le pj controller attach le blob
2. le blob_processor_job se déclenche, il regarde si qq a appelé `fetch_later` pour l'analyse ocr. ce n'est pas le cas, il finit son travail sans appeler l'analyse OCR
3. le controller appelle `fetch_later`, mais malheureusement c'est trop tard.

La correction ? 

faire l'appel `fetch_later` dans la transaction de l'étape 1.