### PR TITLE
Tech: migrer Dsfr::ToggleComponent de HAML vers ERB

### DIFF
--- a/app/components/dsfr/toggle_component/toggle_component.html.erb
+++ b/app/components/dsfr/toggle_component/toggle_component.html.erb
@@ -1,0 +1,8 @@
+<div class="fr-toggle <%= no_label_class %> <%= extra_class_names %>">
+  <%= @form.check_box target, check_box_options %>
+  <%= @form.label target, title || html_title&.html_safe, label_options %>
+
+  <% if hint -%>
+    <p class="fr-hint-text"><%= hint %></p>
+  <% end -%>
+</div>

--- a/app/components/dsfr/toggle_component/toggle_component.html.haml
+++ b/app/components/dsfr/toggle_component/toggle_component.html.haml
@@ -1,6 +1,0 @@
-%div{ class: "fr-toggle #{no_label_class} #{extra_class_names}" }
-  = @form.check_box target, check_box_options
-  = @form.label target, title || html_title&.html_safe, label_options
-
-  - if hint
-    %p.fr-hint-text= hint


### PR DESCRIPTION
# Probleme

On migre HAML → ERB. C'est lent, pénible, et c'est une charge mentale.

# Solution

Skill [`/haml-migration`](https://github.com/mfo/night-shift/blob/main/.claude/skills/haml-migration/SKILL.md)

### Dsfr::ToggleComponent — ✅ identique au byte

**Validation :** formatter herb ✅, tests ✅, apostrophes ✅

**Avant :**
![haml](https://gist.githubusercontent.com/mfo/91af9a155129a056d0c90d8576f54db1/raw/haml-usage1-component-1.png)

**Après :**
![erb](https://gist.githubusercontent.com/mfo/91af9a155129a056d0c90d8576f54db1/raw/erb-usage1-component-1.png)

**Couverture visuelle (2/2 utilisations) :**
- ✅ `http://localhost:3210/admin/procedures/142054/edit` — usage dans le formulaire d'édition (informations)
- ✅ `http://localhost:3210/procedures/142054/notification_preferences` — usage dans les préférences de notifications

[Voir tous les screenshots](https://gist.github.com/mfo/91af9a155129a056d0c90d8576f54db1)

Generated with [Claude Code](https://claude.com/claude-code)