### PR TITLE
Datagouv : nouveau jeu de données sur la création de compte DN via ProConnect

### DIFF
--- a/app/jobs/cron/datagouv/base_job.rb
+++ b/app/jobs/cron/datagouv/base_job.rb
@@ -24,7 +24,7 @@ class Cron::Datagouv::BaseJob < Cron::CronJob
   end
 
   def missing_months(csv)
-    last_date = Date.strptime(csv[-1]['mois'], DATE_FORMAT) if csv.present?
+    last_date = Date.strptime(csv[-1]['mois'], DATE_FORMAT).in_time_zone if csv.present?
 
     start_month = last_date.present? ? last_date + 1.month : previous_month
 
@@ -35,6 +35,6 @@ class Cron::Datagouv::BaseJob < Cron::CronJob
   private
 
   def previous_month
-    1.month.ago.beginning_of_month.to_date
+    1.month.ago.beginning_of_month
   end
 end

--- a/app/jobs/cron/datagouv/user_connected_with_france_connect_by_month_job.rb
+++ b/app/jobs/cron/datagouv/user_connected_with_france_connect_by_month_job.rb
@@ -2,7 +2,7 @@
 
 class Cron::Datagouv::UserConnectedWithFranceConnectByMonthJob < Cron::Datagouv::BaseJob
   self.schedule_expression = "every month at 3:45"
-  HEADERS = ["mois", "nb_utilisateurs_connectes_france_connect_par_mois"]
+  HEADERS = ["mois", "nb_utilisateurs_crees_avec_france_connect_par_mois"]
   FILE_NAME = HEADERS[1]
   RESOURCE = 'f688e8aa-5c21-4b61-ba03-b69e33c112f7'
 

--- a/app/jobs/cron/datagouv/user_with_pro_connect_by_month_job.rb
+++ b/app/jobs/cron/datagouv/user_with_pro_connect_by_month_job.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class Cron::Datagouv::UserWithProConnectByMonthJob < Cron::Datagouv::BaseJob
+  self.schedule_expression = "every month at 3:30"
+  HEADERS = ["mois", "nb_usagers_crees", "nb_instructeurs_crees", "nb_administrateurs_crees", "nb_usagers_convertis", "nb_instructeurs_convertis", "nb_administrateurs_convertis"]
+  FILE_NAME = 'nb_utilisateurs_avec_pro_connect_par_mois'
+  RESOURCE = '4f00b392-be6a-4c93-84f3-ee5819b5daa4'
+
+  def perform
+    super(RESOURCE, HEADERS, FILE_NAME)
+  end
+
+  private
+
+  def data_for(month:)
+    administrateurs_on_pro_connect = Administrateur
+      .joins("INNER JOIN agent_connect_informations ON agent_connect_informations.user_id = administrateurs.user_id")
+      .where(agent_connect_informations: { created_at: month.all_month })
+      .distinct
+
+    administrateurs_on_pro_connect_count = administrateurs_on_pro_connect.count
+
+    new_administrateurs_through_pro_connect_count = administrateurs_on_pro_connect
+      .where(administrateurs: { created_at: month.all_month })
+      .count
+
+    administrateurs_convert_to_pro_connect_count = administrateurs_on_pro_connect_count - new_administrateurs_through_pro_connect_count
+
+    instructeurs_on_pro_connect = Instructeur
+      .joins("INNER JOIN agent_connect_informations ON agent_connect_informations.user_id = instructeurs.user_id")
+      .where(agent_connect_informations: { created_at: month.all_month })
+      .left_joins(user: :administrateur)
+      .where(administrateurs: { id: nil })
+      .distinct
+
+    instructeurs_on_pro_connect_count = instructeurs_on_pro_connect.count
+
+    new_instructeurs_through_pro_connect_count = instructeurs_on_pro_connect
+      .where(instructeurs: { created_at: month.all_month })
+      .count
+
+    instructeurs_convert_to_pro_connect_count = instructeurs_on_pro_connect_count - new_instructeurs_through_pro_connect_count
+
+    users_on_pro_connect = User
+      .joins("INNER JOIN agent_connect_informations ON agent_connect_informations.user_id = users.id")
+      .where(agent_connect_informations: { created_at: month.all_month })
+      .where.missing(:instructeur)
+      .distinct
+
+    users_on_pro_connect_count = users_on_pro_connect.count
+
+    new_users_through_pro_connect_count = users_on_pro_connect
+      .where(users: { created_at: month.all_month })
+      .count
+
+    users_convert_to_pro_connect_count = users_on_pro_connect_count - new_users_through_pro_connect_count
+
+    [
+      month.strftime(DATE_FORMAT),
+      new_users_through_pro_connect_count,
+      new_instructeurs_through_pro_connect_count,
+      new_administrateurs_through_pro_connect_count,
+      users_convert_to_pro_connect_count,
+      instructeurs_convert_to_pro_connect_count,
+      administrateurs_convert_to_pro_connect_count,
+    ]
+  end
+end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -180,7 +180,7 @@ class Procedure < ApplicationRecord
   scope :publiques,              -> do
     publiees_ou_closes
       .opendata
