### PR TITLE
Tech: l'authentification admin doit précéder retrieve_procedure (RAILS-K79)

### DIFF
--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -4,9 +4,11 @@ module Administrateurs
   class TypesDeChampController < AdministrateurController
     include ActiveSupport::NumberHelper
     include CsvParsingConcern
+
+    before_action :retrieve_procedure
+
     include SimpliscoreConcern
 
-    prepend_before_action :retrieve_procedure
     before_action :reload_procedure_with_includes, only: [:destroy]
 
     def create

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -26,6 +26,16 @@ describe Administrateurs::TypesDeChampController, type: :controller do
 
   before { sign_in(procedure.administrateurs.first.user) }
 
+  describe 'unauthenticated access' do
+    before { sign_out(procedure.administrateurs.first.user) }
+
+    it 'redirects to sign in instead of raising' do
+      get :new_simplify, params: { procedure_id: procedure.id }
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
   describe '#create' do
     let(:params) { default_params }
 


### PR DESCRIPTION
Sur `TypesDeChampController`, `retrieve_procedure` était déclaré en `prepend_before_action`, donc exécuté **avant** `authenticate_administrateur!`. Pour une requête non authentifiée (essentiellement des bots tapant les URLs `/admin/.../simplify/...`), `current_administrateur` est `nil` → `nil.procedures` lève un `NoMethodError` (500) au lieu de rediriger vers la connexion. C'est l'unique contrôleur admin dans ce cas (tous les autres utilisent un `before_action` classique).

Le `prepend` avait été ajouté pour que `retrieve_procedure` passe avant les guards de `SimpliscoreConcern` (`ensure_simpliscore_enabled`, `ensure_valid_tunnel`) qui dépendent de `@procedure`. Le correctif le repositionne en `before_action` classique **avant** `include SimpliscoreConcern`, ce qui donne l'ordre : `authenticate_administrateur!` → `retrieve_procedure` → guards Simpliscore. Les deux contraintes sont respectées.

Fixes RAILS-K79
https://demarches-simplifiees.sentry.io/issues/RAILS-K79