### PR TITLE
Tech: affiche Dossiers::ChangesComponent comme une liste à puces

### DIFF
--- a/app/assets/stylesheets/changes_component.scss
+++ b/app/assets/stylesheets/changes_component.scss
@@ -1,0 +1,17 @@
+.dossiers-changes-component {
+  // Keep the semantic <dl>, but render it as a bulleted list:
+  // a bullet on each key (<dt>) and no indentation on the value (<dd>).
+  padding-inline-start: 1.5em;
+
+  dt {
+    display: list-item;
+    list-style-type: disc;
+  }
+
+  dd {
+    // Align the value line with the key text (under the bullet, not the marker).
+    // DSFR adds a padding-inline-start on <dd>, so reset it too.
+    margin-inline-start: 0;
+    padding-inline-start: 0;
+  }
+}

--- a/app/components/dossiers/changes_component/changes_component.html.erb
+++ b/app/components/dossiers/changes_component/changes_component.html.erb
@@ -1,4 +1,4 @@
-<dl class="fr-mb-0">
+<dl class="dossiers-changes-component fr-mb-0">
   <% changed_columns.each do |changed_column| %>
     <dt><%= changed_column.label %> :</dt>
     <dd><%= change_content(changed_column) %></dd>


### PR DESCRIPTION
Le composant `Dossiers::ChangesComponent` reste sémantiquement une liste `<dl>` (clé/valeur), mais est désormais affiché comme une liste à puces : une puce par couple, et la ligne « valeur » alignée sur le texte de la clé (la puce ne s'applique qu'à la clé).

Le `padding-inline-start` ajouté par le DSFR sur `<dd>` est réinitialisé pour obtenir cet alignement.

### Avant / Après (`Dossiers::ChangesComponentPreview` — `all_types`)

| Avant | Après |
|-------|-------|
| ![Avant](https://raw.githubusercontent.com/demarche-numerique/demarche.numerique.gouv.fr/assets/changes-component-preview/docs/screenshots/changes-component-before.png) | ![Après](https://raw.githubusercontent.com/demarche-numerique/demarche.numerique.gouv.fr/assets/changes-component-preview/docs/screenshots/changes-component-after.png) |
