### PR TITLE
Tech: suppression du feature flag pdf_variant

### DIFF
--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -21,7 +21,7 @@ module Administrateurs
         format.pdf do
           html = render_to_string('/administrateurs/attestation_template_v2s/show', layout: 'attestation', formats: [:html])
 
-          options = { procedure_id: @procedure.id, path: request.path, user_id: current_user.id, pdf_variant: WeasyprintService::PDF_UA_VARIANT }
+          options = { procedure_id: @procedure.id, path: request.path, user_id: current_user.id }
 
           pdf = WeasyprintService.generate_pdf(html, options)
 

--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -21,8 +21,7 @@ module Administrateurs
         format.pdf do
           html = render_to_string('/administrateurs/attestation_template_v2s/show', layout: 'attestation', formats: [:html])
 
-          options = { procedure_id: @procedure.id, path: request.path, user_id: current_user.id }
-          options[:pdf_variant] = WeasyprintService::PDF_UA_VARIANT if @procedure.feature_enabled?(:pdf_variant)
+          options = { procedure_id: @procedure.id, path: request.path, user_id: current_user.id, pdf_variant: WeasyprintService::PDF_UA_VARIANT }
 
           pdf = WeasyprintService.generate_pdf(html, options)
 

--- a/app/controllers/concerns/groupe_instructeurs_signature_concern.rb
+++ b/app/controllers/concerns/groupe_instructeurs_signature_concern.rb
@@ -37,7 +37,7 @@ module GroupeInstructeursSignatureConcern
 
       html = render_to_string('/administrateurs/attestation_template_v2s/show', layout: 'attestation', formats: [:html])
 
-      options = { procedure_id: procedure.id, path: request.path, pdf_variant: WeasyprintService::PDF_UA_VARIANT }
+      options = { procedure_id: procedure.id, path: request.path }
 
       pdf = WeasyprintService.generate_pdf(html, options)
       send_data(pdf, filename: 'attestation.pdf', type: 'application/pdf', disposition: 'inline')

--- a/app/controllers/concerns/groupe_instructeurs_signature_concern.rb
+++ b/app/controllers/concerns/groupe_instructeurs_signature_concern.rb
@@ -37,8 +37,7 @@ module GroupeInstructeursSignatureConcern
 
       html = render_to_string('/administrateurs/attestation_template_v2s/show', layout: 'attestation', formats: [:html])
 
-      options = { procedure_id: procedure.id, path: request.path }
-      options[:pdf_variant] = WeasyprintService::PDF_UA_VARIANT if procedure.feature_enabled?(:pdf_variant)
+      options = { procedure_id: procedure.id, path: request.path, pdf_variant: WeasyprintService::PDF_UA_VARIANT }
 
       pdf = WeasyprintService.generate_pdf(html, options)
       send_data(pdf, filename: 'attestation.pdf', type: 'application/pdf', disposition: 'inline')

--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -242,8 +242,7 @@ class AttestationTemplate < ApplicationRecord
       assigns: { attestation_template: self, body:, signature: }
     )
 
-    options = { procedure_id: procedure.id, dossier_id: dossier.id }
-    options[:pdf_variant] = WeasyprintService::PDF_UA_VARIANT if procedure.feature_enabled?(:pdf_variant)
+    options = { procedure_id: procedure.id, dossier_id: dossier.id, pdf_variant: WeasyprintService::PDF_UA_VARIANT }
 
     WeasyprintService.generate_pdf(html, options)
   end

--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -242,7 +242,7 @@ class AttestationTemplate < ApplicationRecord
       assigns: { attestation_template: self, body:, signature: }
     )
 
-    options = { procedure_id: procedure.id, dossier_id: dossier.id, pdf_variant: WeasyprintService::PDF_UA_VARIANT }
+    options = { procedure_id: procedure.id, dossier_id: dossier.id }
 
     WeasyprintService.generate_pdf(html, options)
   end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -871,8 +871,7 @@ class Dossier < ApplicationRecord
       assigns: { dossier: self }
     )
 
-    options = { procedure_id: procedure.id, dossier_id: id }
-    options[:pdf_variant] = WeasyprintService::PDF_UA_VARIANT if procedure.feature_enabled?(:pdf_variant)
+    options = { procedure_id: procedure.id, dossier_id: id, pdf_variant: WeasyprintService::PDF_UA_VARIANT }
 
     pdf = WeasyprintService.generate_pdf(html, options)
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -871,7 +871,7 @@ class Dossier < ApplicationRecord
       assigns: { dossier: self }
     )
 
