### PR TITLE
Tech: renommer le modèle Champ en ChampData

### DIFF
--- a/app/components/attachment/gallery_item_component.rb
+++ b/app/components/attachment/gallery_item_component.rb
@@ -14,9 +14,9 @@ class Attachment::GalleryItemComponent < ApplicationComponent
 
   def origin
     case record
-    in Champ if record.public?
+    in ChampData if record.public?
       t(".dossier_usager")
-    in Champ if record.private?
+    in ChampData if record.private?
       t(".annotation_privee")
     in Commentaire if record.instructeur.present?
       t(".messagerie_instructeur")
@@ -38,7 +38,7 @@ class Attachment::GalleryItemComponent < ApplicationComponent
   end
 
   def updated?
-    record.is_a?(Champ) && record.public? && updated_at > record.dossier.depose_at
+    record.is_a?(ChampData) && record.public? && updated_at > record.dossier.depose_at
   end
 
   def updated_at

--- a/app/components/dsfr/input_component.rb
+++ b/app/components/dsfr/input_component.rb
@@ -77,7 +77,7 @@ class Dsfr::InputComponent < ApplicationComponent
 
   def error_id
     case object
-    when Champ
+    when ChampData
       object.error_id(@attribute)
     else
       describedby_id

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -31,7 +31,7 @@ module Dsfr
       def errors_on_attribute?
         # When the object is a Champ, errors can be stored as nested errors on the dossier
         # or directly on the champ object
-        if object.is_a?(Champ)
+        if object.is_a?(ChampData)
           dossier_errors_for_champ.any? || errors.any?
         else
           errors.has_key?(attribute_or_rich_body)
@@ -43,7 +43,7 @@ module Dsfr
         # When the object is a Champ, errors can be stored as nested errors on the dossier
         # because validation adds errors to champ instances that may differ from the form object
         # or directly on the champ object
-        if object.is_a?(Champ)
+        if object.is_a?(ChampData)
           # Keep only message text (without attribute prefix) to avoid displaying
           # the same error twice with two different formats.
           (dossier_errors_for_champ + errors.map(&:message)).uniq

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -102,7 +102,7 @@ class AttachmentsController < ApplicationController
   end
 
   def record = @attachment.record
-  def champ? = record.is_a?(Champ)
+  def champ? = record.is_a?(ChampData)
   def procedure? = record.is_a?(Procedure)
   def avis? = record.is_a?(Avis)
   def attestation_template? = record.is_a?(AttestationTemplate)

--- a/app/graphql/mutations/dossier_modifier_annotation.rb
+++ b/app/graphql/mutations/dossier_modifier_annotation.rb
@@ -41,7 +41,7 @@ module Mutations
     end
 
     def find_annotation(dossier, annotation_id)
-      stable_id, row_id = Champ.decode_typed_id(annotation_id)
+      stable_id, row_id = ChampData.decode_typed_id(annotation_id)
       type_de_champ = dossier.find_type_de_champ_by_stable_id(stable_id, :private)
 
       return nil if type_de_champ.nil? || !type_de_champ.type_champ.in?(annotation_type_champ)

--- a/app/graphql/mutations/dossier_modifier_annotation_ajouter_ligne.rb
+++ b/app/graphql/mutations/dossier_modifier_annotation_ajouter_ligne.rb
@@ -29,7 +29,7 @@ module Mutations
     private
 
     def find_annotation(dossier, annotation_id)
-      stable_id, _row_id = Champ.decode_typed_id(annotation_id)
+      stable_id, _row_id = ChampData.decode_typed_id(annotation_id)
       type_de_champ = dossier.find_type_de_champ_by_stable_id(stable_id, :private)
 
       return nil if type_de_champ.nil? || !type_de_champ.repetition?

--- a/app/graphql/mutations/dossier_modifier_annotations.rb
+++ b/app/graphql/mutations/dossier_modifier_annotations.rb
@@ -67,7 +67,7 @@ module Mutations
     end
 
     def find_annotation(dossier, annotation)
-      stable_id, row_id = Champ.decode_typed_id(annotation.id)
+      stable_id, row_id = ChampData.decode_typed_id(annotation.id)
       type_de_champ = dossier.find_type_de_champ_by_stable_id(stable_id, :private)
       return :not_found if type_de_champ.nil? || !type_de_champ.type_champ.in?(accepted_types)
 

--- a/app/graphql/types/columns/attachments_column_type.rb
+++ b/app/graphql/types/columns/attachments_column_type.rb
@@ -10,7 +10,7 @@ module Types::Columns
       # In the dossier → champs → columns path, `parent` is a Champ and we
       # batch-preload attachments. In the changedColumns path, `parent` is a
       # Traitement and the value is already precomputed by ChangedColumn.
-      return object.value(parent) unless parent.is_a?(Champ)
+      return object.value(parent) unless parent.is_a?(ChampData)
 
       dataloader.with(Sources::Association, piece_justificative_file_attachments: :blob).load(parent)
       object.value(parent)

--- a/app/graphql/types/personne_morale_type.rb
+++ b/app/graphql/types/personne_morale_type.rb
@@ -118,7 +118,7 @@ module Types
     field :complement_adresse, String, null: true, deprecation_reason: "Utilisez le champ `address` à la place."
 
     def address
-      address = object.champ&.value_json
+      address = object.champ_data&.value_json
       if address.blank? || !address.key?("departement_code")
         address = APIGeoService.parse_etablissement_address(object)
       end

--- a/app/helpers/champ_helper.rb
+++ b/app/helpers/champ_helper.rb
@@ -10,7 +10,7 @@ module ChampHelper
   end
 
   def auto_attach_url(object, procedure_id: nil)
-    if object.is_a?(Champ)
+    if object.is_a?(ChampData)
       champs_piece_justificative_url(object.dossier, object.stable_id, row_id: object.row_id)
     elsif object.is_a?(TypeDeChamp) && object.piece_justificative?
       piece_justificative_template_admin_procedure_type_de_champ_url(stable_id: object.stable_id, procedure_id:)

--- a/app/helpers/gallery_helper.rb
+++ b/app/helpers/gallery_helper.rb
@@ -3,7 +3,7 @@
 module GalleryHelper
   def record_libelle(record)
     case record
-    in Champ
+    in ChampData
       record.libelle
     in Commentaire
       'Pièce jointe au message'

--- a/app/jobs/api_entreprise/job.rb
+++ b/app/jobs/api_entreprise/job.rb
@@ -58,8 +58,8 @@ class APIEntreprise::Job < ApplicationJob
     if etablissement.present?
       if etablissement.dossier.present?
         etablissement.dossier.log_api_entreprise_job_exception(exception)
-      elsif etablissement.champ.present?
-        etablissement.champ.save_additional_job_exception(exception, :unkonwn)
+      elsif etablissement.champ_data.present?
+        etablissement.champ_data.save_additional_job_exception(exception, :unkonwn)
       end
     end
   end

--- a/app/jobs/backfill_variants_for_dossier_job.rb
+++ b/app/jobs/backfill_variants_for_dossier_job.rb
@@ -9,7 +9,7 @@ class BackfillVariantsForDossierJob < ApplicationJob
   def perform(dossier_id, file_type)
     dossier = Dossier.find(dossier_id)
 
-    champ_ids = Champ
+    champ_ids = ChampData
       .where(dossier_id: dossier)
       .where(type: "Champs::PieceJustificativeChamp")
       .ids

--- a/app/jobs/cron/backfill_siret_degraded_mode_job.rb
+++ b/app/jobs/cron/backfill_siret_degraded_mode_job.rb
@@ -22,9 +22,9 @@ class Cron::BackfillSiretDegradedModeJob < Cron::CronJob
   end
 
   def fix_etablissement_with_champs
-    Etablissement.joins(:champ).where(adresse: nil).find_each do |etablissement|
+    Etablissement.joins(:champ_data).where(adresse: nil).find_each do |etablissement|
       begin
-        procedure_id = etablissement.champ.procedure.id
+        procedure_id = etablissement.champ_data.procedure.id
 
         APIEntrepriseService.update_etablissement_from_degraded_mode(etablissement, procedure_id)
       rescue => e

--- a/app/jobs/migrations/backfill_row_id_job.rb
+++ b/app/jobs/migrations/backfill_row_id_job.rb
@@ -3,7 +3,7 @@
 class Migrations::BackfillRowIdJob < ApplicationJob
   def perform(batch)
     batch.each do |(row_id, champ_ids)|
-      Champ.where(id: champ_ids).update_all(row_id:)
+      ChampData.where(id: champ_ids).update_all(row_id:)
     end
   end
 end

--- a/app/jobs/migrations/backfill_stable_id_job.rb
+++ b/app/jobs/migrations/backfill_stable_id_job.rb
@@ -13,7 +13,7 @@ class Migrations::BackfillStableIdJob < ApplicationJob
     query = ActiveRecord::Base.sanitize_sql_array([sql, limit])
     ActiveRecord::Base.connection.execute(query)
 
-    if Champ.exists?(stable_id: nil)
+    if ChampData.exists?(stable_id: nil)
       Migrations::BackfillStableIdJob.set(wait: 2.seconds).perform_later(iteration + 1, limit)
     end
   end

--- a/app/lib/recovery/importer.rb
+++ b/app/lib/recovery/importer.rb
@@ -110,7 +110,7 @@ module Recovery
             Etablissement.insert(champ.etablissement.attributes)
           end
 
-          Champ.insert(champ.attributes)
+          ChampData.insert(champ.attributes)
 
           if champ.geo_areas.present?
             champ.geo_areas.each { GeoArea.insert(_1.attributes) }

--- a/app/models/address_proxy.rb
+++ b/app/models/address_proxy.rb
@@ -51,7 +51,7 @@ class AddressProxy
 
   def make(champ_or_etablissement)
     case champ_or_etablissement
-    when Champ then ChampAddressPresenter.new(champ_or_etablissement)
+    when ChampData then ChampAddressPresenter.new(champ_or_etablissement)
     when Etablissement then EtablissementAddressPresenter.new(champ_or_etablissement)
     else raise NotImplementedError("Unsupported address from #{champ_or_etablissement.class.name}")
     end

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champ < ApplicationRecord
+class ChampData < ApplicationRecord
   include ChampConditionalConcern
   include ChampValidateConcern
   include ChampRevisionConcern
@@ -8,7 +8,27 @@ class Champ < ApplicationRecord
   include ChampStreamConcern
   include ChampPrefillTrackingConcern
 
+  self.table_name = 'champs'
   self.ignored_columns += [:type_de_champ_id, :parent_id]
+
+  # Polymorphic references (active_storage_attachments.record_type) predate the
+  # rename and store 'Champ'; keep writing the historical name so old and new
+  # rows stay uniform. The read side is resolved by
+  # ChampDataPolymorphicNameResolution (initializer).
+  def self.polymorphic_name
+    'Champ'
+  end
+
+  # i18n lookups (activerecord.errors.models.champ.*) and dom ids predate the
+  # rename. Scoped to the base class so STI subclasses keep their own
+  # champs/* i18n keys.
+  def self.model_name
+    if self == ChampData
+      @champ_model_name ||= ActiveModel::Name.new(self, nil, 'Champ')
+    else
+      super
+    end
+  end
 
   attr_readonly :stable_id
 
@@ -18,7 +38,10 @@ class Champ < ApplicationRecord
   # We declare champ specific relationships (Champs::CarteChamp, Champs::SiretChamp and Champs::RepetitionChamp)
   # here because otherwise we can't easily use includes in our queries.
   has_many :geo_areas, -> { order(:created_at) }, dependent: :destroy, inverse_of: :champ
