### PR TITLE
ETQ super admin, réinitialiser l'OTP d'un·e collègue depuis le Manager

### DIFF
--- a/app/controllers/manager/super_admins_controller.rb
+++ b/app/controllers/manager/super_admins_controller.rb
@@ -2,5 +2,33 @@
 
 module Manager
   class SuperAdminsController < Manager::ApplicationController
+    include RequiresFreshSuperAdminOtp
+
+    before_action :set_super_admin, only: [:reset_otp_edit, :reset_otp]
+    before_action :refuse_self_otp_reset, only: [:reset_otp_edit, :reset_otp]
+    before_action :verify_fresh_super_admin_otp!, only: [:reset_otp]
+
+    def reset_otp_edit
+    end
+
+    def reset_otp
+      @super_admin.disable_otp!
+
+      flash[:notice] = t('.success', email: @super_admin.email)
+      redirect_to manager_super_admin_path(@super_admin)
+    end
+
+    private
+
+    def set_super_admin
+      @super_admin = SuperAdmin.find(params[:id])
+    end
+
+    def refuse_self_otp_reset
+      return if @super_admin != current_super_admin
+
+      flash[:alert] = t('manager.super_admins.self_otp_reset_forbidden')
+      redirect_to manager_super_admin_path(current_super_admin)
+    end
   end
 end

--- a/app/views/manager/super_admins/reset_otp_edit.html.erb
+++ b/app/views/manager/super_admins/reset_otp_edit.html.erb
@@ -1,0 +1,22 @@
+<% content_for(:title) { t('.title') } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title"><%= content_for(:title) %></h1>
+</header>
+
+<section class="main-content__body">
+  <p><%= t('.warning_html', email: @super_admin.email).html_safe %></p>
+
+  <%= form_tag reset_otp_manager_super_admin_path(@super_admin), method: :post, class: "form" do %>
+    <% if SUPER_ADMIN_OTP_ENABLED %>
+      <p><%= t('.otp_intro') %></p>
+      <div class="field-unit field-unit--string field-unit--required">
+        <%= render Manager::OtpAttemptInputComponent.new %>
+      </div>
+    <% end %>
+
+    <div class="form-actions">
+      <%= submit_tag t('.submit'), class: "button button--danger" %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/manager/super_admins/reset_otp_edit.html.erb
+++ b/app/views/manager/super_admins/reset_otp_edit.html.erb
@@ -5,7 +5,7 @@
 </header>
 
 <section class="main-content__body">
-  <p><%= t('.warning_html', email: @super_admin.email).html_safe %></p>
+  <p><%= t('.warning_html', email: @super_admin.email) %></p>
 
   <%= form_tag reset_otp_manager_super_admin_path(@super_admin), method: :post, class: "form" do %>
     <% if SUPER_ADMIN_OTP_ENABLED %>

--- a/app/views/manager/super_admins/show.html.erb
+++ b/app/views/manager/super_admins/show.html.erb
@@ -1,0 +1,38 @@
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title"><%= content_for(:title) %></h1>
+
+  <div>
+    <% if page.resource.otp_required_for_login? && page.resource != current_super_admin %>
+      <%= link_to "Réinitialiser l’OTP", reset_otp_edit_manager_super_admin_path(page.resource), class: "button button--danger" %>
+    <% end %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <% page.attributes.each do |title, attributes| %>
+      <fieldset class="<%= "field-unit--nested" if title.present? %>">
+        <% if title.present? %>
+          <legend>
+            <%= t "helpers.label.#{page.resource_name}.#{title}", default: title %>
+          </legend>
+        <% end %>
+
+        <% attributes.each do |attribute| %>
+          <dt class="attribute-label" id="<%= attribute.name %>">
+            <%= t(
+            "helpers.label.#{resource_name}.#{attribute.name}",
+            default: page.resource.class.human_attribute_name(attribute.name),
+          ) %>
+          </dt>
+
+          <dd class="attribute-data attribute-data--<%= attribute.html_class %>">
+            <%= render_field attribute, page: page %>
+          </dd>
+        <% end %>
+      </fieldset>
+    <% end %>
+  </dl>
+</section>

