### PR TITLE
Tech: renommer la relation dossier.champs en champ_data

### DIFF
--- a/app/components/instructeurs/cell_component.rb
+++ b/app/components/instructeurs/cell_component.rb
@@ -33,7 +33,7 @@ class Instructeurs::CellComponent < ApplicationComponent
 
   def raw_value_for_column(dossier, column)
     data = if @column.champ_column?
-      @dossier.champs.find { _1.stable_id == column.stable_id }
+      @dossier.champ_data.find { _1.stable_id == column.stable_id }
     else
       @dossier
     end

--- a/app/controllers/champs/champ_controller.rb
+++ b/app/controllers/champs/champ_controller.rb
@@ -8,7 +8,7 @@ class Champs::ChampController < ApplicationController
   private
 
   def find_champ
-    dossier = Dossier.with_revision.includes(:champs).find(params[:dossier_id])
+    dossier = Dossier.with_revision.includes(:champ_data).find(params[:dossier_id])
     authorize dossier, :read?
 
     type_de_champ = dossier.find_type_de_champ_by_stable_id(params[:stable_id])

--- a/app/jobs/bulk_route_job.rb
+++ b/app/jobs/bulk_route_job.rb
@@ -6,7 +6,7 @@ class BulkRouteJob < ApplicationJob
   def perform(procedure)
     dossiers = procedure.dossiers
       .with_revision
-      .includes(:procedure, :groupe_instructeur, :champs)
+      .includes(:procedure, :groupe_instructeur, :champ_data)
       .state_not_termine
 
     dossiers.each do |dossier|

--- a/app/jobs/migrations/backfill_dossier_repetition_job.rb
+++ b/app/jobs/migrations/backfill_dossier_repetition_job.rb
@@ -3,16 +3,16 @@
 class Migrations::BackfillDossierRepetitionJob < ApplicationJob
   def perform(dossier_ids)
     Dossier.where(id: dossier_ids)
-      .includes(:champs, revision: :types_de_champ)
+      .includes(:champ_data, revision: :types_de_champ)
       .find_each do |dossier|
         dossier
           .revision
           .types_de_champ
           .filter do |type_de_champ|
-            type_de_champ.type_champ == 'repetition' && dossier.champs.none? { _1.stable_id == type_de_champ.stable_id }
+            type_de_champ.type_champ == 'repetition' && dossier.champ_data.none? { _1.stable_id == type_de_champ.stable_id }
           end
           .each do |type_de_champ|
-            dossier.champs << type_de_champ.build_champ
+            dossier.champ_data << type_de_champ.build_champ
           end
       end
   end

--- a/app/lib/recovery/importer.rb
+++ b/app/lib/recovery/importer.rb
@@ -97,7 +97,7 @@ module Recovery
           import(dossier.justificatif_motivation)
         end
 
-        dossier.champs.each do |champ|
+        dossier.champ_data.each do |champ|
           champ.piece_justificative_file.each { |pj| import(pj) }
 
           if champ.etablissement.present?

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -199,19 +199,19 @@ module DossierChampsConcern
   end
 
   def reset_user_buffer_stream!
-    champs.where(stream: Champ::USER_BUFFER_STREAM).destroy_all
+    champ_data.where(stream: Champ::USER_BUFFER_STREAM).destroy_all
 
     # update loaded champ instances
-    association(:champs).target = champs.filter { _1.stream != Champ::USER_BUFFER_STREAM }
+    association(:champ_data).target = champ_data.filter { _1.stream != Champ::USER_BUFFER_STREAM }
 
     reset_champs_cache
   end
 
   def reset_instructeur_buffer_stream!
-    champs.where(stream: Champ::INSTRUCTEUR_BUFFER_STREAM).destroy_all
+    champ_data.where(stream: Champ::INSTRUCTEUR_BUFFER_STREAM).destroy_all
 
     # update loaded champ instances
-    association(:champs).target = champs.filter { _1.stream != Champ::INSTRUCTEUR_BUFFER_STREAM }
+    association(:champ_data).target = champ_data.filter { _1.stream != Champ::INSTRUCTEUR_BUFFER_STREAM }
 
     reset_champs_cache
   end
@@ -268,7 +268,7 @@ module DossierChampsConcern
   end
 
   def history
-    champs.filter(&:history_stream?)
+    champ_data.filter(&:history_stream?)
   end
 
   def set_default_value_for_france_connect_champs(user_email)
@@ -302,13 +302,13 @@ module DossierChampsConcern
   private
 
   def changed_champ_ids_for_merge(stream)
-    stream_h = champs.where(stream:, stable_id: revision_stable_ids)
+    stream_h = champ_data.where(stream:, stable_id: revision_stable_ids)
       .pluck(:stable_id, :row_id, :id)
       .to_h { |(stable_id, row_id, id)| [TypeDeChamp.public_id(stable_id, row_id), id] }
 
     return [[], []] if stream_h.empty?
 
-    main_h = champs.where(stream: Champ::MAIN_STREAM, stable_id: revision_stable_ids)
+    main_h = champ_data.where(stream: Champ::MAIN_STREAM, stable_id: revision_stable_ids)
       .pluck(:stable_id, :row_id, :id)
       .to_h { |(stable_id, row_id, id)| [TypeDeChamp.public_id(stable_id, row_id), id] }
 
@@ -318,14 +318,14 @@ module DossierChampsConcern
     changed_ids = main_public_ids.intersection(stream_public_ids).map { main_h[it] }
     stream_ids = stream_h.values
 
-    # mark champs in discarded rows as changed
-    discarded_row_ids = champs.where(stream:, stable_id: revision_stable_ids)
+    # mark champ_data in discarded rows as changed
+    discarded_row_ids = champ_data.where(stream:, stable_id: revision_stable_ids)
       .where.not(row_id: nil)
       .where.not(discarded_at: nil)
       .pluck(:row_id)
 
     if discarded_row_ids.present?
-      changed_ids += champs.where(stream: Champ::MAIN_STREAM, row_id: discarded_row_ids).pluck(:id)
+      changed_ids += champ_data.where(stream: Champ::MAIN_STREAM, row_id: discarded_row_ids).pluck(:id)
     end
 
     [stream_ids, changed_ids]
@@ -334,25 +334,25 @@ module DossierChampsConcern
   def merge_buffer_champs(buffer_ids, changed_ids, stream)
     now = Time.zone.now
     history_stream = "#{Champ::HISTORY_STREAM}#{now}"
-    buffer_champs = champs.filter { buffer_ids.member?(it.id) }
+    buffer_champs = champ_data.filter { buffer_ids.member?(it.id) }
 
     transaction do
       # if merging user buffer, discard any instructeur made changes
       if stream == Champ::USER_BUFFER_STREAM
-        champs.where(id: buffer_ids, stream:).pluck(:stable_id, :row_id).each do |(stable_id, row_id)|
-          champs.where(stream: Champ::INSTRUCTEUR_BUFFER_STREAM, stable_id:, row_id:).destroy_all
+        champ_data.where(id: buffer_ids, stream:).pluck(:stable_id, :row_id).each do |(stable_id, row_id)|
+          champ_data.where(stream: Champ::INSTRUCTEUR_BUFFER_STREAM, stable_id:, row_id:).destroy_all
         end
       end
 
-      # move champs with changes from "main" to "history" stream
-      champs.where(id: changed_ids, stream: Champ::MAIN_STREAM).update_all(stream: history_stream)
-      # move champs from "buffer" to "main"
-      champs.where(id: buffer_ids, stream:).update_all(stream: Champ::MAIN_STREAM, updated_at: now, checkpoint: history_stream)
+      # move champ_data with changes from "main" to "history" stream
+      champ_data.where(id: changed_ids, stream: Champ::MAIN_STREAM).update_all(stream: history_stream)
+      # move champ_data from "buffer" to "main"
+      champ_data.where(id: buffer_ids, stream:).update_all(stream: Champ::MAIN_STREAM, updated_at: now, checkpoint: history_stream)
       update_champs_timestamps(buffer_champs, stream)
     end
 
     # update loaded champ instances
-    champs.each do |champ|
+    champ_data.each do |champ|
       if champ.id.in?(changed_ids)
         champ.stream = history_stream
       elsif champ.id.in?(buffer_ids)
@@ -401,7 +401,7 @@ module DossierChampsConcern
     when Champ::INSTRUCTEUR_BUFFER_STREAM
       (champs_on_instructeur_buffer_stream + champs_on_main_stream).uniq(&:public_id)
     when Champ::USER_HISTORY_STREAM
-      champs
+      champ_data
         # only "main" and "history"
         .reject(&:buffer_stream?)
         # only updates made before last submission
@@ -420,11 +420,11 @@ module DossierChampsConcern
   end
 
   def champs_in_revision
-    champs.filter { stable_id_in_revision?(_1.stable_id) }
+    champ_data.filter { stable_id_in_revision?(_1.stable_id) }
   end
 
   def discarded_champs_on_main_stream
-    champs.filter(&:main_stream?).reject { stable_id_in_revision?(_1.stable_id) }
+    champ_data.filter(&:main_stream?).reject { stable_id_in_revision?(_1.stable_id) }
   end
 
   def champs_on_main_stream
@@ -466,11 +466,11 @@ module DossierChampsConcern
     Champ.where(dossier_id: id, row_id: Champ::NULL_ROW_ID).update_all(row_id: nil)
 
     # FIXME: Try to find the champ in memory before querying the database
-    champ = champs.find { _1.stream == stream && _1.public_id == type_de_champ.public_id(row_id) }
+    champ = champ_data.find { _1.stream == stream && _1.public_id == type_de_champ.public_id(row_id) }
 
     if champ.nil?
       champ = Dossier.no_touching do
-        champs
+        champ_data
           .create_with(**type_de_champ.params_for_champ, source_stream: stream)
           .create_or_find_by!(stable_id: type_de_champ.stable_id, row_id:, stream:)
       end
@@ -481,14 +481,14 @@ module DossierChampsConcern
       champ = champ.becomes!(type_de_champ.champ_class)
       champ.assign_attributes(value: nil, value_json: nil, external_id: nil, data: nil)
     elsif stream != Champ::MAIN_STREAM && champ.previously_new_record?
-      main_stream_champ = champs.find_by(stable_id: type_de_champ.stable_id, row_id:, stream: Champ::MAIN_STREAM)
+      main_stream_champ = champ_data.find_by(stable_id: type_de_champ.stable_id, row_id:, stream: Champ::MAIN_STREAM)
       champ.clone_value_from(main_stream_champ) if main_stream_champ.present?
     end
 
-    # If the champ returned from `create_or_find_by` is not the same as the one already loaded in `dossier.champs`, we need to update the association cache
-    loaded_champ = champs.find { [_1.stream, _1.public_id] == [champ.stream, champ.public_id] }
+    # If the champ returned from `create_or_find_by` is not the same as the one already loaded in `dossier.champ_data`, we need to update the association cache
+    loaded_champ = champ_data.find { [_1.stream, _1.public_id] == [champ.stream, champ.public_id] }
     if loaded_champ.present? && loaded_champ.object_id != champ.object_id
-      association(:champs).target = champs - [loaded_champ] + [champ]
+      association(:champ_data).target = champ_data - [loaded_champ] + [champ]
     end
 
     # If the dossier instance on champ has changed we need to update the association cache

--- a/app/models/concerns/dossier_clone_concern.rb
+++ b/app/models/concerns/dossier_clone_concern.rb
@@ -27,7 +27,7 @@ module DossierCloneConcern
         kopy.parent_dossier = original
         kopy.user = user || original.user
         kopy.state = Dossier.states.fetch(:brouillon)
-        kopy.champs = cloned_champs.map do |champ|
+        kopy.champ_data = cloned_champs.map do |champ|
           champ.dossier = kopy
           champ
         end

--- a/app/models/concerns/dossier_rebase_concern.rb
+++ b/app/models/concerns/dossier_rebase_concern.rb
@@ -40,15 +40,15 @@ module DossierRebaseConcern
     # update dossier revision
     update_column(:revision_id, target_revision.id)
 
-    # mark updated champs as rebased
-    champs.where(stable_id: updated_stable_ids).update_all(rebased_at: Time.zone.now)
+    # mark updated champ_data as rebased
+    champ_data.where(stable_id: updated_stable_ids).update_all(rebased_at: Time.zone.now)
 
     # add rows for new repetitions
     target_revision
       .types_de_champ
       .filter { _1.repetition? && _1.stable_id.in?(added_stable_ids) && (_1.mandatory? || _1.private?) }
       .each do |type_de_champ|
-        self.champs << type_de_champ.build_champ(row_id: ULID.generate, rebased_at: Time.zone.now)
+        self.champ_data << type_de_champ.build_champ(row_id: ULID.generate, rebased_at: Time.zone.now)
       end
   end
 end

--- a/app/models/concerns/dossier_state_concern.rb
+++ b/app/models/concerns/dossier_state_concern.rb
@@ -391,14 +391,14 @@ module DossierStateConcern
   private
 
   def remove_not_in_revision_champs!
-    champs.where.not(stable_id: revision_stable_ids).where(stream: Champ::MAIN_STREAM).destroy_all
+    champ_data.where.not(stable_id: revision_stable_ids).where(stream: Champ::MAIN_STREAM).destroy_all
   end
 
   def remove_discarded_rows!
-    row_to_remove_ids = champs.filter { _1.row? && _1.discarded? }.map(&:row_id)
+    row_to_remove_ids = champ_data.filter { _1.row? && _1.discarded? }.map(&:row_id)
 
     return if row_to_remove_ids.empty?
-    champs.where(row_id: row_to_remove_ids, stream: Champ::MAIN_STREAM).destroy_all
+    champ_data.where(row_id: row_to_remove_ids, stream: Champ::MAIN_STREAM).destroy_all
   end
 
   def remove_not_visible_or_empty_repetitions!
@@ -407,7 +407,7 @@ module DossierStateConcern
       .flat_map(&:row_ids)
 
     return if row_to_remove_ids.empty?
-    champs.where(row_id: row_to_remove_ids, stream: Champ::MAIN_STREAM).destroy_all
+    champ_data.where(row_id: row_to_remove_ids, stream: Champ::MAIN_STREAM).destroy_all
   end
 
   def clear_not_visible_or_empty_champs!
@@ -415,19 +415,19 @@ module DossierStateConcern
       .reject(&:repetition?)
       .filter { _1.blank? || !_1.visible? }
 
-    champs.where(id: champs_to_clear, stream: Champ::MAIN_STREAM).find_each(&:clear)
+    champ_data.where(id: champs_to_clear, stream: Champ::MAIN_STREAM).find_each(&:clear)
   end
 
   def clear_france_connect_champs_piece_justificatives!
     champs_to_clear = project_champs_public.filter(&:france_connect?)
 
     return if champs_to_clear.empty?
-    champs.where(id: champs_to_clear).find_each(&:clear_piece_justificative)
+    champ_data.where(id: champs_to_clear).find_each(&:clear_piece_justificative)
   end
 
   def clear_titres_identite!
-    champ_to_clear_stable_ids = champs.filter do |champ|
-      # Use STI type to avoid querying type_de_champ for orphaned champs
+    champ_to_clear_stable_ids = champ_data.filter do |champ|
+      # Use STI type to avoid querying type_de_champ for orphaned champ_data
       next false unless champ.is_a?(Champs::PieceJustificativeChamp)
 
       begin
@@ -438,7 +438,7 @@ module DossierStateConcern
       end
     end.to_set(&:stable_id)
 
-    champs.where(stable_id: champ_to_clear_stable_ids).find_each(&:clear)
+    champ_data.where(stable_id: champ_to_clear_stable_ids).find_each(&:clear)
   end
 
   def clear_auto_purged_piece_justificatives!
@@ -450,7 +450,7 @@ module DossierStateConcern
       .filter(&:pj_auto_purge?)
       .map(&:stable_id)
 
-    champs.where(stable_id: champ_to_clear_stable_ids).find_each(&:clear)
+    champ_data.where(stable_id: champ_to_clear_stable_ids).find_each(&:clear)
   end
 
   def remove_attente_avis_notification
@@ -462,7 +462,7 @@ module DossierStateConcern
 
     return if champ_to_remove_ids.empty?
 
-    champs.where(id: champ_to_remove_ids, stream: Champ::MAIN_STREAM).destroy_all
+    champ_data.where(id: champ_to_remove_ids, stream: Champ::MAIN_STREAM).destroy_all
   end
 
   def enqueue_ami_notification(trigger: :dossier_state_change, state: nil)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -60,7 +60,7 @@ class Dossier < ApplicationRecord
 
   # autosave is required to import champ validation errors on the dossier
   # when validating with the :champs_public_value/:champs_private_value contexts
-  has_many :champs, dependent: :destroy, autosave: true
+  has_many :champ_data, dependent: :destroy, class_name: 'Champ', autosave: true
   has_many :commentaires, inverse_of: :dossier, dependent: :destroy
   has_many :commentaires_chronological, -> { chronological }, class_name: 'Commentaire', inverse_of: :dossier
   has_many :preloaded_commentaires, -> { includes(:dossier_correction, :dossier_pending_response, :instructeur, :expert, piece_jointe_attachments: :blob).order(created_at: :desc) }, class_name: 'Commentaire', inverse_of: :dossier
@@ -280,7 +280,7 @@ class Dossier < ApplicationRecord
   scope :hidden_by_administration_since, -> (since) { where('dossiers.hidden_by_administration_at IS NOT NULL AND dossiers.hidden_by_administration_at >= ?', since) }
   scope :hidden_since,                   -> (since) { hidden_by_user_since(since).or(hidden_by_administration_since(since)) }
 
-  scope :with_type_de_champ, -> (stable_id) { joins(:champs).where(champs: { stream: 'main', stable_id: }) }
+  scope :with_type_de_champ, -> (stable_id) { joins(:champ_data).where(champs: { stream: 'main', stable_id: }) }
   scope :without_type_de_champ, -> (stable_id) { where.not(id: with_type_de_champ(stable_id).select(:id)) }
 
   scope :with_unread_messages_for_user, -> {
@@ -1139,7 +1139,7 @@ class Dossier < ApplicationRecord
   def purge_freeing_champs_cascade
     transaction do
       yield if block_given?
-      champs.in_batches(of: 50).each(&:destroy_all)
+      champ_data.in_batches(of: 50).each(&:destroy_all)
       destroy
     rescue => e
       Sentry.capture_exception(e, extra: { dossier: id })
@@ -1150,12 +1150,12 @@ class Dossier < ApplicationRecord
   end
 
   def build_default_champs
-    build_default_champs_for(revision.types_de_champ_public) if !champs.any?(&:public?)
-    build_default_champs_for(revision.types_de_champ_private) if !champs.any?(&:private?)
+    build_default_champs_for(revision.types_de_champ_public) if !champ_data.any?(&:public?)
+    build_default_champs_for(revision.types_de_champ_private) if !champ_data.any?(&:private?)
   end
 
   def build_default_champs_for(types_de_champ)
-    self.champs << types_de_champ.filter(&:fillable?).filter_map do |type_de_champ|
+    self.champ_data << types_de_champ.filter(&:fillable?).filter_map do |type_de_champ|
       if type_de_champ.repetition?
         if type_de_champ.private? || type_de_champ.mandatory?
           type_de_champ.build_champ(dossier: self, row_id: ULID.generate)

--- a/app/models/dossier_preloader.rb
+++ b/app/models/dossier_preloader.rb
@@ -126,7 +126,7 @@ class DossierPreloader
     if submitted_revision.present?
       dossier.association(:submitted_revision).target = submitted_revision
     end
-    dossier.association(:champs).target = champs
+    dossier.association(:champ_data).target = champs
 
     champs.each do |champ|
       champ.association(:dossier).target = dossier

--- a/app/models/traitement.rb
+++ b/app/models/traitement.rb
@@ -99,7 +99,7 @@ class Traitement < ApplicationRecord
   def reference_champs
     if checkpoint.present?
       changed_keys = changed_champs.keys
-      dossier.champs.filter { _1.stream == checkpoint && _1.public_id.in?(changed_keys) }
+      dossier.champ_data.filter { _1.stream == checkpoint && _1.public_id.in?(changed_keys) }
     else
       []
     end.index_by(&:public_id)
@@ -107,7 +107,7 @@ class Traitement < ApplicationRecord
 
   def changed_champs
     if checkpoint.present?
-      dossier.champs.filter { _1.checkpoint == checkpoint && !_1.row? }
+      dossier.champ_data.filter { _1.checkpoint == checkpoint && !_1.row? }
     else
       []
     end.index_by(&:public_id)

--- a/app/services/dossier_projection_service.rb
+++ b/app/services/dossier_projection_service.rb
@@ -32,7 +32,7 @@ class DossierProjectionService
       champs = Champ.where(dossier_id: dossiers_ids, stable_id: stable_ids, stream: 'main').includes(:piece_justificative_file_attachments).group_by(&:dossier_id)
 
       dossiers.each do |dossier|
-        dossier.association(:champs).target = champs[dossier.id] || []
+        dossier.association(:champ_data).target = champs[dossier.id] || []
       end
     end
 

--- a/app/services/referentiel_service.rb
+++ b/app/services/referentiel_service.rb
@@ -112,7 +112,7 @@ class ReferentielService
       values_source[tag_id]
     else
       stable_id = tag_id.delete_prefix("tdc").to_i
-      champ = values_source.champs.find { _1.stable_id == stable_id }
+      champ = values_source.filled_champs.find { _1.stable_id == stable_id }
       champ&.value
     end
   end

--- a/app/tasks/maintenance/t20250526_nullify_row_id_task.rb
+++ b/app/tasks/maintenance/t20250526_nullify_row_id_task.rb
@@ -16,7 +16,7 @@ module Maintenance
     end
 
     def process(dossier)
-      with_nil_row_id, with_null_row_id = dossier.champs
+      with_nil_row_id, with_null_row_id = dossier.champ_data
         .where(row_id: [nil, Champ::NULL_ROW_ID])
         .pluck(:row_id, :stream, :stable_id, :id, :updated_at)
         .partition { _1.first == nil }
@@ -26,13 +26,13 @@ module Maintenance
         if with_nil_row_id[[stream, stable_id]].present?
           with_nil_updated_at, with_nil_id = with_nil_row_id[[stream, stable_id]].reverse
           if with_nil_updated_at > updated_at
-            dossier.champs.where(id: id).destroy_all
+            dossier.champ_data.where(id: id).destroy_all
           else
-            dossier.champs.where(id: with_nil_id).destroy_all
-            dossier.champs.where(id:).update_all(row_id: nil)
+            dossier.champ_data.where(id: with_nil_id).destroy_all
+            dossier.champ_data.where(id:).update_all(row_id: nil)
           end
         else
-          dossier.champs.where(id:).update_all(row_id: nil)
+          dossier.champ_data.where(id:).update_all(row_id: nil)
         end
       end
     end

--- a/app/tasks/maintenance/t20250605fix_conflictual_row_id_during_mep_task.rb
+++ b/app/tasks/maintenance/t20250605fix_conflictual_row_id_during_mep_task.rb
@@ -17,7 +17,7 @@ module Maintenance
     end
 
     def process(dossier)
-      duplicated_champ_ids = dossier.champs.where(row_id: [Champ::NULL_ROW_ID, nil])
+      duplicated_champ_ids = dossier.champ_data.where(row_id: [Champ::NULL_ROW_ID, nil])
         .order(updated_at: :desc)
         .select(:id, :stream, :stable_id, :row_id)
         .group_by { "#{_1.stream}-#{_1.public_id}" }
@@ -25,9 +25,9 @@ module Maintenance
         .flat_map { _1[1..].map(&:id) }
       Dossier.transaction do
         if duplicated_champ_ids.present?
-          Dossier.no_touching { dossier.champs.where(id: duplicated_champ_ids).destroy_all }
+          Dossier.no_touching { dossier.champ_data.where(id: duplicated_champ_ids).destroy_all }
         end
-        dossier.champs.where(row_id: Champ::NULL_ROW_ID).update_all(row_id: nil)
+        dossier.champ_data.where(row_id: Champ::NULL_ROW_ID).update_all(row_id: nil)
       end
     end
   end

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -310,7 +310,7 @@
     %h1.fr-mt-4w Attachment::FileFieldComponent (single file)
     %span.fr-hint-text Note: direct upload, suppression ne marchent pas comme attendu ici.
 
-    - champ = @dossier.champs.find { _1.type_champ == TypeDeChamp.type_champs.fetch(:piece_justificative) }
+    - champ = @dossier.project_champs_public.find { _1.type_champ == TypeDeChamp.type_champs.fetch(:piece_justificative) }
     - tdc = champ.type_de_champ
     - avis = Avis.new
 

--- a/spec/components/attachment/attachment_row_component_spec.rb
+++ b/spec/components/attachment/attachment_row_component_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Attachment::AttachmentRowComponent, type: :component do
   let_it_be(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative, nature: 'titre_identite' }]) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
   let(:attached_file) { champ.piece_justificative_file }
   let(:attachment) { attached_file.attachments.first }
   let(:filename) { attachment.filename.to_s }

