### PR TITLE
ETQ Instructeur, je n'ai plus de bug sur des données RNA manquantes

### DIFF
--- a/app/components/dossiers/referentiel_component.rb
+++ b/app/components/dossiers/referentiel_component.rb
@@ -9,7 +9,17 @@ class Dossiers::ReferentielComponent < Referentiels::ReferentielDisplayBaseCompo
   end
 
   def call
-    render Dossiers::ExternalChampComponent.new(data:, source:)
+    if champ.external_id.blank? && champ.value.blank? # exact_match remplit external_id, autocomplete remplit value
+      tag.p(t('not_filled', scope: 'activerecord.attributes.type_de_champ'), class: "fr-mt-1w")
+    elsif champ.value_json.present? # TODO: use champ.fetched? when ref champ change state in autocomplete
+      render Dossiers::ExternalChampComponent.new(data:, source:)
+    elsif champ.pending?
+      tag.p(t('shared.champs.external_data.pending', identifier: champ.external_id), class: "fr-mt-1w")
+    elsif champ.external_data_not_found?
+      tag.p(t('shared.champs.external_data.not_found', identifier: champ.external_id), class: "fr-mt-1w")
+    elsif champ.external_error?
+      tag.p(t('shared.champs.external_data.error', identifier: champ.external_id), class: "fr-mt-1w")
+    end
   end
 
   private

--- a/app/components/dossiers/rna_component.rb
+++ b/app/components/dossiers/rna_component.rb
@@ -14,6 +14,8 @@ class Dossiers::RNAComponent < ApplicationComponent
       tag.p(t('shared.champs.external_data.pending', identifier: champ.external_id), class: "fr-mt-1w")
     elsif champ.external_data_not_found?
       tag.p(t('shared.champs.external_data.not_found', identifier: champ.external_id), class: "fr-mt-1w")
+    elsif champ.external_error?
+      tag.p(t('shared.champs.external_data.error', identifier: champ.external_id), class: "fr-mt-1w")
     end
   end
 

--- a/app/components/dossiers/rna_component.rb
+++ b/app/components/dossiers/rna_component.rb
@@ -10,6 +10,8 @@ class Dossiers::RNAComponent < ApplicationComponent
   def call
     if champ.fetched?
       render Dossiers::ExternalChampComponent.new(data:, details:, source:)
+    elsif champ.pending?
+      tag.p(t('shared.champs.external_data.pending', identifier: champ.external_id), class: "fr-mt-1w")
     end
   end
 

--- a/app/components/dossiers/rna_component.rb
+++ b/app/components/dossiers/rna_component.rb
@@ -8,7 +8,9 @@ class Dossiers::RNAComponent < ApplicationComponent
   end
 
   def call
-    render Dossiers::ExternalChampComponent.new(data:, details:, source:)
+    if champ.fetched?
+      render Dossiers::ExternalChampComponent.new(data:, details:, source:)
+    end
   end
 
   private

--- a/app/components/dossiers/rna_component.rb
+++ b/app/components/dossiers/rna_component.rb
@@ -12,6 +12,8 @@ class Dossiers::RNAComponent < ApplicationComponent
       render Dossiers::ExternalChampComponent.new(data:, details:, source:)
     elsif champ.pending?
       tag.p(t('shared.champs.external_data.pending', identifier: champ.external_id), class: "fr-mt-1w")
+    elsif champ.external_data_not_found?
+      tag.p(t('shared.champs.external_data.not_found', identifier: champ.external_id), class: "fr-mt-1w")
     end
   end
 

--- a/app/components/dossiers/rna_component.rb
+++ b/app/components/dossiers/rna_component.rb
@@ -8,7 +8,9 @@ class Dossiers::RNAComponent < ApplicationComponent
   end
 
   def call
-    if champ.fetched?
+    if champ.external_id.blank?
+      tag.p(t('not_filled', scope: 'activerecord.attributes.type_de_champ'), class: "fr-mt-1w")
+    elsif champ.fetched?
       render Dossiers::ExternalChampComponent.new(data:, details:, source:)
     elsif champ.pending?
       tag.p(t('shared.champs.external_data.pending', identifier: champ.external_id), class: "fr-mt-1w")

--- a/app/components/dossiers/rnf_component.rb
+++ b/app/components/dossiers/rnf_component.rb
@@ -8,12 +8,16 @@ class Dossiers::RNFComponent < ApplicationComponent
   end
 
   def call
