### PR TITLE
feat(attestation): ETQ administrateur, je peux selectionner des champs conditionnés dans l'attestation et utiliser les valeurs des champs carte

### DIFF
--- a/app/assets/stylesheets/attestation_template_2_edit.scss
+++ b/app/assets/stylesheets/attestation_template_2_edit.scss
@@ -66,7 +66,7 @@
   }
 
   // scss-lint:disable SelectorFormat
-  #show_maybe_null + label {
+  #show_optional + label {
     margin-bottom: 0.25rem;
 
     .fr-hint-text {

--- a/app/assets/stylesheets/tiptap.scss
+++ b/app/assets/stylesheets/tiptap.scss
@@ -26,8 +26,7 @@
     max-height: 500px;
   }
 
-  .fr-tag:not(.fr-menu .fr-tag) {
-    // style span rendered by tiptap like a button/link tag
+  .fr-tag:not(.fr-menu .fr-tag, .fr-tag--purple-glycine) {
     color: var(--text-action-high-blue-france);
     background-color: var(--background-action-low-blue-france);
   }

--- a/app/components/tags_button_list_component.rb
+++ b/app/components/tags_button_list_component.rb
@@ -17,15 +17,19 @@ class TagsButtonListComponent < ApplicationComponent
 
   def each_category
     tags.each_pair do |category, tags|
-      yield category, tags, can_toggle_nullable?(category)
+      yield category, tags, can_toggle_optional?(category)
     end
   end
 
   private
 
-  def can_toggle_nullable?(category)
+  def optional_tag?(tag)
+    tag[:maybe_null] || tag[:conditional]
+  end
+
+  def can_toggle_optional?(category)
     return false if category != :champ_public
 
-    tags[category].any? { _1[:maybe_null] }
+    tags[category].any? { optional_tag?(_1) }
   end
 end

--- a/app/components/tags_button_list_component/tags_button_list_component.html.haml
+++ b/app/components/tags_button_list_component/tags_button_list_component.html.haml
@@ -6,14 +6,17 @@
       - if can_toggle_nullable
         .fr-fieldset__element.fr-ml-4w
           .fr-checkbox-group.fr-checkbox-group--sm
-            = check_box_tag("show_maybe_null", 1, false, data: { "no-autosubmit" => true, action: "change->attestation#toggleMaybeNull"})
-            = label_tag "show_maybe_null", for: :show_maybe_null do
-              Voir les champs facultatifs
-              %span.hidden.fr-hint-text Un champ non rempli restera vide dans l’attestation.
+            = check_box_tag("show_optional", 1, false, data: { "no-autosubmit" => true, action: "change->attestation#toggleOptional"})
+            = label_tag "show_optional", for: :show_optional do
+              Voir les champs facultatifs et/ou conditionnels
+              %span.hidden.fr-hint-text Un champ non rempli restera vide dans l'attestation.
 
   %ul.fr-tags-group{ data: { category: category } }
     - tags.each do |tag|
-      %li{ class: class_names("hidden" => can_toggle_nullable && tag[:maybe_null]), data: { "maybe-null" => can_toggle_nullable && tag[:maybe_null].present? } }
-        - label = button_label(tag)
-        %button.fr-tag.fr-tag--sm{ class: class_names('fr-tag--blue-ecume': tag[:highlight]), type: "button", title: button_title(tag), data: { action: 'click->tiptap#insertTag', tiptap_target: 'tag', tag_id: tag[:id], tag_label: label } }
+      - is_optional = can_toggle_nullable && optional_tag?(tag)
+      - label = button_label(tag)
+      %li{ class: class_names("hidden" => is_optional), data: { "optional-tag" => is_optional.presence } }
+        %button.fr-tag.fr-tag--sm{ class: class_names("fr-tag--blue-ecume" => tag[:highlight], "fr-tag--purple-glycine" => is_optional), type: "button", title: button_title(tag), data: { action: "click->tiptap#insertTag", "tiptap-target": "tag", "tag-id": tag[:id], "tag-label": label, "tag-optional": is_optional.to_s } }
           = label
+          - if can_toggle_nullable && !is_optional
+            *

--- a/app/javascript/controllers/attestation_controller.ts
+++ b/app/javascript/controllers/attestation_controller.ts
@@ -32,16 +32,15 @@ export class AttestationController extends ApplicationController {
     });
   }
 