--- a/spec/components/attachment/file_field_component_spec.rb
+++ b/spec/components/attachment/file_field_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
   describe 'with has_many_attached (Champ.piece_justificative_file)' do
     let_it_be(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     let(:context) { Attachment::Context.new(champ:) }
 
     it 'deduces max=10 and shows drop zone' do
@@ -55,7 +55,7 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
   describe 'override max (RIB case: has_many but max=1)' do
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     let(:context) { Attachment::Context.new(champ:) }
 
     it 'uses forced max=1 despite has_many' do
@@ -68,7 +68,7 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
   describe 'drop_zone validation' do
     let_it_be(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
     let_it_be(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     let(:context) { Attachment::Context.new(champ:) }
 
     it 'accepts :none' do
@@ -91,7 +91,7 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
 
     let_it_be(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
     let_it_be(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     let(:context) { Attachment::Context.new(champ:) }
 
     let(:drop_area) { render_inline(described_class.new(context:, drop_zone: :integrated)).at_css('.attachment-drop-area') }
@@ -109,7 +109,7 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
   describe 'drop zone file input tab order (issue #13104)' do
     let_it_be(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
     let_it_be(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     let(:context) { Attachment::Context.new(champ:) }
 
     context 'with an integrated drop zone' do
@@ -135,7 +135,7 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
     context 'when champ is a piece_justificative with titre_identite nature' do
       let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative, nature: 'titre_identite' }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
       let(:context) { Attachment::Context.new(champ:) }
 
       it 'renders exhaustive format list without tooltip' do
@@ -147,7 +147,7 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
     context 'when champ is a piece_justificative with no format limit' do
       let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
       let(:context) { Attachment::Context.new(champ:) }
 
       it 'does not render format info, only max size' do
@@ -159,7 +159,7 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
     context 'when champ is a piece_justificative limited to document_texte' do
       let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
       let(:context) { Attachment::Context.new(champ:) }
 
       before do
@@ -179,7 +179,7 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
     context 'when champ is a piece_justificative limited to document_texte + image_scan' do
       let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
       let(:context) { Attachment::Context.new(champ:) }
 
       before do
@@ -198,7 +198,7 @@ RSpec.describe Attachment::FileFieldComponent, type: :component do
     context 'when champ is a piece_justificative with RIB nature' do
       let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative, nature: 'rib' }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
       let(:context) { Attachment::Context.new(champ:) }
 
       it 'renders exhaustive format list without tooltip' do

--- a/spec/components/attachment/file_input_component_spec.rb
+++ b/spec/components/attachment/file_input_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Attachment::FileInputComponent, type: :component do
   let_it_be(:types_de_champ_public) { [{ type: :piece_justificative }] }
   let_it_be(:procedure) { create(:procedure, :published, types_de_champ_public:) }
   let_it_be(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.reload.first }
+  let(:champ) { dossier.champ_data.reload.first }
   let(:attached_file) { champ.piece_justificative_file }
   let(:context_kwargs) { {} }
   let(:kwargs) { {} }

--- a/spec/components/attachment/gallery_item_component_spec.rb
+++ b/spec/components/attachment/gallery_item_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Attachment::GalleryItemComponent, type: :component do
 
   context "when attachment is from a public piece justificative champ" do
     let(:champ) do
-      dossier.champs.where(private: false).first
+      dossier.champ_data.where(private: false).first
     end
     let(:libelle) { champ.libelle }
     let(:attachment) { champ.piece_justificative_file.attachments.first }
@@ -49,7 +49,7 @@ RSpec.describe Attachment::GalleryItemComponent, type: :component do
 
   context "when attachment is from a private piece justificative champ" do
     let(:annotation) do
-      dossier.champs.where(private: true).first
+      dossier.champ_data.where(private: true).first
     end
     let(:libelle) { annotation.libelle }
     let(:attachment) { annotation.piece_justificative_file.attachments.first }

--- a/spec/components/attachment/hints_component_spec.rb
+++ b/spec/components/attachment/hints_component_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Attachment::HintsComponent, type: :component do
   let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
   let(:attached_file) { champ.piece_justificative_file }
 
   let(:component) do

--- a/spec/components/attachment/show_component_spec.rb
+++ b/spec/components/attachment/show_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Attachment::ShowComponent, type: :component do
   let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
   let(:types_de_champ_public) { [{ type: :piece_justificative }] }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   let(:attachment) { champ.piece_justificative_file.attachments.first }
   let(:filename) { attachment.filename.to_s }

--- a/spec/components/attachment/thumbnail_component_spec.rb
+++ b/spec/components/attachment/thumbnail_component_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Attachment::ThumbnailComponent, type: :component do
   let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
   let(:dossier) { create(:dossier, :en_construction, procedure:) }
-  let(:champ_pj) { dossier.champs.first }
+  let(:champ_pj) { dossier.champ_data.first }
   let(:attachment) do
     champ_pj.piece_justificative_file.attach(
       io: file,

--- a/spec/components/dossiers/errors_full_messages_component_spec.rb
+++ b/spec/components/dossiers/errors_full_messages_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dossiers::ErrorsFullMessagesComponent, type: :component do
     end
 
     context 'when dossier have error' do
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       subject do
         dossier.validate(:champs_public_value)
@@ -26,7 +26,7 @@ RSpec.describe Dossiers::ErrorsFullMessagesComponent, type: :component do
       end
 
       context 'when champ is repetition' do
-        let(:champ_repetition) { dossier.champs.first }
+        let(:champ_repetition) { dossier.champ_data.first }
         let(:rows) { champ_repetition.rows }
         let(:champ_child) { rows.first.first }
 

--- a/spec/components/dossiers/geo_area_component_spec.rb
+++ b/spec/components/dossiers/geo_area_component_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Dossiers::GeoAreaComponent, type: :component do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :carte }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
   let(:geo_area) { create(:geo_area, :selection_utilisateur, :polygon, champ:) }
 
   before { render_inline(described_class.new(geo_area:, editing:)) }

--- a/spec/components/dsfr/input_status_message_component_spec.rb
+++ b/spec/components/dsfr/input_status_message_component_spec.rb
@@ -3,7 +3,7 @@
 describe Dsfr::InputStatusMessageComponent, type: :component do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: 'rib' }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   describe 'announcement mode' do
     context 'when the RIB analysis is pending' do

--- a/spec/components/editable_champ/communes_component_spec.rb
+++ b/spec/components/editable_champ/communes_component_spec.rb
@@ -4,7 +4,7 @@ describe EditableChamp::CommunesComponent, type: :component do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :communes }]) }
   let(:dossier) { create(:dossier, procedure:) }
   let(:tdc) { procedure.active_revision.types_de_champ.first }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   describe 'aria-describedby' do
     let(:react_component) { page.find('react-component') }

--- a/spec/components/editable_champ/drop_down_list_component_spec.rb
+++ b/spec/components/editable_champ/drop_down_list_component_spec.rb
@@ -7,7 +7,7 @@ describe EditableChamp::DropDownListComponent, type: :component do
   let(:types_de_champ_public) { [{ type: :drop_down_list }] }
   let(:dossier) { create(:dossier, procedure:) }
   let(:tdc) { procedure.active_revision.types_de_champ.first }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   subject(:render) do
     component = nil

--- a/spec/components/editable_champ/piece_justificative_component/piece_justificative_component_spec.rb
+++ b/spec/components/editable_champ/piece_justificative_component/piece_justificative_component_spec.rb
@@ -4,7 +4,7 @@ describe EditableChamp::PieceJustificativeComponent, type: :component do
   let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
   let(:types_de_champ_public) { [{ type: :piece_justificative }] }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   let(:component) {
     described_class.new(form: instance_double(ActionView::Helpers::FormBuilder, object_name: "dossier[champs_public_attributes]"), champ:)

--- a/spec/components/editable_champ/piece_justificative_component_spec.rb
+++ b/spec/components/editable_champ/piece_justificative_component_spec.rb
@@ -3,7 +3,7 @@
 describe EditableChamp::PieceJustificativeComponent, type: :component do
   let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   let(:component) { described_class.new(form: nil, champ:) }
 

--- a/spec/components/editable_champ/yes_no_component_spec.rb
+++ b/spec/components/editable_champ/yes_no_component_spec.rb
@@ -4,7 +4,7 @@ describe EditableChamp::YesNoComponent, type: :component do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :yes_no }]) }
   let(:dossier) { create(:dossier, procedure:) }
   let(:tdc) { procedure.active_revision.types_de_champ.first }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   subject(:render) do
     component = nil

--- a/spec/components/input_status_message_component_spec.rb
+++ b/spec/components/input_status_message_component_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Dsfr::InputStatusMessageComponent, type: :component do
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
   let(:champ_component) { instance_double("ChampComponent", errors_on_attribute?: errors_on_attribute, error_full_messages:, attribute: :value) }
   let(:component) { described_class.new(champ_component:, champ:) }
 

--- a/spec/components/instructeurs/cell_component_spec.rb
+++ b/spec/components/instructeurs/cell_component_spec.rb
@@ -51,7 +51,7 @@ describe Instructeurs::CellComponent do
       let(:types_de_champ_public) { [{ type: :yes_no, libelle: 'yes_no' }] }
       let(:column) { dossier.procedure.find_column(label: 'yes_no') }
 
-      before { dossier.champs.first.update(value: 'true') }
+      before { dossier.champ_data.first.update(value: 'true') }
 
       it { is_expected.to eq('Oui') }
     end
@@ -67,7 +67,7 @@ describe Instructeurs::CellComponent do
       let(:types_de_champ_public) { [{ type: :checkbox, libelle: 'checkbox' }] }
       let(:column) { dossier.procedure.find_column(label: 'checkbox') }
 
-      before { dossier.champs.first.update(value: 'true') }
+      before { dossier.champ_data.first.update(value: 'true') }
 
       it { is_expected.to eq('coché') }
     end
@@ -82,7 +82,7 @@ describe Instructeurs::CellComponent do
       let(:types_de_champ_public) { [{ type: :date, libelle: 'date' }] }
       let(:column) { dossier.procedure.find_column(label: 'date') }
 
-      before { dossier.champs.first.update(value: Date.parse("12/02/2025")) }
+      before { dossier.champ_data.first.update(value: Date.parse("12/02/2025")) }
 
       it { is_expected.to eq('12/02/2025') }
     end
@@ -91,7 +91,7 @@ describe Instructeurs::CellComponent do
       let(:types_de_champ_public) { [{ type: :datetime, libelle: 'datetime' }] }
       let(:column) { dossier.procedure.find_column(label: 'datetime') }
 
-      before { dossier.champs.first.update(value: Time.zone.parse("12/02/2025 09:19").iso8601) }
+      before { dossier.champ_data.first.update(value: Time.zone.parse("12/02/2025 09:19").iso8601) }
 
       it { is_expected.to eq('12/02/2025 09:19') }
     end
@@ -102,7 +102,7 @@ describe Instructeurs::CellComponent do
       let(:etablissement) { build(:etablissement, entreprise_date_creation: Date.new(2015, 8, 10)) }
 
       before {
-        dossier.champs.first.update(value: etablissement.siret, etablissement:)
+        dossier.champ_data.first.update(value: etablissement.siret, etablissement:)
         etablissement.update_champ_value_json!
       }
 
@@ -113,7 +113,7 @@ describe Instructeurs::CellComponent do
       let(:types_de_champ_public) { [{ type: :drop_down_list, libelle: 'drop_down_list', options: ['a', 'b', 'c'] }] }
       let(:column) { dossier.procedure.find_column(label: 'drop_down_list') }
 
-      before { dossier.champs.first.update(value: 'b') }
+      before { dossier.champ_data.first.update(value: 'b') }
 
       it { is_expected.to eq('b') }
     end
@@ -122,7 +122,7 @@ describe Instructeurs::CellComponent do
       let(:types_de_champ_public) { [{ type: :multiple_drop_down_list, libelle: 'multiple_drop_down_list', options: ['a', 'b', 'c'] }] }
       let(:column) { dossier.procedure.find_column(label: 'multiple_drop_down_list') }
 
-      before { dossier.champs.first.update(value: ['b', 'c']) }
+      before { dossier.champ_data.first.update(value: ['b', 'c']) }
 
       it { is_expected.to eq('b, c') }
     end

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -1506,9 +1506,9 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
     let!(:dossier3) { create(:dossier, :accepte, :with_populated_champs, procedure: procedure) }
 
     before do
-      dossier1.champs.first.update(value: 'Paris')
-      dossier2.champs.first.update(value: 'Lyon')
-      dossier3.champs.first.update(value: 'Marseille')
+      dossier1.champ_data.first.update(value: 'Paris')
+      dossier2.champ_data.first.update(value: 'Lyon')
+      dossier3.champ_data.first.update(value: 'Marseille')
       post :create_simple_routing, params: { procedure_id: procedure.id, create_simple_routing: { stable_id: drop_down_tdc.stable_id } }
       post :bulk_route, params: { procedure_id: procedure.id }
     end

--- a/spec/controllers/api/public/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/dossiers_controller_spec.rb
@@ -248,6 +248,6 @@ RSpec.describe API::Public::V1::DossiersController, type: :controller do
   private
 
   def find_champ_by_stable_id(dossier, stable_id)
-    dossier.champs.find_by(stable_id:)
+    dossier.champ_data.find_by(stable_id:)
   end
 end

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -872,7 +872,7 @@ describe API::V2::GraphqlController do
 
     describe "champ piece_justificative" do
       let(:types_de_champ_public) { [{ type: :piece_justificative }] }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
       let(:byte_size) { 2712286911 }
 
       context "with deprecated file field" do
@@ -1600,7 +1600,7 @@ describe API::V2::GraphqlController do
                 },
                 errors: nil,
               })
-              expect(dossier.champs.first.value).not_to be_nil
+              expect(dossier.champ_data.first.value).not_to be_nil
             end
           end
         end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -5,8 +5,8 @@ describe AttachmentsController, type: :controller do
   let(:attachment) { champ.piece_justificative_file.attachments.first }
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
   let(:dossier) { create(:dossier, :with_populated_champs, user:, procedure:) }
-  let(:champ) { dossier.champs.first }
-  let(:user_buffer_champ) { dossier.champs.reload.find(&:user_buffer_stream?) }
+  let(:champ) { dossier.champ_data.first }
+  let(:user_buffer_champ) { dossier.champ_data.reload.find(&:user_buffer_stream?) }
   let(:signed_id) { attachment.blob.signed_id }
 
   describe '#show' do
@@ -63,7 +63,7 @@ describe AttachmentsController, type: :controller do
       let(:instructeur) { create(:instructeur) }
       let(:procedure) { create(:procedure, instructeurs: [instructeur], types_de_champ_private: [{ type: :piece_justificative }]) }
       let(:dossier) { create(:dossier, :with_populated_annotations, procedure:) }
-      let(:champ) { dossier.champs.private_only.first }
+      let(:champ) { dossier.champ_data.private_only.first }
 
       before { sign_in(instructeur.user) }
 
@@ -75,7 +75,7 @@ describe AttachmentsController, type: :controller do
       let(:instructeur) { create(:instructeur) }
       let(:procedure) { create(:procedure, instructeurs: [instructeur], types_de_champ_private: [{ type: :piece_justificative }]) }
       let(:dossier) { create(:dossier, :with_populated_annotations, procedure:) }
-      let(:champ) { dossier.champs.private_only.first }
+      let(:champ) { dossier.champ_data.private_only.first }
 
       before { sign_in(other_instructeur.user) }
 
@@ -344,7 +344,7 @@ describe AttachmentsController, type: :controller do
         let(:procedure) { create(:procedure, instructeurs: [instructeur], types_de_champ_private: [{ type: :piece_justificative }]) }
         let(:dossier) { create(:dossier, procedure:) }
         let(:champ) do
-          dossier.champs.private_only.first.tap do |c|
+          dossier.champ_data.private_only.first.tap do |c|
             c.piece_justificative_file.attach({ io: Rails.root.join('spec/fixtures/files/Contrat.pdf').open, filename: 'Contrat.pdf' })
           end
         end

--- a/spec/controllers/champs/carte_controller_spec.rb
+++ b/spec/controllers/champs/carte_controller_spec.rb
@@ -16,7 +16,7 @@ describe Champs::CarteController, type: :controller do
       stable_id: champ.stable_id,
     }
   end
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   describe 'ensure_legitimate_access' do
     before do

--- a/spec/controllers/champs/repetition_controller_spec.rb
+++ b/spec/controllers/champs/repetition_controller_spec.rb
@@ -33,12 +33,12 @@ describe Champs::RepetitionController, type: :controller do
   end
 
   describe '#remove' do
-    let(:row) { dossier.champs.find(&:row?) }
+    let(:row) { dossier.champ_data.find(&:row?) }
 
     subject { delete :remove, params: { dossier_id: dossier, stable_id: repetition.stable_id, row_id: row.row_id }, format: :turbo_stream }
 
     context 'removes repetition' do
-      it { expect { subject }.not_to change { dossier.reload.champs.size } }
+      it { expect { subject }.not_to change { dossier.reload.champ_data.size } }
       it { expect { subject }.to change { dossier.reload; dossier.project_champs_public.find(&:repetition?).row_ids.size }.from(1).to(0) }
       it { expect { subject }.to change { row.reload.discarded_at }.from(nil).to(Time) }
       it { expect { subject }.to change { dossier.reload.last_champ_updated_at } }
@@ -49,7 +49,7 @@ describe Champs::RepetitionController, type: :controller do
     subject { post :add, params: { dossier_id: dossier, stable_id: repetition.stable_id }, format: :turbo_stream }
 
     context 'add repetition' do
-      it { expect { subject }.to change { dossier.reload.champs.size } }
+      it { expect { subject }.to change { dossier.reload.champ_data.size } }
       it { expect { subject }.to change { dossier.reload.last_champ_updated_at } }
     end
   end

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -578,7 +578,7 @@ describe Experts::AvisController, type: :controller do
         let(:invite_linked_dossiers) { true }
 
         before do
-          dossier_link_champ = dossier.champs.find_by(type: "Champs::DossierLinkChamp")
+          dossier_link_champ = dossier.champ_data.find_by(type: "Champs::DossierLinkChamp")
           dossier_link_champ.update!(value: linked_dossier.id)
         end
 

