### PR TITLE
Tech : génère l'attestation v2 (acceptation/refus) de dépôt en PDF/UA accessible (derrière feature flag)

### DIFF
--- a/app/assets/stylesheets/attestation.scss
+++ b/app/assets/stylesheets/attestation.scss
@@ -188,7 +188,7 @@
     font-weight: bold;
   }
 
-  li p {
+  li {
     margin: 0.25rem 0;
   }
 

--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -21,7 +21,10 @@ module Administrateurs
         format.pdf do
           html = render_to_string('/administrateurs/attestation_template_v2s/show', layout: 'attestation', formats: [:html])
 
-          pdf = WeasyprintService.generate_pdf(html, procedure_id: @procedure.id, path: request.path, user_id: current_user.id)
+          options = { procedure_id: @procedure.id, path: request.path, user_id: current_user.id }
+          options[:pdf_variant] = WeasyprintService::PDF_UA_VARIANT if @procedure.feature_enabled?(:pdf_variant)
+
+          pdf = WeasyprintService.generate_pdf(html, options)
 
           send_data(pdf, filename: 'attestation.pdf', type: 'application/pdf', disposition: 'inline')
         end

--- a/app/controllers/concerns/groupe_instructeurs_signature_concern.rb
+++ b/app/controllers/concerns/groupe_instructeurs_signature_concern.rb
@@ -36,7 +36,11 @@ module GroupeInstructeursSignatureConcern
       @signature = attributes.fetch(:signature)
 
       html = render_to_string('/administrateurs/attestation_template_v2s/show', layout: 'attestation', formats: [:html])
-      pdf = WeasyprintService.generate_pdf(html, procedure_id: procedure.id, path: request.path)
+
+      options = { procedure_id: procedure.id, path: request.path }
+      options[:pdf_variant] = WeasyprintService::PDF_UA_VARIANT if procedure.feature_enabled?(:pdf_variant)
+
+      pdf = WeasyprintService.generate_pdf(html, options)
       send_data(pdf, filename: 'attestation.pdf', type: 'application/pdf', disposition: 'inline')
     else
       @attestation = attributes

--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -242,6 +242,9 @@ class AttestationTemplate < ApplicationRecord
       assigns: { attestation_template: self, body:, signature: }
     )
 
-    WeasyprintService.generate_pdf(html, { procedure_id: procedure.id, dossier_id: dossier.id })
+    options = { procedure_id: procedure.id, dossier_id: dossier.id }
+    options[:pdf_variant] = WeasyprintService::PDF_UA_VARIANT if procedure.feature_enabled?(:pdf_variant)
+
+    WeasyprintService.generate_pdf(html, options)
   end
 end

--- a/app/services/tiptap_service.rb
+++ b/app/services/tiptap_service.rb
@@ -60,6 +60,19 @@ class TiptapService
     content.map { node_to_html(_1, substitutions, level) }.join
   end
 
+  def list_item_body(content, substitutions, level)
+    content.map do |node|
+      case node
+      in type: 'paragraph', content: paragraph_content
+        children(paragraph_content, substitutions, level + 1)
+      in type: 'paragraph' # empty paragraph
+        ''
+      else
+        node_to_html(node, substitutions, level)
+      end
+    end.join
+  end
+
   def node_to_html(node, substitutions, level)
     if level == 0 && !@body_started && node[:type].in?(['paragraph', 'heading']) && node.key?(:content)
       @body_started = true
@@ -84,7 +97,7 @@ class TiptapService
     in type: 'orderedList', content:, **rest
       "<ol#{class_list(rest[:attrs])}>#{children(content, substitutions, level + 1)}</ol>"
     in type: 'listItem', content:
-      "<li>#{children(content, substitutions, level + 1)}</li>"
+      "<li>#{list_item_body(content, substitutions, level + 1)}</li>"
     in type: 'descriptionList', content:
       "<dl>#{children(content, substitutions, level + 1)}</dl>"
     in type: 'descriptionTerm', content:, **rest

--- a/app/views/administrateurs/attestation_template_v2s/show.html.erb
+++ b/app/views/administrateurs/attestation_template_v2s/show.html.erb
@@ -3,14 +3,14 @@
     <header class="first-header">
       <div class="left">
         <%- if @attestation_template.official_layout? -%>
-          <%= image_tag('centered_marianne.svg', alt: '', class: 'marianne') %>
+          <%= image_tag('centered_marianne.svg', alt: 'République française', class: 'marianne') %>
           <div class="bloc-marque">
             <%= simple_format @attestation_template.label_logo.presence || "INTITULE de\nVOTRE INSTITUTION", class: "intitule" %>
-            <%= image_tag('liberte2.svg', alt: '', class: 'devise') %>
+            <%= image_tag('liberte2.svg', alt: 'Liberté Égalité Fraternité', class: 'devise') %>
           </div>
         <%- elsif @attestation_template.logo.present? -%>
           <div class="bloc-marque logo-free-layout">
-            <%= image_tag(@attestation_template.logo_url) %>
+            <%= image_tag(@attestation_template.logo_url, alt: @attestation_template.label_logo.presence || "Logo de l’administration") %>
           </div>
         <%- end -%>
       </div>
@@ -18,7 +18,7 @@
       <div class="right">
         <%- if @attestation_template.official_layout? && @attestation_template.logo.present? -%>
           <div class="logo-co-emetteur">
