### PR TITLE
ETQ admin, retire le bandeau du sondage sur le champ tableau

### DIFF
--- a/app/views/administrateurs/procedures/index.html.haml
+++ b/app/views/administrateurs/procedures/index.html.haml
@@ -1,15 +1,4 @@
 - content_for(:title, "Démarches")
-- if ENV.fetch("ADMIN_TABLEAU_SURVEY_ENABLED", "enabled") == "enabled"
-  = render Dsfr::NoticeComponent.new(closable: true, data_attributes: { "data-notice-name" => "admin-sondage-champ-tableau" }) do |c|
-    - c.with_title do
-      Votre avis compte !
-    - c.with_desc do
-      En tant qu’administrateur·trice de formulaire, vous auriez besoin d’un nouveau champ de type ”tableau“ ?
-    - c.with_link do
-      -# haml-lint:disable ApplicationNameLinter
-      = link_to "Répondre au sondage", "https://demarche.numerique.gouv.fr/commencer/sondage-champ-de-type-tableau", class: "fr-notice__link", **external_link_attributes
-      -# haml-lint:enable ApplicationNameLinter
-
 .sub-header
   .fr-container
     %h1.fr-h3 Mes démarches

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -263,9 +263,6 @@ ADMINISTRATION_BANNER_MESSAGE=""
 # for usager only
 USAGER_BANNER_MESSAGE=""
 
-# Survey banner shown to administrateurs about a "tableau" champ type
-# ADMIN_TABLEAU_SURVEY_ENABLED="disabled" # "enabled" by default
-
 # RSA private key to generate JWT tokens for communication with COJO services
 COJO_JWT_RSA_PRIVATE_KEY=""
 COJO_JWT_ISS=""


### PR DESCRIPTION
Retire la notice côté administrateur qui invitait à répondre au sondage sur un futur champ de type « tableau », ainsi que la variable d'environnement `ADMIN_TABLEAU_SURVEY_ENABLED` associée.

Revert de #13025.
