### PR TITLE
Tech: extraire les textes en dur de ExpertMailer vers i18n

### DIFF
--- a/app/mailers/expert_mailer.rb
+++ b/app/mailers/expert_mailer.rb
@@ -9,7 +9,7 @@ class ExpertMailer < ApplicationMailer
     @dossier = @avis.dossier
     email = @avis.expert.email
     @decision = decision_dossier(@dossier)
-    subject = "Dossier n° #{@dossier.id} a été #{@decision} - #{@dossier.procedure.libelle}"
+    subject = default_i18n_subject(id: @dossier.id, decision: @decision, libelle: @dossier.procedure.libelle)
 
     mail(to: email, subject: subject)
   end
@@ -19,7 +19,7 @@ class ExpertMailer < ApplicationMailer
     @dossier = @avis.dossier
     email = @avis.expert.email
     @decision = decision_dossier(@dossier)
-    subject = "Dossier n° #{@dossier.id} a été #{@decision} - #{@dossier.procedure.libelle}"
+    subject = I18n.t("expert_mailer.send_dossier_decision.subject", id: @dossier.id, decision: @decision, libelle: @dossier.procedure.libelle)
 
     mail(template_name: 'send_dossier_decision', to: email, subject: subject)
   end
@@ -31,10 +31,10 @@ end
 
 def decision_dossier(dossier)
   if dossier.accepte?
-    'accepté'
+    I18n.t("expert_mailer.send_dossier_decision.decision.accepte")
   elsif dossier.sans_suite?
-    'classé sans suite'
+    I18n.t("expert_mailer.send_dossier_decision.decision.sans_suite")
   elsif dossier.refuse?
-    'refusé'
+    I18n.t("expert_mailer.send_dossier_decision.decision.refuse")
   end
 end

--- a/app/mailers/groupe_gestionnaire_mailer.rb
+++ b/app/mailers/groupe_gestionnaire_mailer.rb
@@ -6,9 +6,8 @@ class GroupeGestionnaireMailer < ApplicationMailer
   def notify_removed_gestionnaire(groupe_gestionnaire, removed_gestionnaire_email, current_super_admin_email)
     @groupe_gestionnaire = groupe_gestionnaire
     @current_super_admin_email = current_super_admin_email
-    subject = "Vous avez été retiré(e) du groupe gestionnaire \"#{groupe_gestionnaire.name}\""
 
-    mail(to: removed_gestionnaire_email, subject: subject)
+    mail(to: removed_gestionnaire_email, subject: default_i18n_subject(name: groupe_gestionnaire.name))
   end
 
   def notify_added_gestionnaires(groupe_gestionnaire, added_gestionnaires, current_super_admin_email)
@@ -16,17 +15,14 @@ class GroupeGestionnaireMailer < ApplicationMailer
     @groupe_gestionnaire = groupe_gestionnaire
     @current_super_admin_email = current_super_admin_email
 
-    subject = "Vous avez été ajouté(e) en tant que gestionnaire du groupe gestionnaire \"#{groupe_gestionnaire.name}\""
-
-    mail(bcc: added_gestionnaire_emails, subject: subject)
+    mail(bcc: added_gestionnaire_emails, subject: default_i18n_subject(name: groupe_gestionnaire.name))
   end
 
   def notify_removed_administrateur(groupe_gestionnaire, removed_administrateur_email, current_super_admin_email)
     @groupe_gestionnaire = groupe_gestionnaire
     @current_super_admin_email = current_super_admin_email
-    subject = "Vous avez été retiré(e) du groupe gestionnaire \"#{groupe_gestionnaire.name}\""
 
-    mail(to: removed_administrateur_email, subject: subject)
+    mail(to: removed_administrateur_email, subject: default_i18n_subject(name: groupe_gestionnaire.name))
   end
 
   def notify_added_administrateurs(groupe_gestionnaire, added_administrateurs, current_super_admin_email)
@@ -34,9 +30,7 @@ class GroupeGestionnaireMailer < ApplicationMailer
     @groupe_gestionnaire = groupe_gestionnaire
     @current_super_admin_email = current_super_admin_email
 
