### PR TITLE
Tech: extraire les textes en dur de ExpertMailer vers i18n

### DIFF
--- a/app/mailers/expert_mailer.rb
+++ b/app/mailers/expert_mailer.rb
@@ -9,7 +9,7 @@ class ExpertMailer < ApplicationMailer
     @dossier = @avis.dossier
     email = @avis.expert.email
     @decision = decision_dossier(@dossier)
-    subject = "Dossier n° #{@dossier.id} a été #{@decision} - #{@dossier.procedure.libelle}"
+    subject = I18n.t("expert_mailer.send_dossier_decision.subject", id: @dossier.id, decision: @decision, libelle: @dossier.procedure.libelle)
 
     mail(to: email, subject: subject)
   end
@@ -19,7 +19,7 @@ class ExpertMailer < ApplicationMailer
     @dossier = @avis.dossier
     email = @avis.expert.email
     @decision = decision_dossier(@dossier)
-    subject = "Dossier n° #{@dossier.id} a été #{@decision} - #{@dossier.procedure.libelle}"
+    subject = I18n.t("expert_mailer.send_dossier_decision.subject", id: @dossier.id, decision: @decision, libelle: @dossier.procedure.libelle)
 
     mail(template_name: 'send_dossier_decision', to: email, subject: subject)
   end
@@ -31,10 +31,10 @@ end
 
 def decision_dossier(dossier)
   if dossier.accepte?
-    'accepté'
+    I18n.t("expert_mailer.send_dossier_decision.decision.accepte")
   elsif dossier.sans_suite?
-    'classé sans suite'
+    I18n.t("expert_mailer.send_dossier_decision.decision.sans_suite")
   elsif dossier.refuse?
-    'refusé'
+    I18n.t("expert_mailer.send_dossier_decision.decision.refuse")
   end
 end

--- a/config/locales/views/expert_mailer/en.yml
+++ b/config/locales/views/expert_mailer/en.yml
@@ -1,0 +1,8 @@
+en:
+  expert_mailer:
+    send_dossier_decision:
+      subject: "File no. %{id} has been %{decision} - %{libelle}"
+      decision:
+        accepte: "accepted"
+        sans_suite: "closed without follow-up"
+        refuse: "refused"

--- a/config/locales/views/expert_mailer/fr.yml
+++ b/config/locales/views/expert_mailer/fr.yml
@@ -1,0 +1,8 @@
+fr:
+  expert_mailer:
+    send_dossier_decision:
+      subject: "Dossier n° %{id} a été %{decision} - %{libelle}"
+      decision:
+        accepte: "accepté"
+        sans_suite: "classé sans suite"
+        refuse: "refusé"


### PR DESCRIPTION
# Probleme

Textes francais en dur dans `app/mailers/expert_mailer.rb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 5 cles i18n vers `config/locales/views/expert_mailer/`.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `expert_mailer.send_dossier_decision.subject` | "Dossier n° %{id} a été %{decision} - %{libelle}" | "File no. %{id} has been %{decision} - %{libelle}" |
| `expert_mailer.send_dossier_decision.decision.accepte` | "accepté" | "accepted" |
| `expert_mailer.send_dossier_decision.decision.sans_suite` | "classé sans suite" | "closed without follow-up" |
| `expert_mailer.send_dossier_decision.decision.refuse` | "refusé" | "refused" |

### Validation visuelle — SKIP

Le mailer preview (`/rails/mailers/expert_mailer/send_dossier_decision`) crash avec `ActiveModel::UnknownAttributeError: unknown attribute 'email' for Avis` — bug pre-existant dans `expert_mailer_preview.rb` (l'attribut `email` a ete retire du modele `Avis`).

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante (FR + EN)
- [x] Apostrophes typographiques verifiees (`rake lint:apostrophe:fix`)
- [x] Rubocop OK
- [ ] Tests : aucun spec existant pour ExpertMailer
- [ ] Screenshots : preview crash (bug pre-existant)

Generated with [Claude Code](https://claude.com/claude-code)