### PR TITLE
Correctif : ETQ usager, je vois les numéros de parcelle sur la carte cadastrale

### DIFF
--- a/app/javascript/components/shared/maplibre/styles/layers/cadastre.ts
+++ b/app/javascript/components/shared/maplibre/styles/layers/cadastre.ts
@@ -82,6 +82,24 @@ export const layers: LayerSpecification[] = [
     }
   },
   {
+    id: 'parcelles-labels',
+    type: 'symbol',
+    source: 'cadastre',
+    'source-layer': 'parcelles',
+    minzoom: 16,
+    layout: {
+      visibility: 'visible',
+      'text-field': ['get', 'numero'],
+      'text-font': ['Noto Sans Bold'],
+      'text-size': 12
+    },
+    paint: {
+      'text-color': 'rgba(0, 0, 0, 1)',
+      'text-halo-color': 'rgba(255, 255, 255, 1)',
+      'text-halo-width': 1
+    }
+  },
+  {
     id: 'parcelle-highlighted',
     type: 'fill',
     source: 'cadastre',


### PR DESCRIPTION
## Résumé
Suite à un refactor datant de... juillet 2020 (ce [commit](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/commit/f1cbc9846e), lignes 2260-2290 du fichier supprimé `app/javascript/components/MapStyles/orthoCadastre.json` ), on n'affichait plus les numéros de parcelle sur la carte du champ carte avec l'option cadastres activée (merci Claude code, je l'aurais pas trouvé tout seul cette régression 😅).

## Correction
Ajout d'une couche `symbol` `parcelles-labels` dans le style cadastre (`text-field: numero`), reprenant le rendu d'origine (halo blanc, texte noir).