### PR TITLE
Tech: instrumente les filtres mes-dossiers dans Skylight (alertes + liste)

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -49,7 +49,10 @@ module Users
       end
 
       @dossiers = @filter.dossiers.page(page).per(ITEMS_PER_PAGE)
-      @total_count = @dossiers.total_count
+      Skylight.instrument(title: "dossiers.list") do
+        @total_count = @dossiers.total_count
+        @dossiers.load
+      end
       @corbeille_count = current_user.dossiers.hidden_by_user.or(current_user.dossiers.hidden_by_expired).count
       @pending_transfers_count = current_user.dossier_transfers_received_pending.count
       @show_simple_list = params[:search].blank? && !@filter.active? && @total_count <= SIMPLE_LIST_THRESHOLD

--- a/app/services/users/dossier_filter_service.rb
+++ b/app/services/users/dossier_filter_service.rb
@@ -47,7 +47,7 @@ module Users
     def counts
       @counts ||= {
         states:         count_states,
-        alerts:         count_alerts,
+        alerts:         Skylight.instrument(title: "counts.alerts") { count_alerts },
         shared_with_me: scope_without(:shared_with_me).where(id: @user.dossiers_invites.visible_by_user).count,
       }
     end


### PR DESCRIPTION
Empilée sur #13145 (base `feat/12915-foundations`). La base sera repointée vers `main` une fois #13145 mergée.

Ajoute deux spans `Skylight.instrument` pour mesurer distinctement le coût des filtres mes-dossiers dans les traces :

- `counts.alerts` — calcul des compteurs d'alertes du panneau de filtres (`count_alerts`).
- `dossiers.list` — requête de liste des dossiers (COUNT + chargement du SELECT).

Pas de changement fonctionnel : les spans renvoient la valeur encapsulée et n'ajoutent aucune requête. Le `.load` matérialise la page de la liste dans le contrôleur (au lieu du rendu de la vue) pour que le span couvre le SELECT — mêmes requêtes, mêmes résultats.

https://claude.ai/code/session_01DL1Cu5b2a8koZin1pFcBUw
