### PR TITLE
Tech: optimiser les tests de file_input_component_spec

### DIFF
--- a/spec/components/attachment/file_input_component_spec.rb
+++ b/spec/components/attachment/file_input_component_spec.rb
@@ -3,10 +3,10 @@
 RSpec.describe Attachment::FileInputComponent, type: :component do
   include ChampAriaLabelledbyHelper
 
-  let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
-  let(:types_de_champ_public) { [{ type: :piece_justificative }] }
-  let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champs.first }
+  let_it_be(:types_de_champ_public) { [{ type: :piece_justificative }] }
+  let_it_be(:procedure) { create(:procedure, :published, types_de_champ_public:) }
+  let_it_be(:dossier) { create(:dossier, procedure:) }
+  let(:champ) { dossier.champs.reload.first }
   let(:attached_file) { champ.piece_justificative_file }
   let(:context_kwargs) { {} }
   let(:kwargs) { {} }
@@ -95,6 +95,8 @@ RSpec.describe Attachment::FileInputComponent, type: :component do
   end
 
   context 'piece justificative nature titre_identite' do
+    let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
+    let(:dossier) { create(:dossier, procedure:) }
     let(:types_de_champ_public) { [{ type: :piece_justificative, nature: 'titre_identite' }] }
 
     it 'sets accept to jpg/jpeg/png only' do
@@ -110,6 +112,8 @@ RSpec.describe Attachment::FileInputComponent, type: :component do
   end
 
   context 'piece justificative limited to document_texte' do
+    let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
+    let(:dossier) { create(:dossier, procedure:) }
     let(:types_de_champ_public) { [{ type: :piece_justificative, pj_limit_formats: '1', pj_format_families: ['document_texte'] }] }
 
     it 'accept includes .pdf but not .zip' do


### PR DESCRIPTION
# Probleme

Tests lents dans `spec/components/attachment/file_input_component_spec.rb` — temps baseline : 2.80s (mediane locale, 3 runs).

# Solution

Skill [`/test-optimization`](https://github.com/mfo/night-shift/blob/main/.claude/skills/test-optimization/SKILL.md)

### Techniques appliquees

| Technique | Avant | Apres | Gain |
|-----------|-------|-------|------|
| T08 — let_it_be | 2.80s | 1.63s | -41.8% |

### Techniques tentees sans succes

| Technique | Raison |
|-----------|--------|
| T09 — aggregate_failures | Gain marginal (< 0.5s) apres let_it_be ; les tests restants les plus lents sont dans des contextes avec procedure/dossier differents |
| T01 — create→build | Les objets ont besoin d'etre persistes (dossier reference procedure, logo attachment) |

**Resultat final : 2.80s → 1.63s (gain total 41.8%)**

Coverage : 38.54% → 38.56% (maintenue)

Generated with [Claude Code](https://claude.com/claude-code)