--- a/config/locales/views/manager/en.yml
+++ b/config/locales/views/manager/en.yml
@@ -2,5 +2,14 @@ en:
   manager:
     fresh_otp:
       invalid_code: "Invalid or missing OTP code. The operation has been cancelled."
+    super_admins:
+      self_otp_reset_forbidden: "You cannot reset your own two-factor authentication from this screen."
+      reset_otp_edit:
+        title: "Reset two-factor authentication"
+        warning_html: "You are about to reset the two-factor authentication of <strong>%{email}</strong>. They will have to sign in again with their password and then enroll their authenticator app anew."
+        otp_intro: "Confirm with your own OTP code."
+        submit: "Reset OTP"
+      reset_otp:
+        success: "Two-factor authentication for %{email} has been reset."
     gestionnaires:
       manage_root_groupe_gestionnaire: Root group management

--- a/config/locales/views/manager/fr.yml
+++ b/config/locales/views/manager/fr.yml
@@ -9,6 +9,15 @@ fr:
         wrong_address:
           one: "%{emails} n’est pas une adresse électronique valide"
           other: "%{emails} ne sont pas des adresses électroniques valides"
+    super_admins:
+      self_otp_reset_forbidden: "Vous ne pouvez pas réinitialiser votre propre authentification double-facteur depuis cet écran."
+      reset_otp_edit:
+        title: "Réinitialiser l’authentification double-facteur"
+        warning_html: "Vous allez réinitialiser l’authentification double-facteur de <strong>%{email}</strong>. Cette personne devra se reconnecter avec son mot de passe puis enrôler à nouveau son application d’authentification."
+        otp_intro: "Confirmez avec votre propre code OTP."
+        submit: "Réinitialiser l’OTP"
+      reset_otp:
+        success: "L’authentification double-facteur de %{email} a été réinitialisée."
     administrateurs:
       delete:
         cannot_be_deleted: "L’administrateur ne peut pas être supprimé"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,12 @@ Rails.application.routes.draw do
 
     resources :services, only: [:index, :show]
 
-    resources :super_admins, only: [:index, :show, :destroy]
+    resources :super_admins, only: [:index, :show, :destroy] do
+      member do
+        get :reset_otp_edit
+        post :reset_otp
+      end
+    end
 
     resources :zones, only: [:index, :show]
 

--- a/spec/controllers/manager/super_admins_controller_spec.rb
+++ b/spec/controllers/manager/super_admins_controller_spec.rb
@@ -21,4 +21,96 @@ describe Manager::SuperAdminsController, type: :controller do
       end
     end
   end
