### PR TITLE
Tech: fiabilise le test système « adding a dropdown champ »

### DIFF
--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -245,12 +245,20 @@ describe 'As an administrateur I can edit types de champ', js: true do
     add_champ
     hide_autonotice_message
 
+    # Each autosave responds with a `turbo_stream.replace` of the whole champ editor,
+    # so a field whose value is not yet persisted gets wiped when a previous save's
+    # response lands. We therefore wait for each field to be persisted before editing
+    # the next one, to avoid concurrent saves racing each other (debounce is 0 in test).
     select('Choix simple', from: 'Type de champ')
-    fill_in 'Libellé du champ', with: 'Libellé de champ menu déroulant', fill_options: { clear: :backspace }
-    fill_in 'Options de la liste', with: 'Un menu', fill_options: { clear: :backspace }
-    check "Proposer une option « autre » avec un texte libre"
+    wait_until { procedure.active_revision.reload.types_de_champ_public.first.drop_down_list? }
 
+    fill_in 'Libellé du champ', with: 'Libellé de champ menu déroulant', fill_options: { clear: :backspace }
+    wait_until { procedure.active_revision.reload.types_de_champ_public.first.libelle == 'Libellé de champ menu déroulant' }
+
+    fill_in 'Options de la liste', with: 'Un menu', fill_options: { clear: :backspace }
     wait_until { procedure.active_revision.reload.types_de_champ_public.first.drop_down_options == ['Un menu'] }
+
+    check "Proposer une option « autre » avec un texte libre"
     wait_until { procedure.active_revision.reload.types_de_champ_public.first.drop_down_other == "1" }
     expect(page).to have_content('Formulaire enregistré')
 


### PR DESCRIPTION
## Contexte

Le test système `spec/system/administrateurs/types_de_champ_spec.rb:244` (« adding a dropdown champ ») était flaky.

## Cause

Chaque autosave de l'éditeur de champs répond par un `turbo_stream.replace` du bloc éditeur entier (`_insert.turbo_stream.haml`) : une valeur saisie mais pas encore persistée est écrasée quand la réponse d'une sauvegarde voisine arrive. En environnement de test `debounce_delay = 0`, remplir le libellé puis les options coup sur coup déclenche deux sauvegardes quasi simultanées dont les `replace` se télescopent, et le textarea des options était parfois relu vide.

## Correctif

Sérialiser les interactions : attendre que chaque champ soit persisté en base avant d'éditer le suivant. Une fois un champ persisté, les `replace` ultérieurs le conservent. Changement limité au test.