### PR TITLE
ETQ usager, le PDF de mon dossier vide est plus accessible (PDF/UA via WeasyPrint)

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -5,4 +5,5 @@
 //= link administrate/application.js
 //= link manager.css
 //= link attestation.css
+//= link dossier_vide_pdf.css
 //= link_tree ../../../node_modules/@gouvfr/dsfr/dist/artwork

--- a/app/assets/stylesheets/dossier_vide_pdf.scss
+++ b/app/assets/stylesheets/dossier_vide_pdf.scss
@@ -82,7 +82,7 @@ dl.identity {
 
 .label {
   font-weight: bold;
-  margin-bottom: 1mm;
+  margin-bottom: 1.5mm;
 }
 // Keep a label (and any description/instruction that follows it) attached to the
 // field below it, so a page break never leaves the label stranded from its box.
@@ -100,11 +100,11 @@ dl.identity {
 }
 .explanation {
   margin-top: 1mm;
-  margin-bottom: 0;
+  margin-bottom: 1.5mm;
 }
 
 .champ {
-  margin-bottom: 4mm;
+  margin-bottom: 7mm;
 }
 
 .annexes {
@@ -143,6 +143,9 @@ ul.options li.secondary {
   display: inline-flex;
   align-items: center;
   gap: 2mm;
+  // Centre the checkbox on the line instead of letting it hang above the
+  // baseline, which otherwise inflates the gap above and between checkboxes.
+  vertical-align: middle;
 }
 .checkbox {
   display: inline-block;

--- a/app/assets/stylesheets/dossier_vide_pdf.scss
+++ b/app/assets/stylesheets/dossier_vide_pdf.scss
@@ -1,0 +1,139 @@
+@font-face {
+  font-family: 'Marianne';
+  src: url('marianne-regular.ttf');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Marianne';
+  src: url('marianne-bold.ttf');
+  font-weight: bold;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Marianne';
+  src: url('marianne-regular-italic.woff2');
+  font-weight: normal;
+  font-style: italic;
+}
+
+@page {
+  size: A4;
+  margin: 17mm 17mm 24mm;
+
+  @bottom-center {
+    font-size: 8pt;
+    content: counter(page) ' / ' counter(pages);
+    margin-top: 10mm;
+    white-space: nowrap;
+  }
+}
+
+body {
+  font-family: 'Marianne', sans-serif;
+  font-size: 10pt;
+  color: #161616;
+}
+
+h1 {
+  font-size: 18pt;
+}
+h2 {
+  font-size: 14pt;
+  margin-top: 8mm;
+}
+h3 {
+  font-size: 12pt;
+}
+h4 {
+  font-size: 11pt;
+}
+h5 {
+  font-size: 10pt;
+}
+
+.logo {
+  display: block;
+  width: 100mm;
+  height: auto;
+  margin: 0 auto 8mm;
+}
+
+dl.header,
+dl.identity {
+  margin: 0 0 6mm;
+}
+
+.field-pair {
+  display: flex;
+  gap: 4mm;
+  margin-bottom: 2mm;
+
+  dt {
+    width: 45mm;
+    font-weight: bold;
+  }
+  dd {
+    flex: 1;
+  }
+}
+
+.label {
+  font-weight: bold;
+  margin-bottom: 1mm;
+}
+// Keep a label (and any description/instruction that follows it) attached to the
+// field below it, so a page break never leaves the label stranded from its box.
+.label,
+.description,
+.explanation {
+  break-after: avoid;
+}
+.description,
+.explanation {
+  font-style: italic;
+}
+.explanation {
+  margin-top: 1mm;
+  margin-bottom: 0;
+}
+
+.champ {
+  margin-bottom: 4mm;
+}
+
+.box {
+  border: 1px solid #161616;
+}
+.box--line {
+  height: 6mm;
+}
+.box--block {
+  height: 22mm;
+}
+
+ul.options {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+ul.options li {
+  margin-bottom: 1mm;
+}
+ul.options li.secondary {
+  padding-left: 6mm;
+}
+
+.option {
+  display: inline-flex;
+  align-items: center;
+  gap: 2mm;
+}
+.checkbox {
+  display: inline-block;
+  width: 3mm;
+  height: 3mm;
+  border: 1px solid #161616;
+}

--- a/app/assets/stylesheets/dossier_vide_pdf.scss
+++ b/app/assets/stylesheets/dossier_vide_pdf.scss
@@ -104,6 +104,16 @@ dl.identity {
   margin-bottom: 4mm;
 }
 
+.annexes {
+  page-break-before: always;
+}
+.annex {
+  margin-bottom: 6mm;
+}
+.annex h3 {
+  break-after: avoid;
+}
+
 .box {
   border: 1px solid #161616;
 }

--- a/app/assets/stylesheets/dossier_vide_pdf.scss
+++ b/app/assets/stylesheets/dossier_vide_pdf.scss
@@ -88,23 +88,44 @@ dl.identity {
 // field below it, so a page break never leaves the label stranded from its box.
 .label,
 .description,
-.explanation {
+.explanation,
+.condition {
   break-after: avoid;
 }
 // Champ descriptions stay italic to read as helper text; the procedure
 // presentation (.presentation) keeps the admin's own formatting instead.
 .description,
 .explanation,
+.condition,
 .mailing {
   font-style: italic;
 }
-.explanation {
+// Admin rich text is rendered as markdown (SimpleFormat), so each authored line
+// becomes a <p>: drop the browser default paragraph margins and keep tight,
+// even spacing between them.
+.presentation p,
+.description p,
+.explication p {
+  margin: 0;
+}
+.presentation p + p,
+.description p + p,
+.explication p + p {
+  margin-top: 1.5mm;
+}
+.explanation,
+.condition {
   margin-top: 1mm;
   margin-bottom: 1.5mm;
 }
 
 .champ {
   margin-bottom: 7mm;
+}
+// Light shading grouping a conditional field (label + instruction + box).
+.champ--conditional {
+  padding: 3mm;
+  background-color: #f6f6f6;
 }
 
 .annexes {

--- a/app/assets/stylesheets/dossier_vide_pdf.scss
+++ b/app/assets/stylesheets/dossier_vide_pdf.scss
@@ -91,8 +91,11 @@ dl.identity {
 .explanation {
   break-after: avoid;
 }
+// Champ descriptions stay italic to read as helper text; the procedure
+// presentation (.presentation) keeps the admin's own formatting instead.
 .description,
-.explanation {
+.explanation,
+.mailing {
   font-style: italic;
 }
 .explanation {

--- a/app/components/dossiers/dossier_vide_pdf_component.html.erb
+++ b/app/components/dossiers/dossier_vide_pdf_component.html.erb
@@ -41,7 +41,9 @@
 <% end %>
 
 <% types_de_champ_public.each do |type_de_champ| %>
-  <section class="champ"><%= render_champ(type_de_champ) %></section>
+  <section class="<%= champ_css_class(type_de_champ) %>">
+    <%= render_champ(type_de_champ) %>
+  </section>
 <% end %>
 
 <% if annexes.any? %>

--- a/app/components/dossiers/dossier_vide_pdf_component.html.erb
+++ b/app/components/dossiers/dossier_vide_pdf_component.html.erb
@@ -1,0 +1,41 @@
+<% content_for(:title, procedure.libelle) %>
+
+<%= image_tag('header/logo-ds-wide.png', alt: "Logo de l’administration", width: 300, class: 'logo') %>
+
+<h1><%= procedure.libelle %></h1>
+
+<dl class="header">
+  <div class="field-pair">
+    <dt>Organisme</dt>
+    <dd><%= organisation %></dd>
+  </div>
+</dl>
+
+<h2>Identité du demandeur</h2>
+
+<dl class="identity">
+  <%= fillable_field("Email") %>
+
+  <% if procedure.for_individual? %>
+    <%= fillable_field("Civilité") %>
+    <%= fillable_field("Nom") %>
+    <%= fillable_field("Prénom") %>
+    <% if procedure.ask_birthday? %>
+      <%= fillable_field("Date de naissance") %>
+    <% end %>
+  <% else %>
+    <%= fillable_field("SIRET") %>
+    <%= fillable_field("Dénomination") %>
+    <%= fillable_field("Forme juridique") %>
+  <% end %>
+</dl>
+
+<h2>Formulaire</h2>
+
+<% if procedure.description.present? %>
+  <div class="presentation"><%= simple_format(procedure.description) %></div>
+<% end %>
+
+<% types_de_champ_public.each do |type_de_champ| %>
+  <section class="champ"><%= render_champ(type_de_champ) %></section>
+<% end %>

--- a/app/components/dossiers/dossier_vide_pdf_component.html.erb
+++ b/app/components/dossiers/dossier_vide_pdf_component.html.erb
@@ -39,3 +39,15 @@
 <% types_de_champ_public.each do |type_de_champ| %>
   <section class="champ"><%= render_champ(type_de_champ) %></section>
 <% end %>
+
+<% if annexes.any? %>
+  <section class="annexes">
+    <h2>Annexes</h2>
+
+    <% annexes.each_with_index do |type_de_champ, index| %>
+      <section class="annex">
+        <%= render_annex(type_de_champ, index + 1) %>
+      </section>
+    <% end %>
+  </section>
+<% end %>

--- a/app/components/dossiers/dossier_vide_pdf_component.html.erb
+++ b/app/components/dossiers/dossier_vide_pdf_component.html.erb
@@ -36,6 +36,10 @@
   <div class="presentation"><%= simple_format(procedure.description) %></div>
 <% end %>
 
+<% if mailing_instruction %>
+  <p class="mailing"><%= mailing_instruction %></p>
+<% end %>
+
 <% types_de_champ_public.each do |type_de_champ| %>
   <section class="champ"><%= render_champ(type_de_champ) %></section>
 <% end %>

--- a/app/components/dossiers/dossier_vide_pdf_component.rb
+++ b/app/components/dossiers/dossier_vide_pdf_component.rb
@@ -19,6 +19,13 @@ class Dossiers::DossierVidePdfComponent < ApplicationComponent
 
   def organisation = procedure.organisation_name.presence || "En attente de saisie"
 
+  def mailing_instruction
+    service = procedure.service
+    return if service.blank?
+
+    ["À envoyer à #{service.nom}", service.adresse.to_s.squish.presence].compact.join(' - ')
+  end
+
   # Empty field to fill in by hand: a bordered box (meaning carried by the preceding label)
   def fillable_box(height: :line)
     tag.div('', class: "box box--#{height}", aria: { hidden: true })

--- a/app/components/dossiers/dossier_vide_pdf_component.rb
+++ b/app/components/dossiers/dossier_vide_pdf_component.rb
@@ -26,5 +26,111 @@ class Dossiers::DossierVidePdfComponent < ApplicationComponent
     end
   end
 
-  def render_champ(_type_de_champ) = "".html_safe # replaced in next commit
+  REPETITION_OCCURRENCES = 3
+
+  def render_champ(type_de_champ)
+    case type_de_champ.type_champ
+    when TypeDeChamp.type_champs.fetch(:header_section)
+      safe_join([header_section_heading(type_de_champ), description(type_de_champ)].compact)
+    when TypeDeChamp.type_champs.fetch(:explication)
+      safe_join([libelle(type_de_champ), tag.div(simple_format(type_de_champ.description), class: 'explication')].compact)
+    when TypeDeChamp.type_champs.fetch(:piece_justificative)
+      safe_join([
+        tag.p('Pièce justificative à joindre en complément du dossier', class: 'label'),
+        checkboxes([type_de_champ.libelle]),
+        description(type_de_champ),
+      ].compact)
+    when TypeDeChamp.type_champs.fetch(:yes_no), TypeDeChamp.type_champs.fetch(:checkbox)
+      field_with_options(type_de_champ, ['Oui', 'Non'], explanation: 'Cochez la mention applicable')
+    when TypeDeChamp.type_champs.fetch(:civilite)
+      field_with_options(type_de_champ, [Individual::GENDER_FEMALE, Individual::GENDER_MALE])
+    when TypeDeChamp.type_champs.fetch(:drop_down_list)
+      if type_de_champ.drop_down_advanced? || too_many_options?(type_de_champ)
+        libelle_and_box(type_de_champ)
+      else
+        field_with_options(type_de_champ, type_de_champ.drop_down_options, explanation: 'Cochez la mention applicable, une seule valeur possible')
+      end
+    when TypeDeChamp.type_champs.fetch(:multiple_drop_down_list)
+      if too_many_options?(type_de_champ)
+        libelle_and_box(type_de_champ)
+      else
+        field_with_options(type_de_champ, type_de_champ.drop_down_options, explanation: 'Cochez la mention applicable, plusieurs valeurs possibles')
+      end
+    when TypeDeChamp.type_champs.fetch(:linked_drop_down_list)
+      linked_field(type_de_champ)
+    when TypeDeChamp.type_champs.fetch(:siret)
+      establishment(type_de_champ.libelle)
+    when TypeDeChamp.type_champs.fetch(:repetition)
+      repetition(type_de_champ)
+    else
+      libelle_and_box(type_de_champ)
+    end
+  end
+
+  def libelle(type_de_champ) = tag.p(type_de_champ.libelle, class: 'label')
+
+  def description(type_de_champ)
+    return if type_de_champ.description.blank?
+
+    tag.div(simple_format(type_de_champ.description), class: 'description')
+  end
+
+  # Renders admin-authored rich text (bold, italic, links, line breaks) exactly
+  # like the web form does, so the printed form matches the on-screen one.
+  def simple_format(text) = render(SimpleFormatComponent.new(text, allow_a: true))
+
+  def libelle_and_box(type_de_champ)
+    safe_join([libelle(type_de_champ), description(type_de_champ), fillable_box(height: :block)].compact)
+  end
+
+  # A decorative checkbox (aria-hidden) followed by the real meaning-bearing label
+  def checkbox(label)
+    tag.span(class: 'option') do
+      safe_join([tag.span('', class: 'checkbox', aria: { hidden: true }), tag.span(label)])
+    end
+  end
+
+  def checkboxes(labels)
+    tag.ul(class: 'options') { safe_join(labels.map { |l| tag.li(checkbox(option_label(l))) }) }
+  end
+
+  def field_with_options(type_de_champ, options, explanation: nil)
+    explanation_tag = tag.p(explanation, class: 'explanation') if explanation
+    safe_join([libelle(type_de_champ), description(type_de_champ), explanation_tag, checkboxes(options)].compact)
+  end
+
+  def linked_field(type_de_champ)
+    items = type_de_champ.primary_options.compact_blank.flat_map do |primary|
+      secondaries = type_de_champ.secondary_options[primary].to_a.compact_blank
+      [tag.li(checkbox(primary))] +
+        secondaries.map { |s| tag.li(checkbox(s), class: 'secondary') }
+    end
+    safe_join([libelle(type_de_champ), tag.ul(safe_join(items), class: 'options')])
+  end
+
+  def establishment(label)
+    safe_join([
+      tag.p(label, class: 'label'),
+      fillable_field('SIRET'),
+      fillable_field('Dénomination'),
+      fillable_field('Forme juridique'),
+    ])
+  end
+
+  def repetition(type_de_champ)
+    children = revision.children_of(type_de_champ)
+    occurrences = Array.new(REPETITION_OCCURRENCES) do
+      safe_join(children.map { |child| tag.section(render_champ(child), class: 'champ') })
+    end
+    safe_join([libelle(type_de_champ), *occurrences])
+  end
+
+  # drop_down_options may contain Strings or [text, value] pairs
+  def option_label(option) = option.is_a?(Array) ? option.first : option
+
+  # Past this many options the web form switches to a searchable combobox, so
+  # listing every option on paper would span pages: fall back to a write-in box.
+  def too_many_options?(type_de_champ)
+    type_de_champ.drop_down_options.size >= Champs::DropDownListChamp::THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE
+  end
 end

--- a/app/components/dossiers/dossier_vide_pdf_component.rb
+++ b/app/components/dossiers/dossier_vide_pdf_component.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Dossiers::DossierVidePdfComponent < ApplicationComponent
+  attr_reader :revision, :procedure
+
+  def initialize(revision:)
+    @revision = revision
+    @procedure = revision.procedure
+  end
+
+  private
+
+  def types_de_champ_public = revision.root_types_de_champ_public
+
+  def organisation = procedure.organisation_name.presence || "En attente de saisie"
+
+  # Empty field to fill in by hand: a bordered box (meaning carried by the preceding label)
+  def fillable_box(height: :line)
+    tag.div('', class: "box box--#{height}", aria: { hidden: true })
+  end
+
+  # Label / fillable area pair
+  def fillable_field(label)
+    tag.div(class: 'field-pair') do
+      safe_join([tag.dt(label), tag.dd(fillable_box)])
+    end
+  end
+
+  def render_champ(_type_de_champ) = "".html_safe # replaced in next commit
+end

--- a/app/components/dossiers/dossier_vide_pdf_component.rb
+++ b/app/components/dossiers/dossier_vide_pdf_component.rb
@@ -6,11 +6,16 @@ class Dossiers::DossierVidePdfComponent < ApplicationComponent
   def initialize(revision:)
     @revision = revision
     @procedure = revision.procedure
+    @annexes = []
   end
 
   private
 
   def types_de_champ_public = revision.root_types_de_champ_public
+
+  # Populated while rendering champs (see boxed_field_with_annex); read by the
+  # template after the form to append the "Annexes" pages.
+  def annexes = @annexes
 
   def organisation = procedure.organisation_name.presence || "En attente de saisie"
 
@@ -45,14 +50,18 @@ class Dossiers::DossierVidePdfComponent < ApplicationComponent
     when TypeDeChamp.type_champs.fetch(:civilite)
       field_with_options(type_de_champ, [Individual::GENDER_FEMALE, Individual::GENDER_MALE])
     when TypeDeChamp.type_champs.fetch(:drop_down_list)
-      if type_de_champ.drop_down_advanced? || too_many_options?(type_de_champ)
+      if type_de_champ.drop_down_advanced?
         libelle_and_box(type_de_champ)
+      elsif too_many_options?(type_de_champ)
+        boxed_field_with_annex(type_de_champ, multiple: false)
       else
         field_with_options(type_de_champ, type_de_champ.drop_down_options, explanation: 'Cochez la mention applicable, une seule valeur possible')
       end
     when TypeDeChamp.type_champs.fetch(:multiple_drop_down_list)
-      if too_many_options?(type_de_champ)
+      if type_de_champ.drop_down_advanced?
         libelle_and_box(type_de_champ)
+      elsif too_many_options?(type_de_champ)
+        boxed_field_with_annex(type_de_champ, multiple: true)
       else
         field_with_options(type_de_champ, type_de_champ.drop_down_options, explanation: 'Cochez la mention applicable, plusieurs valeurs possibles')
       end
@@ -129,8 +138,39 @@ class Dossiers::DossierVidePdfComponent < ApplicationComponent
   def option_label(option) = option.is_a?(Array) ? option.first : option
 
   # Past this many options the web form switches to a searchable combobox, so
-  # listing every option on paper would span pages: fall back to a write-in box.
+  # listing every option inline would span pages: keep a write-in box in the
+  # form and move the full list to an annex at the end of the document.
   def too_many_options?(type_de_champ)
     type_de_champ.drop_down_options.size >= Champs::DropDownListChamp::THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE
+  end
+
+  # Write-in box referencing the annex that lists every option. The annex is a
+  # reference the applicant reads to fill in the box, not something to print/tick.
+  def boxed_field_with_annex(type_de_champ, multiple:)
+    number = register_annex(type_de_champ)
+    instruction = if multiple
+      'Renseignez les mentions applicables, plusieurs valeurs possibles'
+    else
+      'Renseignez la mention applicable, une seule valeur possible'
+    end
+    reference = tag.p("La liste complète des options figure en Annexe #{number}. #{instruction}", class: 'explanation')
+    safe_join([libelle(type_de_champ), description(type_de_champ), reference, fillable_box(height: :block)].compact)
+  end
+
+  # Records the champ (once, even across repetition occurrences) and returns its
+  # 1-based annex number, following document order.
+  def register_annex(type_de_champ)
+    @annexes << type_de_champ unless @annexes.include?(type_de_champ)
+    @annexes.index(type_de_champ) + 1
+  end
+
+  # A plain reference list (no checkboxes): the applicant reads it to fill in the
+  # form and can skip printing it when it is long.
+  def render_annex(type_de_champ, number)
+    items = type_de_champ.drop_down_options.map { |option| tag.li(option_label(option)) }
+    safe_join([
+      tag.h3("Annexe #{number} : #{type_de_champ.libelle}"),
+      tag.ul(safe_join(items), class: 'annex-options'),
+    ])
   end
 end

--- a/app/components/dossiers/dossier_vide_pdf_component.rb
+++ b/app/components/dossiers/dossier_vide_pdf_component.rb
@@ -83,7 +83,64 @@ class Dossiers::DossierVidePdfComponent < ApplicationComponent
     end
   end
 
-  def libelle(type_de_champ) = tag.p(type_de_champ.libelle, class: 'label')
+  # Maps the section level to a heading below the "Formulaire" <h2>, mirroring the
+  # web form (level 1 → h3), so the PDF/UA tag tree preserves the document outline.
+  def header_section_heading(type_de_champ)
+    level = [type_de_champ.level_for_revision(revision) + 2, 6].min
+    tag.public_send("h#{level}", type_de_champ.libelle)
+  end
+
+  # Label followed, for a conditional champ, by the "À remplir si …" instruction.
+  def libelle(type_de_champ)
+    safe_join([tag.p(type_de_champ.libelle, class: 'label'), condition_instruction(type_de_champ)].compact)
+  end
+
+  # 'champ champ--conditional' shades a conditional field so the applicant sees
+  # the instruction and the box belong together.
+  def champ_css_class(type_de_champ)
+    displayable_condition?(type_de_champ) ? 'champ champ--conditional' : 'champ'
+  end
+
+  def condition_instruction(type_de_champ)
+    return unless displayable_condition?(type_de_champ)
+
+    tag.p("À remplir si #{humanize_condition(type_de_champ.condition)}", class: 'condition')
+  end
+
+  # An admin editing a procedure can persist an unfinished condition row
+  # (Logic::EmptyOperator with Logic::Empty members); such a condition carries no
+  # meaning and has no operator label, so we never surface it in the PDF.
+  def displayable_condition?(type_de_champ)
+    condition = type_de_champ.condition
+    condition.present? && condition.terms.none? { it.is_a?(Logic::EmptyOperator) || it.is_a?(Logic::Empty) }
+  end
+
+  # Reuses the operator labels from the admin condition editor (logic.operators),
+  # falling back to the technical form (Logic#to_s) for anything we do not phrase.
+  def humanize_condition(term)
+    case term
+    when Logic::NAryOperator
+      term.operands.map { humanize_condition(it) }.join(" #{operator_label(term)} ")
+    when Logic::BinaryOperator
+      "« #{term.left.to_s(condition_type_de_champs)} » #{operator_label(term)} « #{condition_value(term)} »"
+    else
+      term.to_s(condition_type_de_champs)
+    end
+  end
+
+  def operator_label(term) = I18n.t(term.class.name, scope: 'logic.operators').sub(/\A./, &:downcase)
+
+  # Human label of the compared value (e.g. a region code → its name), taken from
+  # the referenced champ's options; falls back to the raw value.
+  def condition_value(term)
+    raw = term.right.is_a?(Logic::Constant) ? term.right.value : nil
+    options = term.left.is_a?(Logic::ChampValue) ? term.left.options(condition_type_de_champs, term.class.name) : nil
+    options&.find { |(_label, value)| value == raw }&.first || term.right.to_s(condition_type_de_champs)
+  rescue StandardError
+    term.right.to_s(condition_type_de_champs)
+  end
+
+  def condition_type_de_champs = revision.flat_types_de_champ_public
 
   def description(type_de_champ)
     return if type_de_champ.description.blank?
@@ -136,7 +193,7 @@ class Dossiers::DossierVidePdfComponent < ApplicationComponent
   def repetition(type_de_champ)
     children = revision.children_of(type_de_champ)
     occurrences = Array.new(REPETITION_OCCURRENCES) do
-      safe_join(children.map { |child| tag.section(render_champ(child), class: 'champ') })
+      safe_join(children.map { |child| tag.section(render_champ(child), class: champ_css_class(child)) })
     end
     safe_join([libelle(type_de_champ), *occurrences])
   end

--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -179,8 +179,37 @@ module Users
 
     def generate_empty_pdf(revision)
       @revision = revision
-      data = render_to_string(template: 'dossiers/dossier_vide', formats: [:pdf])
-      send_data(data, filename: "#{revision.procedure.libelle}.pdf")
+      @procedure = revision.procedure
+      filename = "#{@procedure.libelle}.pdf"
+
+      if @procedure.feature_enabled?(:dossier_vide_weasyprint)
+        send_data(generate_empty_pdf_weasyprint(revision), filename:, type: 'application/pdf')
+      else
+        send_data(render_dossier_vide_prawn, filename:)
+      end
+    rescue StandardError => e
+      # Any failure of the new WeasyPrint path falls back to the proven Prawn rendering.
+      Sentry.capture_exception(e, extra: { procedure_id: @procedure.id })
+      send_data(render_dossier_vide_prawn, filename:)
+    end
+
+    def generate_empty_pdf_weasyprint(revision)
+      html = render_to_string(
+        Dossiers::DossierVidePdfComponent.new(revision:),
+        layout: 'dossier_vide_pdf',
+        formats: [:html]
+      )
+
+      options = {
+        procedure_id: revision.procedure.id,
+        path: request.path,
+      }
+
+      WeasyprintService.generate_pdf(html, options)
+    end
+
+    def render_dossier_vide_prawn
+      render_to_string(template: 'dossiers/dossier_vide', formats: [:pdf])
     end
   end
 end

--- a/app/views/layouts/dossier_vide_pdf.html.erb
+++ b/app/views/layouts/dossier_vide_pdf.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+
+<html lang="fr">
+  <head>
+    <%= stylesheet_link_tag 'dossier_vide_pdf', media: 'all' %>
+    <title><%= content_for?(:title) ? yield(:title) : 'Dossier vide' %></title>
+    <meta name="generator" content="<%= ENV.fetch('APP_HOST', '') %>">
+    <meta name="dcterms.created" content="<%= Time.zone.now.iso8601 %>">
+  </head>
+
+  <body id="dossier-vide-pdf"><%= yield %></body>
+</html>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -38,6 +38,7 @@ features = [
   :llm_nightly_improve_procedure,
   :ami_notifications,
   :api_entreprise_tva_job,
+  :dossier_vide_weasyprint,
   :usager_dossiers_alert_filters,
   :s3_storage,
 ]

--- a/spec/components/dossiers/dossier_vide_pdf_component_spec.rb
+++ b/spec/components/dossiers/dossier_vide_pdf_component_spec.rb
@@ -94,10 +94,21 @@ RSpec.describe Dossiers::DossierVidePdfComponent, type: :component do
         [{ type: :drop_down_list, libelle: 'Choix', options: }]
       end
 
-      it 'falls back to a fillable box instead of listing every option' do
+      it 'falls back to a fillable box in the form, without listing options inline' do
         expect(subject).to have_content('Choix')
-        expect(subject).to have_selector('.box')
-        expect(subject).not_to have_selector('ul.options li')
+        expect(subject).to have_selector('.champ .box')
+        expect(subject).not_to have_selector('.champ ul.options li')
+      end
+
+      it 'references the annex from the form field with the single-value instruction' do
+        expect(subject).to have_selector('.champ', text: 'La liste complète des options figure en Annexe 1. Renseignez la mention applicable, une seule valeur possible')
+      end
+
+      it 'lists every option as a plain list without checkboxes in an Annexes page' do
+        expect(subject).to have_selector('section.annexes h2', text: 'Annexes')
+        expect(subject).to have_selector('.annexes h3', text: 'Annexe 1 : Choix')
+        expect(subject).to have_selector('.annexes ul li', count: options.size)
+        expect(subject).not_to have_selector('.annexes .checkbox')
       end
     end
 
@@ -119,10 +130,43 @@ RSpec.describe Dossiers::DossierVidePdfComponent, type: :component do
         [{ type: :multiple_drop_down_list, libelle: 'Choix', options: }]
       end
 
-      it 'falls back to a fillable box instead of listing every option' do
+      it 'falls back to a fillable box in the form, without listing options inline' do
         expect(subject).to have_content('Choix')
-        expect(subject).to have_selector('.box')
-        expect(subject).not_to have_selector('ul.options li')
+        expect(subject).to have_selector('.champ .box')
+        expect(subject).not_to have_selector('.champ ul.options li')
+      end
+
+      it 'references the annex from the form field with the multiple-values instruction' do
+        expect(subject).to have_selector('.champ', text: 'La liste complète des options figure en Annexe 1. Renseignez les mentions applicables, plusieurs valeurs possibles')
+      end
+
+      it 'lists every option as a plain list without checkboxes' do
+        expect(subject).to have_selector('.annexes h3', text: 'Annexe 1 : Choix')
+        expect(subject).to have_selector('.annexes ul li', count: options.size)
+        expect(subject).not_to have_selector('.annexes .checkbox')
+      end
+    end
+
+    context 'several champs with too many options' do
+      let(:options) { (1..Champs::DropDownListChamp::THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE).map { |i| "Option #{i}" } }
+      let(:types_de_champ_public) do
+        [
+          { type: :drop_down_list, libelle: 'Premier', options: },
+          { type: :multiple_drop_down_list, libelle: 'Second', options: },
+        ]
+      end
+
+      it 'numbers the annexes in document order' do
+        expect(subject).to have_selector('.annexes h3', text: 'Annexe 1 : Premier')
+        expect(subject).to have_selector('.annexes h3', text: 'Annexe 2 : Second')
+      end
+    end
+
+    context 'no champ needs an annex' do
+      let(:types_de_champ_public) { [{ type: :text, libelle: 'Votre nom' }] }
+
+      it 'does not render an Annexes section' do
+        expect(subject).not_to have_selector('section.annexes')
       end
     end
 

--- a/spec/components/dossiers/dossier_vide_pdf_component_spec.rb
+++ b/spec/components/dossiers/dossier_vide_pdf_component_spec.rb
@@ -32,4 +32,123 @@ RSpec.describe Dossiers::DossierVidePdfComponent, type: :component do
       end
     end
   end
+
+  describe 'dispatch per champ type' do
+    let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
+
+    context 'header_section' do
+      let(:types_de_champ_public) do
+        [
+          { type: :header_section, libelle: 'Niveau 1', level: 1 },
+          { type: :header_section, libelle: 'Niveau 2', level: 2 },
+          { type: :header_section, libelle: 'Niveau 3', level: 3 },
+        ]
+      end
+
+      it 'maps each section level to a heading below the h2 form title' do
+        expect(subject).to have_selector('h3', text: 'Niveau 1')
+        expect(subject).to have_selector('h4', text: 'Niveau 2')
+        expect(subject).to have_selector('h5', text: 'Niveau 3')
+      end
+    end
+
+    context 'yes_no' do
+      let(:types_de_champ_public) { [{ type: :yes_no, libelle: 'D’accord ?' }] }
+
+      it 'renders two Oui/Non checkboxes with real labels' do
+        expect(subject).to have_content('D’accord ?')
+        expect(subject).to have_content('Oui')
+        expect(subject).to have_content('Non')
+        expect(subject).to have_selector('.checkbox[aria-hidden="true"]', count: 2)
+      end
+
+      it 'explains the applicable option must be checked' do
+        expect(subject).to have_content('Cochez la mention applicable')
+      end
+    end
+
+    context 'civilite' do
+      let(:types_de_champ_public) { [{ type: :civilite, libelle: 'Civilité' }] }
+
+      it { is_expected.to have_selector('.checkbox', count: 2) }
+    end
+
+    context 'simple drop_down_list' do
+      let(:types_de_champ_public) do
+        [{ type: :drop_down_list, libelle: 'Choix', options: ['A', 'B', 'C'] }]
+      end
+
+      it 'renders an options list without <p> inside <li>' do
+        expect(subject).to have_selector('ul li', count: 3)
+        expect(subject).not_to have_selector('li p')
+      end
+
+      it 'explains a single value can be selected' do
+        expect(subject).to have_content('Cochez la mention applicable, une seule valeur possible')
+      end
+    end
+
+    context 'simple drop_down_list with too many options' do
+      let(:options) { (1..Champs::DropDownListChamp::THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE).map { |i| "Option #{i}" } }
+      let(:types_de_champ_public) do
+        [{ type: :drop_down_list, libelle: 'Choix', options: }]
+      end
+
+      it 'falls back to a fillable box instead of listing every option' do
+        expect(subject).to have_content('Choix')
+        expect(subject).to have_selector('.box')
+        expect(subject).not_to have_selector('ul.options li')
+      end
+    end
+
+    context 'multiple_drop_down_list' do
+      let(:types_de_champ_public) do
+        [{ type: :multiple_drop_down_list, libelle: 'Choix', options: ['A', 'B'] }]
+      end
+
+      it { is_expected.to have_selector('ul li', count: 2) }
+
+      it 'explains several values can be selected' do
+        expect(subject).to have_content('Cochez la mention applicable, plusieurs valeurs possibles')
+      end
+    end
+
+    context 'multiple_drop_down_list with too many options' do
+      let(:options) { (1..Champs::DropDownListChamp::THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE).map { |i| "Option #{i}" } }
+      let(:types_de_champ_public) do
+        [{ type: :multiple_drop_down_list, libelle: 'Choix', options: }]
+      end
+
+      it 'falls back to a fillable box instead of listing every option' do
+        expect(subject).to have_content('Choix')
+        expect(subject).to have_selector('.box')
+        expect(subject).not_to have_selector('ul.options li')
+      end
+    end
+
+    context 'piece_justificative' do
+      let(:types_de_champ_public) { [{ type: :piece_justificative, libelle: 'RIB' }] }
+
+      it { is_expected.to have_content('RIB') }
+    end
+
+    context 'repetition' do
+      let(:types_de_champ_public) do
+        [{ type: :repetition, libelle: 'Personnes', children: [{ type: :text, libelle: 'Nom' }] }]
+      end
+
+      it 'renders 3 occurrences of the child champ' do
+        expect(subject).to have_content('Nom', count: 3)
+      end
+    end
+
+    context 'default text champ' do
+      let(:types_de_champ_public) { [{ type: :text, libelle: 'Votre nom' }] }
+
+      it 'renders a label and a fillable box' do
+        expect(subject).to have_content('Votre nom')
+        expect(subject).to have_selector('.box')
+      end
+    end
+  end
 end

--- a/spec/components/dossiers/dossier_vide_pdf_component_spec.rb
+++ b/spec/components/dossiers/dossier_vide_pdf_component_spec.rb
@@ -50,6 +50,104 @@ RSpec.describe Dossiers::DossierVidePdfComponent, type: :component do
     end
   end
 
+  describe 'conditional champ' do
+    let(:types_de_champ_public) do
+      [
+        { type: :drop_down_list, libelle: 'Choix simple', options: ['Fromage', 'Dessert'] },
+        { type: :text, libelle: 'Précisez' },
+      ]
+    end
+    let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
+    let(:source) { procedure.active_revision.types_de_champ.find { it.libelle == 'Choix simple' } }
+    let(:target) { procedure.active_revision.types_de_champ.find { it.libelle == 'Précisez' } }
+
+    def set_condition(condition) = target.update!(condition:)
+
+    context 'with an equality condition' do
+      before { set_condition(Logic::Eq.new(Logic::ChampValue.new(source.stable_id), Logic::Constant.new('Dessert'))) }
+
+      it 'renders a humanized instruction inside the conditional block' do
+        expect(subject).to have_selector('.champ--conditional .condition', text: 'À remplir si « Choix simple » égal à « Dessert »')
+      end
+
+      it 'marks only the conditional champ' do
+        expect(subject).to have_selector('.champ', count: 2)
+        expect(subject).to have_selector('.champ--conditional', count: 1)
+      end
+    end
+
+    context 'with a negated condition' do
+      before { set_condition(Logic::NotEq.new(Logic::ChampValue.new(source.stable_id), Logic::Constant.new('Fromage'))) }
+
+      it { is_expected.to have_selector('.condition', text: 'À remplir si « Choix simple » n’est pas « Fromage »') }
+    end
+
+    context 'with a composed OR condition' do
+      before do
+        set_condition(Logic::Or.new([
+          Logic::Eq.new(Logic::ChampValue.new(source.stable_id), Logic::Constant.new('Dessert')),
+          Logic::Eq.new(Logic::ChampValue.new(source.stable_id), Logic::Constant.new('Fromage')),
+        ]))
+      end
+
+      it { is_expected.to have_selector('.condition', text: 'À remplir si « Choix simple » égal à « Dessert » ou « Choix simple » égal à « Fromage »') }
+    end
+
+    context 'without a condition' do
+      it 'renders no condition instruction and no conditional block' do
+        expect(subject).not_to have_selector('.condition')
+        expect(subject).not_to have_selector('.champ--conditional')
+      end
+    end
+
+    context 'with an unfinished condition (empty operator)' do
+      before { set_condition(Logic::EmptyOperator.new(Logic::Empty.new, Logic::Empty.new)) }
+
+      it 'ignores it entirely (no translation-missing instruction, no shading)' do
+        expect(subject).not_to have_selector('.condition')
+        expect(subject).not_to have_selector('.champ--conditional')
+        expect(subject).not_to have_text('translation missing', normalize_ws: true)
+      end
+    end
+  end
+
+  describe 'admin rich text (parity with the web SimpleFormat rendering)' do
+    subject { render_inline(described_class.new(revision: procedure.active_revision)) }
+
+    let(:procedure) { create(:procedure, :published, description: 'Présentation en <b>valorisée</b>', types_de_champ_public:) }
+
+    context 'formatting tags' do
+      let(:types_de_champ_public) do
+        [
+          { type: :text, libelle: 'Nom', description: 'Consigne en <b>appuyée</b>' },
+          { type: :explication, libelle: 'Infos', description: 'Détail en <b>souligné</b>' },
+        ]
+      end
+
+      it 'renders the procedure presentation tags instead of escaping them' do
+        expect(subject).to have_selector('.presentation b', text: 'valorisée')
+      end
+
+      it 'renders a champ description tags instead of stripping them' do
+        expect(subject).to have_selector('.champ .description b', text: 'appuyée')
+      end
+
+      it 'renders an explication body tags' do
+        expect(subject).to have_selector('.explication b', text: 'souligné')
+      end
+    end
+
+    context 'authored line breaks' do
+      let(:types_de_champ_public) do
+        [{ type: :text, libelle: 'Nom', description: "Ligne 1\nLigne 2" }]
+      end
+
+      it 'keeps them as separate paragraphs, like the web' do
+        expect(subject).to have_selector('.champ .description p', count: 2)
+      end
+    end
+  end
+
   describe 'dispatch per champ type' do
     let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
 

--- a/spec/components/dossiers/dossier_vide_pdf_component_spec.rb
+++ b/spec/components/dossiers/dossier_vide_pdf_component_spec.rb
@@ -33,6 +33,23 @@ RSpec.describe Dossiers::DossierVidePdfComponent, type: :component do
     end
   end
 
+  describe 'mailing instruction' do
+    context 'with a service' do
+      let(:service) { create(:service, nom: 'DDT du Rhône', adresse: "12 rue de la Paix\n69000 Lyon") }
+      let(:procedure) { create(:procedure, :published, service:) }
+
+      it 'tells where to send the form on a single line' do
+        expect(subject).to have_selector('.mailing', text: 'À envoyer à DDT du Rhône - 12 rue de la Paix 69000 Lyon')
+      end
+    end
+
+    context 'without a service' do
+      let(:procedure) { create(:procedure, :published, service: nil) }
+
+      it { is_expected.not_to have_selector('.mailing') }
+    end
+  end
+
   describe 'dispatch per champ type' do
     let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
 

--- a/spec/components/dossiers/dossier_vide_pdf_component_spec.rb
+++ b/spec/components/dossiers/dossier_vide_pdf_component_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Dossiers::DossierVidePdfComponent, type: :component do
+  subject { render_inline(described_class.new(revision: procedure.active_revision)) }
+
+  describe 'header and identity' do
+    context 'procedure for a legal entity' do
+      let(:procedure) do
+        create(:procedure, :published, libelle: 'Ma démarche', for_individual: false)
+      end
+
+      it 'renders the title, header and establishment identity' do
+        expect(subject).to have_selector('h1', text: 'Ma démarche')
+        expect(subject).to have_selector('h2', text: 'Identité du demandeur')
+        expect(subject).to have_selector('h2', text: 'Formulaire')
+        expect(subject).to have_content('SIRET')
+        expect(subject).to have_selector('img[alt]')
+        # non-empty alt (PDF/UA safeguard)
+        expect(subject.at_css('img')['alt']).to be_present
+      end
+    end
+
+    context 'procedure for an individual' do
+      let(:procedure) do
+        create(:procedure, :published, for_individual: true)
+      end
+
+      it 'renders the individual identity' do
+        expect(subject).to have_content('Nom')
+        expect(subject).to have_content('Prénom')
+        expect(subject).not_to have_content('SIRET')
+      end
+    end
+  end
+end

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -494,6 +494,59 @@ describe Users::CommencerController, type: :controller do
         expect(response).to have_http_status(:success)
       end
     end
+
+    context 'with the :dossier_vide_weasyprint flag enabled' do
+      render_views
+      let(:procedure) { create(:procedure, :published, :with_service, :with_path, libelle: 'Ma démarche') }
+
+      before do
+        Flipper.enable(:dossier_vide_weasyprint, procedure)
+        allow(WeasyprintService).to receive(:generate_pdf).and_return('%PDF-fake')
+        get :dossier_vide_pdf, params: { path: procedure.path }
+      end
+
+      it 'generates the PDF via WeasyPrint' do
+        expect(WeasyprintService).to have_received(:generate_pdf)
+          .with(anything, hash_including(procedure_id: procedure.id))
+        expect(response).to have_http_status(:success)
+        expect(response.body).to eq('%PDF-fake')
+      end
+
+      it 'titles the document with the procedure libelle (PDF/UA metadata)' do
+        expect(WeasyprintService).to have_received(:generate_pdf)
+          .with(a_string_matching(%r{<title>Ma démarche</title>}), anything)
+      end
+    end
+
+    context 'with the flag enabled but WeasyPrint failing' do
+      let(:procedure) { create(:procedure, :published, :with_service, :with_path) }
+
+      before do
+        Flipper.enable(:dossier_vide_weasyprint, procedure)
+        allow(WeasyprintService).to receive(:generate_pdf).and_raise(WeasyprintService::Error)
+        get :dossier_vide_pdf, params: { path: procedure.path }
+      end
+
+      it 'falls back to the Prawn rendering without failing' do
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'with the flag enabled but the PDF rendering raising unexpectedly' do
+      let(:procedure) { create(:procedure, :published, :with_service, :with_path) }
+
+      before do
+        Flipper.enable(:dossier_vide_weasyprint, procedure)
+        allow(Sentry).to receive(:capture_exception)
+        allow(WeasyprintService).to receive(:generate_pdf).and_raise(StandardError, 'boom')
+        get :dossier_vide_pdf, params: { path: procedure.path }
+      end
+
+      it 'falls back to the Prawn rendering and reports to Sentry' do
+        expect(response).to have_http_status(:success)
+        expect(Sentry).to have_received(:capture_exception)
+      end
+    end
   end
 
   describe '#dossier_vide_test_pdf' do


### PR DESCRIPTION
## Contexte

Le PDF du « dossier vide » (le formulaire vierge, à imprimer/remplir à la main) est aujourd'hui généré par Prawn, qui produit un PDF **non balisé, donc non accessible**.

## Objectif

Le générer via le microservice **WeasyPrint** en variante **PDF/UA-1** (balisé, accessible), comme l'attestation v2.

## Périmètre (étape 1)

- Génération **à la volée** au clic, derrière le flag `:dossier_vide_weasyprint`.
- **Repli sur Prawn** si le flag est désactivé **ou** si WeasyPrint échoue (erreur remontée à Sentry).

## Implémentation

- Nouveau `Dossiers::DossierVidePdfComponent` + layout et feuille de style dédiés.
- `render_champ` reproduit le rendu Prawn type par type : mentions d'aide à la saisie (« Cochez la mention applicable… »), cases à cocher, répétitions, SIRET, etc.
- Accessibilité : hiérarchie de titres (h1 démarche → h2 sections), `alt` non vide, listes sans `<li><p>`, langue du document, italique via une fonte Marianne dédiée.

## Hors périmètre

Étape suivante : génération à la publication d'une révision + cache ActiveStorage