--- a/spec/controllers/instructeurs/champs_controller_spec.rb
+++ b/spec/controllers/instructeurs/champs_controller_spec.rb
@@ -6,7 +6,7 @@ describe Instructeurs::ChampsController, type: :controller do
   let(:types_de_champ_public) { [{ type: :piece_justificative, nature: 'rib' }] }
   let(:procedure) { create(:procedure, instructeurs:, types_de_champ_public:) }
   let(:dossier) { create(:dossier, :en_construction, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   before { sign_in(instructeur.user) }
 
@@ -63,7 +63,7 @@ describe Instructeurs::ChampsController, type: :controller do
         ]
       end
 
-      let(:address_champ) { dossier.champs.find { _1.type_champ == TypeDeChamp.type_champs.fetch(:address) } }
+      let(:address_champ) { dossier.champ_data.find { _1.type_champ == TypeDeChamp.type_champs.fetch(:address) } }
       let(:original_address) { { 'label' => '12 rue du Test, 75000 Paris', 'postal_code' => '75000', 'city_name' => 'Paris' } }
 
       before { address_champ.update!(value: original_address['label'], value_json: original_address) }

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -1153,7 +1153,7 @@ describe Instructeurs::DossiersController, type: :controller do
           context 'and the expert can access the linked dossiers' do
             let(:saved_avis) { Avis.last(2).first }
             let(:linked_avis) { Avis.last }
-            let(:linked_dossier) { Dossier.find_by(id: dossier.champs.first.value) }
+            let(:linked_dossier) { Dossier.find_by(id: dossier.champ_data.first.value) }
             let(:invite_linked_dossiers) do
               instructeur.assign_to_procedure(linked_dossier.procedure)
               true
@@ -1681,8 +1681,8 @@ describe Instructeurs::DossiersController, type: :controller do
 
     context 'when a conditional annotation exists alongside the polled annotation' do
       before do
-        dossier.champs.find(&:referentiel?).update_columns(external_id: 'kthxbye', value: 'OK', data: {})
-        dossier.champs.find { _1.stable_id == checkbox_stable_id }.update_columns(value: 'true')
+        dossier.champ_data.find(&:referentiel?).update_columns(external_id: 'kthxbye', value: 'OK', data: {})
+        dossier.champ_data.find { _1.stable_id == checkbox_stable_id }.update_columns(value: 'true')
       end
 
       it 'recomputes visibility of conditional annotations after polling' do
@@ -2065,7 +2065,7 @@ describe Instructeurs::DossiersController, type: :controller do
     let(:avis) { create(:avis, :with_answer, :with_piece_justificative, dossier: dossier, claimant: expert, experts_procedure: experts_procedure) }
 
     before do
-      dossier.champs.first.piece_justificative_file.attach(
+      dossier.champ_data.first.piece_justificative_file.attach(
         io: File.open(logo_path),
         filename: "logo_test_procedure.png",
         content_type: "image/png",

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -238,7 +238,7 @@ describe Users::CommencerController, type: :controller do
             expect(Dossier.count).to eq(1)
             expect(session[:prefill_token]).to eq(Dossier.last.prefill_token)
             expect(session[:prefill_params_digest]).to eq(PrefillChamps.digest({ "champ_#{type_de_champ_text.to_typed_id}" => "blabla" }))
-            expect(Dossier.last.champs.where(stable_id: type_de_champ_text.stable_id).first.value).to eq("blabla")
+            expect(Dossier.last.champ_data.where(stable_id: type_de_champ_text.stable_id).first.value).to eq("blabla")
             expect(Dossier.last.individual.nom).to eq("Dupont")
           end
         end

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1070,7 +1070,7 @@ describe Users::DossiersController, type: :controller do
 
     context 'when the champ is an address' do
       let(:types_de_champ_public) { [{ type: :address }] }
-      let(:address_champ) { dossier.champs.first }
+      let(:address_champ) { dossier.champ_data.first }
       let(:initial_value_json) do
         {
           'label' => '33 Rue Rébeval 75019 Paris',
@@ -2578,7 +2578,7 @@ describe Users::DossiersController, type: :controller do
     let(:types_de_champ_public) { [{ type: :text, stable_id: }] }
     let(:procedure) { create(:procedure, types_de_champ_public:) }
     let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:, user:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     before do
       sign_in(user)
@@ -2616,7 +2616,7 @@ describe Users::DossiersController, type: :controller do
       end
 
       context 'while the analysis is still pending' do
-        before { dossier.champs.first.update_column(:external_state, :waiting_for_job) }
+        before { dossier.champ_data.first.update_column(:external_state, :waiting_for_job) }
 
         it 'does not re-announce the pending status on a poll' do
           subject
@@ -2625,7 +2625,7 @@ describe Users::DossiersController, type: :controller do
       end
 
       context 'when the analysis has completed' do
-        before { dossier.champs.first.update_columns(external_state: :fetched, value_json: { 'rib' => { 'iban' => 'FR7612345' } }) }
+        before { dossier.champ_data.first.update_columns(external_state: :fetched, value_json: { 'rib' => { 'iban' => 'FR7612345' } }) }
 
         it 'announces the result on the poll that observes completion' do
           subject
@@ -2639,7 +2639,7 @@ describe Users::DossiersController, type: :controller do
       let(:types_de_champ_public) { [{ type: :referentiel, referentiel:, stable_id: }] }
 
       context 'when the requested external_id had not been fetched' do
-        before { dossier.champs.first.update_columns(external_id: 'kthxbye') }
+        before { dossier.champ_data.first.update_columns(external_id: 'kthxbye') }
 
         it 'does not validates errors' do
           subject
@@ -2648,7 +2648,7 @@ describe Users::DossiersController, type: :controller do
       end
 
       context 'when the requested external_id had been fetched' do
-        before { dossier.champs.find(&:referentiel?).update_columns(external_id: 'kthxbye', value: "OK", data: {}) }
+        before { dossier.champ_data.find(&:referentiel?).update_columns(external_id: 'kthxbye', value: "OK", data: {}) }
         it 'validates errors' do
           subject
           expect(response).not_to include('Référence trouvée : OK')
@@ -2683,7 +2683,7 @@ describe Users::DossiersController, type: :controller do
           end
 
           it 'inclut le champ principal et les champs pré-remplis dans @to_update' do
-            dossier.champs.find(&:referentiel?).update_external_data!(data: { ok: 'valeur préremplie', repetition: [{ nom: 'Jeanne' }, { nom: "Bob" }, {}] })
+            dossier.champ_data.find(&:referentiel?).update_external_data!(data: { ok: 'valeur préremplie', repetition: [{ nom: 'Jeanne' }, { nom: "Bob" }, {}] })
 
             get :champ, params: { id: dossier.id, stable_id: referentiel_stable_id }, format: :turbo_stream
 
@@ -2697,7 +2697,7 @@ describe Users::DossiersController, type: :controller do
       end
 
       context 'when the requested external_id is in error' do
-        before { dossier.champs.first.update_columns(external_id: 'kthxbye', value: "OK", fetch_external_data_exceptions: [ExternalDataException.new(error: "thxbye", code: 429)]) }
+        before { dossier.champ_data.first.update_columns(external_id: 'kthxbye', value: "OK", fetch_external_data_exceptions: [ExternalDataException.new(error: "thxbye", code: 429)]) }
         it 'validates errors' do
           subject
           expect(response).not_to include('Trop de demandes. Nous réessayons pour vous.')
@@ -2721,8 +2721,8 @@ describe Users::DossiersController, type: :controller do
         let(:stable_id) { async_stable_id }
 
         before do
-          dossier.champs.find(&:referentiel?).update_columns(external_id: 'kthxbye', value: 'OK', data: {})
-          dossier.champs.find { _1.stable_id == checkbox_stable_id }.update_columns(value: 'true')
+          dossier.champ_data.find(&:referentiel?).update_columns(external_id: 'kthxbye', value: 'OK', data: {})
+          dossier.champ_data.find { _1.stable_id == checkbox_stable_id }.update_columns(value: 'true')
         end
 
         it 'recomputes visibility of conditional champs after polling' do
@@ -2878,6 +2878,6 @@ describe Users::DossiersController, type: :controller do
   private
 
   def find_champ_by_stable_id(dossier, stable_id)
-    dossier.champs.joins(:type_de_champ).find_by(types_de_champ: { stable_id: stable_id })
+    dossier.champ_data.joins(:type_de_champ).find_by(types_de_champ: { stable_id: stable_id })
   end
 end

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -310,7 +310,7 @@ def dossier_factory_create_champ_or_repetition(type_de_champ, dossier)
     types_de_champ = dossier.revision.children_of(type_de_champ)
     2.times do
       row_id = ULID.generate
-      dossier.champs << type_de_champ.build_champ(row_id:)
+      dossier.champ_data << type_de_champ.build_champ(row_id:)
       types_de_champ.each do |type_de_champ|
         dossier_factory_create_champ(type_de_champ, dossier, row_id:)
       end
@@ -329,5 +329,5 @@ def dossier_factory_create_champ(type_de_champ, dossier, row_id: nil)
     type_de_champ.drop_down_options.first(2).to_json
   end
   attrs = { stable_id: type_de_champ.stable_id, private: type_de_champ.private?, row_id:, value: }.compact
-  dossier.champs << build(:"champ_do_not_use_#{type_de_champ.type_champ}", **attrs)
+  dossier.champ_data << build(:"champ_do_not_use_#{type_de_champ.type_champ}", **attrs)
 end

--- a/spec/helpers/gallery_helper_spec.rb
+++ b/spec/helpers/gallery_helper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe GalleryHelper, type: :helper do
   let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
   let(:types_de_champ_public) { [{ type: :piece_justificative, stable_id: 3, libelle: 'Justificatif de domicile' }] }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ_pj) { dossier.champs.first }
+  let(:champ_pj) { dossier.champ_data.first }
 
   let(:attachment) do
     champ_pj.piece_justificative_file.attach(

--- a/spec/jobs/api_entreprise/job_spec.rb
+++ b/spec/jobs/api_entreprise/job_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe APIEntreprise::Job, type: :job do
       let(:dossier) { create(:dossier, procedure:) }
 
       it "re-raises so sidekiq can retry" do
-        champ = dossier.champs.first
+        champ = dossier.champ_data.first
         champ.update!(value: '12345678901234')
 
         etablissement = create(:etablissement, champ:)

--- a/spec/jobs/backfill_variants_for_dossier_job_spec.rb
+++ b/spec/jobs/backfill_variants_for_dossier_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe BackfillVariantsForDossierJob, type: :job do
 
   describe '#skip_attachment?' do
     let(:job) { described_class.new }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     let(:attachment) { champ.piece_justificative_file.first }
 
     before do

--- a/spec/jobs/bulk_route_job_spec.rb
+++ b/spec/jobs/bulk_route_job_spec.rb
@@ -26,9 +26,9 @@ describe BulkRouteJob, type: :job do
     end
 
     before do
-      dossier1.champs.first.update(value: 'Paris')
-      dossier2.champs.first.update(value: 'Lyon')
-      dossier3.champs.first.update(value: 'Marseille')
+      dossier1.champ_data.first.update(value: 'Paris')
+      dossier2.champ_data.first.update(value: 'Lyon')
+      dossier3.champ_data.first.update(value: 'Marseille')
       subject
     end
 

--- a/spec/jobs/champ_fetch_external_data_job_spec.rb
+++ b/spec/jobs/champ_fetch_external_data_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ChampFetchExternalDataJob, type: :job do
 
   let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :rnf }]) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
   let(:external_id) { champ.external_id }
 
   describe 'perform' do

--- a/spec/jobs/cron/backfill_siret_degraded_mode_job_spec.rb
+++ b/spec/jobs/cron/backfill_siret_degraded_mode_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Cron::BackfillSiretDegradedModeJob, type: :job do
       let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
       let(:types_de_champ_public) { [{ type: :siret }] }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ_siret) { dossier.champs.first }
+      let(:champ_siret) { dossier.champ_data.first }
 
       before do
         champ_siret

--- a/spec/jobs/cron/fallback_fetch_cadastre_real_geometry_job_spec.rb
+++ b/spec/jobs/cron/fallback_fetch_cadastre_real_geometry_job_spec.rb
@@ -4,7 +4,7 @@ describe Cron::FallbackFetchCadastreRealGeometryJob, type: :job do
   describe '#perform' do
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :carte, options: { cadastres: true } }]) }
     let(:dossier) { create(:dossier, procedure: procedure) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     context 'when cadastre lookup works' do
       it 'processes pending geo areas' do

--- a/spec/jobs/delayed_purge_job_spec.rb
+++ b/spec/jobs/delayed_purge_job_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe DelayedPurgeJob, type: :job do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
   let!(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:blob) { dossier.champs.first.piece_justificative_file.first.blob }
+  let(:blob) { dossier.champ_data.first.piece_justificative_file.first.blob }
   let(:job) { described_class.new(blob) }
   let(:client) { double('OpenStack client') }
   let(:pool) { double('ConnectionPool') }
@@ -35,7 +35,7 @@ describe DelayedPurgeJob, type: :job do
     end
 
     it 'without attachments' do
-      dossier.champs.first.piece_justificative_file.first.delete
+      dossier.champ_data.first.piece_justificative_file.first.delete
       expect(client).to receive(:copy_object)
         .with(container, blob.key, container, blob.key, { 'X-Delete-At' => anything, "Content-Type" => blob.content_type })
         .and_return(double(status: 201))

--- a/spec/jobs/dossier_index_search_terms_job_spec.rb
+++ b/spec/jobs/dossier_index_search_terms_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe DossierIndexSearchTermsJob, type: :job do
   let(:types_de_champ_public) { [{ type: :text }] }
   let(:types_de_champ_private) { [{ type: :text }] }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:champ_siret) { dossier.champs.first }
+  let(:champ_siret) { dossier.champ_data.first }
 
   subject(:perform_job) { described_class.perform_now(dossier.reload) }
 

--- a/spec/jobs/fetch_cadastre_real_geometry_job_spec.rb
+++ b/spec/jobs/fetch_cadastre_real_geometry_job_spec.rb
@@ -4,7 +4,7 @@ describe FetchCadastreRealGeometryJob, type: :job do
   describe '#perform' do
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :carte, options: { cadastres: true } }]) }
     let(:dossier) { create(:dossier, procedure: procedure) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     let!(:geo_area) { create(:geo_area, :cadastre, properties:, champ:) }
     let(:job) { described_class.new(geo_area) }
     subject { job.perform_now }

--- a/spec/jobs/migrations/batch_update_datetime_values_job_spec.rb
+++ b/spec/jobs/migrations/batch_update_datetime_values_job_spec.rb
@@ -4,7 +4,7 @@ describe Migrations::BatchUpdateDatetimeValuesJob, type: :job do
   let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
   let(:types_de_champ_public) { [{ type: :datetime, mandatory: }] }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:datetime_champ) { dossier.champs.first }
+  let(:datetime_champ) { dossier.champ_data.first }
   let(:mandatory) { true }
 
   before do

--- a/spec/jobs/migrations/batch_update_pays_values_job_spec.rb
+++ b/spec/jobs/migrations/batch_update_pays_values_job_spec.rb
@@ -4,7 +4,7 @@ describe Migrations::BatchUpdatePaysValuesJob, type: :job do
   let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
   let(:types_de_champ_public) { [{ type: :pays, mandatory: }] }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:pays_champ) { dossier.champs.first }
+  let(:pays_champ) { dossier.champ_data.first }
   let(:mandatory) { true }
   before { pays_champ.update_columns(attributes) }
   subject { described_class.perform_now([pays_champ.id]) }

--- a/spec/jobs/migrations/normalize_communes_job_spec.rb
+++ b/spec/jobs/migrations/normalize_communes_job_spec.rb
@@ -5,7 +5,7 @@ describe Migrations::NormalizeCommunesJob, type: :job do
     let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
     let(:types_de_champ_public) { [{ type: :communes }] }
     let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     before { champ.update_columns(external_id: "", value: "", value_json: { code_departement: 'undefined', departement: 'undefined' }) }
     subject { described_class.perform_now([champ.id]) }

--- a/spec/lib/recovery/dossier_life_cycle_spec.rb
+++ b/spec/lib/recovery/dossier_life_cycle_spec.rb
@@ -50,9 +50,9 @@ describe 'Dossier::Recovery::LifeCycle' do
     end
 
     def repetition(d) = d.project_champs_public.find(&:repetition?)
-    def pj_champ(d) = d.champs.find_by(type: "Champs::PieceJustificativeChamp")
-    def carte(d) = d.champs.find_by(type: "Champs::CarteChamp")
-    def siret(d) = d.champs.find_by(type: "Champs::SiretChamp")
+    def pj_champ(d) = d.champ_data.find_by(type: "Champs::PieceJustificativeChamp")
+    def carte(d) = d.champ_data.find_by(type: "Champs::CarteChamp")
+    def siret(d) = d.champ_data.find_by(type: "Champs::SiretChamp")
 
     def cleanup_export_file
       if File.exist?(fp)
@@ -69,7 +69,7 @@ describe 'Dossier::Recovery::LifeCycle' do
     after { cleanup_export_file }
     it 'reloads the full grappe', :slow do
       expect(Dossier.count).to eq(1)
-      expect(Dossier.first.champs.count).not_to be(0)
+      expect(Dossier.first.champ_data.count).not_to be(0)
 
       @dossier_ids = Dossier.ids
 
@@ -81,7 +81,7 @@ describe 'Dossier::Recovery::LifeCycle' do
 
       reloaded_dossier = Dossier.first
 
-      expect(reloaded_dossier.champs.count).not_to be(0)
+      expect(reloaded_dossier.champ_data.count).not_to be(0)
 
       expect(repetition(reloaded_dossier).rows.flatten.map(&:type)).to match_array(["Champs::PieceJustificativeChamp", "Champs::PieceJustificativeChamp", "Champs::PieceJustificativeChamp"])
       expect(pj_champ(reloaded_dossier).piece_justificative_file).to be_attached

--- a/spec/lib/recovery/revision_life_cycle_spec.rb
+++ b/spec/lib/recovery/revision_life_cycle_spec.rb
@@ -30,7 +30,7 @@ describe 'Recovery::Revision::LifeCycle' do
       it do
         expect { DossierPreloader.load_one(dossier) }.not_to raise_error
         expect(dossier.project_champs_public.size).to eq(1)
-        expect(dossier.champs.size).to eq(2)
+        expect(dossier.champ_data.size).to eq(2)
         importer.load
         expect { DossierPreloader.load_one(dossier) }.not_to raise_error
         expect(dossier.project_champs_public.size).to eq(2)

--- a/spec/models/champ_blank_json_not_touched_spec.rb
+++ b/spec/models/champ_blank_json_not_touched_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'A blank champ must not be touched when another champ is correcte
   let(:user) { dossier.user }
 
   def second_champ
-    dossier.reload.champs.find { _1.stream == Champ::MAIN_STREAM && _1.stable_id == 100 }
+    dossier.reload.champ_data.find { _1.stream == Champ::MAIN_STREAM && _1.stable_id == 100 }
   end
 
   # Reproduces the usager correction flow: edit only the text champ on the user
@@ -44,7 +44,7 @@ RSpec.describe 'A blank champ must not be touched when another champ is correcte
       let(:second_type) { type }
 
       it "leaves the blank #{type} champ untouched and still blank" do
-        dossier.champs.find { _1.stable_id == 100 }.update_columns(value: nil, value_json: nil, external_id: nil)
+        dossier.champ_data.find { _1.stable_id == 100 }.update_columns(value: nil, value_json: nil, external_id: nil)
         updated_at_before = second_champ.updated_at
 
         travel_to(1.hour.from_now) { correct_text_only }

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -497,7 +497,7 @@ describe Champ do
     context 'when type_champ is type_de_champ_piece_justificative' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       context 'and there is a blob' do
         before do
@@ -527,7 +527,7 @@ describe Champ do
     context 'when type_champ is piece_justificative with titre_identite nature' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: 'titre_identite' }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       before do
         allow(ClamavService).to receive(:safe_file?).and_return(true)
@@ -585,7 +585,7 @@ describe Champ do
     let(:procedure) { create(:procedure, types_de_champ_private:, types_de_champ_public:) }
     let(:types_de_champ_private) { [] }
     let(:types_de_champ_public) { [] }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     subject { champ.clone }
 
@@ -620,7 +620,7 @@ describe Champ do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, mandatory: false, children: [{ type: :text }] }]) }
     let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
 
-    let(:champ) { dossier.champs.where(type: "Champs::TextChamp").first }
+    let(:champ) { dossier.champ_data.where(type: "Champs::TextChamp").first }
 
     it "returns the parent" do
       expect(champ.parent).to eq(TypeDeChamp.find_by(type_champ: "repetition"))
@@ -630,7 +630,7 @@ describe Champ do
   describe '#clone_value_from' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:source_champ) { dossier.champs.first }
+    let(:source_champ) { dossier.champ_data.first }
     let(:target_champ) { source_champ.dup.tap { it.stream = Champ::USER_BUFFER_STREAM } }
 
     before do

--- a/spec/models/champs/address_champ_spec.rb
+++ b/spec/models/champs/address_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::AddressChamp do
   let(:types_de_champ_public) { [{ type: :address }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first.tap { _1.update(value:, value_json:) } }
+  let(:champ) { dossier.champ_data.first.tap { _1.update(value:, value_json:) } }
   let(:value) { nil }
   let(:value_json) { nil }
 

--- a/spec/models/champs/annuaire_education_champ_spec.rb
+++ b/spec/models/champs/annuaire_education_champ_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Champs::AnnuaireEducationChamp do
   describe '#update_external_data!' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :annuaire_education }]) }
     let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-    let(:champ) { dossier.champs.first.tap { _1.update_column(:data, 'any data') } }
+    let(:champ) { dossier.champ_data.first.tap { _1.update_column(:data, 'any data') } }
     subject { champ.send(:update_external_data!, data: data) }
 
     shared_examples "a data updater (without updating the value)" do |data|

