### PR TITLE
Tech: valider les champs via les projections du dossier plutôt que via la relation champ_data

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -396,7 +396,7 @@ module Instructeurs
       @dossier = dossier_with_champs
       type_de_champ = @dossier.find_type_de_champ_by_stable_id(params[:stable_id], :private)
       annotation = @dossier.project_champ(type_de_champ, row_id: params[:row_id])
-      annotation.validate(:champs_public_value) if annotation.done?
+      annotation.validate(:champ_value) if annotation.done?
 
       respond_to do |format|
         format.turbo_stream do

--- a/app/controllers/instructeurs/edit_controller.rb
+++ b/app/controllers/instructeurs/edit_controller.rb
@@ -55,7 +55,7 @@ module Instructeurs
     def champ
       type_de_champ = dossier.find_type_de_champ_by_stable_id(params[:stable_id], :public)
       champ = dossier.project_champ(type_de_champ, row_id: params[:row_id])
-      champ.validate(:champs_public_value) if champ.done?
+      champ.validate(:champ_value) if champ.done?
 
       respond_to do |format|
         format.turbo_stream do

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -354,7 +354,7 @@ module Users
       type_de_champ = dossier.find_type_de_champ_by_stable_id(params[:stable_id], :public)
       champ = dossier.project_champ(type_de_champ, row_id: params[:row_id])
 
-      champ.validate(:champs_public_value) if champ.done?
+      champ.validate(:champ_value) if champ.done?
       respond_to do |format|
         format.turbo_stream do
           @to_show, @to_hide, @to_update = champ_to_turbo_update(champ, dossier.project_champs_public_all)

--- a/app/graphql/mutations/dossier_modifier_annotation.rb
+++ b/app/graphql/mutations/dossier_modifier_annotation.rb
@@ -22,7 +22,7 @@ module Mutations
         annotation.value = value
       end
 
-      if annotation.validate(:champs_private_value) && annotation.save
+      if annotation.validate(:champ_value) && annotation.save
         { annotation: }
       else
         { errors: annotation.errors.full_messages }

--- a/app/graphql/mutations/dossier_modifier_annotations.rb
+++ b/app/graphql/mutations/dossier_modifier_annotations.rb
@@ -60,7 +60,7 @@ module Mutations
             annotation
           end
         end
-        .partition { _1.repetition? || (_1.validate(:champs_private_value) && _1.save) }
+        .partition { _1.repetition? || (_1.validate(:champ_value) && _1.save) }
       errors += invalid_annotations.flat_map { _1.errors.full_messages }
 
       { annotations:, errors: errors.presence }

--- a/app/jobs/migrations/batch_update_pays_values_job.rb
+++ b/app/jobs/migrations/batch_update_pays_values_job.rb
@@ -77,7 +77,10 @@ class Migrations::BatchUpdatePaysValuesJob < ApplicationJob
     ids.each do |id|
       pays_champ = Champs::PaysChamp.find(id)
 
-      next if pays_champ.valid?(pays_champ.public? ? :champs_public_value : :champs_private_value)
+      # orphaned champs (stable_id no longer in the dossier revision) can not
+      # be validated: resolving their type_de_champ raises
+      next unless pays_champ.dossier.stable_id_in_revision?(pays_champ.stable_id)
+      next if pays_champ.valid?(:champ_value)
       code = APIGeoService.country_code(pays_champ.value)
       value = if code.present?
         APIGeoService.country_name(code)

--- a/app/models/concerns/champ_revision_concern.rb
+++ b/app/models/concerns/champ_revision_concern.rb
@@ -5,19 +5,7 @@ module ChampRevisionConcern
 
   protected
 
-  def is_same_type_as_revision?
-    is_type?(type_de_champ.type_champ)
-  end
-
   def in_dossier_revision?
     dossier.stable_id_in_revision?(stable_id)
-  end
-
-  def in_discarded_row?
-    if child?
-      repetition_type_de_champ = dossier.revision.parent_of(type_de_champ)
-      row_ids = dossier.repetition_row_ids(repetition_type_de_champ)
-      !row_id.in?(row_ids)
-    end
   end
 end

--- a/app/models/concerns/champ_validate_concern.rb
+++ b/app/models/concerns/champ_validate_concern.rb
@@ -11,23 +11,13 @@ module ChampValidateConcern
 
   def should_validate_in_current_context?
     case validation_context
-    when :champs_public_value
-      public? && is_validation_relevant? && visible?
-    when :champs_private_value
-      private? && is_validation_relevant? && visible?
+    when :champ_value
+      visible?
     when :prefill
       true
     else
       false
     end
-  end
-
-  def is_validation_relevant?
-    in_dossier_stream? && in_dossier_revision? && is_same_type_as_revision? && !in_discarded_row?
-  end
-
-  def in_dossier_stream?
-    dossier.stream == stream
   end
 
   def validate_external_data_response?

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -58,7 +58,7 @@ module DossierChampsConcern
   end
 
   def project_champs_public_all
-    revision.types_de_champ_public.flat_map do |type_de_champ|
+    @project_champs_public_all ||= revision.types_de_champ_public.flat_map do |type_de_champ|
       champ = project_champ(type_de_champ)
       if type_de_champ.repetition?
         [champ] + project_rows_for(type_de_champ).flatten
@@ -69,7 +69,7 @@ module DossierChampsConcern
   end
 
   def project_champs_private_all
-    revision.types_de_champ_private.flat_map do |type_de_champ|
+    @project_champs_private_all ||= revision.types_de_champ_private.flat_map do |type_de_champ|
       champ = project_champ(type_de_champ)
       if type_de_champ.repetition?
         [champ] + project_rows_for(type_de_champ).flatten
