### PR TITLE
Correctif: ETQ usager, pouvoir supprimer un tag en cliquant sur toute sa surface

### DIFF
--- a/app/assets/stylesheets/combobox.scss
+++ b/app/assets/stylesheets/combobox.scss
@@ -28,9 +28,32 @@
     gap: 0.3rem;
     margin-bottom: 0.5rem;
   }
-  .fr-tag--dismiss button:focus {
-    outline: 1px solid currentColor;
-    outline-offset: -2px;
+  .fr-tag.fr-tag--dismiss {
+    position: relative;
+    cursor: pointer;
+    padding-right: 1.5rem;
+  }
+
+  .fr-tag--dismiss button {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+
+    &::after {
+      position: absolute;
+      right: 0.625rem;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
+    &:focus {
+      outline: 1px solid currentColor;
+      outline-offset: -2px;
+    }
   }
 }
 

--- a/app/javascript/components/react-aria/components/Select.css
+++ b/app/javascript/components/react-aria/components/Select.css
@@ -36,4 +36,32 @@
     gap: 0.25rem;
     margin-top: 0.25rem;
   }
+
+  .fr-tag.fr-tag--dismiss {
+    position: relative;
+    cursor: pointer;
+    padding-right: 1.5rem;
+  }
+
+  .fr-tag--dismiss button {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+  }
+
+  .fr-tag--dismiss button::after {
+    position: absolute;
+    right: 0.625rem;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .fr-tag--dismiss button:focus {
+    outline: 1px solid currentColor;
+    outline-offset: -2px;
+  }
 }

--- a/spec/system/users/dropdown_spec.rb
+++ b/spec/system/users/dropdown_spec.rb
@@ -82,3 +82,39 @@ describe 'dropdown list with other option activated', js: true do
     expect(page).to have_current_path(brouillon_dossier_path(user_dossier))
   end
 end
+
+describe 'multiple dropdown tag removal', js: true do
+  let(:user) { create(:user) }
+  let(:options) { (1..7).map { "Option #{_1}" } }
+  let(:procedure) do
+    create(:procedure, :published, :for_individual, types_de_champ_public: [
+      { type: :multiple_drop_down_list, libelle: 'Multi choix', drop_down_options: options },
+    ])
+  end
+
+  before do
+    login_as(user, scope: :user)
+    visit "/commencer/#{procedure.path}?locale=fr"
+    click_on 'Commencer la démarche'
+    find('label', text: "Pour vous").click
+    within('.individual-infos') do
+      fill_in('Prénom', with: 'prenom')
+      fill_in('Nom', with: 'nom')
+    end
+    within "#identite-form" do
+      click_on 'Continuer'
+    end
+  end
+
+  scenario 'clicking on a tag removes the selection' do
+    select_autocomplete('Multi choix', 'Option 1')
+    select_autocomplete('Multi choix', 'Option 2')
+
+    expect(page).to have_css('.fr-tag', text: 'Option 1')
+    expect(page).to have_css('.fr-tag', text: 'Option 2')
+
+    find('.fr-tag', text: 'Option 1').click
+    expect(page).not_to have_css('.fr-tag', text: 'Option 1')
+    expect(page).to have_css('.fr-tag', text: 'Option 2')
+  end
+end


### PR DESCRIPTION
# Probleme

Sur les champs choix multiple, seule la petite croix du tag est cliquable pour supprimer une selection. Sur mobile cette zone est trop petite pour etre facilement tapee. Le DSFR et les filtres instructeur permettent deja de cliquer sur tout le tag pour le supprimer.

Ref: https://github.com/demarche-numerique/demarche.numerique.gouv.fr/issues/12886

# Solution

Le `<Button slot="remove">` de React Aria est positionne en `absolute` pour couvrir toute la surface du tag, avec un fond transparent. La croix DSFR (pseudo-element `::after` du bouton) reste visible et correctement espacee. Cliquer n'importe ou sur le tag declenche la suppression.

Le changement est CSS-only, pas de modification des composants React. La semantique ARIA et la navigation clavier sont preservees.

Applique sur les deux contextes d'utilisation des tags :
- `MultiComboBox` (`combobox.scss`)
- `MultipleSelect` (`Select.css`)

Generated with [Claude Code](https://claude.com/claude-code)