-  toggleMaybeNull(event: Event) {
+  toggleOptional(event: Event) {
     const checkbox = event.target as HTMLInputElement;
     const visible = checkbox.checked;
 
-    // toggle hidden class on next label element
     checkbox.nextElementSibling
       ?.querySelector('.fr-hint-text')
       ?.classList?.toggle('hidden', !visible);
 
-    document.querySelectorAll('li[data-maybe-null]').forEach((tag) => {
+    document.querySelectorAll('li[data-optional-tag]').forEach((tag) => {
       tag.classList.toggle('hidden', !visible);
     });
   }

--- a/app/javascript/shared/tiptap/editor.ts
+++ b/app/javascript/shared/tiptap/editor.ts
@@ -160,13 +160,30 @@ function getEditorOptions(
   }
 
   if (tags.length > 0) {
+    const optionalTagIds = new Set(
+      tags.filter((t) => t.optional).map((t) => t.id)
+    );
+    const allChampTagIds = new Set(tags.map((t) => t.id));
+
+    const OptionalMention = Mention.extend({
+      renderHTML({ node, HTMLAttributes }) {
+        const classes = ['fr-tag', 'fr-tag--sm'];
+        const id = node.attrs.id;
+        if (optionalTagIds.has(id)) {
+          classes.push('fr-tag--purple-glycine');
+        }
+        const label =
+          allChampTagIds.has(id) && !optionalTagIds.has(id)
+            ? `${node.attrs.label} *`
+            : node.attrs.label;
+        return ['span', { ...HTMLAttributes, class: classes.join(' ') }, label];
+      }
+    });
+
     extensions.push(
-      Mention.configure({
+      OptionalMention.configure({
         renderLabel({ node }) {
           return node.attrs.label;
-        },
-        HTMLAttributes: {
-          class: 'fr-tag fr-tag--sm'
         },
         suggestion: createSuggestionMenu(tags, element)
       })

--- a/app/javascript/shared/tiptap/tags.ts
+++ b/app/javascript/shared/tiptap/tags.ts
@@ -4,12 +4,21 @@ import tippy, { type Instance as TippyInstance } from 'tippy.js';
 import { matchSorter } from 'match-sorter';
 
 export const tagSchema = s.coerce(
-  s.object({ label: s.string(), id: s.string() }),
+  s.object({
+    label: s.string(),
+    id: s.string(),
+    optional: s.optional(s.boolean())
+  }),
   s.type({
     tagLabel: s.string(),
-    tagId: s.string()
+    tagId: s.string(),
+    tagOptional: s.optional(s.string())
   }),
-  ({ tagId, tagLabel }) => ({ label: tagLabel, id: tagId })
+  ({ tagId, tagLabel, tagOptional }) => ({
+    label: tagLabel,
+    id: tagId,
+    optional: tagOptional === 'true'
+  })
 );
 export type TagSchema = s.Infer<typeof tagSchema>;
 

--- a/app/models/champ_presentations/carte_presentation.rb
+++ b/app/models/champ_presentations/carte_presentation.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class ChampPresentations::CartePresentation < ChampPresentations::BasePresentation
+  attr_reader :geo_areas
+
+  def initialize(geo_areas)
+    @geo_areas = geo_areas
+  end
+
+  def to_s
+    geo_areas.map { format_label(_1) }.join("\n")
+  end
+
+  def to_tiptap_node
+    {
+      type: 'bulletList',
+      content: geo_areas.map do |geo_area|
+        {
+          type: 'listItem',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: format_label(geo_area),
+                },
+              ],
+            },
+          ],
+        }
+      end,
+    }
+  end
+
+  private
+
+  def format_label(geo_area)
+    label = geo_area.label
+    if geo_area.point?
+      coords = geo_area.geometry['coordinates']
+      "#{label} (#{coords[1].round(6)}, #{coords[0].round(6)})"
+    else
+      label
+    end
+  end
+end

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -392,12 +392,12 @@ module TagsSubstitutionConcern
   end
 
   def champ_public_tags(dossier: nil)
-    types_de_champ = (dossier || procedure.active_revision).types_de_champ_public.filter { !_1.condition? }
+    types_de_champ = (dossier || procedure.active_revision).types_de_champ_public
     types_de_champ_tags(types_de_champ, Dossier::SOUMIS)
   end
 
   def champ_private_tags(dossier: nil)
-    types_de_champ = (dossier || procedure.active_revision).types_de_champ_private.filter { !_1.condition? }
+    types_de_champ = (dossier || procedure.active_revision).types_de_champ_private
     types_de_champ_tags(types_de_champ, Dossier::INSTRUCTION_COMMENCEE)
   end
 

--- a/app/models/types_de_champ/carte_type_de_champ.rb
+++ b/app/models/types_de_champ/carte_type_de_champ.rb
@@ -19,7 +19,11 @@ class TypesDeChamp::CarteTypeDeChamp < TypesDeChamp::TypeDeChampBase
     FILL_DURATION_LONG
   end
 
-  def tags_for_template = [].freeze
+  def champ_value_for_tag(champ, path = :value)
+    return nil if path != :value
+    return '' if champ.geo_areas.blank?
+    ChampPresentations::CartePresentation.new(champ.geo_areas)
+  end
 
   def champ_value_for_api(champ, version: 2)
     nil

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -16,10 +16,12 @@ class TypesDeChamp::TypeDeChampBase
 
   def tags_for_template
     type_de_champ = @type_de_champ
+    conditional = type_de_champ.condition.present?
     paths.map do |path|
       path.merge(
         libelle: TagsSubstitutionConcern::TagsParser.normalize(path[:libelle]),
         id: path[:path] == :value ? "tdc#{stable_id}" : "tdc#{stable_id}/#{path[:path]}",
+        conditional:,
         lambda: -> (dossier) { dossier.champ_value_for_tag(type_de_champ, path[:path]) }
       )
     end

--- a/app/views/administrateurs/attestation_template_v2s/_form.html.haml
+++ b/app/views/administrateurs/attestation_template_v2s/_form.html.haml
@@ -90,7 +90,7 @@
             %p.fr-hint-text
               Tapez le caractère
               %strong.fr-text-title--grey @
-              suivi du nom de la balise, ou cliquez sur les boutons ci-dessous. Les champs conditionnés ne sont pas disponibles.
+              suivi du nom de la balise, ou cliquez sur les boutons ci-dessous.
 
             = render TagsButtonListComponent.new(tags: attestation_template.tags_categorized)
 

--- a/spec/components/tags_button_list_component_spec.rb
+++ b/spec/components/tags_button_list_component_spec.rb
@@ -14,9 +14,15 @@ RSpec.describe TagsButtonListComponent, type: :component do
         },
         {
           id: 'tdc13',
-          libelle: 'Un champ avec un nom très ' + 'long ' * 12,
-          description: 'Ce libellé a été tronqué',
-          maybe_null:,
+          libelle: 'Un champ facultatif',
+          description: 'Ce champ est facultatif',
+          maybe_null: true,
+        },
+        {
+          id: 'tdc14',
+          libelle: 'Un champ conditionnel',
+          description: 'Ce champ est conditionnel',
+          conditional: true,
         },
       ],
 
@@ -28,7 +34,6 @@ RSpec.describe TagsButtonListComponent, type: :component do
       ],
     }
   end