@@ -539,6 +539,8 @@ module DossierChampsConcern
     @filled_champs_private = nil
     @project_champs_public = nil
     @project_champs_private = nil
+    @project_champs_public_all = nil
+    @project_champs_private_all = nil
     @repetition_row_ids = nil
     @revision_stable_ids = nil
     @champs_on_stream = nil

--- a/app/models/concerns/dossier_validate_concern.rb
+++ b/app/models/concerns/dossier_validate_concern.rb
@@ -3,6 +3,11 @@
 module DossierValidateConcern
   extend ActiveSupport::Concern
 
+  included do
+    validate :validate_champs_public_value, on: :champs_public_value
+    validate :validate_champs_private_value, on: :champs_private_value
+  end
+
   def champs_public_valid?
     validate(:champs_public_value)
     check_mandatory_and_visible_champs_for(project_champs_public)
@@ -16,6 +21,21 @@ module DossierValidateConcern
   end
 
   private
+
+  def validate_champs_public_value
+    validate_projected_champs(project_champs_public_all)
+  end
+
+  def validate_champs_private_value
+    validate_projected_champs(project_champs_private_all)
+  end
+
+  def validate_projected_champs(champs)
+    champs.each do |champ|
+      next if champ.validate(:champ_value)
+      champ.errors.each { errors.import(it) }
+    end
+  end
 
   def check_mandatory_and_visible_champs_for(collection)
     collection.filter(&:visible?).each do |champ|

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -58,9 +58,10 @@ class Dossier < ApplicationRecord
   has_one_attached :justificatif_motivation
   has_one_attached :attestation_depot_pdf
 
-  # autosave is required to import champ validation errors on the dossier
-  # when validating with the :champs_public_value/:champs_private_value contexts
-  has_many :champ_data, dependent: :destroy, class_name: 'Champ', autosave: true
+  # autosave persists champ changes when saving the dossier; champ validation
+  # is driven by DossierValidateConcern over projected champs, so `validate: false`
+  # keeps autosave from cascading validation into every loaded champ.
+  has_many :champ_data, dependent: :destroy, class_name: 'Champ', autosave: true, validate: false
   has_many :commentaires, inverse_of: :dossier, dependent: :destroy
   has_many :commentaires_chronological, -> { chronological }, class_name: 'Commentaire', inverse_of: :dossier
   has_many :preloaded_commentaires, -> { includes(:dossier_correction, :dossier_pending_response, :instructeur, :expert, piece_jointe_attachments: :blob).order(created_at: :desc) }, class_name: 'Commentaire', inverse_of: :dossier

--- a/app/services/attachment/piece_justificative_service.rb
+++ b/app/services/attachment/piece_justificative_service.rb
@@ -9,9 +9,14 @@ class Attachment::PieceJustificativeService
   # the attachments left by the previous one.
   def self.attach_champ_pj(champ, blob_signed_id)
     updated_by = champ.updated_by
+    dossier = champ.dossier
 
     Champ.transaction do
       champ.reload(lock: true) # SELECT FOR UPDATE + clear association cache
+      # restore the stream-scoped dossier: a fresh association load defaults to
+      # the main stream, and conditional visibility (the validation gate) must
+      # be computed on the stream being edited
+      champ.association(:dossier).target = dossier
       champ.updated_by = updated_by # keep record dirty so attach defers save to us
       champ.piece_justificative_file.attach(blob_signed_id)
 
@@ -19,8 +24,7 @@ class Attachment::PieceJustificativeService
       # race condition with processor_job
       champ.fetch_later if champ.has_async_external_data? && champ.may_fetch_later?
 
-      context = champ.public? ? :champs_public_value : :champs_private_value
-      champ.save(context:)
+      champ.save(context: :champ_value)
     end
   end
 end

--- a/spec/jobs/migrations/batch_update_pays_values_job_spec.rb
+++ b/spec/jobs/migrations/batch_update_pays_values_job_spec.rb
@@ -49,4 +49,16 @@ describe Migrations::BatchUpdatePaysValuesJob, type: :job do
       expect(pays_champ.reload.external_id).to eq('CX')
     end
   end
+
+  context "the champ is not in the dossier revision anymore" do
+    let(:attributes) { { value: 'RUSSIE' } }
+
+    before { dossier.revision.remove_type_de_champ(pays_champ.stable_id) }
+
+    it 'skips the champ without raising' do
+      # call perform directly to bypass retry_on, which swallows the error
+      expect { described_class.new.perform([pays_champ.id]) }.not_to raise_error
+      expect(pays_champ.reload.value).to eq('RUSSIE')
+    end
+  end
 end

--- a/spec/models/champs/commune_champ_spec.rb
+++ b/spec/models/champs/commune_champ_spec.rb
@@ -42,7 +42,7 @@ describe Champs::CommuneChamp do
 
       it 'fails' do
         expect(champ).to receive(:instrument_external_id_error)
-        expect(champ.validate(:champs_public_value)).to be_falsey
+        expect(champ.validate(:champ_value)).to be_falsey
         expect(champ.errors).to include('external_id')
       end
     end

--- a/spec/models/champs/date_champ_spec.rb
+++ b/spec/models/champs/date_champ_spec.rb
@@ -70,7 +70,7 @@ describe Champs::DateChamp do
 
   context 'when the value is not in the past' do
     let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     context 'all dates are accepted' do
       let(:value) { Date.today }
@@ -91,7 +91,7 @@ describe Champs::DateChamp do
 
   context 'when there is a range' do
     let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     before { champ.type_de_champ.update(options: { range_date: '1', start_date: '2017-11-30', end_date: '2017-12-31' }) }
     context 'the value is in the range' do