-  belongs_to :etablissement, optional: true, dependent: :destroy
+  # inverse_of can no longer be inferred automatically: Rails derives the
+  # inverse name from the defining class (:champ_data), but the association
+  # on the other side is still named :champ.
+  belongs_to :etablissement, optional: true, dependent: :destroy, inverse_of: :champ
 
   delegate :procedure, to: :dossier
   normalizes :value, with: NORMALIZES_NON_PRINTABLE_PROC
@@ -258,7 +281,7 @@ class Champ < ApplicationRecord
     relationships = !private? ? [:etablissement, :geo_areas] : []
 
     deep_clone(only: champ_attributes + value_attributes, include: relationships, validate: true) do |original, kopy|
-      if original.is_a?(Champ)
+      if original.is_a?(ChampData)
         kopy.write_attribute(:stable_id, original.stable_id)
         kopy.write_attribute(:stream, Dossier::MAIN_STREAM)
       end
@@ -280,7 +303,7 @@ class Champ < ApplicationRecord
 
   def clear
     update_columns(value: nil, value_json: nil, external_id: nil, data: nil)
-    Champ.no_touching do
+    ChampData.no_touching do
       etablissement&.destroy
       geo_areas.destroy_all
       piece_justificative_file.purge_later

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -37,11 +37,8 @@ class ChampData < ApplicationRecord
 
   # We declare champ specific relationships (Champs::CarteChamp, Champs::SiretChamp and Champs::RepetitionChamp)
   # here because otherwise we can't easily use includes in our queries.
-  has_many :geo_areas, -> { order(:created_at) }, dependent: :destroy, inverse_of: :champ
-  # inverse_of can no longer be inferred automatically: Rails derives the
-  # inverse name from the defining class (:champ_data), but the association
-  # on the other side is still named :champ.
-  belongs_to :etablissement, optional: true, dependent: :destroy, inverse_of: :champ
+  has_many :geo_areas, -> { order(:created_at) }, dependent: :destroy, inverse_of: :champ_data
+  belongs_to :etablissement, optional: true, dependent: :destroy, inverse_of: :champ_data
 
   delegate :procedure, to: :dossier
   normalizes :value, with: NORMALIZES_NON_PRINTABLE_PROC

--- a/app/models/champs/boolean_champ.rb
+++ b/app/models/champs/boolean_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::BooleanChamp < Champ
+class Champs::BooleanChamp < ChampData
   TRUE_VALUE = 'true'
   FALSE_VALUE = 'false'
 

--- a/app/models/champs/carte_champ.rb
+++ b/app/models/champs/carte_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::CarteChamp < Champ
+class Champs::CarteChamp < ChampData
   # Default map location. Center of the World, ahm, France...
   DEFAULT_LON = 2.428462
   DEFAULT_LAT = 46.538192

--- a/app/models/champs/civilite_champ.rb
+++ b/app/models/champs/civilite_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::CiviliteChamp < Champ
+class Champs::CiviliteChamp < ChampData
   validates :value, inclusion: [Individual::GENDER_MALE, Individual::GENDER_FEMALE], allow_nil: true, allow_blank: false, if: :should_validate_in_current_context?
 
   def legend_label?

--- a/app/models/champs/cojo_champ.rb
+++ b/app/models/champs/cojo_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::COJOChamp < Champ
+class Champs::COJOChamp < ChampData
   store :external_id, accessors: [:accreditation_number, :accreditation_birthdate], coder: JSON
   store_accessor :data, :accreditation_success, :accreditation_first_name, :accreditation_last_name
 

--- a/app/models/champs/date_champ.rb
+++ b/app/models/champs/date_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::DateChamp < Champ
+class Champs::DateChamp < ChampData
   attr_accessor :prefilling_from_france_connect_information
 
   validates_with DateLimitValidator, if: :should_validate_in_current_context?

--- a/app/models/champs/datetime_champ.rb
+++ b/app/models/champs/datetime_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::DatetimeChamp < Champ
+class Champs::DatetimeChamp < ChampData
   validates_with DateLimitValidator, if: :should_validate_in_current_context?
   normalizes :value, with: -> { DateDetectionUtils.convert_to_iso8601_datetime(it) }
   validate :iso_8601

--- a/app/models/champs/decimal_number_champ.rb
+++ b/app/models/champs/decimal_number_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::DecimalNumberChamp < Champ
+class Champs::DecimalNumberChamp < ChampData
   validates_with NumberFormatValidator, if: :should_validate_in_current_context?
   validates_with NumberLimitValidator, if: :should_validate_in_current_context?
   normalizes :value, with: -> { NumberFormatValidator.normalize(it, decimal: true) }

--- a/app/models/champs/dossier_link_champ.rb
+++ b/app/models/champs/dossier_link_champ.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class Champs::DossierLinkChamp < Champ
+class Champs::DossierLinkChamp < ChampData
   validates_with DossierLinkValidator, if: -> { should_validate_in_current_context? && value.present? }
 end

--- a/app/models/champs/drop_down_list_champ.rb
+++ b/app/models/champs/drop_down_list_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::DropDownListChamp < Champ
+class Champs::DropDownListChamp < ChampData
   store_accessor :value_json, :other, :referentiel
   THRESHOLD_NB_OPTIONS_AS_RADIO = 5
   THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE = 20

--- a/app/models/champs/engagement_juridique_champ.rb
+++ b/app/models/champs/engagement_juridique_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::EngagementJuridiqueChamp < Champ
+class Champs::EngagementJuridiqueChamp < ChampData
   # cf: https://communaute.chorus-pro.gouv.fr/documentation/creer-un-engagement/#1522314752186-a34f3662-0644b5d1-16c22add-8ea097de-3a0a
   validates_with ExpressionReguliereValidator,
                 expression_reguliere: /([A-Z]|[0-9]|\-|\_|\+|\/)+/,

--- a/app/models/champs/formatted_champ.rb
+++ b/app/models/champs/formatted_champ.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class Champs::FormattedChamp < Champ
+class Champs::FormattedChamp < ChampData
   validates_with FormattedChampValidator, if: :should_validate_in_current_context?
 end

--- a/app/models/champs/france_connect_champ.rb
+++ b/app/models/champs/france_connect_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::FranceConnectChamp < Champ
+class Champs::FranceConnectChamp < ChampData
   REFRESH_DELAY = 24.hours
 
   attr_accessor :preview_state

--- a/app/models/champs/header_section_champ.rb
+++ b/app/models/champs/header_section_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::HeaderSectionChamp < Champ
+class Champs::HeaderSectionChamp < ChampData
   def search_terms
     # The user cannot enter any information here so it doesn’t make much sense to search
   end

--- a/app/models/champs/iban_champ.rb
+++ b/app/models/champs/iban_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::IbanChamp < Champ
+class Champs::IbanChamp < ChampData
   validates_with IbanValidator, if: :should_validate_in_current_context?
   after_validation :format_iban
 

--- a/app/models/champs/integer_number_champ.rb
+++ b/app/models/champs/integer_number_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::IntegerNumberChamp < Champ
+class Champs::IntegerNumberChamp < ChampData
   validates_with NumberFormatValidator, if: :should_validate_in_current_context?
   validates_with NumberLimitValidator, if: :should_validate_in_current_context?
   normalizes :value, with: -> { NumberFormatValidator.normalize(it) }

--- a/app/models/champs/linked_drop_down_list_champ.rb
+++ b/app/models/champs/linked_drop_down_list_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::LinkedDropDownListChamp < Champ
+class Champs::LinkedDropDownListChamp < ChampData
   delegate :primary_options, :secondary_options, to: :type_de_champ
 
   def primary_value

--- a/app/models/champs/multiple_drop_down_list_champ.rb
+++ b/app/models/champs/multiple_drop_down_list_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::MultipleDropDownListChamp < Champ
+class Champs::MultipleDropDownListChamp < ChampData
   store_accessor :value_json, :referentiels
   validates_with DropDownOptionsValidator, if: -> { value.present? && should_validate_in_current_context? }
   before_save :store_referentiels, if: :drop_down_advanced?

--- a/app/models/champs/number_champ.rb
+++ b/app/models/champs/number_champ.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-class Champs::NumberChamp < Champ
+class Champs::NumberChamp < ChampData
 end

--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::PieceJustificativeChamp < Champ
+class Champs::PieceJustificativeChamp < ChampData
   FILE_MAX_SIZE = 200.megabytes
 
   has_many_attached :piece_justificative_file

--- a/app/models/champs/pre_rempli_champ.rb
+++ b/app/models/champs/pre_rempli_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::PreRempliChamp < Champ
+class Champs::PreRempliChamp < ChampData
   def selected
     value
   end

--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::ReferentielChamp < Champ
+class Champs::ReferentielChamp < ChampData
   delegate :referentiel,
            :referentiel_mapping_displayable,
            :referentiel_mapping_prefillable_with_stable_id,

--- a/app/models/champs/repetition_champ.rb
+++ b/app/models/champs/repetition_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::RepetitionChamp < Champ
+class Champs::RepetitionChamp < ChampData
   delegate :libelle_for_export, to: :type_de_champ
 
   def row_libelle

