### PR TITLE
ETQ usager, badges « Expire dans X j. » et « Partagé avec moi »

### DIFF
--- a/app/components/dsfr/callout_component.rb
+++ b/app/components/dsfr/callout_component.rb
@@ -26,6 +26,8 @@ class Dsfr::CalloutComponent < ApplicationComponent
     case theme
     when :warning
       "fr-callout--brown-caramel"
+    when :orange_terre_battue
+      "fr-callout--orange-terre-battue"
     when :success
       "fr-callout--green-emeraude"
     when :neutral

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -125,6 +125,13 @@ module DossierHelper
     )
   end
 
+  def partage_badge(html_class: nil)
+    tag.span(
+      Dossier.human_attribute_name("partage.for_user"),
+      class: class_names("fr-badge fr-badge--sm fr-badge--blue-cumulus", html_class => true)
+    )
+  end
+
   def pending_correction_badge(profile, html_class: nil)
     tag.span(Dossier.human_attribute_name("pending_correction.#{profile}"), class:
       class_names(

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -116,6 +116,15 @@ module DossierHelper
     tag.span(status_text, class: "fr-badge #{status_class} ")
   end
 
+  def expiration_badge(dossier, html_class: nil)
+    return unless dossier.expirable? && dossier.close_to_expiration?
+
+    tag.span(
+      t('views.users.dossiers.dossiers_list.expiration_badge', count: dossier.nb_days_before_expiration),
+      class: class_names("fr-badge fr-badge--sm fr-badge--warning", html_class => true)
+    )
+  end
+
   def pending_correction_badge(profile, html_class: nil)
     tag.span(Dossier.human_attribute_name("pending_correction.#{profile}"), class:
       class_names(

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -637,6 +637,10 @@ class Dossier < ApplicationRecord
     expired_at < Expired::REMAINING_WEEKS_BEFORE_EXPIRATION.weeks.from_now && Time.zone.now < expired_at
   end
 
+  def nb_days_before_expiration
+    (expired_at.to_date - Date.current).to_i
+  end
+
   def has_expired?
     return false if en_instruction? || en_construction?
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -634,6 +634,7 @@ class Dossier < ApplicationRecord
 
   def close_to_expiration?
     return false if en_instruction? || en_construction?
+    return false if expired_at.nil?
     expired_at < Expired::REMAINING_WEEKS_BEFORE_EXPIRATION.weeks.from_now && Time.zone.now < expired_at
   end
 

--- a/app/views/users/dossiers/_dossiers_list.html.erb
+++ b/app/views/users/dossiers/_dossiers_list.html.erb
@@ -41,6 +41,11 @@
               <br>
               <%= badge %>
             <% end %>
+
+            <% unless current_user.owns?(dossier) %>
+              <br>
+              <%= partage_badge %>
+            <% end %>
           </div>
 
           <p class="fr-icon--sm fr-icon-user-line">
@@ -75,7 +80,7 @@
               <% end %>
             </p>
             <% if dossier.invites.present? %>
-              <p class="fr-icon--sm fr-icon-shield-line">
+              <p class="fr-icon--sm fr-icon-group-line">
                 <%= t('views.users.dossiers.dossiers_list.shared_with', owner: dossier.user_email_for(:display)) %>
                 <%= dossier.invites.map(&:email).join(', ') %>
               </p>
@@ -104,6 +109,11 @@
           <% if (badge = expiration_badge(dossier)) %>
             <br>
             <%= badge %>
+          <% end %>
+
+          <% unless current_user.owns?(dossier) %>
+            <br>
+            <%= partage_badge %>
           <% end %>
         </div>
       </div>

--- a/app/views/users/dossiers/_dossiers_list.html.erb
+++ b/app/views/users/dossiers/_dossiers_list.html.erb
@@ -25,27 +25,23 @@
               <%= number_with_html_delimiter(dossier.id) %>
             </p>
 
-            <%= status_badge_user(dossier, 'fr-mb-1w') %>
+            <div class="flex column align-start flex-gap-1">
+              <%= status_badge_user(dossier) %>
 
-            <% if dossier.pending_correction? %>
-              <br>
-              <%= pending_correction_badge(:for_user) %>
-            <% end %>
+              <% if dossier.pending_correction? %>
+                <%= pending_correction_badge(:for_user) %>
+              <% end %>
 
-            <% if dossier.pending_response? %>
-              <br>
-              <%= pending_response_badge(:for_user) %>
-            <% end %>
+              <% if dossier.pending_response? %>
+                <%= pending_response_badge(:for_user) %>
+              <% end %>
 
-            <% if (badge = expiration_badge(dossier)) %>
-              <br>
-              <%= badge %>
-            <% end %>
+              <% if (badge = expiration_badge(dossier)) %>
+                <%= badge %>
+              <% end %>
 
-            <% unless current_user.owns?(dossier) %>
-              <br>
-              <%= partage_badge %>
-            <% end %>
+              <%= partage_badge unless current_user.owns?(dossier) %>
+            </div>
           </div>
 
           <p class="fr-icon--sm fr-icon-user-line">
@@ -94,27 +90,23 @@
             <%= number_with_html_delimiter(dossier.id) %>
           </p>
 
-          <%= status_badge_user(dossier, 'fr-mb-1w') %>
+          <div class="flex column align-end flex-gap-1">
+            <%= status_badge_user(dossier) %>
 
-          <% if dossier.pending_correction? %>
-            <br>
-            <%= pending_correction_badge(:for_user) %>
-          <% end %>
+            <% if dossier.pending_correction? %>
+              <%= pending_correction_badge(:for_user) %>
+            <% end %>
 
-          <% if dossier.pending_response? %>
-            <br>
-            <%= pending_response_badge(:for_user) %>
-          <% end %>
+            <% if dossier.pending_response? %>
+              <%= pending_response_badge(:for_user) %>
+            <% end %>
 
-          <% if (badge = expiration_badge(dossier)) %>
-            <br>
-            <%= badge %>
-          <% end %>
+            <% if (badge = expiration_badge(dossier)) %>
+              <%= badge %>
+            <% end %>
 
-          <% unless current_user.owns?(dossier) %>
-            <br>
-            <%= partage_badge %>
-          <% end %>
+            <%= partage_badge unless current_user.owns?(dossier) %>
+          </div>
         </div>
       </div>
 

--- a/app/views/users/dossiers/_dossiers_list.html.erb
+++ b/app/views/users/dossiers/_dossiers_list.html.erb
@@ -36,9 +36,7 @@
                 <%= pending_response_badge(:for_user) %>
               <% end %>
 
-              <% if (badge = expiration_badge(dossier)) %>
-                <%= badge %>
-              <% end %>
+              <%= expiration_badge(dossier) %>
 
               <%= partage_badge unless current_user.owns?(dossier) %>
             </div>
@@ -101,9 +99,7 @@
               <%= pending_response_badge(:for_user) %>
             <% end %>
 
-            <% if (badge = expiration_badge(dossier)) %>
-              <%= badge %>
-            <% end %>
+            <%= expiration_badge(dossier) %>
 
             <%= partage_badge unless current_user.owns?(dossier) %>
           </div>

--- a/app/views/users/dossiers/_dossiers_list.html.erb
+++ b/app/views/users/dossiers/_dossiers_list.html.erb
@@ -36,6 +36,11 @@
               <br>
               <%= pending_response_badge(:for_user) %>
             <% end %>
+
+            <% if (badge = expiration_badge(dossier)) %>
+              <br>
+              <%= badge %>
+            <% end %>
           </div>
 
           <p class="fr-icon--sm fr-icon-user-line">
@@ -94,6 +99,11 @@
           <% if dossier.pending_response? %>
             <br>
             <%= pending_response_badge(:for_user) %>
+          <% end %>
+
+          <% if (badge = expiration_badge(dossier)) %>
+            <br>
+            <%= badge %>
           <% end %>
         </div>
       </div>

--- a/app/views/users/dossiers/_expiration_banner.html.haml
+++ b/app/views/users/dossiers/_expiration_banner.html.haml
@@ -5,12 +5,10 @@
 
   - if dossier.close_to_expiration? || dossier.has_expired?
     - title = dossier.has_expired? ? 'title_expired' : 'title'
-    = render Dsfr::CalloutComponent.new(title: t("users.dossiers.header.banner.#{title}"), theme: :warning) do |c|
+    = render Dsfr::CalloutComponent.new(title: t("users.dossiers.header.banner.#{title}"), theme: :orange_terre_battue) do |c|
       - c.with_body do
         - if dossier.brouillon?
           = t('users.dossiers.header.banner.states.brouillon')
-        - elsif dossier.en_construction?
-          = t('users.dossiers.header.banner.states.en_construction', nominal_duration_months: dossier.procedure.duree_conservation_dossiers_dans_ds)
         - elsif dossier.termine?
           = t('users.dossiers.header.banner.states.termine')
 
@@ -18,3 +16,6 @@
         - c.with_bottom do
           = button_to users_dossier_repousser_expiration_path(dossier), class: 'fr-btn', id: 'test-user-repousser-expiration' do
             = t('users.dossiers.header.banner.button_delay_expiration', count: dossier.procedure.duree_conservation_dossiers_dans_ds)
+      - elsif dossier.termine?
+        - c.with_bottom do
+          = render(partial: 'users/dossiers/show/download_dossier', locals: { dossier: dossier })

--- a/app/views/users/dossiers/_expiration_banner.html.haml
+++ b/app/views/users/dossiers/_expiration_banner.html.haml
@@ -16,6 +16,3 @@
         - c.with_bottom do
           = button_to users_dossier_repousser_expiration_path(dossier), class: 'fr-btn', id: 'test-user-repousser-expiration' do
             = t('users.dossiers.header.banner.button_delay_expiration', count: dossier.procedure.duree_conservation_dossiers_dans_ds)
-      - elsif dossier.termine?
-        - c.with_bottom do
-          = render(partial: 'users/dossiers/show/download_dossier', locals: { dossier: dossier })

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -10,8 +10,8 @@
         = status_badge_user(dossier, 'super')
         = pending_correction_badge(:for_user) if dossier.pending_correction?
         = pending_response_badge(:for_user) if dossier.pending_response?
-        = expiration_badge(dossier)
-        = partage_badge unless current_user.owns?(dossier)
+        = expiration_badge(dossier, html_class: 'super')
+        = partage_badge(html_class: 'super') unless current_user.owns?(dossier)
 
     = render(partial: 'users/dossiers/expiration_banner', locals: {dossier: dossier})
 

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -11,6 +11,7 @@
         = pending_correction_badge(:for_user) if dossier.pending_correction?
         = pending_response_badge(:for_user) if dossier.pending_response?
         = expiration_badge(dossier)
+        = partage_badge unless current_user.owns?(dossier)
 
     = render(partial: 'users/dossiers/expiration_banner', locals: {dossier: dossier})
 

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -10,6 +10,7 @@
         = status_badge_user(dossier, 'super')
         = pending_correction_badge(:for_user) if dossier.pending_correction?
         = pending_response_badge(:for_user) if dossier.pending_response?
+        = expiration_badge(dossier)
 
     = render(partial: 'users/dossiers/expiration_banner', locals: {dossier: dossier})
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -571,6 +571,7 @@ en:
         dossiers_list:
           n_dossier: "File no."
           expiration_badge:
+            zero: "Expires today"
             one: "Expires in %{count} day"
             other: "Expires in %{count} days"
           no_result_title: No files

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -572,7 +572,7 @@ en:
           n_dossier: "File no."
           expiration_badge:
             zero: "Expires today"
-            one: "Expires in %{count} day"
+            one: "Expires tomorrow"
             other: "Expires in %{count} days"
           no_result_title: No files
           no_result_text_html: "To fill a procedure, contact your administration asking for the procedure link. <br> It should look like %{app_base}/commencer/xxx."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -570,6 +570,9 @@ en:
           administration_no_longer_processes: "The administration will no longer process your request."
         dossiers_list:
           n_dossier: "File no."
+          expiration_badge:
+            one: "Expires in %{count} day"
+            other: "Expires in %{count} days"
           no_result_title: No files
           no_result_text_html: "To fill a procedure, contact your administration asking for the procedure link. <br> It should look like %{app_base}/commencer/xxx."
           no_result_text_with_search: found with search terms

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -581,6 +581,7 @@ fr:
         dossiers_list:
           n_dossier: "dossier n°"
           expiration_badge:
+            zero: "Expire aujourd'hui"
             one: "Expire dans %{count} j."
             other: "Expire dans %{count} j."
           no_result_title: Aucun dossier

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -581,7 +581,7 @@ fr:
         dossiers_list:
           n_dossier: "dossier n°"
           expiration_badge:
-            zero: "Expire aujourd'hui"
+            zero: "Expire aujourd’hui"
             one: "Expire dans %{count} j."
             other: "Expire dans %{count} j."
           no_result_title: Aucun dossier

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -580,6 +580,9 @@ fr:
           administration_no_longer_processes: "L’administration ne traitera plus votre demande."
         dossiers_list:
           n_dossier: "dossier n°"
+          expiration_badge:
+            one: "Expire dans %{count} j."
+            other: "Expire dans %{count} j."
           no_result_title: Aucun dossier
           no_result_text_html: "Pour remplir une démarche, contactez votre administration en lui demandant le lien de la démarche. <br> Celui ci doit ressembler à %{app_base}/commencer/xxx."
           no_result_text_with_search: ne correspond aux termes recherchés

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -582,7 +582,7 @@ fr:
           n_dossier: "dossier n°"
           expiration_badge:
             zero: "Expire aujourd’hui"
-            one: "Expire dans %{count} j."
+            one: "Expire demain"
             other: "Expire dans %{count} j."
           no_result_title: Aucun dossier
           no_result_text_html: "Pour remplir une démarche, contactez votre administration en lui demandant le lien de la démarche. <br> Celui ci doit ressembler à %{app_base}/commencer/xxx."

--- a/config/locales/models/dossier/en.yml
+++ b/config/locales/models/dossier/en.yml
@@ -40,6 +40,8 @@ en:
         for_user: "PENDING RESPONSE"
         for_instructeur: "pending response"
         responded: "Response given"
+      partage:
+        for_user: "Shared with me"
       traitement:
         state: "State"
       traitement/state:

--- a/config/locales/models/dossier/fr.yml
+++ b/config/locales/models/dossier/fr.yml
@@ -41,6 +41,8 @@ fr:
         for_instructeur: "en attente de réponse"
         responded: "Réponse donnée"
         discarded: "Demande de réponse annulée"
+      partage:
+        for_user: "Partagé avec moi"
       traitement:
         state: "État"
       traitement/state:

--- a/config/locales/views/users/header/en.yml
+++ b/config/locales/views/users/header/en.yml
@@ -14,7 +14,6 @@ en:
           contact_service_html: For more information, please contact the service %{service_name}, available at  %{service_phone_number} or by email to <a href="mailto:%{service_email}">%{service_email}</a>
           states:
             brouillon: Your file is still in draft and will soon expire. So it will be deleted soon without being instructed. If you want to pursue your procedure you can submit it now. Otherwise you are able to delay its expiration by clicking on the underneath button.
-            en_construction: Your file is pending for instruction. The maximum delay is %{nominal_duration_months} months, but you can extend the duration by clicking on the underneath button.
             termine: Your file had been processed and will soon expire. So it will be deleted soon. If you want to keep it, you can dowload a PDF file of it.
           button_delay_expiration:
             one: "Keep for %{count} more month"

--- a/config/locales/views/users/header/fr.yml
+++ b/config/locales/views/users/header/fr.yml
@@ -15,7 +15,6 @@ fr:
           title_expired: Votre dossier a expiré
           states:
             brouillon: Votre dossier est en brouillon, mais va bientôt être supprimé sans avoir été déposé. Si vous souhaitez le conserver afin de poursuivre la démarche, vous pouvez étendre la durée de conversation en cliquant sur le bouton ci-dessous.
-            en_construction: Votre dossier est en attente de prise en charge par l’administration. Le délai de prise en charge maximal est de %{nominal_duration_months} mois. Vous pouvez toutefois étendre cette durée en cliquant sur le bouton ci-dessous.
             termine: Le traitement de votre dossier est terminé, mais il va bientôt être supprimé. Si vous souhaitez en conserver une trace, vous pouvez le télécharger au format PDF.
           button_delay_expiration:
             one: "Conserver %{count} mois supplémentaire"

--- a/config/locales/views/users/header/fr.yml
+++ b/config/locales/views/users/header/fr.yml
@@ -14,7 +14,7 @@ fr:
           title: Votre dossier va expirer
           title_expired: Votre dossier a expiré
           states:
-            brouillon: Votre dossier est en brouillon, mais va bientôt être supprimé sans avoir été déposé. Si vous souhaitez le conserver afin de poursuivre la démarche, vous pouvez étendre la durée de conversation en cliquant sur le bouton ci-dessous.
+            brouillon: Votre dossier est en brouillon, mais va bientôt être supprimé sans avoir été déposé. Si vous souhaitez le conserver afin de poursuivre la démarche, vous pouvez étendre la durée de conservation en cliquant sur le bouton ci-dessous.
             termine: Le traitement de votre dossier est terminé, mais il va bientôt être supprimé. Si vous souhaitez en conserver une trace, vous pouvez le télécharger au format PDF.
           button_delay_expiration:
             one: "Conserver %{count} mois supplémentaire"

--- a/spec/components/dsfr/callout_component_spec.rb
+++ b/spec/components/dsfr/callout_component_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Dsfr::CalloutComponent, type: :component do
+  subject(:rendered) { render_inline(described_class.new(title: "Mon titre", theme:)) }
+
+  context "with the orange_terre_battue theme" do
+    let(:theme) { :orange_terre_battue }
+
+    it { is_expected.to have_css(".fr-callout.fr-callout--orange-terre-battue") }
+  end
+
+  context "with the warning theme" do
+    let(:theme) { :warning }
+
+    it { is_expected.to have_css(".fr-callout.fr-callout--brown-caramel") }
+  end
+end

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -265,6 +265,12 @@ RSpec.describe DossierHelper, type: :helper do
     end
   end
 
+  describe ".partage_badge" do
+    subject { partage_badge }
+
+    it { is_expected.to have_css(".fr-badge--blue-cumulus", text: "Partagé avec moi") }
+  end
+
   describe ".expiration_badge" do
     subject { expiration_badge(dossier) }
 

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -282,6 +282,14 @@ RSpec.describe DossierHelper, type: :helper do
       it { is_expected.to have_css(".fr-badge--warning", text: "Expire dans 5 j.") }
     end
 
+    context "when dossier expires today" do
+      let(:dossier) { create(:dossier) }
+
+      before { dossier.update_column(:expired_at, Time.zone.now.end_of_day) }
+
+      it { is_expected.to have_css(".fr-badge--warning", text: "Expire aujourd'hui") }
+    end
+
     context "when dossier is not close to expiration" do
       let(:dossier) { create(:dossier) }
 

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -265,6 +265,43 @@ RSpec.describe DossierHelper, type: :helper do
     end
   end
 
+  describe ".expiration_badge" do
+    subject { expiration_badge(dossier) }
+
+    context "when dossier is a brouillon close to expiration" do
+      let(:dossier) { create(:dossier) }
+
+      before { dossier.update_column(:expired_at, 5.days.from_now.change(hour: 23)) }
+
+      it { is_expected.to have_css(".fr-badge--warning", text: "Expire dans 5 j.") }
+    end
+
+    context "when dossier is not close to expiration" do
+      let(:dossier) { create(:dossier) }
+
+      before { dossier.update_column(:expired_at, 1.year.from_now) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when dossier is en_construction (never expires)" do
+      let(:dossier) { create(:dossier, :en_construction) }
+
+      before { dossier.update_column(:expired_at, 5.days.from_now) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when dossier is termine without procedure_expires_when_termine_enabled" do
+      let(:procedure) { create(:procedure, :published, procedure_expires_when_termine_enabled: false) }
+      let(:dossier) { create(:dossier, :accepte, procedure:) }
+
+      before { dossier.update_column(:expired_at, 5.days.from_now) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe ".clean_string_for_pdf" do
     subject { clean_string_for_pdf(input) }
 

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe DossierHelper, type: :helper do
 
       before { dossier.update_column(:expired_at, Time.zone.now.end_of_day) }
 
-      it { is_expected.to have_css(".fr-badge--warning", text: "Expire aujourd'hui") }
+      it { is_expected.to have_css(".fr-badge--warning", text: "Expire aujourd’hui") }
     end
 
     context "when dossier is not close to expiration" do

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -282,6 +282,14 @@ RSpec.describe DossierHelper, type: :helper do
       it { is_expected.to have_css(".fr-badge--warning", text: "Expire dans 5 j.") }
     end
 
+    context "when dossier expires tomorrow" do
+      let(:dossier) { create(:dossier) }
+
+      before { dossier.update_column(:expired_at, 1.day.from_now.change(hour: 23)) }
+
+      it { is_expected.to have_css(".fr-badge--warning", text: "Expire demain") }
+    end
+
     context "when dossier expires today" do
       let(:dossier) { create(:dossier) }
 

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -223,6 +223,16 @@ describe Dossier, type: :model do
     end
   end
 
+  describe '#close_to_expiration?' do
+    context 'when expired_at is nil' do
+      let(:dossier) { create(:dossier) }
+
+      before { dossier.update_column(:expired_at, nil) }
+
+      it { expect(dossier.close_to_expiration?).to be(false) }
+    end
+  end
+
   describe "en_construction never expires (#13178)" do
     let(:procedure) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 2) }
     let(:dossier) { create(:dossier, :en_construction, procedure:, en_construction_at: 50.days.ago) }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -214,6 +214,15 @@ describe Dossier, type: :model do
     end
   end
 
+  describe '#nb_days_before_expiration' do
+    let(:dossier) { create(:dossier) }
+
+    it 'counts the number of days until expired_at' do
+      dossier.update_column(:expired_at, 5.days.from_now.change(hour: 23))
+      expect(dossier.nb_days_before_expiration).to eq(5)
+    end
+  end
+
   describe "en_construction never expires (#13178)" do
     let(:procedure) { create(:procedure, :published, duree_conservation_dossiers_dans_ds: 2) }
     let(:dossier) { create(:dossier, :en_construction, procedure:, en_construction_at: 50.days.ago) }

--- a/spec/system/users/list_dossiers_spec.rb
+++ b/spec/system/users/list_dossiers_spec.rb
@@ -59,6 +59,19 @@ describe 'user access to the list of their dossiers', js: true do
     end
   end
 
+  context 'when the user is invited on a shared dossier' do
+    let(:owner) { create(:user) }
+    let!(:shared_dossier) { create(:dossier, :en_construction, user: owner) }
+    let!(:invite) { create(:invite, dossier: shared_dossier, user:) }
+
+    before { visit dossiers_path(statut: 'dossiers-invites') }
+
+    it 'displays the "Partagé avec moi" badge and the group-line sharing icon' do
+      expect(page).to have_css('.fr-badge--blue-cumulus', text: 'Partagé avec moi')
+      expect(page).to have_css('.fr-icon-group-line')
+    end
+  end
+
   context 'when there are dossiers from other users' do
     let!(:dossier_other_user) { create(:dossier) }
 

--- a/spec/system/users/list_dossiers_spec.rb
+++ b/spec/system/users/list_dossiers_spec.rb
@@ -47,6 +47,18 @@ describe 'user access to the list of their dossiers', js: true do
     expect(page.body).to match(/#{last_updated_dossier.procedure.libelle}.*#{dossier_en_instruction.procedure.libelle}/m)
   end
 
+  context 'when a brouillon is close to expiration' do
+    let!(:dossier_expirant) do
+      create(:dossier, user:).tap { it.update_column(:expired_at, 5.days.from_now) }
+    end
+
+    before { visit dossiers_path }
+
+    it 'displays the expiration badge on the card' do
+      expect(page).to have_text('Expire dans 5 j.')
+    end
+  end
+
   context 'when there are dossiers from other users' do
     let!(:dossier_other_user) { create(:dossier) }
 

--- a/spec/views/users/dossiers/_expiration_banner.html.haml_spec.rb
+++ b/spec/views/users/dossiers/_expiration_banner.html.haml_spec.rb
@@ -97,10 +97,11 @@ describe 'users/dossiers/expiration_banner', type: :view do
       let(:attributes) { { processed_at: 6.months.ago } }
       let(:state) { :accepte }
 
-      it 'renders the orange callout with the PDF download button' do
+      it 'renders the orange callout without any action button (download is handled by the header)' do
         expect(subject).to have_selector('.fr-callout.fr-callout--orange-terre-battue')
         expect(subject).not_to have_selector('#test-user-repousser-expiration')
-        expect(subject).to have_link(href: dossier_path(dossier, format: :pdf))
+        expect(subject).not_to have_selector('.fr-callout a')
+        expect(subject).not_to have_selector('.fr-callout button')
       end
     end
   end

--- a/spec/views/users/dossiers/_expiration_banner.html.haml_spec.rb
+++ b/spec/views/users/dossiers/_expiration_banner.html.haml_spec.rb
@@ -77,4 +77,31 @@ describe 'users/dossiers/expiration_banner', type: :view do
       end
     end
   end
+
+  context 'when close to expiration' do
+    let(:expiration_enabled) { true }
+
+    before { allow(dossier).to receive(:close_to_expiration?).and_return(true) }
+
+    context 'with a brouillon' do
+      let(:attributes) { { created_at: 6.months.ago } }
+      let(:state) { :brouillon }
+
+      it 'renders the orange callout with the postpone button' do
+        expect(subject).to have_selector('.fr-callout.fr-callout--orange-terre-battue')
+        expect(subject).to have_selector('#test-user-repousser-expiration')
+      end
+    end
+
+    context 'with a termine dossier' do
+      let(:attributes) { { processed_at: 6.months.ago } }
+      let(:state) { :accepte }
+
+      it 'renders the orange callout with the PDF download button' do
+        expect(subject).to have_selector('.fr-callout.fr-callout--orange-terre-battue')
+        expect(subject).not_to have_selector('#test-user-repousser-expiration')
+        expect(subject).to have_link(href: dossier_path(dossier, format: :pdf))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Évolution des badges de notification de l'usager sur ses dossiers (cf. #13018).
Deux cas traités ici pour ne pas bloquer la MEP de #12915

## EXPIRE DANS X J. (dossiers expirants)
- Nouveau badge « Expire dans X j. » (statut avertissement) sur la carte de la
  liste et l'en-tête de la page Dossier, affiché de J‑14 jusqu'à l'expiration,
  pour les dossiers **brouillon ou traités** uniquement (un dossier en
  construction / en instruction n'expire jamais). Le dernier jour, le badge
  affiche « Expire aujourd'hui ».
- Refonte du bandeau de la page Dossier : accent « orange‑terre‑battue »
  (nouveau thème `Dsfr::CalloutComponent`), bouton « Conserver X mois »
  (brouillon) ; le téléchargement PDF (traité) reste géré par l'en‑tête.

## PARTAGÉ AVEC MOI (dossiers partagés)
- Nouveau badge « Partagé avec moi » (accent « blue‑cumulus ») affiché quand
  l'usager courant est invité sur le dossier (pas le propriétaire), sur la carte
  et l'en‑tête de la page Dossier.
- Ligne d'info de partage : icône passée de `shield-line` à `group-line`.

Les badges sont calculés à partir de l'état du dossier (comme les badges
« à corriger » / « en attente de réponse » existants) ; `DossierNotification`
reste réservé aux instructeurs. Les filtres associés sont traités dans #12915.

L'empilement des badges sur la carte utilise désormais un conteneur flex
(`flex column flex-gap-1`) plutôt que des `<br>`, pour un espacement homogène
et un balisage plus accessible. `Dossier#close_to_expiration?` renvoie `false`
quand `expired_at` est nil (évite un `NoMethodError` lorsque le badge est
calculé pour un dossier sans date d'expiration).

## Captures d'écran (avant / après)

| Écran | Avant (`main`) | Après (cette PR) |
|---|---|---|
| Badge Expirant | <img width="1400" height="1400" alt="before_list" src="https://github.com/user-attachments/assets/6f086a31-4b6a-4f6c-a174-aa7597c7d594" /> | <img width="1400" height="1400" alt="after_list" src="https://github.com/user-attachments/assets/98f5d723-3d94-4f43-bf82-c6d566f5aa38" /> |
| Badge partagé | <img width="1400" height="1400" alt="before_invites" src="https://github.com/user-attachments/assets/9b813360-4a63-4ba3-a637-4c806e3884d5" /> | <img width="1400" height="1400" alt="after_invites" src="https://github.com/user-attachments/assets/83b9c8d6-16be-41da-b5a0-26812e383c52" />  |
| Page Dossier (en‑tête + bandeau) | <img width="1400" height="1400" alt="before_show" src="https://github.com/user-attachments/assets/df9fd84d-2c41-46a7-a819-46e8c0f1087b" /> | <img width="1400" height="1400" alt="after_show" src="https://github.com/user-attachments/assets/96781ac6-1c3f-488a-a43d-972c7ba55424" />|