--- a/spec/models/champs/carte_champ_spec.rb
+++ b/spec/models/champs/carte_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::CarteChamp do
   let(:types_de_champ_public) { [{ type: :carte }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first.tap { _1.update(geo_areas:) } }
+  let(:champ) { dossier.champ_data.first.tap { _1.update(geo_areas:) } }
   let(:coordinates) { [[[2.3859214782714844, 48.87442541960633], [2.3850631713867183, 48.87273183590832], [2.3809432983398438, 48.87081237174292], [2.3859214782714844, 48.87442541960633]]] }
   let(:geo_json) do
     {

--- a/spec/models/champs/checkbox_champ_spec.rb
+++ b/spec/models/champs/checkbox_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::CheckboxChamp do
   let(:types_de_champ_public) { [{ type: :checkbox }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:boolean_champ) { dossier.champs.first.tap { _1.update_column(:value, value) } }
+  let(:boolean_champ) { dossier.champ_data.first.tap { _1.update_column(:value, value) } }
   let(:value) { '' }
   it_behaves_like "a boolean champ", false
 

--- a/spec/models/champs/cojo_champ_spec.rb
+++ b/spec/models/champs/cojo_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::COJOChamp, type: :model do
   let(:types_de_champ_public) { [{ type: :cojo }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   let(:external_id) { nil }
   let(:url) { COJOService.new.send(:url) }

--- a/spec/models/champs/commune_champ_spec.rb
+++ b/spec/models/champs/commune_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::CommuneChamp do
   let(:types_de_champ_public) { [{ type: :communes }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   let(:code_insee) { '63102' }
   let(:code_postal) { '63290' }

--- a/spec/models/champs/date_champ_spec.rb
+++ b/spec/models/champs/date_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::DateChamp do
   let(:types_de_champ_public) { [{ type: :date }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:date_champ) { dossier.champs.first }
+  let(:date_champ) { dossier.champ_data.first }
 
   describe '#convert_to_iso8601_date' do
     it 'preserves nil' do
@@ -63,7 +63,7 @@ describe Champs::DateChamp do
   end
 
   context 'when the value is not in the past' do
-    let(:champ) { dossier.champs.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
     subject { champ.validate(:champs_public_value) }
 
     context 'all dates are accepted' do
@@ -84,7 +84,7 @@ describe Champs::DateChamp do
   end
 
   context 'when there is a range' do
-    let(:champ) { dossier.champs.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
     subject { champ.validate(:champs_public_value) }
 
     before { champ.type_de_champ.update(options: { range_date: '1', start_date: '2017-11-30', end_date: '2017-12-31' }) }
@@ -139,7 +139,7 @@ describe Champs::DateChamp do
   end
 
   context 'when birthdate option is enabled' do
-    let(:champ) { dossier.champs.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
     subject { champ.validate(:champs_public_value) }
 
     before { champ.type_de_champ.update(options: { birthdate: "1" }) }

--- a/spec/models/champs/datetime_champ_spec.rb
+++ b/spec/models/champs/datetime_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::DatetimeChamp do
   let(:types_de_champ_public) { [{ type: :datetime }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:datetime_champ) { dossier.champs.first }
+  let(:datetime_champ) { dossier.champ_data.first }
 
   describe '#normalizes' do
     it 'preserves nil' do
@@ -99,7 +99,7 @@ describe Champs::DatetimeChamp do
   end
 
   context 'when there is a range' do
-    let(:champ) { dossier.champs.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
     subject { champ.validate(:champs_public_value) }
 
     before { champ.type_de_champ.update(options: { range_date: '1', start_date: '2017-11-30', end_date: '2017-12-31' }) }

--- a/spec/models/champs/decimal_number_champ_spec.rb
+++ b/spec/models/champs/decimal_number_champ_spec.rb
@@ -5,7 +5,7 @@ describe Champs::DecimalNumberChamp do
   let(:types_de_champ_private) { [] }
   let(:procedure) { create(:procedure, types_de_champ_public:, types_de_champ_private:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
   let(:value) { nil }
 
   describe 'validation' do

--- a/spec/models/champs/departement_champ_spec.rb
+++ b/spec/models/champs/departement_champ_spec.rb
@@ -3,7 +3,7 @@
 describe Champs::DepartementChamp, type: :model do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :departements }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first.tap { _1.update_columns(value:, external_id:) } }
+  let(:champ) { dossier.champ_data.first.tap { _1.update_columns(value:, external_id:) } }
   let(:value) { nil }
   let(:external_id) { nil }
 

--- a/spec/models/champs/dossier_link_champ_spec.rb
+++ b/spec/models/champs/dossier_link_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::DossierLinkChamp, type: :model do
   let(:types_de_champ_public) { [{ type: :dossier_link, mandatory: }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, :en_construction, procedure:) }
-  let(:champ) { dossier.champs.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
   let(:value) { nil }
   let(:mandatory) { false }
 

--- a/spec/models/champs/drop_down_list_champ_spec.rb
+++ b/spec/models/champs/drop_down_list_champ_spec.rb
@@ -6,7 +6,7 @@ describe Champs::DropDownListChamp do
   let(:dossier) { create(:dossier, procedure:) }
   let(:referentiel) { nil }
   let(:drop_down_mode) { nil }
-  let(:champ) { dossier.champs.first.tap { _1.update(value:, other:) } }
+  let(:champ) { dossier.champ_data.first.tap { _1.update(value:, other:) } }
   let(:value) { nil }
   let(:other) { nil }
 

--- a/spec/models/champs/email_champ_spec.rb
+++ b/spec/models/champs/email_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::EmailChamp do
   describe 'validation' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{}, { type: :email }, {}]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.second }
+    let(:champ) { dossier.champ_data.second }
     let(:value) { nil }
     before { champ.value = value }
     subject { champ.validate(:champs_public_value) }

--- a/spec/models/champs/engagement_juridique_champ_spec.rb
+++ b/spec/models/champs/engagement_juridique_champ_spec.rb
@@ -5,7 +5,7 @@ describe Champs::EngagementJuridiqueChamp do
     let(:types_de_champ_public) { [{ type: :engagement_juridique }] }
     let(:procedure) { create(:procedure, types_de_champ_public:) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
     let(:value) { nil }
 
     subject { champ.validate(:champs_public_value) }

--- a/spec/models/champs/epci_champ_spec.rb
+++ b/spec/models/champs/epci_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::EpciChamp, type: :model do
   let(:types_de_champ_public) { [{ type: :epci }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first.tap { _1.code_departement = code_departement } }
+  let(:champ) { dossier.champ_data.first.tap { _1.code_departement = code_departement } }
   let(:code_departement) { nil }
 
   describe 'validations' do

--- a/spec/models/champs/formatted_champ_spec.rb
+++ b/spec/models/champs/formatted_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::FormattedChamp do
   let(:types_de_champ_public) { [tdc_definition] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   before do
     champ.value = value

--- a/spec/models/champs/iban_champ_spec.rb
+++ b/spec/models/champs/iban_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::IbanChamp do
   let(:types_de_champ_public) { [{ type: :iban }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   describe '#valid?' do
     def with_value(value)

--- a/spec/models/champs/integer_number_champ_spec.rb
+++ b/spec/models/champs/integer_number_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::IntegerNumberChamp do
   let(:types_de_champ_public) { [{ type: :integer_number }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
   let(:value) { nil }
   subject { champ.validate(:champs_public_value) }
 

--- a/spec/models/champs/linked_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/linked_drop_down_list_champ_spec.rb
@@ -10,7 +10,7 @@ describe Champs::LinkedDropDownListChamp do
   end
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
   let(:value) { nil }
   let(:mandatory) { true }
   let(:options) { nil }

--- a/spec/models/champs/multiple_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/multiple_drop_down_list_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::MultipleDropDownListChamp do
   let(:types_de_champ_public) { [{ type: :multiple_drop_down_list, options: ["val1", "val2", "val3", "[brackets] val4"] }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
   let(:value) { nil }
 
   describe 'validations' do

--- a/spec/models/champs/phone_champ_spec.rb
+++ b/spec/models/champs/phone_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::PhoneChamp do
   let(:types_de_champ_public) { [{ type: :phone }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   describe '#validate' do
     it do

--- a/spec/models/champs/piece_justificative_champ_spec.rb
+++ b/spec/models/champs/piece_justificative_champ_spec.rb
@@ -7,7 +7,7 @@ describe Champs::PieceJustificativeChamp do
 
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   describe "validations" do
     subject { champ }
@@ -83,7 +83,7 @@ describe Champs::PieceJustificativeChamp do
     context 'titre_identite nature' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: 'titre_identite' }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       it 'accepts jpeg under 20MB' do
         champ.piece_justificative_file.purge
@@ -116,7 +116,7 @@ describe Champs::PieceJustificativeChamp do
       context "#{ocr_nature} nature" do
         let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: ocr_nature }]) }
         let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-        let(:champ) { dossier.champs.first }
+        let(:champ) { dossier.champ_data.first }
 
         it 'accepts pdf' do
           champ.piece_justificative_file.purge
@@ -136,7 +136,7 @@ describe Champs::PieceJustificativeChamp do
     context 'pj_limit_formats with document_texte' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, pj_limit_formats: '1', pj_format_families: ['document_texte'] }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       it 'accepts pdf' do
         champ.piece_justificative_file.purge
@@ -161,7 +161,7 @@ describe Champs::PieceJustificativeChamp do
     context 'pj_limit_formats enabled with empty families' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, pj_limit_formats: '1', pj_format_families: [] }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       it 'accepts pdf' do
         champ.piece_justificative_file.purge
@@ -180,7 +180,7 @@ describe Champs::PieceJustificativeChamp do
   describe '#ocr_result' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: 'justificatif_domicile' }]) }
     let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     context 'when not fetched' do
       before { allow(champ).to receive(:fetched?).and_return(false) }

--- a/spec/models/champs/pre_rempli_champ_spec.rb
+++ b/spec/models/champs/pre_rempli_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::PreRempliChamp do
   let(:types_de_champ_public) { [{ type: :pre_rempli }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first.tap { _1.update_column(:value, value) } }
+  let(:champ) { dossier.champ_data.first.tap { _1.update_column(:value, value) } }
 
   describe '#selected' do
     subject { champ.selected }

--- a/spec/models/champs/quotient_familial_champ_spec.rb
+++ b/spec/models/champs/quotient_familial_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::QuotientFamilialChamp, type: :model do
   let(:types_de_champ_public) { [{ type: :quotient_familial }] }
   let(:procedure) { create(:procedure, types_de_champ_public:, for_individual: true) }
   let(:dossier) { create(:dossier, procedure:, for_tiers: false, for_procedure_preview: false) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
   let!(:fci) { create(:france_connect_information, user: dossier.user) }
 
   describe '#ready_for_external_call?' do

--- a/spec/models/champs/referentiel_champ_cast_displayable_spec.rb
+++ b/spec/models/champs/referentiel_champ_cast_displayable_spec.rb
@@ -10,7 +10,7 @@ describe Champs::ReferentielChamp, type: :model do
   let(:types_de_champ_public) { [{ type: :referentiel, referentiel: }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:referentiel_champ) { dossier.champs.find(&:referentiel?) }
+  let(:referentiel_champ) { dossier.champ_data.find(&:referentiel?) }
 
   describe '#cast_displayable_values' do
     before do

--- a/spec/models/champs/referentiel_champ_cast_value_spec.rb
+++ b/spec/models/champs/referentiel_champ_cast_value_spec.rb
@@ -8,7 +8,7 @@ describe Champs::ReferentielChamp, type: :model do
   let(:types_de_champ_public) { [{ type: :referentiel, referentiel: }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:referentiel_champ) { dossier.champs.find(&:referentiel?) }
+  let(:referentiel_champ) { dossier.champ_data.find(&:referentiel?) }
 
   describe '#cast_value_for_type_de_champ' do
     subject { referentiel_champ.update_external_data!(data:) }
@@ -613,7 +613,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: [{ nom: 'Jeanne', age: 120 }, { nom: "Bob", age: 12 }, {}] } }
           it 'creates a rows' do
             subject
-            values = dossier.reload.champs.filter(&:text?).map(&:value)
+            values = dossier.reload.champ_data.filter(&:text?).map(&:value)
             expect(values).to include('Jeanne')
             expect(values).to include('Bob')
           end
@@ -628,7 +628,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { nom: 'Jeanne', age: 120 } }
           it 'creates a rows' do
             subject
-            values = dossier.reload.champs.filter(&:text?).map(&:value)
+            values = dossier.reload.champ_data.filter(&:text?).map(&:value)
             expect(values).to include('Jeanne')
           end
         end
@@ -651,7 +651,7 @@ describe Champs::ReferentielChamp, type: :model do
             },
           ]
         end
-        let(:repetition_champ) { dossier.champs.find(&:repetition?) }
+        let(:repetition_champ) { dossier.champ_data.find(&:repetition?) }
         let(:referentiel_champ) { repetition_champ.rows.first.find(&:referentiel?) }
 
         context 'when mapping and data are arrays' do
@@ -678,7 +678,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { nom: 'Jeanne' } }
           it 'update existing row' do
             subject
-            values = dossier.reload.champs.filter(&:text?).map(&:value)
+            values = dossier.reload.champ_data.filter(&:text?).map(&:value)
             expect(values).to include('Jeanne')
           end
         end

--- a/spec/models/champs/referentiel_champ_spec.rb
+++ b/spec/models/champs/referentiel_champ_spec.rb
@@ -8,7 +8,7 @@ describe Champs::ReferentielChamp, type: :model do
   let(:types_de_champ_public) { [{ type: :referentiel, referentiel: }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:referentiel_champ) { dossier.champs.find(&:referentiel?) }
+  let(:referentiel_champ) { dossier.champ_data.find(&:referentiel?) }
   let(:champ) { referentiel_champ }
 
   describe '#valid?' do

--- a/spec/models/champs/region_champ_spec.rb
+++ b/spec/models/champs/region_champ_spec.rb
@@ -3,7 +3,7 @@
 describe Champs::RegionChamp, type: :model do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :regions }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first.tap { _1.update(value:, external_id:) } }
+  let(:champ) { dossier.champ_data.first.tap { _1.update(value:, external_id:) } }
   let(:value) { nil }
   let(:external_id) { nil }
 

--- a/spec/models/champs/rna_champ_spec.rb
+++ b/spec/models/champs/rna_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::RNAChamp do
   let(:types_de_champ_public) { [{ type: :rna }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
   let(:value) { "W182736273" }
 
   def with_external_id(external_id)

--- a/spec/models/champs/rnf_champ_spec.rb
+++ b/spec/models/champs/rnf_champ_spec.rb
@@ -11,7 +11,7 @@ describe Champs::RNFChamp, type: :model do
   describe '#valid?' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.find(&:rnf?) }
+    let(:champ) { dossier.champ_data.find(&:rnf?) }
 
     def with_state(external_id:, data:, fetch_external_data_exceptions: [])
       champ.tap do
@@ -86,7 +86,7 @@ describe Champs::RNFChamp, type: :model do
   describe 'format validation' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.find(&:rnf?) }
+    let(:champ) { dossier.champ_data.find(&:rnf?) }
 
     before { champ.update_columns(external_id:) }
 

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -3,7 +3,7 @@
 describe Champs::SiretChamp do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first.tap { _1.update(external_id:, etablissement:) } }
+  let(:champ) { dossier.champ_data.first.tap { _1.update(external_id:, etablissement:) } }
   let(:external_id) { "" }
   let(:etablissement) { nil }
 
@@ -75,7 +75,7 @@ describe Champs::SiretChamp do
     let(:token_expired) { false }
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let!(:champ) { dossier.champs.first.tap { _1.update!(etablissement: create(:etablissement), external_id: siret, external_state: 'waiting_for_job') } }
+    let!(:champ) { dossier.champ_data.first.tap { _1.update!(etablissement: create(:etablissement), external_id: siret, external_state: 'waiting_for_job') } }
 
     before do
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)

--- a/spec/models/columns/champ_column_spec.rb
+++ b/spec/models/columns/champ_column_spec.rb
@@ -183,7 +183,7 @@ describe Columns::ChampColumn do
       let(:dossiers) { procedure.dossiers }
 
       before do
-        dossier_with_value.champs.first.update!(value: champ_value)
+        dossier_with_value.champ_data.first.update!(value: champ_value)
       end
 
       let(:champ_value) { 'olala le text est "là"' }
@@ -212,7 +212,7 @@ describe Columns::ChampColumn do
       let(:dossiers) { procedure.dossiers }
 
       before do
-        dossier_with_value.champs.first.update!(value: champ_value)
+        dossier_with_value.champ_data.first.update!(value: champ_value)
       end
 
       let(:champ_value) { "[\"Fromage \\\"blanc\\\"\",\"Fromage\"]" }
@@ -244,9 +244,9 @@ describe Columns::ChampColumn do
       let(:dossiers) { procedure.dossiers }
 
       before do
-        dossier_with_yes.champs.first.update!(value: "true")
-        dossier_with_no.champs.first.update!(value: "false")
-        dossier_not_filled.champs.first.destroy!
+        dossier_with_yes.champ_data.first.update!(value: "true")
+        dossier_with_no.champ_data.first.update!(value: "false")
+        dossier_not_filled.champ_data.first.destroy!
       end
 
       context "when searching for a yes" do
@@ -280,8 +280,8 @@ describe Columns::ChampColumn do
       let(:dossier_not_checked) { create(:dossier, :en_instruction, procedure:) }
 
       before do
-        dossier_with_checked.champs.first.update!(value: "true")
-        dossier_not_checked.champs.first.destroy!
+        dossier_with_checked.champ_data.first.update!(value: "true")
+        dossier_not_checked.champ_data.first.destroy!
       end
 
       let(:column) { procedure.find_column(label: "checkbox") }
@@ -310,8 +310,8 @@ describe Columns::ChampColumn do
       let(:dossier_not_checked) { create(:dossier, :en_instruction, procedure:) }
 
       before do
-        dossier_with_checked.champs.first.update!(value: "true")
-        dossier_not_checked.champs.first.destroy!
+        dossier_with_checked.champ_data.first.update!(value: "true")
+        dossier_not_checked.champ_data.first.destroy!
       end
 
       let(:column) { procedure.find_column(label: "checkbox") }
@@ -341,9 +341,9 @@ describe Columns::ChampColumn do
       let(:dossier_with_chocolat) { create(:dossier, :en_instruction, procedure:) }
 
       before do
-        dossier_with_fromage.champs.first.update!(value: "Fromage")
-        dossier_with_dessert.champs.first.update!(value: "Dessert")
-        dossier_with_chocolat.champs.first.update!(value: "Chocolat")
+        dossier_with_fromage.champ_data.first.update!(value: "Fromage")
+        dossier_with_dessert.champ_data.first.update!(value: "Dessert")
+        dossier_with_chocolat.champ_data.first.update!(value: "Chocolat")
       end
 
       let(:column) { procedure.find_column(label: "drop_down_list") }
@@ -372,8 +372,8 @@ describe Columns::ChampColumn do
       let(:dossier_de) { create(:dossier, :en_instruction, procedure:) }
 
       before do
-        dossier_fr.champs.first.update!(value: 'FR')
-        dossier_de.champs.first.update!(value: 'DE')
+        dossier_fr.champ_data.first.update!(value: 'FR')
+        dossier_de.champ_data.first.update!(value: 'DE')
       end
 
       let(:column) { procedure.find_column(label: "pays") }
@@ -401,8 +401,8 @@ describe Columns::ChampColumn do
         let(:dossier2) { create(:dossier, :en_instruction, procedure:) }
 
         before do
-          dossier.champs.first.update!(value: "2025-02-13")
-          dossier2.champs.first.update!(value: "2025-02-15")
+          dossier.champ_data.first.update!(value: "2025-02-13")
+          dossier2.champ_data.first.update!(value: "2025-02-15")
         end
 
         let(:filter) { { operator: 'before', value: ["2025-02-14"] } }
@@ -417,8 +417,8 @@ describe Columns::ChampColumn do
         let(:dossier2) { create(:dossier, :en_instruction, procedure:) }
 
         before do
-          dossier.champs.first.update!(value: "2025-02-13")
-          dossier2.champs.first.update!(value: "2025-02-15")
+          dossier.champ_data.first.update!(value: "2025-02-13")
+          dossier2.champ_data.first.update!(value: "2025-02-15")
         end
 
         let(:filter) { { operator: 'after', value: ["2025-02-14"] } }
@@ -437,10 +437,10 @@ describe Columns::ChampColumn do
         let(:dossier_month_after) { create(:dossier, :en_instruction, procedure:) }
 
         before do
-          dossier_at_the_beginning_of_the_month.champs.first.update!(value: "2025-02-01")
-          dossier_at_the_end_of_the_month.champs.first.update!(value: "2025-02-28")
-          dossier_month_before.champs.first.update!(value: "2025-01-13")
-          dossier_month_after.champs.first.update!(value: "2025-03-13")
+          dossier_at_the_beginning_of_the_month.champ_data.first.update!(value: "2025-02-01")
+          dossier_at_the_end_of_the_month.champ_data.first.update!(value: "2025-02-28")
+          dossier_month_before.champ_data.first.update!(value: "2025-01-13")
+          dossier_month_after.champ_data.first.update!(value: "2025-03-13")
 
           travel_to(Time.zone.parse("2025-02-13"))
         end
@@ -459,10 +459,10 @@ describe Columns::ChampColumn do
         let(:dossier_week_after) { create(:dossier, :en_instruction, procedure:) }
 
         before do
-          dossier_at_the_beginning_of_the_week.champs.first.update!(value: "2025-02-03")
-          dossier_at_the_end_of_the_week.champs.first.update!(value: "2025-02-09")
-          dossier_week_before.champs.first.update!(value: "2025-02-02")
-          dossier_week_after.champs.first.update!(value: "2025-02-10")
+          dossier_at_the_beginning_of_the_week.champ_data.first.update!(value: "2025-02-03")
+          dossier_at_the_end_of_the_week.champ_data.first.update!(value: "2025-02-09")
+          dossier_week_before.champ_data.first.update!(value: "2025-02-02")
+          dossier_week_after.champ_data.first.update!(value: "2025-02-10")
 
           travel_to(Time.zone.parse("2025-02-08"))
         end
@@ -481,10 +481,10 @@ describe Columns::ChampColumn do
         let(:dossier_year_after) { create(:dossier, :en_instruction, procedure:) }
 
         before do
-          dossier_at_the_beginning_of_the_year.champs.first.update!(value: "2024-01-01")
-          dossier_at_the_end_of_the_year.champs.first.update!(value: "2024-12-31")
-          dossier_year_before.champs.first.update!(value: "2023-12-31")
-          dossier_year_after.champs.first.update!(value: "2025-01-01")
+          dossier_at_the_beginning_of_the_year.champ_data.first.update!(value: "2024-01-01")
+          dossier_at_the_end_of_the_year.champ_data.first.update!(value: "2024-12-31")
+          dossier_year_before.champ_data.first.update!(value: "2023-12-31")
+          dossier_year_after.champ_data.first.update!(value: "2025-01-01")
 
           travel_to(Time.zone.parse("2024-02-13"))
         end
@@ -508,8 +508,8 @@ describe Columns::ChampColumn do
         let(:dossier2) { create(:dossier, :en_instruction, procedure:) }
 
         before do
-          dossier.champs.first.update!(value: "2025-02-13T12:00:00+01:00")
-          dossier2.champs.first.update!(value: "2025-02-15T12:00:00+01:00")
+          dossier.champ_data.first.update!(value: "2025-02-13T12:00:00+01:00")
+          dossier2.champ_data.first.update!(value: "2025-02-15T12:00:00+01:00")
         end
 
         let(:filter) { { operator: 'before', value: ["2025-02-14"] } }
@@ -524,8 +524,8 @@ describe Columns::ChampColumn do
         let(:dossier2) { create(:dossier, :en_instruction, procedure:) }
 
         before do
-          dossier.champs.first.update!(value: "2025-02-13T12:00:00+01:00")
-          dossier2.champs.first.update!(value: "2025-02-15T12:00:00+01:00")
+          dossier.champ_data.first.update!(value: "2025-02-13T12:00:00+01:00")
+          dossier2.champ_data.first.update!(value: "2025-02-15T12:00:00+01:00")
         end
 
         let(:filter) { { operator: 'after', value: ["2025-02-14"] } }
@@ -544,10 +544,10 @@ describe Columns::ChampColumn do
         let(:dossier_week_after) { create(:dossier, :en_instruction, procedure:) }
 
         before do
-          dossier_at_the_beginning_of_the_week.champs.first.update!(value: "2025-02-03T12:00:00+01:00")
-          dossier_at_the_end_of_the_week.champs.first.update!(value: "2025-02-09T12:00:00+01:00")
-          dossier_week_before.champs.first.update!(value: "2025-02-02T12:00:00+01:00")
-          dossier_week_after.champs.first.update!(value: "2025-02-10T12:00:00+01:00")
+          dossier_at_the_beginning_of_the_week.champ_data.first.update!(value: "2025-02-03T12:00:00+01:00")
+          dossier_at_the_end_of_the_week.champ_data.first.update!(value: "2025-02-09T12:00:00+01:00")
+          dossier_week_before.champ_data.first.update!(value: "2025-02-02T12:00:00+01:00")
+          dossier_week_after.champ_data.first.update!(value: "2025-02-10T12:00:00+01:00")
 
           travel_to(Time.zone.parse("2025-02-08"))
         end
@@ -566,10 +566,10 @@ describe Columns::ChampColumn do
         let(:dossier_month_after) { create(:dossier, :en_instruction, procedure:) }
 
         before do
-          dossier_at_the_beginning_of_the_month.champs.first.update!(value: "2025-02-01T12:00:00+01:00")
-          dossier_at_the_end_of_the_month.champs.first.update!(value: "2025-02-28T12:00:00+01:00")
-          dossier_month_before.champs.first.update!(value: "2025-01-13T12:00:00+01:00")
-          dossier_month_after.champs.first.update!(value: "2025-03-13T12:00:00+01:00")
+          dossier_at_the_beginning_of_the_month.champ_data.first.update!(value: "2025-02-01T12:00:00+01:00")
+          dossier_at_the_end_of_the_month.champ_data.first.update!(value: "2025-02-28T12:00:00+01:00")
+          dossier_month_before.champ_data.first.update!(value: "2025-01-13T12:00:00+01:00")
+          dossier_month_after.champ_data.first.update!(value: "2025-03-13T12:00:00+01:00")
 
           travel_to(Time.zone.parse("2025-02-13"))
         end
@@ -588,10 +588,10 @@ describe Columns::ChampColumn do
         let(:dossier_year_after) { create(:dossier, :en_instruction, procedure:) }
 
         before do
-          dossier_at_the_beginning_of_the_year.champs.first.update!(value: "2024-01-01T12:00:00+01:00")
-          dossier_at_the_end_of_the_year.champs.first.update!(value: "2024-12-31T12:00:00+01:00")
-          dossier_year_before.champs.first.update!(value: "2023-12-31T12:00:00+01:00")
-          dossier_year_after.champs.first.update!(value: "2025-01-01T12:00:00+01:00")
+          dossier_at_the_beginning_of_the_year.champ_data.first.update!(value: "2024-01-01T12:00:00+01:00")
+          dossier_at_the_end_of_the_year.champ_data.first.update!(value: "2024-12-31T12:00:00+01:00")
+          dossier_year_before.champ_data.first.update!(value: "2023-12-31T12:00:00+01:00")
+          dossier_year_after.champ_data.first.update!(value: "2025-01-01T12:00:00+01:00")
 
           travel_to(Time.zone.parse("2024-02-13"))
         end

--- a/spec/models/columns/json_path_column_spec.rb
+++ b/spec/models/columns/json_path_column_spec.rb
@@ -3,7 +3,7 @@
 describe Columns::JSONPathColumn do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :address }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
   let(:stable_id) { champ.stable_id }
   let(:tdc_type) { champ.type_champ }
   let(:column) { described_class.new(procedure_id: procedure.id, label: 'label', stable_id:, tdc_type:, jsonpath:, displayable: true, mandatory: true) }
@@ -83,8 +83,8 @@ describe Columns::JSONPathColumn do
 
       context 'bounded on both sides (this_year)' do
         before do
-          dossier_in_range.champs.first.update(value_json: { issue_date: Date.current.iso8601 })
-          dossier_out_range.champs.first.update(value_json: { issue_date: 5.years.ago.to_date.iso8601 })
+          dossier_in_range.champ_data.first.update(value_json: { issue_date: Date.current.iso8601 })
+          dossier_out_range.champ_data.first.update(value_json: { issue_date: 5.years.ago.to_date.iso8601 })
         end
 
         subject { column.filtered_ids(Dossier.all, { operator: 'this_year' }) }
@@ -97,8 +97,8 @@ describe Columns::JSONPathColumn do
 
       context 'bounded only on the right (before operator)' do
         before do
-          dossier_in_range.champs.first.update(value_json: { issue_date: '2020-06-15' })
-          dossier_out_range.champs.first.update(value_json: { issue_date: '2022-06-15' })
+          dossier_in_range.champ_data.first.update(value_json: { issue_date: '2020-06-15' })
+          dossier_out_range.champ_data.first.update(value_json: { issue_date: '2022-06-15' })
         end
 
         subject { column.filtered_ids(Dossier.all, { operator: 'before', value: ['2021-01-01'] }) }
@@ -111,8 +111,8 @@ describe Columns::JSONPathColumn do
 
       context 'bounded only on the left (after operator)' do
         before do
-          dossier_in_range.champs.first.update(value_json: { issue_date: '2022-06-15' })
-          dossier_out_range.champs.first.update(value_json: { issue_date: '2020-06-15' })
+          dossier_in_range.champ_data.first.update(value_json: { issue_date: '2022-06-15' })
+          dossier_out_range.champ_data.first.update(value_json: { issue_date: '2020-06-15' })
         end
 
         subject { column.filtered_ids(Dossier.all, { operator: 'after', value: ['2021-01-01'] }) }
@@ -125,8 +125,8 @@ describe Columns::JSONPathColumn do
 
       context 'nil..nil range' do
         before do
-          dossier_in_range.champs.first.update(value_json: { issue_date: '2022-06-15' })
-          dossier_out_range.champs.first.update(value_json: { issue_date: '2020-06-15' })
+          dossier_in_range.champ_data.first.update(value_json: { issue_date: '2022-06-15' })
+          dossier_out_range.champ_data.first.update(value_json: { issue_date: '2020-06-15' })
         end
 
         subject { column.filtered_ids(Dossier.all, { operator: 'after', value: [nil] }) }
@@ -142,8 +142,8 @@ describe Columns::JSONPathColumn do
       let(:dossier_no_match) { create(:dossier, procedure:) }
 
       before do
-        dossier_match.champs.first.update(value_json: { issue_integer: 2000 })
-        dossier_no_match.champs.first.update(value_json: { issue_integer: 2012 })
+        dossier_match.champ_data.first.update(value_json: { issue_integer: 2000 })
+        dossier_no_match.champ_data.first.update(value_json: { issue_integer: 2012 })
       end
 
       subject { column.filtered_ids(Dossier.all, { operator: 'match', value: }) }
@@ -192,8 +192,8 @@ describe Columns::JSONPathColumn do
       let(:dossiers) { Dossier.where(id: [dossier1.id, dossier2.id, dossier3.id]) }
 
       before do
-        dossier1.champs.first.update(value_json: { postal_code: '60580' })
-        dossier2.champs.first.update(value_json: { postal_code: '75001' })
+        dossier1.champ_data.first.update(value_json: { postal_code: '60580' })
+        dossier2.champ_data.first.update(value_json: { postal_code: '75001' })
       end
 
       context 'when filter value contains only blank strings' do
@@ -212,8 +212,8 @@ describe Columns::JSONPathColumn do
       let(:dossier_with_incorrect_data) { create(:dossier, procedure:) }
 
       before do
-        dossier_with_correct_data.champs.first.update(value_json: { fc_data: 123 }, value: 'true')
-        dossier_with_incorrect_data.champs.first.update(value_json: { fc_data: 123 }, value: 'false')
+        dossier_with_correct_data.champ_data.first.update(value_json: { fc_data: 123 }, value: 'true')
+        dossier_with_incorrect_data.champ_data.first.update(value_json: { fc_data: 123 }, value: 'false')
       end
 
       subject { column.filtered_ids(Dossier.all, { operator: 'match', value: ['123'] }) }

--- a/spec/models/columns/linked_drop_down_column_spec.rb
+++ b/spec/models/columns/linked_drop_down_column_spec.rb
@@ -36,10 +36,10 @@ describe Columns::LinkedDropDownColumn do
       let(:column) { procedure.find_column(label: 'linked') }
 
       before do
-        kept_dossier.champs.find_by(stable_id: type_de_champ.stable_id)
+        kept_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id)
           .update(value: %{["section 1","option A"]})
 
-        discarded_dossier.champs.find_by(stable_id: type_de_champ.stable_id)
+        discarded_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id)
           .update(value: %{["section 1","option B"]})
       end
 
@@ -75,10 +75,10 @@ describe Columns::LinkedDropDownColumn do
 
     context 'when path is not :value' do
       before do
-        kept_dossier.champs.find_by(stable_id: type_de_champ.stable_id)
+        kept_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id)
           .update(value: %{["1","2"]})
 
-        discarded_dossier.champs.find_by(stable_id: type_de_champ.stable_id)
+        discarded_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id)
           .update(value: %{["2","1"]})
       end
 

--- a/spec/models/concerns/blob_processor_concern_spec.rb
+++ b/spec/models/concerns/blob_processor_concern_spec.rb
@@ -27,7 +27,7 @@ describe BlobProcessorConcern do
     context 'with PieceJustificativeChamp with nature=titre_identite' do
       let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative, nature: 'titre_identite' }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, :en_construction, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       it 'requires watermark' do
         champ.piece_justificative_file.attach(
@@ -45,7 +45,7 @@ describe BlobProcessorConcern do
     context 'with PieceJustificativeChamp with nature=titre_identite' do
       let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative, nature: 'titre_identite' }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, :en_construction, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       it 'requires watermark' do
         champ.piece_justificative_file.attach(
@@ -63,7 +63,7 @@ describe BlobProcessorConcern do
     context 'with regular PieceJustificativeChamp (no nature)' do
       let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, :en_construction, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       it 'does not require watermark' do
         champ.piece_justificative_file.attach(

--- a/spec/models/concerns/champ_conditional_concern_spec.rb
+++ b/spec/models/concerns/champ_conditional_concern_spec.rb
@@ -5,8 +5,8 @@ describe ChampConditionalConcern do
 
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :decimal_number, stable_id: 99 }, { type: :decimal_number, stable_id: 999, condition: }]) }
   let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.champs.find { _1.stable_id == 99 }.tap { _1.update_column(:value, '1.1234') } }
