### PR TITLE
Correctif : ETQ usager, sur un champ carte, quand je clique sur une zone de la carte dans "Sélections utilisateur", le zoom est automatique

### DIFF
--- a/app/components/dossiers/geo_area_component.html.haml
+++ b/app/components/dossiers/geo_area_component.html.haml
@@ -1,4 +1,4 @@
-%li{ class: editing ? 'fr-mb-1w' : 'flex column fr-mb-2w', data: { controller: 'geo-area', geo_area_id_value: geo_area.id } }
+%li{ class: editing ? 'fr-mb-1w' : 'flex column fr-mb-2w', data: { controller: 'geo-area', geo_area_id_value: geo_area.uuid || geo_area.id } }
   - if editing
     = link_to '#', data: { action: 'geo-area#onClick' } do
       = geo_area.label

--- a/app/javascript/controllers/geo_area_controller.tsx
+++ b/app/javascript/controllers/geo_area_controller.tsx
@@ -2,11 +2,11 @@ import { ApplicationController } from './application_controller';
 
 export class GeoAreaController extends ApplicationController {
   static values = {
-    id: Number
+    id: String
   };
   static targets = ['description'];
 
-  declare readonly idValue: number;
+  declare readonly idValue: string;
   declare readonly descriptionTarget: HTMLInputElement;
 
   onFocus() {

--- a/spec/components/dossiers/geo_area_component_spec.rb
+++ b/spec/components/dossiers/geo_area_component_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Dossiers::GeoAreaComponent, type: :component do
+  let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :carte }]) }
+  let(:dossier) { create(:dossier, procedure:) }
+  let(:champ) { dossier.champs.first }
+  let(:geo_area) { create(:geo_area, :selection_utilisateur, :polygon, champ:) }
+
+  before { render_inline(described_class.new(geo_area:, editing:)) }
+
+  shared_examples 'exposes the geojson feature id' do
+    it "matches the id of the map's geojson feature so clicking it can zoom to the right shape" do
+      expect(page.find("[data-controller='geo-area']")['data-geo-area-id-value'])
+        .to eq(geo_area.to_feature[:properties][:id])
+    end
+  end
+
+  context 'when editing' do
+    let(:editing) { true }
+
+    include_examples 'exposes the geojson feature id'
+  end
+
+  context 'when not editing' do
+    let(:editing) { false }
+
+    include_examples 'exposes the geojson feature id'
+  end
+end


### PR DESCRIPTION
## Résumé

Depuis l'ajout d'un `uuid` stable sur `GeoArea` pour l'identification cross-stream, dans [cette PR](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/13192), cliquer sur une zone dans "Sélections utilisateur" ne zoome plus dessus. 

Cf [ce retour au support](https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_4ffebec7-920a-4671-9795-73a195f89d01/)

`GeoArea#to_feature` expose désormais `id: (uuid || id).to_s` (une string) dans le GeoJSON, mais le composant/contrôleur front envoyait toujours l'`id` numérique brut lors du clic. La comparaison stricte (`===`) entre les deux ne matchait donc plus jamais.

## Changements

- `geo_area_component.html.haml` : utilise `geo_area.uuid || geo_area.id`
- `geo_area_controller.tsx` : value Stimulus `id` passée de `Number` à `String`