@@ -146,7 +146,7 @@ describe Champs::DateChamp do
 
   context 'when birthdate option is enabled' do
     let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     before { champ.type_de_champ.update(options: { birthdate: "1" }) }
 

--- a/spec/models/champs/datetime_champ_spec.rb
+++ b/spec/models/champs/datetime_champ_spec.rb
@@ -67,7 +67,7 @@ describe Champs::DatetimeChamp do
   end
 
   context 'when the value is not in the past' do
-    subject { datetime_champ.validate(:champs_public_value) }
+    subject { datetime_champ.validate(:champ_value) }
 
     context 'all dates are accepted' do
       before { datetime_champ.update(value: DateTime.now.iso8601) }
@@ -105,7 +105,7 @@ describe Champs::DatetimeChamp do
 
   context 'when there is a range' do
     let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     before { champ.type_de_champ.update(options: { range_date: '1', start_date: '2017-11-30', end_date: '2017-12-31' }) }
     context 'the value is in the range' do

--- a/spec/models/champs/decimal_number_champ_spec.rb
+++ b/spec/models/champs/decimal_number_champ_spec.rb
@@ -9,15 +9,15 @@ describe Champs::DecimalNumberChamp do
   let(:value) { nil }
 
   describe 'validation' do
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     context 'when the value is a valid number' do
       it 'validates integer and decimal numbers' do
         champ.value = 2
-        expect(champ.validate(:champs_public_value)).to be_truthy
+        expect(champ.validate(:champ_value)).to be_truthy
 
         champ.value = 2.6
-        expect(champ.validate(:champs_public_value)).to be_truthy
+        expect(champ.validate(:champ_value)).to be_truthy
       end
     end
 
@@ -47,10 +47,10 @@ describe Champs::DecimalNumberChamp do
     context 'when the value is blank or nil' do
       it 'validates empty values' do
         champ.value = ''
-        expect(champ.validate(:champs_public_value)).to be_truthy
+        expect(champ.validate(:champ_value)).to be_truthy
 
         champ.value = nil
-        expect(champ.validate(:champs_public_value)).to be_truthy
+        expect(champ.validate(:champ_value)).to be_truthy
       end
     end
 
@@ -124,12 +124,12 @@ describe Champs::DecimalNumberChamp do
       end
     end
 
-    context 'when the champ is private, value is invalid, but validation is public' do
+    context 'when the champ is private and the value is invalid' do
       let(:types_de_champ_public) { [] }
       let(:types_de_champ_private) { [{ type: :decimal_number }] }
       let(:value) { '2.6666' }
 
-      it { is_expected.to be_truthy }
+      it { is_expected.to be_falsey }
     end
   end
 

--- a/spec/models/champs/departement_champ_spec.rb
+++ b/spec/models/champs/departement_champ_spec.rb
@@ -8,7 +8,7 @@ describe Champs::DepartementChamp, type: :model do
   let(:external_id) { nil }
 
   describe 'validations' do
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     describe 'external link' do
       context 'when nil' do

--- a/spec/models/champs/dossier_link_champ_spec.rb
+++ b/spec/models/champs/dossier_link_champ_spec.rb
@@ -46,7 +46,7 @@ describe Champs::DossierLinkChamp, type: :model do
   end
 
   describe 'validation' do
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     context 'when not mandatory' do
       let(:mandatory) { false }
@@ -84,7 +84,7 @@ describe Champs::DossierLinkChamp, type: :model do
   end
 
   describe 'dossier_in_allowed_procedures validation' do
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     let(:mandatory) { false }
     let(:user) { dossier.user }

--- a/spec/models/champs/drop_down_list_champ_spec.rb
+++ b/spec/models/champs/drop_down_list_champ_spec.rb
@@ -12,7 +12,7 @@ describe Champs::DropDownListChamp do
 
   describe 'validations' do
     describe 'inclusion' do
-      subject { champ.validate(:champs_public_value) }
+      subject { champ.validate(:champ_value) }
 
       context 'when the other value is accepted' do
         let(:other) { true }

--- a/spec/models/champs/email_champ_spec.rb
+++ b/spec/models/champs/email_champ_spec.rb
@@ -7,7 +7,7 @@ describe Champs::EmailChamp do
     let(:champ) { dossier.champ_data.second }
     let(:value) { nil }
     before { champ.value = value }
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     context 'when nil' do
       it { is_expected.to be_truthy }
@@ -25,7 +25,7 @@ describe Champs::EmailChamp do
 
         invalid_emails.each do |email|
           champ.value = email
-          expect(champ.validate(:champs_public_value)).to be_falsey
+          expect(champ.validate(:champ_value)).to be_falsey
         end
       end
     end
@@ -43,7 +43,7 @@ describe Champs::EmailChamp do
 
         valid_emails.each do |email|
           champ.value = email
-          expect(champ.validate(:champs_public_value)).to be_truthy
+          expect(champ.validate(:champ_value)).to be_truthy
         end
       end
     end
@@ -57,9 +57,15 @@ describe Champs::EmailChamp do
     end
 
     context 'when type_de_champ is not in dossier revision anymore' do
-      before { dossier.revision.remove_type_de_champ(champ.stable_id) }
-      let(:value) { 'username' }
-      it { is_expected.to be_truthy }
+      before {
+        champ.update_column(:value, 'username')
+        dossier.revision.remove_type_de_champ(champ.stable_id)
+        dossier.reload
+      }
+
+      it 'is not projected, so the dossier does not validate the invalid value' do
+        expect(dossier.validate(:champs_public_value)).to be_truthy
+      end
     end
   end
 end