--- a/app/models/champs/rna_champ.rb
+++ b/app/models/champs/rna_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::RNAChamp < Champ
+class Champs::RNAChamp < ChampData
   RNA_REGEXP = /\AW[0-9A-Z]{9}\z/
 
   validates :external_id, allow_blank: true, format: {

--- a/app/models/champs/rnf_champ.rb
+++ b/app/models/champs/rnf_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::RNFChamp < Champ
+class Champs::RNFChamp < ChampData
   RNF_REGEXP = /\A[A-Za-z0-9-]{12,20}\z/i.freeze
 
   store_accessor :data, :title, :email, :phone, :createdAt, :updatedAt, :dissolvedAt, :address

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Champs::SiretChamp < Champ
+class Champs::SiretChamp < ChampData
   include Dry::Monads[:result]
   validate :validate_etablissement, if: :should_validate_in_current_context?
   normalizes :external_id, with: -> siret { siret.gsub(/[[:space:]]/, "") }

--- a/app/models/champs/text_champ.rb
+++ b/app/models/champs/text_champ.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-class Champs::TextChamp < Champ
+class Champs::TextChamp < ChampData
 end

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -5,15 +5,15 @@ module DossierChampsConcern
 
   def project_champ(type_de_champ, row_id: nil)
     check_valid_row_id_on_read?(type_de_champ, row_id)
-    champ = champs_by_public_id[type_de_champ.public_id(row_id)]
-    if champ.nil? || !champ.is_type?(type_de_champ.type_champ)
-      value = type_de_champ.champ_blank?(champ) ? nil : champ.value
-      updated_at = champ&.updated_at || depose_at || created_at
-      rebased_at = champ&.rebased_at
+    data = champ_data_by_public_id[type_de_champ.public_id(row_id)]
+    if data.nil? || !data.is_type?(type_de_champ.type_champ)
+      value = type_de_champ.champ_blank?(data) ? nil : data.value
+      updated_at = data&.updated_at || depose_at || created_at
+      rebased_at = data&.rebased_at
       type_de_champ.build_champ(dossier: self, row_id:, updated_at:, rebased_at:, value:, stream:)
     else
-      champ.type_de_champ = type_de_champ
-      champ
+      data.type_de_champ = type_de_champ
+      data
     end
   end
 
@@ -153,7 +153,7 @@ module DossierChampsConcern
   def repetition_row_ids(type_de_champ)
     return [] if !type_de_champ.repetition?
     @repetition_row_ids ||= {}
-    @repetition_row_ids[type_de_champ.stable_id] ||= champs_on_stream
+    @repetition_row_ids[type_de_champ.stable_id] ||= champ_data_on_stream
       .filter { _1.row? && _1.stable_id == type_de_champ.stable_id && !_1.discarded? }
       .map(&:row_id)
       .sort
@@ -183,19 +183,19 @@ module DossierChampsConcern
   end
 
   def merge_user_buffer_stream!
-    buffer_ids, changed_ids = changed_champ_ids_for_merge(Dossier::USER_BUFFER_STREAM)
+    buffer_ids, changed_ids = changed_champ_data_ids_for_merge(Dossier::USER_BUFFER_STREAM)
 
     return if buffer_ids.blank?
 
-    merge_buffer_champs(buffer_ids, changed_ids, Dossier::USER_BUFFER_STREAM)
+    merge_buffer_champ_data(buffer_ids, changed_ids, Dossier::USER_BUFFER_STREAM)
   end
 
   def merge_instructeur_buffer_stream!
-    buffer_ids, changed_ids = changed_champ_ids_for_merge(Dossier::INSTRUCTEUR_BUFFER_STREAM)
+    buffer_ids, changed_ids = changed_champ_data_ids_for_merge(Dossier::INSTRUCTEUR_BUFFER_STREAM)
 
     return if buffer_ids.blank?
 
-    merge_buffer_champs(buffer_ids, changed_ids, Dossier::INSTRUCTEUR_BUFFER_STREAM)
+    merge_buffer_champ_data(buffer_ids, changed_ids, Dossier::INSTRUCTEUR_BUFFER_STREAM)
   end
 
   def reset_user_buffer_stream!
@@ -217,11 +217,11 @@ module DossierChampsConcern
   end
 
   def user_buffer_changes?
-    champs_on_user_buffer_stream.present?
+    champ_data_on_user_buffer_stream.present?
   end
 
   def instructeur_buffer_changes?
-    champs_on_instructeur_buffer_stream.present?
+    champ_data_on_instructeur_buffer_stream.present?
   end
 
   def history
@@ -230,9 +230,9 @@ module DossierChampsConcern
 
   def set_default_value_for_france_connect_champs(user_email)
     revision.root_types_de_champ_public.filter(&:france_connect?).each do |type_de_champ|
-      existing_champ_on_main_stream = champs_on_main_stream.any? { _1.stable_id == type_de_champ.stable_id }
+      existing_champ_data_on_main_stream = champ_data_on_main_stream.any? { _1.stable_id == type_de_champ.stable_id }
 
-      next if existing_champ_on_main_stream && en_construction?
+      next if existing_champ_data_on_main_stream && en_construction?
 
       champ = champ_for_update(type_de_champ, updated_by: user_email)
 
@@ -242,7 +242,7 @@ module DossierChampsConcern
 
   def user_changed_columns
     if user_buffer_changes?
-      ChangedColumn.columns(revision, champs_on_user_buffer_stream.index_by(&:public_id), champs_on_main_stream.index_by(&:public_id))
+      ChangedColumn.columns(revision, champ_data_on_user_buffer_stream.index_by(&:public_id), champ_data_on_main_stream.index_by(&:public_id))
     else
       []
     end
@@ -250,7 +250,7 @@ module DossierChampsConcern
 
   def instructeur_changed_columns
     if instructeur_buffer_changes?
-      ChangedColumn.columns(revision, champs_on_instructeur_buffer_stream.index_by(&:public_id), champs_on_main_stream.index_by(&:public_id))
+      ChangedColumn.columns(revision, champ_data_on_instructeur_buffer_stream.index_by(&:public_id), champ_data_on_main_stream.index_by(&:public_id))
     else
       []
     end
@@ -258,7 +258,7 @@ module DossierChampsConcern
 
   private
 
-  def changed_champ_ids_for_merge(stream)
+  def changed_champ_data_ids_for_merge(stream)
     stream_h = champ_data.where(stream:, stable_id: revision_stable_ids)
       .pluck(:stable_id, :row_id, :id)
       .to_h { |(stable_id, row_id, id)| [TypeDeChamp.public_id(stable_id, row_id), id] }
@@ -288,10 +288,10 @@ module DossierChampsConcern
     [stream_ids, changed_ids]
   end
 
-  def merge_buffer_champs(buffer_ids, changed_ids, stream)
+  def merge_buffer_champ_data(buffer_ids, changed_ids, stream)
     now = Time.zone.now
     history_stream = "#{Dossier::HISTORY_STREAM}#{now}"
-    buffer_champs = champ_data.filter { buffer_ids.member?(it.id) }
+    buffer_champ_data = champ_data.filter { buffer_ids.member?(it.id) }
 
     transaction do
       # if merging user buffer, discard any instructeur made changes
@@ -305,41 +305,41 @@ module DossierChampsConcern
       champ_data.where(id: changed_ids, stream: Dossier::MAIN_STREAM).update_all(stream: history_stream)
       # move champ_data from "buffer" to "main"
       champ_data.where(id: buffer_ids, stream:).update_all(stream: Dossier::MAIN_STREAM, updated_at: now, checkpoint: history_stream)
-      update_champs_timestamps(buffer_champs, stream)
+      update_champs_timestamps(buffer_champ_data, stream)
     end
 
-    # update loaded champ instances
-    champ_data.each do |champ|
-      if champ.id.in?(changed_ids)
-        champ.stream = history_stream
-      elsif champ.id.in?(buffer_ids)
-        champ.stream = Dossier::MAIN_STREAM
-        champ.checkpoint = history_stream
+    # update loaded champ data instances
+    champ_data.each do |data|
+      if data.id.in?(changed_ids)
+        data.stream = history_stream
+      elsif data.id.in?(buffer_ids)
+        data.stream = Dossier::MAIN_STREAM
+        data.checkpoint = history_stream
       end
     end
 
     reset_champs_cache
 
     with_main_stream do
-      prefill_and_enqueue_fetch_external_data_jobs(buffer_champs.filter(&:referentiel?), types_de_champ_private_all)
+      prefill_and_enqueue_fetch_external_data_jobs(buffer_champ_data.filter(&:referentiel?), types_de_champ_private_all)
     end
 
     history_stream
   end
 
-  def champs_by_public_id
-    @champs_by_public_id ||= champs_on_stream.index_by(&:public_id)
+  def champ_data_by_public_id
+    @champ_data_by_public_id ||= champ_data_on_stream.index_by(&:public_id)
   end
 
-  def discarded_champs_by_public_id
-    @discarded_champs_by_public_id ||= discarded_champs_on_main_stream.index_by(&:public_id)
+  def discarded_champ_data_by_public_id
+    @discarded_champ_data_by_public_id ||= discarded_champ_data_on_main_stream.index_by(&:public_id)
   end
 
-  def champs_on_stream
-    @champs_on_stream ||= if user_buffer_stream?
-      (champs_on_user_buffer_stream + champs_on_main_stream).uniq(&:public_id)
+  def champ_data_on_stream
+    @champ_data_on_stream ||= if user_buffer_stream?
+      (champ_data_on_user_buffer_stream + champ_data_on_main_stream).uniq(&:public_id)
     elsif instructeur_buffer_stream?
-      (champs_on_instructeur_buffer_stream + champs_on_main_stream).uniq(&:public_id)
+      (champ_data_on_instructeur_buffer_stream + champ_data_on_main_stream).uniq(&:public_id)
     elsif user_history_stream?
       champ_data
         # only "main" and "history"
@@ -351,7 +351,7 @@ module DossierChampsConcern
         # compact
         .uniq(&:public_id)
     else
-      champs_on_main_stream
+      champ_data_on_main_stream
     end
   end
 
@@ -359,42 +359,42 @@ module DossierChampsConcern
     @revision_stable_ids ||= revision.types_de_champ.map(&:stable_id).to_set
   end
 
-  def champs_in_revision
+  def champ_data_in_revision
     champ_data.filter { stable_id_in_revision?(_1.stable_id) }
   end
 
-  def discarded_champs_on_main_stream
+  def discarded_champ_data_on_main_stream
     champ_data.filter(&:main_stream?).reject { stable_id_in_revision?(_1.stable_id) }
   end
 
-  def champs_on_main_stream
-    champs_in_revision.filter(&:main_stream?)
+  def champ_data_on_main_stream
+    champ_data_in_revision.filter(&:main_stream?)
   end
 
-  def champs_on_user_buffer_stream
-    champs_in_revision.filter(&:user_buffer_stream?)
+  def champ_data_on_user_buffer_stream
+    champ_data_in_revision.filter(&:user_buffer_stream?)
   end
 
-  def champs_on_instructeur_buffer_stream
-    champs_in_revision.filter(&:instructeur_buffer_stream?)
+  def champ_data_on_instructeur_buffer_stream
+    champ_data_in_revision.filter(&:instructeur_buffer_stream?)
   end
 
   def filled_champ(type_de_champ, row_id: nil, with_discarded: false)
     champ_public_id = type_de_champ.public_id(row_id)
-    champ = champs_by_public_id[champ_public_id]
+    data = champ_data_by_public_id[champ_public_id]
 
-    if champ.nil? && with_discarded
-      champ = discarded_champs_by_public_id[champ_public_id]
+    if data.nil? && with_discarded
+      data = discarded_champ_data_by_public_id[champ_public_id]
     end
 
-    return nil if type_de_champ.champ_blank?(champ)
+    return nil if type_de_champ.champ_blank?(data)
 
-    if discarded_champs_by_public_id.key?(champ_public_id)
-      champ
-    elsif !champ.visible?
+    if discarded_champ_data_by_public_id.key?(champ_public_id)
+      data
+    elsif !data.visible?
       nil
     else
-      champ
+      data
     end
   end
 
@@ -402,11 +402,11 @@ module DossierChampsConcern
     check_valid_stream_on_write?(type_de_champ)
     check_valid_row_id_on_write?(type_de_champ, row_id)
 
-    # FIXME: Try to find the champ in memory before querying the database
-    champ = champ_data.find { _1.stream == stream && _1.public_id == type_de_champ.public_id(row_id) }
+    # FIXME: Try to find the champ data in memory before querying the database
+    data = champ_data.find { _1.stream == stream && _1.public_id == type_de_champ.public_id(row_id) }
 
-    if champ.nil?
-      champ = Dossier.no_touching do
+    if data.nil?
+      data = Dossier.no_touching do
         champ_data
           .create_with(**type_de_champ.params_for_champ, source_stream: stream)
           .create_or_find_by!(stable_id: type_de_champ.stable_id, row_id:, stream:)
@@ -414,30 +414,30 @@ module DossierChampsConcern
     end
 
     # Needed when a revision change the champ type in this case, we reset the champ data
-    if champ.class != type_de_champ.champ_class
-      champ = champ.becomes!(type_de_champ.champ_class)
-      champ.assign_attributes(value: nil, value_json: nil, external_id: nil, data: nil)
-    elsif !main_stream? && champ.previously_new_record?
-      main_stream_champ = champ_data.find_by(stable_id: type_de_champ.stable_id, row_id:, stream: Dossier::MAIN_STREAM)
-      champ.clone_value_from(main_stream_champ) if main_stream_champ.present?
+    if data.class != type_de_champ.champ_class
+      data = data.becomes!(type_de_champ.champ_class)
+      data.assign_attributes(value: nil, value_json: nil, external_id: nil, data: nil)
+    elsif !main_stream? && data.previously_new_record?
+      main_stream_data = champ_data.find_by(stable_id: type_de_champ.stable_id, row_id:, stream: Dossier::MAIN_STREAM)
+      data.clone_value_from(main_stream_data) if main_stream_data.present?
     end
 
-    # If the champ returned from `create_or_find_by` is not the same as the one already loaded in `dossier.champ_data`, we need to update the association cache
-    loaded_champ = champ_data.find { [_1.stream, _1.public_id] == [champ.stream, champ.public_id] }
-    if loaded_champ.present? && loaded_champ.object_id != champ.object_id
-      association(:champ_data).target = champ_data - [loaded_champ] + [champ]
+    # If the champ data returned from `create_or_find_by` is not the same as the one already loaded in `dossier.champ_data`, we need to update the association cache
+    loaded_data = champ_data.find { [_1.stream, _1.public_id] == [data.stream, data.public_id] }
+    if loaded_data.present? && loaded_data.object_id != data.object_id
+      association(:champ_data).target = champ_data - [loaded_data] + [data]
     end
 
-    # If the dossier instance on champ has changed we need to update the association cache
-    if champ.dossier.object_id != object_id
-      champ.association(:dossier).target = self
+    # If the dossier instance on the champ data has changed we need to update the association cache
+    if data.dossier.object_id != object_id
+      data.association(:dossier).target = self
     end
 
     reset_champs_cache
 
-    champ.save!
-    champ.type_de_champ = type_de_champ
-    champ
+    data.save!
+    data.type_de_champ = type_de_champ
+    data
   end
 
   def check_valid_stream_on_write?(type_de_champ)
@@ -471,8 +471,8 @@ module DossierChampsConcern
   end
 
   def reset_champs_cache
-    @champs_by_public_id = nil
-    @discarded_champs_by_public_id = nil
+    @champ_data_by_public_id = nil
+    @discarded_champ_data_by_public_id = nil
     @filled_champs_public = nil
     @filled_champs_private = nil
     @root_champs_public = nil
@@ -481,6 +481,6 @@ module DossierChampsConcern
     @flat_champs_private = nil
     @repetition_row_ids = nil
     @revision_stable_ids = nil
-    @champs_on_stream = nil
+    @champ_data_on_stream = nil
   end
 end

--- a/app/models/concerns/dossier_clone_concern.rb
+++ b/app/models/concerns/dossier_clone_concern.rb
@@ -12,10 +12,10 @@ module DossierCloneConcern
     dossier_attributes = [:autorisation_donnees, :revision_id]
     relationships = [:individual, :etablissement]
 
-    discarded_row_ids = champs_on_main_stream
+    discarded_row_ids = champ_data_on_main_stream
       .filter { _1.row? && _1.discarded? }
       .to_set(&:row_id)
-    champs_to_clone = champs_on_main_stream
+    champs_to_clone = champ_data_on_main_stream
       .reject { discarded_row_ids.member?(_1.row_id) }
     ActiveRecord::Associations::Preloader.new(records: champs_to_clone, associations: [:geo_areas, :etablissement]).call
     cloned_champs = champs_to_clone.map(&:clone)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -63,7 +63,7 @@ class Dossier < ApplicationRecord
   # autosave persists champ changes when saving the dossier; champ validation
   # is driven by DossierValidateConcern over projected champs, so `validate: false`
   # keeps autosave from cascading validation into every loaded champ.
-  has_many :champ_data, dependent: :destroy, class_name: 'Champ', autosave: true, validate: false
+  has_many :champ_data, dependent: :destroy, class_name: 'ChampData', autosave: true, validate: false
   has_many :commentaires, inverse_of: :dossier, dependent: :destroy
   has_many :commentaires_chronological, -> { chronological }, class_name: 'Commentaire', inverse_of: :dossier
   has_many :preloaded_commentaires, -> { includes(:dossier_correction, :dossier_pending_response, :instructeur, :expert, piece_jointe_attachments: :blob).order(created_at: :desc) }, class_name: 'Commentaire', inverse_of: :dossier

--- a/app/models/dossier_operation_log.rb
+++ b/app/models/dossier_operation_log.rb
@@ -119,7 +119,7 @@ class DossierOperationLog < ApplicationRecord
       case subject
       when Dossier
         SerializerService.dossier(subject)
-      when Champ
+      when ChampData
         SerializerService.champ(subject)
       when Avis
         SerializerService.avis(subject)

--- a/app/models/dossier_preloader.rb
+++ b/app/models/dossier_preloader.rb
@@ -89,7 +89,7 @@ class DossierPreloader
       },
     ]
 