-  let(:last_champ) { dossier.champs.find { _1.stable_id == 999 }.tap { _1.update_column(:value, '1.1234') } }
+  let(:champ) { dossier.champ_data.find { _1.stable_id == 99 }.tap { _1.update_column(:value, '1.1234') } }
+  let(:last_champ) { dossier.champ_data.find { _1.stable_id == 999 }.tap { _1.update_column(:value, '1.1234') } }
   let(:condition) { nil }
 
   describe '#dependent_conditions?' do
@@ -56,8 +56,8 @@ describe ChampConditionalConcern do
       end
 
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:first_repet) { dossier.champs.find { it.type == "Champs::RepetitionChamp" } }
-      let(:first_yes_no) { dossier.champs.find { it.type == "Champs::YesNoChamp" && it.row_id == first_repet.row_id } }
+      let(:first_repet) { dossier.champ_data.find { it.type == "Champs::RepetitionChamp" } }
+      let(:first_yes_no) { dossier.champ_data.find { it.type == "Champs::YesNoChamp" && it.row_id == first_repet.row_id } }
 
       context 'when the repetition is visible' do
         let(:condition) { nil }

--- a/spec/models/concerns/champ_external_data_concern_spec.rb
+++ b/spec/models/concerns/champ_external_data_concern_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ChampExternalDataConcern do
   describe '#save_external_error' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     context "add execption to the log" do
       it do
         champ.send(:save_external_error, double(inspect: 'PAN'), 404)
@@ -18,7 +18,7 @@ RSpec.describe ChampExternalDataConcern do
   describe '#external_data_not_found?' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     before do
       champ.external_state = external_state
@@ -50,7 +50,7 @@ RSpec.describe ChampExternalDataConcern do
   describe 'the state machine' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     describe 'initial state' do
       it { expect(champ).to be_idle }

--- a/spec/models/concerns/champ_validate_concern_spec.rb
+++ b/spec/models/concerns/champ_validate_concern_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ChampValidateConcern do
         dossier.validate(:champs_public_value)
       }
       it {
-        expect(dossier.champs).not_to be_empty
+        expect(dossier.champ_data).not_to be_empty
         expect(dossier.errors).to be_empty
       }
     end
@@ -29,7 +29,7 @@ RSpec.describe ChampValidateConcern do
         dossier.validate(:champs_public_value)
       }
       it {
-        expect(dossier.champs).not_to be_empty
+        expect(dossier.champ_data).not_to be_empty
         expect(dossier.errors).not_to be_empty
       }
     end
@@ -45,7 +45,7 @@ RSpec.describe ChampValidateConcern do
       }
       it {
         expect(dossier.revision.revision_types_de_champ).to be_empty
-        expect(dossier.champs).not_to be_empty
+        expect(dossier.champ_data).not_to be_empty
         expect(dossier.errors).to be_empty
       }
     end
@@ -60,7 +60,7 @@ RSpec.describe ChampValidateConcern do
       }
       it {
         expect(dossier.revision.revision_types_de_champ).to be_empty
-        expect(dossier.champs).not_to be_empty
+        expect(dossier.champ_data).not_to be_empty
         expect(dossier.errors).to be_empty
       }
     end
@@ -75,7 +75,7 @@ RSpec.describe ChampValidateConcern do
       }
       it {
         expect(dossier.revision.revision_types_de_champ).to be_empty
-        expect(dossier.champs).not_to be_empty
+        expect(dossier.champ_data).not_to be_empty
         expect(dossier.errors).to be_empty
       }
     end
@@ -86,13 +86,13 @@ RSpec.describe ChampValidateConcern do
       before do
         allow_any_instance_of(Champs::PieceJustificativeChamp).to receive(:external_data_needed_for_validation?).and_return(true)
 
-        dossier.champs.first.update_column(:external_state, 'waiting_for_job')
+        dossier.champ_data.first.update_column(:external_state, 'waiting_for_job')
         dossier.revision.revision_types_de_champ.delete_all
 
         dossier.reload
       end
 
-      it { expect(dossier.champs.first.send(:validate_external_data_response?)).to be(false) }
+      it { expect(dossier.champ_data.first.send(:validate_external_data_response?)).to be(false) }
     end
   end
 
@@ -105,9 +105,9 @@ RSpec.describe ChampValidateConcern do
         dossier.validate(:champs_public_value)
       }
       it {
-        expect(dossier.champs.first.last_write_type_champ).to eq('email')
+        expect(dossier.champ_data.first.last_write_type_champ).to eq('email')
         expect(type_de_champ.type_champ).to eq('text')
-        expect(dossier.champs).not_to be_empty
+        expect(dossier.champ_data).not_to be_empty
         expect(dossier.errors).to be_empty
       }
     end
@@ -125,7 +125,7 @@ RSpec.describe ChampValidateConcern do
         dossier.validate(:champs_public_value)
       }
       it {
-        expect(dossier.champs).not_to be_empty
+        expect(dossier.champ_data).not_to be_empty
         expect(dossier.errors).to be_empty
       }
     end
@@ -136,7 +136,7 @@ RSpec.describe ChampValidateConcern do
         dossier.validate(:champs_public_value)
       }
       it {
-        expect(dossier.champs).not_to be_empty
+        expect(dossier.champ_data).not_to be_empty
         expect(dossier.errors).not_to be_empty
       }
     end
@@ -149,7 +149,7 @@ RSpec.describe ChampValidateConcern do
         dossier.validate(:champs_public_value)
       }
       it {
-        expect(dossier.champs).not_to be_empty
+        expect(dossier.champ_data).not_to be_empty
         expect(dossier.errors).to be_empty
       }
     end

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe DossierChampsConcern do
       end
 
       context "missing champ" do
-        before { dossier.champs.where(type: 'Champs::TextChamp').destroy_all; dossier.reload }
+        before { dossier.champ_data.where(type: 'Champs::TextChamp').destroy_all; dossier.reload }
 
         it {
           expect(subject.new_record?).to be_truthy
@@ -130,7 +130,7 @@ RSpec.describe DossierChampsConcern do
       it { expect(subject.persisted?).to be_truthy }
 
       context "missing champ" do
-        before { dossier.champs.where(type: 'Champs::TextChamp').destroy_all; dossier.reload }
+        before { dossier.champ_data.where(type: 'Champs::TextChamp').destroy_all; dossier.reload }
 
         it {
           expect(subject.new_record?).to be_truthy
@@ -157,7 +157,7 @@ RSpec.describe DossierChampsConcern do
       end
 
       context "missing champ" do
-        before { dossier.champs.where(type: 'Champs::TextChamp').destroy_all; dossier.reload }
+        before { dossier.champ_data.where(type: 'Champs::TextChamp').destroy_all; dossier.reload }
 
         it {
           expect(subject.new_record?).to be_truthy
@@ -440,7 +440,7 @@ RSpec.describe DossierChampsConcern do
 
     it {
       subject
-      expect(dossier.champs.any?(&:changed_for_autosave?)).to be_truthy
+      expect(dossier.champ_data.any?(&:changed_for_autosave?)).to be_truthy
       expect(champ_99.changed?).to be_truthy
       expect(champ_991.changed?).to be_truthy
       expect(champ_994.changed?).to be_truthy
@@ -455,7 +455,7 @@ RSpec.describe DossierChampsConcern do
 
       it {
         subject
-        expect(dossier.champs.any?(&:changed_for_autosave?)).to be_truthy
+        expect(dossier.champ_data.any?(&:changed_for_autosave?)).to be_truthy
         expect(champ_99.changed?).to be_truthy
         expect(champ_991.changed?).to be_truthy
         expect(champ_994.changed?).to be_truthy
@@ -480,12 +480,12 @@ RSpec.describe DossierChampsConcern do
         end
 
         it {
-          expect { subject }.to change { dossier.champs.find_by(stable_id: 99).last_write_type_champ }
+          expect { subject }.to change { dossier.champ_data.find_by(stable_id: 99).last_write_type_champ }
             .from(TypeDeChamp.type_champs.fetch(:text))
             .to(TypeDeChamp.type_champs.fetch(:linked_drop_down_list))
           expect(champ_99.persisted?).to be_truthy
           expect(champ_99.last_write_type_champ).to eq(TypeDeChamp.type_champs.fetch(:linked_drop_down_list))
-          expect(dossier.champs.any?(&:changed_for_autosave?)).to be_truthy
+          expect(dossier.champ_data.any?(&:changed_for_autosave?)).to be_truthy
           expect(champ_99.changed?).to be_truthy
           expect(champ_99.value).to eq('["primary",""]')
         }
@@ -505,12 +505,12 @@ RSpec.describe DossierChampsConcern do
         end
 
         it {
-          expect { subject }.to change { dossier.champs.find_by(stable_id: 99).last_write_type_champ }
+          expect { subject }.to change { dossier.champ_data.find_by(stable_id: 99).last_write_type_champ }
             .from(TypeDeChamp.type_champs.fetch(:textarea))
             .to(TypeDeChamp.type_champs.fetch(:text))
           expect(champ_99.persisted?).to be_truthy
           expect(champ_99.last_write_type_champ).to eq(TypeDeChamp.type_champs.fetch(:text))
-          expect(dossier.champs.any?(&:changed_for_autosave?)).to be_truthy
+          expect(dossier.champ_data.any?(&:changed_for_autosave?)).to be_truthy
           expect(champ_99.changed?).to be_truthy
           expect(champ_99.value).to eq('test text')
         }
@@ -530,12 +530,12 @@ RSpec.describe DossierChampsConcern do
         end
 
         it {
-          expect { subject }.to change { dossier.champs.find_by(stable_id: 99).last_write_type_champ }
+          expect { subject }.to change { dossier.champ_data.find_by(stable_id: 99).last_write_type_champ }
             .from(TypeDeChamp.type_champs.fetch(:yes_no))
             .to(TypeDeChamp.type_champs.fetch(:checkbox))
           expect(champ_99.persisted?).to be_truthy
           expect(champ_99.last_write_type_champ).to eq(TypeDeChamp.type_champs.fetch(:checkbox))
-          expect(dossier.champs.any?(&:changed_for_autosave?)).to be_truthy
+          expect(dossier.champ_data.any?(&:changed_for_autosave?)).to be_truthy
           expect(champ_99.changed?).to be_truthy
           expect(champ_99.value).to eq('true')
         }
@@ -555,12 +555,12 @@ RSpec.describe DossierChampsConcern do
         end
 
         it {
-          expect { subject }.to change { dossier.champs.find_by(stable_id: 99).last_write_type_champ }
+          expect { subject }.to change { dossier.champ_data.find_by(stable_id: 99).last_write_type_champ }
             .from(TypeDeChamp.type_champs.fetch(:regions))
             .to(TypeDeChamp.type_champs.fetch(:text))
           expect(champ_99.persisted?).to be_truthy
           expect(champ_99.last_write_type_champ).to eq(TypeDeChamp.type_champs.fetch(:text))
-          expect(dossier.champs.any?(&:changed_for_autosave?)).to be_truthy
+          expect(dossier.champ_data.any?(&:changed_for_autosave?)).to be_truthy
           expect(champ_99.changed?).to be_truthy
           expect(champ_99.value).to eq('test text')
         }
@@ -588,7 +588,7 @@ RSpec.describe DossierChampsConcern do
 
     it {
       subject
-      expect(dossier.champs.any?(&:changed_for_autosave?)).to be_truthy
+      expect(dossier.champ_data.any?(&:changed_for_autosave?)).to be_truthy
       expect(annotation_995.changed?).to be_truthy
       expect(annotation_995.value).to eq("Hello")
     }
@@ -598,7 +598,7 @@ RSpec.describe DossierChampsConcern do
 
       it {
         subject
-        expect(dossier.champs.any?(&:changed_for_autosave?)).to be_truthy
+        expect(dossier.champ_data.any?(&:changed_for_autosave?)).to be_truthy
         expect(annotation_995.changed?).to be_truthy
         expect(annotation_995.value).to eq("Hello")
       }
@@ -721,7 +721,7 @@ RSpec.describe DossierChampsConcern do
       }
 
       context "missing champs" do
-        before { dossier; Champs::TextChamp.destroy_all; dossier.champs.reload }
+        before { dossier; Champs::TextChamp.destroy_all; dossier.champ_data.reload }
 
         it {
           subject
@@ -944,7 +944,7 @@ RSpec.describe DossierChampsConcern do
         expect(dossier.history.size).to eq(0)
 
         dossier.merge_instructeur_buffer_stream!
-        dossier.champs.reload
+        dossier.champ_data.reload
 
         expect(main_champ_99.value).to eq("Hello")
         expect(main_champ_991.value).to eq("World")
@@ -972,7 +972,7 @@ RSpec.describe DossierChampsConcern do
 
           dossier.merge_user_buffer_stream!
           dossier.touch(:en_construction_at)
-          dossier.champs.reload
+          dossier.champ_data.reload
         end
 
         expect(draft_champ_99.value).to eq("Hello???")
@@ -982,7 +982,7 @@ RSpec.describe DossierChampsConcern do
 
         travel_to(30.minutes.from_now) do
           dossier.merge_instructeur_buffer_stream!
-          dossier.champs.reload
+          dossier.champ_data.reload
         end
 
         expect(main_champ_99.value).to eq("Hello???")
@@ -1006,7 +1006,7 @@ RSpec.describe DossierChampsConcern do
           dossier.with_instructeur_buffer_stream { assign_champs_attributes(attributes_2) }
           dossier.save!
           dossier.merge_instructeur_buffer_stream!
-          dossier.champs.reload
+          dossier.champ_data.reload
         end
 
         expect(main_champ_99.value).to eq("Hello...")
@@ -1027,7 +1027,7 @@ RSpec.describe DossierChampsConcern do
   describe '#set_default_value_for_france_connect_champs' do
     let!(:procedure) { create(:procedure, :published, :with_api_particulier_token, types_de_champ_public:, for_individual: true) }
     let(:types_de_champ_public) { [{ type: :quotient_familial }] }
-    let(:champ_qf) { dossier.champs.first }
+    let(:champ_qf) { dossier.champ_data.first }
     let!(:fci) { create(:france_connect_information, user: dossier.user) }
 
     context 'when dossier is in a brouillon' do

--- a/spec/models/concerns/dossier_clone_concern_spec.rb
+++ b/spec/models/concerns/dossier_clone_concern_spec.rb
@@ -136,8 +136,8 @@ RSpec.describe DossierCloneConcern do
 
         context 'for Champs::CarteChamp with geo areas, original_champ.geo_areas are duped' do
           let(:types_de_champ_public) { [{ type: :carte }] }
-          let(:champ_carte) { dossier.champs.first }
-          let(:cloned_champ_carte) { new_dossier.champs.first }
+          let(:champ_carte) { dossier.champ_data.first }
+          let(:cloned_champ_carte) { new_dossier.champ_data.first }
 
           it do
             expect(cloned_champ_carte.geo_areas.count).to eq(2)
@@ -147,8 +147,8 @@ RSpec.describe DossierCloneConcern do
 
         context 'for Champs::SiretChamp, original_champ.etablissement is duped' do
           let(:types_de_champ_public) { [{ type: :siret }] }
-          let(:champ_siret) { dossier.champs.first }
-          let(:cloned_champ_siret) { new_dossier.champs.first }
+          let(:champ_siret) { dossier.champ_data.first }
+          let(:cloned_champ_siret) { new_dossier.champ_data.first }
 
           it do
             expect(champ_siret.etablissement).not_to be_nil
@@ -158,16 +158,16 @@ RSpec.describe DossierCloneConcern do
 
         context 'for Champs::PieceJustificative, original_champ.piece_justificative_file is duped' do
           let(:types_de_champ_public) { [{ type: :piece_justificative }] }
-          let(:champ_piece_justificative) { dossier.champs.first }
-          let(:cloned_champ_piece_justificative) { new_dossier.champs.first }
+          let(:champ_piece_justificative) { dossier.champ_data.first }
+          let(:cloned_champ_piece_justificative) { new_dossier.champ_data.first }
 
           it { expect(cloned_champ_piece_justificative.piece_justificative_file.first.blob).to eq(champ_piece_justificative.piece_justificative_file.first.blob) }
         end
 
         context 'for Champs::AddressChamp, original_champ.data is duped' do
           let(:types_de_champ_public) { [{ type: :address }] }
-          let(:champ_address) { dossier.champs.first }
-          let(:cloned_champ_address) { new_dossier.champs.first }
+          let(:champ_address) { dossier.champ_data.first }
+          let(:cloned_champ_address) { new_dossier.champ_data.first }
 
           before { champ_address.update(external_id: 'Address', data: { city_code: '75019' }) }
 

--- a/spec/models/concerns/dossier_prefillable_concern_spec.rb
+++ b/spec/models/concerns/dossier_prefillable_concern_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe DossierPrefillableConcern do
     private
 
     def find_champ_by_stable_id(dossier, stable_id)
-      dossier.champs.find_by(stable_id:)
+      dossier.champ_data.find_by(stable_id:)
     end
   end
 end

--- a/spec/models/concerns/dossier_rebase_concern_spec.rb
+++ b/spec/models/concerns/dossier_rebase_concern_spec.rb
@@ -180,14 +180,14 @@ describe DossierRebaseConcern do
         # Add two rows then remove previous to last row in order to create a "hole" in the sequence
         repetition_champ.add_row(updated_by: 'test')
         repetition_champ.add_row(updated_by: 'test')
-        repetition_champ.dossier.champs.where(row_id: repetition_champ.row_ids[-2]).destroy_all
+        repetition_champ.dossier.champ_data.where(row_id: repetition_champ.row_ids[-2]).destroy_all
         dossier.reload
       end
 
       it "updates the brouillon champs with the latest revision changes", :slow do
         expect(dossier.revision).to eq(procedure.published_revision)
         expect(dossier.project_champs_public.size).to eq(5)
-        expect(dossier.champs.count(&:public?)).to eq(6)
+        expect(dossier.champ_data.count(&:public?)).to eq(6)
         expect(repetition_champ.rows.size).to eq(2)
         expect(repetition_champ.rows[0].size).to eq(1)
         expect(repetition_champ.rows[1].size).to eq(1)
@@ -200,7 +200,7 @@ describe DossierRebaseConcern do
         expect(procedure.revisions.size).to eq(3)
         expect(dossier.revision).to eq(procedure.published_revision)
         expect(dossier.project_champs_public.size).to eq(7)
-        expect(dossier.champs.count(&:public?)).to eq(7)
+        expect(dossier.champ_data.count(&:public?)).to eq(7)
         expect(rebased_text_champ.value).to eq(text_champ.value)
         expect(rebased_text_champ.type_de_champ).not_to eq(text_champ.type_de_champ)
         expect(rebased_datetime_champ.type_champ).to eq(TypeDeChamp.type_champs.fetch(:date))

--- a/spec/models/concerns/dossier_sections_concern_spec.rb
+++ b/spec/models/concerns/dossier_sections_concern_spec.rb
@@ -73,7 +73,7 @@ describe DossierSectionsConcern do
     let(:number_value) { nil }
 
     before do
-      dossier.champs.find { _1.stable_id == number_stable_id }&.update(value: number_value)
+      dossier.champ_data.find { _1.stable_id == number_stable_id }&.update(value: number_value)
       dossier.reload
     end
 

--- a/spec/models/concerns/dossier_state_concern_spec.rb
+++ b/spec/models/concerns/dossier_state_concern_spec.rb
@@ -30,17 +30,17 @@ RSpec.describe DossierStateConcern do
       dossier.reload
       champ_repetition = dossier.project_champs_public.find { _1.stable_id == 94 }
       row_id = champ_repetition.row_ids.first
-      dossier.champs.filter(&:row?).find { _1.row_id == row_id }.touch(:discarded_at)
+      dossier.champ_data.filter(&:row?).find { _1.row_id == row_id }.touch(:discarded_at)
     end
   end
 
   describe 'submit brouillon' do
     it do
-      expect(dossier.champs.size).to eq(20)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id == 94 }.size).to eq(2)
-      expect(dossier.champs.filter { _1.row? && _1.discarded? }.size).to eq(1)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id.in?([95, 96]) }.size).to eq(4)
-      expect(dossier.champs.filter { _1.stable_id.in?([90, 92, 93, 97, 961, 951]) }.size).to eq(8)
+      expect(dossier.champ_data.size).to eq(20)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id == 94 }.size).to eq(2)
+      expect(dossier.champ_data.filter { _1.row? && _1.discarded? }.size).to eq(1)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id.in?([95, 96]) }.size).to eq(4)
+      expect(dossier.champ_data.filter { _1.stable_id.in?([90, 92, 93, 97, 961, 951]) }.size).to eq(8)
 
       champ_text = dossier.project_champs_public.find { _1.stable_id == 90 }
       champ_text.update(value: '')
