### PR TITLE
Tech: retire le flag `column_conditions` maintenant qu'il est 100% activé

### DIFF
--- a/app/components/conditions/conditions_component.rb
+++ b/app/components/conditions/conditions_component.rb
@@ -76,7 +76,7 @@ class Conditions::ConditionsComponent < ApplicationComponent
   end
 
   def column_mode?
-    feature_enabled?(:column_conditions) && !@champ_value_in_condition
+    !@champ_value_in_condition
   end
 
   def sources_by_section

--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -716,7 +716,7 @@ module Administrateurs
     end
 
     def column_mode?
-      feature_enabled?(:column_conditions) && !procedure.champ_value_in_condition?
+      !procedure.champ_value_in_condition?
     end
   end
 end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -37,7 +37,6 @@ features = [
   :switch_domain,
   :llm_nightly_improve_procedure,
   :ami_notifications,
-  :column_conditions,
   :api_entreprise_tva_job,
 ]
 

--- a/spec/components/conditions/champs_conditions_component_spec.rb
+++ b/spec/components/conditions/champs_conditions_component_spec.rb
@@ -13,7 +13,7 @@ describe Conditions::ChampsConditionsComponent, type: :component do
     let(:column_mode) { false }
 
     before do
-      allow(component).to receive(:feature_enabled?).with(:column_conditions).and_return(column_mode)
+      allow(procedure).to receive(:champ_value_in_condition?).and_return(!column_mode)
       render_inline(component)
     end
 

--- a/spec/components/conditions/ineligibilite_rules_component_spec.rb
+++ b/spec/components/conditions/ineligibilite_rules_component_spec.rb
@@ -5,11 +5,6 @@ describe Conditions::IneligibiliteRulesComponent, type: :component do
   let(:procedure) { create(:procedure) }
   let(:component) { described_class.new(draft_revision: procedure.draft_revision) }
 
-  before do
-    allow_any_instance_of(described_class)
-      .to receive(:feature_enabled?).with(:column_conditions).and_return(false)
-  end
-
   describe 'render' do
     let(:ineligibilite_message) { 'ok' }
     let(:ineligibilite_enabled) { true }

--- a/spec/components/conditions/routing_rules_component_spec.rb
+++ b/spec/components/conditions/routing_rules_component_spec.rb
@@ -13,8 +13,6 @@ describe Conditions::RoutingRulesComponent, type: :component do
     let(:groupe_instructeur) { procedure.groupe_instructeurs.first }
     let(:component) { Conditions::RoutingRulesComponent.new(groupe_instructeur:) }
 
-    before { allow(component).to receive(:feature_enabled?).with(:column_conditions).and_return(true) }
-
     it 'excludes repetition tdcs from condition targets' do
       libelles = component.send(:sources_by_section).values.flatten(1).map(&:first)
 
@@ -33,7 +31,6 @@ describe Conditions::RoutingRulesComponent, type: :component do
 
     before do
       groupe_instructeur.update(routing_rule: routing_rule)
-      allow(component).to receive(:feature_enabled?).with(:column_conditions).and_return(false)
       render_inline(component)
     end
 

--- a/spec/components/procedures/one_group_management_component_spec.rb
+++ b/spec/components/procedures/one_group_management_component_spec.rb
@@ -23,8 +23,6 @@ describe Procedure::OneGroupeManagementComponent, type: :component do
         })
         procedure.publish_revision!(procedure.administrateurs.first)
         procedure.reload
-        allow_any_instance_of(Conditions::RoutingRulesComponent)
-          .to receive(:feature_enabled?).with(:column_conditions).and_return(false)
         subject
       end
       it { expect(page).to have_text('aucune règle') }