-    all_champs = Champ
+    all_champs = ChampData
       .includes(to_include)
       .where(dossier_id: dossiers)
       .to_a
@@ -136,7 +136,7 @@ class DossierPreloader
         champ.piece_justificative_file.attachments.each do |attachment|
           if attachment.blob.attachments.loaded?
             attachment.blob.attachments.each do |blob_attachment|
-              if blob_attachment.record.is_a?(Champ)
+              if blob_attachment.record.is_a?(ChampData)
                 blob_attachment.record.association(:dossier).target = dossier
               end
             end

--- a/app/models/dossier_preloader.rb
+++ b/app/models/dossier_preloader.rb
@@ -112,7 +112,7 @@ class DossierPreloader
       etablissement = etablissements_by_id[champ.etablissement_id]
       champ.association(:etablissement).target = etablissement
       if etablissement
-        etablissement.association(:champ).target = champ
+        etablissement.association(:champ_data).target = champ
       end
     end
   end
@@ -145,11 +145,11 @@ class DossierPreloader
       end
     end
 
-    # We need to do this because of the check on `Etablissement#champ` in
+    # We need to do this because of the check on `Etablissement#champ_data` in
     # `Etablissement#libelle_for_export`. By assigning `nil` to `target` we mark association
-    # as loaded and so the check on `Etablissement#champ` will not trigger n+1 query.
+    # as loaded and so the check on `Etablissement#champ_data` will not trigger n+1 query.
     if dossier.etablissement
-      dossier.etablissement.association(:champ).target = nil
+      dossier.etablissement.association(:champ_data).target = nil
     end
 
     dossier.send(:reset_champs_cache)

--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -3,7 +3,7 @@
 class Etablissement < ApplicationRecord
   belongs_to :dossier, optional: true, touch: true
 
-  has_one :champ, class_name: 'Champs::SiretChamp', touch: true
+  has_one :champ, class_name: 'Champs::SiretChamp', touch: true, inverse_of: :etablissement
 
   has_many :exercices, dependent: :destroy
 

--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -3,7 +3,7 @@
 class Etablissement < ApplicationRecord
   belongs_to :dossier, optional: true, touch: true
 
-  has_one :champ, class_name: 'Champs::SiretChamp', touch: true, inverse_of: :etablissement
+  has_one :champ_data, class_name: 'ChampData', touch: true, inverse_of: :etablissement
 
   has_many :exercices, dependent: :destroy
 
@@ -241,9 +241,9 @@ class Etablissement < ApplicationRecord
   end
 
   def update_champ_value_json!
-    return if champ.nil?
+    return if champ_data.nil?
 
-    champ.update!(value_json: champ_value_json)
+    champ_data.update!(value_json: champ_value_json)
   end
 
   def champ_value_json
@@ -283,13 +283,13 @@ class Etablissement < ApplicationRecord
   def dossier_id_for_export
     if dossier_id
       dossier_id.to_s
-    elsif champ
-      champ.dossier_id.to_s
+    elsif champ_data
+      champ_data.dossier_id.to_s
     end
   end
 
   def libelle_for_export
-    champ&.libelle || 'Dossier'
+    champ_data&.libelle || 'Dossier'
   end
 
   def bilans_headers

--- a/app/models/geo_area.rb
+++ b/app/models/geo_area.rb
@@ -2,7 +2,7 @@
 
 class GeoArea < ApplicationRecord
   include ActionView::Helpers::NumberHelper
-  belongs_to :champ, class_name: 'ChampData', optional: false, inverse_of: :geo_areas
+  belongs_to :champ_data, class_name: 'ChampData', foreign_key: :champ_id, optional: false, inverse_of: :geo_areas
   before_create :set_default_uuid
 
   enum :cadastre_state, %w[cadastre_fetched cadastre_error].index_by(&:itself)
@@ -59,11 +59,11 @@ class GeoArea < ApplicationRecord
         description: description,
         filename: filename,
         id: (uuid || id).to_s,
-        champ_label: champ.libelle,
-        champ_id: champ.stable_id,
-        champ_row: champ.row_id,
-        champ_private: champ.private?,
-        dossier_id: champ.dossier_id
+        champ_label: champ_data.libelle,
+        champ_id: champ_data.stable_id,
+        champ_row: champ_data.row_id,
+        champ_private: champ_data.private?,
+        dossier_id: champ_data.dossier_id
       ).compact,
     }
   end
@@ -256,7 +256,7 @@ class GeoArea < ApplicationRecord
   end
 
   def set_default_uuid
-    if champ.main_stream?
+    if champ_data.main_stream?
       self.uuid ||= SecureRandom.uuid
     end
   end

--- a/app/models/geo_area.rb
+++ b/app/models/geo_area.rb
@@ -2,7 +2,7 @@
 
 class GeoArea < ApplicationRecord
   include ActionView::Helpers::NumberHelper
-  belongs_to :champ, optional: false
+  belongs_to :champ, class_name: 'ChampData', optional: false, inverse_of: :geo_areas
   before_create :set_default_uuid
 
   enum :cadastre_state, %w[cadastre_fetched cadastre_error].index_by(&:itself)

--- a/app/models/prefill_champs.rb
+++ b/app/models/prefill_champs.rb
@@ -20,7 +20,7 @@ class PrefillChamps
 
   def build_prefill_values
     value_by_stable_id = params
-      .map { |prefixed_typed_id, value| [Champ.stable_id_from_typed_id(prefixed_typed_id), value] }
+      .map { |prefixed_typed_id, value| [ChampData.stable_id_from_typed_id(prefixed_typed_id), value] }
       .filter { |stable_id, value| stable_id.present? && value.present? }
       .to_h
 

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -667,7 +667,7 @@ class Procedure < ApplicationRecord
   def average_dossier_weight
     if dossiers.termine.any?
       dossiers_sample = dossiers.termine.limit(100)
-      total_size = Champ
+      total_size = ChampData
         .includes(piece_justificative_file_attachments: :blob)
         .where(type: Champs::PieceJustificativeChamp.to_s, dossier: dossiers_sample)
         .sum('active_storage_blobs.byte_size')

--- a/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
@@ -61,7 +61,7 @@ class TypesDeChamp::PrefillRepetitionTypeDeChamp < TypesDeChamp::PrefillTypeDeCh
       repetition.filter_map do |key, value|
         next if !key.is_a?(String) || !key.starts_with?("champ_")
 
-        stable_id = Champ.stable_id_from_typed_id(key)
+        stable_id = ChampData.stable_id_from_typed_id(key)
         type_de_champ = revision.types_de_champ.find { _1.stable_id == stable_id }
         next unless type_de_champ
 

--- a/app/serializers/dossier_serializer.rb
+++ b/app/serializers/dossier_serializer.rb
@@ -24,7 +24,7 @@ class DossierSerializer < ActiveModel::Serializer
   has_one :etablissement
   has_many :cerfa
   has_many :commentaires
-  has_many :champs_private
+  has_many :champs_private, serializer: ChampSerializer
   has_many :pieces_justificatives
   has_many :types_de_piece_justificative
   has_many :avis

--- a/app/services/attachment/piece_justificative_service.rb
+++ b/app/services/attachment/piece_justificative_service.rb
@@ -11,7 +11,7 @@ class Attachment::PieceJustificativeService
     updated_by = champ.updated_by
     dossier = champ.dossier
 
-    Champ.transaction do
+    ChampData.transaction do
       champ.reload(lock: true) # SELECT FOR UPDATE + clear association cache
       # restore the stream-scoped dossier: a fresh association load defaults to
       # the main stream, and conditional visibility (the validation gate) must