-    options = { procedure_id: procedure.id, dossier_id: id, pdf_variant: WeasyprintService::PDF_UA_VARIANT }
+    options = { procedure_id: procedure.id, dossier_id: id }
 
     pdf = WeasyprintService.generate_pdf(html, options)
 

--- a/app/services/weasyprint_service.rb
+++ b/app/services/weasyprint_service.rb
@@ -13,7 +13,7 @@ class WeasyprintService
 
     body = {
       html:,
-      upstream_context: options,
+      upstream_context: { pdf_variant: PDF_UA_VARIANT, **options },
     }.to_json
 
     response = Typhoeus.post(WEASYPRINT_URL, headers:, body:)

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -39,7 +39,6 @@ features = [
   :llm_nightly_improve_procedure,
   :ami_notifications,
   :api_entreprise_tva_job,
-  :pdf_variant,
   :usager_dossiers_alert_filters,
   :s3_storage,
 ]

--- a/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
@@ -125,17 +125,10 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
         is_expected.to eq('PDF_DATA')
       end
 
-      context 'when the pdf_variant feature is enabled' do
-        before do
-          Flipper.enable(:pdf_variant, procedure)
-          allow(WeasyprintService).to receive(:generate_pdf).and_return('PDF_DATA')
-        end
-
-        it 'requests the pdf/ua-1 variant through the options' do
-          subject
-          expect(WeasyprintService).to have_received(:generate_pdf)
-            .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
-        end
+      it 'requests the pdf/ua-1 variant through the options' do
+        subject
+        expect(WeasyprintService).to have_received(:generate_pdf)
+          .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
       end
     end
   end

--- a/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
@@ -124,12 +124,6 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
       it do
         is_expected.to eq('PDF_DATA')
       end
-
-      it 'requests the pdf/ua-1 variant through the options' do
-        subject
-        expect(WeasyprintService).to have_received(:generate_pdf)
-          .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
-      end
     end
   end
 

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -1504,12 +1504,6 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         expect(response).to have_http_status(:ok)
         expect(WeasyprintService).to have_received(:generate_pdf)
       end
-
-      it 'requests the pdf/ua-1 variant through the options' do
-        subject
-        expect(WeasyprintService).to have_received(:generate_pdf)
-          .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
-      end
     end
   end
 end

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -1505,14 +1505,10 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         expect(WeasyprintService).to have_received(:generate_pdf)
       end
 
-      context 'when the pdf_variant feature is enabled' do
-        before { Flipper.enable(:pdf_variant, procedure) }
-
-        it 'requests the pdf/ua-1 variant through the options' do
-          subject
-          expect(WeasyprintService).to have_received(:generate_pdf)
-            .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
-        end
+      it 'requests the pdf/ua-1 variant through the options' do
+        subject
+        expect(WeasyprintService).to have_received(:generate_pdf)
+          .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
       end
     end
   end

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -2061,19 +2061,13 @@ describe Users::DossiersController, type: :controller do
       it 'calls WeasyPrint with the correct context' do
         subject
         expect(WeasyprintService).to have_received(:generate_pdf)
