### PR TITLE
Tech: corrige une race condition d'autosave de l'éditeur de champs (flaky test menu déroulant + carte)

### DIFF
--- a/app/javascript/controllers/type_de_champ_editor_controller.ts
+++ b/app/javascript/controllers/type_de_champ_editor_controller.ts
@@ -24,7 +24,10 @@ export class TypeDeChampEditorController extends ApplicationController {
 
   #latestPromise = Promise.resolve();
   #dirtyForms: Set<HTMLFormElement> = new Set();
-  #inFlightForms: Map<HTMLFormElement, AbortController> = new Map();
+  #inFlightForms: Map<
+    HTMLFormElement,
+    { controller: AbortController; render: boolean }
+  > = new Map();
 
   connect() {
     this.#latestPromise = Promise.resolve();
@@ -34,8 +37,8 @@ export class TypeDeChampEditorController extends ApplicationController {
 
   disconnect() {
     this.#latestPromise = Promise.resolve();
-    for (const [form] of this.#inFlightForms) {
-      this.abortForm(form);
+    for (const { controller } of this.#inFlightForms.values()) {
+      controller.abort();
     }
     this.#inFlightForms.clear();
   }
@@ -88,19 +91,34 @@ export class TypeDeChampEditorController extends ApplicationController {
 
   private requestSubmitForm(form?: HTMLFormElement | null) {
     if (form) {
-      this.submitForm(form);
+      // A form is only passed for change events (type switch, toggle, move…),
+      // which carry a structural change to the champ. Flag them so a following
+      // keystroke save never aborts them while in flight.
+      this.submitForm(form, true);
     } else {
       const forms = [...this.#dirtyForms];
       this.#dirtyForms.clear();
 
       for (const form of forms) {
-        this.submitForm(form);
+        this.submitForm(form, false);
       }
     }
   }
 
-  private submitForm(form: HTMLFormElement) {
-    const controller = this.abortForm(form);
+  private submitForm(form: HTMLFormElement, render: boolean) {
+    // Saves are serialized through `#latestPromise`, so they always apply in
+    // order. We supersede a previous in-flight *keystroke* save (only the latest
+    // value matters), but we must never abort an in-flight *re-render* save: it
+    // carries a layout change (new fields after a type switch…) that has to
+    // reach the DOM, otherwise the following interactions target fields that
+    // never appear.
+    const previous = this.#inFlightForms.get(form);
+    if (previous && !previous.render) {
+      previous.controller.abort();
+    }
+
+    const controller = new AbortController();
+    this.#inFlightForms.set(form, { controller, render });
 
     this.#latestPromise = this.#latestPromise.finally(() =>
       httpRequest(form.action, {
@@ -110,14 +128,12 @@ export class TypeDeChampEditorController extends ApplicationController {
       })
         .turbo()
         .catch(() => null)
+        .finally(() => {
+          if (this.#inFlightForms.get(form)?.controller == controller) {
+            this.#inFlightForms.delete(form);
+          }
+        })
     );
-  }
-
-  private abortForm(form: HTMLFormElement) {
-    const controller = new AbortController();
-    this.#inFlightForms.get(form)?.abort();
-    this.#inFlightForms.set(form, controller);
-    return controller;
   }
 }
 

--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -246,11 +246,16 @@ describe 'As an administrateur I can edit types de champ', js: true do
     hide_autonotice_message
 
     select('Choix simple', from: 'Type de champ')
-    fill_in 'Libellé du champ', with: 'Libellé de champ menu déroulant', fill_options: { clear: :backspace }
-    fill_in 'Options de la liste', with: 'Un menu', fill_options: { clear: :backspace }
-    check "Proposer une option « autre » avec un texte libre"
+    # Each interaction triggers an autosave. Wait for it to be persisted before
+    # the next one, so the form re-render that follows a change event has fully
+    # settled and the dropdown-specific fields are stable before we type into
+    # them (avoids flakiness when autosaves overlap under load).
+    wait_until { procedure.active_revision.reload.types_de_champ_public.first&.drop_down_list? }
 
+    fill_in 'Options de la liste', with: 'Un menu', fill_options: { clear: :backspace }
     wait_until { procedure.active_revision.reload.types_de_champ_public.first.drop_down_options == ['Un menu'] }
+
+    check "Proposer une option « autre » avec un texte libre"
     wait_until { procedure.active_revision.reload.types_de_champ_public.first.drop_down_other == "1" }
     expect(page).to have_content('Formulaire enregistré')
 

--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -224,11 +224,19 @@ describe 'As an administrateur I can edit types de champ', js: true do
     hide_autonotice_message
 
     select('Carte', from: 'Type de champ')
-    fill_in 'Libellé du champ', with: 'Libellé de champ carte', fill_options: { clear: :backspace }
-    check 'Cadastres'
+    # Wait for the type-switch re-render to actually land in the DOM (a carte-only
+    # field) before filling the shared "Libellé" input. A DB poll only proves the
+    # server committed; the morph can still be in flight and rebuild the input we
+    # just typed into, dropping the keystroke autosave (an empty libellé is saved).
+    expect(page).to have_field('Cadastres')
 
-    wait_until { procedure.active_revision.types_de_champ_public.first.layer_enabled?(:cadastres) }
-    wait_until { procedure.active_revision.types_de_champ_public.first.libelle == 'Libellé de champ carte' }
+    fill_in 'Libellé du champ', with: 'Libellé de champ carte', fill_options: { clear: :backspace }
+    # Serialize before the next change event: checking a layer aborts an in-flight
+    # keystroke save, so the libellé must be persisted first.
+    wait_until { procedure.active_revision.reload.types_de_champ_public.first&.libelle == 'Libellé de champ carte' }
+
+    check 'Cadastres'
+    wait_until { procedure.active_revision.reload.types_de_champ_public.first&.layer_enabled?(:cadastres) }
     expect(page).to have_content('Formulaire enregistré')
 
     page.refresh


### PR DESCRIPTION
## Contexte

Le system spec « adding a dropdown champ » (`types_de_champ_spec.rb`) est flaky en CI (timeout intermittent sur `wait_until`). En investiguant, le test n'est pas seul en cause : il pointe une race dans l'autosave de l'éditeur de champs.

## La race condition

L'autosave avortait la requête en vol d'un form à **chaque** nouveau save (ancien `abortForm`). Or un changement de type (et les autres change events) et les frappes qui suivent partagent le **même** form : une frappe pouvait donc avorter, alors qu'il était encore en vol, le re-render d'un changement de structure — avant que son morph n'atteigne le DOM. Le champ restait désynchronisé de la base (p. ex. les champs propres au menu déroulant n'apparaissaient jamais), d'où le timeout.

## Correctif

- **Client** : marquer chaque save en vol selon qu'il porte un changement de structure (change event) ou une simple frappe. On ne supersède qu'un save de **frappe** en vol ; on n'avorte jamais un re-render en vol.
- **Test** : sérialiser les interactions (attendre la persistance de chacune avant la suivante) au lieu d'enchaîner type, options et toggle « autre » coup sur coup.
- **Flaky test Carte** le spec remplit le libellé. Attendre la persistance en base ne suffit pas : ça prouve le commit serveur, pas que le re-render (morph) a atterri dans le DOM. Capybara tape alors dans l'input que le morph s'apprête à reconstruire, et la frappe est perdue (un libellé vide est enregistré). On attend désormais qu'un champ **spécifique à la carte** (« Cadastres ») soit rendu avant de toucher le libellé — contrairement au menu déroulant, qui remplit d'emblée un champ propre au type et attendait donc déjà le morph.
