### PR TITLE
ETQ super-admin je vois les attributs ProConnect et robots_indexable manquants dans le manager

### DIFF
--- a/app/dashboards/procedure_dashboard.rb
+++ b/app/dashboards/procedure_dashboard.rb
@@ -56,9 +56,12 @@ class ProcedureDashboard < Administrate::BaseDashboard
     tags: Field::Text,
     template: Field::Boolean,
     opendata: Field::Boolean,
+    robots_indexable: Field::Boolean,
     hide_instructeurs_email: Field::Boolean,
     dossiers_count: Field::Number,
     no_gender: Field::Boolean,
+    pro_connect_restriction: Field::String,
+    pro_connect_for_moral_procedure: Field::Boolean,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -108,6 +111,8 @@ class ProcedureDashboard < Administrate::BaseDashboard
     :published_types_de_champ_public,
     :published_types_de_champ_private,
     :for_individual,
+    :pro_connect_restriction,
+    :pro_connect_for_moral_procedure,
     :api_entreprise_token,
     :auto_archive_on,
     :passer_en_construction_email_template,
@@ -126,6 +131,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     :for_tiers_enabled,
     :hide_instructeurs_email,
     :opendata,
+    :robots_indexable,
     :replaced_by_procedure_id,
   ].freeze
 

--- a/spec/controllers/manager/procedures_controller_spec.rb
+++ b/spec/controllers/manager/procedures_controller_spec.rb
@@ -51,6 +51,9 @@ describe Manager::ProceduresController, type: :controller do
     it do
       expect(response.body).to include('sub type de champ')
       expect(response.body).to include('Hidden At As Template')
+      expect(response.body).to include('Pro Connect Restriction')
+      expect(response.body).to include('Pro Connect For Moral Procedure')
+      expect(response.body).to include('Robots Indexable')
     end
   end
 


### PR DESCRIPTION
Plusieurs attributs de configuration des démarches ajoutés ces derniers mois n'apparaissaient pas sur la page show d'une démarche dans le manager :

- `pro_connect_restriction` (niveau de restriction ProConnect)
- `pro_connect_for_moral_procedure`
- `robots_indexable`

Ils sont désormais affichés car c'est pratique pour le support