--- a/spec/components/types_de_champ_editor/champ_component_spec.rb
+++ b/spec/components/types_de_champ_editor/champ_component_spec.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 describe TypesDeChampEditor::ChampComponent, type: :component do
-  before do
-    allow_any_instance_of(Conditions::ChampsConditionsComponent)
-      .to receive(:feature_enabled?).with(:column_conditions).and_return(false)
-  end
-
   describe 'render' do
     let(:component) { described_class.new(coordinate:, upper_coordinates: []) }
     let(:routing_rules_stable_ids) { [] }

--- a/spec/components/types_de_champ_editor/editor_component_spec.rb
+++ b/spec/components/types_de_champ_editor/editor_component_spec.rb
@@ -6,11 +6,6 @@ describe TypesDeChampEditor::EditorComponent, type: :component do
   let(:types_de_champ_private) { [{ type: :repetition, children: [], libelle: 'private' }] }
   let(:types_de_champ_public) { [{ type: :repetition, children: [], libelle: 'public' }] }
 
-  before do
-    allow_any_instance_of(Conditions::ChampsConditionsComponent)
-      .to receive(:feature_enabled?).with(:column_conditions).and_return(false)
-  end
-
   describe 'render' do
     subject { render_inline(described_class.new(revision:, is_annotation:)) }
 

--- a/spec/components/types_de_champ_editor/explication_component_spec.rb
+++ b/spec/components/types_de_champ_editor/explication_component_spec.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 describe TypesDeChampEditor::ChampComponent, type: :component do
-  before do
-    allow_any_instance_of(Conditions::ChampsConditionsComponent)
-      .to receive(:feature_enabled?).with(:column_conditions).and_return(false)
-  end
-
   describe 'render by type' do
     context 'explication' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :explication }]) }

--- a/spec/controllers/administrateurs/conditions_controller_spec.rb
+++ b/spec/controllers/administrateurs/conditions_controller_spec.rb
@@ -141,7 +141,6 @@ describe Administrateurs::ConditionsController, type: :controller do
       let(:int_column) { dropdown_tdc.columns(procedure_id: procedure.id).first }
 
       before do
-        Flipper.enable(:column_conditions)
         sign_in(procedure.administrateurs.first.user)
         patch :change_targeted_champ,
           params: {

--- a/spec/system/administrateurs/condition_spec.rb
+++ b/spec/system/administrateurs/condition_spec.rb
@@ -43,7 +43,7 @@ describe 'As an administrateur I can edit types de champ condition', js: true do
         end
       end
 
-      expected_condition = greater_than_eq(target_value, constant(18))
+      expected_condition = greater_than_eq(champ_column_value(first_tdc.columns(procedure_id:).first), constant(18))
       wait_until { second_tdc.reload.condition == expected_condition }
     end
 
@@ -145,9 +145,6 @@ describe 'As an administrateur I can edit types de champ condition', js: true do
   end
 
   context 'in column_value mode' do
-    before { Flipper.enable(:column_conditions) }
-    after { Flipper.disable(:column_conditions) }
-
     let(:target_value) { champ_column_value(first_tdc.columns(procedure_id:).first) }
 
     include_examples 'condition editor'

--- a/spec/system/administrateurs/procedure_ineligibilite_spec.rb
+++ b/spec/system/administrateurs/procedure_ineligibilite_spec.rb
@@ -42,6 +42,6 @@ describe 'Administrateurs can edit procedures', js: true do
     # rules are setup
     wait_until { procedure.reload.draft_revision.ineligibilite_enabled == true }
     expect(procedure.draft_revision.ineligibilite_message).to eq("vous n’etes pas eligible")
-    expect(procedure.draft_revision.ineligibilite_rules).to eq(ds_eq(champ_value(first_tdc.stable_id), constant(true)))
+    expect(procedure.draft_revision.ineligibilite_rules).to eq(ds_eq(champ_column_value(first_tdc.columns(procedure_id: procedure.id).first), constant(true)))
   end
 end


### PR DESCRIPTION
Bien sûr on garde la capacité à gérer les 2 types de conditions champ value / columns