+
+  describe 'POST #reset_otp' do
+    let!(:signed_in_super_admin) { create(:super_admin, :with_otp) }
+    let(:super_admin) { signed_in_super_admin }
+    let(:target) { create(:super_admin, :with_otp) }
+    let(:otp_attempt) { current_otp_for(super_admin) }
+
+    subject { post :reset_otp, params: { id: target.id, otp_attempt: } }
+
+    it_behaves_like "a manager action gated by a fresh super-admin OTP" do
+      let(:action_matcher) { change { target.reload.otp_required_for_login } }
+      let(:replay_subject) do
+        -> { post :reset_otp, params: { id: target.id, otp_attempt: otp_attempt } }
+      end
+    end
+
+    context 'with a fresh OTP code' do
+      it 'disables the target OTP and redirects with a notice' do
+        subject
+
+        target.reload
+        expect(target.otp_required_for_login).to be(false)
+        expect(target.otp_secret).to be_nil
+        expect(response).to redirect_to(manager_super_admin_path(target))
+        expect(flash[:notice]).to include(target.email)
+      end
+    end
+
+    context 'when targeting themselves' do
+      it 'refuses and keeps their own OTP enabled' do
+        expect { post :reset_otp, params: { id: super_admin.id, otp_attempt: } }
+          .not_to change { super_admin.reload.otp_required_for_login }
+
+        expect(response).to redirect_to(manager_super_admin_path(super_admin))
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    render_views
+
+    let!(:signed_in_super_admin) { create(:super_admin, :with_otp) }
+
+    context 'when viewing another enrolled super admin' do
+      let(:target) { create(:super_admin, :with_otp) }
+
+      it 'shows the reset OTP button' do
+        get :show, params: { id: target.id }
+        expect(response.body).to include(reset_otp_edit_manager_super_admin_path(target))
+      end
+    end
+
+    context 'when viewing a super admin without OTP' do
+      let(:target) { create(:super_admin, otp_required_for_login: false) }
+
+      it 'does not show the reset OTP button' do
+        get :show, params: { id: target.id }
+        expect(response.body).not_to include(reset_otp_edit_manager_super_admin_path(target))
+      end
+    end
+
+    context 'when viewing themselves' do
+      it 'does not show the reset OTP button' do
+        get :show, params: { id: signed_in_super_admin.id }
+        expect(response.body).not_to include(reset_otp_edit_manager_super_admin_path(signed_in_super_admin))
+      end
+    end
+  end
+
+  describe 'GET #reset_otp_edit' do
+    render_views
+
+    let!(:signed_in_super_admin) { create(:super_admin, :with_otp) }
+    let(:target) { create(:super_admin, :with_otp) }
+
+    it 'renders the OTP step-up input' do
+      get :reset_otp_edit, params: { id: target.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('name="otp_attempt"')
+    end
+
+    context 'when targeting themselves' do
+      it 'refuses' do
+        get :reset_otp_edit, params: { id: signed_in_super_admin.id }
+
+        expect(response).to redirect_to(manager_super_admin_path(signed_in_super_admin))
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Contexte

Depuis la sécurisation des comptes SuperAdmin, un·e super admin enrôlé·e en 2FA qui perd son authenticator (changement de téléphone) se retrouve bloqué·e : le login exige l'OTP qu'iel n'a plus, et « Mot de passe oublié » ne désactive plus l'OTP. Le seul recours restant passe par la console (`disable_otp!`), réservé aux personnes ayant un accès prod.

## Changement

Ajout d'un bouton **« Réinitialiser l'OTP »** sur la fiche d'un·e super admin dans le Manager, permettant à un·e collègue non-tech de débloquer la situation. L'action ouvre un écran de confirmation puis appelle `disable_otp!` sur la cible : celle-ci se reconnecte ensuite avec son mot de passe et est automatiquement redirigée vers le ré-enrôlement de son application d'authentification.

## Sécurité

- Action protégée par un **step-up OTP frais** de l'opérateur·rice (`RequiresFreshSuperAdminOtp`, code consommé / anti-rejeu) — même pattern que le transfert de dossier et l'écrasement d'email.
- Refus **côté serveur** si un·e SA cible son propre compte (pas seulement le masquage du bouton) ; le self-service reste `edit_super_admin_otp`.
- Bouton masqué sur les comptes non enrôlés.
- Réutilise la méthode `disable_otp!` jusqu'ici inutilisée.

<img width="1132" height="471" alt="pr-1-bouton-reset-otp" src="https://github.com/user-attachments/assets/49179c6c-6946-4f9c-809a-77987bfcf711" />
<img width="1175" height="429" alt="pr-2-confirmation-step-up-otp" src="https://github.com/user-attachments/assets/61c656e6-1ad3-4c4e-9145-2cc78ae0f974" />
<img width="1153" height="577" alt="pr-3-succes-otp-reinitialise" src="https://github.com/user-attachments/assets/4a189160-afc5-4122-85e1-acbb101d8079" />