-    if champ.value.blank?
+    if champ.external_id.blank?
       tag.p(t('not_filled', scope: 'activerecord.attributes.type_de_champ'), class: "fr-mt-1w")
-    elsif champ.data.blank?
-      tag.p(t('not_found', rnf: champ.value, scope: 'activerecord.errors.models.champs/rnf_champ.attributes.value'), class: "fr-mt-1w")
-    else
+    elsif champ.fetched?
       render Dossiers::ExternalChampComponent.new(data:, details:, source:)
+    elsif champ.pending?
+      tag.p(t('shared.champs.external_data.pending', identifier: champ.value), class: "fr-mt-1w")
+    elsif champ.external_data_not_found?
+      tag.p(t('shared.champs.external_data.not_found', identifier: champ.value), class: "fr-mt-1w")
+    elsif champ.external_error?
+      tag.p(t('shared.champs.external_data.error', identifier: champ.value), class: "fr-mt-1w")
     end
   end
 

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -66,6 +66,7 @@ module ChampExternalDataConcern
 
   def pending? = waiting_for_job? || fetching?
   def done? = fetched? || external_error?
+  def external_data_not_found? = external_error? && fetch_external_data_exceptions.last.not_found?
 
   def has_async_external_data? = false
 

--- a/app/models/external_data_exception.rb
+++ b/app/models/external_data_exception.rb
@@ -7,4 +7,8 @@ class ExternalDataException
     @error = error
     @code = code
   end
+
+  def not_found?
+    code == 404
+  end
 end

--- a/app/tasks/maintenance/t20260623backfill_rna_external_state_task.rb
+++ b/app/tasks/maintenance/t20260623backfill_rna_external_state_task.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260623backfillRNAExternalStateTask < MaintenanceTasks::Task
+    # Documentation: la refacto rna_use_external_champ_concern (#12725) a recopié value -> external_id
+    # (t20260616) et re-rempli data/value_json (populate_rna_json_value), mais certaines valeurs n'ont pas été remplies
+    # (api down / 404 ?) et aucune tâche n'a aligné external state
+    # Tous les anciens champs RNA sont donc restés à `idle` (NULL) :
+    #   - ceux qui ont déjà une data -> on les passe en `fetched`
+    #   - ceux qui ont un external_id valide mais pas de data -> on relance le workflow async
+    #     (fetch_later!) pour récupérer la donnée ou enregistrer une external_error propre.
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    run_on_first_deploy
+
+    # on étale les fetch sur 2h pour ne pas saturer API Entreprise
+    # on a ~ 12K champs concernés et uniquement 230 qui vont faire un appel api
+    MAX_WAIT = 2.hours.to_i
+
+    def collection
+      # external_state idle est stocké à NULL ; sans external_id aucune des deux branches ne s'applique
+      Champs::RNAChamp.where(external_state: nil).where.not(external_id: nil)
+    end
+
+    def process(champ)
+      return unless champ.idle?
+
+      if champ.data.present?
+        champ.update_column(:external_state, 'fetched')
+      elsif champ.may_fetch_later?
+        champ.fetch_later!(wait: rand(0..MAX_WAIT))
+      end
+    end
+
+    def count
+      # la table champs est volumineuse, le COUNT déclenche des PG statement timeout
+    end
+  end
+end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -141,6 +141,7 @@ ignore_unused:
   # used in app/components/dossiers/user_search_component mobile search panel (excluded from search above)
   - 'views.users.dossiers.index.search.open'
   - 'views.users.dossiers.index.search.panel_title'
+  - 'shared.champs.external_data.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/views/shared/champs/external_data/en.yml
+++ b/config/locales/views/shared/champs/external_data/en.yml
@@ -4,3 +4,4 @@ en:
     champs:
       external_data:
         pending: "Retrieving data for identifier “%{identifier}”…"
+        not_found: "No data found for identifier “%{identifier}”."

--- a/config/locales/views/shared/champs/external_data/en.yml
+++ b/config/locales/views/shared/champs/external_data/en.yml
@@ -5,3 +5,4 @@ en:
       external_data:
         pending: "Retrieving data for identifier “%{identifier}”…"
         not_found: "No data found for identifier “%{identifier}”."
+        error: "An error occurred while retrieving data for identifier “%{identifier}”."

--- a/config/locales/views/shared/champs/external_data/en.yml
+++ b/config/locales/views/shared/champs/external_data/en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  shared:
+    champs:
+      external_data:
+        pending: "Retrieving data for identifier “%{identifier}”…"