--- a/app/services/attachment/validation.rb
+++ b/app/services/attachment/validation.rb
@@ -14,7 +14,7 @@ class Attachment::Validation
   end
 
   def champ
-    @champ ||= record if record.is_a?(Champ)
+    @champ ||= record if record.is_a?(ChampData)
   end
 
   def max_file_size

--- a/app/services/dossier_projection_service.rb
+++ b/app/services/dossier_projection_service.rb
@@ -31,7 +31,7 @@ class DossierProjectionService
 
     champ_data_by_dossier_id = if champ_columns.any?
       stable_ids = champ_columns.map(&:stable_id)
-      Champ.where(dossier_id: dossiers_ids, stable_id: stable_ids, stream: Dossier::MAIN_STREAM)
+      ChampData.where(dossier_id: dossiers_ids, stable_id: stable_ids, stream: Dossier::MAIN_STREAM)
         .includes(:piece_justificative_file_attachments)
         .group_by(&:dossier_id)
     else

--- a/app/tasks/maintenance/backfill_city_name_task.rb
+++ b/app/tasks/maintenance/backfill_city_name_task.rb
@@ -9,7 +9,7 @@ module Maintenance
     validates :champ_ids, presence: true
 
     def collection
-      Champ.where(id: champ_ids.split(',').map(&:strip).map(&:to_i))
+      ChampData.where(id: champ_ids.split(',').map(&:strip).map(&:to_i))
     end
 
     def process(champ)

--- a/app/tasks/maintenance/backfill_effectif_annuel_annee_task.rb
+++ b/app/tasks/maintenance/backfill_effectif_annuel_annee_task.rb
@@ -10,7 +10,7 @@ module Maintenance
 
     def process(etablissement)
       year = etablissement.created_at.year - 1
-      procedure = (etablissement.dossier || etablissement.champ&.dossier)&.procedure
+      procedure = (etablissement.dossier || etablissement.champ_data&.dossier)&.procedure
       APIEntreprise::EffectifsAnnuelsJob.perform_later(etablissement.id, procedure&.id, year)
     end
   end

--- a/app/tasks/maintenance/backfill_missing_entreprise_data_task.rb
+++ b/app/tasks/maintenance/backfill_missing_entreprise_data_task.rb
@@ -10,7 +10,7 @@ module Maintenance
         .where(created_at: 6.months.ago..)
         .where.not(siret: nil)
         .where(entreprise_siren: nil)
-        .left_joins(:dossier, :champ)
+        .left_joins(:dossier, :champ_data)
         .where("dossiers.id IS NOT NULL OR champs.id IS NOT NULL")
         .distinct
     end
@@ -41,7 +41,7 @@ module Maintenance
     end
 
     def dossier(etablissement)
-      etablissement.dossier || etablissement.champ&.dossier
+      etablissement.dossier || etablissement.champ_data&.dossier
     end
   end
 end

--- a/app/tasks/maintenance/concerns/statements_helpers_concern.rb
+++ b/app/tasks/maintenance/concerns/statements_helpers_concern.rb
@@ -12,7 +12,7 @@ module Maintenance
     # Examples:
     # def collection
     #   with_statement_timeout("0") do
-    #     Champ.all.pluck(:id)
+    #     ChampData.all.pluck(:id)
     #     # No effect with Dossier.all because the collection will be lazy loaded later in batches by MaintenanceTask.
     #   end
     # end

--- a/app/tasks/maintenance/create_previews_for_pj_of_latest_dossiers_task.rb
+++ b/app/tasks/maintenance/create_previews_for_pj_of_latest_dossiers_task.rb
@@ -23,7 +23,7 @@ module Maintenance
     def process(dossier)
       require "vips"
 
-      champ_ids = Champ
+      champ_ids = ChampData
         .where(dossier_id: dossier)
         .where(type: "Champs::PieceJustificativeChamp")
         .ids

--- a/app/tasks/maintenance/create_variants_for_pj_of_latest_dossiers_task.rb
+++ b/app/tasks/maintenance/create_variants_for_pj_of_latest_dossiers_task.rb
@@ -27,7 +27,7 @@ module Maintenance
     def process(dossier)
       require "vips"
 
-      champ_ids = Champ
+      champ_ids = ChampData
         .where(dossier_id: dossier)
         .where(type: "Champs::PieceJustificativeChamp")
         .ids

--- a/app/tasks/maintenance/remove_non_unique_champs_task.rb
+++ b/app/tasks/maintenance/remove_non_unique_champs_task.rb
@@ -6,7 +6,7 @@ module Maintenance
     validates :stable_ids, presence: true
 
     def collection
-      champs = Champ.where(stable_id: stable_ids.split(',').map(&:strip).map(&:to_i))
+      champs = ChampData.where(stable_id: stable_ids.split(',').map(&:strip).map(&:to_i))
       champs
         .group_by { [_1.dossier_id, _1.stream, _1.stable_id, _1.row_id] }
         .values

--- a/app/tasks/maintenance/t20250825backfill_champ_external_state_task.rb
+++ b/app/tasks/maintenance/t20250825backfill_champ_external_state_task.rb
@@ -32,7 +32,7 @@ module Maintenance
       # "Champs::MESRIChamp",
       # "Champs::PoleEmploiChamp",
 
-      Champ.where(type: targets)
+      ChampData.where(type: targets)
     end
 
     def process(champ)

--- a/app/tasks/maintenance/t20260126fix_etablissements_with_json_address_task.rb
+++ b/app/tasks/maintenance/t20260126fix_etablissements_with_json_address_task.rb
@@ -13,7 +13,7 @@ module Maintenance
     end
 
     def process(etablissement)
-      dossier = etablissement.dossier || etablissement.champ&.dossier
+      dossier = etablissement.dossier || etablissement.champ_data&.dossier
       return if dossier.nil? # some etablissements does not have dossier or champ (?)
       return if dossier.termine?
 

--- a/app/tasks/maintenance/t20260129destroy_orphan_etablissements_task.rb
+++ b/app/tasks/maintenance/t20260129destroy_orphan_etablissements_task.rb
@@ -9,7 +9,7 @@ module Maintenance
 
     def collection
       with_statement_timeout("5min") do
-        Etablissement.where(dossier_id: nil).where.missing(:champ)
+        Etablissement.where(dossier_id: nil).where.missing(:champ_data)
       end
     end
 

--- a/app/tasks/maintenance/t20260319migrate_orphan_titre_identite_champs_task.rb
+++ b/app/tasks/maintenance/t20260319migrate_orphan_titre_identite_champs_task.rb
@@ -15,7 +15,7 @@ module Maintenance
     no_collection
 
     def process
-      Champ.where(type: "Champs::TitreIdentiteChamp")
+      ChampData.where(type: "Champs::TitreIdentiteChamp")
         .update_all(type: "Champs::PieceJustificativeChamp")
     end
   end

--- a/app/tasks/maintenance/t20260504_backfill_canonical_keys_in_commune_champs_task.rb
+++ b/app/tasks/maintenance/t20260504_backfill_canonical_keys_in_commune_champs_task.rb
@@ -8,8 +8,8 @@ module Maintenance
     RANGE_SIZE = 50_000
 
     def collection
-      min_id = Champ.minimum(:id) || 0
-      max_id = Champ.maximum(:id) || 0
+      min_id = ChampData.minimum(:id) || 0
+      max_id = ChampData.maximum(:id) || 0
       (min_id..max_id).step(RANGE_SIZE).map { |from| from...(from + RANGE_SIZE) }
     end
 

--- a/app/tasks/maintenance/t20260504_backfill_canonical_keys_in_departement_champs_task.rb
+++ b/app/tasks/maintenance/t20260504_backfill_canonical_keys_in_departement_champs_task.rb
@@ -8,8 +8,8 @@ module Maintenance
     RANGE_SIZE = 50_000
 
     def collection
-      min_id = Champ.minimum(:id) || 0
-      max_id = Champ.maximum(:id) || 0
+      min_id = ChampData.minimum(:id) || 0
+      max_id = ChampData.maximum(:id) || 0
       (min_id..max_id).step(RANGE_SIZE).map { |from| from...(from + RANGE_SIZE) }
     end
 

--- a/app/tasks/maintenance/t20260521_backfill_geo_area_uuid_task.rb
+++ b/app/tasks/maintenance/t20260521_backfill_geo_area_uuid_task.rb
@@ -12,15 +12,15 @@ module Maintenance
     # run_on_first_deploy
 
     def collection
-      GeoArea.joins(:champ).where(champs: { stream: Dossier::MAIN_STREAM })
+      GeoArea.joins(:champ_data).where(champs: { stream: Dossier::MAIN_STREAM })
     end
 
     def process(geo_area)
       uuid = geo_area.uuid || SecureRandom.uuid
       geo_area.update_column(:uuid, uuid) if geo_area.uuid.nil?
-      champ = geo_area.champ
-      GeoArea.joins(:champ)
-        .where(geometry: geo_area.geometry, champs: { dossier_id: champ.dossier_id, stable_id: champ.stable_id, row_id: champ.row_id })
+      champ_data = geo_area.champ_data
+      GeoArea.joins(:champ_data)
+        .where(geometry: geo_area.geometry, champs: { dossier_id: champ_data.dossier_id, stable_id: champ_data.stable_id, row_id: champ_data.row_id })
         .where.not(champs: { stream: Dossier::MAIN_STREAM })
         .update_all(uuid:)
     end

--- a/app/tasks/maintenance/t20260522_backfill_partial_etablissements_task.rb
+++ b/app/tasks/maintenance/t20260522_backfill_partial_etablissements_task.rb
@@ -24,11 +24,11 @@ module Maintenance
       Etablissement
         .where(entreprise_siren: nil)
         .where.not(siret: nil)
-        .includes(dossier: :procedure, champ: { dossier: :procedure })
+        .includes(dossier: :procedure, champ_data: { dossier: :procedure })
     end
 
     def process(etablissement)
-      procedure_id = etablissement.dossier&.procedure&.id || etablissement.champ&.dossier&.procedure&.id
+      procedure_id = etablissement.dossier&.procedure&.id || etablissement.champ_data&.dossier&.procedure&.id
       return if procedure_id.nil?
 
       result = APIEntreprise::EtablissementAdapter.new(etablissement.siret, procedure_id).to_params

--- a/app/tasks/maintenance/t20260527_backfill_naf_2025_task.rb
+++ b/app/tasks/maintenance/t20260527_backfill_naf_2025_task.rb
@@ -48,7 +48,7 @@ module Maintenance
     private
 
     def find_procedure_id(etablissement)
-      (etablissement.dossier || etablissement.champ&.dossier)&.procedure&.id
+      (etablissement.dossier || etablissement.champ_data&.dossier)&.procedure&.id
     end
   end
 end

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -327,7 +327,7 @@
 
       %h3.fr-mt-4w Existing attachment, error
       - attachment.blob.metadata[:virus_scan_result] = ActiveStorage::VirusScanner::INFECTED
-      = render Attachment::FileFieldComponent.new(context: Attachment::Context.new(champ: Champ.new), drop_zone: :none)
+      = render Attachment::FileFieldComponent.new(context: Attachment::Context.new(champ: ChampData.new), drop_zone: :none)
 
 
       %h3.fr-mt-4w New attachment on TypeDeChamp

--- a/config/initializers/action_view_record_identifier.rb
+++ b/config/initializers/action_view_record_identifier.rb
@@ -5,7 +5,7 @@ module ActionView::RecordIdentifier
   alias original_record_key_for_dom_id record_key_for_dom_id
 
   def dom_class(record_or_class, prefix = nil)