--- a/spec/models/champs/engagement_juridique_champ_spec.rb
+++ b/spec/models/champs/engagement_juridique_champ_spec.rb
@@ -8,7 +8,7 @@ describe Champs::EngagementJuridiqueChamp do
     let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
     let(:value) { nil }
 
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     context 'with [A-Z]' do
       let(:value) { "ABC" }

--- a/spec/models/champs/epci_champ_spec.rb
+++ b/spec/models/champs/epci_champ_spec.rb
@@ -8,7 +8,7 @@ describe Champs::EpciChamp, type: :model do
   let(:code_departement) { nil }
 
   describe 'validations' do
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     describe 'code_departement' do
       context 'when nil' do

--- a/spec/models/champs/formatted_champ_spec.rb
+++ b/spec/models/champs/formatted_champ_spec.rb
@@ -11,7 +11,7 @@ describe Champs::FormattedChamp do
   end
 
   describe 'validation' do
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     context 'with simple mode' do
       context 'only numbers accepted' do

--- a/spec/models/champs/iban_champ_spec.rb
+++ b/spec/models/champs/iban_champ_spec.rb
@@ -11,17 +11,17 @@ describe Champs::IbanChamp do
       champ.tap { _1.value = value }
     end
     it do
-      expect(with_value(nil).valid?(:champs_public_value)).to be_truthy
-      expect(with_value("FR35 KDSQFDJQSMFDQMFDQ").valid?(:champs_public_value)).to be_falsey
-      expect(with_value("FR7630006000011234567890189").valid?(:champs_public_value)).to be_truthy
-      expect(with_value("FR76 3000 6000 0112 3456 7890 189").valid?(:champs_public_value)).to be_truthy
-      expect(with_value("FR76 3000 6000 0112 3456 7890 189DSF").valid?(:champs_public_value)).to be_falsey
-      expect(with_value("FR76	3000	6000	0112	3456	7890	189").valid?(:champs_public_value)).to be_truthy
+      expect(with_value(nil).valid?(:champ_value)).to be_truthy
+      expect(with_value("FR35 KDSQFDJQSMFDQMFDQ").valid?(:champ_value)).to be_falsey
+      expect(with_value("FR7630006000011234567890189").valid?(:champ_value)).to be_truthy
+      expect(with_value("FR76 3000 6000 0112 3456 7890 189").valid?(:champ_value)).to be_truthy
+      expect(with_value("FR76 3000 6000 0112 3456 7890 189DSF").valid?(:champ_value)).to be_falsey
+      expect(with_value("FR76	3000	6000	0112	3456	7890	189").valid?(:champ_value)).to be_truthy
     end
 
     it 'format value after validation' do
       with_value("FR76	3000	6000	0112	3456	7890	189")
-      champ.valid?(:champs_public_value)
+      champ.valid?(:champ_value)
       expect(champ.value).to eq("FR76 3000 6000 0112 3456 7890 189")
     end
   end

--- a/spec/models/champs/integer_number_champ_spec.rb
+++ b/spec/models/champs/integer_number_champ_spec.rb
@@ -6,7 +6,7 @@ describe Champs::IntegerNumberChamp do
   let(:dossier) { create(:dossier, procedure:) }
   let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
   let(:value) { nil }
-  subject { champ.validate(:champs_public_value) }
+  subject { champ.validate(:champ_value) }
 
   describe '#valid?' do
     context 'when the value is integer number' do

--- a/spec/models/champs/multiple_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/multiple_drop_down_list_champ_spec.rb
@@ -8,7 +8,7 @@ describe Champs::MultipleDropDownListChamp do
   let(:value) { nil }
 
   describe 'validations' do
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     describe 'inclusion' do
       context 'when the value is nil' do

--- a/spec/models/champs/phone_champ_spec.rb
+++ b/spec/models/champs/phone_champ_spec.rb
@@ -8,42 +8,42 @@ describe Champs::PhoneChamp do
 
   describe '#validate' do
     it do
-      expect(champ_with_value(nil).validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("0123456789 0123456789").validate(:champs_public_value)).to_not be_truthy
-      expect(champ_with_value("01.23.45.67.89 01.23.45.67.89").validate(:champs_public_value)).to_not be_truthy
-      expect(champ_with_value("3646").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("0123456789").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("01.23.45.67.89").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("0123 45.67.89").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("0033 123-456-789").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("0033 123-456-789").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("0033(0)123456789").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("+33-1.23.45.67.89").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("+33 - 123 456 789").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("+33(0) 123 456 789").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("+33 (0)123 45 67 89").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("+33 (0)1 2345-6789").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("+33(0) - 123456789").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("+1(0) - 123456789").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("+49 2109 87654321").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("012345678").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value(nil).validate(:champ_value)).to be_truthy
+      expect(champ_with_value("0123456789 0123456789").validate(:champ_value)).to_not be_truthy
+      expect(champ_with_value("01.23.45.67.89 01.23.45.67.89").validate(:champ_value)).to_not be_truthy
+      expect(champ_with_value("3646").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("0123456789").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("01.23.45.67.89").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("0123 45.67.89").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("0033 123-456-789").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("0033 123-456-789").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("0033(0)123456789").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("+33-1.23.45.67.89").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("+33 - 123 456 789").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("+33(0) 123 456 789").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("+33 (0)123 45 67 89").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("+33 (0)1 2345-6789").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("+33(0) - 123456789").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("+1(0) - 123456789").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("+49 2109 87654321").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("012345678").validate(:champ_value)).to be_truthy
       # DROM numbers should be valid
