### PR TITLE
ETQ admin, je n'ai plus de bouton saut de ligne dans l'éditeur d'attestation v2

### DIFF
--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -47,7 +47,6 @@ module Administrateurs
           ['Liste numérotée', 'orderedList', 'list-ordered'],
         ],
         [
-          ['Saut de ligne', 'hardBreak', 'corner-down-left-line'],
           ['Saut de page', 'pageBreak', 'page-separator'],
         ],
         [

--- a/app/javascript/shared/tiptap/actions.ts
+++ b/app/javascript/shared/tiptap/actions.ts
@@ -107,14 +107,6 @@ const EDITOR_ACTIONS: Record<string, (editor: Editor) => EditorAction> = {
     isActive: () => false,
     isDisabled: () => !editor.can().chain().focus().redo().run()
   }),
-  hardBreak: (editor) => ({
-    run: () => editor.chain().focus().setHardBreak().run(),
-    isActive: () => false,
-    isDisabled: () =>
-      editor.isActive('title') ||
-      editor.isActive('header') ||
-      editor.isActive('footer')
-  }),
   link: (editor) => ({
     run: () => {
       // Link action is handled directly by the controller's menuButton method

--- a/app/javascript/shared/tiptap/editor.ts
+++ b/app/javascript/shared/tiptap/editor.ts
@@ -18,7 +18,6 @@ import Mention from '@tiptap/extension-mention';
 import Typography from '@tiptap/extension-typography';
 import Heading from '@tiptap/extension-heading';
 import Link from '@tiptap/extension-link';
-import HardBreak from '@tiptap/extension-hard-break';
 
 import {
   Editor,
@@ -115,9 +114,6 @@ function getEditorOptions(
         break;
       case 'title':
         extensions.push(Header, HeaderColumn, Title);
-        break;
-      case 'hardBreak':
-        extensions.push(HardBreak);
         break;
       case 'link':
         extensions.push(

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,6 @@
         "@tiptap/extension-bullet-list": "^2.2.4",
         "@tiptap/extension-document": "^2.2.4",
         "@tiptap/extension-gapcursor": "^2.2.4",
-        "@tiptap/extension-hard-break": "^2.2.4",
         "@tiptap/extension-heading": "^2.2.4",
         "@tiptap/extension-highlight": "^2.2.4",
         "@tiptap/extension-history": "^2.2.4",
@@ -559,8 +558,6 @@
     "@tiptap/extension-document": ["@tiptap/extension-document@2.2.4", "", { "peerDependencies": { "@tiptap/core": "^2.0.0" } }, "sha512-z+05xGK0OFoXV1GL+/8bzcZuWMdMA3+EKwk5c+iziG60VZcvGTF7jBRsZidlu9Oaj0cDwWHCeeo6L9SgSh6i2A=="],
 
     "@tiptap/extension-gapcursor": ["@tiptap/extension-gapcursor@2.2.4", "", { "peerDependencies": { "@tiptap/core": "^2.0.0", "@tiptap/pm": "^2.0.0" } }, "sha512-Y6htT/RDSqkQ1UwG2Ia+rNVRvxrKPOs3RbqKHPaWr3vbFWwhHyKhMCvi/FqfI3d5pViVHOZQ7jhb5hT/a0BmNw=="],
-
-    "@tiptap/extension-hard-break": ["@tiptap/extension-hard-break@2.2.4", "", { "peerDependencies": { "@tiptap/core": "^2.0.0" } }, "sha512-FPvS57GcqHIeLbPKGJa3gnH30Xw+YB1PXXnAWG2MpnMtc2Vtj1l5xaYYBZB+ADdXLAlU0YMbKhFLQO4+pg1Isg=="],
 
     "@tiptap/extension-heading": ["@tiptap/extension-heading@2.2.4", "", { "peerDependencies": { "@tiptap/core": "^2.0.0" } }, "sha512-gkq7Ns2FcrOCRq7Q+VRYt5saMt2R9g4REAtWy/jEevJ5UV5vA2AiGnYDmxwAkHutoYU0sAUkjqx37wE0wpamNw=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@tiptap/extension-bullet-list": "^2.2.4",
     "@tiptap/extension-document": "^2.2.4",
     "@tiptap/extension-gapcursor": "^2.2.4",
-    "@tiptap/extension-hard-break": "^2.2.4",
     "@tiptap/extension-heading": "^2.2.4",
     "@tiptap/extension-highlight": "^2.2.4",
     "@tiptap/extension-history": "^2.2.4",

--- a/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
@@ -180,6 +180,12 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
           expect(response.body).not_to have_button("Souligner")
           expect(response.body).not_to include('data-tiptap-action="underline"')
         end
+
+        it 'renders the editor toolbar without a line break button' do
+          subject
+          expect(response.body).not_to have_button("Saut de ligne")
+          expect(response.body).not_to include('data-tiptap-action="hardBreak"')
+        end
       end
 
       context 'if an attestation template already exist on v1' do


### PR DESCRIPTION
## Pourquoi

Le bouton « Saut de ligne » de l'éditeur Tiptap des attestations v2 insérait un double `<br>`. Cela pose un problème d'accessibilité (non conforme PDF/UA). Ce n'était pas gênant tant que les pdfs n'étaient pas balisés, mais ça le devient maintenant que c'est le cas.

## Ce que fait la PR

- Retrait du bouton de la barre d'outils de l'éditeur.
- Suppression du code mort associé : action Tiptap `hardBreak`, extension `HardBreak` et dépendance `@tiptap/extension-hard-break`.
- `TiptapService` continue de rendre les nœuds `hardBreak` existants en `<br><br>` : les quelques attestations qui l'utilisent restent rendues correctement en PDF.

## À noter

Une attestation existante contenant un saut de ligne s'affiche toujours bien. En revanche, si elle est ré-éditée, l'éditeur ne charge plus l'extension et les sauts de ligne seront supprimés à l'enregistrement.