--- a/config/locales/views/shared/champs/external_data/fr.yml
+++ b/config/locales/views/shared/champs/external_data/fr.yml
@@ -1,0 +1,6 @@
+---
+fr:
+  shared:
+    champs:
+      external_data:
+        pending: "Récupération des données en cours pour l’identifiant « %{identifier} »…"

--- a/config/locales/views/shared/champs/external_data/fr.yml
+++ b/config/locales/views/shared/champs/external_data/fr.yml
@@ -4,3 +4,4 @@ fr:
     champs:
       external_data:
         pending: "Récupération des données en cours pour l’identifiant « %{identifier} »…"
+        not_found: "Aucune donnée trouvée pour l’identifiant « %{identifier} »."

--- a/config/locales/views/shared/champs/external_data/fr.yml
+++ b/config/locales/views/shared/champs/external_data/fr.yml
@@ -5,3 +5,4 @@ fr:
       external_data:
         pending: "Récupération des données en cours pour l’identifiant « %{identifier} »…"
         not_found: "Aucune donnée trouvée pour l’identifiant « %{identifier} »."
+        error: "Une erreur est survenue lors de la récupération des données pour l’identifiant « %{identifier} »."

--- a/spec/components/dossiers/referentiel_component_spec.rb
+++ b/spec/components/dossiers/referentiel_component_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+RSpec.describe Dossiers::ReferentielComponent, type: :component do
+  let(:referentiel) { create(:api_referentiel, :exact_match) }
+  let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :referentiel, referentiel: }]) }
+  let(:dossier) { create(:dossier, procedure:) }
+  let(:champ) { dossier.project_champs_public.first }
+
+  let(:pending) { false }
+  let(:not_found) { false }
+  let(:value_json) { nil }
+  let(:external_error) { false }
+  let(:value) { 'ABC123' }
+  let(:external_id) { value }
+
+  subject { render_inline(described_class.new(champ:, profile: 'usager')) }
+
+  before do
+    allow(champ).to receive(:pending?).and_return(pending)
+    allow(champ).to receive(:value_json).and_return(value_json)
+    allow(champ).to receive(:external_data_not_found?).and_return(not_found)
+    allow(champ).to receive(:external_error?).and_return(external_error)
+    allow(champ).to receive(:value).and_return(value)
+    allow(champ).to receive(:external_id).and_return(external_id)
+    allow(champ).to receive(:to_s).and_return(value.to_s)
+    allow(Dossiers::ExternalChampComponent).to receive(:new).and_call_original
+    subject
+  end
+
+  # exact_match : external_id est renseigné mais value reste blank jusqu'au succès du fetch
+  context 'when the champ is waiting for a job (exact_match)' do
+    let(:external_id) { 'ABC123' }
+    let(:value) { nil }
+    let(:pending) { true }
+
+    it 'displays a pending message with the identifier' do
+      expect(subject).to have_text('Récupération des données en cours pour l’identifiant « ABC123 »')
+    end
+  end
+
+  context 'when the external data is not found (exact_match)' do
+    let(:external_id) { 'ABC123' }
+    let(:value) { nil }
+    let(:not_found) { true }
+
+    it 'displays a not found message with the identifier' do
+      expect(subject).to have_text('Aucune donnée trouvée pour l’identifiant « ABC123 »')
+    end
+  end
+
+  context 'when the champ is in external error with a technical error (exact_match)' do
+    let(:external_id) { 'ABC123' }
+    let(:value) { nil }
+    let(:external_error) { true }
+
+    it 'displays a generic error message with the identifier' do
+      expect(subject).to have_text('Une erreur est survenue lors de la récupération des données pour l’identifiant « ABC123 »')
+    end
+  end
+
+  context 'when the value_json is present' do
+    let(:value) { 'Mon référentiel' }
+    let(:value_json) { { something: true } }
+
+    it 'renders ExternalChampComponent with the identifier' do
+      expect(Dossiers::ExternalChampComponent).to have_received(:new) do |data:, **|
+        expect(data).to include(['Identifiant', 'Mon référentiel'])
+      end
+    end
+  end
+
+  context 'when the value is blank' do
+    let(:value) { nil }
+
+    it 'displays a not filled message' do
+      expect(subject).to have_text('Non renseigné')
+    end
+  end
+end