-    if record_or_class.is_a?(Champ)
+    if record_or_class.is_a?(ChampData)
       prefix ? "#{prefix}#{JOIN}champ" : "champ"
     else
       original_dom_class(record_or_class, prefix)
@@ -15,7 +15,7 @@ module ActionView::RecordIdentifier
   private
 
   def record_key_for_dom_id(record)
-    if record.is_a?(Champ)
+    if record.is_a?(ChampData)
       record.public_id
     else
       original_record_key_for_dom_id(record)

--- a/config/initializers/champ_data_polymorphic_name.rb
+++ b/config/initializers/champ_data_polymorphic_name.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Polymorphic rows (active_storage_attachments) written before the
+# Champ -> ChampData rename carry record_type 'Champ'; ChampData also keeps
+# writing that historical name (see ChampData.polymorphic_name) so old and new
+# rows stay uniform. Resolution must be patched on ActiveRecord::Base (not
+# ApplicationRecord) because ActiveStorage::Attachment resolves record_type
+# through its own base class, ActiveStorage::Record.
+module ChampDataPolymorphicNameResolution
+  def polymorphic_class_for(name)
+    name == 'Champ' ? ChampData : super
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Base.singleton_class.prepend(ChampDataPolymorphicNameResolution)
+end

--- a/spec/components/attachment/file_field_component_spec.rb
+++ b/spec/components/attachment/file_field_component_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Attachment::FileFieldComponent, type: :component do
-  describe 'with has_many_attached (Champ.piece_justificative_file)' do
+  describe 'with has_many_attached (ChampData.piece_justificative_file)' do
     let_it_be(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
     let(:dossier) { create(:dossier, procedure:) }
     let(:champ) { dossier.champ_data.first }

--- a/spec/components/dossiers/geo_area_component_spec.rb
+++ b/spec/components/dossiers/geo_area_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Dossiers::GeoAreaComponent, type: :component do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :carte }]) }
   let(:dossier) { create(:dossier, procedure:) }
   let(:champ) { dossier.champ_data.first }
-  let(:geo_area) { create(:geo_area, :selection_utilisateur, :polygon, champ:) }
+  let(:geo_area) { create(:geo_area, :selection_utilisateur, :polygon, champ_data: champ) }
 
   before { render_inline(described_class.new(geo_area:, editing:)) }
 

--- a/spec/components/editable_champ/champ_label_content_component_spec.rb
+++ b/spec/components/editable_champ/champ_label_content_component_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe EditableChamp::ChampLabelContentComponent, type: :component do
   let(:form) { double(object: champ) }
 
-  let(:champ_class) { Champ }
+  let(:champ_class) { ChampData }
   let(:champ) do
     instance_double(
       champ_class,

--- a/spec/controllers/champs/carte_controller_spec.rb
+++ b/spec/controllers/champs/carte_controller_spec.rb
@@ -38,7 +38,7 @@ describe Champs::CarteController, type: :controller do
 
   describe 'features' do
     let(:feature) { attributes_for(:geo_area, :polygon) }
-    let(:geo_area) { create(:geo_area, :selection_utilisateur, :polygon, champ: champ) }
+    let(:geo_area) { create(:geo_area, :selection_utilisateur, :polygon, champ_data: champ) }
 
     before do
       sign_in user

--- a/spec/controllers/instructeurs/champs_controller_spec.rb
+++ b/spec/controllers/instructeurs/champs_controller_spec.rb
@@ -16,7 +16,7 @@ describe Instructeurs::ChampsController, type: :controller do
     it do
       is_expected.to have_http_status(:ok)
       # simple check to ensure no duplicate champs are created
-      expect(Champ.where(stable_id: champ.stable_id, row_id: champ.row_id).count).to eq(1)
+      expect(ChampData.where(stable_id: champ.stable_id, row_id: champ.row_id).count).to eq(1)
     end
 
     context 'when the instructeur is not assigned to the dossier' do
@@ -44,7 +44,7 @@ describe Instructeurs::ChampsController, type: :controller do
       is_expected.to redirect_to(instructeur_dossier_path(procedure, dossier))
       expect(flash[:notice]).to end_with("ont bien été modifiées.")
 
-      mains, others = Champ.where(stable_id: champ.stable_id, row_id: champ.row_id).partition(&:main_stream?)
+      mains, others = ChampData.where(stable_id: champ.stable_id, row_id: champ.row_id).partition(&:main_stream?)
       expect((mains + others).count).to eq(2)
 
       main = mains.first
@@ -75,7 +75,7 @@ describe Instructeurs::ChampsController, type: :controller do
       it 'rejects the request and does not overwrite the address champ' do
         expect { cross_type_request }.to raise_error(ActiveRecord::RecordNotFound)
 
-        main_address = Champ.find_by!(dossier_id: dossier.id, stable_id: address_champ.stable_id, stream: Dossier::MAIN_STREAM)
+        main_address = ChampData.find_by!(dossier_id: dossier.id, stable_id: address_champ.stable_id, stream: Dossier::MAIN_STREAM)
         expect(main_address.value_json).not_to have_key('rib')
         expect(main_address.value_json).to include('label' => original_address['label'])
         expect(main_address.type).to eq('Champs::AddressChamp')

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1231,7 +1231,7 @@ describe Users::DossiersController, type: :controller do
         end
 
         before do
-          expect_any_instance_of(Champ).to receive(:fetch_external_data_later)
+          expect_any_instance_of(ChampData).to receive(:fetch_external_data_later)
           first_champ.update_columns(external_state: 'fetched', value_json: 'a value')
         end
 

--- a/spec/factories/champ.rb
+++ b/spec/factories/champ.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :champ_do_not_use, class: 'Champ' do
+  factory :champ_do_not_use, class: 'ChampData' do
     stream { Dossier::MAIN_STREAM }
     add_attribute(:private) { false }
 

--- a/spec/jobs/api_entreprise/job_spec.rb
+++ b/spec/jobs/api_entreprise/job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe APIEntreprise::Job, type: :job do
         champ = dossier.champ_data.first
         champ.update!(value: '12345678901234')
 
-        etablissement = create(:etablissement, champ:)
+        etablissement = create(:etablissement, champ_data: champ)
 
         expect { ErrorJob.perform_now(etablissement) }
           .to raise_error(StandardError, /API Entreprise error/)

--- a/spec/jobs/cron/fallback_fetch_cadastre_real_geometry_job_spec.rb
+++ b/spec/jobs/cron/fallback_fetch_cadastre_real_geometry_job_spec.rb
@@ -8,9 +8,9 @@ describe Cron::FallbackFetchCadastreRealGeometryJob, type: :job do
 
     context 'when cadastre lookup works' do
       it 'processes pending geo areas' do
-        create(:geo_area, :selection_utilisateur, cadastre_state: nil, champ:)
-        create(:geo_area, :cadastre, cadastre_state: :cadastre_fetched, champ:)
-        enqueued_geoarea = create(:geo_area, :cadastre, cadastre_state: nil, champ:)
+        create(:geo_area, :selection_utilisateur, cadastre_state: nil, champ_data: champ)
+        create(:geo_area, :cadastre, cadastre_state: :cadastre_fetched, champ_data: champ)
+        enqueued_geoarea = create(:geo_area, :cadastre, cadastre_state: nil, champ_data: champ)
         expect { described_class.perform_now }.to have_enqueued_job(FetchCadastreRealGeometryJob).with(enqueued_geoarea)
       end
     end

--- a/spec/jobs/fetch_cadastre_real_geometry_job_spec.rb
+++ b/spec/jobs/fetch_cadastre_real_geometry_job_spec.rb
@@ -5,7 +5,7 @@ describe FetchCadastreRealGeometryJob, type: :job do
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :carte, options: { cadastres: true } }]) }
     let(:dossier) { create(:dossier, procedure: procedure) }
     let(:champ) { dossier.champ_data.first }
-    let!(:geo_area) { create(:geo_area, :cadastre, properties:, champ:) }
+    let!(:geo_area) { create(:geo_area, :cadastre, properties:, champ_data: champ) }
     let(:job) { described_class.new(geo_area) }
     subject { job.perform_now }
 

--- a/spec/models/address_proxy_spec.rb
+++ b/spec/models/address_proxy_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AddressProxy, type: :model do
     subject { AddressProxy.new(champ_or_etablissement) }
 
     context 'when champ_or_etablissement is an instance of Champ' do
-      let(:champ_or_etablissement) { Champ.new }
+      let(:champ_or_etablissement) { ChampData.new }
 
       context 'when value_json is nil' do
         before { allow(champ_or_etablissement).to receive(:value_json).and_return(nil) }

--- a/spec/models/champ_data_private_spec.rb
+++ b/spec/models/champ_data_private_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Champ do
+describe ChampData do
   describe '#private?' do
     let(:type_de_champ) { build(:type_de_champ, :private) }
     let(:champ) { type_de_champ.build_champ }

--- a/spec/models/champ_data_spec.rb
+++ b/spec/models/champ_data_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Champ do
+describe ChampData do
   include ActiveJob::TestHelper
 
   describe 'mandatory_blank?' do
@@ -70,20 +70,20 @@ describe Champ do
 
   describe "normalization" do
     it "should remove null bytes char using unicode escape sequence" do
-      champ = Champ.new(value: "foo\u0000bar")
+      champ = ChampData.new(value: "foo\u0000bar")
       champ.validate
       expect(champ.value).to eq "foobar"
     end
 
     it 'removes remove null bytes char hexadecimal escape sequence' do
-      champ = Champ.new(value: "Valid\x00Value")
+      champ = ChampData.new(value: "Valid\x00Value")
       champ.validate
       expect(champ.value).to eq("ValidValue")
     end
   end
 
   describe 'public and private' do
-    let(:champ) { Champ.new }
+    let(:champ) { ChampData.new }
     let(:dossier) { create(:dossier) }
 
     it 'partition public and private' do

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -789,13 +789,13 @@ RSpec.describe DossierChampsConcern do
 
       def main_row(stable_id, row_id)
         dossier.with_main_stream do
-          dossier.send(:champs_on_stream).find { _1.stable_id == stable_id && _1.row_id == row_id }
+          dossier.send(:champ_data_on_stream).find { _1.stable_id == stable_id && _1.row_id == row_id }
         end
       end
 
       def draft_row(stable_id, row_id)
         dossier.with_update_stream(dossier.user) do
-          dossier.send(:champs_on_stream).find { _1.stable_id == stable_id && _1.row_id == row_id }
+          dossier.send(:champ_data_on_stream).find { _1.stable_id == stable_id && _1.row_id == row_id }
         end
       end
 
@@ -1102,7 +1102,7 @@ RSpec.describe DossierChampsConcern do
         it 'does not set a default champ on user_buffer, and does not attempt to fetch the main_stream_champ again' do
           subject
           expect(champ_qf).not_to have_received(:may_fetch_later!)
-          expect(dossier.send(:champs_on_user_buffer_stream)).to be_empty
+          expect(dossier.send(:champ_data_on_user_buffer_stream)).to be_empty
         end
       end
 
@@ -1134,8 +1134,8 @@ RSpec.describe DossierChampsConcern do
           fetched_ids = @fetched_instances.map(&:stable_id)
           expect(fetched_ids).to include(@new_qf.stable_id)
           expect(fetched_ids).not_to include(@old_qf.stable_id)
-          expect(dossier.send(:champs_on_user_buffer_stream).count).to eq(1)
-          expect(dossier.send(:champs_on_user_buffer_stream).first.stable_id).to eq(dossier.revision.types_de_champ.sort_by(&:created_at).last.stable_id)
+          expect(dossier.send(:champ_data_on_user_buffer_stream).count).to eq(1)
+          expect(dossier.send(:champ_data_on_user_buffer_stream).first.stable_id).to eq(dossier.revision.types_de_champ.sort_by(&:created_at).last.stable_id)
         end
       end
     end