-          .with(a_string_matching(/#{dossier.procedure.libelle}/), { procedure_id: dossier.procedure.id, dossier_id: dossier.id, pdf_variant: 'pdf/ua-1' })
+          .with(a_string_matching(/#{dossier.procedure.libelle}/), { procedure_id: dossier.procedure.id, dossier_id: dossier.id })
       end
 
       it 'includes dossier identity in the HTML' do
         subject
         expect(WeasyprintService).to have_received(:generate_pdf)
           .with(a_string_matching(/#{dossier.individual.prenom}/), anything)
-      end
-
-      it 'requests the pdf/ua-1 variant through the options' do
-        subject
-        expect(WeasyprintService).to have_received(:generate_pdf)
-          .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
       end
     end
 

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -2061,7 +2061,7 @@ describe Users::DossiersController, type: :controller do
       it 'calls WeasyPrint with the correct context' do
         subject
         expect(WeasyprintService).to have_received(:generate_pdf)
-          .with(a_string_matching(/#{dossier.procedure.libelle}/), { procedure_id: dossier.procedure.id, dossier_id: dossier.id })
+          .with(a_string_matching(/#{dossier.procedure.libelle}/), { procedure_id: dossier.procedure.id, dossier_id: dossier.id, pdf_variant: 'pdf/ua-1' })
       end
 
       it 'includes dossier identity in the HTML' do
@@ -2070,14 +2070,10 @@ describe Users::DossiersController, type: :controller do
           .with(a_string_matching(/#{dossier.individual.prenom}/), anything)
       end
 
-      context 'when the pdf_variant feature is enabled' do
-        before { Flipper.enable(:pdf_variant, dossier.procedure) }
-
-        it 'requests the pdf/ua-1 variant through the options' do
-          subject
-          expect(WeasyprintService).to have_received(:generate_pdf)
-            .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
-        end
+      it 'requests the pdf/ua-1 variant through the options' do
+        subject
+        expect(WeasyprintService).to have_received(:generate_pdf)
+          .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
       end
     end
 

--- a/spec/models/attestation_template_spec.rb
+++ b/spec/models/attestation_template_spec.rb
@@ -182,7 +182,7 @@ describe AttestationTemplate, type: :model do
         stub_request(:post, WEASYPRINT_URL)
           .with(body: {
             html: /Ministère des specs.+Mon titre pour #{procedure.libelle}.+Dossier: n° #{dossier.id}/m,
-            upstream_context: { procedure_id: procedure.id, dossier_id: dossier.id },
+            upstream_context: { procedure_id: procedure.id, dossier_id: dossier.id, pdf_variant: 'pdf/ua-1' },
           })
           .to_return(body: 'PDF_DATA')
       end
@@ -191,17 +191,11 @@ describe AttestationTemplate, type: :model do
         expect(subject.pdf).to be_attached
       end
 
-      context 'when the pdf_variant feature is enabled' do
-        before do
-          Flipper.enable(:pdf_variant, procedure)
-          allow(WeasyprintService).to receive(:generate_pdf).and_return('PDF_DATA')
-        end
-
-        it 'requests the pdf/ua-1 variant through the options' do
-          subject
-          expect(WeasyprintService).to have_received(:generate_pdf)
-            .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
-        end
+      it 'requests the pdf/ua-1 variant through the options' do
+        allow(WeasyprintService).to receive(:generate_pdf).and_return('PDF_DATA')
+        subject
+        expect(WeasyprintService).to have_received(:generate_pdf)
+          .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
       end
     end
   end

--- a/spec/models/attestation_template_spec.rb
+++ b/spec/models/attestation_template_spec.rb
@@ -190,13 +190,6 @@ describe AttestationTemplate, type: :model do
       it 'generates an attestation' do
         expect(subject.pdf).to be_attached
       end
-
-      it 'requests the pdf/ua-1 variant through the options' do
-        allow(WeasyprintService).to receive(:generate_pdf).and_return('PDF_DATA')
-        subject
-        expect(WeasyprintService).to have_received(:generate_pdf)
-          .with(anything, hash_including(pdf_variant: 'pdf/ua-1'))
-      end
     end
   end
 

--- a/spec/services/weasyprint_service_spec.rb
+++ b/spec/services/weasyprint_service_spec.rb
@@ -3,18 +3,26 @@
 describe WeasyprintService do
   let(:html) { '<html><body>Hello, World!</body></html>' }
   let(:options) { { procedure_id: 1, dossier_id: 2 } }
+  let(:expected_context) { { pdf_variant: 'pdf/ua-1', **options } }
 
   describe '#generate_pdf' do
     context 'when the Weasyprint API responds successfully' do
       before do
         stub_request(:post, WEASYPRINT_URL)
-          .with(body: { html: html, upstream_context: options })
+          .with(body: { html:, upstream_context: expected_context })
           .to_return(body: 'PDF_DATA')
       end
 
       it 'returns the PDF data' do
         pdf = described_class.generate_pdf(html, options)
         expect(pdf).to eq('PDF_DATA')
+      end
+
+      it 'requests the PDF/UA variant by default' do
+        described_class.generate_pdf(html, options)
+        expect(
+          a_request(:post, WEASYPRINT_URL).with(body: { html:, upstream_context: expected_context })
+        ).to have_been_made
       end
     end
 


### PR DESCRIPTION
Le feature flag `pdf_variant` est désormais activé globalement en production. Cette PR le supprime : le variant PDF/UA devient le comportement par défaut pour tous les PDF générés via WeasyPrint (attestations v2 et attestation de dépôt).