-    subject = "Vous avez été ajouté(e) en tant qu’administrateur du groupe gestionnaire \"#{groupe_gestionnaire.name}\""
-
-    mail(bcc: added_administrateur_emails, subject: subject)
+    mail(bcc: added_administrateur_emails, subject: default_i18n_subject(name: groupe_gestionnaire.name))
   end
 
   def notify_new_commentaire_groupe_gestionnaire(groupe_gestionnaire, commentaire, sender_email, recipient_email, commentaire_url)
@@ -44,7 +38,7 @@ class GroupeGestionnaireMailer < ApplicationMailer
     @commentaire = commentaire
     @sender_email = sender_email
     @commentaire_url = commentaire_url
-    @subject = "Vous avez un nouveau message dans le groupe gestionnaire \"#{groupe_gestionnaire.name}\""
+    @subject = default_i18n_subject(name: groupe_gestionnaire.name)
 
     mail(to: recipient_email, subject: @subject)
   end

--- a/app/mailers/groupe_instructeur_mailer.rb
+++ b/app/mailers/groupe_instructeur_mailer.rb
@@ -8,9 +8,9 @@ class GroupeInstructeurMailer < ApplicationMailer
     @current_instructeur_email = current_instructeur_email
     @still_assigned_to_procedure = removed_instructeur.in?(group.procedure.instructeurs)
     subject = if @still_assigned_to_procedure
-      "Vous avez été retiré(e) du groupe \"#{group.label}\" de la démarche \"#{group.procedure.libelle}\""
+      t(".subject_assigned", groupe: group.label, procedure: group.procedure.libelle)
     else
-      "Vous avez été désaffecté(e) de la démarche \"#{group.procedure.libelle}\""
+      t(".subject_unassigned", procedure: group.procedure.libelle)
     end
 
     mail(to: removed_instructeur.email, subject: subject)
@@ -23,13 +23,9 @@ class GroupeInstructeurMailer < ApplicationMailer
     @still_assigned_to_procedure = still_assigned
 
     subject = if @still_assigned_to_procedure
-      if removed_from_groupes.one?
-        "Vous avez été retiré(e) du groupe \"#{removed_from_groupes.first.label}\" de la démarche \"#{procedure.libelle}\""
-      else
-        "Vous avez été retiré(e) de #{removed_from_groupes.count} groupes de la démarche \"#{procedure.libelle}\""
-      end
+      t(".subject_assigned", count: removed_from_groupes.count, groupe: removed_from_groupes.first.label, procedure: procedure.libelle)
     else
-      "Vous avez été désaffecté(e) de la démarche \"#{procedure.libelle}\""
+      t(".subject_unassigned", procedure: procedure.libelle)
     end
 
     mail(to: removed_instructeur.email, subject: subject)
@@ -40,11 +36,7 @@ class GroupeInstructeurMailer < ApplicationMailer
     @group = group
     @current_instructeur_email = current_instructeur_email
 
-    subject = if group.procedure.groupe_instructeurs.many?
-      "Vous avez été ajouté(e) au groupe « #{group.label} » de la démarche « #{group.procedure.libelle} »"
-    else
-      "Vous avez été affecté(e) à la démarche « #{group.procedure.libelle} »"
-    end
+    subject = t(".subject", count: group.procedure.groupe_instructeurs.count, groupe: group.label, procedure: group.procedure.libelle)
 
     mail(bcc: added_instructeur_emails, subject: subject)
   end
@@ -55,11 +47,7 @@ class GroupeInstructeurMailer < ApplicationMailer
     @current_instructeur_email = current_instructeur_email
     @reset_password_token = instructeur.user.send(:set_reset_password_token)
 
-    subject = if group.procedure.groupe_instructeurs.many?
-      "Vous avez été ajouté(e) au groupe \"#{group.label}\" de la démarche \"#{group.procedure.libelle}\""
-    else
-      "Vous avez été affecté(e) à la démarche \"#{group.procedure.libelle}\""
-    end
+    subject = t(".subject", count: group.procedure.groupe_instructeurs.count, groupe: group.label, procedure: group.procedure.libelle)
 
     bypass_unverified_mail_protection!
 
