### PR TITLE
Tech: activer le cop RuboCop Style/UnlessLogicalOperators

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1497,6 +1497,10 @@ Style/TrivialAccessors:
 Style/UnlessElse:
   Enabled: true
 
+Style/UnlessLogicalOperators:
+  Enabled: true
+  EnforcedStyle: forbid_logical_operators
+
 Style/RedundantCapitalW:
   Enabled: true
 

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -46,7 +46,7 @@ class AttachmentsController < ApplicationController
     return if user_or_invite_changing_an_attachment?
     return if instructeur_changing_a_private_attachment?
     return if expert_changing_its_avis?
-    return unless champ? || avis?
+    return if !champ? && !avis?
 
     head :not_found
   end

--- a/app/controllers/recherche_controller.rb
+++ b/app/controllers/recherche_controller.rb
@@ -78,7 +78,7 @@ class RechercheController < ApplicationController
   end
 
   def handle_special_cases
-    return false unless instructeur_signed_in? && DossierSearchService.id_compatible?(@search_terms)
+    return false if !instructeur_signed_in? || !DossierSearchService.id_compatible?(@search_terms)
 
     @deleted_dossier = current_instructeur.deleted_dossiers.find_by(dossier_id: @search_terms)
     return true if @deleted_dossier.present?

--- a/app/graphql/mutations/demarche_publier.rb
+++ b/app/graphql/mutations/demarche_publier.rb
@@ -17,7 +17,7 @@ module Mutations
       demarche_number = demarche.number.presence || ApplicationRecord.id_from_typed_id(demarche.id)
       demarche = Procedure.find_by(id: demarche_number)
 
-      unless demarche.present? && context.authorized_demarche?(demarche)
+      if demarche.blank? || !context.authorized_demarche?(demarche)
         return { errors: ["La démarche \"#{demarche_number}\" n'existe pas ou vous n'avez pas le droit de la publier."] }
       end
       if demarche.publiee_or_close?

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -113,7 +113,7 @@ module DossierHelper
   end
 
   def expiration_badge(dossier, html_class: nil)
