### PR TITLE
ETQ admin, j'ai un message d'erreur plus clair pour un champ sans libellé dans un bloc répétable

### DIFF
--- a/app/validators/types_de_champ/libelle_validator.rb
+++ b/app/validators/types_de_champ/libelle_validator.rb
@@ -2,16 +2,34 @@
 
 class TypesDeChamp::LibelleValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
-    types_de_champ
-      .flat_map { it.repetition? ? [it, *procedure.draft_revision.children_of(it)] : [it] }
-      .each do |tdc|
-      if tdc.libelle.blank?
-        procedure.errors.add(
-          attribute,
-          procedure.errors.generate_message(attribute, :missing_libelle, { position: tdc.revision_types_de_champ.last.position + 1 }),
-          type_de_champ: tdc
-        )
+    types_de_champ.each do |tdc|
+      validate_libelle(procedure, attribute, tdc)
+
+      next unless tdc.repetition?
+
+      procedure.draft_revision.children_of(tdc).each do |child|
+        validate_libelle(procedure, attribute, child, parent: tdc)
       end
     end
   end
+
+  private
+
+  def validate_libelle(procedure, attribute, tdc, parent: nil)
+    return if tdc.libelle.present?
+
+    message_key, options = if parent
+      [:missing_libelle_in_repetition, { position: position_of(tdc), parent_position: position_of(parent) }]
+    else
+      [:missing_libelle, { position: position_of(tdc) }]
+    end
+
+    procedure.errors.add(
+      attribute,
+      procedure.errors.generate_message(attribute, message_key, options),
+      type_de_champ: tdc
+    )
+  end
+
+  def position_of(tdc) = tdc.revision_types_de_champ.last.position + 1
 end

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -90,6 +90,7 @@ en:
               empty_csv: 'requires at least one csv file'
               inconsistent_header_section: "%{custom_message}"
               missing_libelle: "field label in position %{position} must be filled"
+              missing_libelle_in_repetition: "field label in position %{position}, within the repetition in position %{parent_position}, must be filled"
               expression_reguliere_invalid: "is invalid"
               referentiel_not_ready: "is not configured"
             draft_types_de_champ_private:
@@ -100,6 +101,7 @@ en:
               empty_csv: 'requires at least one csv file'
               inconsistent_header_section: "%{custom_message}"
               missing_libelle: "field label in position %{position} must be filled"
+              missing_libelle_in_repetition: "field label in position %{position}, within the repetition in position %{parent_position}, must be filled"
               expression_reguliere_invalid: "is invalid"
               referentiel_not_ready: "is not configured"
             attestation_template:

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -97,6 +97,7 @@ fr:
               empty_csv: 'doit comporter au moins un fichier csv'
               inconsistent_header_section: "%{custom_message}"
               missing_libelle:  "Le libellé du champ en position %{position} doit être rempli"
+              missing_libelle_in_repetition: "Le libellé du champ en position %{position}, dans le bloc répétable en position %{parent_position}, doit être rempli"
               expression_reguliere_invalid: "est invalide, veuillez la corriger"
               referentiel_not_ready: "n’est pas configuré"
             draft_types_de_champ_private:
@@ -107,6 +108,7 @@ fr:
               empty_csv: 'doit comporter au moins un fichier csv'
               inconsistent_header_section: "%{custom_message}"
               missing_libelle:  "Le libellé du champ en position %{position} doit être rempli"
+              missing_libelle_in_repetition: "Le libellé du champ en position %{position}, dans le bloc répétable en position %{parent_position}, doit être rempli"
               expression_reguliere_invalid: "est invalide, veuillez la corriger"
               referentiel_not_ready: "n’est pas configuré"
             attestation_template:

--- a/spec/validators/types_de_champ/libelle_validator_spec.rb
+++ b/spec/validators/types_de_champ/libelle_validator_spec.rb
@@ -34,6 +34,29 @@ RSpec.describe TypesDeChamp::LibelleValidator do
     end
   end
 
+  context 'with a champ inside a repetition' do
+    let(:types) { [{ type: :repetition, children: [{ type: :text }] }] }
+    let(:repetition) { procedure.active_revision.types_de_champ_public.find(&:repetition?) }
+    let(:child) { procedure.draft_revision.children_of(repetition).first }
+
+    context 'when the child libelle is empty' do
+      before { child.update(libelle: '') }
+
+      it 'adds an error mentioning both the child position and the parent repetition position' do
+        subject
+
+        expect(procedure.errors.messages_for(:draft_types_de_champ_public))
+          .to include(
+            I18n.t(
+              'activerecord.errors.models.procedure.attributes.draft_types_de_champ_public.missing_libelle_in_repetition',
+              position: child.revision_types_de_champ.last.position + 1,
+              parent_position: repetition.revision_types_de_champ.last.position + 1
+            )
+          )
+      end
+    end
+  end
+
   context 'with linked drop down list type de champ' do
     let(:types) { [type: :linked_drop_down_list] }
     context 'when libelle is filled' do


### PR DESCRIPTION
## Contexte

En tant qu'admin configurant les champs d'une démarche, lorsqu'un champ à l'intérieur d'un bloc répétable n'a pas de libellé, le message d'erreur n'indiquait que la position locale du champ dans le bloc :

> Le libellé du champ en position 1 doit être rempli

Cela incitait à tenter de corriger le 1er champ du formulaire.

## Changement

Le message précise désormais la position du bloc répétable parent :

> Le libellé du champ en position 1, dans le bloc répétable en position 42, doit être rempli
