### PR TITLE
Tech : génère l'attestation de dépôt en PDF/UA accessible (derrière feature flag)

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -866,7 +866,10 @@ class Dossier < ApplicationRecord
       assigns: { dossier: self }
     )
 
-    pdf = WeasyprintService.generate_pdf(html, { procedure_id: procedure.id, dossier_id: id })
+    options = { procedure_id: procedure.id, dossier_id: id }
+    options[:pdf_variant] = WeasyprintService::PDF_UA_VARIANT if procedure.feature_enabled?(:pdf_variant)
+
+    pdf = WeasyprintService.generate_pdf(html, options)
 
     attestation_depot_pdf.attach(
       io: StringIO.new(pdf),

--- a/app/services/weasyprint_service.rb
+++ b/app/services/weasyprint_service.rb
@@ -3,6 +3,8 @@
 class WeasyprintService
   class Error < StandardError; end
 
+  PDF_UA_VARIANT = 'pdf/ua-1'
+
   def self.generate_pdf(html, options = {})
     headers = {
       'Content-Type' => 'application/json',

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -39,6 +39,7 @@ features = [
   :llm_nightly_improve_procedure,
   :ami_notifications,
   :api_entreprise_tva_job,
+  :pdf_variant,
 ]
 
 def database_exists?

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -2052,6 +2052,16 @@ describe Users::DossiersController, type: :controller do
         expect(WeasyprintService).to have_received(:generate_pdf)
           .with(a_string_matching(/#{dossier.individual.prenom}/), anything)
       end
+
+      context 'when the pdf_variant feature is enabled' do
+        before { Flipper.enable(:pdf_variant, dossier.procedure) }
+
+        it 'requests the pdf/ua-1 variant through the options' do
+          subject
+          expect(WeasyprintService).to have_received(:generate_pdf)
+            .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
+        end
+      end
     end
 
     context 'when the dossier is still a draft' do


### PR DESCRIPTION
## Pourquoi

Les pdfs générés par WeasyPrint ne sont pas balisés (tagged pdf) et ne sont donc pas conformes PDF/UA (accessibilité). On teste la génération d'une version balisée, uniquement sur l'attestation de dépôt, pour commencer, avec un feature flag par démarche. Ensuite, on pourra élargir aux autres pdfs générés dans DN.

## Quoi

- `WeasyprintService.generate_pdf` accepte un nouveau paramètre `pdf_variant` (optionnel), transmis au serveur weasyprint dans le corps de la requête uniquement s'il est présent. Les appels existants restent inchangés.
- `Dossier#generate_or_reuse_attestation_depot` envoie `pdf_variant: "pdf/ua-1"` quand le feature flag `pdf_variant` est activé sur la procédure, sinon rien.
- Enregistrement du flag `:pdf_variant` (désactivé par défaut, activable par procédure).

> ⚠️ Nécessite le serveur weasyprint capable de traiter `pdf_variant` dans la requête, via la [PR 45 du repo weasyprint](https://github.com/demarche-numerique/weasyprint_server/pull/45/). Cependant, pas de question d'ordre de déploiement, les 2 PR fonctionnent indépendamment