--- a/spec/components/dossiers/rna_component_spec.rb
+++ b/spec/components/dossiers/rna_component_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Dossiers::RNAComponent, type: :component do
   let(:champ) do
-    Champs::RNAChamp.new(external_state:, data: rna_data)
+    Champs::RNAChamp.new(external_state:, external_id: 'W173847273', data: rna_data)
       .tap { |c| allow(c).to receive(:to_s).and_return('W173847273') }
   end
 
@@ -31,6 +31,15 @@ RSpec.describe Dossiers::RNAComponent, type: :component do
         expect(details).to include(['Date de création', '1949-01-01'])
         expect(source.to_s).to include('RNA')
       end
+    end
+  end
+
+  context 'when the champ is waiting for a job' do
+    let(:external_state) { 'waiting_for_job' }
+    let(:rna_data) { nil }
+
+    it 'displays a pending message with the identifier' do
+      expect(subject).to have_text('Récupération des données en cours pour l’identifiant « W173847273 »')
     end
   end
 end

--- a/spec/components/dossiers/rna_component_spec.rb
+++ b/spec/components/dossiers/rna_component_spec.rb
@@ -54,4 +54,14 @@ RSpec.describe Dossiers::RNAComponent, type: :component do
       expect(subject).to have_text('Aucune donnée trouvée pour l’identifiant « W173847273 »')
     end
   end
+
+  context 'when the champ is in external error with a technical error' do
+    let(:external_state) { 'external_error' }
+    let(:rna_data) { nil }
+    let(:fetch_external_data_exceptions) { [ExternalDataException.new(error: 'Boom', code: 500)] }
+
+    it 'displays a generic error message with the identifier' do
+      expect(subject).to have_text('Une erreur est survenue lors de la récupération des données pour l’identifiant « W173847273 »')
+    end
+  end
 end

--- a/spec/components/dossiers/rna_component_spec.rb
+++ b/spec/components/dossiers/rna_component_spec.rb
@@ -3,8 +3,10 @@
 RSpec.describe Dossiers::RNAComponent, type: :component do
   let(:fetch_external_data_exceptions) { [] }
 
+  let(:external_id) { 'W173847273' }
+
   let(:champ) do
-    Champs::RNAChamp.new(external_state:, external_id: 'W173847273', data: rna_data, fetch_external_data_exceptions:)
+    Champs::RNAChamp.new(external_state:, external_id:, data: rna_data, fetch_external_data_exceptions:)
       .tap { |c| allow(c).to receive(:to_s).and_return('W173847273') }
   end
 
@@ -62,6 +64,16 @@ RSpec.describe Dossiers::RNAComponent, type: :component do
 
     it 'displays a generic error message with the identifier' do
       expect(subject).to have_text('Une erreur est survenue lors de la récupération des données pour l’identifiant « W173847273 »')
+    end
+  end
+
+  context 'when the external_id is blank' do
+    let(:external_state) { nil }
+    let(:external_id) { nil }
+    let(:rna_data) { nil }
+
+    it 'displays a not filled message' do
+      expect(subject).to have_text('Non renseigné')
     end
   end
 end

--- a/spec/components/dossiers/rna_component_spec.rb
+++ b/spec/components/dossiers/rna_component_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Dossiers::RNAComponent, type: :component do
+  let(:fetch_external_data_exceptions) { [] }
+
   let(:champ) do
-    Champs::RNAChamp.new(external_state:, external_id: 'W173847273', data: rna_data)
+    Champs::RNAChamp.new(external_state:, external_id: 'W173847273', data: rna_data, fetch_external_data_exceptions:)
       .tap { |c| allow(c).to receive(:to_s).and_return('W173847273') }
   end
 
@@ -40,6 +42,16 @@ RSpec.describe Dossiers::RNAComponent, type: :component do
 
     it 'displays a pending message with the identifier' do
       expect(subject).to have_text('Récupération des données en cours pour l’identifiant « W173847273 »')
+    end
+  end
+
+  context 'when the champ is in external error with a 404' do
+    let(:external_state) { 'external_error' }
+    let(:rna_data) { nil }
+    let(:fetch_external_data_exceptions) { [ExternalDataException.new(error: 'NotFound', code: 404)] }
+
+    it 'displays a not found message with the identifier' do
+      expect(subject).to have_text('Aucune donnée trouvée pour l’identifiant « W173847273 »')
     end
   end
 end

