### PR TITLE
Tech: purge silencieuse des brouillons expirés jamais notifiés

### DIFF
--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -36,7 +36,7 @@ class Avis < ApplicationRecord
   scope :for_dossier, -> (dossier_id) { where(dossier_id: dossier_id) }
   scope :by_latest, -> { order(updated_at: :desc) }
   scope :updated_since?, -> (date) { where('avis.updated_at > ?', date) }
-  scope :termine_expired, -> { unscope(:joins).where(dossier: Dossier.termine_expired) }
+  scope :termine_expired_after_notice_grace, -> { unscope(:joins).where(dossier: Dossier.termine_expired_after_notice_grace) }
   scope :not_hidden_by_administration, -> { where(dossiers: { hidden_by_administration_at: nil }) }
   scope :not_revoked, -> { where(revoked_at: nil) }
   scope :not_termine, -> { where.not(dossiers: { state: Dossier::TERMINE }) }

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -357,7 +357,7 @@ class Dossier < ApplicationRecord
   scope :brouillon_expired_without_notice, -> do
     state_brouillon
       .where(expired_at: ..Time.zone.now)
-      .where(hidden_by_user_at: nil, hidden_by_expired_at: nil)
+      .where(hidden_by_user_at: nil)
       .joins(:procedure)
       .where("dossiers.for_procedure_preview = TRUE OR procedures.aasm_state IN (?)", %w[close brouillon])
   end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1031,21 +1031,17 @@ class Dossier < ApplicationRecord
   end
 
   def purge_discarded
-    transaction do
+    purge_freeing_champs_cascade do
       DeletedDossier.create_from_dossier(self, hidden_by_reason)
       dossier_operation_logs.purge_discarded
-      # Vider les champs par lots libère leur cascade (geo_areas, etablissement,
-      # AS attachments) avant le destroy du dossier, évitant le pic mémoire dû
-      # au chargement complet de la cascade dependent: :destroy.
-      # Important: destroy_all (et non delete_all) preserve les callbacks Rails.
-      champs.in_batches(of: 50).each(&:destroy_all)
-      destroy
-    rescue => e
-      Sentry.capture_exception(e, extra: { dossier: id })
-      # Rollback explicite : sans cela, le rescue avale l'erreur et la transaction
-      # commit un état partiel (champs deja batch-destroy, dossier intact).
-      raise ActiveRecord::Rollback
     end
+  end
+
+  # Suppression silencieuse d'un brouillon expiré jamais notifié (preview ou
+  # procédure non-notifiable). Pas de DeletedDossier ni d'email, comme la
+  # suppression de brouillon existante.
+  def purge_without_notice
+    purge_freeing_champs_cascade
   end
 
   def skip_user_notification_email?
@@ -1133,6 +1129,24 @@ class Dossier < ApplicationRecord
   end
 
   private
+
+  # Détruit le dossier en libérant la cascade des champs (geo_areas, etablissement,
+  # AS attachments) par lots de 50 avant le destroy, évitant le pic mémoire dû au
+  # chargement complet de la cascade dependent: :destroy. Le bloc optionnel exécute
+  # la traçabilité (DeletedDossier, operation logs) dans la même transaction.
+  # Important: destroy_all (et non delete_all) preserve les callbacks Rails.
+  def purge_freeing_champs_cascade
+    transaction do
+      yield if block_given?
+      champs.in_batches(of: 50).each(&:destroy_all)
+      destroy
+    rescue => e
+      Sentry.capture_exception(e, extra: { dossier: id })
+      # Rollback explicite : sans cela, le rescue avale l'erreur et la transaction
+      # commit un état partiel (champs deja batch-destroy, dossier intact).
+      raise ActiveRecord::Rollback
+    end
+  end
 
   def build_default_champs
     build_default_champs_for(revision.types_de_champ_public) if !champs.any?(&:public?)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -353,6 +353,15 @@ class Dossier < ApplicationRecord
       .visible_by_user
       .where(brouillon_close_to_expiration_notice_sent_at: ...(Time.zone.now - Expired::REMAINING_WEEKS_BEFORE_EXPIRATION.weeks))
   end
