### PR TITLE
ETQ instructeur, clarifier le message « en test » sur la suppression des dossiers

### DIFF
--- a/app/components/instructeurs/tabs_explanations_component/tabs_explanations_component.en.yml
+++ b/app/components/instructeurs/tabs_explanations_component/tabs_explanations_component.en.yml
@@ -3,7 +3,7 @@ en:
     title: What do the tabs include?
     close: Close
     tabs_en_cours_html: <strong>“in progress”</strong> tab brings together published procedures as well as closed procedures that still have files to process.
-    tabs_en_test_html: <strong>“in testing”</strong> tab groups together the procedures which have not yet been published. Files submitted during the test phase will be automatically deleted when the process is modified or published.
+    tabs_en_test_html: <strong>“in testing”</strong> tab groups together the procedures which have not yet been published. Files submitted during the test phase are deleted when the procedure’s settings are modified or when it is published.
     tabs_close_html: <strong>“finished”</strong> tab groups together closed procedures with no more files to process.
     tabs_a_suivre_html: <strong>“to follow”</strong> tab contains all the files which are not followed by any instructor. To assign the file, simply click on “Follow” the file.
     tabs_suivis_html: <strong>“followed by me“</strong> tab contains the files followed by you. When you (or another instructor) follow a folder, that folder no longer appears in the “to follow” folders. You can discuss with the applicant until you can accept, refuse and close their file without further action.

--- a/app/components/instructeurs/tabs_explanations_component/tabs_explanations_component.fr.yml
+++ b/app/components/instructeurs/tabs_explanations_component/tabs_explanations_component.fr.yml
@@ -3,7 +3,7 @@ fr:
     title: Que regroupent les onglets ?
     close: Fermer
     tabs_en_cours_html: L’onglet <strong>« en cours »</strong> regroupe les démarches publiées ainsi que les démarches closes ayant encore des dossiers à traiter.
-    tabs_en_test_html: L’onglet <strong>« en test »</strong> regroupe les démarches qui ne sont pas encore publiées. Les dossiers déposés pendant la phase de test seront automatiquement supprimés lors de la modification ou de la publication de la démarche.
+    tabs_en_test_html: L’onglet <strong>« en test »</strong> regroupe les démarches qui ne sont pas encore publiées. Les dossiers déposés pendant la phase de test sont supprimés lorsque les réglages de la démarche sont modifiés ou lorsqu’elle est publiée.
     tabs_close_html: L’onglet <strong>« terminée »</strong> regroupe les démarches closes n’ayant plus de dossiers à traiter.
     tabs_a_suivre_html: L’onglet <strong>« à suivre »</strong> contient l’ensemble des dossiers qui ne sont suivis par aucun instructeur. Pour s’affecter le dossier, il suffit de cliquer sur « Suivre » le dossier.
     tabs_suivis_html: L’onglet <strong>« suivis par moi »</strong> contient les dossiers que vous suivez. Lorsque vous (ou un autre instructeur) suivez un dossier, ce dossier n’apparaît plus dans les dossiers « à suivre ». Vous pouvez échanger avec le demandeur jusqu’à pouvoir accepter, refuser classer sans suite son dossier.

--- a/app/components/instructeurs/warning_banner_component/warning_banner_component.en.yml
+++ b/app/components/instructeurs/warning_banner_component/warning_banner_component.en.yml
@@ -1,4 +1,4 @@
 ---
 en:
-    draft_procedures_html: "The files submitted on these procedures <strong>in test</strong> can be <strong>deleted at any time</strong> and without prior notice, even after being accepted."
-    draft_procedure_html: "The files submitted on this procedure <strong>in test</strong> can be <strong>deleted at any time</strong> and without prior notice, even after being accepted."
+    draft_procedures_html: "The files submitted on these procedures <strong>in test</strong> are <strong>deleted</strong> when their settings are modified or when they are published."
+    draft_procedure_html: "The files submitted on this procedure <strong>in test</strong> are <strong>deleted</strong> when its settings are modified or when it is published."

--- a/app/components/instructeurs/warning_banner_component/warning_banner_component.fr.yml
+++ b/app/components/instructeurs/warning_banner_component/warning_banner_component.fr.yml
@@ -1,4 +1,4 @@
 ---
 fr:
-  draft_procedures_html: Les dossiers déposés sur ces démarches <strong>en test</strong> pourront être <strong>supprimés à tout moment</strong> et sans préavis, même après avoir été acceptés.
-  draft_procedure_html: Les dossiers déposés sur cette démarche <strong>en test</strong> pourront être <strong>supprimés à tout moment</strong> et sans préavis, même après avoir été acceptés.
+  draft_procedures_html: Les dossiers déposés sur ces démarches <strong>en test</strong> sont <strong>supprimés</strong> lorsque leurs réglages sont modifiés ou lorsqu’elles sont publiées.
+  draft_procedure_html: Les dossiers déposés sur cette démarche <strong>en test</strong> sont <strong>supprimés</strong> lorsque ses réglages sont modifiés ou lorsqu’elle est publiée.


### PR DESCRIPTION
Le message d'explication de l'onglet « en test » indiquait que les dossiers de test étaient supprimés « lors de la modification ou de la publication » de la démarche.

Depuis la refonte du reset du brouillon, modifier le formulaire ne supprime plus les dossiers de test : le wording était donc trompeur. 

https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_9677c721-e912-4eb1-b6b5-dd100d7be14c/