### PR TITLE
[Fix] Les messages aux usagers en brouillon sur démarche déclarative ne sont pas envoyés

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1040,7 +1040,6 @@ class Dossier < ApplicationRecord
   end
 
   def skip_user_notification_email?
-    return true if brouillon? && procedure.declarative?
     return true if for_procedure_preview?
     return true if user_deleted?
 

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -90,6 +90,18 @@ RSpec.describe DossierMailer, type: :mailer do
     it { expect(subject.perform_deliveries).to be_falsy }
   end
 
+  describe '.notify_new_answer with dossier brouillon on a declarative procedure' do
+    let(:procedure) { create(:simple_procedure, declarative_with_state: 'en_instruction') }
+    let(:dossier) { create(:dossier, :brouillon, procedure:) }
+    let(:commentaire) { create(:commentaire, dossier:) }
+
+    subject { described_class.with(commentaire:).notify_new_answer }
+
+    it 'delivers the email (bug fix  06/2026)' do
+      expect(subject.perform_deliveries).to be_truthy
+    end
+  end
+
   describe '.notify_en_construction_deletion_to_administration' do
     let(:hidden_dossier) { build(:dossier) }
 

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -3028,4 +3028,15 @@ describe Dossier, type: :model do
       create(:dossier, :accepte, :archived, :with_attestation_acceptation, procedure: procedure)
     end
   end
+
+  describe "#skip_user_notification_email?" do
+    context "when the dossier is brouillon for a declarative procedure" do
+      let(:procedure) { create(:procedure, :published, declarative_with_state: :en_instruction) }
+      let(:dossier) { create(:dossier, :brouillon, procedure:) }
+
+      it "allows the email to be sent (bug fix  06/2026)" do
+        expect(dossier.skip_user_notification_email?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Suite à une remontée sur [Crisp](https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_e4d292e1-b05e-488e-8aaf-0111aaac0534/), on a détecté qu'on n'envoyait pas les emails aux usagers ayant un dossier en brouillon sur les démarches déclaratives. Après discussion, on en a déduit que cette condition relevait d'un comportement historique qui n'a plus lieu d'être : on l'a donc simplement retirée.