### PR TITLE
Tech: fix N+1 sur export_template dans ArchivesController

### DIFF
--- a/app/controllers/administrateurs/archives_controller.rb
+++ b/app/controllers/administrateurs/archives_controller.rb
@@ -8,7 +8,7 @@ module Administrateurs
     helper_method :create_archive_url
 
     def index
-      @exports = Export.for_groupe_instructeurs(all_groupe_instructeurs).ante_chronological
+      @exports = Export.for_groupe_instructeurs(all_groupe_instructeurs).ante_chronological.includes(:export_template)
       @average_dossier_weight = @procedure.average_dossier_weight
       @count_dossiers_termines_by_month = @procedure
         .dossiers


### PR DESCRIPTION
# Probleme

N+1 detecte par [Prosopite](https://github.com/charkost/prosopite) (scan des tests) — pas de donnees Skylight production disponibles (RPM=0, P95=0).

**Triage Prosopite** : 1 pattern PROD / 4 patterns TEST ignores.

# Solution

Skill [`/n1-query-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/n1-query-fix/SKILL.md)

### Patterns corriges (PROD uniquement)

| Association | Table | Strategy | Call site (app/) |
|-------------|-------|----------|------------------|
| `Export#export_template` | export_templates | `includes(:export_template)` | `app/components/dossiers/export_link_component/export_link_component.html.haml:10` |

### Patterns ignores (TEST)

| Table | SQL pattern | Raison |
|-------|-------------|--------|
| flipper_features | SELECT "flipper_features" WHERE key = $1 | Flipper middleware, pas de call stack app/ |
| flipper_gates | SELECT "flipper_gates" WHERE feature_key = $1 | Flipper middleware, pas de call stack app/ |
| dossiers (COUNT) | SELECT COUNT(*) FROM "dossiers" WHERE user_id = $1 | Factory setup (`light_user_brouillon?` dans `dossier_searchable_concern.rb`) |
| procedures | SELECT "procedures" FROM "procedures" WHERE id = $1 | Factory setup (`expiration_date` dans `dossier.rb`) |
| champs | SELECT "champs" WHERE dossier_id = $1 | Factory setup (`build_default_champs` dans `dossier.rb`) |

### Validation

- [x] Tests passes (rspec — 11 exemples, 0 echecs)
- [x] Rubocop OK
- [x] Seuls des fichiers app/ et config/ commites

Generated with [Claude Code](https://claude.com/claude-code)