### PR TITLE
ETQ usager, corriger un champ ne modifie plus un champ adresse vide

### DIFF
--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -21,6 +21,13 @@ class Champ < ApplicationRecord
   delegate :procedure, to: :dossier
   normalizes :value, with: NORMALIZES_NON_PRINTABLE_PROC
 
+  # Reading any `store_accessor` attribute (e.g. `country_code`,
+  # `code_departement`) on a champ whose JSON column is nil silently
+  # initializes that column to `{}`. Left as-is, this empty hash is persisted as
+  # a spurious change — bumping `updated_at` and making an untouched blank champ
+  # look like it was edited. Revert blank-equivalent JSON columns before saving.
+  before_save :nullify_blank_json_columns
+
   def type_de_champ
     @type_de_champ ||= dossier.revision
       .types_de_champ
@@ -357,6 +364,15 @@ class Champ < ApplicationRecord
   end
 
   private
+
+  def nullify_blank_json_columns
+    [:value_json, :data].each do |column|
+      next unless has_attribute?(column) && public_send(:"#{column}_changed?")
+
+      value = public_send(column)
+      self[column] = nil if value.is_a?(Hash) && value.compact.blank?
+    end
+  end
 
   # The input id is used to generate the HTML id of the input element.
   # It is used to link the label to the input, and for ARIA attributes.

--- a/app/models/champs/address_champ.rb
+++ b/app/models/champs/address_champ.rb
@@ -311,10 +311,14 @@ class Champs::AddressChamp < Champs::TextChamp
         address_data.merge!(city_data) if city_data.present?
       end
 
-      address_data['country_code'] ||= 'FR'
+      # Only default the country code when the champ actually carries address
+      # data. Otherwise a blank champ — whose value_json may have been silently
+      # initialized to `{}` by an incidental store_accessor read — would be
+      # fabricated into a non-blank "France" address and persisted.
+      address_data['country_code'] ||= 'FR' if address_data.present?
     end
 
-    self.value_json = address_data.compact
+    self.value_json = address_data.compact.presence
 
     if full_address? && !ban?
       self.value_json['label'] = format_label

--- a/spec/models/champ_blank_json_not_touched_spec.rb
+++ b/spec/models/champ_blank_json_not_touched_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Regression test for a bug where submitting a correction on one champ would
+# silently "touch" an *untouched* blank champ of another type.
+#
+# Root cause: reading any `store_accessor` attribute (e.g. AddressChamp#country_code)
+# on a champ whose JSON column is nil initializes that column to `{}`. When the
+# buffer stream is merged, `dossier.save!` autosaves the now-dirty (but untouched)
+# champ. For an address this was even worse: `set_full_address` defaulted
+# `country_code` to 'FR', turning an empty optional champ into a filled "France"
+# address shown as if the usager had entered it.
+RSpec.describe 'A blank champ must not be touched when another champ is corrected', type: :model do
+  let(:procedure) do
+    create(:procedure, :published,
+      types_de_champ_public: [
+        { type: 'text', libelle: 'Texte', stable_id: 99 },
+        { type: second_type, libelle: 'Second', stable_id: 100, mandatory: false },
+      ])
+  end
+  let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
+  let(:user) { dossier.user }
+
+  def second_champ
+    dossier.reload.champs.find { _1.stream == Champ::MAIN_STREAM && _1.stable_id == 100 }
+  end
+
+  # Reproduces the usager correction flow: edit only the text champ on the user
+  # buffer stream, validate the whole dossier (which reads every champ), then merge.
+  def correct_text_only
+    edited = Dossier.find(dossier.id)
+    edited.with_update_stream(user) do
+      edited.public_champ_for_update('99', updated_by: user.email).assign_attributes(value: 'corrigé')
+    end
+    edited.save!
+
+    submitted = Dossier.find(dossier.id)
+    submitted.champs_public_valid?
+    submitted.merge_user_buffer_stream!
+    submitted.save!
+  end
+
+  %w[address communes regions departements epci].each do |type|
+    context "with a blank #{type} champ" do
+      let(:second_type) { type }
+
+      it "leaves the blank #{type} champ untouched and still blank" do
+        dossier.champs.find { _1.stable_id == 100 }.update_columns(value: nil, value_json: nil, external_id: nil)
+        updated_at_before = second_champ.updated_at
+
+        travel_to(1.hour.from_now) { correct_text_only }
+
+        expect(second_champ.value_json).to be_nil
+        expect(second_champ.updated_at).to be_within(1.second).of(updated_at_before)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Le bug

Sur une démarche comportant un champ **adresse facultatif laissé vide** par l’usager, le simple fait de corriger **un autre champ** (ex. un champ texte) transformait le champ adresse vide en une adresse « France » remplie, avec un `updated_at` rafraîchi — comme si l’usager l’avait saisie lui-même. Le champ apparaissait alors comme modifié dans l’historique.

Le bug a été repéré dans le flux « dossier modifié par l’instructeur », mais la cause est partagée par tous les flux qui fusionnent un *buffer stream* (correction usager incluse).

## La cause

Deux étapes s’enchaînent :

1. **Une simple lecture d’un `store_accessor` salit un champ vide.** `Champs::AddressChamp` déclare `store_accessor :value_json, :country_code, …`. Quand `value_json` vaut `nil` (champ facultatif vide), **lire** n’importe quel accesseur — ce qui arrive partout : `champ_blank?`, `ban?`, `france?`, rendu des vues, `champs_public_valid?` — fait écrire `{}` dans `value_json` par ActiveRecord, marquant l’enregistrement comme modifié (`nil → {}`). C’est un piège classique d’ActiveRecord `store_accessor`.

2. **La fusion persiste le champ involontairement sali.** `…_submit_en_construction!` appelle `dossier.save!`, qui *autosave* tous les champs chargés, y compris le champ vide jamais touché. Son callback `before_validation :set_full_address` se déclenche (car `value_json_changed?`) et `address_data['country_code'] ||= 'FR'` fabrique une valeur France par défaut : le champ vide est enregistré comme `{country_code:'FR'}` avec un nouveau `updated_at`.

## Vérification des autres types de champ

J’ai audité les 9 champs utilisant `store_accessor`. La salissure « `nil → {}` à la lecture » est **générique**, mais la persistance néfaste lors de la fusion ne touche que :
- **`address`** — grave : fabrique un `country_code:'FR'` (le bug signalé) ;
- **`epci`** — mineur : persiste `{}`, ne fait que rafraîchir `updated_at` ;
- **`regions` / `departements` / `communes`** — sûrs : leurs getters de valeur/code ne lisent pas de `store_accessor` sur un champ vide ;
- `rnf` / `cojo` utilisent la colonne `data` sans callback fabriquant de valeur (latent uniquement).

## Le correctif

1. **`Champ#nullify_blank_json_columns`** (`before_save`) : remet à `nil` une colonne `value_json`/`data` équivalente à vide, pour que le changement parasite `nil → {}` ne soit pas persisté (`partial_writes` saute alors l’`UPDATE`, `updated_at` n’est pas touché). Couvre `epci` et protège toute la famille.
2. **`AddressChamp#set_full_address`** : ne fixe le `country_code` par défaut que si le champ porte réellement des données d’adresse, et remet `value_json` à `nil` lorsque le résultat est vide.

## Tests

`spec/models/champ_blank_json_not_touched_spec.rb` rejoue le flux de correction usager (édition du seul champ texte sur le *user buffer stream*, validation, fusion) pour `address` / `communes` / `regions` / `departements` / `epci`, et vérifie que le champ vide reste vide et non modifié. Le test échoue sans le correctif (adresse fabriquée) et passe avec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