@@ -48,11 +48,11 @@ RSpec.describe DossierStateConcern do
       dossier.passer_en_construction!
       dossier.reload
 
-      expect(dossier.champs.size).to eq(7)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id == 94 }.size).to eq(1)
-      expect(dossier.champs.filter { _1.row? && _1.discarded? }.size).to eq(0)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id.in?([95, 96]) }.size).to eq(0)
-      expect(dossier.champs.filter { _1.stable_id.in?([90, 92, 93, 97, 961, 951]) && !(_1.blank? || !_1.visible?) }.size).to eq(0)
+      expect(dossier.champ_data.size).to eq(7)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id == 94 }.size).to eq(1)
+      expect(dossier.champ_data.filter { _1.row? && _1.discarded? }.size).to eq(0)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id.in?([95, 96]) }.size).to eq(0)
+      expect(dossier.champ_data.filter { _1.stable_id.in?([90, 92, 93, 97, 961, 951]) && !(_1.blank? || !_1.visible?) }.size).to eq(0)
       expect(dossier.submitted_revision_id).to eq(dossier.revision_id)
     end
 
@@ -83,20 +83,20 @@ RSpec.describe DossierStateConcern do
     let(:dossier_state) { :en_construction }
 
     it do
-      expect(dossier.champs.size).to eq(20)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id == 94 }.size).to eq(2)
-      expect(dossier.champs.filter { _1.row? && _1.discarded? }.size).to eq(1)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id.in?([95, 96]) }.size).to eq(4)
-      expect(dossier.champs.filter { _1.stable_id.in?([92, 93, 97, 961, 951]) }.size).to eq(7)
+      expect(dossier.champ_data.size).to eq(20)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id == 94 }.size).to eq(2)
+      expect(dossier.champ_data.filter { _1.row? && _1.discarded? }.size).to eq(1)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id.in?([95, 96]) }.size).to eq(4)
+      expect(dossier.champ_data.filter { _1.stable_id.in?([92, 93, 97, 961, 951]) }.size).to eq(7)
 
       dossier.usager_submit_en_construction!
       dossier.reload
 
-      expect(dossier.champs.size).to eq(7)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id == 94 }.size).to eq(1)
-      expect(dossier.champs.filter { _1.row? && _1.discarded? }.size).to eq(0)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id.in?([95, 96]) }.size).to eq(0)
-      expect(dossier.champs.filter { _1.stable_id.in?([92, 93, 97, 961, 951]) && !(_1.blank? || !_1.visible?) }.size).to eq(0)
+      expect(dossier.champ_data.size).to eq(7)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id == 94 }.size).to eq(1)
+      expect(dossier.champ_data.filter { _1.row? && _1.discarded? }.size).to eq(0)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id.in?([95, 96]) }.size).to eq(0)
+      expect(dossier.champ_data.filter { _1.stable_id.in?([92, 93, 97, 961, 951]) && !(_1.blank? || !_1.visible?) }.size).to eq(0)
       expect(dossier.submitted_revision_id).to eq(dossier.revision_id)
     end
 
@@ -181,16 +181,16 @@ RSpec.describe DossierStateConcern do
     let(:dossier_state) { :en_instruction }
 
     it do
-      expect(dossier.champs.size).to eq(20)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id == 94 }.size).to eq(2)
-      expect(dossier.champs.filter { _1.stable_id.in?([93, 98]) }.size).to eq(2)
+      expect(dossier.champ_data.size).to eq(20)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id == 94 }.size).to eq(2)
+      expect(dossier.champ_data.filter { _1.stable_id.in?([93, 98]) }.size).to eq(2)
 
       dossier.accepter!(motivation: 'test')
       dossier.reload
 
-      expect(dossier.champs.size).to eq(17)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id == 94 }.size).to eq(1)
-      expect(dossier.champs.filter { _1.stable_id.in?([93, 98]) && _1.blank? }.size).to eq(2)
+      expect(dossier.champ_data.size).to eq(17)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id == 94 }.size).to eq(1)
+      expect(dossier.champ_data.filter { _1.stable_id.in?([93, 98]) && _1.blank? }.size).to eq(2)
     end
 
     context "when dossier has attente_avis notification" do
@@ -209,16 +209,16 @@ RSpec.describe DossierStateConcern do
     let(:dossier_state) { :en_instruction }
 
     it do
-      expect(dossier.champs.size).to eq(20)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id == 94 }.size).to eq(2)
-      expect(dossier.champs.filter { _1.stable_id.in?([93, 98]) }.size).to eq(2)
+      expect(dossier.champ_data.size).to eq(20)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id == 94 }.size).to eq(2)
+      expect(dossier.champ_data.filter { _1.stable_id.in?([93, 98]) }.size).to eq(2)
 
       dossier.refuser!(motivation: 'test')
       dossier.reload
 
-      expect(dossier.champs.size).to eq(17)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id == 94 }.size).to eq(1)
-      expect(dossier.champs.filter { _1.stable_id.in?([93, 98]) && _1.blank? }.size).to eq(2)
+      expect(dossier.champ_data.size).to eq(17)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id == 94 }.size).to eq(1)
+      expect(dossier.champ_data.filter { _1.stable_id.in?([93, 98]) && _1.blank? }.size).to eq(2)
     end
 
     context "when dossier has attente_avis notification" do
@@ -237,16 +237,16 @@ RSpec.describe DossierStateConcern do
     let(:dossier_state) { :en_instruction }
 
     it '', :slow do
-      expect(dossier.champs.size).to eq(20)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id == 94 }.size).to eq(2)
-      expect(dossier.champs.filter { _1.stable_id.in?([93, 98]) }.size).to eq(2)
+      expect(dossier.champ_data.size).to eq(20)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id == 94 }.size).to eq(2)
+      expect(dossier.champ_data.filter { _1.stable_id.in?([93, 98]) }.size).to eq(2)
 
       dossier.classer_sans_suite!(motivation: 'test')
       dossier.reload
 
-      expect(dossier.champs.size).to eq(17)
-      expect(dossier.champs.filter { _1.row? && _1.stable_id == 94 }.size).to eq(1)
-      expect(dossier.champs.filter { _1.stable_id.in?([93, 98]) && _1.blank? }.size).to eq(2)
+      expect(dossier.champ_data.size).to eq(17)
+      expect(dossier.champ_data.filter { _1.row? && _1.stable_id == 94 }.size).to eq(1)
+      expect(dossier.champ_data.filter { _1.stable_id.in?([93, 98]) && _1.blank? }.size).to eq(2)
     end
 
     context "when dossier has an attestation from a previous acceptation" do
@@ -281,16 +281,16 @@ RSpec.describe DossierStateConcern do
       let(:declarative_with_state) { Dossier.states.fetch(:accepte) }
 
       it do
-        expect(dossier.champs.size).to eq(20)
-        expect(dossier.champs.filter { _1.row? && _1.stable_id == 94 }.size).to eq(2)
-        expect(dossier.champs.filter { _1.stable_id.in?([93, 98]) }.size).to eq(2)
+        expect(dossier.champ_data.size).to eq(20)
+        expect(dossier.champ_data.filter { _1.row? && _1.stable_id == 94 }.size).to eq(2)
+        expect(dossier.champ_data.filter { _1.stable_id.in?([93, 98]) }.size).to eq(2)
 
         dossier.accepter_automatiquement!
         dossier.reload
 
-        expect(dossier.champs.size).to eq(17)
-        expect(dossier.champs.filter { _1.row? && _1.stable_id == 94 }.size).to eq(1)
-        expect(dossier.champs.filter { _1.stable_id.in?([93, 98]) && _1.blank? }.size).to eq(2)
+        expect(dossier.champ_data.size).to eq(17)
+        expect(dossier.champ_data.filter { _1.row? && _1.stable_id == 94 }.size).to eq(1)
+        expect(dossier.champ_data.filter { _1.stable_id.in?([93, 98]) && _1.blank? }.size).to eq(2)
       end
     end
 
@@ -319,7 +319,7 @@ RSpec.describe DossierStateConcern do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: 'titre_identite' }]) }
       let(:dossier) { create(:dossier, :en_instruction, :followed, procedure:) }
       let(:instructeur) { dossier.followers_instructeurs.first }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       it 'destroys champ on accepter' do
         champ.piece_justificative_file.attach(file)
@@ -332,7 +332,7 @@ RSpec.describe DossierStateConcern do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: 'titre_identite' }]) }
       let(:dossier) { create(:dossier, :en_instruction, :followed, procedure:) }
       let(:instructeur) { dossier.followers_instructeurs.first }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       it 'destroys champ on accepter' do
         champ.piece_justificative_file.attach(file)
@@ -345,7 +345,7 @@ RSpec.describe DossierStateConcern do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, pj_auto_purge: '1' }]) }
       let(:dossier) { create(:dossier, :en_instruction, :followed, procedure:) }
       let(:instructeur) { dossier.followers_instructeurs.first }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       it 'destroys champ on accepter' do
         champ.piece_justificative_file.attach(file)
@@ -358,7 +358,7 @@ RSpec.describe DossierStateConcern do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
       let(:dossier) { create(:dossier, :en_instruction, :followed, procedure:) }
       let(:instructeur) { dossier.followers_instructeurs.first }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       it 'keeps attachments on accepter' do
         champ.piece_justificative_file.attach(file)
@@ -409,7 +409,7 @@ RSpec.describe DossierStateConcern do
   describe '#clear_france_connect_champs_piece_justificatives (after user submits a dossier or modifications)' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :quotient_familial }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     subject { dossier.send(:clear_france_connect_champs_piece_justificatives!) }
 

--- a/spec/models/dossier_preloader_spec.rb
+++ b/spec/models/dossier_preloader_spec.rb
@@ -30,14 +30,14 @@ describe DossierPreloader do
 
         expect(first_child.type).to eq('Champs::TextChamp')
         expect(repetition).not_to eq(first_child)
-        expect(subject.champs.first.dossier).to eq(subject)
-        expect(subject.champs.find(&:public?).dossier).to eq(subject)
+        expect(subject.champ_data.first.dossier).to eq(subject)
+        expect(subject.champ_data.find(&:public?).dossier).to eq(subject)
         expect(subject.project_champs_public.first.dossier).to eq(subject)
 
         expect(subject.project_champs_public.first.type_de_champ.piece_justificative_template.attached?).to eq(false)
 
-        expect(subject.champs.first.conditional?).to eq(false)
-        expect(subject.champs.find(&:public?).conditional?).to eq(false)
+        expect(subject.champ_data.first.conditional?).to eq(false)
+        expect(subject.champ_data.find(&:public?).conditional?).to eq(false)
         expect(subject.project_champs_public.first.conditional?).to eq(false)
 
         expect(repetition.rows.first.first.public_id).to eq(first_child.public_id)
@@ -158,7 +158,7 @@ describe DossierPreloader do
             dossier.followers_instructeurs.to_a
             dossier.avis.each { |a| a.claimant&.email; a.expert&.email }
             dossier.pending_corrections.to_a
-            dossier.champs.to_a # champs préchargés via load_dossiers
+            dossier.champ_data.to_a # champs préchargés via load_dossiers
           end
         end
         expect(count).to eq(0)

--- a/spec/models/dossier_purge_spec.rb
+++ b/spec/models/dossier_purge_spec.rb
@@ -16,7 +16,7 @@ describe Dossier, type: :model do
       let(:dossier) { create(:dossier) }
 
       it 'destroys champs in batches of 50 before destroying the dossier' do
-        expect(dossier.champs).to receive(:in_batches).with(hash_including(of: 50)).at_least(:once).and_call_original
+        expect(dossier.champ_data).to receive(:in_batches).with(hash_including(of: 50)).at_least(:once).and_call_original
         dossier.purge_discarded
       end
     end
@@ -28,13 +28,13 @@ describe Dossier, type: :model do
       before do
         51.times do |i|
           type_de_champ = create(:type_de_champ_text, procedure:, libelle: "Test #{i}")
-          dossier.champs << type_de_champ.build_champ(value: "value #{i}")
+          dossier.champ_data << type_de_champ.build_champ(value: "value #{i}")
         end
         dossier.save!
       end
 
       it 'destroys all champs even when count exceeds in_batches size' do
-        expect(dossier.champs.count).to be > 50
+        expect(dossier.champ_data.count).to be > 50
         dossier.purge_discarded
         expect(Champ.where(dossier_id: dossier.id)).to be_empty
       end
@@ -44,7 +44,7 @@ describe Dossier, type: :model do
       let(:procedure) { create(:procedure_with_dossiers, :published) }
       let(:dossier) { procedure.dossiers.first }
       let(:type_de_champ) { create(:type_de_champ_text, procedure:, libelle: 'Test') }
-      let!(:champ) { dossier.champs.create!(type_de_champ:, value: 'kept') }
+      let!(:champ) { dossier.champ_data.create!(type_de_champ:, value: 'kept') }
 
       before do
         allow(dossier).to receive(:destroy).and_raise(StandardError, 'boom')
@@ -79,7 +79,7 @@ describe Dossier, type: :model do
     end
 
     it 'destroys champs in batches of 50 before destroying the dossier' do
-      expect(dossier.champs).to receive(:in_batches).with(hash_including(of: 50)).at_least(:once).and_call_original
+      expect(dossier.champ_data).to receive(:in_batches).with(hash_including(of: 50)).at_least(:once).and_call_original
       dossier.purge_without_notice
     end
 
@@ -90,13 +90,13 @@ describe Dossier, type: :model do
       before do
         51.times do |i|
           type_de_champ = create(:type_de_champ_text, procedure:, libelle: "Test #{i}")
-          dossier.champs << type_de_champ.build_champ(value: "value #{i}")
+          dossier.champ_data << type_de_champ.build_champ(value: "value #{i}")
         end
         dossier.save!
       end
 
       it 'destroys all champs even when count exceeds in_batches size' do
-        expect(dossier.champs.count).to be > 50
+        expect(dossier.champ_data.count).to be > 50
         dossier.purge_without_notice
         expect(Champ.where(dossier_id: dossier.id)).to be_empty
       end
@@ -106,7 +106,7 @@ describe Dossier, type: :model do
       let(:procedure) { create(:procedure_with_dossiers, :published) }
       let(:dossier) { procedure.dossiers.first }
       let(:type_de_champ) { create(:type_de_champ_text, procedure:, libelle: 'Test') }
-      let!(:champ) { dossier.champs.create!(type_de_champ:, value: 'kept') }
+      let!(:champ) { dossier.champ_data.create!(type_de_champ:, value: 'kept') }
 
       before do
         allow(dossier).to receive(:destroy).and_raise(StandardError, 'boom')

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -774,7 +774,7 @@ describe Dossier, type: :model do
           procedure.defaut_groupe_instructeur = gi
           procedure.save!
           procedure.toggle_routing
-          dossier.champs.first.value = gi_libelle
+          dossier.champ_data.first.value = gi_libelle
           dossier.save!
           dossier.passer_en_construction!
           dossier.reload
@@ -2018,7 +2018,7 @@ describe Dossier, type: :model do
       let(:dossier_ok) { create(:dossier, :en_instruction, :with_populated_champs, procedure:) }
 
       before do
-        dossier_incomplete.champs.first.update(etablissement: Etablissement.new(siret: build(:etablissement).siret))
+        dossier_incomplete.champ_data.first.update(etablissement: Etablissement.new(siret: build(:etablissement).siret))
       end
 
       it "can't accepter" do
@@ -2058,7 +2058,7 @@ describe Dossier, type: :model do
 
     context "with mandatory champs" do
       let(:type_de_champ) { { mandatory: true } }
-      let(:champ_with_error) { dossier.champs.first }
+      let(:champ_with_error) { dossier.champ_data.first }
 
       before do
         champ_with_error.value = nil
@@ -2082,7 +2082,7 @@ describe Dossier, type: :model do
 
     context "with mandatory SIRET champ" do
       let(:type_de_champ) { { type: :siret, mandatory: true } }
-      let(:champ_siret) { dossier.champs.first }
+      let(:champ_siret) { dossier.champ_data.first }
 
       before do
         champ_siret.update(value: '44011762001530')
@@ -2112,10 +2112,10 @@ describe Dossier, type: :model do
 
       context "when no champs" do
         it 'should have errors' do
-          dossier.champs.first.row_ids.each do |row_id|
+          dossier.champ_data.first.row_ids.each do |row_id|
             dossier.repetition_remove_row(type_de_champ_repetition, row_id, updated_by: 'test')
           end
-          expect(dossier.champs.first.rows).to be_empty
+          expect(dossier.champ_data.first.rows).to be_empty
           expect(errors).not_to be_empty
           expect(errors.first.full_message).to eq("Le champ « Value » doit être rempli")
         end
@@ -2123,7 +2123,7 @@ describe Dossier, type: :model do
 
       context "when mandatory champ inside repetition" do
         it 'should have errors' do
-          expect(dossier.champs.first.rows).not_to be_empty
+          expect(dossier.champ_data.first.rows).not_to be_empty
           expect(errors).not_to be_empty
           expect(errors.first.full_message).to eq("Le champ « Value » doit être rempli")
         end
@@ -2133,13 +2133,13 @@ describe Dossier, type: :model do
           let(:type_de_champ) { { type: :repetition, mandatory: true, children: [{ mandatory: true }], condition: ds_eq(champ_value(99), constant(true)) } }
 
           it 'should not have errors' do
-            expect(dossier.champs.second.rows).not_to be_empty
+            expect(dossier.champ_data.second.rows).not_to be_empty
             expect(errors).to be_empty
           end
 
           it 'should have errors' do
-            dossier.champs.first.update(value: 'true')
-            expect(dossier.champs.second.rows).not_to be_empty
+            dossier.champ_data.first.update(value: 'true')
+            expect(dossier.champ_data.second.rows).not_to be_empty
             expect(errors).not_to be_empty
             expect(errors.first.full_message).to eq("Le champ « Value » doit être rempli")
           end
@@ -2503,7 +2503,7 @@ describe Dossier, type: :model do
   describe "to_feature_collection" do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :carte }]) }
     let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-    let(:champ_carte) { dossier.champs.first }
+    let(:champ_carte) { dossier.champ_data.first }
     let(:geo_area) { build(:geo_area, :selection_utilisateur, :polygon) }
 
     before do
@@ -2975,7 +2975,7 @@ describe Dossier, type: :model do
   describe '#update_champs_timestamps' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{}, { type: :piece_justificative }, { type: :piece_justificative, nature: 'titre_identite' }]) }
     let(:dossier) { create(:dossier, procedure:, brouillon_close_to_expiration_notice_sent_at: 10.days.ago) }
-    let(:changed_champs) { dossier.champs.filter(&:text?) }
+    let(:changed_champs) { dossier.champ_data.filter(&:text?) }
 
     subject { -> { dossier.update_champs_timestamps(changed_champs, Champ::USER_BUFFER_STREAM) } }
 
@@ -2985,7 +2985,7 @@ describe Dossier, type: :model do
     end
 
     context 'when there is piece justificative' do
-      let(:changed_champs) { dossier.champs.filter(&:piece_justificative?) }
+      let(:changed_champs) { dossier.champ_data.filter(&:piece_justificative?) }
 
       it do
         is_expected.to change(dossier, :last_champ_updated_at)
@@ -2994,7 +2994,7 @@ describe Dossier, type: :model do
     end
 
     context 'when there is titre identite' do
-      let(:changed_champs) { dossier.champs.filter(&:titre_identite?) }
+      let(:changed_champs) { dossier.champ_data.filter(&:titre_identite?) }
 
       it do
         is_expected.to change(dossier, :last_champ_updated_at)

--- a/spec/models/etablissement_spec.rb
+++ b/spec/models/etablissement_spec.rb
@@ -188,7 +188,7 @@ describe Etablissement do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
     let(:dossier) { create(:dossier, procedure:) }
     let(:etablissement) { create(:etablissement) }
-    let(:champ) { dossier.champs[0] }
+    let(:champ) { dossier.champ_data[0] }
     let(:address_data) do
       {
         "street_number" => "6",

--- a/spec/models/logic/champ_column_value_spec.rb
+++ b/spec/models/logic/champ_column_value_spec.rb
@@ -9,7 +9,7 @@ describe Logic::ChampColumnValue do
 
   describe '#compute' do
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     before { champ.update(value: 'true') }
 
@@ -49,7 +49,7 @@ describe Logic::ChampColumnValue do
     let(:column) { procedure.find_column(label: 'menu') }
     let(:champ_column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     context "when the user picked 'other' without typing a value" do
       before { champ.update!(value: Champs::DropDownListChamp::OTHER) }

--- a/spec/models/prefill_champs_spec.rb
+++ b/spec/models/prefill_champs_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe PrefillChamps do
       let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
       let(:type_de_champ_child_value) { "value" }
       let(:type_de_champ_child_value2) { "value2" }
-      let(:child_champs) { dossier.champs.where(stable_id: type_de_champ_child.stable_id) }
+      let(:child_champs) { dossier.champ_data.where(stable_id: type_de_champ_child.stable_id) }
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => [{ "champ_#{type_de_champ_child.to_typed_id_for_query}" => type_de_champ_child_value }, { "champ_#{type_de_champ_child.to_typed_id_for_query}" => type_de_champ_child_value2 }] } }
 
@@ -204,7 +204,7 @@ RSpec.describe PrefillChamps do
       let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
       let(:type_de_champ_child_value) { "value" }
       let(:type_de_champ_child_value2) { "value2" }
-      let(:child_champs) { dossier.champs.where(stable_id: type_de_champ_child.stable_id) }
+      let(:child_champs) { dossier.champ_data.where(stable_id: type_de_champ_child.stable_id) }
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => [{ "champ_#{type_de_champ_child.to_typed_id_for_query}" => type_de_champ_child_value }, { "champ_#{type_de_champ_child.to_typed_id_for_query}" => type_de_champ_child_value2 }] } }
 
@@ -305,7 +305,7 @@ RSpec.describe PrefillChamps do
   private
 
   def find_champ_by_stable_id(dossier, stable_id)
-    dossier.champs.find_by(stable_id:)
+    dossier.champ_data.find_by(stable_id:)
   end
 
   def attributes(champ, value)

--- a/spec/models/routing_engine_spec.rb
+++ b/spec/models/routing_engine_spec.rb
@@ -50,7 +50,7 @@ describe RoutingEngine, type: :model do
       context 'with a matching rule' do
         before do
           gi_2.update(routing_rule: ds_eq(champ_value(drop_down_tdc.stable_id), constant('Lyon')))
-          dossier.champs.first.update(value: 'Lyon')
+          dossier.champ_data.first.update(value: 'Lyon')
         end
 
         it { is_expected.to eq(gi_2) }
@@ -65,7 +65,7 @@ describe RoutingEngine, type: :model do
       context 'with a non equals rule' do
         before do
           gi_2.update(routing_rule: ds_not_eq(champ_value(drop_down_tdc.stable_id), constant('Lyon')))
-          dossier.champs.first.update(value: 'Paris')
+          dossier.champ_data.first.update(value: 'Paris')
         end
 
         it do
@@ -87,7 +87,7 @@ describe RoutingEngine, type: :model do
       context 'with a matching rule' do
         before do
           gi_2.update(routing_rule: ds_eq(champ_value(departements_tdc.stable_id), constant('43')))
-          dossier.champs.first.update(value: 'Haute-Loire')
+          dossier.champ_data.first.update(value: 'Haute-Loire')
         end
 
         it { is_expected.to eq(gi_2) }
@@ -106,7 +106,7 @@ describe RoutingEngine, type: :model do
       context 'with a matching rule' do
         before do
           gi_2.update(routing_rule: ds_eq(champ_value(regions_tdc.stable_id), constant('04')))