+
+  scope :brouillon_expired_without_notice, -> do
+    state_brouillon
+      .where(expired_at: ..Time.zone.now)
+      .where(hidden_by_user_at: nil, hidden_by_expired_at: nil)
+      .joins(:procedure)
+      .where("dossiers.for_procedure_preview = TRUE OR procedures.aasm_state IN (?)", %w[close brouillon])
+  end
+
   scope :termine_expired, -> do
     state_termine
       .visible_by_user_or_administration

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -348,7 +348,7 @@ class Dossier < ApplicationRecord
   end
 
   scope :never_touched_brouillon_expired, -> { visible_by_user.brouillon.where.missing(:etablissement, :individual).where(last_champ_updated_at: nil, identity_updated_at: nil, parent_dossier: nil, last_commentaire_updated_at: nil).where(created_at: ..2.weeks.ago) }
-  scope :brouillon_expired, -> do
+  scope :brouillon_expired_after_notice_grace, -> do
     state_brouillon
       .visible_by_user
       .where(brouillon_close_to_expiration_notice_sent_at: ...(Time.zone.now - Expired::REMAINING_WEEKS_BEFORE_EXPIRATION.weeks))
@@ -362,7 +362,7 @@ class Dossier < ApplicationRecord
       .where("dossiers.for_procedure_preview = TRUE OR procedures.aasm_state IN (?)", %w[close brouillon])
   end
 
-  scope :termine_expired, -> do
+  scope :termine_expired_after_notice_grace, -> do
     state_termine
       .visible_by_user_or_administration
       .where(termine_close_to_expiration_notice_sent_at: ...(Time.zone.now - Expired::REMAINING_WEEKS_BEFORE_EXPIRATION.weeks))

--- a/app/models/dossier_operation_log.rb
+++ b/app/models/dossier_operation_log.rb
@@ -24,8 +24,8 @@ class DossierOperationLog < ApplicationRecord
 
   scope :not_deletion, -> { where.not(operation: operations.fetch(:supprimer)) }
   scope :with_data, -> { where.not(data: nil) }
-  scope :brouillon_expired, -> { where(dossier: Dossier.brouillon_expired).not_deletion }
-  scope :termine_expired, -> { where(dossier: Dossier.termine_expired).not_deletion }
+  scope :brouillon_expired_after_notice_grace, -> { where(dossier: Dossier.brouillon_expired_after_notice_grace).not_deletion }
+  scope :termine_expired_after_notice_grace, -> { where(dossier: Dossier.termine_expired_after_notice_grace).not_deletion }
 
   def move_to_cold_storage!
     if data.present?

--- a/app/services/expired/dossiers_deletion_service.rb
+++ b/app/services/expired/dossiers_deletion_service.rb
@@ -8,6 +8,7 @@ class Expired::DossiersDeletionService < Expired::MailRateLimiter
   def process_expired_dossiers_brouillon
     send_brouillon_expiration_notices
     delete_expired_brouillons_and_notify
+    delete_expired_brouillons_without_notice
   end
 
   def process_expired_dossiers_termine
@@ -62,6 +63,10 @@ class Expired::DossiersDeletionService < Expired::MailRateLimiter
       )
       send_with_delay(mail)
     end
+  end
+
+  def delete_expired_brouillons_without_notice
+    Dossier.brouillon_expired_without_notice.in_batches.destroy_all
   end
 
   def delete_expired_termine_and_notify

--- a/app/services/expired/dossiers_deletion_service.rb
+++ b/app/services/expired/dossiers_deletion_service.rb
@@ -51,10 +51,10 @@ class Expired::DossiersDeletionService < Expired::MailRateLimiter
   end
 
   def delete_expired_brouillons_and_notify
-    user_notifications = group_by_user_email(Dossier.brouillon_expired)
+    user_notifications = group_by_user_email(Dossier.brouillon_expired_after_notice_grace)
       .map { |(email, dossiers)| [email, dossiers.map(&:hash_for_deletion_mail)] }
 
