### PR TITLE
Tech: streame les exports CSV pour réduire l'empreinte mémoire des jobs

### DIFF
--- a/app/services/procedure_export_service.rb
+++ b/app/services/procedure_export_service.rb
@@ -11,9 +11,11 @@ class ProcedureExportService
   end
 
   def to_csv
-    @dossiers = @dossiers.downloadable_sorted_batch
-    io = StringIO.new(SpreadsheetArchitect.to_csv(options_for(:dossiers, :csv)))
-    create_blob(io, :csv)
+    Tempfile.create(['export', '.csv'], binmode: true) do |file|
+      CsvExport.new(procedure:, dossiers:, export_template: @export_template).write_to(file)
+      file.rewind
+      create_blob(file, :csv)
+    end
   end
 
   def to_xlsx

--- a/app/services/procedure_export_service/csv_export.rb
+++ b/app/services/procedure_export_service/csv_export.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Streams a procedure's dossiers into a CSV file with bounded memory: rows are
+# written batch by batch via DossierPreloader, so only one batch of dossiers
+# (and their champs) is materialized at a time. Mirrors XlsxExport without its
+# secondary sheets — the CSV is single-sheet, établissement columns inline.
+class ProcedureExportService::CsvExport
+  def initialize(procedure:, dossiers:, export_template:)
+    @procedure = procedure
+    @dossiers = dossiers
+    @export_template = export_template
+  end
+
+  def write_to(io)
+    csv = CSV.new(io)
+    headers_written = false
+
+    DossierPreloader
+      .new(@dossiers.ordered_for_export)
+      .in_batches(includes: DossierPreloader::SHEET_EXPORT_INCLUDES) do |batch|
+      batch.each do |dossier|
+        columns = dossier.spreadsheet_columns_csv(types_de_champ:, export_template: @export_template)
+
+        unless headers_written
+          csv << columns.map(&:first)
+          headers_written = true
+        end
+
+        csv << columns.map { |(_libelle, value)| resolve(dossier, value) }
+      end
+    end
+  end
+
+  private
+
+  def resolve(instance, value)
+    if value.is_a?(Symbol)
+      instance.send(value)
+    else
+      value
+    end
+  end
+
+  def types_de_champ = @types_de_champ ||= @procedure.types_de_champ_for_procedure_export.to_a
+end

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -324,6 +324,15 @@ describe ProcedureExportService do
         it 'should have headers' do
           expect(dossiers_sheet_headers).to match_array(nominal_headers)
         end
+
+        it 'streams one data row per dossier with resolved, stringified values' do
+          expect(subject.size).to eq(2) # header + 1 dossier
+
+          data_row = subject.last
+          expect(data_row[dossiers_sheet_headers.index('ID')]).to eq(dossier.id.to_s) # littéral
+          expect(data_row[dossiers_sheet_headers.index('FranceConnect ?')]).to eq('false') # booléen littéral
+          expect(data_row[dossiers_sheet_headers.index('À archiver')]).to eq('false') # Symbol résolu via send
+        end
       end
 
       it 'should have headers and data' do


### PR DESCRIPTION
Suite du [streaming des exports XLSX](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/13232)

Les exports chargeaient tous les dossiers et leurs champs en mémoire d'un coup avant de générer le fichier (des millions de champs simultanés sur les grosses démarches).

On streame maintenant les lignes batch par batch via `DossierPreloader#in_batches` — le même chemin borné en mémoire que l'export XLSX — avec écriture directe dans un `Tempfile`. La sortie est inchangée (md5 identique avant/après), une spec de caractérisation garde le refactor.