@@ -72,12 +60,7 @@ class GroupeInstructeurMailer < ApplicationMailer
     @procedure = groups.first.procedure
     @current_instructeur_email = current_instructeur_email
 
-    group_labels = groups.map(&:label).join(', ')
-    subject = if groups.count == 1
-      "Vous avez été ajouté(e) au groupe instructeur « #{group_labels} » de la démarche « #{@procedure.libelle} »"
-    else
-      "Vous avez été ajouté(e) à #{groups.count} groupes instructeurs de la démarche « #{@procedure.libelle} »"
-    end
+    subject = t(".subject", count: groups.count, groupe: groups.first.label, procedure: @procedure.libelle)
 
     mail(to: instructeur.email, subject: subject)
   end
@@ -93,12 +76,7 @@ class GroupeInstructeurMailer < ApplicationMailer
     @current_instructeur_email = current_instructeur_email
     @reset_password_token = instructeur.user.send(:set_reset_password_token)
 
-    group_labels = groups.map(&:label).join(', ')
-    subject = if groups.count == 1
-      "Vous avez été ajouté(e) au groupe \"#{group_labels}\" de la démarche \"#{@procedure.libelle}\""
-    else
-      "Vous avez été ajouté(e) à #{groups.count} groupes de la démarche \"#{@procedure.libelle}\""
-    end
+    subject = t(".subject", count: groups.count, groupe: groups.first.label, procedure: @procedure.libelle)
 
     bypass_unverified_mail_protection!
 

--- a/config/locales/views/expert_mailer/send_dossier_decision/en.yml
+++ b/config/locales/views/expert_mailer/send_dossier_decision/en.yml
@@ -1,0 +1,8 @@
+en:
+  expert_mailer:
+    send_dossier_decision:
+      subject: "File no. %{id} has been %{decision} - %{libelle}"
+      decision:
+        accepte: accepted
+        sans_suite: closed without follow-up
+        refuse: refused

--- a/config/locales/views/expert_mailer/send_dossier_decision/fr.yml
+++ b/config/locales/views/expert_mailer/send_dossier_decision/fr.yml
@@ -1,0 +1,8 @@
+fr:
+  expert_mailer:
+    send_dossier_decision:
+      subject: "Dossier n° %{id} a été %{decision} - %{libelle}"
+      decision:
+        accepte: accepté
+        sans_suite: classé sans suite
+        refuse: refusé

--- a/config/locales/views/groupe_gestionnaire_mailer/notify_added_administrateurs/en.yml
+++ b/config/locales/views/groupe_gestionnaire_mailer/notify_added_administrateurs/en.yml
@@ -1,4 +1,5 @@
 en:
   groupe_gestionnaire_mailer:
     notify_added_administrateurs:
+      subject: "You have been added as administrator of the admins group \"%{name}\""
       email_body: "You were assigned as administrateur on the admins group %{groupe_gestionnaire_name} on %{application_name} by « %{email} »"

--- a/config/locales/views/groupe_gestionnaire_mailer/notify_added_administrateurs/fr.yml
+++ b/config/locales/views/groupe_gestionnaire_mailer/notify_added_administrateurs/fr.yml
@@ -1,4 +1,5 @@
 fr:
   groupe_gestionnaire_mailer:
     notify_added_administrateurs:
+      subject: "Vous avez été ajouté(e) en tant qu’administrateur du groupe gestionnaire \"%{name}\""
       email_body: "Vous venez d’être nommé administrateur du groupe gestionnaire %{groupe_gestionnaire_name} sur %{application_name} par « %{email} »."

--- a/config/locales/views/groupe_gestionnaire_mailer/notify_added_gestionnaires/en.yml
+++ b/config/locales/views/groupe_gestionnaire_mailer/notify_added_gestionnaires/en.yml
@@ -1,4 +1,5 @@
 en:
   groupe_gestionnaire_mailer:
     notify_added_gestionnaires:
