### PR TITLE
ETQ Administrateur je veux cloner une démarche avec son service via GraphQL

### DIFF
--- a/app/graphql/mutations/demarche_cloner.rb
+++ b/app/graphql/mutations/demarche_cloner.rb
@@ -6,16 +6,17 @@ module Mutations
 
     argument :demarche, Types::DemarcheDescriptorType::FindDemarcheInput, "La démarche", required: true
     argument :title, String, "Le titre de la nouvelle démarche.", required: false
+    argument :clone_service, Boolean, "Cloner le service de la démarche.", required: false
 
     field :demarche, Types::DemarcheDescriptorType, null: true
     field :errors, [Types::ValidationErrorType], null: true
 
-    def resolve(demarche:, title: nil)
+    def resolve(demarche:, title: nil, clone_service: nil)
       demarche_number = demarche.number.presence || ApplicationRecord.id_from_typed_id(demarche.id)
       demarche = Procedure.with_active_revision.find_by(id: demarche_number)
 
       if demarche.present? && (demarche.opendata? || context.authorized_demarche?(demarche))
-        cloned_demarche = demarche.clone(admin: context.current_administrateur)
+        cloned_demarche = demarche.clone(admin: context.current_administrateur, options: { clone_service: })
         cloned_demarche.update!(libelle: title) if title.present?
 
         { demarche: cloned_demarche.draft_revision }

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1403,6 +1403,11 @@ input DemarcheClonerInput {
   clientMutationId: String
 
   """
+  Cloner le service de la démarche.
+  """
+  cloneService: Boolean
+
+  """
   La démarche
   """
   demarche: FindDemarcheInput!

--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -90,7 +90,7 @@ module ProcedureCloneConcern
   NEW_MAX_DUREE_CONSERVATION = Expired::DEFAULT_DOSSIER_RENTENTION_IN_MONTH
 
   def clone(options: nil, admin:)
-    options = default_options if options.nil?
+    options = default_options.merge(options || {})
 
     populate_champ_stable_ids
 

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -1460,6 +1460,26 @@ describe API::V2::GraphqlController do
           expect(Procedure.last.libelle).to eq(new_title)
         }
       end
+
+      context 'with cloneService: true' do
+        let(:variables) { { input: { demarche: { id: procedure.to_typed_id }, cloneService: true } } }
+
+        it {
+          expect(gql_errors).to be_nil
+          expect(gql_data[:demarcheCloner][:errors]).to be_nil
+          expect(Procedure.last.service).to eq(procedure.service)
+        }
+      end
+
+      context 'without cloneService' do
+        let(:variables) { { input: { demarche: { id: procedure.to_typed_id } } } }
+
+        it {
+          expect(gql_errors).to be_nil
+          expect(gql_data[:demarcheCloner][:errors]).to be_nil
+          expect(Procedure.last.service).to be_nil
+        }
+      end
     end
 
     context 'dossierEnvoyerMessage' do


### PR DESCRIPTION
fix #12996

Nous ajoutons l'option `cloneService` dans la mutation graphql de `clonerDemarche` afin de pouvoir conserver le service de la démarche initial sur la nouvelle démarche.

 