-  let(:maybe_null) { true }
 
   let(:component) do
     described_class.new(tags:)
@@ -43,16 +48,28 @@ RSpec.describe TagsButtonListComponent, type: :component do
     expect(subject).to have_text("Montant accordé")
   end
 
-  it "hide nullable tag" do
-    expect(subject).to have_selector(".hidden button.fr-tag", text: "Un champ avec un nom")
+  it "hides optional and conditional tags by default" do
+    expect(subject).to have_selector(".hidden button.fr-tag", text: "Un champ facultatif")
+    expect(subject).to have_selector(".hidden button.fr-tag", text: "Un champ conditionnel")
     expect(subject).to have_selector(":not(.hidden) button.fr-tag", text: "Votre avis")
-    expect(subject).to have_text("Voir les champs facultatifs")
+    expect(subject).to have_text("Voir les champs facultatifs et/ou conditionnels")
   end
 
-  context "all champs are visible" do
-    let(:maybe_null) { false }
-    it {
-      expect(subject).not_to have_text("Voir les champs facultatifs")
-    }
+  it "applies purple-glycine style to optional and conditional tags" do
+    expect(subject).to have_selector("button.fr-tag.fr-tag--purple-glycine", text: "Un champ facultatif")
+    expect(subject).to have_selector("button.fr-tag.fr-tag--purple-glycine", text: "Un champ conditionnel")
+    expect(subject).not_to have_selector("button.fr-tag.fr-tag--purple-glycine", text: "Votre avis")
+  end
+
+  context "no optional or conditional champs" do
+    let(:tags) do
+      {
+        champ_public: [
+          { id: 'tdc12', libelle: 'Votre avis', description: '' },
+        ],
+      }
+    end
+
+    it { expect(subject).not_to have_text("Voir les champs facultatifs et conditionnels") }
   end
 end