+      subject: "You have been added as manager of the admins group \"%{name}\""
       email_body: "You were assigned as manager on the admins group %{groupe_gestionnaire_name} on %{application_name} by « %{email} »"

--- a/config/locales/views/groupe_gestionnaire_mailer/notify_added_gestionnaires/fr.yml
+++ b/config/locales/views/groupe_gestionnaire_mailer/notify_added_gestionnaires/fr.yml
@@ -1,4 +1,5 @@
 fr:
   groupe_gestionnaire_mailer:
     notify_added_gestionnaires:
+      subject: "Vous avez été ajouté(e) en tant que gestionnaire du groupe gestionnaire \"%{name}\""
       email_body: "Vous venez d’être nommé gestionnaire du groupe gestionnaire %{groupe_gestionnaire_name} sur %{application_name} par « %{email} »."

--- a/config/locales/views/groupe_gestionnaire_mailer/notify_new_commentaire_groupe_gestionnaire/en.yml
+++ b/config/locales/views/groupe_gestionnaire_mailer/notify_new_commentaire_groupe_gestionnaire/en.yml
@@ -1,0 +1,6 @@
+en:
+  groupe_gestionnaire_mailer:
+    notify_new_commentaire_groupe_gestionnaire:
+      subject: "You have a new message in the admins group \"%{name}\""
+      body: You have a new message from %{sender_email} in the admins group %{groupe_gestionnaire_name} messaging
+      see_message: "View the message"

--- a/config/locales/views/groupe_gestionnaire_mailer/notify_new_commentaire_groupe_gestionnaire/fr.yml
+++ b/config/locales/views/groupe_gestionnaire_mailer/notify_new_commentaire_groupe_gestionnaire/fr.yml
@@ -1,5 +1,6 @@
 fr:
   groupe_gestionnaire_mailer:
     notify_new_commentaire_groupe_gestionnaire:
+      subject: "Vous avez un nouveau message dans le groupe gestionnaire \"%{name}\""
       body: Vous avez un nouveau message envoyé de la part de %{sender_email} dans la messagerie du groupe gestionnaire %{groupe_gestionnaire_name}
       see_message: "Consulter le message"

--- a/config/locales/views/groupe_gestionnaire_mailer/notify_removed_administrateur/en.yml
+++ b/config/locales/views/groupe_gestionnaire_mailer/notify_removed_administrateur/en.yml
@@ -1,4 +1,5 @@
 en:
   groupe_gestionnaire_mailer:
     notify_removed_administrateur:
+      subject: "You have been removed from the admins group \"%{name}\""
       email_body: "You were removed from the admins group %{groupe_gestionnaire_name} on %{application_name} by « %{email} »"

--- a/config/locales/views/groupe_gestionnaire_mailer/notify_removed_administrateur/fr.yml
+++ b/config/locales/views/groupe_gestionnaire_mailer/notify_removed_administrateur/fr.yml
@@ -1,4 +1,5 @@
 fr:
   groupe_gestionnaire_mailer:
     notify_removed_administrateur:
+      subject: "Vous avez été retiré(e) du groupe gestionnaire \"%{name}\""
       email_body: "Vous venez d’être supprimé(e) du groupe gestionnaire %{groupe_gestionnaire_name} sur %{application_name} par « %{email} »."

--- a/config/locales/views/groupe_gestionnaire_mailer/notify_removed_gestionnaire/en.yml
+++ b/config/locales/views/groupe_gestionnaire_mailer/notify_removed_gestionnaire/en.yml
@@ -1,4 +1,5 @@
 en:
   groupe_gestionnaire_mailer:
     notify_removed_gestionnaire:
+      subject: "You have been removed from the admins group \"%{name}\""
       email_body: "You were removed from the admins group %{groupe_gestionnaire_name} on %{application_name} by « %{email} »"

