### PR TITLE
Tech: corrige le setup sur une base de données vierge (Flipper et french_unaccent)

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -44,7 +44,9 @@ features = [
 ]
 
 def database_exists?
-  ActiveRecord::Base.connection
+  # A simple query is required: since Rails 7.2 `connection` is lazy and does
+  # not connect until first use, so it never raises here on a missing database.
+  ActiveRecord::Base.connection.select_value('SELECT 1')
   true
 rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::NoDatabaseError, PG::ConnectionBad
   false

--- a/lib/tasks/db_functions.rake
+++ b/lib/tasks/db_functions.rake
@@ -4,11 +4,27 @@ require_relative "../../db/migrate/20260402182757_recreate_search_terms_indexes_
 
 namespace :db do
   namespace :schema do
+    # In development, db:schema:load also loads the schema into the test
+    # database, so the text search configuration must be created in every
+    # database of every targeted environment, not just the primary connection.
     task create_functions: :environment do
-      ActiveRecord::Base.connection.execute <<~SQL.squish
-        CREATE EXTENSION IF NOT EXISTS unaccent;
-        #{RecreateSearchTermsIndexesWithUnaccent::CREATE_FRENCH_UNACCENT_FTS_CONFIG}
-      SQL
+      env_names = [Rails.env]
+      env_names << "test" if Rails.env.development?
+
+      env_names.each do |env_name|
+        ActiveRecord::Base.configurations.configs_for(env_name:).each do |db_config|
+          ActiveRecord::Base.establish_connection(db_config)
+          connection = ActiveRecord::Base.connection
+          next if connection.select_value("SELECT 1 FROM pg_ts_config WHERE cfgname = 'french_unaccent'")
+
+          connection.execute <<~SQL.squish
+            CREATE EXTENSION IF NOT EXISTS unaccent;
+            #{RecreateSearchTermsIndexesWithUnaccent::CREATE_FRENCH_UNACCENT_FTS_CONFIG}
+          SQL
+        end
+      end
+    ensure
+      ActiveRecord::Base.establish_connection(Rails.env.to_sym)
     end
   end
 end


### PR DESCRIPTION
## Contexte

Deux correctifs liés à l'initialisation des bases de données (`bin/setup` / `db:schema:load`) :

### Flipper : vraie vérification de l'existence de la base

Depuis Rails 7.2, `ActiveRecord::Base.connection` est lazy et ne se connecte plus immédiatement : `database_exists?` retournait donc toujours `true`, même sans base. On exécute désormais un `SELECT 1` pour forcer la connexion et détecter réellement l'absence de base.

### `french_unaccent` : création dans toutes les bases

`db:schema:create_functions` ne créait la configuration de recherche plein texte que sur la connexion primaire. Or en développement, `db:schema:load` charge aussi le schéma de la base de test — qui se retrouvait sans `french_unaccent`. La tâche itère maintenant sur toutes les configurations de bases de l'environnement (+ `test` en développement), en sautant celles où la configuration existe déjà (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)