### PR TITLE
Tech: extraire les textes en dur de DepartementComponent vers i18n

### DIFF
--- a/app/components/dossiers/departement_component.rb
+++ b/app/components/dossiers/departement_component.rb
@@ -24,5 +24,5 @@ class Dossiers::DepartementComponent < ApplicationComponent
     ]
   end
 
-  def source = "référentiels géographiques nationaux"
+  def source = t(".source")
 end

--- a/app/components/dossiers/departement_component/departement_component.en.yml
+++ b/app/components/dossiers/departement_component/departement_component.en.yml
@@ -1,0 +1,2 @@
+en:
+  source: "national geographic reference datasets"

--- a/app/components/dossiers/departement_component/departement_component.fr.yml
+++ b/app/components/dossiers/departement_component/departement_component.fr.yml
@@ -1,0 +1,2 @@
+fr:
+  source: "référentiels géographiques nationaux"

--- a/app/components/dossiers/epci_component.en.yml
+++ b/app/components/dossiers/epci_component.en.yml
@@ -1,0 +1,2 @@
+en:
+  source_referentials: "national geographic referentials"

--- a/app/components/dossiers/epci_component.fr.yml
+++ b/app/components/dossiers/epci_component.fr.yml
@@ -1,0 +1,2 @@
+fr:
+  source_referentials: "référentiels géographiques nationaux"

--- a/app/components/dossiers/epci_component.rb
+++ b/app/components/dossiers/epci_component.rb
@@ -33,5 +33,5 @@ class Dossiers::EpciComponent < ApplicationComponent
     end
   end
 
-  def source = tag.span("référentiels géographiques nationaux")
+  def source = tag.span(t(".source_referentials"))
 end


### PR DESCRIPTION
jbloque la PR temporairement pour avancer sur mon orchestrateur en local. jdois regler une question de concurrence, mon model local gere 1 conversation/skill, pas 4 en parallel 😟

# Probleme

Textes francais en dur dans `app/components/dossiers/departement_component.rb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 1 cle i18n vers `app/components/dossiers/departement_component/departement_component.yml`.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `source` | "référentiels géographiques nationaux" | "national geographic reference datasets" |

### Validation visuelle

Aucun preview direct disponible pour ce composant (pas de preview ViewComponent ni de page reelle identifiee).

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante
- [x] Apostrophes typographiques verifiees
- [x] Rubocop OK
- [x] 1 cle extraite, 1 fichier YAML sidecar cree

Generated with [Claude Code](https://claude.com/claude-code)

---

# Probleme

Textes francais en dur dans `app/components/dossiers/epci_component.rb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 1 cle i18n vers `app/components/dossiers/epci_component.yml`.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `dossiers.epci.source_referentials` | "référentiels géographiques nationaux" | "national geographic referentials" |

### Validation visuelle — RESULTAT

**Couverture :**
- ⏭️ Pas de preview ViewComponent disponible — les routes de preview ne sont pas montees dans cet environnement

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante
- [x] Apostrophes typographiques verifiees
- [x] Tests passes (aucun test ne reference cette chaine)
- [x] Rubocop OK
- [x] Screenshots avant/apres : non realisables (pas de preview disponible)

Generated with [Claude Code](https://claude.com/claude-code)