### PR TITLE
Tech: fix N+1 sur les attachments Procedure (logo, notice, deliberation) dans GraphQL

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -21,7 +21,7 @@ module Types
     field :demarches_publiques, DemarcheDescriptorType.connection_type, null: false, internal: true
 
     def demarches_publiques
-      Procedure.publiques.includes(draft_revision: :procedure, published_revision: :procedure)
+      Procedure.publiques.includes(draft_revision: :procedure, published_revision: :procedure).with_attached_logo.with_attached_notice.with_attached_deliberation
     end
 
     def demarche_descriptor(demarche:)

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -197,7 +197,7 @@ class Procedure < ApplicationRecord
   end
 
   scope :for_api, -> { with_active_revision.includes(:administrateurs, :module_api_carto) }
-  scope :for_api_v2, -> { with_active_revision.includes(administrateurs: :user) }
+  scope :for_api_v2, -> { with_active_revision.includes(administrateurs: :user).with_attached_logo.with_attached_notice.with_attached_deliberation }
   scope :with_active_revision, -> { includes(draft_revision: :revision_types_de_champ, published_revision: :revision_types_de_champ) }
 
   scope :order_by_position_for, -> (instructeur) {


### PR DESCRIPTION
# Probleme

N+1 detecte par [Prosopite](https://github.com/charkost/prosopite) (scan des tests) et confirme par [Skylight](https://www.skylight.io/) (production).

**Donnees de production** (depuis `.skill-context.json`) :

| Endpoint | Score |
|----------|-------|
| `API::V2::GraphqlController` | 5125ms |

**Triage Prosopite** : 1 pattern PROD / 0 patterns TEST ignores.

# Solution

Skill [`/n1-query-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/n1-query-fix/SKILL.md)

### Patterns corriges (PROD uniquement)

| Association | Table | Strategy | Call site (app/) |
|-------------|-------|----------|------------------|
| `logo_attachment`, `notice_attachment`, `deliberation_attachment` | `active_storage_attachments` | `with_attached_logo.with_attached_notice.with_attached_deliberation` | `Procedure.for_api_v2`, `QueryType#demarches_publiques` |

Les scopes `for_api_v2` et `demarches_publiques` chargent des procedures sans preload des attachments ActiveStorage. Quand les champs GraphQL `notice { url }`, `logo { url }` ou `deliberation { url }` sont demandes (via `DemarcheDescriptorType`), chaque procedure declenche des queries individuelles sur `active_storage_attachments`.

Le fix ajoute `.with_attached_logo.with_attached_notice.with_attached_deliberation` aux deux points de chargement, permettant au batch loader (`Loaders::Association`) de detecter `association_loaded?` et de retourner immediatement.

### Validation

- [x] Tests passes (rspec) — 61 controller specs, 2 N+1 specs
- [x] Rubocop OK
- [x] Seuls des fichiers app/ commites

Generated with [Claude Code](https://claude.com/claude-code)