### PR TITLE
ETQ Admin : je ne peux pas publier une révision avec champ API Part si je n'ai pas renseigné de token

### DIFF
--- a/app/assets/stylesheets/02_utils.scss
+++ b/app/assets/stylesheets/02_utils.scss
@@ -216,3 +216,7 @@
 .rounded-4 {
   border-radius: 4px;
 }
+
+.inactive {
+  opacity: 0.5;
+}

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
@@ -581,7 +581,7 @@
     <% end %>
 
     <% if type_de_champ.quotient_familial? %>
-      <%= render(TypesDeChampEditor::QuotientFamilialComponent.new()) %>
+      <%= render(TypesDeChampEditor::QuotientFamilialComponent.new(procedure:)) %>
     <% end %>
 
     <% if type_de_champ.repetition? %>

--- a/app/components/types_de_champ_editor/quotient_familial_component.rb
+++ b/app/components/types_de_champ_editor/quotient_familial_component.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class TypesDeChampEditor::QuotientFamilialComponent < ApplicationComponent
+  def initialize(procedure:)
+    @procedure = procedure
+  end
 end

--- a/app/components/types_de_champ_editor/quotient_familial_component/quotient_familial_component.html.haml
+++ b/app/components/types_de_champ_editor/quotient_familial_component/quotient_familial_component.html.haml
@@ -1,22 +1,35 @@
 .fr-px-2w
-  %hr.fr-hr
+  - if @procedure.api_particulier_token.nil?
+    = render Dsfr::AlertComponent.new(state: '', extra_class_names: 'fr-mb-3w fr-icon-lock-fill') do |c|
+      - c.with_body do
+        %p
+          L'utilisation de ce champ nécessite une
+          %strong autorisation spécifique.
+        %p
+          Vous devez renseigner un
+          %strong jeton API Particulier
+          sur cette démarche en vous rendant sur l'écran
+          = link_to 'Jetons API', admin_procedure_jetons_path(@procedure), helpers.external_link_attributes
 
-  .fr-mb-1w.cell
-    %p.fake-label.fr-text--bold.flex-grow.fr-mb-1v Si les données sont récupérées correctement
-    %p L'usager n'a pas besoin de transmettre un justificatif de quotient familial
+  %div{ class: class_names(inactive: @procedure.api_particulier_token.nil?) }
+    %hr.fr-hr
 
-  %hr.fr-hr
+    .fr-mb-1w.cell
+      %p.fake-label.fr-text--bold.flex-grow.fr-mb-1v Si les données sont récupérées correctement
+      %p L'usager n'a pas besoin de transmettre un justificatif de quotient familial
 
-  .fr-mb-1w.cell
-    %p.fake-label.fr-text--bold.flex-grow.fr-mb-1v Si les données ne sont pas récupérées ou incorrectes
-    %p.fr-mb-0 L'usager doit transmettre un justificatif de quotient familial.
+    %hr.fr-hr
 
-  .fr-notice.fr-notice--info.fr-mb-2w.fr-px-3w
-    %p
-      .fr-notice__title Information importante
-      Un champ de type "Pièce à joindre" sera affiché dans les cas suivants :
-      .notice__desc
-        %ul.fr-mt-1v.fr-ml-4w
-          %li L'usager ne s'est pas connecté via FranceConnect ;
-          %li L'usager s'est connecté via FranceConnect mais n'a pas confirmé l'exactitude des données récupérées ;
-          %li L'usager s'est connecté via FranceConnect mais la récupération de son quotient familial n'a pas fonctionné.
+    .fr-mb-1w.cell
+      %p.fake-label.fr-text--bold.flex-grow.fr-mb-1v Si les données ne sont pas récupérées ou incorrectes
+      %p.fr-mb-0 L'usager doit transmettre un justificatif de quotient familial.
+
+    .fr-notice.fr-notice--info.fr-mb-2w.fr-px-3w
+      %p
+        .fr-notice__title Information importante
+        Un champ de type "Pièce à joindre" sera affiché dans les cas suivants :
+        .notice__desc
+          %ul.fr-mt-1v.fr-ml-4w
+            %li L'usager ne s'est pas connecté via FranceConnect ;
+            %li L'usager s'est connecté via FranceConnect mais n'a pas confirmé l'exactitude des données récupérées ;
+            %li L'usager s'est connecté via FranceConnect mais la récupération de son quotient familial n'a pas fonctionné.