--- a/config/locales/views/groupe_gestionnaire_mailer/notify_removed_gestionnaire/fr.yml
+++ b/config/locales/views/groupe_gestionnaire_mailer/notify_removed_gestionnaire/fr.yml
@@ -1,4 +1,5 @@
 fr:
   groupe_gestionnaire_mailer:
     notify_removed_gestionnaire:
+      subject: "Vous avez été retiré(e) du groupe gestionnaire \"%{name}\""
       email_body: "Vous venez d’être supprimé(e) du groupe gestionnaire %{groupe_gestionnaire_name} sur %{application_name} par « %{email} »."

--- a/config/locales/views/groupe_instructeur_mailer/confirm_and_notify_added_instructeur/en.yml
+++ b/config/locales/views/groupe_instructeur_mailer/confirm_and_notify_added_instructeur/en.yml
@@ -1,6 +1,9 @@
 en:
   groupe_instructeur_mailer:
     confirm_and_notify_added_instructeur:
+      subject:
+        one: "You were assigned to procedure \"%{procedure}\""
+        other: "You were added to group \"%{groupe}\" of procedure \"%{procedure}\""
       title: "Procedure assignment"
       email_body:
         html:

--- a/config/locales/views/groupe_instructeur_mailer/confirm_and_notify_added_instructeur/fr.yml
+++ b/config/locales/views/groupe_instructeur_mailer/confirm_and_notify_added_instructeur/fr.yml
@@ -1,6 +1,9 @@
 fr:
   groupe_instructeur_mailer:
     confirm_and_notify_added_instructeur:
+      subject:
+        one: "Vous avez été affecté(e) à la démarche \"%{procedure}\""
+        other: "Vous avez été ajouté(e) au groupe \"%{groupe}\" de la démarche \"%{procedure}\""
       title: "Affectation à une démarche"
       email_body:
         html:

--- a/config/locales/views/groupe_instructeur_mailer/confirm_and_notify_added_instructeur_in_many_groupes/en.yml
+++ b/config/locales/views/groupe_instructeur_mailer/confirm_and_notify_added_instructeur_in_many_groupes/en.yml
@@ -1,6 +1,9 @@
 en:
   groupe_instructeur_mailer:
     confirm_and_notify_added_instructeur_in_many_groupes:
+      subject:
+        one: "You were added to group \"%{groupe}\" of procedure \"%{procedure}\""
+        other: "You were added to %{count} groups of procedure \"%{procedure}\""
       title: "Procedure assignment"
       email_body:
         html:

--- a/config/locales/views/groupe_instructeur_mailer/confirm_and_notify_added_instructeur_in_many_groupes/fr.yml
+++ b/config/locales/views/groupe_instructeur_mailer/confirm_and_notify_added_instructeur_in_many_groupes/fr.yml
@@ -1,6 +1,9 @@
 fr:
   groupe_instructeur_mailer:
     confirm_and_notify_added_instructeur_in_many_groupes:
+      subject:
+        one: "Vous avez été ajouté(e) au groupe \"%{groupe}\" de la démarche \"%{procedure}\""
+        other: "Vous avez été ajouté(e) à %{count} groupes de la démarche \"%{procedure}\""
       title: "Affectation à une démarche"
       email_body:
         html:

--- a/config/locales/views/groupe_instructeur_mailer/notify_added_instructeur_in_many_groupes/en.yml
+++ b/config/locales/views/groupe_instructeur_mailer/notify_added_instructeur_in_many_groupes/en.yml
@@ -1,6 +1,9 @@
 en:
   groupe_instructeur_mailer:
     notify_added_instructeur_in_many_groupes:
+      subject:
+        one: "You were added to group « %{groupe} » of procedure « %{procedure} »"
+        other: "You were added to %{count} groups of procedure « %{procedure} »"
       title: "Procedure assignment"
       email_body:
         html:

--- a/config/locales/views/groupe_instructeur_mailer/notify_added_instructeur_in_many_groupes/fr.yml
+++ b/config/locales/views/groupe_instructeur_mailer/notify_added_instructeur_in_many_groupes/fr.yml
@@ -1,6 +1,9 @@
 fr:
   groupe_instructeur_mailer:
     notify_added_instructeur_in_many_groupes:
+      subject:
+        one: "Vous avez été ajouté(e) au groupe instructeur « %{groupe} » de la démarche « %{procedure} »"
+        other: "Vous avez été ajouté(e) à %{count} groupes instructeurs de la démarche « %{procedure} »"
       title: "Affectation à une démarche"
       email_body:
         html:

--- a/config/locales/views/groupe_instructeur_mailer/notify_added_instructeurs/en.yml
+++ b/config/locales/views/groupe_instructeur_mailer/notify_added_instructeurs/en.yml
@@ -1,6 +1,9 @@
 en:
   groupe_instructeur_mailer:
     notify_added_instructeurs:
+      subject:
+        one: "You were assigned to procedure « %{procedure} »"
+        other: "You were added to group « %{groupe} » of procedure « %{procedure} »"
       title: "Procedure assignment"
       email_body:
         html:

--- a/config/locales/views/groupe_instructeur_mailer/notify_added_instructeurs/fr.yml
+++ b/config/locales/views/groupe_instructeur_mailer/notify_added_instructeurs/fr.yml
@@ -1,6 +1,9 @@
 fr:
   groupe_instructeur_mailer:
     notify_added_instructeurs:
+      subject:
+        one: "Vous avez été affecté(e) à la démarche « %{procedure} »"
+        other: "Vous avez été ajouté(e) au groupe « %{groupe} » de la démarche « %{procedure} »"
       title: "Affectation à une démarche"
       email_body:
         html:

--- a/config/locales/views/groupe_instructeur_mailer/notify_removed_instructeur/en.yml
+++ b/config/locales/views/groupe_instructeur_mailer/notify_removed_instructeur/en.yml
@@ -1,6 +1,8 @@
 en:
   groupe_instructeur_mailer:
     notify_removed_instructeur:
+      subject_assigned: "You were removed from group \"%{groupe}\" of procedure \"%{procedure}\""
+      subject_unassigned: "You were unassigned from procedure \"%{procedure}\""
       email_body:
         assigned: "You were removed from the group « %{groupe} » by « %{email} », in charge of procedure « %{procedure} »."
         unassigned: "You were unassigned from the procedure « %{procedure} » by « %{email} »."

--- a/config/locales/views/groupe_instructeur_mailer/notify_removed_instructeur/fr.yml
+++ b/config/locales/views/groupe_instructeur_mailer/notify_removed_instructeur/fr.yml
@@ -1,6 +1,8 @@
 fr:
   groupe_instructeur_mailer:
     notify_removed_instructeur:
+      subject_assigned: "Vous avez été retiré(e) du groupe \"%{groupe}\" de la démarche \"%{procedure}\""
+      subject_unassigned: "Vous avez été désaffecté(e) de la démarche \"%{procedure}\""
       email_body:
         assigned: "Vous avez été retiré(e) du groupe « %{groupe} » par « %{email} », en charge de la démarche « %{procedure} »."
         unassigned: "Vous avez été désaffecté(e) de la démarche « %{procedure} » par « %{email} »."

--- a/config/locales/views/groupe_instructeur_mailer/notify_removed_instructeur_from_all_groupes/en.yml
+++ b/config/locales/views/groupe_instructeur_mailer/notify_removed_instructeur_from_all_groupes/en.yml
@@ -1,6 +1,10 @@
 en:
   groupe_instructeur_mailer:
     notify_removed_instructeur_from_many_groupes:
+      subject_assigned:
+        one: "You were removed from group \"%{groupe}\" of procedure \"%{procedure}\""
+        other: "You were removed from %{count} groups of procedure \"%{procedure}\""
+      subject_unassigned: "You were unassigned from procedure \"%{procedure}\""
       email_body:
         assigned:
           one: "You were removed from group « %{groupe} » of procedure « %{procedure} » by « %{email} »."