--- a/spec/models/champ_presentations/carte_presentation_spec.rb
+++ b/spec/models/champ_presentations/carte_presentation_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+describe ChampPresentations::CartePresentation do
+  let(:cadastre_label) { "Parcelle n° 0042 - Feuille 000 AB - 1234 m² – Commune 75056" }
+  let(:point_coordinates) { [2.428439, 46.538477] }
+  let(:point_label) { "Un point situé à 46°32'19\"N 2°25'42\"E" }
+
+  let(:cadastre_area) { instance_double(GeoArea, label: cadastre_label, point?: false) }
+  let(:point_area) { instance_double(GeoArea, label: point_label, point?: true, geometry: { 'coordinates' => point_coordinates }) }
+
+  let(:geo_areas) { [cadastre_area, point_area] }
+  let(:presentation) { described_class.new(geo_areas) }
+
+  describe '#to_s' do
+    it 'formats labels, adding decimal coordinates for points' do
+      expect(presentation.to_s).to eq(
+        "#{cadastre_label}\n#{point_label} (#{point_coordinates[1]}, #{point_coordinates[0]})"
+      )
+    end
+  end
+
+  describe '#to_tiptap_node' do
+    it 'returns a bullet list with formatted labels' do
+      expected_labels = [cadastre_label, "#{point_label} (#{point_coordinates[1]}, #{point_coordinates[0]})"]
+
+      expected = {
+        type: 'bulletList',
+        content: expected_labels.map do |label|
+          {
+            type: 'listItem',
+            content: [
+              {
+                type: 'paragraph',
+                content: [
+                  { type: 'text', text: label },
+                ],
+              },
+            ],
+          }
+        end,
+      }
+
+      expect(presentation.to_tiptap_node).to eq(expected)
+    end
+  end
+
+  describe '#block_level?' do
+    it { expect(presentation.block_level?).to be true }
+  end
+end

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -571,7 +571,7 @@ describe TagsSubstitutionConcern, type: :model do
 
       it do
         is_expected.to include(include({ libelle: 'public' }))