-          dossier.champs.first.update(value: 'La Réunion')
+          dossier.champ_data.first.update(value: 'La Réunion')
         end
 
         it { is_expected.to eq(gi_2) }
@@ -125,7 +125,7 @@ describe RoutingEngine, type: :model do
       context 'with a matching rule' do
         before do
           gi_2.update(routing_rule: ds_in_departement(champ_value(communes_tdc.stable_id), constant('92')))
-          dossier.champs.first.update(code_postal: '92500', external_id: '92063')
+          dossier.champ_data.first.update(code_postal: '92500', external_id: '92063')
         end
 
         it { is_expected.to eq(gi_2) }
@@ -144,7 +144,7 @@ describe RoutingEngine, type: :model do
       context 'with a matching rule' do
         before do
           gi_2.update(routing_rule: ds_in_departement(champ_value(epci_tdc.stable_id), constant('42')))
-          dossier.champs.first.update_columns(
+          dossier.champ_data.first.update_columns(
             external_id: 244200895,
             value: 'CC du Pilat Rhodanien',
             value_json: { code_departement: '42' }
@@ -169,7 +169,7 @@ describe RoutingEngine, type: :model do
       context 'with a matching rule' do
         before do
           gi_2.update(routing_rule: ds_in_departement(champ_value(address_tdc.stable_id), constant('42')))
-          dossier.champs.first.update_columns(
+          dossier.champ_data.first.update_columns(
             value: "2 rue de l'Hôtel de Ville 42000 Saint-Étienne",
             value_json: { department_code: '42', region_code: '83', city_code: '42218', postal_code: '42000', street_address: "2 rue de l'Hôtel de Ville", country_code: 'FR' }
           )
@@ -193,7 +193,7 @@ describe RoutingEngine, type: :model do
       context 'with a matching rule' do
         before do
           gi_2.update(routing_rule: ds_eq(champ_value(pays_tdc.stable_id), constant('BE')))
-          dossier.champs.first.update_columns(
+          dossier.champ_data.first.update_columns(
             value: "Belgique"
           )
         end
@@ -221,7 +221,7 @@ describe RoutingEngine, type: :model do
           defaut_groupe.update(label: 'a')
           gi_2.update(label: 'b', routing_rule: ds_not_eq(champ_value(drop_down_tdc.stable_id), constant('Lyon')))
           gi_3.update(routing_rule: ds_eq(champ_value(drop_down_tdc.stable_id), constant('Marseille')))
-          dossier.champs.first.update(value: 'Marseille')
+          dossier.champ_data.first.update(value: 'Marseille')
         end
 
         it 'computes by groups label order' do

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -666,7 +666,7 @@ describe TypeDeChamp do
     let(:champ_value) { 'hello' }
     let(:champ_type) { TypeDeChamp.type_champ_to_champ_class_name(last_write_type_champ.to_s) }
     let(:type_de_champ) { procedure.active_revision.types_de_champ.first }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     subject { champ.update_columns(type: champ_type, value: champ_value); type_de_champ.champ_value(champ) }
 

--- a/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
@@ -39,7 +39,7 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
     context 'when nature is titre_identite' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: 'titre_identite' }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
       let(:type_de_champ) { champ.type_de_champ }
 
       it 'returns "absent" when no file attached' do
@@ -55,7 +55,7 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
     context 'when nature is not titre_identite' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
       let(:type_de_champ) { champ.type_de_champ }
 
       it 'returns filenames' do
@@ -72,7 +72,7 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
   describe '#champ_value_for_api' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     before { allow(ClamavService).to receive(:safe_file?).and_return(true) }
 

--- a/spec/models/types_de_champ/pre_rempli_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/pre_rempli_type_de_champ_spec.rb
@@ -4,7 +4,7 @@ describe TypesDeChamp::PreRempliTypeDeChamp do
   let(:types_de_champ_public) { [{ type: :pre_rempli }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
   let(:type_de_champ) { champ.type_de_champ }
 
   describe '#tags_for_template' do

--- a/spec/models/types_de_champ/prefill_address_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_address_type_de_champ_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TypesDeChamp::PrefillAddressTypeDeChamp do
   end
 
   describe '#to_assignable_attributes' do
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     subject { described_class.build(type_de_champ, procedure.active_revision).to_assignable_attributes(champ, value) }
 
     context 'when the value is nil' do

--- a/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe TypesDeChamp::PrefillTypeDeChamp, type: :model do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :email }]) }
     let(:dossier) { create(:dossier, procedure:) }
     let(:type_de_champ) { procedure.active_revision.types_de_champ.first }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     let(:value) { "any@email.org" }
     subject(:to_assignable_attributes) { described_class.build(type_de_champ, procedure.active_revision).to_assignable_attributes(champ, value) }
 

--- a/spec/models/types_de_champ/quotient_familial_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/quotient_familial_type_de_champ_spec.rb
@@ -5,7 +5,7 @@ describe TypesDeChamp::QuotientFamilialTypeDeChamp do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :quotient_familial }]) }
     let(:tdc_quotient_familial) { procedure.active_revision.types_de_champ.first }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     subject { tdc_quotient_familial.champ_blank?(champ) }
 

--- a/spec/policies/champ_policy_spec.rb
+++ b/spec/policies/champ_policy_spec.rb
@@ -18,8 +18,8 @@ describe ChampPolicy do
       populate_annotations: true)
   end
   let(:state) { :en_construction }
-  let(:champ) { Champ.find(dossier.champs.find { |c| !c.private? }.id) }
-  let(:annotation) { Champ.find(dossier.champs.find(&:private?).id) }
+  let(:champ) { Champ.find(dossier.champ_data.find { |c| !c.private? }.id) }
+  let(:annotation) { Champ.find(dossier.champ_data.find(&:private?).id) }
 
   describe '#initialize' do
     let(:state) { :brouillon }

--- a/spec/services/attachment/piece_justificative_service_spec.rb
+++ b/spec/services/attachment/piece_justificative_service_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Attachment::PieceJustificativeService do
   let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   let(:blob_1) { ActiveStorage::Blob.create_and_upload!(io: StringIO.new("file1"), filename: "file1.pdf", content_type: "application/pdf") }
   let(:blob_2) { ActiveStorage::Blob.create_and_upload!(io: StringIO.new("file2"), filename: "file2.pdf", content_type: "application/pdf") }

--- a/spec/services/attachment/validation_spec.rb
+++ b/spec/services/attachment/validation_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Attachment::Validation do
   let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
   let(:attached_file) { champ.piece_justificative_file }
   let(:validation) { described_class.new(attached_file:) }
 

--- a/spec/services/dossier_filter_service_spec.rb
+++ b/spec/services/dossier_filter_service_spec.rb
@@ -489,8 +489,8 @@ describe DossierFilterService do
 
       context 'with single value' do
         before do
-          kept_dossier.champs.find_by(stable_id: type_de_champ.stable_id).update(value: 'keep me')
-          discarded_dossier.champs.find_by(stable_id: type_de_champ.stable_id).update(value: 'discard me')
+          kept_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id).update(value: 'keep me')
+          discarded_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id).update(value: 'discard me')
         end
 
         it { is_expected.to contain_exactly(kept_dossier.id) }
@@ -501,9 +501,9 @@ describe DossierFilterService do
         let(:other_kept_dossier) { create(:dossier, procedure:) }
 
         before do
-          kept_dossier.champs.find_by(stable_id: type_de_champ.stable_id).update(value: 'keep me')
-          discarded_dossier.champs.find_by(stable_id: type_de_champ.stable_id).update(value: 'discard me')
-          other_kept_dossier.champs.find_by(stable_id: type_de_champ.stable_id).update(value: 'and me too')
+          kept_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id).update(value: 'keep me')
+          discarded_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id).update(value: 'discard me')
+          other_kept_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id).update(value: 'and me too')
         end
 
         it 'returns every dossier that matches any of the search criteria for a given column' do
@@ -516,8 +516,8 @@ describe DossierFilterService do
         let(:types_de_champ_public) { [{ type: :yes_no }] }
 
         before do
-          kept_dossier.champs.find_by(stable_id: type_de_champ.stable_id).update(value: 'true')
-          discarded_dossier.champs.find_by(stable_id: type_de_champ.stable_id).update(value: 'false')
+          kept_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id).update(value: 'true')
+          discarded_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id).update(value: 'false')
         end
 
         it { is_expected.to contain_exactly(kept_dossier.id) }
@@ -528,8 +528,8 @@ describe DossierFilterService do
         let(:types_de_champ_public) { [{ type: :departements }] }
 
         before do
-          kept_dossier.champs.find_by(stable_id: type_de_champ.stable_id).update(external_id: '13')
-          discarded_dossier.champs.find_by(stable_id: type_de_champ.stable_id).update(external_id: '69')
+          kept_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id).update(external_id: '13')
+          discarded_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id).update(external_id: '69')
         end
 
         it { is_expected.to contain_exactly(kept_dossier.id) }
@@ -540,8 +540,8 @@ describe DossierFilterService do
         let(:types_de_champ_public) { [{ type: :drop_down_list, options: ['Favorable', 'Defavorable'] }] }
 
         before do
-          kept_dossier.champs.find_by(stable_id: type_de_champ.stable_id).update(value: 'Favorable')
-          discarded_dossier.champs.find_by(stable_id: type_de_champ.stable_id).update(external_id: 'Defavorable')
+          kept_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id).update(value: 'Favorable')
+          discarded_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id).update(external_id: 'Defavorable')
         end
 
         it { is_expected.to contain_exactly(kept_dossier.id) }
@@ -565,24 +565,24 @@ describe DossierFilterService do
         let(:another_discarded_dossier) { create(:dossier, procedure:) }
 
         before do
-          kept_champ_resto = kept_dossier.champs.find_by(stable_id: type_de_champ_resto.stable_id)
+          kept_champ_resto = kept_dossier.champ_data.find_by(stable_id: type_de_champ_resto.stable_id)
           kept_champ_resto.value = 'pizzeria'
           kept_champ_resto.save!
 
-          kept_champ_a_emporter = kept_dossier.champs.find_by(stable_id: type_de_champ_a_emporter.stable_id)
+          kept_champ_a_emporter = kept_dossier.champ_data.find_by(stable_id: type_de_champ_a_emporter.stable_id)
           kept_champ_a_emporter.value = 'true'
           kept_champ_a_emporter.save!
 
-          discarded_champ_resto = discarded_dossier.champs.find_by(stable_id: type_de_champ_resto.stable_id)
+          discarded_champ_resto = discarded_dossier.champ_data.find_by(stable_id: type_de_champ_resto.stable_id)
           discarded_champ_resto.value = 'pizzeria'
-          discarded_champ_a_emporter = discarded_dossier.champs.find_by(stable_id: type_de_champ_a_emporter.stable_id)
+          discarded_champ_a_emporter = discarded_dossier.champ_data.find_by(stable_id: type_de_champ_a_emporter.stable_id)
           discarded_champ_a_emporter.value = 'false'
           discarded_champ_resto.save!
           discarded_champ_a_emporter.save!
 
-          another_discarded_champ_resto = another_discarded_dossier.champs.find_by(stable_id: type_de_champ_resto.stable_id)
+          another_discarded_champ_resto = another_discarded_dossier.champ_data.find_by(stable_id: type_de_champ_resto.stable_id)
           another_discarded_champ_resto.value = 'fast-food'
-          another_discarded_champ_a_emporter = another_discarded_dossier.champs.find_by(stable_id: type_de_champ_a_emporter.stable_id)
+          another_discarded_champ_a_emporter = another_discarded_dossier.champ_data.find_by(stable_id: type_de_champ_a_emporter.stable_id)
           another_discarded_champ_a_emporter.value = 'true'
           another_discarded_champ_resto.save!
           another_discarded_champ_a_emporter.save!
@@ -596,11 +596,11 @@ describe DossierFilterService do
         let(:types_de_champ_public) { [{ type: :multiple_drop_down_list, options: ['champ', 'champignon'] }] }
 
         before do
-          kept_champ = kept_dossier.champs.find_by(stable_id: type_de_champ.stable_id)
+          kept_champ = kept_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id)
           kept_champ.value = ['champ', 'champignon']
           kept_champ.save!
 
-          discarded_champ = discarded_dossier.champs.find_by(stable_id: type_de_champ.stable_id)
+          discarded_champ = discarded_dossier.champ_data.find_by(stable_id: type_de_champ.stable_id)
           discarded_champ.value = ['champignon']
           discarded_champ.save!
         end
@@ -645,9 +645,9 @@ describe DossierFilterService do
         let(:discarded_dossier) { create(:dossier, procedure:) }
 
         before do
-          kept_dossier.champs.first.update!(value: 'Fromage')
-          kept_dossier_2.champs.first.update!(value: 'Dessert')
-          discarded_dossier.champs.first.update!(value: 'Chocolat')
+          kept_dossier.champ_data.first.update!(value: 'Fromage')
+          kept_dossier_2.champ_data.first.update!(value: 'Dessert')
+          discarded_dossier.champ_data.first.update!(value: 'Chocolat')
         end
 
         it { is_expected.to contain_exactly(kept_dossier.id, kept_dossier_2.id) }
@@ -662,8 +662,8 @@ describe DossierFilterService do
       let(:type_de_champ_private) { procedure.active_revision.types_de_champ_private.first }
 
       before do
-        kept_dossier.champs.find_by(stable_id: type_de_champ_private.stable_id).update(value: 'keep me')
-        discarded_dossier.champs.find_by(stable_id: type_de_champ_private.stable_id).update(value: 'discard me')
+        kept_dossier.champ_data.find_by(stable_id: type_de_champ_private.stable_id).update(value: 'keep me')
+        discarded_dossier.champ_data.find_by(stable_id: type_de_champ_private.stable_id).update(value: 'discard me')
       end
 
       it { is_expected.to contain_exactly(kept_dossier.id) }
@@ -919,8 +919,8 @@ describe DossierFilterService do
         let(:discarded_dossier) { create(:dossier, procedure:) }
 
         before do
-          kept_dossier.champs.first.update!(value: 'true')
-          discarded_dossier.champs.first.update!(value: 'false')
+          kept_dossier.champ_data.first.update!(value: 'true')
+          discarded_dossier.champ_data.first.update!(value: 'false')
         end
 
         it { is_expected.to contain_exactly(kept_dossier.id) }

--- a/spec/services/dossier_projection_service_spec.rb
+++ b/spec/services/dossier_projection_service_spec.rb
@@ -22,7 +22,7 @@ describe DossierProjectionService do
       expect(dossiers.size).to eq(2)
 
       # only load the champs required for the columns
-      expect(dossiers.first.champs.size).to eq(1)
+      expect(dossiers.first.champ_data.size).to eq(1)
     end
   end
 end

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -213,7 +213,7 @@ describe ProcedureExportService do
         let(:procedure) { create(:procedure, :published, :for_individual, types_de_champ_public:) }
         let!(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure: procedure) }
         let(:types_de_champ_public) { [{ type: :text, libelle: 'text' }] }
-        before { dossier.champs.first.update(value: user_input) }
+        before { dossier.champ_data.first.update(value: user_input) }
         let(:user_input) { "franco￾allemand" }
         it 'can be read with BOM content' do
           expect(dossiers_sheet).not_to be_nil
@@ -226,7 +226,7 @@ describe ProcedureExportService do
         let(:procedure) { create(:procedure, :published, :for_individual, types_de_champ_public:) }
         let!(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure: procedure) }
         let(:types_de_champ_public) { [{ type: :text, libelle: 'text' }] }
-        before { dossier.champs.first.update(value: user_input) }
+        before { dossier.champ_data.first.update(value: user_input) }
         let(:user_input) { "Notation <A B C is OK" }
         it 'is not escaped' do
           expect(dossiers_sheet).not_to be_nil

--- a/spec/services/procedure_export_service_tabular_spec.rb
+++ b/spec/services/procedure_export_service_tabular_spec.rb
@@ -160,7 +160,7 @@ describe ProcedureExportService do
         let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
         before { dossier }
         it do
-          champ_value = Time.zone.parse(dossier.champs.first.value)
+          champ_value = Time.zone.parse(dossier.champ_data.first.value)
           offset = champ_value.utc_offset
           sheet_value = Time.zone.at(dossiers_sheet.data.last.last - offset.seconds)
           expect(sheet_value).to eq(champ_value.round)

--- a/spec/services/referentiel_service_spec.rb
+++ b/spec/services/referentiel_service_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe ReferentielService, type: :service do
       end
 
       before do
-        dossier.champs.find { _1.stable_id == type_de_champ.stable_id }.update!(value: "75")
+        dossier.champ_data.find { _1.stable_id == type_de_champ.stable_id }.update!(value: "75")
       end
 
       it 'resolves tdc tags from dossier champs' do
@@ -189,7 +189,7 @@ RSpec.describe ReferentielService, type: :service do
 
       context 'when champ value is blank' do
         before do
-          dossier.champs.find { _1.stable_id == type_de_champ.stable_id }.update!(value: "")
+          dossier.champ_data.find { _1.stable_id == type_de_champ.stable_id }.update!(value: "")
         end
 
         it { expect(service.send(:resolve_tiptap_url, "search", dossier)).to be_nil }
@@ -224,7 +224,7 @@ RSpec.describe ReferentielService, type: :service do
 
       context 'when value is false' do
         before do
-          dossier.champs.find { _1.stable_id == type_de_champ.stable_id }.update!(value: "false")
+          dossier.champ_data.find { _1.stable_id == type_de_champ.stable_id }.update!(value: "false")
         end
 
         it 'resolves boolean false value' do

--- a/spec/services/serializer_service_spec.rb
+++ b/spec/services/serializer_service_spec.rb
@@ -3,7 +3,7 @@
 describe SerializerService do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
   let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
   let(:etablissement) { champ.etablissement }
 
   describe 'champ' do

--- a/spec/system/experts/expert_spec.rb
+++ b/spec/system/experts/expert_spec.rb
@@ -12,7 +12,7 @@ describe 'Inviting an expert:', js: true do
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }, { type: :dossier_link }], types_de_champ_private:, instructeurs: [instructeur]) }
     let(:experts_procedure) { create(:experts_procedure, expert: expert, procedure:) }
     let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, :with_populated_annotations, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     let(:avis) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure, confidentiel: true) }
     let(:avis_with_question) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure, confidentiel: true, question_label: 'Question ?') }
     let(:dossier_accepte) { create(:dossier, :accepte, procedure:) }

--- a/spec/system/instructeurs/dossier_link_no_access_spec.rb
+++ b/spec/system/instructeurs/dossier_link_no_access_spec.rb
@@ -8,7 +8,7 @@ describe 'Instructeur viewing a linked dossier they cannot access:', js: true do
   let(:dossier) { create(:dossier, :en_instruction, procedure:) }
 
   before do
-    dossier.champs.find { _1.is_a?(Champs::DossierLinkChamp) }.update(value: linked_dossier.id)
+    dossier.champ_data.find { _1.is_a?(Champs::DossierLinkChamp) }.update(value: linked_dossier.id)
     login_as(instructeur.user, scope: :user)
     visit instructeur_dossier_path(procedure, dossier)
   end

--- a/spec/system/instructeurs/edit_dossier_spec.rb
+++ b/spec/system/instructeurs/edit_dossier_spec.rb
@@ -7,7 +7,7 @@ describe 'Editing a dossier as an instructeur:', js: true do
   let!(:instructeur) { create(:instructeur, password: password) }
 
   def buffered_value(dossier, stable_id)
-    dossier.reload.champs
+    dossier.reload.champ_data
       .find { _1.stream == Champ::INSTRUCTEUR_BUFFER_STREAM && _1.stable_id == stable_id }
       &.value
   end
@@ -15,7 +15,7 @@ describe 'Editing a dossier as an instructeur:', js: true do
   # The merge moves the previous main champ to the history stream and promotes
   # the buffered champ as the new main one, so we must look it up by stream.
   def main_value(dossier, stable_id)
-    dossier.reload.champs
+    dossier.reload.champ_data
       .find { _1.stream == Champ::MAIN_STREAM && _1.stable_id == stable_id }
       &.value
   end
@@ -123,7 +123,7 @@ describe 'Editing a dossier as an instructeur:', js: true do
     before { login_as(instructeur.user, scope: :user) }
 
     def buffered_pj(stable_id)
-      dossier.reload.champs
+      dossier.reload.champ_data
         .find { _1.stream == Champ::INSTRUCTEUR_BUFFER_STREAM && _1.stable_id == stable_id }
         &.piece_justificative_file
     end

--- a/spec/system/instructeurs/expert_spec.rb
+++ b/spec/system/instructeurs/expert_spec.rb
@@ -12,7 +12,7 @@ describe 'Inviting an expert:', js: true do
   let(:expert_password) { 'mot de passe d’expert' }
   let(:procedure) { create(:procedure, :published, instructeurs: [instructeur], types_de_champ_public: [{ type: :dossier_link }]) }
   let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
-  let(:linked_dossier) { Dossier.find_by(id: dossier.champs.first.value) }
+  let(:linked_dossier) { Dossier.find_by(id: dossier.champ_data.first.value) }
 
   before do
     clear_emails

--- a/spec/system/instructeurs/procedure_filters_spec.rb
+++ b/spec/system/instructeurs/procedure_filters_spec.rb
@@ -138,7 +138,7 @@ describe "procedure filters" do
     describe 'departements' do
       let(:types_de_champ_public) { [{ type: :departements }] }
       scenario "should be able to find by departements with custom enum lookup", js: true do
-        departement_champ = new_unfollow_dossier.champs.find(&:departements?)
+        departement_champ = new_unfollow_dossier.champ_data.find(&:departements?)
         departement_champ.update!(value: 'Oise', external_id: '60')
         departement_champ.reload
         champ_select_value = "#{departement_champ.external_id} – #{departement_champ.value}"
@@ -153,7 +153,7 @@ describe "procedure filters" do
     describe 'rna' do
       let(:types_de_champ_public) { [{ type: :rna }] }
       scenario "should be able to find by rna addresse with custom enum lookup", js: true do
-        rna_champ = new_unfollow_dossier.champs.find(&:rna?)
+        rna_champ = new_unfollow_dossier.champ_data.find(&:rna?)
         rna_champ.update!(
           value: 'W412005131',
           value_json: {
@@ -182,7 +182,7 @@ describe "procedure filters" do
     describe 'region' do
       let(:types_de_champ_public) { [{ type: :regions }] }
       scenario "should be able to find by region with custom enum lookup", js: true do
-        region_champ = new_unfollow_dossier.champs.find(&:regions?)
+        region_champ = new_unfollow_dossier.champ_data.find(&:regions?)
         region_champ.update!(value: 'Bretagne', external_id: '53')
         region_champ.reload
 

--- a/spec/system/users/dossier_prefill_get_spec.rb
+++ b/spec/system/users/dossier_prefill_get_spec.rb
@@ -106,7 +106,7 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
     let(:types_de_champ_public) { [{}] }
 
     before do
-      dossier.champs.first.update(value: text_value)
+      dossier.champ_data.first.update(value: text_value)
       page.set_rack_session(prefill_token: "token")
       page.set_rack_session(prefill_params_digest: PrefillChamps.digest({ "champ_#{type_de_champ_text.to_typed_id}" => text_value }))
 

--- a/spec/system/users/dropdown_rebase_spec.rb
+++ b/spec/system/users/dropdown_rebase_spec.rb
@@ -16,7 +16,7 @@ describe 'Multiple dropdown after rebase removes an option', js: true do
 
   before do
     # User had selected "Bravo" and "Charlie" before submitting
-    champ = dossier.champs.find { _1.stable_id == stable_id }
+    champ = dossier.champ_data.find { _1.stable_id == stable_id }
     champ.update_columns(value: '["Bravo","Charlie"]')
 
     # Admin removes "Bravo" from options and publishes

--- a/spec/system/users/linked_dropdown_spec.rb
+++ b/spec/system/users/linked_dropdown_spec.rb
@@ -80,7 +80,7 @@ describe 'linked dropdown lists', js: true do
 
       # The error summary link and the secondary select both target the secondary input,
       # and the secondary select is associated to the error region for screen readers.
-      champ = user_dossier.champs.first
+      champ = user_dossier.champ_data.first
       expect(page).to have_link('Valeur secondaire dépendant de la première', href: "##{champ.focusable_input_id(:secondary_value)}")
       expect(find("##{champ.focusable_input_id(:secondary_value)}")['aria-describedby']).to include(champ.error_id(:value))
     end

--- a/spec/system/users/quotient_familial_upload_spec.rb
+++ b/spec/system/users/quotient_familial_upload_spec.rb
@@ -31,7 +31,7 @@ describe 'Quotient familial piece justificative upload', js: true do
     end
 
     dossier = Dossier.last
-    champ = dossier.champs.find { _1.type_champ == 'quotient_familial' }
+    champ = dossier.champ_data.find { _1.type_champ == 'quotient_familial' }
     wait_until { champ.reload.piece_justificative_file.attached? }
 
     expect(champ.piece_justificative_file).to be_attached

--- a/spec/tasks/maintenance/create_previews_for_pj_of_latest_dossiers_task_spec.rb
+++ b/spec/tasks/maintenance/create_previews_for_pj_of_latest_dossiers_task_spec.rb
@@ -7,7 +7,7 @@ module Maintenance
     describe "#process" do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, stable_id: 3, libelle: 'Justificatif de domicile' }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ_pj) { dossier.champs.first }