--- a/config/locales/views/groupe_instructeur_mailer/notify_removed_instructeur_from_all_groupes/fr.yml
+++ b/config/locales/views/groupe_instructeur_mailer/notify_removed_instructeur_from_all_groupes/fr.yml
@@ -1,6 +1,10 @@
 fr:
   groupe_instructeur_mailer:
     notify_removed_instructeur_from_many_groupes:
+      subject_assigned:
+        one: "Vous avez été retiré(e) du groupe \"%{groupe}\" de la démarche \"%{procedure}\""
+        other: "Vous avez été retiré(e) de %{count} groupes de la démarche \"%{procedure}\""
+      subject_unassigned: "Vous avez été désaffecté(e) de la démarche \"%{procedure}\""
       email_body:
         assigned:
           one: "Vous avez été retiré(e) du groupe « %{groupe} » de la démarche « %{procedure} » par « %{email} »."


### PR DESCRIPTION
# Probleme

Textes francais en dur dans `app/mailers/expert_mailer.rb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 5 cles i18n vers `config/locales/views/expert_mailer/send_dossier_decision/`.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `expert_mailer.send_dossier_decision.subject` | "Dossier n° %{id} a été %{decision} - %{libelle}" | "File no. %{id} has been %{decision} - %{libelle}" |
| `expert_mailer.send_dossier_decision.decision.accepte` | "accepté" | "accepted" |
| `expert_mailer.send_dossier_decision.decision.sans_suite` | "classé sans suite" | "closed without follow-up" |
| `expert_mailer.send_dossier_decision.decision.refuse` | "refusé" | "refused" |

### Validation visuelle — SKIP

⏭️ Le mailer preview (`/rails/mailers/expert_mailer/send_dossier_decision`) crash avec `ActiveModel::UnknownAttributeError: unknown attribute 'email' for Avis` — bug pre-existant dans `expert_mailer_preview.rb`, non lie a cette extraction.

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante (FR + EN)
- [x] `default_i18n_subject` utilise pour `send_dossier_decision`, `I18n.t` explicite pour `send_dossier_decision_v2` (reutilise la meme cle)
- [x] Apostrophes typographiques verifiees
- [x] Rubocop OK
- [x] Pas de specs existantes pour ExpertMailer (hors preview)

Generated with [Claude Code](https://claude.com/claude-code)

---

# Probleme

Textes francais en dur dans `app/mailers/groupe_gestionnaire_mailer.rb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 5 cles i18n (subjects) vers `config/locales/views/groupe_gestionnaire_mailer/`. Creation du fichier `en.yml` manquant pour `notify_new_commentaire_groupe_gestionnaire`.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `groupe_gestionnaire_mailer.notify_removed_gestionnaire.subject` | "Vous avez été retiré(e) du groupe gestionnaire \"%{name}\"" | "You have been removed from the admins group \"%{name}\"" |
| `groupe_gestionnaire_mailer.notify_added_gestionnaires.subject` | "Vous avez été ajouté(e) en tant que gestionnaire du groupe gestionnaire \"%{name}\"" | "You have been added as manager of the admins group \"%{name}\"" |
| `groupe_gestionnaire_mailer.notify_removed_administrateur.subject` | "Vous avez été retiré(e) du groupe gestionnaire \"%{name}\"" | "You have been removed from the admins group \"%{name}\"" |
| `groupe_gestionnaire_mailer.notify_added_administrateurs.subject` | "Vous avez été ajouté(e) en tant qu'administrateur du groupe gestionnaire \"%{name}\"" | "You have been added as administrator of the admins group \"%{name}\"" |
| `groupe_gestionnaire_mailer.notify_new_commentaire_groupe_gestionnaire.subject` | "Vous avez un nouveau message dans le groupe gestionnaire \"%{name}\"" | "You have a new message in the admins group \"%{name}\"" |

### Validation visuelle — IDENTIQUE

