### PR TITLE
WIP – Tech: stabiliser les tests flaky de l'editeur de types de champ

### DIFF
--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -195,6 +195,7 @@ describe 'As an administrateur I can edit types de champ', js: true do
     hide_autonotice_message
 
     select('Bloc répétable', from: 'Type de champ')
+    expect(page).to have_content('Formulaire enregistré')
     fill_in 'Libellé du champ', with: 'libellé de champ'
 
     expect(page).to have_content('Formulaire enregistré')
@@ -213,6 +214,9 @@ describe 'As an administrateur I can edit types de champ', js: true do
 
     within '.type-de-champ:nth-child(2)' do
       select('Bloc répétable', from: 'Type de champ')
+    end
+    expect(page).to have_content('Formulaire enregistré')
+    within '.type-de-champ:nth-child(2)' do
       fill_in 'Libellé du champ', with: 'libellé de champ 2'
     end
 
@@ -224,11 +228,12 @@ describe 'As an administrateur I can edit types de champ', js: true do
     hide_autonotice_message
 
     select('Carte', from: 'Type de champ')
+    expect(page).to have_content('Formulaire enregistré')
     fill_in 'Libellé du champ', with: 'Libellé de champ carte', fill_options: { clear: :backspace }
     check 'Cadastres'
 
-    wait_until { procedure.active_revision.types_de_champ_public.first.layer_enabled?(:cadastres) }
-    wait_until { procedure.active_revision.types_de_champ_public.first.libelle == 'Libellé de champ carte' }
+    wait_until { procedure.active_revision.reload.types_de_champ_public.first.layer_enabled?(:cadastres) }
+    wait_until { procedure.active_revision.reload.types_de_champ_public.first.libelle == 'Libellé de champ carte' }
     expect(page).to have_content('Formulaire enregistré')
 
     page.refresh
@@ -246,6 +251,7 @@ describe 'As an administrateur I can edit types de champ', js: true do
     hide_autonotice_message
 
     select('Choix simple', from: 'Type de champ')
+    expect(page).to have_content('Formulaire enregistré')
     fill_in 'Libellé du champ', with: 'Libellé de champ menu déroulant', fill_options: { clear: :backspace }
     fill_in 'Options de la liste', with: 'Un menu', fill_options: { clear: :backspace }
     check "Proposer une option « autre » avec un texte libre"


### PR DESCRIPTION
# Probleme

Le fichier `spec/system/administrateurs/types_de_champ_spec.rb` echoue de maniere intermittente en CI (18 echecs merge queue — branches sans modification de code).

Tests concernes :
- "adding a carte champ"
- "adding a repetition champ"
- "adding a dropdown champ"

# Solution

Skill [`/flaky-test-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/flaky-test-fix/SKILL.md)

### Causes identifiees et fixes

| Cause | Fix | Tests concernes |
|-------|-----|-----------------|
| Cache ActiveRecord non invalide — `wait_until` poll des objets stales sans `.reload`, timeout systematique | Ajout `.reload` sur les `wait_until` DB polls | adding a carte champ |
| Race condition Turbo Stream — `fill_in` s'execute avant la reponse PATCH, les valeurs sont saisies dans l'ancien noeud DOM detruit par le remplacement | Ajout `expect(page).to have_content('Formulaire enregistre')` apres chaque `select` de type | repetition, carte, dropdown |

### Verification

Spec lance 10x en ordre aleatoire — 10/10 passes.

Generated with [Claude Code](https://claude.com/claude-code)