### PR TITLE
ETQ admin, les noms de service longs passent à la ligne dans la liste des services

### DIFF
--- a/app/views/administrateurs/services/index.html.haml
+++ b/app/views/administrateurs/services/index.html.haml
@@ -11,7 +11,7 @@
 
   = link_to "Nouveau service", new_admin_service_path(procedure_id: @procedure.id), class: "fr-btn fr-btn--primary fr-btn--icon-left fr-icon-add-circle-line fr-mb-6v"
 
-  .fr-table.fr-table--layout-fixed
+  .fr-table
     .fr-table__wrapper
       .fr-table__container
         .fr-table__content
@@ -27,7 +27,7 @@
             %tbody
               - @services.each do |service|
                 %tr
-                  %td
+                  %td.fr-cell--multiline
                     = service.nom
                   %td.fr-col-4
                     .fr-container.flex.fr-px-0


### PR DESCRIPTION
Suite aux récentes modernisationx du tableau, les noms de service long poussaient trop vers la droite les boutons d'action (sans possibilité de scroll).
<img width="1262" height="306" alt="Capture d’écran 2026-07-01 à 15 17 58" src="https://github.com/user-attachments/assets/49a6cec3-ea1d-45e2-a2ea-c2c7e940ac69" />