-    return unless dossier.expirable? && dossier.close_to_expiration?
+    return if !dossier.expirable? || !dossier.close_to_expiration?
 
     tag.span(
       t('views.users.dossiers.dossiers_list.expiration_badge', count: dossier.nb_days_before_expiration),

--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -85,7 +85,7 @@ class AttestationTemplate < ApplicationRecord
     pdf_data = build_pdf(dossier)
 
     # Guard against race condition: dossier state may have changed during PDF generation
-    return unless dossier.reload.accepte? || dossier.refuse?
+    return if !dossier.reload.accepte? && !dossier.refuse?
 
     # Upload the file before creating the attestation: if the upload fails,
     # nothing is persisted, so a retry of the job regenerates the attestation

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -368,7 +368,7 @@ class Champ < ApplicationRecord
 
   def nullify_blank_json_columns
     [:value_json, :data].each do |column|
-      next unless has_attribute?(column) && public_send(:"#{column}_changed?")
+      next if !has_attribute?(column) || !public_send(:"#{column}_changed?")
 
       value = public_send(column)
       self[column] = nil if value.is_a?(Hash) && value.compact.blank?

--- a/app/models/referentiels/api_referentiel.rb
+++ b/app/models/referentiels/api_referentiel.rb
@@ -153,7 +153,7 @@ class Referentiels::APIReferentiel < Referentiel
       errors.add(:url_tiptap, :missing_query_params)
     end
 
-    unless uri.tld == "gouv.fr" && uri.domain != "beta.gouv.fr"
+    if uri.tld != "gouv.fr" || uri.domain == "beta.gouv.fr"
       allowed_hosts = ENV.fetch('ALLOWED_API_DOMAINS_FROM_FRONTEND', '').split(',').filter_map { Addressable::URI.parse(_1).host rescue nil }
       if uri.host.blank? || allowed_hosts.none? { uri.host == _1 || uri.host.end_with?(".#{_1}") }
         errors.add(:url_tiptap, :not_allowed, contact_email: CONTACT_EMAIL)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -944,7 +944,7 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def clean_referentiel
-    return unless persisted? && type_champ_changed? && referentiel_id?
+    return if !persisted? || !type_champ_changed? || !referentiel_id?
     self.referentiel_id = nil
   end
 

--- a/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
@@ -59,7 +59,7 @@ class TypesDeChamp::PrefillRepetitionTypeDeChamp < TypesDeChamp::PrefillTypeDeCh
       row_id = champ.row_ids[index] || champ.add_row(updated_by: nil)
 
       repetition.map do |key, value|
-        next unless key.is_a?(String) && key.starts_with?("champ_")
+        next if !key.is_a?(String) || !key.starts_with?("champ_")
 
         stable_id = Champ.stable_id_from_typed_id(key)
         type_de_champ = revision.types_de_champ.find { _1.stable_id == stable_id }

--- a/app/services/geojson_service.rb
+++ b/app/services/geojson_service.rb
@@ -26,7 +26,7 @@ class GeojsonService
   # longitude: -180 to 180
   # latitude: -90 to 90
   def self.valid_wgs84_coord?(coord)
-    return false unless coord.is_a?(Array) && coord.size >= 2
+    return false if !coord.is_a?(Array) || coord.size < 2
     lng, lat = coord[0], coord[1]
     lng >= -180 && lng <= 180 && lat >= -90 && lat <= 90
   end
@@ -98,7 +98,7 @@ class GeojsonService
   def self.yield_each_coordinate_in_geojson(geojson)
     geometries = geometries_from_geojson(geojson)
     geometries.each do |geometry|
-      next unless geometry && geometry[:type]
+      next if geometry.nil? || geometry[:type].nil?
 
       case geometry[:type]
       when "GeometryCollection"

--- a/app/validators/geo_json_validator.rb
+++ b/app/validators/geo_json_validator.rb
@@ -6,11 +6,11 @@ class GeoJSONValidator < ActiveModel::EachValidator
       record.errors.add(attribute, :blank)
     end
 
-    unless value.blank? || GeojsonService.valid_schema?(value)
+    if value.present? && !GeojsonService.valid_schema?(value)
       record.errors.add(attribute, :invalid_geometry)
     end
 
-    unless value.blank? || GeojsonService.valid_wgs84_coordinates?(value)
+    if value.present? && !GeojsonService.valid_wgs84_coordinates?(value)
       record.errors.add(attribute, :invalid_crs)
     end
   end

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -57,7 +57,7 @@ class URLValidator < ActiveModel::EachValidator
   def validate_url(record, attribute, value, message, schemes)
     uri = Addressable::URI.parse(value)
 
-    unless options.fetch(:accept_email) && uri.path.match?(/^(.+)@(.+)$/)
+    if !options.fetch(:accept_email) || !uri.path.match?(/^(.+)@(.+)$/)
       host = uri && uri.host
       scheme = uri && uri.scheme
 
@@ -65,7 +65,7 @@ class URLValidator < ActiveModel::EachValidator
       valid_no_local = !options.fetch(:no_local) || (host && host.include?('.'))
       valid_suffix = !options.fetch(:public_suffix) || (host && PublicSuffix.valid?(host, default_rule: nil))
 
-      unless valid_scheme && valid_no_local && valid_suffix
+      if !valid_scheme || !valid_no_local || !valid_suffix
         record.errors.add(attribute, message, **filtered_options(value))
       end
     end


### PR DESCRIPTION
# Problème

`unless` combiné avec des opérateurs logiques (`&&`, `||`) rend les conditions difficiles à lire — il faut mentalement appliquer les lois de De Morgan pour comprendre le flow. C'est un retour récurrent en code review (cf. [commentaire de colinux sur #13357](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/13357#discussion_r3490083368)).

# Solution

Activation du cop `Style/UnlessLogicalOperators` avec le style `forbid_logical_operators` et correction des 15 occurrences existantes.

Chaque `unless` avec opérateur logique est réécrit en `if` avec conditions inversées (De Morgan), en privilégiant les prédicats positifs quand possible (`.blank?` plutôt que `!.present?`, `.nil?` plutôt que `!`).

Generated with [Claude Code](https://claude.com/claude-code)