### PR TITLE
Tech: supprime le monkeypatch de l'association champs dans DossierProjectionService

### DIFF
--- a/app/components/instructeurs/cell_component.rb
+++ b/app/components/instructeurs/cell_component.rb
@@ -3,9 +3,10 @@
 class Instructeurs::CellComponent < ApplicationComponent
   include DossierHelper
 
-  def initialize(dossier:, column:)
+  def initialize(dossier:, column:, champ_data:)
     @dossier = dossier
     @column = column
+    @champ_data = champ_data
   end
 
   def call
@@ -25,20 +26,20 @@ class Instructeurs::CellComponent < ApplicationComponent
   end
 
   def simple_layout
-    raw_value = raw_value_for_column(@dossier, @column)
+    raw_value = raw_value_for_column(@dossier, @column, @champ_data)
     return '' if raw_value.nil?
 
     format(raw_value, @column.type)
   end
 
-  def raw_value_for_column(dossier, column)
-    data = if @column.champ_column?
-      @dossier.champ_data.find { _1.stable_id == column.stable_id }
+  def raw_value_for_column(dossier, column, champ_data)
+    data = if column.champ_column?
+      champ_data[column.stable_id]
     else
-      @dossier
+      dossier
     end
 
-    @column.value(data)
+    column.value(data)
   end
 
   def format(raw_value, type)

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -194,7 +194,7 @@ module Instructeurs
 
       @projected_dossiers = DossierProjectionService.project(@filtered_sorted_paginated_ids, @displayed_columns)
 
-      @disable_checkbox_all = @projected_dossiers.all? { _1.batch_operation_id.present? }
+      @disable_checkbox_all = @projected_dossiers.all? { it.dossier.batch_operation_id.present? }
 
       @batch_operations = BatchOperation.joins(:groupe_instructeurs)
         .where(groupe_instructeurs: current_instructeur.groupe_instructeurs.where(procedure_id: @procedure.id))

--- a/app/controllers/recherche_controller.rb
+++ b/app/controllers/recherche_controller.rb
@@ -42,7 +42,7 @@ class RechercheController < ApplicationController
       .page(page)
       .per(ITEMS_PER_PAGE)
 
-    @projected_dossiers = DossierProjectionService.project(@paginated_ids, PROJECTIONS)
+    @projected_dossiers = DossierProjectionService.project(@paginated_ids, PROJECTIONS).map(&:dossier)
 
     @dossiers_count = matching_dossiers_ids.count
     @followed_dossiers_id = current_instructeur&.followed_dossiers&.where(id: @paginated_ids)&.ids || []

--- a/app/services/dossier_projection_service.rb
+++ b/app/services/dossier_projection_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DossierProjectionService
+  ProjectedDossier = Data.define(:dossier, :champ_data)
+
   def self.project(dossiers_ids, columns)
     champ_columns, other_columns = columns.partition(&:champ_column?)
 
@@ -27,15 +29,17 @@ class DossierProjectionService
 
     dossiers = Dossier.includes(:procedure, :corrections, :pending_corrections, :traitements, *to_include).find(dossiers_ids)
 
-    if champ_columns.any?
+    champ_data_by_dossier_id = if champ_columns.any?
       stable_ids = champ_columns.map(&:stable_id)
-      champs = Champ.where(dossier_id: dossiers_ids, stable_id: stable_ids, stream: 'main').includes(:piece_justificative_file_attachments).group_by(&:dossier_id)
-
-      dossiers.each do |dossier|
-        dossier.association(:champ_data).target = champs[dossier.id] || []
-      end
+      Champ.where(dossier_id: dossiers_ids, stable_id: stable_ids, stream: 'main')
+        .includes(:piece_justificative_file_attachments)
+        .group_by(&:dossier_id)
+    else
+      {}
     end
 