--- a/spec/components/dossiers/rna_component_spec.rb
+++ b/spec/components/dossiers/rna_component_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Dossiers::RNAComponent, type: :component do
+  let(:champ) do
+    Champs::RNAChamp.new(external_state:, data: rna_data)
+      .tap { |c| allow(c).to receive(:to_s).and_return('W173847273') }
+  end
+
+  subject { render_inline(described_class.new(champ:)) }
+
+  before do
+    allow(Dossiers::ExternalChampComponent).to receive(:new).and_call_original
+    subject
+  end
+
+  context 'when the data is fetched?' do
+    let(:external_state) { 'fetched' }
+    let(:rna_data) do
+      {
+        'association_titre' => 'LA PRÉVENTION ROUTIÈRE',
+        'association_objet' => 'Prévention des accidents de la route',
+        'association_date_creation' => '1949-01-01',
+      }
+    end
+
+    it 'renders ExternalChampComponent with correct arguments' do
+      expect(Dossiers::ExternalChampComponent).to have_received(:new) do |data:, details:, source:|
+        expect(data).to include(['Numéro RNA', 'W173847273'])
+        expect(data).to include(['Nom de l’association', 'LA PRÉVENTION ROUTIÈRE'])
+        expect(data).to include(['Objet de l’association', 'Prévention des accidents de la route'])
+        expect(details).to include(['Date de création', '1949-01-01'])
+        expect(source.to_s).to include('RNA')
+      end
+    end
+  end
+end

--- a/spec/components/dossiers/rnf_component_spec.rb
+++ b/spec/components/dossiers/rnf_component_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe Dossiers::RNFComponent, type: :component do
+  let(:fetch_external_data_exceptions) { [] }
+
+  let(:external_id) { '075-FDD-00003-01' }
+
+  let(:champ) do
+    Champs::RNFChamp.new(external_state:, external_id:, data: rnf_data, fetch_external_data_exceptions:)
+      .tap { |c| allow(c).to receive(:to_s).and_return('075-FDD-00003-01') }
+  end
+
+  subject { render_inline(described_class.new(champ:)) }
+
+  before do
+    allow(Dossiers::ExternalChampComponent).to receive(:new).and_call_original
+    subject
+  end
+
+  context 'when the data is fetched?' do
+    let(:external_state) { 'fetched' }
+    let(:rnf_data) do
+      {
+        'title' => 'Fondation SFR',
+        'email' => 'contact@fondation-sfr.org',
+      }
+    end
+
+    it 'renders ExternalChampComponent with correct arguments' do
+      # rubocop:disable Lint/UnusedBlockArgument
+      expect(Dossiers::ExternalChampComponent).to have_received(:new) do |data:, details:, source:|
+        expect(data).to include(['Nom de la fondation', 'Fondation SFR'])
+        expect(data).to include(['Adresse électronique', 'contact@fondation-sfr.org'])
+        expect(source.to_s).to include('RNF')
+      end
+      # rubocop:enable Lint/UnusedBlockArgument
+    end
+  end
+
+  context 'when the champ is waiting for a job' do
+    let(:external_state) { 'waiting_for_job' }
+    let(:rnf_data) { nil }
+
+    it 'displays a pending message with the identifier' do
+      expect(subject).to have_text('Récupération des données en cours pour l’identifiant « 075-FDD-00003-01 »')
+    end
+  end
+
+  context 'when the champ is in external error with a 404' do
+    let(:external_state) { 'external_error' }
+    let(:rnf_data) { nil }
+    let(:fetch_external_data_exceptions) { [ExternalDataException.new(error: 'NotFound', code: 404)] }
+
+    it 'displays a not found message with the identifier' do
+      expect(subject).to have_text('Aucune donnée trouvée pour l’identifiant « 075-FDD-00003-01 »')
+    end
+  end
+
+  context 'when the champ is in external error with a technical error' do
+    let(:external_state) { 'external_error' }
+    let(:rnf_data) { nil }
+    let(:fetch_external_data_exceptions) { [ExternalDataException.new(error: 'Boom', code: 500)] }
+
+    it 'displays a generic error message with the identifier' do
+      expect(subject).to have_text('Une erreur est survenue lors de la récupération des données pour l’identifiant « 075-FDD-00003-01 »')
+    end
+  end
+
+  context 'when the value is blank' do
+    let(:external_state) { nil }
+    let(:external_id) { nil }
+    let(:rnf_data) { nil }
+
+    it 'displays a not filled message' do
+      expect(subject).to have_text('Non renseigné')
+    end
+  end
+end

