### PR TITLE
Tech: fix N+1 sur instructeur et expert dans la messagerie

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -61,7 +61,7 @@ class Dossier < ApplicationRecord
   has_many :champs, dependent: :destroy
   has_many :commentaires, inverse_of: :dossier, dependent: :destroy
   has_many :commentaires_chronological, -> { chronological }, class_name: 'Commentaire', inverse_of: :dossier
-  has_many :preloaded_commentaires, -> { includes(:dossier_correction, :dossier_pending_response, piece_jointe_attachments: :blob).order(created_at: :desc) }, class_name: 'Commentaire', inverse_of: :dossier
+  has_many :preloaded_commentaires, -> { includes(:dossier_correction, :dossier_pending_response, :instructeur, :expert, piece_jointe_attachments: :blob).order(created_at: :desc) }, class_name: 'Commentaire', inverse_of: :dossier
 
   has_many :invites, dependent: :destroy
   has_many :follows, -> { active }, inverse_of: :dossier, dependent: :destroy


### PR DESCRIPTION
# Probleme

N+1 queries sur les associations `instructeur` et `expert` de `Commentaire` lors du rendu de la messagerie.

**Call chain** (preuve par le code) :

```
Instructeurs::DossiersController#messagerie
Users::DossiersController#messagerie
Experts::AvisController#messagerie
  → shared/dossiers/_messagerie.html.haml
    → Dossiers::CommentaireListComponent
      → dossier.preloaded_commentaires  (app/models/dossier.rb:64)
        → Dossiers::MessageComponent (pour chaque commentaire)
          → commentaire_issuer → Commentaire#redacted_email → instructeur.email  ← SELECT par commentaire
          → commentaire_from_guest? → Commentaire#email → instructeur.email / expert.email  ← SELECT par commentaire
          → sent_by_connected_user? → Commentaire#sent_by? → Commentaire#email  ← SELECT par commentaire
```

`Commentaire#email` (app/models/commentaire.rb:53) charge `instructeur` ou `expert` par lazy-load. Pour N commentaires d'instructeurs, ca fait N requetes `SELECT "instructeurs".* FROM "instructeurs" WHERE "instructeurs"."id" = $1`.

**Note** : le path GraphQL (`API::V2::GraphqlController`) est deja couvert par un batch loader dans `DossierType#messages` (app/graphql/types/dossier_type.rb:152).

# Solution

Ajout de `:instructeur, :expert` dans le scope `preloaded_commentaires` existant :

```ruby
# avant
has_many :preloaded_commentaires, -> {
  includes(:dossier_correction, :dossier_pending_response, piece_jointe_attachments: :blob)
    .order(created_at: :desc)
}, class_name: 'Commentaire', inverse_of: :dossier

# apres
has_many :preloaded_commentaires, -> {
  includes(:dossier_correction, :dossier_pending_response, :instructeur, :expert, piece_jointe_attachments: :blob)
    .order(created_at: :desc)
}, class_name: 'Commentaire', inverse_of: :dossier
```

N+1 → 2 requetes fixes (une pour `instructeurs`, une pour `experts`), quel que soit le nombre de commentaires.

### Endpoints impactes

| Controller | Action |
|------------|--------|
| `Instructeurs::DossiersController` | `#messagerie` |
| `Users::DossiersController` | `#messagerie` |
| `Experts::AvisController` | `#messagerie` |
| Turbo Stream | `shared/dossiers/create_commentaire` |

### Validation

- [x] Tests existants passent (`spec/models/dossier_spec.rb` - `preloaded_commentaires`)
- [x] Rubocop OK
- [x] Seul fichier modifie : `app/models/dossier.rb`