### PR TITLE
ETQ super-admin, corrige le tri d'une liste par nombre de relations 

### DIFF
--- a/config/initializers/administrate.rb
+++ b/config/initializers/administrate.rb
@@ -1,3 +1,27 @@
 # frozen_string_literal: true
 
 Administrate::Engine.add_stylesheet('manager.css')
+
+require "administrate/order"
+
+# When sorting a has_many column by its associated records count, Administrate's
+# `Order#order_by_count` adds a `GROUP BY <table>.id`. Grouping by the primary key
+# lets PostgreSQL select the other columns of that table, but not the columns of a
+# joined table. Models whose default scope carries an `eager_load` (Administrateur,
+# Instructeur eager loading their user) therefore select `users.*`, which is absent
+# from the GROUP BY, raising PG::GroupingError. Dropping the eager loading from the
+# aggregate query fixes it; the displayed associations are re-included afterwards by
+# Administrate through the dashboard's `collection_includes`.
+module Administrate
+  class Order
+    module EagerLoadCompatibleCount
+      private
+
+      def order_by_count(relation)
+        super(relation.unscope(:eager_load))
+      end
+    end
+
+    prepend EagerLoadCompatibleCount
+  end
+end

--- a/spec/controllers/manager/procedures_controller_spec.rb
+++ b/spec/controllers/manager/procedures_controller_spec.rb
@@ -52,6 +52,16 @@ describe Manager::ProceduresController, type: :controller do
       expect(response.body).to include('sub type de champ')
       expect(response.body).to include('Hidden At As Template')
     end
+
+    context 'when sorting a has_many sub-table by an association column' do
+      let(:procedure) { create(:procedure, administrateurs: [administrateur]) }
+
+      before do
+        get :show, params: { id: procedure.id, administrateurs: { order: 'procedures', direction: 'asc' } }
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+    end
   end
 
   describe '#discard' do


### PR DESCRIPTION
Dans le manager, trier une sous-table par une colonne `has_many` (par exemple la colonne *procedures* de la table *administrateurs*) provoquait une `PG::GroupingError`.

Administrate trie alors par nombre d'associations avec un `GROUP BY` sur la clé primaire. Les modèles dont le `default_scope` fait un `eager_load` ramènent en plus les colonnes de la table jointe, absentes du `GROUP BY` → Postgres refuse.

Le correctif retire l'`eager_load` de la requête d'agrégat ; les associations affichées restent préchargées ensuite via `collection_includes`.

Fix https://demarches-simplifiees.sentry.io/issues/7541522648/