-      .where(estimated_dossiers_count: 4..)
+      .where(estimated_dossiers_count: 1..)
       .where.not('lien_site_web LIKE ?', '%mail%')
       .where.not('lien_site_web LIKE ?', '%intra%')
   end

--- a/spec/jobs/cron/datagouv/base_job_spec.rb
+++ b/spec/jobs/cron/datagouv/base_job_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Cron::Datagouv::BaseJob, type: :job do
     context 'when there is no existing data' do
       let(:csv) { default_csv }
 
-      it { is_expected.to eq([Date.parse('01/01/2024')]) }
+      it { is_expected.to eq([Time.zone.local(2024, 1, 1)]) }
     end
 
     context 'when there is existing data from last month' do
@@ -68,7 +68,7 @@ RSpec.describe Cron::Datagouv::BaseJob, type: :job do
     context 'when there is existing data before last month' do
       let(:csv) { default_csv << [format(Date.parse('01/12/2023')), 1] }
 
-      it { is_expected.to eq([Date.parse('01/01/2024')]) }
+      it { is_expected.to eq([Time.zone.local(2024, 1, 1)]) }
     end
 
     context 'when there is existing data in the future' do

--- a/spec/jobs/cron/datagouv/user_with_pro_connect_by_month_job_spec.rb
+++ b/spec/jobs/cron/datagouv/user_with_pro_connect_by_month_job_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe Cron::Datagouv::UserWithProConnectByMonthJob, type: :job do
+  describe 'data_for' do
+    let(:month) { Date.parse('01/01/2024') }
+
+    subject { Cron::Datagouv::UserWithProConnectByMonthJob.new.send(:data_for, month:) }
+
+    context 'when a new user is created with ProConnect' do
+      let!(:user_witout_pro_connect) { create(:user, created_at: Date.parse('15/01/2024')) }
+      let!(:user_with_pro_connect) { create(:user, created_at: Date.parse('15/01/2024')) }
+      let!(:pci) { create(:pro_connect_information, user: user_with_pro_connect, created_at: Date.parse('15/01/2024')) }
+
+      it { is_expected.to eq(['2024-01', 1, 0, 0, 0, 0, 0]) }
+    end
+
+    context 'when a new instructeur is created with ProConnect' do
+      let!(:user) { create(:user, created_at: Date.parse('15/01/2024')) }
+      let!(:instructeur) { create(:instructeur, user:, created_at: Date.parse('15/01/2024')) }
+      let!(:pci) { create(:pro_connect_information, user:, created_at: Date.parse('15/01/2024')) }
+
+      it { is_expected.to eq(['2024-01', 0, 1, 0, 0, 0, 0]) }
+    end
+
+    context 'when a new administrateur is created with ProConnect' do
+      let!(:user) { create(:user, created_at: Date.parse('15/01/2024')) }
+      let!(:instructeur) { create(:instructeur, user:, created_at: Date.parse('15/01/2024')) }
+      let!(:administrateur) { create(:administrateur, user:, created_at: Date.parse('15/01/2024')) }
+      let!(:pci) { create(:pro_connect_information, user:, created_at: Date.parse('15/01/2024')) }
+
+      it { is_expected.to eq(['2024-01', 0, 0, 1, 0, 0, 0]) }
+    end
+
+    context 'when an existing user is converted on Pro Connect' do
+      let!(:user) { create(:user, created_at: Date.parse('15/01/2023')) }
+      let!(:pci) { create(:pro_connect_information, user:, created_at: Date.parse('15/01/2024')) }
+
+      it { is_expected.to eq(['2024-01', 0, 0, 0, 1, 0, 0]) }
+    end
+
+    context 'when an existing instructeur is converted on Pro Connect' do
+      let!(:user) { create(:user, created_at: Date.parse('15/01/2023')) }
+      let!(:instructeur) { create(:instructeur, user:, created_at: Date.parse('15/01/2023')) }
+      let!(:pci) { create(:pro_connect_information, user:, created_at: Date.parse('15/01/2024')) }
+
+      it { is_expected.to eq(['2024-01', 0, 0, 0, 0, 1, 0]) }
+    end
+
+    context 'when an existing administrateur is converted on Pro Connect' do
+      let!(:user) { create(:user, created_at: Date.parse('15/01/2023')) }
+      let!(:instructeur) { create(:instructeur, user:, created_at: Date.parse('15/01/2023')) }
+      let!(:administrateur) { create(:administrateur, user:, created_at: Date.parse('15/01/2023')) }
+      let!(:pci) { create(:pro_connect_information, user:, created_at: Date.parse('15/01/2024')) }
+
+      it { is_expected.to eq(['2024-01', 0, 0, 0, 0, 0, 1]) }
+    end
+
+    context 'when an existing instructeur is promoted, and then logs with Pro Connect' do
+      let!(:user) { create(:user, created_at: Date.parse('15/01/2023')) }
+      let!(:instructeur) { create(:instructeur, user:, created_at: Date.parse('15/01/2023')) }
+      let!(:administrateur) { create(:administrateur, user:, created_at: Date.parse('15/01/2024')) }
+      let!(:pci) { create(:pro_connect_information, user:, created_at: Date.parse('15/01/2024')) }
+
+      it { is_expected.to eq(['2024-01', 0, 0, 1, 0, 0, 0]) }
+    end
+  end
+end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -901,7 +901,7 @@ describe Procedure do
     let(:draft_procedure) { create(:procedure_with_dossiers, :draft, estimated_dossiers_count: 4, lien_site_web: 'https://monministere.gouv.fr/cparici') }
     let(:published_procedure) { create(:procedure_with_dossiers, :published, estimated_dossiers_count: 4, lien_site_web: 'https://monministere.gouv.fr/cparici') }
     let(:published_procedure_no_opendata) { create(:procedure_with_dossiers, :published, estimated_dossiers_count: 4, opendata: false) }
