### PR TITLE
Tech: renomme `value_columns` en `canonical_column`

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -59,7 +59,7 @@ module Administrateurs
         tdc_options = APIGeoService.region_options
         create_groups_from_territorial_tdc(tdc_options, stable_id, rule_operator, region_column)
       when TypeDeChamp.type_champs.fetch(:pays)
-        pays_column = tdc.columns(procedure_id: procedure.id).find { it.class == Columns::ChampColumn }
+        pays_column = tdc.canonical_column(procedure_id: procedure.id)
         rule_operator = :ds_eq
         tdc_options = APIGeoService.countries.map { ["#{_1[:code]} – #{_1[:name]}", _1[:code]] }
         create_groups_from_territorial_tdc(tdc_options, stable_id, rule_operator, pays_column)
@@ -696,7 +696,7 @@ module Administrateurs
       tdc_options = tdc.options_for_select
 
       source = if column_mode?
-        champ_column_value(tdc.columns(procedure_id: procedure.id).find { it.class == Columns::ChampColumn })
+        champ_column_value(tdc.canonical_column(procedure_id: procedure.id))
       else
         champ_value(stable_id)
       end

--- a/app/graphql/types/champ_type.rb
+++ b/app/graphql/types/champ_type.rb
@@ -20,7 +20,7 @@ module Types
       if object.repetition?
         []
       elsif object.carte?
-        object.type_de_champ.canonical_columns(procedure_id: object.procedure.id)
+        [object.type_de_champ.canonical_column(procedure_id: object.procedure.id)]
       else
         object.type_de_champ.columns(procedure_id: object.procedure.id)
       end

--- a/app/graphql/types/champ_type.rb
+++ b/app/graphql/types/champ_type.rb
@@ -20,7 +20,7 @@ module Types
       if object.repetition?
         []
       elsif object.carte?
-        object.type_de_champ.value_columns(procedure_id: object.procedure.id)
+        object.type_de_champ.canonical_columns(procedure_id: object.procedure.id)
       else
         object.type_de_champ.columns(procedure_id: object.procedure.id)
       end

--- a/app/models/changed_column.rb
+++ b/app/models/changed_column.rb
@@ -23,13 +23,13 @@ class ChangedColumn
           row_ids.flat_map do |row_id|
             types_de_champ.flat_map do |type_de_champ|
               public_id = type_de_champ.public_id(row_id)
-              columns = type_de_champ.value_columns(procedure_id: revision.procedure_id, prefix:)
+              columns = type_de_champ.canonical_columns(procedure_id: revision.procedure_id, prefix:)
               diff_columns(columns, champs[public_id], reference_champs[public_id])
             end
           end
         else
           public_id = type_de_champ.public_id(nil)
-          columns = type_de_champ.value_columns(procedure_id: revision.procedure_id)
+          columns = type_de_champ.canonical_columns(procedure_id: revision.procedure_id)
           diff_columns(columns, champs[public_id], reference_champs[public_id])
         end
       end

--- a/app/models/changed_column.rb
+++ b/app/models/changed_column.rb
@@ -21,31 +21,30 @@ class ChangedColumn
           prefix = type_de_champ.libelle
           types_de_champ = revision.children_of(type_de_champ)
           row_ids.flat_map do |row_id|
-            types_de_champ.flat_map do |type_de_champ|
+            types_de_champ.filter_map do |type_de_champ|
               public_id = type_de_champ.public_id(row_id)
-              columns = type_de_champ.canonical_columns(procedure_id: revision.procedure_id, prefix:)
-              diff_columns(columns, champs[public_id], reference_champs[public_id])
+              column = type_de_champ.canonical_column(procedure_id: revision.procedure_id, prefix:)
+              diff_column(column, champs[public_id], reference_champs[public_id])
             end
           end
         else
           public_id = type_de_champ.public_id(nil)