-            <%= image_tag(@attestation_template.logo_url) %>
+            <%= image_tag(@attestation_template.logo_url, alt: @attestation_template.label_logo.presence || "Logo de l’administration") %>
           </div>
         <%- end -%>
 
@@ -37,7 +37,7 @@
 
       <%- if @signature&.attached? -%>
         <div class="signature">
-          <%= image_tag(Rails.application.routes.url_helpers.url_for(@signature)) %>
+          <%= image_tag(Rails.application.routes.url_helpers.url_for(@signature), alt: "Signature") %>
         </div>
       <%- end -%>
     </div>

--- a/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
@@ -112,6 +112,19 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
       it do
         is_expected.to eq('PDF_DATA')
       end
+
+      context 'when the pdf_variant feature is enabled' do
+        before do
+          Flipper.enable(:pdf_variant, procedure)
+          allow(WeasyprintService).to receive(:generate_pdf).and_return('PDF_DATA')
+        end
+
+        it 'requests the pdf/ua-1 variant through the options' do
+          subject
+          expect(WeasyprintService).to have_received(:generate_pdf)
+            .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
+        end
+      end
     end
   end
 

--- a/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
@@ -94,6 +94,18 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
           is_expected.to include("black.png")
         end
       end
+
+      context 'with images requiring an alternative text (PDF/UA)' do
+        let(:attestation_acceptation_template) { build(:attestation_template, :v2, logo:, signature:) }
+
+        it 'renders an informative alt text on every image and leaves none empty' do
+          is_expected.to include('alt="République française"')
+          is_expected.to include('alt="Liberté Égalité Fraternité"')
+          is_expected.to include('alt="Ministère des devs"')
+          is_expected.to include('alt="Signature"')
+          is_expected.not_to include('alt=""')
+        end
+      end
     end
 
     context 'pdf' do

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -1504,6 +1504,16 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         expect(response).to have_http_status(:ok)
         expect(WeasyprintService).to have_received(:generate_pdf)
       end
+
+      context 'when the pdf_variant feature is enabled' do
+        before { Flipper.enable(:pdf_variant, procedure) }
+
+        it 'requests the pdf/ua-1 variant through the options' do
+          subject
+          expect(WeasyprintService).to have_received(:generate_pdf)
+            .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
+        end
+      end
     end
   end
 end

--- a/spec/models/attestation_template_spec.rb
+++ b/spec/models/attestation_template_spec.rb
@@ -190,6 +190,19 @@ describe AttestationTemplate, type: :model do
       it 'generates an attestation' do
         expect(subject.pdf).to be_attached
       end
+
+      context 'when the pdf_variant feature is enabled' do
+        before do
+          Flipper.enable(:pdf_variant, procedure)
+          allow(WeasyprintService).to receive(:generate_pdf).and_return('PDF_DATA')
+        end
+
+        it 'requests the pdf/ua-1 variant through the options' do
+          subject
+          expect(WeasyprintService).to have_received(:generate_pdf)
+            .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
+        end
+      end
     end
   end
 

--- a/spec/services/tiptap_service_spec.rb
+++ b/spec/services/tiptap_service_spec.rb
@@ -169,9 +169,9 @@ RSpec.describe TiptapService do
         '<h3 style="text-align: center">Heading 3</h3>',
         '<p style="text-align: right">First paragraph</p>',
         '<p><s><em>Bonjour </em></s><u><strong>Paul</strong></u> <mark>!</mark></p>',
-        '<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>',
-        '<ol><li><p>Item 1</p></li><li><p>Item 2</p></li></ol>',
-        '<p>Langages de prédilection:</p><ul><li><p>ruby</p></li><li><p>rust</p></li></ul>',
+        '<ul><li>Item 1</li><li>Item 2</li></ul>',
+        '<ol><li>Item 1</li><li>Item 2</li></ol>',
+        '<p>Langages de prédilection:</p><ul><li>ruby</li><li>rust</li></ul>',
         '<footer>Footer</footer>',
       ].join
     end
@@ -354,7 +354,7 @@ RSpec.describe TiptapService do
       end
 
       it "set class attribute" do
-        expect(described_class.new.to_html(json, substitutions)).to eq('<ol class="my-class"><li><p>Item 1</p></li></ol>')
+        expect(described_class.new.to_html(json, substitutions)).to eq('<ol class="my-class"><li>Item 1</li></ol>')
       end
     end
   end


### PR DESCRIPTION
## Résumé

Suite à https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/13314, on ajoute le balisage aux pdfs des attestations v2 

## Changements

- **Variante PDF/UA-1** demandée à WeasyPrint quand le flag `pdf_variant` est activé sur la démarche, sur les trois chemins de génération de l'attestation v2 :
  - prévisualisation côté admin (`AttestationTemplateV2sController#show`)
  - prévisualisation de la signature (`GroupeInstructeursSignatureConcern`)
  - génération de l'attestation d'un dossier (`AttestationTemplate#generate_pdf`)

- 2 corrections pour obtenir un test de conformité avec verapdf (` verapdf -f ua1 [path_to_pdf]`): 
  - **Textes alternatifs** ajoutés sur les images de l'attestation (Marianne, devise, logos, signature) — obligatoires en PDF/UA.
  - **Structure des listes** corrigée : le paragraphe interne d'un `<li>` est déballé pour que WeasyPrint balise `LI > LBody` au lieu de `LI > P` (requis par PDF/UA, ISO 14289-1 §7.2). Ajustement CSS associé.