--- a/app/components/types_de_champ_editor/quotient_familial_component/quotient_familial_component.html.haml
+++ b/app/components/types_de_champ_editor/quotient_familial_component/quotient_familial_component.html.haml
@@ -1,5 +1,5 @@
 .fr-px-2w
-  - if @procedure.api_particulier_token.nil?
+  - if @procedure.api_particulier_token.blank?
     = render Dsfr::AlertComponent.new(state: '', extra_class_names: 'fr-mb-3w fr-icon-lock-fill') do |c|
       - c.with_body do
         %p
@@ -11,7 +11,7 @@
           sur cette démarche en vous rendant sur l'écran
           = link_to 'Jetons API', admin_procedure_jetons_path(@procedure), helpers.external_link_attributes
 
-  %div{ class: class_names(inactive: @procedure.api_particulier_token.nil?) }
+  %div{ class: class_names(inactive: @procedure.api_particulier_token.blank?) }
     %hr.fr-hr
 
     .fr-mb-1w.cell

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -251,6 +251,7 @@ class Procedure < ApplicationRecord
     'types_de_champ/number': true,
     'types_de_champ/date': true,
     'types_de_champ/repetition': true,
+    'types_de_champ/api_particulier': true,
     on: [:types_de_champ_public_editor, :publication]
 
   validates :draft_types_de_champ_private,

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -461,7 +461,9 @@ class TypeDeChamp < ApplicationRecord
     !private?
   end
 
-  def france_connect? = type_champ.in?(API_PART_FC_TDC)
+  def france_connect? = type_champ.in?([*API_PART_FC_TDC])
+
+  def api_particulier? = type_champ.in?(API_PART_FC_TDC)
 
   def child?(revision)
     revision.coordinate_for(self)&.child?

--- a/app/validators/types_de_champ/api_particulier_validator.rb
+++ b/app/validators/types_de_champ/api_particulier_validator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class TypesDeChamp::APIParticulierValidator < ActiveModel::EachValidator
+  def validate_each(procedure, attribute, types_de_champ)
+    types_de_champ.filter(&:api_particulier?).each do |api_part_tdc|
+      validate_api_particulier_token_presence(procedure, attribute, api_part_tdc)
+    end
+  end
+
+  private
+
+  def validate_api_particulier_token_presence(procedure, attribute, api_part_tdc)
+    if procedure.api_particulier_token.nil?
+      procedure.errors.add(
+        attribute,
+        :missing_api_particulier_token,
+        value: api_part_tdc.libelle,
+        type_de_champ: api_part_tdc
+      )
+    end
+  end
+end

--- a/app/validators/types_de_champ/api_particulier_validator.rb
+++ b/app/validators/types_de_champ/api_particulier_validator.rb
@@ -10,7 +10,7 @@ class TypesDeChamp::APIParticulierValidator < ActiveModel::EachValidator
   private
 
   def validate_api_particulier_token_presence(procedure, attribute, api_part_tdc)
