### PR TITLE
Tech: re-pin connection_pool < 3 pour ne pas tuer le scheduler Sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,10 @@ gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'sentry-sidekiq'
 gem 'sib-api-v3-sdk'
+# connection_pool 3.0 changed TimedStack#pop signature, which crashes the
+# Sidekiq::Scheduled::Poller thread (scheduled/retry jobs stop being enqueued).
+# Sidekiq must be >= 8.1 before bumping to connection_pool 3.x; keep < 3 until then.
+gem 'connection_pool', '< 3'
 gem 'sidekiq', '< 7.3' # 7.3 needs to migrate to sidekiq-cron 2.0
 gem 'sidekiq-cron', '< 2.0' # wait for a release without "keys command"
 gem 'siret_validator', github: "CodeursenLiberte/siret_validator", ref: "ba421bb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.7)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     content_disposition (1.0.0)
     crack (1.0.0)
       bigdecimal
@@ -1041,6 +1041,7 @@ DEPENDENCIES
   charlock_holmes
   chartkick
   clamav-client
+  connection_pool (< 3)
   daemons
   deep_cloneable
   delayed_cron_job


### PR DESCRIPTION
Avec le passage à Rails 8 (#13258) on pensait pouvoir upgrade `connection_pool 3`.

Mais `connection_pool 3.0` change la signature de `ConnectionPool::TimedStack#pop` et le schéduler sidekiq ne marche plus.

Conséquence : avec le poller mort, **tous les jobs planifiés** (`deliver_later(wait:)`) **et les retries** ne sont plus déplacés vers leur queue. Les jobs immédiats, eux, continuent de passer.

Symptôme côté usager : les mails de messagerie (`DossierMailer#notify_new_answer`, seul mail avec `wait: 5.minutes`) ne partaient plus — ainsi que les demandes de correction, les digests instructeurs, etc. 

**Fix** : on restaure le pin `connection_pool < 3` (présent avant l'upgrade). Au redémarrage de Sidekiq, le poller revient et draine le backlog `schedule`/`retry` → les mails manqués repartent seuls. Le passage à `connection_pool 3.x` nécessitera `sidekiq >= 8.1`.