--- a/spec/models/concerns/dossier_rebase_concern_spec.rb
+++ b/spec/models/concerns/dossier_rebase_concern_spec.rb
@@ -559,7 +559,7 @@ describe DossierRebaseConcern do
         end
 
         it { expect { subject }.to change { dossier.root_champs_public.find(&:repetition?)&.libelle }.from('p1').to(nil) }
-        it { expect { subject }.not_to change { Champ.count } }
+        it { expect { subject }.not_to change { ChampData.count } }
       end
     end
   end

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -256,8 +256,8 @@ describe TagsSubstitutionConcern, type: :model do
 
       context 'with cadastre geo areas' do
         before do
-          create(:geo_area, :cadastre, champ:)
-          create(:geo_area, :cadastre, champ:, properties: { numero: '0103', section: 'CD', prefixe: '000', commune: '75056', contenance: 5678, id: '75056000CD0103' })
+          create(:geo_area, :cadastre, champ_data: champ)
+          create(:geo_area, :cadastre, champ_data: champ, properties: { numero: '0103', section: 'CD', prefixe: '000', commune: '75056', contenance: 5678, id: '75056000CD0103' })
           dossier.reload
         end
 
@@ -266,7 +266,7 @@ describe TagsSubstitutionConcern, type: :model do
 
       context 'with legacy cadastre geo areas' do
         before do
-          create(:geo_area, :legacy_cadastre, champ:, properties: { numero: '42', section: 'A11', code_com: '127', code_dep: '75', code_arr: '000', surface_parcelle: 1234, surface_intersection: 1234 })
+          create(:geo_area, :legacy_cadastre, champ_data: champ, properties: { numero: '42', section: 'A11', code_com: '127', code_dep: '75', code_arr: '000', surface_parcelle: 1234, surface_intersection: 1234 })
           dossier.reload
         end
 
@@ -275,7 +275,7 @@ describe TagsSubstitutionConcern, type: :model do
 
       context 'with selection_utilisateur polygon' do
         before do
-          create(:geo_area, :selection_utilisateur, :polygon, champ:)
+          create(:geo_area, :selection_utilisateur, :polygon, champ_data: champ)
           dossier.reload
         end
 
@@ -284,7 +284,7 @@ describe TagsSubstitutionConcern, type: :model do
 
       context 'with selection_utilisateur line_string' do
         before do
-          create(:geo_area, :selection_utilisateur, :line_string, champ:)
+          create(:geo_area, :selection_utilisateur, :line_string, champ_data: champ)
           dossier.reload
         end
 
@@ -293,7 +293,7 @@ describe TagsSubstitutionConcern, type: :model do
 
       context 'with selection_utilisateur point' do
         before do
-          create(:geo_area, :selection_utilisateur, :point, champ:)
+          create(:geo_area, :selection_utilisateur, :point, champ_data: champ)
           dossier.reload
         end
 

--- a/spec/models/dossier_purge_spec.rb
+++ b/spec/models/dossier_purge_spec.rb
@@ -36,7 +36,7 @@ describe Dossier, type: :model do
       it 'destroys all champs even when count exceeds in_batches size' do
         expect(dossier.champ_data.count).to be > 50
         dossier.purge_discarded
-        expect(Champ.where(dossier_id: dossier.id)).to be_empty
+        expect(ChampData.where(dossier_id: dossier.id)).to be_empty
       end
     end
 
@@ -53,7 +53,7 @@ describe Dossier, type: :model do
 
       it 'rolls back the transaction so no champ is destroyed' do
         dossier.purge_discarded
-        expect(Champ.where(id: champ.id)).to exist
+        expect(ChampData.where(id: champ.id)).to exist
       end
 
       it 'does not enqueue ActiveStorage::PurgeJob (after_destroy_commit gated by commit)' do
@@ -98,7 +98,7 @@ describe Dossier, type: :model do
       it 'destroys all champs even when count exceeds in_batches size' do
         expect(dossier.champ_data.count).to be > 50
         dossier.purge_without_notice
-        expect(Champ.where(dossier_id: dossier.id)).to be_empty
+        expect(ChampData.where(dossier_id: dossier.id)).to be_empty
       end
     end
 
@@ -115,7 +115,7 @@ describe Dossier, type: :model do
 
       it 'rolls back so no champ is destroyed and does not propagate the exception' do
         expect { dossier.purge_without_notice }.not_to raise_error
-        expect(Champ.where(id: champ.id)).to exist
+        expect(ChampData.where(id: champ.id)).to exist
       end
     end
   end

--- a/spec/models/etablissement_spec.rb
+++ b/spec/models/etablissement_spec.rb
@@ -203,7 +203,7 @@ describe Etablissement do
         .with(etablissement)
         .and_return(address_data.dup)
 
-      etablissement.champ = champ
+      etablissement.champ_data = champ
     end
 
     subject(:value_json) {

--- a/spec/models/geo_area_spec.rb
+++ b/spec/models/geo_area_spec.rb
@@ -2,25 +2,25 @@
 
 RSpec.describe GeoArea, type: :model do
   describe '#area' do
-    let(:geo_area) { build(:geo_area, :polygon, champ: nil) }
+    let(:geo_area) { build(:geo_area, :polygon, champ_data: nil) }
 
     it { expect(geo_area.area).to eq(103.6) }
   end
 
   describe '#area (hourglass polygon)' do
-    let(:geo_area) { build(:geo_area, :hourglass_polygon, champ: nil) }
+    let(:geo_area) { build(:geo_area, :hourglass_polygon, champ_data: nil) }
 
     it { expect(geo_area.area).to eq(32.4) }
   end
 
   describe '#length' do
-    let(:geo_area) { build(:geo_area, :line_string, champ: nil) }
+    let(:geo_area) { build(:geo_area, :line_string, champ_data: nil) }
 
     it { expect(geo_area.length).to eq(21.2) }
   end
 
   describe '#location' do
-    let(:geo_area) { build(:geo_area, :point, champ: nil) }
+    let(:geo_area) { build(:geo_area, :point, champ_data: nil) }
 
     it { expect(geo_area.location).to eq("46°32'19\"N 2°25'42\"E") }
   end
@@ -30,17 +30,17 @@ RSpec.describe GeoArea, type: :model do
       subject! { geo_area.validate }
 
       context 'polygon' do
-        let(:geo_area) { build(:geo_area, :polygon, champ: nil) }
+        let(:geo_area) { build(:geo_area, :polygon, champ_data: nil) }
         it { expect(geo_area.errors).not_to have_key(:geometry) }
       end
 
       context 'line_string' do
-        let(:geo_area) { build(:geo_area, :line_string, champ: nil) }
+        let(:geo_area) { build(:geo_area, :line_string, champ_data: nil) }
         it { expect(geo_area.errors).not_to have_key(:geometry) }
       end
 
       context 'point' do
-        let(:geo_area) { build(:geo_area, :point, champ: nil) }
+        let(:geo_area) { build(:geo_area, :point, champ_data: nil) }
         it { expect(geo_area.errors).not_to have_key(:geometry) }
       end
 
@@ -58,7 +58,7 @@ RSpec.describe GeoArea, type: :model do
       end
 
       context 'invalid point' do
-        let(:geo_area) { build(:geo_area, :invalid_point, champ: nil) }
+        let(:geo_area) { build(:geo_area, :invalid_point, champ_data: nil) }
         it do
           expect(geo_area.errors).to have_key(:geometry)
           expect(geo_area.errors[:geometry]).to include(I18n.t('activerecord.errors.models.geo_area.attributes.geometry.invalid_crs'))
@@ -66,32 +66,32 @@ RSpec.describe GeoArea, type: :model do
       end
 
       context 'invalid_right_hand_rule_polygon' do
-        let(:geo_area) { build(:geo_area, :invalid_right_hand_rule_polygon, champ: nil) }
+        let(:geo_area) { build(:geo_area, :invalid_right_hand_rule_polygon, champ_data: nil) }
         it { expect(geo_area.errors).to have_key(:geometry) }
       end
 
       context 'hourglass_polygon' do
-        let(:geo_area) { build(:geo_area, :hourglass_polygon, champ: nil) }
+        let(:geo_area) { build(:geo_area, :hourglass_polygon, champ_data: nil) }
         it { expect(geo_area.errors).to have_key(:geometry) }
       end
 
       context 'point_invalid' do
-        let(:geo_area) { build(:geo_area, :point_invalid, champ: nil) }
+        let(:geo_area) { build(:geo_area, :point_invalid, champ_data: nil) }
         it { expect(geo_area.errors).to have_key(:geometry) }
       end
 
       context 'linestring_invalid' do
-        let(:geo_area) { build(:geo_area, :linestring_invalid, champ: nil) }
+        let(:geo_area) { build(:geo_area, :linestring_invalid, champ_data: nil) }
         it { expect(geo_area.errors).to have_key(:geometry) }
       end
 
       context 'multipoint_invalid' do
-        let(:geo_area) { build(:geo_area, :multipoint_invalid, champ: nil) }
+        let(:geo_area) { build(:geo_area, :multipoint_invalid, champ_data: nil) }
         it { expect(geo_area.errors).to have_key(:geometry) }
       end
 
       context 'polygon_invalid' do
-        let(:geo_area) { build(:geo_area, :polygon_invalid, champ: nil) }
+        let(:geo_area) { build(:geo_area, :polygon_invalid, champ_data: nil) }
         it do
           expect(geo_area.errors).to have_key(:geometry)
           expect(geo_area.errors[:geometry]).to include(I18n.t('activerecord.errors.models.geo_area.attributes.geometry.invalid_crs'))
@@ -99,25 +99,25 @@ RSpec.describe GeoArea, type: :model do
       end
 
       context 'multilinestring_invalid' do
-        let(:geo_area) { build(:geo_area, :multilinestring_invalid, champ: nil) }
+        let(:geo_area) { build(:geo_area, :multilinestring_invalid, champ_data: nil) }
         it { expect(geo_area.errors).to have_key(:geometry) }
       end
 
       context 'multipolygon_invalid' do
-        let(:geo_area) { build(:geo_area, :multipolygon_invalid, champ: nil) }
+        let(:geo_area) { build(:geo_area, :multipolygon_invalid, champ_data: nil) }
         it { expect(geo_area.errors).to have_key(:geometry) }
       end
 
       context 'geometrycollection_invalid' do
-        let(:geo_area) { build(:geo_area, :geometrycollection_invalid, champ: nil) }
+        let(:geo_area) { build(:geo_area, :geometrycollection_invalid, champ_data: nil) }
         it { expect(geo_area.errors).to have_key(:geometry) }
       end
     end
   end
 
   describe "cadastre properties" do
-    let(:geo_area) { build(:geo_area, :cadastre, champ: nil) }
-    let(:legacy_geo_area) { build(:geo_area, :legacy_cadastre, champ: nil) }
+    let(:geo_area) { build(:geo_area, :cadastre, champ_data: nil) }
+    let(:legacy_geo_area) { build(:geo_area, :legacy_cadastre, champ_data: nil) }
 
     it "should be backward compatible" do
       expect("#{geo_area.code_dep}#{geo_area.code_com}").to eq(geo_area.commune)
@@ -137,7 +137,7 @@ RSpec.describe GeoArea, type: :model do
 
   describe 'description' do
     context 'when properties is nil' do
-      let(:geo_area) { build(:geo_area, properties: nil, champ: nil) }
+      let(:geo_area) { build(:geo_area, properties: nil, champ_data: nil) }
 
       it { expect(geo_area.description).to be_nil }
     end
@@ -145,7 +145,7 @@ RSpec.describe GeoArea, type: :model do
 
   describe "#label" do
     context "when geo is a line" do
-      let(:geo_area) { build(:geo_area, :selection_utilisateur, :line_string, champ: nil) }
+      let(:geo_area) { build(:geo_area, :selection_utilisateur, :line_string, champ_data: nil) }
       it "should return the label" do
         expect(geo_area.label).to eq("Une ligne longue de 21,2 m")
       end
@@ -157,7 +157,7 @@ RSpec.describe GeoArea, type: :model do
     end
 
     context "when geo is a polygon" do
-      let(:geo_area) { build(:geo_area, :selection_utilisateur, :polygon, champ: nil) }
+      let(:geo_area) { build(:geo_area, :selection_utilisateur, :polygon, champ_data: nil) }
       it "should return the label" do
         expect(geo_area.label).to eq("Une aire de surface 103,6 m²")
       end
@@ -169,27 +169,27 @@ RSpec.describe GeoArea, type: :model do
     end
 
     context "when geo is a point" do
-      let(:geo_area) { build(:geo_area, :selection_utilisateur, :point, champ: nil) }
+      let(:geo_area) { build(:geo_area, :selection_utilisateur, :point, champ_data: nil) }
       it "should return the label" do
         expect(geo_area.label).to eq("Un point situé à 46°32'19\"N 2°25'42\"E")
       end
     end
 
     context "when geo is a point with elevation" do
-      let(:geo_area) { build(:geo_area, :selection_utilisateur, :point_with_z, champ: nil) }
+      let(:geo_area) { build(:geo_area, :selection_utilisateur, :point_with_z, champ_data: nil) }
       it "should return the label" do
         expect(geo_area.label).to eq("Un point situé à 46°32'19\"N 2°25'42\"E")
       end
     end
 
     context "when geo is a cadastre parcelle" do
-      let(:geo_area) { build(:geo_area, :selection_utilisateur, :cadastre, champ: nil) }
+      let(:geo_area) { build(:geo_area, :selection_utilisateur, :cadastre, champ_data: nil) }
       it "should return the label" do
         expect(geo_area.label).to eq("Parcelle n° 42 - Feuille 000 A11 - 123 m² – commune 75127")
       end
 
       context "when area is nil" do
-        let(:geo_area) { build(:geo_area, :selection_utilisateur, :cadastre, properties: { "description" => "48°51'45.81\"N 2°17'15,33\"E" }, geometry: { "type" => "Point", "coordinates" => [7.754444, 48.610556] }, champ: nil) }
+        let(:geo_area) { build(:geo_area, :selection_utilisateur, :cadastre, properties: { "description" => "48°51'45.81\"N 2°17'15,33\"E" }, geometry: { "type" => "Point", "coordinates" => [7.754444, 48.610556] }, champ_data: nil) }
 
         before { allow(geo_area).to receive(:area).and_return(nil) }
 

--- a/spec/policies/champ_policy_spec.rb
+++ b/spec/policies/champ_policy_spec.rb
@@ -18,8 +18,8 @@ describe ChampPolicy do
       populate_annotations: true)
   end
   let(:state) { :en_construction }
