### PR TITLE
Tech: optimiser les tests de attachment_row_component_spec

### DIFF
--- a/spec/components/attachment/attachment_row_component_spec.rb
+++ b/spec/components/attachment/attachment_row_component_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Attachment::AttachmentRowComponent, type: :component do
-  let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
-  let(:types_de_champ_public) { [{ type: :piece_justificative, nature: 'titre_identite' }] }
+  let_it_be(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative, nature: 'titre_identite' }]) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
   let(:champ) { dossier.champs.first }
   let(:attached_file) { champ.piece_justificative_file }


### PR DESCRIPTION
# Probleme

Tests lents dans `spec/components/attachment/attachment_row_component_spec.rb` — temps baseline : 2.37s (mediane locale, 3 runs).

# Solution

Skill [`/test-optimization`](https://github.com/mfo/night-shift/blob/main/.claude/skills/test-optimization/SKILL.md)

### Techniques appliquees

| Technique | Avant | Apres | Gain |
|-----------|-------|-------|------|
| T08 let_it_be (procedure) | 2.37s | 1.53s | -35% |

### Techniques tentees sans succes

| Technique | Raison |
|-----------|--------|
| T09 aggregate_failures | Gain < seuil (seuls 2 tests top-level fusionnables, setup trop leger) |

**Resultat final : 2.37s → 1.53s (gain total 35%)**

Coverage : 38.24% → 38.24% (maintenue)

Generated with [Claude Code](https://claude.com/claude-code)