-    dossiers
+    dossiers.map do |dossier|
+      ProjectedDossier.new(dossier:, champ_data: champ_data_by_dossier_id.fetch(dossier.id, []).index_by(&:stable_id))
+    end
   end
 end

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -90,7 +90,8 @@
                   %tbody
                     = render Dossiers::BatchSelectMoreComponent.new(dossiers_count: @dossiers_count, filtered_sorted_ids: @filtered_sorted_ids)
 
-                    - @projected_dossiers.each do |dossier|
+                    - @projected_dossiers.each do |projected_dossier|
+                      - dossier, champ_data = projected_dossier.dossier, projected_dossier.champ_data
                       - path = instructeur_dossier_path(@procedure, dossier.id, statut: params[:statut])
                       %tr{ class: class_names("file-hidden-by-user" => dossier.hidden_by_user_at.present?), id: "table-dossiers-row-#{dossier.id}", "aria-selected" => "false", "data-row-key" => dossier.id }
                         - if batch_operation_component.render?
@@ -128,11 +129,11 @@
                           %td.fr-cell--multiline
                             - if dossier.hidden_by_administration_at.present?
                               %span
-                                = render Instructeurs::CellComponent.new(dossier:, column:)
+                                = render Instructeurs::CellComponent.new(dossier:, column:, champ_data:)
                                 = "- #{t("views.instructeurs.dossiers.deleted_reason.#{dossier.hidden_by_reason}")}" if dossier.hidden_by_user_at.present?
                             - else
                               %a{ href: path }
-                                = render Instructeurs::CellComponent.new(dossier:, column:)
+                                = render Instructeurs::CellComponent.new(dossier:, column:, champ_data:)
                                 = "- #{t("views.instructeurs.dossiers.deleted_reason.#{dossier.hidden_by_reason}")}" if dossier.hidden_by_user_at.present?
 
                         %td

--- a/spec/components/instructeurs/cell_component_spec.rb
+++ b/spec/components/instructeurs/cell_component_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 describe Instructeurs::CellComponent do
-  let(:component) { described_class.new(dossier:, column:) }
+  let(:component) { described_class.new(dossier:, column:, champ_data:) }
+  let(:champ_data) { dossier.champ_data.index_by(&:stable_id) }
 
   describe '#call' do
     let(:procedure) { create(:procedure, :for_individual, types_de_champ_public:) }

--- a/spec/services/dossier_projection_service_spec.rb
+++ b/spec/services/dossier_projection_service_spec.rb
@@ -17,12 +17,21 @@ describe DossierProjectionService do
     let(:columns) { [text_column] }
 
     it do
-      dossiers = subject
+      projections = subject
 
-      expect(dossiers.size).to eq(2)
+      expect(projections.size).to eq(2)
 
-      # only load the champs required for the columns
-      expect(dossiers.first.champ_data.size).to eq(1)
+      projection = projections.first
+      expect(projection.dossier).to eq(dossiers.first)
+
+      # only load the champ_data required for the columns
+      expect(projection.champ_data.keys).to eq([text_column.stable_id])
+    end
+
+    context 'without champ columns' do
+      let(:columns) { [procedure.dossier_id_column] }
+
+      it { expect(subject.first.champ_data).to eq({}) }
     end
   end
 end


### PR DESCRIPTION
## Contexte

`DossierProjectionService` injectait les champs préchargés en écrasant la cible de l'association ActiveRecord (`dossier.association(:champs).target = ...`). Tout code lisant ensuite `dossier.champs` voyait un ensemble tronqué, filtré par les colonnes affichées.

## Changements

- Le service retourne désormais des projections explicites : `ProjectedDossier = Data.define(:dossier, :champs)`, où `champs` est un hash des champs (stream `main`) indexés par `stable_id`. L'association `champs` des dossiers reste intacte.
- `Instructeurs::CellComponent` reçoit le hash `champs:` et résout les colonnes champ via `champs[column.stable_id]` au lieu de parcourir `dossier.champs`.
- `RechercheController` utilise `.map(&:dossier)` (pas de colonnes champ dans la recherche).

Aucun changement de comportement pour les instructeurs — le tableau des dossiers s'affiche à l'identique (même préchargement des champs qu'avant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)