-  let(:champ) { Champ.find(dossier.champ_data.find { |c| !c.private? }.id) }
-  let(:annotation) { Champ.find(dossier.champ_data.find(&:private?).id) }
+  let(:champ) { ChampData.find(dossier.champ_data.find { |c| !c.private? }.id) }
+  let(:annotation) { ChampData.find(dossier.champ_data.find(&:private?).id) }
 
   describe '#initialize' do
     let(:state) { :brouillon }

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -489,7 +489,7 @@ describe ProcedureExportService do
       context 'with empty repetition' do
         before do
           dossiers.flat_map { |dossier| dossier.root_champs_public.filter(&:repetition?) }.each do |champ|
-            Champ.where(row_id: champ.row_ids).destroy_all
+            ChampData.where(row_id: champ.row_ids).destroy_all
           end
         end
 
@@ -515,10 +515,10 @@ describe ProcedureExportService do
           rep = -> (dossier, stable_id) { dossier.root_champs_public.find { _1.repetition? && _1.stable_id == stable_id } }
 
           dossiers.first.update!(depose_at: 2.days.ago)
-          Champ.where(row_id: rep.call(dossiers.first, canonical.first.stable_id).row_ids).destroy_all
+          ChampData.where(row_id: rep.call(dossiers.first, canonical.first.stable_id).row_ids).destroy_all
 
           dossiers.second.update!(depose_at: 1.day.ago)
-          Champ.where(row_id: rep.call(dossiers.second, canonical.last.stable_id).row_ids).destroy_all
+          ChampData.where(row_id: rep.call(dossiers.second, canonical.last.stable_id).row_ids).destroy_all
 
           dossiers.each(&:reload)
         end

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -630,7 +630,7 @@ describe ProcedureExportService do
     let(:properties) { subject['features'].first['properties'] }
 
     before do
-      create(:geo_area, :polygon, champ: champ_carte)
+      create(:geo_area, :polygon, champ_data: champ_carte)
     end
 
     it 'should have features' do

--- a/spec/system/instructeurs/procedure_filters_spec.rb
+++ b/spec/system/instructeurs/procedure_filters_spec.rb
@@ -6,9 +6,9 @@ describe "procedure filters" do
   let(:types_de_champ_public) { [{ type: :text }] }
   let!(:type_de_champ) { procedure.active_revision.root_types_de_champ_public.first }
   let!(:new_unfollow_dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_instruction)) }
-  let!(:champ) { Champ.find_by(stable_id: type_de_champ.stable_id, dossier_id: new_unfollow_dossier.id) }
+  let!(:champ) { ChampData.find_by(stable_id: type_de_champ.stable_id, dossier_id: new_unfollow_dossier.id) }
   let!(:new_unfollow_dossier_2) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_instruction)) }
-  let!(:champ_2) { Champ.find_by(stable_id: type_de_champ.stable_id, dossier_id: new_unfollow_dossier_2.id) }
+  let!(:champ_2) { ChampData.find_by(stable_id: type_de_champ.stable_id, dossier_id: new_unfollow_dossier_2.id) }
 
   before do
     champ.update(value: "Mon champ rempli")

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -161,7 +161,7 @@ describe 'The user', js: true do
       wait_until { page.all(".repetition-row").size == 1 }
       # removing a repetition means one child only, thus its button destroy is not visible
       expect(page).to have_selector(".repetition .repetition-row:first-child .utils-repetition-required-destroy-button", count: 1, visible: false)
-    end.to change { Champ.where.not(discarded_at: nil).count }
+    end.to change { ChampData.where.not(discarded_at: nil).count }
   end
 
   let(:procedure_with_repetition_limited) do

--- a/spec/tasks/maintenance/t20250527drop_invalide_geo_areas_task_spec.rb
+++ b/spec/tasks/maintenance/t20250527drop_invalide_geo_areas_task_spec.rb
@@ -12,7 +12,7 @@ module Maintenance
       let(:champ) { dossier.champ_data.first }
 
       context "with a valid geo_area (point)" do
-        let!(:geo_area) { create(:geo_area, :point, champ:) }
+        let!(:geo_area) { create(:geo_area, :point, champ_data: champ) }
         let(:element) { geo_area }
         it "does not destroy the geo_area" do
           expect { process }.not_to change { GeoArea.exists?(geo_area.id) }.from(true)
@@ -20,7 +20,7 @@ module Maintenance
       end
 
       context "with an invalid geo_area (invalid_point)" do
-        let!(:geo_area) { create(:geo_area, :point, champ:) }
+        let!(:geo_area) { create(:geo_area, :point, champ_data: champ) }
         let(:invalid_geometry) { build(:geo_area, :invalid_point).geometry }
         before { geo_area.update_column(:geometry, invalid_geometry) }
         let(:element) { geo_area }

--- a/spec/tasks/maintenance/t20260521_backfill_geo_area_uuid_task_spec.rb
+++ b/spec/tasks/maintenance/t20260521_backfill_geo_area_uuid_task_spec.rb
@@ -9,7 +9,7 @@ module Maintenance
       let(:dossier) { create(:dossier, procedure:) }
       let(:main_champ) { dossier.champ_data.first }
       let(:main_geo_area) do
-        ga = create(:geo_area, :selection_utilisateur, :polygon, champ: main_champ)
+        ga = create(:geo_area, :selection_utilisateur, :polygon, champ_data: main_champ)
         ga.update_column(:uuid, nil)
         ga.reload
       end
@@ -36,7 +36,7 @@ module Maintenance
           champ.save!(validate: false)
           champ
         end
-        let!(:buffer_geo_area) { create(:geo_area, :selection_utilisateur, :polygon, champ: buffer_champ) }
+        let!(:buffer_geo_area) { create(:geo_area, :selection_utilisateur, :polygon, champ_data: buffer_champ) }
 
         it 'propagates the same uuid to the matching geo_area' do
           process
@@ -51,7 +51,7 @@ module Maintenance
           champ.save!(validate: false)
           champ
         end
-        let!(:buffer_geo_area) { create(:geo_area, :selection_utilisateur, :point, champ: buffer_champ) }
+        let!(:buffer_geo_area) { create(:geo_area, :selection_utilisateur, :point, champ_data: buffer_champ) }
 
         it 'does not update its uuid' do
           expect(buffer_geo_area.reload.uuid).to be_nil


### PR DESCRIPTION
Renommage mécanique du modèle `Champ` en `ChampData`, pour libérer la constante `Champ` en vue de la séparation à venir (`ChampData` = persistance, `Champ` = modèle métier projeté). STI et comportement inchangés ; les sous-classes `Champs::*` héritent désormais de `ChampData`.

Points d'attention pour la review — shims de compatibilité là où Rails dérive un comportement du nom de classe :

- `polymorphic_name` reste `'Champ'` (colonne `active_storage_attachments.record_type`), avec la résolution en lecture patchée sur `ActiveRecord::Base` (initializer `champ_data_polymorphic_name.rb`), car `ActiveStorage::Record` n'hérite pas d'`ApplicationRecord`
- `model_name` reste `'Champ'` sur la classe de base uniquement, pour que les clés i18n `activerecord.errors.models.champ.*` continuent de résoudre via `lookup_ancestors`
- `inverse_of` explicites sur les associations `etablissement`/`geo_areas` (la détection automatique dérive désormais `:champ_data`)
- serializer explicite sur `champs_private` (AMS ne retombe plus implicitement sur `ChampSerializer`)
- les ids typés GraphQL continuent d'encoder la chaîne `'Champ'` (visible côté API)

Un second commit clarifie le nommage dans `DossierChampsConcern` (et son point d'appel dans `DossierCloneConcern`) : les méthodes privées qui manipulent des lignes persistées sont renommées en `champ_data_*` (`champ_data_on_stream`, `champ_data_by_public_id`, `changed_champ_data_ids_for_merge`, …) et les variables locales correspondantes en `data`, pour distinguer les données persistées des champs projetés. Renommage pur, sans changement de comportement.

Un troisième commit renomme les associations `champ` en `champ_data` sur `Etablissement` (`has_one`, désormais déclarée `class_name: 'ChampData'` au lieu de `Champs::SiretChamp`) et `GeoArea` (`belongs_to`, la colonne `champ_id` est conservée via `foreign_key:`) : ce qu'elles pointent est une ligne persistée `ChampData`, pas un champ projeté. Les clés des propriétés GeoJSON (`champ_label`, `champ_id`, …) sont inchangées.

Empilée sur #13410, elle-même empilée sur #13406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
