### PR TITLE
WIP – Tech: fix N+1 queries dans l'API GraphQL (DemarcheType + for_api_v2)

### DIFF
--- a/app/graphql/types/demarche_type.rb
+++ b/app/graphql/types/demarche_type.rb
@@ -87,6 +87,14 @@ module Types
       Loaders::Association.for(object.class, :service).load(object)
     end
 
+    def labels
+      Loaders::Association.for(object.class, labels: :procedure).load(object)
+    end
+
+    def administrateurs
+      Loaders::Association.for(object.class, administrateurs: :user).load(object)
+    end
+
     def revisions
       Loaders::Association.for(object.class, revisions: :revision_types_de_champ).load(object)
     end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -397,7 +397,7 @@ class Dossier < ApplicationRecord
   scope :with_revision, -> { includes(revision: :revision_types_de_champ) }
   scope :for_api_v2, -> {
     with_revision
-      .includes(:attestation_acceptation_template, :etablissement, :individual, :traitement, procedure: [:administrateurs], user: [:france_connect_informations])
+      .includes(:attestation_acceptation_template, :attestation_refus_template, :etablissement, :individual, :traitement, procedure: [:administrateurs], user: [:france_connect_informations])
   }
 
   scope :with_notifications, -> (instructeur) {


### PR DESCRIPTION
# Probleme

N+1 detectes par analyse du code GraphQL et confirmes par [Skylight](https://www.skylight.io/) (production).

**Donnees de production** (depuis `.skill-context.json`) :

| Endpoint | Score Skylight | Table |
|----------|---------------|-------|
| `API::V2::GraphqlController` | 976.2 | `administrateurs` |
| `API::V2::GraphqlController` | 1708.3 + 1220.2 | `active_storage_attachments` |

**Triage Prosopite** : Prosopite ne peut pas tracer les N+1 dans GraphQL (lazy resolution via GraphQL::Batch produit des call stacks vides). Les patterns ont ete identifies par analyse statique du code.

# Solution

Skill [`/n1-query-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/n1-query-fix/SKILL.md)

### Patterns corriges (PROD)

| Association | Table | Strategy | Call site (app/) |
|-------------|-------|----------|------------------|
| `attestation_refus_template` | `attestation_templates` | `includes` dans `for_api_v2` | `app/graphql/types/dossier_type.rb:218` |
| `labels` → `procedure` | `procedures` | `Loaders::Association` batch loader | `app/graphql/types/label_type.rb:17` (authorized?) |
| `administrateurs` → `user` | `administrateurs` | `Loaders::Association` batch loader | `app/graphql/types/demarche_type.rb:70` (field sans resolver) |

### Details

1. **`attestation_refus_template` manquant dans `for_api_v2`** : le scope incluait `attestation_acceptation_template` mais pas `attestation_refus_template`. `DossierType#attestation` accede aux deux templates (ligne 218), causant un N+1 sur `attestation_templates` pour chaque dossier termine.

2. **`DemarcheType#labels` sans batch loader** : le champ `labels` n'avait pas de methode resolver — GraphQL appelait `object.labels` directement. Puis `LabelType.authorized?` accedait `object.procedure` sans preload, causant un N+1 par label.

3. **`DemarcheType#administrateurs` sans batch loader** : meme pattern — champ sans resolver. Ajoute un batch loader avec preload de `:user` (necessaire pour `ProfileType`).

### Patterns ignores (TEST / framework)

| Table | Raison |
|-------|--------|
| `flipper_features` | N+1 framework Flipper (feature flags) — pas de call stack app/ |
| `flipper_gates` | N+1 framework Flipper — pas de call stack app/ |
| `dossiers` | Call stack vide (lazy resolution GraphQL::Batch) — non classifiable |

### Validation

- [x] Tests passes (61 examples, 0 failures)
- [x] Rubocop OK
- [x] Seuls des fichiers app/ commites

Generated with [Claude Code](https://claude.com/claude-code)