### PR TITLE
ETQ admin, je suis mieux alerté si la condition d'affichage d'un bloc répétable est invalide

### DIFF
--- a/app/validators/types_de_champ/condition_validator.rb
+++ b/app/validators/types_de_champ/condition_validator.rb
@@ -28,9 +28,10 @@ class TypesDeChamp::ConditionValidator < ActiveModel::EachValidator
     end
   end
 
-  # find children in repetitions
+  # find children in repetitions, keeping the repetition itself so its own
+  # condition is validated too
   def tdcs_with_children(procedure, tdcs)
     tdcs.to_a
-      .flat_map { _1.repetition? ? procedure.draft_revision.children_of(_1) : _1 }
+      .flat_map { _1.repetition? ? [_1, *procedure.draft_revision.children_of(_1)] : _1 }
   end
 end

--- a/spec/validators/types_de_champ/condition_validator_spec.rb
+++ b/spec/validators/types_de_champ/condition_validator_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe TypesDeChamp::ConditionValidator do
+  include Logic
+
+  let(:procedure) { create(:procedure, types_de_champ_public:) }
+
+  subject do
+    procedure.validate(:types_de_champ_public_editor)
+    procedure.errors.messages_for(:draft_types_de_champ_public)
+  end
+
+  let(:invalid_condition_message) do
+    I18n.t('activerecord.errors.models.procedure.attributes.draft_types_de_champ_public.invalid_condition')
+  end
+
+  context 'when a child references an upper sibling in the same repetition' do
+    let(:types_de_champ_public) do
+      [
+        {
+          type: :repetition, libelle: 'Bloc', stable_id: 1, children: [
+            { type: :yes_no, libelle: 'Booléen', stable_id: 2 },
+            { type: :text, libelle: 'Conditionnel', stable_id: 3, condition: ds_eq(champ_value(2), constant(true)) },
+          ],
+        },
+      ]
+    end
+
+    it 'is valid' do
+      expect(subject).not_to include(invalid_condition_message)
+    end
+  end
+
+  context 'when a repetition itself has an invalid condition' do
+    let(:types_de_champ_public) do
+      [
+        {
+          type: :repetition, libelle: 'Bloc', stable_id: 1,
+          condition: ds_eq(champ_value(2), constant(true)),
+          children: [{ type: :text, libelle: 'Enfant', stable_id: 10 }],
+        },
+        { type: :yes_no, libelle: 'Booléen plus bas', stable_id: 2 },
+      ]
+    end
+
+    it 'adds an error on the repetition condition' do
+      expect(subject).to include(invalid_condition_message)
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Dans la foulée de #13328 , j'ai regardé s'il n'y avait pas d'autres trous dans la raquette à propos de la validation des blocs répétables et j'ai trouvé ça.
Le validateur de conditions remplaçait un bloc répétable par ses seuls enfants : la condition d'affichage portée par le bloc répétable lui-même n'était donc jamais validée. Un admin pouvait configurer une condition invalide sur un bloc (par exemple une référence à un champ supprimé ou placé en dessous) sans que l'erreur soit remontée en haut de page.  Il y avait déjà une alerte au niveau du bloc répétable via `Conditions::ConditionsErrorsComponent` mais qui ne bloquait pas la publication.

## Changement

Le bloc répétable est désormais conservé dans la liste des champs validés, en plus de ses enfants. Sa condition est donc vérifiée comme celle de n'importe quel autre champ.

