### PR TITLE
Tech: fix N+1 sur procedure_paths dans DemarcheDescriptorType

### DIFF
--- a/app/graphql/types/demarche_descriptor_type.rb
+++ b/app/graphql/types/demarche_descriptor_type.rb
@@ -85,7 +85,10 @@ Cela évite l’accès récursif aux dossiers."
     delegate :description, :opendata, :tags, to: :procedure
 
     def demarche_url
-      Rails.application.routes.url_helpers.commencer_url(path: procedure.path)
+      dataloader.with(Sources::Association, :procedure_paths).load(procedure).then do |paths|
+        path = paths.last&.path
+        Rails.application.routes.url_helpers.commencer_url(path: path)
+      end
     end
     alias demarcheUrl demarche_url
     alias demarcheURL demarche_url

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -21,13 +21,13 @@ module Types
     field :demarches_publiques, DemarcheDescriptorType.connection_type, null: false, internal: true
 
     def demarches_publiques
-      Procedure.publiques.includes(draft_revision: :procedure, published_revision: :procedure)
+      Procedure.publiques.includes(:procedure_paths, draft_revision: :procedure, published_revision: :procedure)
     end
 
     def demarche_descriptor(demarche:)
       demarche_number = demarche.number.presence || ApplicationRecord.id_from_typed_id(demarche.id)
       Procedure
-        .includes(draft_revision: :procedure, published_revision: :procedure)
+        .includes(:procedure_paths, draft_revision: :procedure, published_revision: :procedure)
         .find(demarche_number)
     end
 


### PR DESCRIPTION
# Problème

N+1 détecté par [Skylight](https://www.skylight.io/) (production) sur le controller `API::V2::GraphqlController`.

**Données de production** (depuis `.skill-context.json`) :

| Endpoint | RPM | P95 | Waste |
|----------|-----|-----|-------|
| API::V2::GraphqlController | — | — | 3172ms |

**Patterns Skylight** :

| Table | Score | Rank | SQL Pattern |
|-------|-------|------|-------------|
| `procedures` | 2196.4 | 4 | SELECT "procedures"."id", "procedures"."aasm_state", ... |
| `procedure_paths` | 976.2 | 13 | SELECT "procedure_paths".* WHERE "procedure_paths"."path" = ? LIMIT ? |

# Solution

Skill [`/n1-query-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/n1-query-fix/SKILL.md)

Le N+1 sur `procedure_paths` est causé par l'appel à `procedure.path` (via `ProcedurePathConcern#canonical_path` → `procedure_paths.last`) dans `DemarcheDescriptorType#demarche_url`. Lorsque plusieurs procédures sont résolues en batch (dans `demarches_publiques` ou via `dossier.demarche`), chaque appel déclenche une requête SQL séparée.

### Pattern corrigé (PROD uniquement)

| Association | Table | Strategy | Call site (app/) |
|-------------|-------|----------|------------------|
| `procedure_paths` | `procedure_paths` | `includes` + `Sources::Association` dataloader | `app/graphql/types/query_type.rb:24,30` / `app/graphql/types/demarche_descriptor_type.rb:88` |

### Détail des modifications

1. **`app/graphql/types/query_type.rb`** :
   - `demarches_publiques` : ajout de `:procedure_paths` dans les `includes`
   - `demarche_descriptor` : ajout de `:procedure_paths` dans les `includes`

2. **`app/graphql/types/demarche_descriptor_type.rb`** :
   - `demarche_url` : utilisation du dataloader `Sources::Association` pour précharger `procedure_paths` de façon batchée

### Validation

- [x] Tests passés (`graphql_controller_n+1_spec.rb`, `graphql_controller_stored_queries_spec.rb`, `procedure_path_concern_spec.rb`)
- [x] Rubocop OK
- [x] Seuls des fichiers `app/` commités

Generated with [Claude Code](https://claude.com/claude-code)