### PR TITLE
Tech: stabiliser les tests flaky de spec/system/users/list_dossiers_spec.rb

### DIFF
--- a/spec/system/users/list_dossiers_spec.rb
+++ b/spec/system/users/list_dossiers_spec.rb
@@ -124,8 +124,8 @@ describe 'user dossiers list', js: true do
 
       visit trash_path
 
-      expect(page).to have_content(hidden.id)
-      expect(page).not_to have_content(visible.id)
+      expect(page).to have_css("#dossier_#{hidden.id}")
+      expect(page).not_to have_css("#dossier_#{visible.id}")
     end
 
     it 'does not show search or filter UI' do


### PR DESCRIPTION
# Probleme

Le fichier `spec/system/users/list_dossiers_spec.rb` echoue de maniere intermittente en CI (4 echecs merge queue, 0 retries).

Test concerne :
- `lists only hidden dossiers`

# Solution

Skill [`/flaky-test-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/flaky-test-fix/SKILL.md)

### Causes identifiees et fixes

| Cause | Scope | Fix | Tests concernes |
|-------|-------|-----|-----------------|
| `have_content` substring matching sur l'ID numerique du dossier | test | Remplacer `have_content(id)` / `not_to have_content(id)` par `have_css("#dossier_<id>")` / `not_to have_css("#dossier_<id>")` pour cibler l'element de carte dossier specifique | `lists only hidden dossiers` |

### Verification

Le test passe de maniere reproductible (6 runs consecutifs, 0 echecs). Le script `verify-flaky.sh` echoue en raison d'un bug de parsing (tail -1 ne correspond pas a la ligne de resume avec --format progress), pas d'un echec du test.

Generated with [Claude Code](https://claude.com/claude-code)