### PR TITLE
Tech: déclare le feature flag pre_rempli_type_de_champ

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -33,6 +33,7 @@ features = [
   :analyse_justificatif_domicile,
   :pro_connect_restricted,
   :quotient_familial_type_de_champ,
+  :pre_rempli_type_de_champ,
   :rdv,
   :sva,
   :switch_domain,


### PR DESCRIPTION
Ajoute `pre_rempli_type_de_champ` à la liste des features de l'initializer Flipper pour corriger le démarche du serveur de dev