-          columns = type_de_champ.canonical_columns(procedure_id: revision.procedure_id)
-          diff_columns(columns, champs[public_id], reference_champs[public_id])
+          column = type_de_champ.canonical_column(procedure_id: revision.procedure_id)
+          [diff_column(column, champs[public_id], reference_champs[public_id])].compact
         end
       end
     end
 
     private
 
-    def diff_columns(columns, champ, reference_champ)
-      return [] if champ.nil?
-      columns.filter_map do |column|
-        value = column.value(champ)
-        previous_value = column.value(reference_champ)
-        if value != previous_value
-          new(column, value, previous_value)
-        end
-      end
+    def diff_column(column, champ, reference_champ)
+      return nil if column.nil? || champ.nil?
+
+      value = column.value(champ)
+      previous_value = column.value(reference_champ)
+      return nil if value == previous_value
+
+      new(column, value, previous_value)
     end
   end
 end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -179,7 +179,7 @@ class TypeDeChamp < ApplicationRecord
 
   belongs_to :referentiel, optional: true, inverse_of: :types_de_champ
 
-  delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, :column, :value_columns, :info_columns, to: :dynamic_type
+  delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, :column, :canonical_columns, :info_columns, to: :dynamic_type
 
   class WithIndifferentAccess
     def self.load(options)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -179,7 +179,7 @@ class TypeDeChamp < ApplicationRecord
 
   belongs_to :referentiel, optional: true, inverse_of: :types_de_champ
 
-  delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, :column, :canonical_columns, :info_columns, to: :dynamic_type
+  delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, :column, :canonical_column, :info_columns, to: :dynamic_type
 
   class WithIndifferentAccess
     def self.load(options)

--- a/app/models/types_de_champ/address_type_de_champ.rb
+++ b/app/models/types_de_champ/address_type_de_champ.rb
@@ -46,18 +46,16 @@ class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     end
   end
 
-  def canonical_columns(procedure_id:, displayable: true, prefix: nil)
-    [
-      Columns::AddressColumn.new(
-        procedure_id:,
-        stable_id:,
-        tdc_type: type_champ,
-        label: libelle_with_prefix(prefix),
-        type: TypeDeChamp.column_type(type_champ),
-        displayable:,
-        mandatory: mandatory?
-      ),
-    ]
+  def canonical_column(procedure_id:, displayable: true, prefix: nil)
+    Columns::AddressColumn.new(
+      procedure_id:,
+      stable_id:,
+      tdc_type: type_champ,
+      label: libelle_with_prefix(prefix),
+      type: TypeDeChamp.column_type(type_champ),
+      displayable:,
+      mandatory: mandatory?
+    )
   end
 
   def columns(procedure_id:, displayable: true, prefix: nil)

--- a/app/models/types_de_champ/address_type_de_champ.rb
+++ b/app/models/types_de_champ/address_type_de_champ.rb
@@ -46,7 +46,7 @@ class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     end
   end
 