+      let(:champ_pj) { dossier.champ_data.first }
 
       before do
         champ_pj.piece_justificative_file.attach(

--- a/spec/tasks/maintenance/create_variants_for_pj_of_latest_dossiers_task_spec.rb
+++ b/spec/tasks/maintenance/create_variants_for_pj_of_latest_dossiers_task_spec.rb
@@ -7,7 +7,7 @@ module Maintenance
     describe "#process" do
       let(:procedure) { create(:procedure_with_dossiers, types_de_champ_public: [{ type: :piece_justificative, libelle: 'Justificatif de domicile', stable_id: 3 }]) }
       let(:dossier) { procedure.dossiers.first }
-      let(:champ_pj) { dossier.champs.first }
+      let(:champ_pj) { dossier.champ_data.first }
       let(:attachment) { champ_pj.piece_justificative_file.attachments.first }
       let(:file_type) { '' }
       let(:task) { described_class.new.tap { _1.file_type = file_type } }

--- a/spec/tasks/maintenance/fix_champs_commune_having_value_but_not_external_id_task_spec.rb
+++ b/spec/tasks/maintenance/fix_champs_commune_having_value_but_not_external_id_task_spec.rb
@@ -7,7 +7,7 @@ module Maintenance
     describe "#process" do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :communes }]) }
       let(:dossier) { create(:dossier, state, :with_populated_champs, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
       subject(:process) do
         described_class.process(champ)
       end

--- a/spec/tasks/maintenance/normalize_rna_values_task_spec.rb
+++ b/spec/tasks/maintenance/normalize_rna_values_task_spec.rb
@@ -7,7 +7,7 @@ module Maintenance
     describe "#process" do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rna }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:element) { dossier.champs.first }
+      let(:element) { dossier.champ_data.first }
       subject(:process) { described_class.process(element) }
       let(:error_value) { "999 0 999" }
       it "removes extra spaces" do

--- a/spec/tasks/maintenance/populate_rna_json_value_task_spec.rb
+++ b/spec/tasks/maintenance/populate_rna_json_value_task_spec.rb
@@ -9,7 +9,7 @@ module Maintenance
 
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rna }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:element) { dossier.champs.first }
+      let(:element) { dossier.champ_data.first }
       let(:body) { File.read('spec/fixtures/files/api_entreprise/associations.json') }
       let(:data_source) { JSON.parse(body).with_indifferent_access }
       let(:data) { data_source[:data] }

--- a/spec/tasks/maintenance/populate_rnf_json_value_task_spec.rb
+++ b/spec/tasks/maintenance/populate_rnf_json_value_task_spec.rb
@@ -8,7 +8,7 @@ module Maintenance
       include Dry::Monads[:result]
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:element) { dossier.champs.first }
+      let(:element) { dossier.champ_data.first }
       let(:data) do
         {
           id: 3,

--- a/spec/tasks/maintenance/populate_siret_value_json_task_spec.rb
+++ b/spec/tasks/maintenance/populate_siret_value_json_task_spec.rb
@@ -7,7 +7,7 @@ module Maintenance
     describe "#process" do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:element) { dossier.champs.first }
+      let(:element) { dossier.champ_data.first }
       subject(:process) { described_class.process(element) }
 
       before do

--- a/spec/tasks/maintenance/t20250415remove_misplaced_autodestruction_header_task_spec.rb
+++ b/spec/tasks/maintenance/t20250415remove_misplaced_autodestruction_header_task_spec.rb
@@ -63,7 +63,7 @@ module Maintenance
       context "when the blob belongs to a champ" do
         let(:procedure) { create(:procedure_with_dossiers, types_de_champ_public: [{ type: :piece_justificative, libelle: 'Justificatif de domicile', stable_id: 3 }]) }
         let(:dossier) { procedure.dossiers.first }
-        let(:champ_pj) { dossier.champs.first }
+        let(:champ_pj) { dossier.champ_data.first }
         let(:attachment) { champ_pj.piece_justificative_file.attachments.first }
         let(:blob) { attachment.blob }
         let(:blob_key) { blob.key }

--- a/spec/tasks/maintenance/t20250418send_notification_to_instructeurs_having_lost_pjs_task_spec.rb
+++ b/spec/tasks/maintenance/t20250418send_notification_to_instructeurs_having_lost_pjs_task_spec.rb
@@ -19,8 +19,8 @@ module Maintenance
         let(:procedure_id) { procedure.id }
         let(:dossier) { procedure.dossiers.first }
         let(:instructeur) { create(:instructeur) }
-        let(:champ_pj_1) { dossier.champs.first }
-        let(:champ_pj_2) { dossier.champs.second }
+        let(:champ_pj_1) { dossier.champ_data.first }
+        let(:champ_pj_2) { dossier.champ_data.second }
         let(:file) { fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png') }
 
         before do

--- a/spec/tasks/maintenance/t20250418send_notification_to_users_having_lost_pjs_task_spec.rb
+++ b/spec/tasks/maintenance/t20250418send_notification_to_users_having_lost_pjs_task_spec.rb
@@ -16,8 +16,8 @@ module Maintenance
           ])
         end
         let(:dossier) { procedure.dossiers.first }
-        let(:champ_pj_1) { dossier.champs.first }
-        let(:champ_pj_2) { dossier.champs.second }
+        let(:champ_pj_1) { dossier.champ_data.first }
+        let(:champ_pj_2) { dossier.champ_data.second }
         let(:file) { fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png') }
 
         before do

--- a/spec/tasks/maintenance/t20250513_backfill_no_ban_address_task_spec.rb
+++ b/spec/tasks/maintenance/t20250513_backfill_no_ban_address_task_spec.rb
@@ -8,7 +8,7 @@ module Maintenance
       subject(:process) { described_class.process(champ) }
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :address }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:address_champ) { dossier.champs.first }
+      let(:address_champ) { dossier.champ_data.first }
 
       it do
         address_champ.update_columns(value: "123 Main St", value_json: {})

--- a/spec/tasks/maintenance/t20250522_re_route_procedure_task_spec.rb
+++ b/spec/tasks/maintenance/t20250522_re_route_procedure_task_spec.rb
@@ -13,9 +13,9 @@ module Maintenance
       let!(:dossier2) { create(:dossier, :en_construction, :with_populated_champs, procedure: procedure) }
 
       before do
-        dossier1.champs.last.update(value: 'Aisne')
+        dossier1.champ_data.last.update(value: 'Aisne')
 
-        dossier2.champs.last.update(value: 'Allier')
+        dossier2.champ_data.last.update(value: 'Allier')
 
         tdc = procedure.active_revision.simple_routable_types_de_champ.first
 

--- a/spec/tasks/maintenance/t20250526_nullify_row_id_task_spec.rb
+++ b/spec/tasks/maintenance/t20250526_nullify_row_id_task_spec.rb
@@ -8,10 +8,10 @@ module Maintenance
       subject(:process) { described_class.process(dossier) }
       let(:procedure) { create(:procedure, types_de_champ_public: [{}, { type: :repetition, children: [{ type: :text }] }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champs_with_null_row_id) { dossier.champs.where(row_id: [nil, Champ::NULL_ROW_ID]) }
+      let(:champs_with_null_row_id) { dossier.champ_data.where(row_id: [nil, Champ::NULL_ROW_ID]) }
 
       before do
-        dossier.champs.where(row_id: nil).update_all(row_id: Champ::NULL_ROW_ID)
+        dossier.champ_data.where(row_id: nil).update_all(row_id: Champ::NULL_ROW_ID)
       end
 
       def null_row_id_counts
@@ -26,8 +26,8 @@ module Maintenance
 
       context 'deal with conflicts' do
         before do
-          attributes = dossier.champs.where(row_id: Champ::NULL_ROW_ID).first.attributes
-          dossier.champs.create(attributes.merge(row_id: nil, id: nil))
+          attributes = dossier.champ_data.where(row_id: Champ::NULL_ROW_ID).first.attributes
+          dossier.champ_data.create(attributes.merge(row_id: nil, id: nil))
         end
         it 'nullify row_id' do
           expect { process }. to change { null_row_id_counts }.from([1, 1]).to([1, 0])

--- a/spec/tasks/maintenance/t20250527drop_invalide_geo_areas_task_spec.rb
+++ b/spec/tasks/maintenance/t20250527drop_invalide_geo_areas_task_spec.rb
@@ -9,7 +9,7 @@ module Maintenance
       let(:procedure) { create(:procedure, types_de_champ_public:) }
       let(:types_de_champ_public) { [{ type: :carte }] }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ) { dossier.champs.first }
+      let(:champ) { dossier.champ_data.first }
 
       context "with a valid geo_area (point)" do
         let!(:geo_area) { create(:geo_area, :point, champ:) }

--- a/spec/tasks/maintenance/t20250602fix_bad_address_data_task_spec.rb
+++ b/spec/tasks/maintenance/t20250602fix_bad_address_data_task_spec.rb
@@ -8,7 +8,7 @@ module Maintenance
       subject(:process) { described_class.process(address_champ) }
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :address }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:address_champ) { dossier.champs.first }
+      let(:address_champ) { dossier.champ_data.first }
 
       context "when the address is a partial address with international data" do
         let(:value_json) do

--- a/spec/tasks/maintenance/t20250605fix_conflictual_row_id_during_mep_task_spec.rb
+++ b/spec/tasks/maintenance/t20250605fix_conflictual_row_id_during_mep_task_spec.rb
@@ -11,14 +11,14 @@ module Maintenance
       let(:type_de_champ) { dossier.revision.types_de_champ_public.first }
 
       before {
-        dossier.champs.create(**type_de_champ.params_for_champ.merge(row_id: Champ::NULL_ROW_ID))
+        dossier.champ_data.create(**type_de_champ.params_for_champ.merge(row_id: Champ::NULL_ROW_ID))
       }
 
       it { expect { subject }.not_to change { dossier.reload.updated_at } }
-      it { expect { subject }.not_to change { dossier.champs.order(id: :desc).first.id } }
-      it { expect { subject }.to change { dossier.champs.order(:id).first.id } }
-      it { expect { subject }.to change { dossier.champs.count }.by(-1) }
-      it { expect { subject }.to change { dossier.champs.where(row_id: Champ::NULL_ROW_ID).count }.from(1).to(0) }
+      it { expect { subject }.not_to change { dossier.champ_data.order(id: :desc).first.id } }
+      it { expect { subject }.to change { dossier.champ_data.order(:id).first.id } }
+      it { expect { subject }.to change { dossier.champ_data.count }.by(-1) }
+      it { expect { subject }.to change { dossier.champ_data.where(row_id: Champ::NULL_ROW_ID).count }.from(1).to(0) }
     end
   end
 end

--- a/spec/tasks/maintenance/t20251023_migrate_champs_pays_after_api_geo_update_task_spec.rb
+++ b/spec/tasks/maintenance/t20251023_migrate_champs_pays_after_api_geo_update_task_spec.rb
@@ -9,7 +9,7 @@ module Maintenance
 
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :pays }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ_pays) { dossier.champs.first }
+      let(:champ_pays) { dossier.champ_data.first }
 
       context 'when champ has a country that needs migration' do
         before { champ_pays.update_columns(value: "Guadeloupe", external_id: "GP") }
@@ -23,7 +23,7 @@ module Maintenance
 
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :pays }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ_pays) { dossier.champs.first }
+      let(:champ_pays) { dossier.champ_data.first }
 
       context 'when migrating DOM to France' do
         before { champ_pays.update_columns(value: "Martinique", external_id: "MQ") }

--- a/spec/tasks/maintenance/t20260129destroy_orphan_etablissements_task_spec.rb
+++ b/spec/tasks/maintenance/t20260129destroy_orphan_etablissements_task_spec.rb
@@ -13,7 +13,7 @@ module Maintenance
         procedure = create(:procedure, types_de_champ_public: [{ type: :siret }])
         dossier = create(:dossier, procedure:)
         etablissement = create(:etablissement, dossier: nil)
-        dossier.champs.first.update!(etablissement:)
+        dossier.champ_data.first.update!(etablissement:)
         etablissement
       end
 

--- a/spec/tasks/maintenance/t20260223normalize_drop_down_options_and_related_champs_task_spec.rb
+++ b/spec/tasks/maintenance/t20260223normalize_drop_down_options_and_related_champs_task_spec.rb
@@ -25,7 +25,7 @@ module Maintenance
         end
         let(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }
         let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-        let(:champ) { dossier.champs.first }
+        let(:champ) { dossier.champ_data.first }
 
         before do
           type_de_champ.update_column(:options, type_de_champ.options.merge(drop_down_options: ["  Foo   Bar  ", "Baz"]))
@@ -57,7 +57,7 @@ module Maintenance
         end
         let(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }
         let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-        let!(:champ) { dossier.champs.first }
+        let!(:champ) { dossier.champ_data.first }
 
         before do
           champ.update_columns(value: "  Foo   Bar  ")

--- a/spec/tasks/maintenance/t20260319migrate_orphan_titre_identite_champs_task_spec.rb
+++ b/spec/tasks/maintenance/t20260319migrate_orphan_titre_identite_champs_task_spec.rb
@@ -10,11 +10,11 @@ module Maintenance
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
       let!(:titre_identite_champ) do
-        dossier.champs.first.tap { it.update_column(:type, "Champs::TitreIdentiteChamp") }
+        dossier.champ_data.first.tap { it.update_column(:type, "Champs::TitreIdentiteChamp") }
       end
       let!(:piece_justificative_champ) do
         other_dossier = create(:dossier, :with_populated_champs, procedure:)
-        other_dossier.champs.first
+        other_dossier.champ_data.first
       end
 
       it "migrates orphan TitreIdentiteChamp to PieceJustificativeChamp" do

--- a/spec/tasks/maintenance/t20260504_backfill_canonical_keys_in_commune_champs_task_spec.rb
+++ b/spec/tasks/maintenance/t20260504_backfill_canonical_keys_in_commune_champs_task_spec.rb
@@ -6,7 +6,7 @@ module Maintenance
   RSpec.describe T20260504BackfillCanonicalKeysInCommuneChampsTask do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :communes }]) }
     let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     describe "#process" do
       let(:range) { (champ.id)...(champ.id + 1) }

--- a/spec/tasks/maintenance/t20260504_backfill_canonical_keys_in_departement_champs_task_spec.rb
+++ b/spec/tasks/maintenance/t20260504_backfill_canonical_keys_in_departement_champs_task_spec.rb
@@ -6,7 +6,7 @@ module Maintenance
   RSpec.describe T20260504BackfillCanonicalKeysInDepartementChampsTask do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :departements }]) }
     let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     describe "#process" do
       let(:range) { (champ.id)...(champ.id + 1) }

--- a/spec/tasks/maintenance/t20260521_backfill_geo_area_uuid_task_spec.rb
+++ b/spec/tasks/maintenance/t20260521_backfill_geo_area_uuid_task_spec.rb
@@ -7,7 +7,7 @@ module Maintenance
     describe "#process" do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :carte }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:main_champ) { dossier.champs.first }
+      let(:main_champ) { dossier.champ_data.first }
       let(:main_geo_area) do
         ga = create(:geo_area, :selection_utilisateur, :polygon, champ: main_champ)
         ga.update_column(:uuid, nil)

--- a/spec/tasks/maintenance/t20260616backfill_rna_external_id_task_spec.rb
+++ b/spec/tasks/maintenance/t20260616backfill_rna_external_id_task_spec.rb
@@ -10,9 +10,9 @@ module Maintenance
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rna }, { type: :rna }, { type: :rna }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
 
-      let!(:legacy_champ) { dossier.champs[0].tap { it.update_columns(value: 'W173847273', external_id: nil) } }
-      let!(:already_migrated_champ) { dossier.champs[1].tap { it.update_columns(value: 'W173847273', external_id: 'W999999999') } }
-      let!(:blank_champ) { dossier.champs[2].tap { it.update_columns(value: nil, external_id: nil) } }
+      let!(:legacy_champ) { dossier.champ_data[0].tap { it.update_columns(value: 'W173847273', external_id: nil) } }
+      let!(:already_migrated_champ) { dossier.champ_data[1].tap { it.update_columns(value: 'W173847273', external_id: 'W999999999') } }
+      let!(:blank_champ) { dossier.champ_data[2].tap { it.update_columns(value: nil, external_id: nil) } }
 
       it "recopie value dans external_id pour les anciens champs" do
         expect { process }.to change { legacy_champ.reload.external_id }.from(nil).to('W173847273')

--- a/spec/views/shared/champs/multiple_drop_down_list/_show.html.haml_spec.rb
+++ b/spec/views/shared/champs/multiple_drop_down_list/_show.html.haml_spec.rb
@@ -3,7 +3,7 @@
 describe 'views/shared/champs/multiple_drop_down_list/_show', type: :view do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :multiple_drop_down_list }]) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let(:champ) { dossier.champ_data.first }
 
   before { champ.update(value: champ.drop_down_options) }
   subject { render partial: 'shared/champs/multiple_drop_down_list/show', locals: { champ: } }

--- a/spec/views/shared/dossiers/_champs.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_champs.html.haml_spec.rb
@@ -78,7 +78,7 @@ describe 'shared/dossiers/champs', type: :view do
     let(:types_de_champ_public) { [{ type: :dossier_link }] }
 
     before do
-      dossier.champs.first.update(value: dossier.id)
+      dossier.champ_data.first.update(value: dossier.id)
     end
 
     it "renders the no-access modal trigger" do
@@ -98,7 +98,7 @@ describe 'shared/dossiers/champs', type: :view do
     let(:types_de_champ_public) { [{ type: :dossier_link, mandatory: false }] }
 
     before do
-      dossier.champs.first.update(value: nil)
+      dossier.champ_data.first.update(value: nil)
     end
 
     it { is_expected.not_to include("non saisi") }
@@ -113,7 +113,7 @@ describe 'shared/dossiers/champs', type: :view do
     let(:types_de_champ_public) { [{ type: :piece_justificative, mandatory: false }] }
 
     before do
-      dossier.champs.first.piece_justificative_file.purge
+      dossier.champ_data.first.piece_justificative_file.purge
     end
 
     it { is_expected.not_to include("pièce justificative non saisie") }
@@ -127,7 +127,7 @@ describe 'shared/dossiers/champs', type: :view do
   context "with seen_at" do
     let(:types_de_champ_public) { [{ type: :checkbox }] }
     let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:, depose_at: 1.day.ago.change(usec: 0)) }
-    let(:champ1) { dossier.champs.first }
+    let(:champ1) { dossier.champ_data.first }
 
     context "with a demande_seen_at after champ updated_at" do
       let(:demande_seen_at) { champ1.updated_at + 1.hour }

--- a/spec/views/shared/dossiers/_edit.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_edit.html.haml_spec.rb
@@ -99,7 +99,7 @@ describe 'shared/dossiers/edit', type: :view do
 
   context 'with a multiple-values list' do
     let(:types_de_champ_public) { [{ type: :multiple_drop_down_list, options: }] }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     let(:type_de_champ) { champ.type_de_champ }
     let(:options) { type_de_champ.drop_down_options }
     let(:enabled_options) { type_de_champ.drop_down_options }
@@ -128,7 +128,7 @@ describe 'shared/dossiers/edit', type: :view do
 
   context 'with a mandatory piece justificative' do
     let(:types_de_champ_public) { [{ type: :piece_justificative, mandatory: true }] }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
 
     context 'when dossier is en construction (stream)' do
       let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:).then { |dossier| dossier.with_update_stream(dossier.user) } }
@@ -150,7 +150,7 @@ describe 'shared/dossiers/edit', type: :view do
     let(:procedure) { create(:procedure, :routee, groupe_instructeurs: [groupe_instructeur], types_de_champ_public: [{ type: :drop_down_list, options: }]) }
     let(:options) { [groupe_instructeur.label] }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ_drop_down) { dossier.champs.first }
+    let(:champ_drop_down) { dossier.champ_data.first }
 
     it 'renders the libelle of the type de champ used for routing' do
       expect(subject).to include(champ_drop_down.libelle)

--- a/spec/views/shared/dossiers/_normalized_address.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_normalized_address.html.haml_spec.rb
@@ -6,7 +6,7 @@ describe 'shared/dossiers/normalized_address', type: :view do
   context 'given an champ' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
     let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-    let(:address) { AddressProxy.new(dossier.champs.first) }
+    let(:address) { AddressProxy.new(dossier.champ_data.first) }
 
     it 'render address' do
       expect(subject).to have_text("6 RUE RAOUL NORDLING")

--- a/spec/views/users/dossiers/demande.html.haml_spec.rb
+++ b/spec/views/users/dossiers/demande.html.haml_spec.rb
@@ -89,13 +89,13 @@ describe 'users/dossiers/demande', type: :view do
       ]
     end
     let(:dossier) { create(:dossier, procedure: procedure) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     let(:referentiel) { create(:csv_referentiel, :with_items) }
 
     context 'user choose an option in the list' do
       before do
-        dossier.champs.first.update!(value: referentiel.items.first.id.to_s)
-        dossier.champs.first.referentiel = { 'data' => { 'row' => { 'option' => 'fromage', 'calorie_kcal' => '145', 'poids_g' => '60' }, 'headers' => ['Option', 'Calorie (kcal)', 'Poids (g)'] } }
+        dossier.champ_data.first.update!(value: referentiel.items.first.id.to_s)
+        dossier.champ_data.first.referentiel = { 'data' => { 'row' => { 'option' => 'fromage', 'calorie_kcal' => '145', 'poids_g' => '60' }, 'headers' => ['Option', 'Calorie (kcal)', 'Poids (g)'] } }
         render
       end
 
@@ -107,7 +107,7 @@ describe 'users/dossiers/demande', type: :view do
 
     context 'user choose other option' do
       before do
-        dossier.champs.first.update!(value: '__other__', value_other: 'Texte libre')
+        dossier.champ_data.first.update!(value: '__other__', value_other: 'Texte libre')
         dossier.reload
         render
       end
@@ -125,7 +125,7 @@ describe 'users/dossiers/demande', type: :view do
       ]
     end
     let(:dossier) { create(:dossier, procedure: procedure) }
-    let(:champ) { dossier.champs.first }
+    let(:champ) { dossier.champ_data.first }
     let(:referentiel) { create(:csv_referentiel, :with_items) }
     let(:value) { [referentiel.items.first.id.to_s, referentiel.items.second.id.to_s] }
 


### PR DESCRIPTION
Renommage mécanique de la relation `champs` (sur `Dossier` et consorts) en `champ_data` — aucun changement de comportement, la table `champs` est inchangée. Le nom distingue désormais les lignes de persistance (`champ_data`) des champs métier projetés (`project_champs*`), en préparation de la séparation persistance / modèle métier (#13420).

Première PR de la pile #13406 → #13410 → #13419 → #13420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)