-    if procedure.api_particulier_token.nil?
+    if procedure.api_particulier_token.blank?
       procedure.errors.add(
         attribute,
         :missing_api_particulier_token,

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -96,6 +96,7 @@ en:
               missing_libelle_in_repetition: "field label in position %{position}, within the repetition in position %{parent_position}, must be filled"
               expression_reguliere_invalid: "is invalid"
               referentiel_not_ready: "is not configured"
+              missing_api_particulier_token: "does not work without a API Particulier token"
             draft_types_de_champ_private:
               format: 'Private field %{message}'
               invalid_condition: "have an invalid logic"

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -103,6 +103,7 @@ fr:
               missing_libelle_in_repetition: "Le libellé du champ en position %{position}, dans le bloc répétable en position %{parent_position}, doit être rempli"
               expression_reguliere_invalid: "est invalide, veuillez la corriger"
               referentiel_not_ready: "n’est pas configuré"
+              missing_api_particulier_token: "n'est pas fonctionnel en l'absence d'un jeton API Particulier"
             draft_types_de_champ_private:
               format: 'L’annotation privée %{message}'
               invalid_condition: "a une logique conditionnelle invalide"

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -103,7 +103,7 @@ fr:
               missing_libelle_in_repetition: "Le libellé du champ en position %{position}, dans le bloc répétable en position %{parent_position}, doit être rempli"
               expression_reguliere_invalid: "est invalide, veuillez la corriger"
               referentiel_not_ready: "n’est pas configuré"
-              missing_api_particulier_token: "n'est pas fonctionnel en l'absence d'un jeton API Particulier"
+              missing_api_particulier_token: "n’est pas fonctionnel en l’absence d’un jeton API Particulier"
             draft_types_de_champ_private:
               format: 'L’annotation privée %{message}'
               invalid_condition: "a une logique conditionnelle invalide"

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -988,7 +988,7 @@ RSpec.describe DossierChampsConcern do
   end
 
   describe '#set_default_value_for_france_connect_champs' do
-    let!(:procedure) { create(:procedure, :published, types_de_champ_public:, for_individual: true) }
+    let!(:procedure) { create(:procedure, :published, :with_api_particulier_token, types_de_champ_public:, for_individual: true) }
     let(:types_de_champ_public) { [{ type: :quotient_familial }] }
     let(:dossier) { create(:dossier, procedure:, for_procedure_preview: false, for_tiers: false) }
     let(:champ_qf) { dossier.champs.first }

--- a/spec/validators/types_de_champ/api_particulier_validator_spec.rb
+++ b/spec/validators/types_de_champ/api_particulier_validator_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe TypesDeChamp::APIParticulierValidator do
+  subject { procedure.validate(:types_de_champ_public_editor) }
+
+  context 'when procedure has a API Particulier champ and a API Particulier token' do
+    let(:procedure) { create(:procedure, :with_api_particulier_token, types_de_champ_public:) }
+    let(:types_de_champ_public) { [{ type: :quotient_familial }] }
+
+    it 'does not add errors to the procedure' do
+      subject
+      expect(procedure.errors).to be_empty
+    end
+  end
+
+  context 'when procedure has a API Particulier champ but no API Particulier token' do
+    let(:procedure) { create(:procedure, types_de_champ_public:) }
+    let(:types_de_champ_public) { [{ type: :quotient_familial }] }
+
+    it 'adds errors to the procedure' do
+      subject
+      expect(procedure.errors.details[:draft_types_de_champ_public])
+        .to include(hash_including(error: :missing_api_particulier_token))
+    end
+  end
+end


### PR DESCRIPTION
Suite à l'ouverture complète de la feature Quotient familial, il convient de mettre un garde fou sur la présence d'un token API Part, afin d'éviter que le champ fonctionne en mode dégradé. Pour cela :
- on ajoute un bandeau qui attire l'attention sur le fait qu'un token est nécessaire dans le composant editor ;
- on ajoute un validateur qui vient bloquer la publication si il y a présence d'un champ api part dans la procédure sans que celle-ci ait un jeton API Part.

<img width="1336" height="848" alt="Capture d’écran 2026-06-29 à 17 02 27" src="https://github.com/user-attachments/assets/d26d7650-83a0-4109-a5f1-877c6d078c7f" />
<img width="1336" height="848" alt="Capture d’écran 2026-06-29 à 17 02 46" src="https://github.com/user-attachments/assets/8e4f0050-41df-46cd-9edc-73b007e3829f" />
<img width="1336" height="848" alt="Capture d’écran 2026-06-29 à 17 02 55" src="https://github.com/user-attachments/assets/f34ec3bf-549f-463b-a1b4-aab8a874ff10" />

NB)
- la bonne mise en forme du texte dans dans les fichiers de trad viendront dans le gros refacto qui accompagne l'arrivée des nouveaux endpoints ;
- pour aller plus loin sur cette idée de s'assurer que la procédure dispose des bons droits au regard des champs, dans la foulée de l'arrivée de nouveaux endpoints, on pourrait regarder plus précisément ce que propose comme droits le jeton et si cela est bien cohérent avec le formulaire : https://particulier.api.gouv.fr/api/introspect?token=LeTokenATester