### PR TITLE
ETQ admin, corrige l'erreur 500 lors de la modification d'un service invalide

### DIFF
--- a/app/controllers/administrateurs/services_controller.rb
+++ b/app/controllers/administrateurs/services_controller.rb
@@ -39,7 +39,7 @@ module Administrateurs
     def edit
       @service = service
       @procedure = procedure
-      @other_procedures = @service.procedures.where.not(id: @procedure.id).order(:id)
+      set_other_procedures
     end
 
     def update
@@ -54,6 +54,7 @@ module Administrateurs
           notice: "#{@service.nom} modifié"
       else
         @procedure = procedure
+        set_other_procedures
         flash[:alert] = @service.errors.full_messages
         render :edit
       end
@@ -109,6 +110,10 @@ module Administrateurs
 
     def service
       services.find(params[:id])
+    end
+
+    def set_other_procedures
+      @other_procedures = @service.procedures.where.not(id: @procedure.id).order(:id)
     end
 
     def services

--- a/spec/controllers/administrateurs/services_controller_spec.rb
+++ b/spec/controllers/administrateurs/services_controller_spec.rb
@@ -170,7 +170,7 @@ describe Administrateurs::ServicesController, type: :controller do
       it 'assigns no other procedures and does not render the warning' do
         subject
         expect(assigns(:other_procedures)).to be_empty
-        expect(response.body).not_to include("impactera également les démarches publiées")
+        expect(response.body).not_to include("impactera également les démarches suivantes")
       end
     end
 
@@ -230,10 +230,13 @@ describe Administrateurs::ServicesController, type: :controller do
     end
 
     context 'when updating a service with invalid data' do
+      render_views
+
       let(:service_params) { { nom: '', type_organisme: Service.type_organismes.fetch(:association) } }
 
       it do
         expect(flash.alert).not_to be_nil
+        expect(response).to have_http_status(:ok)
         expect(response).to render_template(:edit)
       end
     end


### PR DESCRIPTION
Depuis #13050, soumettre le formulaire de modification d'un service avec des données invalides provoquait une erreur 500 : le template `edit` est re-rendu par l'action `update`, mais `@other_procedures` n'y était assignée que dans `edit` (`undefined method 'any?' for nil`).

L'assignation est désormais partagée entre les deux chemins de rendu.

Fix https://demarches-simplifiees.sentry.io/issues/7557921251/