-  def value_columns(procedure_id:, displayable: true, prefix: nil)
+  def canonical_columns(procedure_id:, displayable: true, prefix: nil)
     [
       Columns::AddressColumn.new(
         procedure_id:,

--- a/app/models/types_de_champ/carte_type_de_champ.rb
+++ b/app/models/types_de_champ/carte_type_de_champ.rb
@@ -31,19 +31,17 @@ class TypesDeChamp::CarteTypeDeChamp < TypesDeChamp::TypeDeChampBase
 
   def champ_blank?(champ) = champ.geo_areas.blank?
 
-  def canonical_columns(procedure_id:, displayable: true, prefix: nil)
-    [
-      Columns::GeoJSONColumn.new(
-        procedure_id:,
-        stable_id:,
-        tdc_type: type_champ,
-        label: libelle_with_prefix(prefix),
-        type: TypeDeChamp.column_type(type_champ),
-        displayable: false,
-        filterable: false,
-        mandatory: mandatory?
-      ),
-    ]
+  def canonical_column(procedure_id:, displayable: true, prefix: nil)
+    Columns::GeoJSONColumn.new(
+      procedure_id:,
+      stable_id:,
+      tdc_type: type_champ,
+      label: libelle_with_prefix(prefix),
+      type: TypeDeChamp.column_type(type_champ),
+      displayable: false,
+      filterable: false,
+      mandatory: mandatory?
+    )
   end
 
   def columns(procedure_id:, displayable: true, prefix: nil)

--- a/app/models/types_de_champ/carte_type_de_champ.rb
+++ b/app/models/types_de_champ/carte_type_de_champ.rb
@@ -31,7 +31,7 @@ class TypesDeChamp::CarteTypeDeChamp < TypesDeChamp::TypeDeChampBase
 
   def champ_blank?(champ) = champ.geo_areas.blank?
 
-  def value_columns(procedure_id:, displayable: true, prefix: nil)
+  def canonical_columns(procedure_id:, displayable: true, prefix: nil)
     [
       Columns::GeoJSONColumn.new(
         procedure_id:,

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -66,19 +66,17 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
       (has_secondary_options_for_primary?(champ) && secondary_value(champ).blank?)
   end
 
-  def canonical_columns(procedure_id:, displayable: true, prefix: nil)
-    [
-      Columns::LinkedDropDownColumn.new(
-        procedure_id:,
-        label: libelle_with_prefix(prefix),
-        stable_id:,
-        tdc_type: type_champ,
-        type: :text,
-        path: :value,
-        displayable:,
-        mandatory: mandatory?
-      ),
-    ]
+  def canonical_column(procedure_id:, displayable: true, prefix: nil)
+    Columns::LinkedDropDownColumn.new(
+      procedure_id:,
+      label: libelle_with_prefix(prefix),
+      stable_id:,
+      tdc_type: type_champ,
+      type: :text,
+      path: :value,
+      displayable:,
+      mandatory: mandatory?
+    )
   end
 
   def columns(procedure_id:, displayable: true, prefix: nil)

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -66,7 +66,7 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
       (has_secondary_options_for_primary?(champ) && secondary_value(champ).blank?)
   end
 
-  def value_columns(procedure_id:, displayable: true, prefix: nil)
+  def canonical_columns(procedure_id:, displayable: true, prefix: nil)
     [
       Columns::LinkedDropDownColumn.new(
         procedure_id:,

--- a/app/models/types_de_champ/piece_justificative_type_de_champ.rb
+++ b/app/models/types_de_champ/piece_justificative_type_de_champ.rb
@@ -33,32 +33,28 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBas
 
   def champ_blank?(champ) = champ.piece_justificative_file.blank?
 
-  def canonical_columns(procedure_id:, displayable: true, prefix: nil)
+  def canonical_column(procedure_id:, displayable: true, prefix: nil)
     if titre_identite?
-      [
-        Columns::TitreIdentiteColumn.new(
-          procedure_id:,
-          stable_id:,
-          tdc_type: type_champ,
-          label: "#{libelle_with_prefix(prefix)} – filled",
-          type: :text,
-          displayable: true,
-          mandatory: mandatory?
-        ),
-      ]
+      Columns::TitreIdentiteColumn.new(
+        procedure_id:,
+        stable_id:,
+        tdc_type: type_champ,
+        label: "#{libelle_with_prefix(prefix)} – filled",
+        type: :text,
+        displayable: true,
+        mandatory: mandatory?
+      )
     else
-      [
-        Columns::AttachedManyColumn.new(
-          procedure_id:,
-          stable_id:,
-          tdc_type: type_champ,
-          label: libelle_with_prefix(prefix),
-          type: TypeDeChamp.column_type(type_champ),
-          displayable: false,
-          filterable: false,
-          mandatory: mandatory?
-        ),
-      ]
+      Columns::AttachedManyColumn.new(
+        procedure_id:,
+        stable_id:,
+        tdc_type: type_champ,
+        label: libelle_with_prefix(prefix),
+        type: TypeDeChamp.column_type(type_champ),
+        displayable: false,
+        filterable: false,
+        mandatory: mandatory?
+      )
     end
   end
 

--- a/app/models/types_de_champ/piece_justificative_type_de_champ.rb
+++ b/app/models/types_de_champ/piece_justificative_type_de_champ.rb
@@ -33,7 +33,7 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBas
 
   def champ_blank?(champ) = champ.piece_justificative_file.blank?
 
-  def value_columns(procedure_id:, displayable: true, prefix: nil)
+  def canonical_columns(procedure_id:, displayable: true, prefix: nil)
     if titre_identite?
       [
         Columns::TitreIdentiteColumn.new(

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -25,8 +25,8 @@ class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
     ActiveStorage::Filename.new(str.delete('[]*?')).sanitized
   end
 
-  def canonical_columns(procedure_id:, displayable: true, prefix: nil)
-    []
+  def canonical_column(procedure_id:, displayable: true, prefix: nil)
+    nil
   end
 
   def columns(procedure_id:, displayable: true, prefix: nil)

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -25,7 +25,7 @@ class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
     ActiveStorage::Filename.new(str.delete('[]*?')).sanitized
   end
 
-  def value_columns(procedure_id:, displayable: true, prefix: nil)
+  def canonical_columns(procedure_id:, displayable: true, prefix: nil)
     []
   end
 

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -95,27 +95,23 @@ class TypesDeChamp::TypeDeChampBase
   def champ_blank?(champ) = champ.value.blank?
   def champ_blank_or_invalid?(champ) = champ_blank?(champ)
 
-  def canonical_columns(procedure_id:, displayable: true, prefix: nil)
-    if fillable?
-      [
-        Columns::ChampColumn.new(
-          procedure_id:,
-          stable_id:,
-          tdc_type: type_champ,
-          label: libelle_with_prefix(prefix),
-          type: TypeDeChamp.column_type(type_champ),
-          displayable:,
-          options_for_select:,
-          mandatory: mandatory?
-        ),
-      ]
-    else
-      []
-    end
+  def canonical_column(procedure_id:, displayable: true, prefix: nil)
+    return nil unless fillable?
+
+    Columns::ChampColumn.new(
+      procedure_id:,
+      stable_id:,
+      tdc_type: type_champ,
+      label: libelle_with_prefix(prefix),
+      type: TypeDeChamp.column_type(type_champ),
+      displayable:,
+      options_for_select:,
+      mandatory: mandatory?
+    )
   end
 
   def columns(procedure_id:, displayable: true, prefix: nil)
-    canonical_columns(procedure_id:, displayable:, prefix:)
+    [canonical_column(procedure_id:, displayable:, prefix:)].compact
   end
 
   def info_columns(procedure:)

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -95,7 +95,7 @@ class TypesDeChamp::TypeDeChampBase
   def champ_blank?(champ) = champ.value.blank?
   def champ_blank_or_invalid?(champ) = champ_blank?(champ)
 
-  def value_columns(procedure_id:, displayable: true, prefix: nil)
+  def canonical_columns(procedure_id:, displayable: true, prefix: nil)
     if fillable?
       [
         Columns::ChampColumn.new(
@@ -115,7 +115,7 @@ class TypesDeChamp::TypeDeChampBase
   end
 
   def columns(procedure_id:, displayable: true, prefix: nil)
-    value_columns(procedure_id:, displayable:, prefix:)
+    canonical_columns(procedure_id:, displayable:, prefix:)
   end
 
   def info_columns(procedure:)


### PR DESCRIPTION
- [désambiguïse](https://www.larousse.fr/dictionnaires/francais/d%C3%A9sambigu%C3%AFser/24192) `value_columns` en `canonical_column` , pour s'écarter de `column_value` (`ChampColumnValue`) qui est utilisé dans la partie logique
- passe à l'infinitif en supposant qu'il y a toujours une seule colonne canonique
- utilise cette nouvelle notion dans la creation de routage simple