### PR TITLE
ETQ que consommateur d'API, je ne veux pas d'erreur quand j'utilise un stockage S3

### DIFF
--- a/app/graphql/types/file.rb
+++ b/app/graphql/types/file.rb
@@ -15,7 +15,7 @@ module Types
       if object.is_a?(Hash)
         object[:url]
       else
-        object.url(host: Current.host)
+        object.url
       end
     end
 


### PR DESCRIPTION
Quand on utilise le service ActiveStorage `s3`, un appel d'API nécessitant de télécharger une pièce jointe lève une exception "ArgumentError: unexpected value at params[:host]".

## Détails

La stacktrace fait en substance :

- `graphql/types/file.rb:18`: `object.url(host: Current.host)` (object est un Blob)
- `rails/active_storage/service.rb:125`: `private_url(key, **options)`
- `rails/active_storage/s3_service.rb:130`: `presigned_url(**client_opts)`
- `aws-sdk-core/param_validator.rb:92`: `errors << "unexpected value at #{context}[#{name.inspect}]"`

Ce qui se passe, c'est qu'ActiveStorage n'utilise pas le paramètre `host:`, et le fait donc passer au SDK S3. Qui au moment de valider constate que ce paramètre n'existe pas.

Ce problème a été introduit dans #12346. Ce qui est étonnant, c'est que vu que l'option `host:` n'est pas gérée par ActiveStorage, ça n'avait sans doute aucun effet de toute façon.

Trouvé par @maatinito il y a trois semaines (https://github.com/govpf/mes-demarches/commit/ceecad1520135c39bb70b8b31d3e8f03eed1d1ad), et par moi aujourd'hui.