-      expect(champ_with_value("06 96 04 78 07").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("05 94 22 31 31").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("+594 5 94 22 31 31").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("06 96 04 78 07").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("05 94 22 31 31").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("+594 5 94 22 31 31").validate(:champ_value)).to be_truthy
       # polynesian numbers should not return errors in any way
       ## landline numbers start with 40 or 45
-      expect(champ_with_value("45187272").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("40 473 500").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("40473500").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("45473500").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("45187272").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("40 473 500").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("40473500").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("45473500").validate(:champ_value)).to be_truthy
       ## +689 is the international indicator
-      expect(champ_with_value("+689 45473500").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("0145473500").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("+689 45473500").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("0145473500").validate(:champ_value)).to be_truthy
       ## polynesian mobile numbers start with 87, 88, 89
-      expect(champ_with_value("87473500").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("88473500").validate(:champs_public_value)).to be_truthy
-      expect(champ_with_value("89473500").validate(:champs_public_value)).to be_truthy
+      expect(champ_with_value("87473500").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("88473500").validate(:champ_value)).to be_truthy
+      expect(champ_with_value("89473500").validate(:champ_value)).to be_truthy
     end
   end
 

--- a/spec/models/champs/piece_justificative_champ_spec.rb
+++ b/spec/models/champs/piece_justificative_champ_spec.rb
@@ -25,7 +25,7 @@ describe Champs::PieceJustificativeChamp do
 
         champ.piece_justificative_file.attach(blob)
 
-        expect(champ.valid?(:champs_public_value)).to be false
+        expect(champ.valid?(:champ_value)).to be false
         expect(champ.errors[:piece_justificative_file]).to be_present
       end
 
@@ -33,24 +33,27 @@ describe Champs::PieceJustificativeChamp do
         champ.piece_justificative_file.purge
         champ.piece_justificative_file.attach(io: StringIO.new('# titre'), filename: 'notes.md', content_type: 'text/x-markdown')
 
-        expect(champ.valid?(:champs_public_value)).to be true
+        expect(champ.valid?(:champ_value)).to be true
       end
 
-      it "does not validate public PJ when validating private context" do
-        champ.piece_justificative_file.attach(
-          io: StringIO.new('x'),
-          filename: 'bad.exe',
-          content_type: 'application/x-ms-dos-executable'
-        )
+      it "does not validate public PJ when validating private champs" do
+        champ.piece_justificative_file = [
+          {
+            io: StringIO.new('x'),
+            filename: 'bad.exe',
+            content_type: 'application/x-ms-dos-executable',
+          },
+        ]
 
-        expect(champ.valid?(:champs_private_value)).to be true
+        expect(dossier.champs_public_valid?).to be false
+        expect(dossier.champs_private_valid?).to be true
       end
     end
 
     context "when validation is disabled" do
       before { champ.type_de_champ.update(skip_pj_validation: true) }
 
-      it "does not enforce file size on :champs_public_value" do
+      it "does not enforce file size on :champ_value" do
         champ.piece_justificative_file.purge
         blob = ActiveStorage::Blob.create_and_upload!(
           io: StringIO.new('x'),
@@ -60,21 +63,21 @@ describe Champs::PieceJustificativeChamp do
         blob.update_column(:byte_size, Champs::PieceJustificativeChamp::FILE_MAX_SIZE + 1)
         champ.piece_justificative_file.attach(blob)
 
-        expect(champ.valid?(:champs_public_value)).to be true
+        expect(champ.valid?(:champ_value)).to be true
       end
     end
 
     context "when content-type validation is disabled" do
       before { champ.type_de_champ.update(skip_content_type_pj_validation: true) }
 
-      it "does not enforce content_type on :champs_public_value" do
+      it "does not enforce content_type on :champ_value" do
         champ.piece_justificative_file.attach(
           io: StringIO.new('x'),
           filename: 'bad.exe',
           content_type: 'application/x-ms-dos-executable'
         )
 
-        expect(champ.valid?(:champs_public_value)).to be true
+        expect(champ.valid?(:champ_value)).to be true
       end
     end
   end
@@ -88,13 +91,13 @@ describe Champs::PieceJustificativeChamp do
       it 'accepts jpeg under 20MB' do
         champ.piece_justificative_file.purge
         champ.piece_justificative_file.attach(io: StringIO.new('x' * 1024), filename: 'id.jpg', content_type: 'image/jpeg')
-        expect(champ.valid?(:champs_public_value)).to be true
+        expect(champ.valid?(:champ_value)).to be true
       end
 
       it 'rejects pdf' do
         champ.piece_justificative_file.purge
         champ.piece_justificative_file.attach(io: StringIO.new('x'), filename: 'id.pdf', content_type: 'application/pdf')
-        expect(champ.valid?(:champs_public_value)).to be false
+        expect(champ.valid?(:champ_value)).to be false
         expect(champ.errors[:piece_justificative_file]).to be_present
       end
 
@@ -107,7 +110,7 @@ describe Champs::PieceJustificativeChamp do
         )
         blob.update_column(:byte_size, 21.megabytes)
         champ.piece_justificative_file.attach(blob)
-        expect(champ.valid?(:champs_public_value)).to be false
+        expect(champ.valid?(:champ_value)).to be false
         expect(champ.errors[:piece_justificative_file]).to be_present
       end
     end
@@ -121,13 +124,13 @@ describe Champs::PieceJustificativeChamp do
         it 'accepts pdf' do
           champ.piece_justificative_file.purge
           champ.piece_justificative_file.attach(io: StringIO.new('x'), filename: 'doc.pdf', content_type: 'application/pdf')