-        is_expected.not_to include(include({ libelle: 'conditional' }))
+        is_expected.to include(include({ libelle: 'conditional' }))
       end
     end
   end

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -246,6 +246,65 @@ describe TagsSubstitutionConcern, type: :model do
       it { is_expected.to eq("Répétition\n\nNom : Paul\nPrénom : Chavard\n\nNom : Pierre\nPrénom : de La Morinerie") }
     end
 
+    context 'when the procedure has a type de champ carte' do
+      let(:template) { '--Carte--' }
+      let(:types_de_champ_public) { [{ type: :carte, libelle: 'Carte' }] }
+      let(:dossier) { create(:dossier, procedure:) }
+      let(:champ) { dossier.project_champs_public.find { _1.type_de_champ.type_champ == 'carte' } }
+
+      before { dossier.reload }
+
+      context 'with cadastre geo areas' do
+        before do
+          create(:geo_area, :cadastre, champ:)
+          create(:geo_area, :cadastre, champ:, properties: { numero: '0103', section: 'CD', prefixe: '000', commune: '75056', contenance: 5678, id: '75056000CD0103' })
+          dossier.reload
+        end
+
+        it { is_expected.to include('Parcelle n°') }
+      end
+
+      context 'with legacy cadastre geo areas' do
+        before do
+          create(:geo_area, :legacy_cadastre, champ:, properties: { numero: '42', section: 'A11', code_com: '127', code_dep: '75', code_arr: '000', surface_parcelle: 1234, surface_intersection: 1234 })
+          dossier.reload
+        end
+
+        it { is_expected.to include('Parcelle n°') }
+      end
+
+      context 'with selection_utilisateur polygon' do
+        before do
+          create(:geo_area, :selection_utilisateur, :polygon, champ:)
+          dossier.reload
+        end
+
+        it { is_expected.to include('surface') }
+      end
+
+      context 'with selection_utilisateur line_string' do
+        before do
+          create(:geo_area, :selection_utilisateur, :line_string, champ:)
+          dossier.reload
+        end
+
+        it { is_expected.to include('ligne') }
+      end
+
+      context 'with selection_utilisateur point' do
+        before do
+          create(:geo_area, :selection_utilisateur, :point, champ:)
+          dossier.reload
+        end
+
+        it { is_expected.to include("(46.538477, 2.42844)") }
+      end
+
+      context 'with no geo areas' do
+        it { is_expected.to eq('') }
+      end
+    end
+
     context 'when the procedure has a linked drop down menus type de champ' do
       let(:type_de_champ) { procedure.draft_revision.types_de_champ.first }
       let(:types_de_champ_public) { [{ type: :linked_drop_down_list, libelle: 'libelle', options: ["--primo--", "secundo"] }] }


### PR DESCRIPTION
closes: #13360 

tchap: https://tchap.gouv.fr/#/room/!nnbPKmdWGGMekDHsPy:agent.dinum.tchap.gouv.fr/$178245727110059UpHeu:agent.agriculture.tchap.gouv.fr?via=agent.dinum.tchap.gouv.fr&via=agent.tchap.gouv.fr&via=agent.interieur.tchap.gouv.fr

# Problème
ETQ administrateur j'ai une petite urgence concernant les attestation avec :
1. un champ conditionné
2. ce même champ conditionné qui est une carte

# Solution
On ajoute le support des champs conditionnel avec une couleur differente
Ils se comportent comme les champs facultatifs, ac une couleur custom (a adapter une fois l'ux rdy)

> <img width="716" height="770" alt="Capture d’écran 2026-06-26 à 1 32 31 PM" src="https://github.com/user-attachments/assets/c9445ac7-e4bf-4f78-80b9-598c98693447" />




L'attestation peut rendre des champs cartes :
> <img width="515" height="771" alt="Capture d’écran 2026-06-26 à 1 09 57 PM" src="https://github.com/user-attachments/assets/acd41ef5-56f8-4435-9426-42a8e7ce8bb0" />
* Pour les cadastre on mentionne la section
* Pour les points on mentionne les coordonnées DMS/WGS 84
* Pour les lignes leurs distances
* Pour les aires, leurs surfaces