-    let(:published_procedure_with_3_dossiers) { create(:procedure_with_dossiers, :published, estimated_dossiers_count: 3) }
+    let(:published_procedure_without_dossier) { create(:procedure_with_dossiers, :published, estimated_dossiers_count: 0) }
     let(:published_procedure_with_mail) { create(:procedure_with_dossiers, :published, estimated_dossiers_count: 4, lien_site_web: 'par mail') }
     let(:published_procedure_with_intra) { create(:procedure_with_dossiers, :published, estimated_dossiers_count: 4, lien_site_web: 'https://intra.service-etat.gouv.fr') }
 
@@ -925,8 +925,8 @@ describe Procedure do
       expect(Procedure.publiques).not_to include(published_procedure_with_intra)
     end
 
-    it "does not return procedures with less than 4 dossiers" do
-      expect(Procedure.publiques).not_to include(published_procedure_with_3_dossiers)
+    it "does not return procedures without any dossier" do
+      expect(Procedure.publiques).not_to include(published_procedure_without_dossier)
     end
   end
 


### PR DESCRIPTION
Nouveau fichier de données publié mensuellement sur datagouv dans le dataset "Utilisation de DN" : Nombre d'utilisateurs via ProConnect, par type de profil : nouveaux usagers, nouveaux instructeurs, nouveaux administrateurs, usagers convertis, instructeurs convertis, admin convertis.

NB) embarque une demande d'évolution de Kévin sur le fichier json de descriptif des démarches, à savoir que l'on abaisse le seuil à au moins 1 dossier pour que la démarche rentre dans le scope de publication (actuellement on est 4)