-          expect(champ.valid?(:champs_public_value)).to be true
+          expect(champ.valid?(:champ_value)).to be true
         end
 
         it 'rejects zip' do
           champ.piece_justificative_file.purge
           champ.piece_justificative_file.attach(io: StringIO.new('x'), filename: 'arc.zip', content_type: 'application/zip')
-          expect(champ.valid?(:champs_public_value)).to be false
+          expect(champ.valid?(:champ_value)).to be false
           expect(champ.errors[:piece_justificative_file]).to be_present
         end
       end
@@ -141,20 +144,20 @@ describe Champs::PieceJustificativeChamp do
       it 'accepts pdf' do
         champ.piece_justificative_file.purge
         champ.piece_justificative_file.attach(io: StringIO.new('x'), filename: 'doc.pdf', content_type: 'application/pdf')
-        expect(champ.valid?(:champs_public_value)).to be true
+        expect(champ.valid?(:champ_value)).to be true
       end
 
       it 'rejects zip' do
         champ.piece_justificative_file.purge
         champ.piece_justificative_file.attach(io: StringIO.new('x'), filename: 'arc.zip', content_type: 'application/zip')
-        expect(champ.valid?(:champs_public_value)).to be false
+        expect(champ.valid?(:champ_value)).to be false
         expect(champ.errors[:piece_justificative_file]).to be_present
       end
 
       it 'accepts markdown declared as the legacy text/x-markdown content type' do
         champ.piece_justificative_file.purge
         champ.piece_justificative_file.attach(io: StringIO.new('# titre'), filename: 'notes.md', content_type: 'text/x-markdown')
-        expect(champ.valid?(:champs_public_value)).to be true
+        expect(champ.valid?(:champ_value)).to be true
       end
     end
 
@@ -166,13 +169,13 @@ describe Champs::PieceJustificativeChamp do
       it 'accepts pdf' do
         champ.piece_justificative_file.purge
         champ.piece_justificative_file.attach(io: StringIO.new('x'), filename: 'doc.pdf', content_type: 'application/pdf')
-        expect(champ.valid?(:champs_public_value)).to be true
+        expect(champ.valid?(:champ_value)).to be true
       end
 
       it 'accepts zip' do
         champ.piece_justificative_file.purge
         champ.piece_justificative_file.attach(io: StringIO.new('x'), filename: 'arc.zip', content_type: 'application/zip')
-        expect(champ.valid?(:champs_public_value)).to be true
+        expect(champ.valid?(:champ_value)).to be true
       end
     end
   end

--- a/spec/models/champs/referentiel_champ_spec.rb
+++ b/spec/models/champs/referentiel_champ_spec.rb
@@ -16,7 +16,7 @@ describe Champs::ReferentielChamp, type: :model do
       before { champ.update_columns(external_state: 'waiting_for_job') }
 
       it 'adds the correct error message' do
-        champ.validate(:champs_public_value)
+        champ.validate(:champ_value)
         expect(champ.errors[:external_id]).to include(I18n.t('activerecord.errors.messages.api_response_pending'))
       end
     end
@@ -25,7 +25,7 @@ describe Champs::ReferentielChamp, type: :model do
       before { champ.update_columns(external_state: 'fetched') }
 
       it 'is valid' do
-        expect(champ.validate(:champs_public_value)).to be_truthy
+        expect(champ.validate(:champ_value)).to be_truthy
       end
     end
 
@@ -37,7 +37,7 @@ describe Champs::ReferentielChamp, type: :model do
       before { champ.update_columns(external_state: 'external_error', fetch_external_data_exceptions: [external_data_exceptions]) }
 
       it 'adds the correct error message' do
-        champ.validate(:champs_public_value)
+        champ.validate(:champ_value)
 
         expect(champ.errors[:external_id]).to include(I18n.t('activerecord.errors.messages.code_404'))
       end
@@ -47,7 +47,7 @@ describe Champs::ReferentielChamp, type: :model do
       before { champ.update_columns(external_state: 'external_error', fetch_external_data_exceptions: []) }
 
       it 'adds the code_unknown error message without raising an error' do
-        expect { champ.validate(:champs_public_value) }.not_to raise_error
+        expect { champ.validate(:champ_value) }.not_to raise_error
         expect(champ.errors[:external_id]).to include(I18n.t('activerecord.errors.messages.code_unknown'))
       end
     end

--- a/spec/models/champs/region_champ_spec.rb
+++ b/spec/models/champs/region_champ_spec.rb
@@ -8,7 +8,7 @@ describe Champs::RegionChamp, type: :model do
   let(:external_id) { nil }
 
   describe 'validations' do
-    subject { champ.validate(:champs_public_value) }
+    subject { champ.validate(:champ_value) }
 
     describe 'external link' do
       context 'when nil' do

--- a/spec/models/champs/repetition_champ_spec.rb
+++ b/spec/models/champs/repetition_champ_spec.rb
@@ -105,7 +105,7 @@ describe Champs::RepetitionChamp do
       end
 
       it "adds a repetition_too_few error" do
-        champ.valid?(:champs_public_value)
+        champ.valid?(:champ_value)
         expect(champ.errors.where(:value, :repetition_too_few)).to be_present
       end
     end
@@ -120,7 +120,7 @@ describe Champs::RepetitionChamp do
 
       it "adds a repetition_too_few error even without any rows" do
         fresh_champ = dossier.reload.project_champs_public.find(&:repetition?)
-        fresh_champ.valid?(:champs_public_value)
+        fresh_champ.valid?(:champ_value)
         expect(fresh_champ.errors.where(:value, :repetition_too_few)).to be_present
       end
     end
