### PR TITLE
ETQ usager, je ne veux pas me retrouver avec un dossier en vrac, si la requete de n'est pas dans la ban est rejouée

### DIFF
--- a/app/controllers/concerns/dossier_edit_concern.rb
+++ b/app/controllers/concerns/dossier_edit_concern.rb
@@ -73,30 +73,25 @@ module DossierEditConcern
   # static keys. We create a static hash based on the available keys.
   def champs_attributes_params(scope)
     param_key = :"champs_#{scope}_attributes"
-    champ_attributes = [
-      :id,
-      :value,
-      :value_other,
-      :external_id,
-      :code,
-      :primary_value,
-      :secondary_value,
-      :piece_justificative_file,
-      :code_departement,
-      :accreditation_number,
-      :accreditation_birthdate,
-      :address,
+    public_ids = params.dig(:dossier, param_key)&.keys || []
+
+    champs_attributes = public_ids.index_with do |public_id|
+      not_in_ban = params.dig(:dossier, param_key, public_id, :not_in_ban) == 'true'
+      champ_permitted_attributes(scope, not_in_ban:)
+    end
+
+    params.require(:dossier).permit(param_key => champs_attributes).fetch(param_key)
+  end
+
+  def champ_permitted_attributes(scope, not_in_ban:)
+    [
+      :id, :value, :value_other, :external_id, :code,
+      :primary_value, :secondary_value, :piece_justificative_file,
+      :code_departement, :accreditation_number, :accreditation_birthdate,
       :not_in_ban,
-      :street_address,
-      :city_name,
-      :country_code,
-      :commune_code,
-      :postal_code,
       (:preview_state if scope == :public),
+      *(not_in_ban ? [:street_address, :city_name, :country_code, :commune_code, :postal_code] : [:address]),
       value: [],
     ].compact
-    public_ids = params.dig(:dossier, param_key)&.keys || []
-    champs_attributes = public_ids.index_with { champ_attributes }
-    params.require(:dossier).permit(param_key => champs_attributes).fetch(param_key)
   end
 end

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1013,6 +1013,57 @@ describe Users::DossiersController, type: :controller do
       end
     end
 
+    context 'when the champ is an address' do
+      let(:types_de_champ_public) { [{ type: :address }] }
+      let(:address_champ) { dossier.champs.first }
+      let(:initial_value_json) do
+        {
+          'label' => '33 Rue Rébeval 75019 Paris',
+          'city_code' => '75119',
+          'city_name' => 'Paris',
+          'postal_code' => '75019',
+          'street_address' => '33 Rue Rébeval',
+          'department_code' => '75',
+          'department_name' => 'Paris',
+        }
+      end
+
+      before { address_champ.update!(value: '33 Rue Rébeval 75019 Paris', value_json: initial_value_json) }
+
+      context 'when not_in_ban is not set (regular BAN address)' do
+        let(:champs_public_attributes) do
+          { address_champ.public_id => { street_address: 'donnée injectée' } }
+        end
+
+        it 'does not permit the out-of-BAN address fields and keeps the original data intact' do
+          subject
+          expect(address_champ.reload.value_json['street_address']).to eq('33 Rue Rébeval')
+        end
+      end
+
+      context 'when not_in_ban is true' do
+        let(:champs_public_attributes) do
+          {
+            address_champ.public_id => {
+              not_in_ban: 'true',
+              street_address: '12 rue du Test',
+              city_name: 'Lyon',
+              postal_code: '69001',
+            },
+          }
+        end
+
+        it 'permits the out-of-BAN address fields' do
+          subject
+          address_champ.reload
+          expect(address_champ.not_ban?).to be_truthy
+          expect(address_champ.value_json['street_address']).to eq('12 rue du Test')
+          expect(address_champ.value_json['city_name']).to eq('Lyon')
+          expect(address_champ.value_json['postal_code']).to eq('69001')
+        end
+      end
+    end
+
     context 'when the dossier cannot be updated by the user' do
       let(:dossier) { create(:dossier, :en_instruction, user:, procedure:) }
 


### PR DESCRIPTION
sentry: https://demarches-simplifiees.sentry.io/issues/?environment=production&project=1429550&query=is%3Aunresolved%20dossier%3A%EF%80%8DContains%EF%80%8D32003497&referrer=issue-list&statsPeriod=7d

# Probleme 

Impossible de deposer son dossier. C'est lié a de la serialisation du dossier pour les ops logs.
Le stagiaire (Claude), nous avons proposé une cycle de requete qui se passe pas comme souhaité
ETQ usager, je remplis une adresse hors ban. 
ETQ usager, je change d'avis pour une adresse dans la ban, donc je clique sur la checkbox (Je ne trouve pas...). 
La requete est joué deux fois (resend via ffx et les dev tools onglet remote)

# Solution

On évite ce scenario en prefiltrant les donnée permises par Strong Param