--- a/spec/models/concerns/champ_external_data_concern_spec.rb
+++ b/spec/models/concerns/champ_external_data_concern_spec.rb
@@ -15,6 +15,38 @@ RSpec.describe ChampExternalDataConcern do
     end
   end
 
+  describe '#external_data_not_found?' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champs.first }
+
+    before do
+      champ.external_state = external_state
+      champ.fetch_external_data_exceptions = exceptions
+    end
+
+    context 'in external_error with a 404 exception' do
+      let(:external_state) { 'external_error' }
+      let(:exceptions) { [ExternalDataException.new(error: 'NotFound', code: 404)] }
+
+      it { expect(champ).to be_external_data_not_found }
+    end
+
+    context 'in external_error with a non-404 exception' do
+      let(:external_state) { 'external_error' }
+      let(:exceptions) { [ExternalDataException.new(error: 'Boom', code: 500)] }
+
+      it { expect(champ).not_to be_external_data_not_found }
+    end
+
+    context 'when not in error' do
+      let(:external_state) { 'fetched' }
+      let(:exceptions) { [] }
+
+      it { expect(champ).not_to be_external_data_not_found }
+    end
+  end
+
   describe 'the state machine' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
     let(:dossier) { create(:dossier, procedure:) }

--- a/spec/tasks/maintenance/t20260623backfill_rna_external_state_task_spec.rb
+++ b/spec/tasks/maintenance/t20260623backfill_rna_external_state_task_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260623backfillRNAExternalStateTask do
+    describe "#process" do
+      subject(:process) { described_class.process(champ) }
+
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rna }]) }
+      let(:dossier) { create(:dossier, procedure:) }
+      let(:champ) { dossier.project_champs_public.first }
+
+      context "quand le champ est idle avec une data déjà présente" do
+        before do
+          champ.update_columns(external_state: nil, external_id: 'W173847273', data: { 'association_titre' => 'Asso' })
+        end
+
+        it "le passe en fetched sans relancer de fetch" do
+          expect { process }.to change { champ.reload.external_state }.from('idle').to('fetched')
+        end
+      end
+
+      context "quand le champ est idle avec un external_id valide mais sans data" do
+        before do
+          champ.update_columns(external_state: nil, external_id: 'W173847273', data: nil)
+        end
+
+        it "relance le workflow async" do
+          expect { process }.to change { champ.reload.external_state }.from('idle').to('waiting_for_job')
+            .and have_enqueued_job(ChampFetchExternalDataJob).with(champ, 'W173847273')
+        end
+      end
+
+      context "quand le champ est idle avec un external_id invalide et sans data" do
+        before do
+          champ.update_columns(external_state: nil, external_id: 'not-a-rna', data: nil)
+        end
+
+        it "ne fait rien" do
+          expect { process }.not_to change { champ.reload.external_state }.from('idle')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
La tache de migration des champs RNA vers le système external_data_concern semble avoir eu des trous :
- certains champs sur des dossiers en_construction, avec un external_id valide, n'ont pas récupéré leur données (`data` et `value_json` nil)
- certains champs, malgrés avoir récupéré leurs data, sont toujours en `idle` au lieu de `fetched`

Par ailleurs, le component d'affichage du champ rna pour les instructeurs, [plantait](https://demarches-simplifiees.sentry.io/issues/7557756540/?project=1429550) si la valeur `data` était vide.

Cette PR vient donc
- récupérer les données des champs RNA incohérents
- gérer les différents cas d'affichage instructeur (données récupérées + non rempli / non trouvé / erreur api)
- généraliser cette logique pour les champs rnf et référentiel

remarques : 
- le component rna se base sur `champ.data` alors qu'il devrait se baser sur l'attribut redressé `value_json`. TODO pour une prochaine PR
- le champ referentiel, en mode autocomplete, ne met pas son external_state à jour en `fetched`, ni ne remplit son `external_id` ce qui oblige à avoir du code différent de détection dans le component
- on pourrait proposer à l'usager https://www.journal-officiel.gouv.fr/pages/associations-recherche/ au moment il doit remplir son numéro RNA
- on a une incohérence sur la champ_blank? : actuellement le code regarde pour le rna si value.present? et value est remplie une fois le fetch effectué. Cela ne marchera plus lorsque l'on permettra de soumettre avec un champ non encore fetché (car dans le cas des champs connecté, on rempli external_id et non value)