@@ -136,7 +136,7 @@ describe Champs::RepetitionChamp do
       end
 
       it "adds a repetition_too_many error" do
-        champ.valid?(:champs_public_value)
+        champ.valid?(:champ_value)
         expect(champ.errors.where(:value, :repetition_too_many)).to be_present
       end
     end
@@ -150,7 +150,7 @@ describe Champs::RepetitionChamp do
       end
 
       it "does not add any errors" do
-        champ.valid?(:champs_public_value)
+        champ.valid?(:champ_value)
         expect(champ.errors).to be_empty
       end
     end

--- a/spec/models/champs/rna_champ_spec.rb
+++ b/spec/models/champs/rna_champ_spec.rb
@@ -15,16 +15,16 @@ describe Champs::RNAChamp do
 
   describe '#valid?' do
     it do
-      expect(with_external_id(nil).validate(:champs_public_value)).to be_truthy
-      expect(with_external_id("2736251627").validate(:champs_public_value)).to be_falsey
-      expect(with_external_id("A172736283").validate(:champs_public_value)).to be_falsey
-      expect(with_external_id("W1827362718").validate(:champs_public_value)).to be_falsey
-      expect(with_external_id("W182736273").validate(:champs_public_value)).to be_truthy
+      expect(with_external_id(nil).validate(:champ_value)).to be_truthy
+      expect(with_external_id("2736251627").validate(:champ_value)).to be_falsey
+      expect(with_external_id("A172736283").validate(:champ_value)).to be_falsey
+      expect(with_external_id("W1827362718").validate(:champ_value)).to be_falsey
+      expect(with_external_id("W182736273").validate(:champ_value)).to be_truthy
     end
 
     it 'when invalid format, it contains only error message for invalid format' do
       champ = with_external_id("W1827362")
-      champ.validate(:champs_public_value)
+      champ.validate(:champ_value)
       expect(champ.errors.full_messages.join).to match(/doit commencer par un W majuscule suivi de 9 chiffres ou lettres. Exemple : W503726238/)
     end
 
@@ -32,7 +32,7 @@ describe Champs::RNAChamp do
       champ = with_external_id("W182736273")
       error = ExternalDataException.new(error: 'Not retryable', code: 404)
       champ.update_columns(external_state: 'external_error', fetch_external_data_exceptions: [error])
-      champ.validate(:champs_public_value)
+      champ.validate(:champ_value)
       expect(champ.errors.full_messages).to eq(["Le champ « Numéro RNA » Résultat introuvable. Vérifiez vos informations."])
     end
   end

--- a/spec/models/champs/rnf_champ_spec.rb
+++ b/spec/models/champs/rnf_champ_spec.rb
@@ -25,7 +25,7 @@ describe Champs::RNFChamp, type: :model do
       before { champ.update_columns(external_state: 'waiting_for_job') }
 
       it 'adds the correct error message' do
-        champ.validate(:champs_public_value)
+        champ.validate(:champ_value)
 
         expect(champ.errors[:external_id]).to include(I18n.t('activerecord.errors.messages.api_response_pending'))
       end
@@ -35,7 +35,7 @@ describe Champs::RNFChamp, type: :model do
       before { champ.update_columns(external_state: 'fetched') }
 
       it 'is valid' do
-        expect(champ.validate(:champs_public_value)).to be_truthy
+        expect(champ.validate(:champ_value)).to be_truthy
       end
     end
 
@@ -45,7 +45,7 @@ describe Champs::RNFChamp, type: :model do
       before { champ.update_columns(external_state: 'external_error', fetch_external_data_exceptions: [error]) }
 
       it 'adds the correct error message' do
-        champ.validate(:champs_public_value)
+        champ.validate(:champ_value)
 
         expect(champ.errors[:external_id]).to include(I18n.t('activerecord.errors.messages.code_404'))
       end
@@ -55,7 +55,7 @@ describe Champs::RNFChamp, type: :model do
       before { champ.update_columns(external_state: 'external_error', fetch_external_data_exceptions: []) }
 
       it 'adds the code_unknown error message without raising an error' do
-        expect { champ.validate(:champs_public_value) }.not_to raise_error
+        expect { champ.validate(:champ_value) }.not_to raise_error
         expect(champ.errors[:external_id]).to include(I18n.t('activerecord.errors.messages.code_unknown'))
       end
     end
@@ -94,7 +94,7 @@ describe Champs::RNFChamp, type: :model do
       let(:external_id) { 'abc' }
 
       it 'is invalid' do
-        champ.validate(:champs_public_value)
+        champ.validate(:champ_value)
         expect(champ.errors.full_messages.join).to include("pas un numéro RNF valide")
       end
     end
@@ -103,7 +103,7 @@ describe Champs::RNFChamp, type: :model do
       let(:external_id) { '075-FDD-00003-01' }
 
       it 'has no format error' do
-        champ.validate(:champs_public_value)
+        champ.validate(:champ_value)
         expect(champ.errors.full_messages.join).not_to include("pas un numéro RNF valide")
       end
     end
@@ -112,7 +112,7 @@ describe Champs::RNFChamp, type: :model do
       let(:external_id) { nil }
 
       it 'has no format error' do
-        champ.validate(:champs_public_value)
+        champ.validate(:champ_value)
         expect(champ.errors.full_messages.join).not_to include("pas un numéro RNF valide")
       end
     end

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -8,7 +8,7 @@ describe Champs::SiretChamp do
   let(:etablissement) { nil }
 
   describe '#validate' do
-    subject { champ.tap { _1.validate(:champs_public_value) } }
+    subject { champ.tap { _1.validate(:champ_value) } }
 
     context 'when empty' do
       let(:external_id) { nil }

