### PR TITLE
[Fix] Le formulaire d'identité ne se soumet plus après passage en "pour un tiers"

### DIFF
--- a/app/javascript/controllers/for_tiers_controller.ts
+++ b/app/javascript/controllers/for_tiers_controller.ts
@@ -23,7 +23,7 @@ export class ForTiersController extends ApplicationController {
   declare emailContainerTarget: HTMLElement;
   declare emailInputTarget: HTMLInputElement;
 
-  connect() {
+  notificationMethodCheckboxTargetConnected() {
     this.toggleEmailInput();
   }
 


### PR DESCRIPTION
Suite à une remontée Crisp : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_013fcfb7-2c32-4840-a704-8b8f604578a4/

Quand on bascule de "Pour vous" à "Pour une autre personne" sur un dossier déjà créé, le formulaire est remplacé avec turbo et ça ne redéclenche pas le controller stimulus. Donc le champ email caché (lié au tiers) restait required, ce qui bloquait la soumission.