### PR TITLE
Tech: corrige le crash des index Manager (team accounts & dubious procedures)

### DIFF
--- a/app/controllers/manager/dubious_procedures_controller.rb
+++ b/app/controllers/manager/dubious_procedures_controller.rb
@@ -12,6 +12,7 @@ module Manager
         page: page,
         show_search_bar: false,
         search_term: nil,
+        filters: {},
       }
     end
   end

--- a/app/controllers/manager/team_accounts_controller.rb
+++ b/app/controllers/manager/team_accounts_controller.rb
@@ -27,6 +27,7 @@ module Manager
         page: page,
         show_search_bar: false,
         search_term: nil,
+        filters: {},
       }
     end
   end

--- a/spec/controllers/manager/dubious_procedures_controller_spec.rb
+++ b/spec/controllers/manager/dubious_procedures_controller_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+describe Manager::DubiousProceduresController, type: :controller do
+  let(:super_admin) { create(:super_admin, :with_otp) }
+  before { sign_in super_admin }
+
+  render_views
+
+  describe 'GET #index' do
+    it 'affiche la liste des procédures douteuses' do
+      get :index
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/controllers/manager/team_accounts_controller_spec.rb
+++ b/spec/controllers/manager/team_accounts_controller_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+describe Manager::TeamAccountsController, type: :controller do
+  let(:super_admin) { create(:super_admin, :with_otp) }
+  before { sign_in super_admin }
+
+  render_views
+
+  describe 'GET #index' do
+    let!(:team_account) { create(:administrateur, user: create(:user, team_account: true)) }
+
+    it 'liste les comptes équipe' do
+      get :index
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
crash à cause de la personnalisation qu'on fait pour le layout 
https://demarches-simplifiees.sentry.io/issues/7541747475/