-    Dossier.brouillon_expired.in_batches.destroy_all
+    Dossier.brouillon_expired_after_notice_grace.in_batches.destroy_all
 
     user_notifications.each do |(email, dossiers_hash)|
       mail = DossierMailer.notify_brouillon_deletion(
@@ -70,13 +70,13 @@ class Expired::DossiersDeletionService < Expired::MailRateLimiter
   end
 
   def delete_expired_termine_and_notify
-    delete_expired_and_notify(Dossier.termine_expired, notify_on_closed_procedures_to_user: true)
+    delete_expired_and_notify(Dossier.termine_expired_after_notice_grace, notify_on_closed_procedures_to_user: true)
   end
 
   def update_notifications_dossiers_termine
     DossierNotification.create_notifications_for_non_customisable_type(Dossier.termine_close_to_expiration.without_dossier_expirant_notification, :dossier_expirant)
-    DossierNotification.destroy_notifications_by_dossier_and_type(Dossier.termine_expired, :dossier_expirant)
-    DossierNotification.create_notifications_for_non_customisable_type(Dossier.termine_expired, :dossier_suppression)
+    DossierNotification.destroy_notifications_by_dossier_and_type(Dossier.termine_expired_after_notice_grace, :dossier_expirant)
+    DossierNotification.create_notifications_for_non_customisable_type(Dossier.termine_expired_after_notice_grace, :dossier_suppression)
   end
 
   private

--- a/app/services/expired/dossiers_deletion_service.rb
+++ b/app/services/expired/dossiers_deletion_service.rb
@@ -2,6 +2,7 @@
 
 class Expired::DossiersDeletionService < Expired::MailRateLimiter
   BROUILLON_DELETION_EMAILS_LIMIT_PER_DAY = ENV.fetch("BROUILLON_DELETION_EMAILS_LIMIT_PER_DAY", 10_000).to_i
+  BROUILLON_WITHOUT_NOTICE_DELETION_LIMIT_PER_DAY = ENV.fetch("BROUILLON_WITHOUT_NOTICE_DELETION_LIMIT_PER_DAY", 20_000).to_i
 
   def process_never_touched_dossiers_brouillon; delete_never_touched_brouillons; end
 
@@ -66,7 +67,9 @@ class Expired::DossiersDeletionService < Expired::MailRateLimiter
   end
 
   def delete_expired_brouillons_without_notice
-    Dossier.brouillon_expired_without_notice.in_batches.destroy_all
+    Dossier.brouillon_expired_without_notice
+      .limit(BROUILLON_WITHOUT_NOTICE_DELETION_LIMIT_PER_DAY)
+      .in_batches { |batch| batch.each(&:purge_without_notice) }
   end
 
   def delete_expired_termine_and_notify

--- a/spec/models/dossier_purge_spec.rb
+++ b/spec/models/dossier_purge_spec.rb
@@ -66,4 +66,57 @@ describe Dossier, type: :model do
       end
     end
   end
+
+  describe '#purge_without_notice' do
+    let(:dossier) { create(:dossier) }
+
+    it 'destroys the dossier and its champs without creating a DeletedDossier' do
+      expect(DeletedDossier).not_to receive(:create_from_dossier)
+
+      dossier.purge_without_notice
+
+      expect { dossier.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'destroys champs in batches of 50 before destroying the dossier' do
+      expect(dossier.champs).to receive(:in_batches).with(hash_including(of: 50)).at_least(:once).and_call_original
+      dossier.purge_without_notice
+    end
+
+    context 'with multiple champs spanning several in_batches' do
+      let(:procedure) { create(:procedure_with_dossiers, :published) }
+      let(:dossier) { procedure.dossiers.first }
+
+      before do
+        51.times do |i|
+          type_de_champ = create(:type_de_champ_text, procedure:, libelle: "Test #{i}")
+          dossier.champs << type_de_champ.build_champ(value: "value #{i}")
+        end
+        dossier.save!
+      end
+
+      it 'destroys all champs even when count exceeds in_batches size' do
+        expect(dossier.champs.count).to be > 50
+        dossier.purge_without_notice
+        expect(Champ.where(dossier_id: dossier.id)).to be_empty
+      end
+    end
+
+    context 'when destroy raises after champs batching' do
+      let(:procedure) { create(:procedure_with_dossiers, :published) }
+      let(:dossier) { procedure.dossiers.first }
+      let(:type_de_champ) { create(:type_de_champ_text, procedure:, libelle: 'Test') }
+      let!(:champ) { dossier.champs.create!(type_de_champ:, value: 'kept') }
+
+      before do
+        allow(dossier).to receive(:destroy).and_raise(StandardError, 'boom')
+        allow(Sentry).to receive(:capture_exception)
+      end
+
+      it 'rolls back so no champ is destroyed and does not propagate the exception' do
+        expect { dossier.purge_without_notice }.not_to raise_error
+        expect(Champ.where(id: champ.id)).to exist
+      end
+    end
+  end
 end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -140,6 +140,27 @@ describe Dossier, type: :model do
         expect(Dossier.brouillon_expired).to contain_exactly(dossier_brouillon_expired_and_noticed_long_time_ago)
       end
     end
+
+    describe '.brouillon_expired_without_notice' do
+      let(:published_procedure) { create(:procedure, :published) }
+      let(:closed_procedure)    { create(:procedure, :closed) }
+      let(:draft_procedure)     { create(:procedure, :draft) }
+
+      # targets: expired + structurally never notified
+      let!(:expired_on_closed) { create(:dossier, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
+      let!(:expired_on_draft)  { create(:dossier, procedure: draft_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
+      let!(:expired_preview)   { create(:dossier, procedure: published_procedure, for_procedure_preview: true).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
+
+      # non-targets
+      let!(:expired_on_published)  { create(:dossier, procedure: published_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
+      let!(:not_expired_on_closed) { create(:dossier, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.from_now) } }
+      let!(:hidden_on_closed)      { create(:dossier, :hidden_by_user, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
+
+      it 'returns only expired brouillons structurally outside the notice path' do
+        expect(Dossier.brouillon_expired_without_notice)
+          .to contain_exactly(expired_on_closed, expired_on_draft, expired_preview)
+      end
+    end
   end
 
   describe 'validations' do

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -155,10 +155,8 @@ describe Dossier, type: :model do
       let!(:expired_on_published)  { create(:dossier, procedure: published_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
       let!(:not_expired_on_closed) { create(:dossier, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.from_now) } }
       let!(:hidden_on_closed)      { create(:dossier, :hidden_by_user, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
-      # proves hidden_by_expired_at exclusion arm
-      let!(:hidden_expired_on_closed)   { create(:dossier, :hidden_by_expired, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
       # proves state_brouillon gate
-      let!(:en_construction_on_closed)  { create(:dossier, :en_construction, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
+      let!(:en_construction_on_closed) { create(:dossier, :en_construction, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
 
       it 'returns only expired brouillons structurally outside the notice path' do
         expect(Dossier.brouillon_expired_without_notice)

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -155,6 +155,10 @@ describe Dossier, type: :model do
       let!(:expired_on_published)  { create(:dossier, procedure: published_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
       let!(:not_expired_on_closed) { create(:dossier, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.from_now) } }
       let!(:hidden_on_closed)      { create(:dossier, :hidden_by_user, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
+      # proves hidden_by_expired_at exclusion arm
+      let!(:hidden_expired_on_closed)   { create(:dossier, :hidden_by_expired, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
+      # proves state_brouillon gate
+      let!(:en_construction_on_closed)  { create(:dossier, :en_construction, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
 
       it 'returns only expired brouillons structurally outside the notice path' do
         expect(Dossier.brouillon_expired_without_notice)

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -86,7 +86,7 @@ describe Dossier, type: :model do
       end
     end
 
-    describe '.brouillon_expired' do
+    describe '.brouillon_expired_after_notice_grace' do
       let(:interval_between_first_and_second_expiration) { Dossier::MONTHS_AFTER_EXPIRATION.months + Dossier::DAYS_AFTER_EXPIRATION.days }
 
       let!(:dossier_brouillon_expired_and_noticed_long_time_ago) do
@@ -137,7 +137,7 @@ describe Dossier, type: :model do
       end
 
       it 'returns only visible brouillon dossiers whose expiration notice period has passed' do
-        expect(Dossier.brouillon_expired).to contain_exactly(dossier_brouillon_expired_and_noticed_long_time_ago)
+        expect(Dossier.brouillon_expired_after_notice_grace).to contain_exactly(dossier_brouillon_expired_and_noticed_long_time_ago)
       end
     end
 

--- a/spec/services/expired/expired_dossiers_deletion_service_spec.rb
+++ b/spec/services/expired/expired_dossiers_deletion_service_spec.rb
@@ -201,21 +201,6 @@ describe Expired::DossiersDeletionService do
       expect { notifiable_brouillon.reload }.not_to raise_error
     end
 
-    context 'when a brouillon on a closed procedure received a notice within the 2-week grace window' do
-      # Safety invariant: update_expired_at pushes expired_at forward after notice,
-      # so the scope's `expired_at <= now` predicate EXCLUDES it until the grace lapses.
-      let!(:grace_window_brouillon) do
-        create(:dossier, procedure: closed_procedure,
-          brouillon_close_to_expiration_notice_sent_at: (2.weeks - 4.days).ago).tap(&:update_expired_at)
-      end
-
-      it 'is not silently deleted because update_expired_at pushed expired_at into the future' do
-        expect(grace_window_brouillon.reload.expired_at).to be > Time.zone.now # guard: recompute extended expired_at
-        service.delete_expired_brouillons_without_notice
-        expect { grace_window_brouillon.reload }.not_to raise_error
-      end
-    end
-
     context 'when there are more expired brouillons than the per-day limit' do
       let!(:other_expired_on_closed) { create(:dossier, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 2.days.ago) } }
 

--- a/spec/services/expired/expired_dossiers_deletion_service_spec.rb
+++ b/spec/services/expired/expired_dossiers_deletion_service_spec.rb
@@ -47,6 +47,17 @@ describe Expired::DossiersDeletionService do
         expect { expired_brouillon.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+
+    context 'silently drains never-notified expired brouillons' do
+      let(:closed_procedure) { create(:procedure, :closed) }
+      let!(:expired_on_closed) { create(:dossier, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
+
+      before { service.process_expired_dossiers_brouillon }
+
+      it 'destroys them' do
+        expect { expired_on_closed.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 
   describe '#send_brouillon_expiration_notices' do
@@ -162,6 +173,32 @@ describe Expired::DossiersDeletionService do
         expect(DossierMailer).to have_received(:notify_brouillon_deletion).once
         expect(DossierMailer).to have_received(:notify_brouillon_deletion).with(match_array([dossier_1.hash_for_deletion_mail, dossier_2.hash_for_deletion_mail]), user.email)
       end
+    end
+  end
+
+  describe '#delete_expired_brouillons_without_notice' do
+    before { travel_to(reference_date) }
+
+    let(:closed_procedure) { create(:procedure, :closed) }
+    let!(:expired_on_closed)    { create(:dossier, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
+    let!(:notifiable_brouillon) { create(:dossier, procedure: procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
+
+    before do
+      allow(DossierMailer).to receive(:notify_brouillon_deletion).and_call_original
+      allow(DossierMailer).to receive(:notify_brouillon_near_deletion).and_call_original
+    end
+
+    it 'silently deletes never-notified expired brouillons without sending email' do
+      expect { service.delete_expired_brouillons_without_notice }
+        .to change { Dossier.exists?(expired_on_closed.id) }.from(true).to(false)
+
+      expect(DossierMailer).not_to have_received(:notify_brouillon_deletion)
+      expect(DossierMailer).not_to have_received(:notify_brouillon_near_deletion)
+    end
+
+    it 'leaves notifiable brouillons untouched' do
+      service.delete_expired_brouillons_without_notice
+      expect { notifiable_brouillon.reload }.not_to raise_error
     end
   end
 

--- a/spec/services/expired/expired_dossiers_deletion_service_spec.rb
+++ b/spec/services/expired/expired_dossiers_deletion_service_spec.rb
@@ -215,6 +215,17 @@ describe Expired::DossiersDeletionService do
         expect { grace_window_brouillon.reload }.not_to raise_error
       end
     end
+
+    context 'when there are more expired brouillons than the per-day limit' do
+      let!(:other_expired_on_closed) { create(:dossier, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 2.days.ago) } }
+
+      before { stub_const("#{described_class}::BROUILLON_WITHOUT_NOTICE_DELETION_LIMIT_PER_DAY", 1) }
+
+      it 'deletes at most the limit per run' do
+        expect { service.delete_expired_brouillons_without_notice }
+          .to change { Dossier.brouillon_expired_without_notice.count }.by(-1)
+      end
+    end
   end
 
   describe '#send_termine_expiration_notices' do

--- a/spec/services/expired/expired_dossiers_deletion_service_spec.rb
+++ b/spec/services/expired/expired_dossiers_deletion_service_spec.rb
@@ -200,6 +200,21 @@ describe Expired::DossiersDeletionService do
       service.delete_expired_brouillons_without_notice
       expect { notifiable_brouillon.reload }.not_to raise_error
     end
+
+    context 'when a brouillon on a closed procedure received a notice within the 2-week grace window' do
+      # Safety invariant: update_expired_at pushes expired_at forward after notice,
+      # so the scope's `expired_at <= now` predicate EXCLUDES it until the grace lapses.
+      let!(:grace_window_brouillon) do
+        create(:dossier, procedure: closed_procedure,
+          brouillon_close_to_expiration_notice_sent_at: (2.weeks - 4.days).ago).tap(&:update_expired_at)
+      end
+
+      it 'is not silently deleted because update_expired_at pushed expired_at into the future' do
+        expect(grace_window_brouillon.reload.expired_at).to be > Time.zone.now # guard: recompute extended expired_at
+        service.delete_expired_brouillons_without_notice
+        expect { grace_window_brouillon.reload }.not_to raise_error
+      end
+    end
   end
 
   describe '#send_termine_expiration_notices' do


### PR DESCRIPTION
Les brouillons expirés ne sont supprimés que via la chaîne d'email de préavis, bornée par `with_notifiable_procedure` (procédures `publiee`/`depubliee` uniquement). Résultat : les brouillons sur procédures `close`/`brouillon` et les previews ne reçoivent jamais de préavis, donc ne sont jamais supprimés — ~423k dossiers accumulés en prod avec un `expired_at` dépassé depuis des mois.

Ce correctif ajoute un troisième appel **silencieux** (sans email) à `process_expired_dossiers_brouillon`, déjà exécuté chaque nuit par `Cron::ExpiredDossiersBrouillonDeletionJob` — pas de nouveau cron ni job.

- Nouveau scope `Dossier.brouillon_expired_without_notice` : brouillons expirés qui sont des previews ou sur procédure `close`/`brouillon`, hors dossiers déjà cachés. Whitelist positive (`IN`) volontaire : un nouvel état de procédure ne sera jamais supprimé automatiquement sans modification explicite (fail-safe).
- Nouvelle méthode `delete_expired_brouillons_without_notice`.

## Bornage et empreinte mémoire (suite review)

Pour éviter de balayer les ~423k dossiers en une seule passe (timeout) et le pic mémoire de la cascade `dependent: :destroy` sur les champs (déjà corrigé par Colin dans `purge_discarded`, #13185) :

- suppression plafonnée par run via `BROUILLON_WITHOUT_NOTICE_DELETION_LIMIT_PER_DAY` (ENV, défaut **20 000**), sur le modèle de `BROUILLON_DELETION_EMAILS_LIMIT_PER_DAY`. Le backlog se draine sur ~21 nuits, le régime permanent est négligeable ;
- destruction des champs par lots de 50 (libérant la cascade geo_areas/etablissement/pièces jointes AS) avant de détruire le dossier. Cette mécanique (transaction + rescue Sentry + rollback) est factorisée dans un helper privé partagé `Dossier#purge_freeing_champs_cascade`, réutilisé par `purge_discarded` (qui passe sa traçabilité `DeletedDossier` + logs en bloc) et par la nouvelle `purge_without_notice` (sans `DeletedDossier`, cohérent avec la suppression de brouillon existante).

## Inclut aussi : renommage de scopes (refactoring, sans changement de comportement)

Les scopes `brouillon_expired` / `termine_expired` filtraient sur le timestamp du préavis envoyé il y a plus de 2 semaines — le nom cachait qu'ils signifient en réalité « notifié, et le délai de grâce de 2 semaines après le préavis est écoulé ». Renommés en `brouillon_expired_after_notice_grace` / `termine_expired_after_notice_grace` (ainsi que leurs wrappers sur `DossierOperationLog` et `Avis`).