--- a/spec/models/concerns/champ_conditional_concern_spec.rb
+++ b/spec/models/concerns/champ_conditional_concern_spec.rb
@@ -25,10 +25,10 @@ describe ChampConditionalConcern do
     context "when there are no condition" do
       it {
         expect(champ.visible?).to eq(true)
-        expect(champ.valid?(:champs_public_value)).to eq(false)
+        expect(champ.valid?(:champ_value)).to eq(false)
 
         expect(last_champ.visible?).to eq(true)
-        expect(last_champ.valid?(:champs_public_value)).to eq(false)
+        expect(last_champ.valid?(:champ_value)).to eq(false)
       }
     end
 
@@ -37,10 +37,10 @@ describe ChampConditionalConcern do
 
       it {
         expect(champ.visible?).to eq(true)
-        expect(champ.valid?(:champs_public_value)).to eq(false)
+        expect(champ.valid?(:champ_value)).to eq(false)
 
         expect(last_champ.visible?).to eq(false)
-        expect(last_champ.valid?(:champs_public_value)).to eq(true)
+        expect(last_champ.valid?(:champ_value)).to eq(true)
       }
     end
 

--- a/spec/models/concerns/champ_validate_concern_spec.rb
+++ b/spec/models/concerns/champ_validate_concern_spec.rb
@@ -90,9 +90,13 @@ RSpec.describe ChampValidateConcern do
         dossier.revision.revision_types_de_champ.delete_all
 
         dossier.reload
+        dossier.validate(:champs_public_value)
       end
 
-      it { expect(dossier.champ_data.first.send(:validate_external_data_response?)).to be(false) }
+      it {
+        expect(dossier.champ_data).not_to be_empty
+        expect(dossier.errors).to be_empty
+      }
     end
   end
 
@@ -109,6 +113,23 @@ RSpec.describe ChampValidateConcern do
         expect(type_de_champ.type_champ).to eq('text')
         expect(dossier.champ_data).not_to be_empty
         expect(dossier.errors).to be_empty
+      }
+    end
+
+    context 'validate the carried over value with the new champ type' do
+      let(:types_de_champ_public) { [{ type: :text }] }
+
+      before {
+        update_champ('test')
+        type_de_champ.update(type_champ: :email)
+        dossier.reload
+        dossier.validate(:champs_public_value)
+      }
+      it {
+        expect(dossier.champ_data.first.last_write_type_champ).to eq('text')
+        expect(type_de_champ.type_champ).to eq('email')
+        expect(dossier.champ_data).not_to be_empty
+        expect(dossier.errors).not_to be_empty
       }
     end
   end

--- a/spec/services/attachment/piece_justificative_service_spec.rb
+++ b/spec/services/attachment/piece_justificative_service_spec.rb
@@ -52,5 +52,30 @@ RSpec.describe Attachment::PieceJustificativeService do
         expect(champ.reload).to be_idle
       end
     end
+
+    context 'when the PJ is conditioned on a champ edited in the user buffer' do
+      include Logic
+
+      let(:procedure) do
+        create(:procedure, :published, types_de_champ_public: [
+          { type: :yes_no, stable_id: 99 },
+          { type: :piece_justificative, stable_id: 999, condition: ds_eq(champ_value(99), constant(true)) },
+        ])
+      end
+      let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
+      let(:invalid_blob) { ActiveStorage::Blob.create_and_upload!(io: StringIO.new("x"), filename: "bad.exe", content_type: "application/x-ms-dos-executable") }
+
+      it 'computes visibility on the update stream, so the upload is validated' do
+        dossier.champ_data.find { _1.stable_id == 99 }.update_column(:value, 'false')
+
+        dossier.with_update_stream(dossier.user)
+        yes_no_champ = dossier.champ_for_update(dossier.find_type_de_champ_by_stable_id(99), row_id: nil, updated_by: dossier.user.email)
+        yes_no_champ.update(value: 'true')
+        pj_champ = dossier.champ_for_update(dossier.find_type_de_champ_by_stable_id(999), row_id: nil, updated_by: dossier.user.email)
+
+        expect(described_class.attach_champ_pj(pj_champ, invalid_blob.signed_id)).to be_falsey
+        expect(pj_champ.errors[:piece_justificative_file]).to be_present
+      end
+    end
   end
 end


### PR DESCRIPTION
La validation des champs reposait sur la cascade autosave des nested attributes : `dossier.validate(:champs_public_value)` validait tous les `champ_data` chargés, et chaque champ devait se garder lui-même avec `is_validation_relevant?` (stream, révision, type, lignes supprimées).

Désormais, les contextes `:champs_public_value`/`:champs_private_value` du dossier exécutent des validateurs dédiés qui valident exactement les champs retournés par `project_champs_public_all` / `project_champs_private_all` (maintenant mémoïsés), sous un contexte unique côté champ (`:champ_value`), en important les erreurs de chaque champ dans `dossier.errors`. La projection sélectionne déjà le bon stream, la bonne révision, le bon type et les lignes vivantes : le guard de pertinence est supprimé et la cascade de validation autosave désactivée (`validate: false`).

Le contexte `:champ_value` s'appliquant indifféremment aux champs publics et privés, les appelants qui valident ou sauvent un champ isolé n'ont plus à choisir un contexte selon `champ.public?`.

Changements de comportement :
- Sur les buffer streams, la validation couvre la vue projetée fusionnée, pas seulement les champs dont le stream correspond.
- Les champs ayant changé de type en conservant leur ancienne valeur sont désormais validés.
- Corrige le polling des annotations instructeur, qui validait un champ privé avec le contexte public (no-op).

Empilée sur #13406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
