### PR TITLE
Tech: supprime le feature flag export_xlsx_streaming et l'ancien export xlsx

### DIFF
--- a/app/services/procedure_export_service.rb
+++ b/app/services/procedure_export_service.rb
@@ -17,10 +17,10 @@ class ProcedureExportService
   end
 
   def to_xlsx
-    if procedure.feature_enabled?(:export_xlsx_streaming)
-      streamed_xlsx
-    else
-      legacy_xlsx
+    Tempfile.create(['export', '.xlsx'], binmode: true) do |file|
+      XlsxExport.new(procedure:, dossiers:, export_template: @export_template).write_to(file)
+      file.rewind
+      create_blob(file, :xlsx)
     end
   end
 
@@ -60,25 +60,6 @@ class ProcedureExportService
   end
 
   private
-
-  def streamed_xlsx
-    Tempfile.create(['export', '.xlsx'], binmode: true) do |file|
-      XlsxExport.new(procedure:, dossiers:, export_template: @export_template).write_to(file)
-      file.rewind
-      create_blob(file, :xlsx)
-    end
-  end
-
-  def legacy_xlsx
-    @dossiers = @dossiers.downloadable_sorted_batch
-    tables = [:dossiers, :etablissements, :avis] + champs_repetables_options(format: :xlsx)
-
-    # We recursively build multi page spreadsheet
-    io = tables.reduce(nil) do |package, table|
-      SpreadsheetArchitect.to_axlsx_package(options_for(table, :xlsx), package)
-    end.to_stream
-    create_blob(io, :xlsx)
-  end
 
   def create_blob(io, format)
     ActiveStorage::Blob.create_and_upload!(

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -28,7 +28,6 @@ features = [
   :engagement_juridique_type_de_champ,
   :export_avec_horodatage,
   :export_order_by_revision,
-  :export_xlsx_streaming,
   :groupe_instructeur_api_hack,
   :analyse_justificatif_domicile,
   :pro_connect_restricted,

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -21,9 +21,6 @@ describe ProcedureExportService do
         }
     end
 
-    before { Flipper.enable(:export_xlsx_streaming) }
-    after { Flipper.disable(:export_xlsx_streaming) }
-
     let(:dossiers_sheet) { subject.sheets.first }
     let(:etablissements_sheet) { subject.sheets.second }
     let(:avis_sheet) { subject.sheets.third }
@@ -33,17 +30,6 @@ describe ProcedureExportService do
       let(:procedure) { create(:procedure) }
 
       it 'should have a sheet for each record type' do
-        expect(subject.sheets.map(&:name)).to eq(['Dossiers', 'Etablissements', 'Avis'])
-      end
-    end
-
-    context 'when the export_xlsx_streaming feature is disabled' do
-      let(:procedure) { create(:procedure) }
-
-      before { Flipper.disable(:export_xlsx_streaming) }
-
-      it 'generates the export through the legacy caxlsx generator' do
-        expect(ProcedureExportService::XlsxExport).not_to receive(:new)
         expect(subject.sheets.map(&:name)).to eq(['Dossiers', 'Etablissements', 'Avis'])
       end
     end


### PR DESCRIPTION
Le feature flag `export_xlsx_streaming` est désormais activé à 100 %. Cette PR le retire, ainsi que l'ancienne génération d'export xlsx via caxlsx (`SpreadsheetArchitect.to_axlsx_package`).

Les exports xlsx passent maintenant toujours par le générateur streamé. `spreadsheet_architect` reste utilisé par les exports CSV et ODS, la gem est donc conservée.
