### PR TITLE
Correctif: ETQ usager, corriger l'accessibilité des tags de suppression

### DIFF
--- a/app/assets/stylesheets/combobox.scss
+++ b/app/assets/stylesheets/combobox.scss
@@ -27,33 +27,9 @@
     flex-wrap: wrap;
     gap: 0.3rem;
     margin-bottom: 0.5rem;
-  }
-  .fr-tag.fr-tag--dismiss {
-    position: relative;
-    cursor: pointer;
-    padding-right: 1.5rem;
-  }
-
-  .fr-tag--dismiss button {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    background: transparent;
-    border: none;
-    cursor: pointer;
-
-    &::after {
-      position: absolute;
-      right: 0.625rem;
-      top: 50%;
-      transform: translateY(-50%);
-    }
-
-    &:focus {
-      outline: 1px solid currentColor;
-      outline-offset: -2px;
-    }
+    list-style: none;
+    padding: 0;
+    margin-top: 0;
   }
 }
 

--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -10,9 +10,6 @@ import {
   Label,
   Text,
   Button,
-  TagGroup,
-  TagList,
-  Tag,
   Virtualizer,
   ListLayout,
   Collection
@@ -20,7 +17,6 @@ import {
 import { useMemo, useRef, createContext, useContext, useId } from 'react';
 import type { RefObject } from 'react';
 import * as s from 'superstruct';
-import { Trans, useLingui } from '@lingui/react/macro';
 
 import {
   useDispatchChangeEvent,
@@ -39,6 +35,7 @@ import {
   MultiComboBoxProps,
   RemoteComboBoxProps
 } from './react-aria/props';
+import { TagGroup } from './react-aria/components/TagGroup';
 
 function flattenSections(sections: Section[]): Item[] {
   return sections.flatMap((section) => section.items);
@@ -294,8 +291,6 @@ export function MultiComboBox(maybeProps: MultiComboBoxProps) {
   const { ref, dispatch } = useDispatchChangeEvent();
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const { t } = useLingui();
-
   const {
     selectedItems,
     hiddenInputValues,
@@ -327,37 +322,15 @@ export function MultiComboBox(maybeProps: MultiComboBoxProps) {
     [sections, filteredItems]
   );
 
-  const tagGroup =
-    selectedItems.length > 0 && !hideSelectedTags ? (
-      <TagGroup
-        onRemove={onRemove}
-        aria-label={props['aria-label']}
-        className={tagsBelow ? 'fr-mt-1w' : undefined}
-      >
-        <TagList items={selectedItems} className="fr-tag-list">
-          {selectedItems.map((item) => (
-            <Tag
-              key={item.value}
-              id={item.value}
-              textValue={t`Supprimer ${item.label}`}
-              className="fr-tag fr-tag--sm fr-tag--dismiss"
-            >
-              {item.label}
-              <Button
-                aria-labelledby=""
-                aria-label=""
-                slot="remove"
-                className="fr-tag--dismiss"
-              >
-                <span className="fr-sr-only">
-                  <Trans>Supprimer {item.label}</Trans>
-                </span>
-              </Button>
-            </Tag>
-          ))}
-        </TagList>
-      </TagGroup>
-    ) : null;
+  const tagGroup = !hideSelectedTags ? (
+    <TagGroup
+      items={selectedItems}
+      onRemove={(value) => onRemove(new Set([value]))}
+      fallbackFocusRef={inputRef}
+      className={`fr-tag-list${tagsBelow ? ' fr-mt-1w' : ''}`}
+      aria-label={props['aria-label']}
+    />
+  ) : null;
 
   const disabledKeys = useMemo(
     () => selectedItems.map((item) => item.value),

--- a/app/javascript/components/Select.tsx
+++ b/app/javascript/components/Select.tsx
@@ -6,20 +6,16 @@ import {
   Popover,
   Virtualizer,
   ListLayout,
-  TagGroup as AriaTagGroup,
-  TagList,
-  Tag,
   useFilter
 } from 'react-aria-components';
 import type {
   SelectProps as AriaSelectProps,
-  AutocompleteProps,
-  TagGroupProps
+  AutocompleteProps
 } from 'react-aria-components';
 import { useState, useMemo, useRef, useCallback, type Key } from 'react';
 import { flushSync } from 'react-dom';
 import * as s from 'superstruct';
-import { Plural, Trans, useLingui } from '@lingui/react/macro';
+import { Plural } from '@lingui/react/macro';
 
 import './react-aria/components/Select.css';
 import { SearchField } from './react-aria/components/SearchField';
@@ -32,6 +28,7 @@ import {
   SingleSelectProps,
   MultipleSelectProps
 } from './react-aria/props';
+import { TagGroup } from './react-aria/components/TagGroup';
 
 type SelectionMode = 'single' | 'multiple';
 type SelectProps<M extends SelectionMode = 'single'> = AriaSelectProps<
@@ -95,11 +92,12 @@ function Select<M extends SelectionMode = 'single'>({
 }
 
 function MultipleSelectValue() {
+  const selectButtonRef = useRef<HTMLButtonElement>(null);
   return (
     <SelectValue<Item>>
       {({ selectedItems, state, defaultChildren }) => (
         <>
-          <Button className="fr-select">
+          <Button className="fr-select" ref={selectButtonRef}>
             <span className="react-aria-SelectValue" data-placeholder>
               <Plural
                 value={selectedItems.length}
@@ -111,11 +109,13 @@ function MultipleSelectValue() {
           </Button>
           <TagGroup
             items={selectedItems.filter((item) => item != null)}
-            onRemove={(keys) => {
+            onRemove={(value) => {
               if (Array.isArray(state.value)) {
-                state.setValue(state.value.filter((k) => !keys.has(k)));
+                state.setValue(state.value.filter((k) => k !== value));
               }
             }}
+            fallbackFocusRef={selectButtonRef}
+            aria-label="Sélection"
           />
         </>
       )}
@@ -210,35 +210,5 @@ export function MultipleSelect(maybeProps: SelectProps<'multiple'>) {
         ))
       )}
     </>
-  );
-}
-
-function TagGroup({ items, ...props }: TagGroupProps & { items: Item[] }) {
-  const { t } = useLingui();
-  return (
-    <AriaTagGroup {...props} aria-label="selection">
-      <TagList items={items} className="fr-tag-list">
-        {(item) => (
-          <Tag
-            key={item.value}
-            id={item.value}
-            textValue={t`Supprimer ${item.label}`}
-            className="fr-tag fr-tag--sm fr-tag--dismiss"
-          >
-            {item.label}
-            <Button
-              aria-label=""
-              aria-labelledby=""
-              slot="remove"
-              className="fr-tag--dismiss"
-            >
-              <span className="fr-sr-only">
-                <Trans>Supprimer {item.label}</Trans>
-              </span>
-            </Button>
-          </Tag>
-        )}
-      </TagList>
-    </AriaTagGroup>
   );
 }

--- a/app/javascript/components/react-aria/components/Select.css
+++ b/app/javascript/components/react-aria/components/Select.css
@@ -35,33 +35,7 @@
     flex-wrap: wrap;
     gap: 0.25rem;
     margin-top: 0.25rem;
-  }
-
-  .fr-tag.fr-tag--dismiss {
-    position: relative;
-    cursor: pointer;
-    padding-right: 1.5rem;
-  }
-
-  .fr-tag--dismiss button {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    background: transparent;
-    border: none;
-    cursor: pointer;
-  }
-
-  .fr-tag--dismiss button::after {
-    position: absolute;
-    right: 0.625rem;
-    top: 50%;
-    transform: translateY(-50%);
-  }
-
-  .fr-tag--dismiss button:focus {
-    outline: 1px solid currentColor;
-    outline-offset: -2px;
+    list-style: none;
+    padding: 0;
   }
 }

--- a/app/javascript/components/react-aria/components/TagGroup.tsx
+++ b/app/javascript/components/react-aria/components/TagGroup.tsx
@@ -1,0 +1,58 @@
+import { useRef, type RefObject } from 'react';
+import { flushSync } from 'react-dom';
+import { useLingui } from '@lingui/react/macro';
+
+import type { Item } from '../props';
+
+export function TagGroup({
+  items,
+  onRemove,
+  fallbackFocusRef,
+  className,
+  'aria-label': ariaLabel
+}: {
+  items: Item[];
+  onRemove: (value: string) => void;
+  fallbackFocusRef: RefObject<HTMLElement | null>;
+  className?: string;
+  'aria-label'?: string;
+}) {
+  const tagListRef = useRef<HTMLUListElement>(null);
+  const { t } = useLingui();
+
+  if (items.length === 0) return null;
+
+  return (
+    <ul
+      ref={tagListRef}
+      className={className ?? 'fr-tag-list'}
+      aria-label={ariaLabel}
+    >
+      {items.map((item, index) => (
+        <li key={item.value}>
+          <button
+            type="button"
+            className="fr-tag fr-tag--sm fr-tag--dismiss"
+            aria-label={t`Supprimer ${item.label}`}
+            onClick={() => {
+              flushSync(() => {
+                onRemove(item.value);
+              });
+              const buttons =
+                tagListRef.current?.querySelectorAll<HTMLButtonElement>(
+                  'button.fr-tag--dismiss'
+                );
+              if (buttons && buttons.length > 0) {
+                buttons[Math.min(index, buttons.length - 1)].focus();
+              } else {
+                fallbackFocusRef.current?.focus();
+              }
+            }}
+          >
+            {item.label}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/app/javascript/components/react-aria/hooks.ts
+++ b/app/javascript/components/react-aria/hooks.ts
@@ -2,10 +2,7 @@ import { fire, httpRequest } from '@utils';
 import { matchSorter, type MatchSorterOptions } from 'match-sorter';
 import type { Key } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type {
-  ComboBoxProps as AriaComboBoxProps,
-  TagGroupProps
-} from 'react-aria-components';
+import type { ComboBoxProps as AriaComboBoxProps } from 'react-aria-components';
 import isEqual from 'react-fast-compare';
 import { useAsyncList, type AsyncListOptions } from 'react-stately';
 import { useEvent } from 'react-use-event-hook';
@@ -329,22 +326,20 @@ export function useMultiList({
     }
   );
 
-  const onRemove = useEvent<NonNullable<TagGroupProps['onRemove']>>(
-    (removedKeys) => {
-      setSelectedKeys((keys) => {
-        const selectedKeys = new Set(keys.values());
-        for (const key of removedKeys) {
-          selectedKeys.delete(String(key));
-        }
-        // focus input when all items are removed
-        if (selectedKeys.size == 0) {
-          focusInput?.();
-        }
-        return selectedKeys;
-      });
-      onChange?.();
-    }
-  );
+  const onRemove = useEvent<(keys: Set<Key>) => void>((removedKeys) => {
+    setSelectedKeys((keys) => {
+      const selectedKeys = new Set(keys.values());
+      for (const key of removedKeys) {
+        selectedKeys.delete(String(key));
+      }
+      // focus input when all items are removed
+      if (selectedKeys.size == 0) {
+        focusInput?.();
+      }
+      return selectedKeys;
+    });
+    onChange?.();
+  });
 
   const onReset = useEvent(() => {
     setSelectedKeys(new Set());

--- a/app/javascript/locales/en/messages.po
+++ b/app/javascript/locales/en/messages.po
@@ -14,16 +14,18 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: selectedItems.length
-#: app/javascript/components/Select.tsx:104
+#: app/javascript/components/Select.tsx:103
 msgid "{0, plural, =0 {{defaultChildren}} one {1 choix sélectionné} other {# "
 "choix sélectionnés}}"
 msgstr "{0, plural, =0 {{defaultChildren}} one {1 item selected} other {# items "
 "selected}}"
 
+#: app/javascript/components/Select.tsx:115
+msgid "Sélection"
+msgstr "Selection"
+
 #. placeholder {0}: item.label
-#: app/javascript/components/ComboBox.tsx:342
-#: app/javascript/components/ComboBox.tsx:353
-#: app/javascript/components/Select.tsx:225
-#: app/javascript/components/Select.tsx:236
+#: app/javascript/components/ComboBox.tsx:341
+#: app/javascript/components/Select.tsx:124
 msgid "Supprimer {0}"
 msgstr "Delete {0}"

--- a/app/javascript/locales/fr/messages.po
+++ b/app/javascript/locales/fr/messages.po
@@ -14,16 +14,18 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. placeholder {0}: selectedItems.length
-#: app/javascript/components/Select.tsx:104
+#: app/javascript/components/Select.tsx:103
 msgid "{0, plural, =0 {{defaultChildren}} one {1 choix sélectionné} other {# "
 "choix sélectionnés}}"
 msgstr "{0, plural, =0 {{defaultChildren}} one {1 choix sélectionné} other {# "
 "choix sélectionnés}}"
 
+#: app/javascript/components/Select.tsx:115
+msgid "Sélection"
+msgstr "Sélection"
+
 #. placeholder {0}: item.label
-#: app/javascript/components/ComboBox.tsx:342
-#: app/javascript/components/ComboBox.tsx:353
-#: app/javascript/components/Select.tsx:225
-#: app/javascript/components/Select.tsx:236
+#: app/javascript/components/ComboBox.tsx:341
+#: app/javascript/components/Select.tsx:124
 msgid "Supprimer {0}"
 msgstr "Supprimer {0}"

--- a/spec/system/instructeurs/procedure_filters_spec.rb
+++ b/spec/system/instructeurs/procedure_filters_spec.rb
@@ -277,7 +277,7 @@ describe "procedure filters" do
   def remove_column(column_name)
     click_on 'Personnaliser le tableau'
     within '.fr-tag-list' do
-      find('.fr-tag', text: column_name).find('button').click
+      find('.fr-tag', text: column_name).click
     end
     click_button "Enregistrer"
   end

--- a/spec/system/users/dropdown_spec.rb
+++ b/spec/system/users/dropdown_spec.rb
@@ -117,4 +117,32 @@ describe 'multiple dropdown tag removal', js: true do
     expect(page).not_to have_css('.fr-tag', text: 'Option 1')
     expect(page).to have_css('.fr-tag', text: 'Option 2')
   end
+
+  scenario 'tag is a single focusable button with proper aria-label' do
+    select_autocomplete('Multi choix', 'Option 1')
+    select_autocomplete('Multi choix', 'Option 2')
+
+    expect(page).to have_css('.fr-tag', text: 'Option 1')
+
+    tag_button = find('button.fr-tag--dismiss[aria-label="Supprimer Option 1"]')
+    expect(tag_button.tag_name).to eq('button')
+    expect(tag_button['aria-label']).to eq('Supprimer Option 1')
+
+    tag_button.click
+    expect(page).not_to have_css('.fr-tag', text: 'Option 1')
+    expect(page).to have_css('.fr-tag', text: 'Option 2')
+  end
+
+  scenario 'keyboard navigation: tab moves between tags, no double focus' do
+    select_autocomplete('Multi choix', 'Option 1')
+    select_autocomplete('Multi choix', 'Option 2')
+    select_autocomplete('Multi choix', 'Option 3')
+
+    tag1 = find('button.fr-tag--dismiss[aria-label="Supprimer Option 1"]')
+    tag1.send_keys(:tab)
+    expect(page.evaluate_script('document.activeElement.getAttribute("aria-label")')).to eq('Supprimer Option 2')
+
+    find('button.fr-tag--dismiss[aria-label="Supprimer Option 2"]').send_keys(:tab)
+    expect(page.evaluate_script('document.activeElement.getAttribute("aria-label")')).to eq('Supprimer Option 3')
+  end
 end


### PR DESCRIPTION
# Problème

Les tags de suppression (ComboBox multi-select et Select multiple) posent 3 problèmes d'accessibilité ([#13403](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/issues/13403)) :

1. **Double focus clavier** : React Aria TagGroup crée une grille (`role="row"`) avec un bouton imbriqué — Tab focus d'abord le row puis le bouton, ce qui double le nombre d'arrêts clavier
2. **Focus peu visible** : le bouton de suppression utilise `outline: 1px solid currentColor; offset: -2px` au lieu du standard DSFR (`2px solid #0a76f6; offset: 2px`)
3. **Vocalisation trompeuse** : le lecteur d'écran annonce "Supprimer XX" sur le row (qui n'est pas interactif), pas sur le bouton

# Solution

Remplacement de `TagGroup`/`TagList`/`Tag` de React Aria par des `<button>` DSFR natifs (`fr-tag fr-tag--dismiss`), conformes au pattern DSFR des tags supprimables :

- Chaque tag est un seul `<button>` focusable avec `aria-label="Supprimer {label}"`
- Le focus clavier passe d'un tag à l'autre en un seul Tab (pas de double focus)
- Le style de focus est hérité du DSFR (plus besoin de CSS custom)
- Après suppression d'un tag, le focus se déplace sur le tag suivant ; après suppression du dernier, le focus retourne sur l'input

Appliqué à `ComboBox.tsx` (multi-select autocomplete) et `Select.tsx` (multi-select dropdown).

Closes #13403

Generated with [Claude Code](https://claude.com/claude-code)