**Avant :**
![before](https://gist.githubusercontent.com/mfo/0d07d553b2fdb329708051ec95d6a7d8/raw/before-1.png)

**Apres :**
![after](https://gist.githubusercontent.com/mfo/0d07d553b2fdb329708051ec95d6a7d8/raw/after-1.png)

**Couverture :**
- ✅ `localhost:3220/rails/mailers/groupe_gestionnaire_mailer/notify_removed_gestionnaire` — preview mail
- ✅ `localhost:3220/rails/mailers/groupe_gestionnaire_mailer/notify_added_gestionnaires` — preview mail
- ✅ `localhost:3220/rails/mailers/groupe_gestionnaire_mailer/notify_new_commentaire_groupe_gestionnaire` — preview mail

[Voir tous les screenshots](https://gist.github.com/mfo/0d07d553b2fdb329708051ec95d6a7d8)

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante
- [x] Apostrophes typographiques verifiees
- [x] Tests passes (5 examples, 0 failures)
- [x] Rubocop OK
- [x] Screenshots avant/apres identiques

Generated with [Claude Code](https://claude.com/claude-code)

---

# Probleme

Sujets d'emails francais en dur dans `app/mailers/groupe_instructeur_mailer.rb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 13 sujets d'emails (avec variantes conditionnelles et pluralisation) vers les fichiers YAML i18n existants.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `groupe_instructeur_mailer.notify_removed_instructeur.subject_assigned` | "Vous avez été retiré(e) du groupe \"%{groupe}\" de la démarche \"%{procedure}\"" | "You were removed from group \"%{groupe}\" of procedure \"%{procedure}\"" |
| `groupe_instructeur_mailer.notify_removed_instructeur.subject_unassigned` | "Vous avez été désaffecté(e) de la démarche \"%{procedure}\"" | "You were unassigned from procedure \"%{procedure}\"" |
| `groupe_instructeur_mailer.notify_removed_instructeur_from_many_groupes.subject_assigned` (one/other) | "...retiré(e) du groupe / de %{count} groupes..." | "...removed from group / %{count} groups..." |
| `groupe_instructeur_mailer.notify_removed_instructeur_from_many_groupes.subject_unassigned` | "Vous avez été désaffecté(e) de la démarche \"%{procedure}\"" | "You were unassigned from procedure \"%{procedure}\"" |
| `groupe_instructeur_mailer.notify_added_instructeurs.subject` (one/other) | "...affecté(e) à la démarche / ajouté(e) au groupe..." | "...assigned to procedure / added to group..." |
| `groupe_instructeur_mailer.confirm_and_notify_added_instructeur.subject` (one/other) | "...affecté(e) à la démarche / ajouté(e) au groupe..." | "...assigned to procedure / added to group..." |
| `groupe_instructeur_mailer.notify_added_instructeur_in_many_groupes.subject` (one/other) | "...ajouté(e) au groupe instructeur / à %{count} groupes instructeurs..." | "...added to group / %{count} groups..." |
| `groupe_instructeur_mailer.confirm_and_notify_added_instructeur_in_many_groupes.subject` (one/other) | "...ajouté(e) au groupe / à %{count} groupes..." | "...added to group / %{count} groups..." |

### Validation visuelle — IDENTIQUE

**Avant :**
![before](https://gist.githubusercontent.com/mfo/f940d60200fefdde0d1565963aa99a74/raw/before-1.png)

**Apres :**
![after](https://gist.githubusercontent.com/mfo/f940d60200fefdde0d1565963aa99a74/raw/after-1.png)

**Couverture :**
- ✅ `localhost:3220/rails/mailers/groupe_instructeur_mailer/notify_removed_instructeur` — preview mail
- ✅ `localhost:3220/rails/mailers/groupe_instructeur_mailer/notify_added_instructeurs` — preview mail
- ✅ `localhost:3220/rails/mailers/groupe_instructeur_mailer/confirm_and_notify_added_instructeur` — preview mail

[Voir tous les screenshots](https://gist.github.com/mfo/f940d60200fefdde0d1565963aa99a74)

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante (FR + EN)
- [x] Apostrophes typographiques verifiees
- [x] 13 tests passes (0 failures)
- [x] Rubocop OK
- [x] Screenshots avant/apres identiques

Generated with [Claude Code](https://claude.com/claude-code)