### PR TITLE
Tech: suppression de accepts_nested_attributes_for :champs sur Dossier

### DIFF
--- a/app/models/concerns/dossier_prefillable_concern.rb
+++ b/app/models/concerns/dossier_prefillable_concern.rb
@@ -3,16 +3,20 @@
 module DossierPrefillableConcern
   extend ActiveSupport::Concern
 
-  def prefill!(champs_attributes, identity_attributes)
-    return if champs_attributes.empty? && identity_attributes.empty?
+  def prefill!(champs_with_attributes, identity_attributes)
+    return if champs_with_attributes.empty? && identity_attributes.empty?
 
-    attributes = { prefilled: true }
-    attributes[:champs_attributes] = champs_attributes.map { |h| h.merge(prefilled: true) }
-    attributes[:individual_attributes] = identity_attributes if identity_attributes.present?
-    reload
-    assign_attributes(attributes)
-    save(validate: false)
-    prefilled_champs = champs.filter(&:prefilled?)
-    enqueue_fetch_external_data_jobs(prefilled_champs)
+    transaction do
+      champs_with_attributes.each do |champ, attributes|
+        champ.assign_attributes(attributes.merge(prefilled: true))
+        champ.save!(validate: false)
+      end
+
+      assign_attributes(prefilled: true)
+      assign_attributes(individual_attributes: identity_attributes) if identity_attributes.present?
+      save!(validate: false)
+    end
+
+    enqueue_fetch_external_data_jobs(champs_with_attributes.map(&:first))
   end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -58,7 +58,9 @@ class Dossier < ApplicationRecord
   has_one_attached :justificatif_motivation
   has_one_attached :attestation_depot_pdf
 
-  has_many :champs, dependent: :destroy
+  # autosave is required to import champ validation errors on the dossier
+  # when validating with the :champs_public_value/:champs_private_value contexts
+  has_many :champs, dependent: :destroy, autosave: true
   has_many :commentaires, inverse_of: :dossier, dependent: :destroy
   has_many :commentaires_chronological, -> { chronological }, class_name: 'Commentaire', inverse_of: :dossier
   has_many :preloaded_commentaires, -> { includes(:dossier_correction, :dossier_pending_response, :instructeur, :expert, piece_jointe_attachments: :blob).order(created_at: :desc) }, class_name: 'Commentaire', inverse_of: :dossier
@@ -175,7 +177,6 @@ class Dossier < ApplicationRecord
 
   after_destroy_commit :log_destroy
 
-  accepts_nested_attributes_for :champs
   accepts_nested_attributes_for :individual, update_only: true
 
   include AASM

--- a/app/models/prefill_champs.rb
+++ b/app/models/prefill_champs.rb
@@ -9,7 +9,7 @@ class PrefillChamps
   end
 
   def to_a
-    build_prefill_values.filter(&:prefillable?).map(&:champ_attributes).flatten
+    build_prefill_values.filter(&:prefillable?).flat_map(&:champs_with_attributes)
   end
 
   def self.digest(params)
@@ -57,6 +57,12 @@ class PrefillChamps
 
     def prefillable?
       champ.prefillable? && champ_attributes.present? && valid?
+    end
+
+    # An array of [champ, attributes] pairs; a repetition champ expands to
+    # one pair per prefilled subchamp.
+    def champs_with_attributes
+      champ.repetition? ? champ_attributes : [[champ, champ_attributes]]
     end
 
     def champ_attributes

--- a/app/models/types_de_champ/prefill_address_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_address_type_de_champ.rb
@@ -3,6 +3,6 @@
 class TypesDeChamp::PrefillAddressTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
   def to_assignable_attributes(champ, value)
     return nil if !value.is_a?(String) || value.blank?
-    { id: champ.id, value: value, external_id: value }
+    { value: value, external_id: value }
   end
 end

--- a/app/models/types_de_champ/prefill_commune_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_commune_type_de_champ.rb
@@ -18,23 +18,22 @@ class TypesDeChamp::PrefillCommuneTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
     return if !value.one? && !APIGeoService.communes_by_postal_code(postal_code).any? { _1[:code] == commune_code }
 
     if value.one?
-      code_postal_attributes(champ, postal_code)
+      code_postal_attributes(postal_code)
     else
-      code_postal_and_commune_attributes(champ, postal_code, commune_code)
+      code_postal_and_commune_attributes(postal_code, commune_code)
     end
   end
 
   private
 
-  def code_postal_attributes(champ, postal_code)
+  def code_postal_attributes(postal_code)
     {
-      id: champ.id,
       code_postal: postal_code,
     }
   end
 
-  def code_postal_and_commune_attributes(champ, postal_code, commune_code)
-    code_postal_attributes(champ, postal_code).merge(external_id: commune_code)
+  def code_postal_and_commune_attributes(postal_code, commune_code)
+    code_postal_attributes(postal_code).merge(external_id: commune_code)
   end
 
   def departements

--- a/app/models/types_de_champ/prefill_epci_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_epci_type_de_champ.rb
@@ -14,9 +14,9 @@ class TypesDeChamp::PrefillEpciTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
   end
 
   def to_assignable_attributes(champ, value)
-    return { id: champ.id, code_departement: nil, value: nil } if value.blank? || !value.is_a?(Array)
-    return { id: champ.id, code_departement: value.first, value: nil } if value.one?
-    { id: champ.id, code_departement: value.first, value: value.second }
+    return { code_departement: nil, value: nil } if value.blank? || !value.is_a?(Array)
+    return { code_departement: value.first, value: nil } if value.one?
+    { code_departement: value.first, value: value.second }
   end
 
   private

--- a/app/models/types_de_champ/prefill_referentiel_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_referentiel_type_de_champ.rb
@@ -7,6 +7,6 @@ class TypesDeChamp::PrefillReferentielTypeDeChamp < TypesDeChamp::PrefillTypeDeC
 
   def to_assignable_attributes(champ, value)
     return nil if !scalar_prefill_value?(value)
-    { id: champ.id, external_id: value.to_s.presence }
+    { external_id: value.to_s.presence }
   end
 end

--- a/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
@@ -18,7 +18,7 @@ class TypesDeChamp::PrefillRepetitionTypeDeChamp < TypesDeChamp::PrefillTypeDeCh
   def to_assignable_attributes(champ, value)
     return [] unless value.is_a?(Array)
 
-    value.map.with_index do |repetition, index|
+    value.flat_map.with_index do |repetition, index|
       PrefillRepetitionRow.new(champ, repetition, index, @revision).to_assignable_attributes
     end.compact_blank
   end
@@ -58,7 +58,7 @@ class TypesDeChamp::PrefillRepetitionTypeDeChamp < TypesDeChamp::PrefillTypeDeCh
 
       row_id = champ.row_ids[index] || champ.add_row(updated_by: nil)
 
-      repetition.map do |key, value|
+      repetition.filter_map do |key, value|
         next if !key.is_a?(String) || !key.starts_with?("champ_")
 
         stable_id = Champ.stable_id_from_typed_id(key)
@@ -66,8 +66,9 @@ class TypesDeChamp::PrefillRepetitionTypeDeChamp < TypesDeChamp::PrefillTypeDeCh
         next unless type_de_champ
 
         subchamp = champ.dossier.champ_for_update(type_de_champ, row_id:, updated_by: nil)
-        TypesDeChamp::PrefillTypeDeChamp.build(subchamp.type_de_champ, revision).to_assignable_attributes(subchamp, value)
-      end.compact
+        attributes = TypesDeChamp::PrefillTypeDeChamp.build(subchamp.type_de_champ, revision).to_assignable_attributes(subchamp, value)
+        [subchamp, attributes] if attributes.present?
+      end
     end
   end
 end

--- a/app/models/types_de_champ/prefill_siret_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_siret_type_de_champ.rb
@@ -7,6 +7,6 @@ class TypesDeChamp::PrefillSiretTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
 
   def to_assignable_attributes(champ, value)
     return nil if !scalar_prefill_value?(value)
-    { id: champ.id, external_id: value.to_s.presence }
+    { external_id: value.to_s.presence }
   end
 end

--- a/app/models/types_de_champ/prefill_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_type_de_champ.rb
@@ -71,7 +71,7 @@ class TypesDeChamp::PrefillTypeDeChamp < SimpleDelegator
 
   def to_assignable_attributes(champ, value)
     return nil if !acceptable_prefill_value?(value)
-    { id: champ.id, value: value }
+    { value: value }
   end
 
   def acceptable_prefill_value?(value)

--- a/spec/models/concerns/dossier_prefillable_concern_spec.rb
+++ b/spec/models/concerns/dossier_prefillable_concern_spec.rb
@@ -54,17 +54,17 @@ RSpec.describe DossierPrefillableConcern do
 
           let(:type_de_champ_1) { procedure.published_revision.types_de_champ_public.first }
           let(:value_1) { "any value" }
-          let(:champ_id_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id).id }
+          let(:champ_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id) }
 
           let(:type_de_champ_2) { procedure.published_revision.types_de_champ_public.second }
           let(:value_2) { "33612345678" }
-          let(:champ_id_2) { find_champ_by_stable_id(dossier, type_de_champ_2.stable_id).id }
+          let(:champ_2) { find_champ_by_stable_id(dossier, type_de_champ_2.stable_id) }
 
           let(:type_de_champ_3) { procedure.published_revision.types_de_champ_private.first }
           let(:value_3) { "some value" }
-          let(:champ_id_3) { find_champ_by_stable_id(dossier, type_de_champ_3.stable_id).id }
+          let(:champ_3) { find_champ_by_stable_id(dossier, type_de_champ_3.stable_id) }
 
-          let(:values) { [{ id: champ_id_1, value: value_1 }, { id: champ_id_2, value: value_2 }, { id: champ_id_3, value: value_3 }] }
+          let(:values) { [[champ_1, { value: value_1 }], [champ_2, { value: value_2 }], [champ_3, { value: value_3 }]] }
 
           it_behaves_like 'a dossier marked as prefilled'
 
@@ -84,9 +84,9 @@ RSpec.describe DossierPrefillableConcern do
           let(:types_de_champ_public) { [{ type: :phone }] }
           let(:type_de_champ_1) { procedure.published_revision.types_de_champ_public.first }
           let(:value) { "a non phone value" }
-          let(:champ_id) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id).id }
+          let(:champ_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id) }
 
-          let(:values) { [{ id: champ_id, value: value }] }
+          let(:values) { [[champ_1, { value: value }]] }
 
           it_behaves_like 'a dossier marked as prefilled'
 
@@ -110,8 +110,8 @@ RSpec.describe DossierPrefillableConcern do
           let(:types_de_champ_public) { [{ type: :text }] }
           let(:type_de_champ_1) { procedure.published_revision.types_de_champ_public.first }
           let(:value_1) { "any value" }
-          let(:champ_id_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id).id }
-          let(:values) { [{ id: champ_id_1, value: value_1 }] }
+          let(:champ_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id) }
+          let(:values) { [[champ_1, { value: value_1 }]] }
 
           it "updates the champs with the new values and mark them as prefilled" do
             fill
@@ -128,8 +128,8 @@ RSpec.describe DossierPrefillableConcern do
       let(:types_de_champ_public) { [{ type: :pre_rempli }] }
       let(:type_de_champ_1) { procedure.published_revision.types_de_champ_public.first }
       let(:value_1) { "valeur pré-remplie" }
-      let(:champ_id_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id).id }
-      let(:values) { [{ id: champ_id_1, value: value_1 }] }
+      let(:champ_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id) }
+      let(:values) { [[champ_1, { value: value_1 }]] }
 
       it_behaves_like 'a dossier marked as prefilled'
 
@@ -142,10 +142,10 @@ RSpec.describe DossierPrefillableConcern do
 
     context 'when dossier contains champs with external_id' do
       let(:types_de_champ_public) { [{ type: :siret }] }
-      let(:values) { [{ id: champ_id_1, external_id: value_1 }] }
+      let(:values) { [[champ_1, { external_id: value_1 }]] }
       let(:type_de_champ_1) { procedure.published_revision.types_de_champ_public.first }
       let(:value_1) { "130 025 265 00013" }
-      let(:champ_id_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id).id }
+      let(:champ_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id) }
 
       it "updates the champs with the new values and mark them as prefilled" do
         expect { fill }.to have_enqueued_job(ChampFetchExternalDataJob).once

--- a/spec/models/prefill_champs_spec.rb
+++ b/spec/models/prefill_champs_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe PrefillChamps do
       let(:types_de_champ_public) { [{ type: :text }, { type: :textarea }] }
       let(:type_de_champ_1) { procedure.published_revision.types_de_champ_public.first }
       let(:value_1) { "any value" }
-      let(:champ_id_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id).id }
+      let(:champ_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id) }
 
       let(:type_de_champ_2) { procedure.published_revision.types_de_champ_public.second }
       let(:value_2) { "another value" }
-      let(:champ_id_2) { find_champ_by_stable_id(dossier, type_de_champ_2.stable_id).id }
+      let(:champ_2) { find_champ_by_stable_id(dossier, type_de_champ_2.stable_id) }
 
       let(:params) {
         {
@@ -27,10 +27,10 @@ RSpec.describe PrefillChamps do
         }
       }
 
-      it "builds an array of hash(id, value) matching all the given params" do
+      it "builds an array of [champ, attributes] pairs matching all the given params" do
         expect(prefill_champs_array).to match_array([
-          { id: champ_id_1, value: value_1 },
-          { id: champ_id_2, value: value_2 },
+          [champ_1, { value: value_1 }],
+          [champ_2, { value: value_2 }],
         ])
       end
     end
@@ -85,8 +85,8 @@ RSpec.describe PrefillChamps do
 
         let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => champ_value } }
 
-        it "builds an array of hash matching the given params", :slow do
-          expect(prefill_champs_array).to match([{ id: champ.id }.merge(attributes(champ, champ_value))])
+        it "builds an array of [champ, attributes] pairs matching the given params", :slow do
+          expect(prefill_champs_array).to match([[champ, attributes(champ, champ_value)]])
         end
       end
     end
@@ -110,8 +110,8 @@ RSpec.describe PrefillChamps do
 
         let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => champ_value } }
 
-        it "builds an array of hash matching the given params", :slow do
-          expect(prefill_champs_array).to match([{ id: champ.id }.merge(attributes(champ, champ_value))])
+        it "builds an array of [champ, attributes] pairs matching the given params", :slow do
+          expect(prefill_champs_array).to match([[champ, attributes(champ, champ_value)]])
         end
       end
     end
@@ -166,8 +166,8 @@ RSpec.describe PrefillChamps do
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => [{ "champ_#{type_de_champ_child.to_typed_id_for_query}" => type_de_champ_child_value }, { "champ_#{type_de_champ_child.to_typed_id_for_query}" => type_de_champ_child_value2 }] } }
 
-      it "builds an array of hash(id, value) matching the given params" do
-        expect(prefill_champs_array).to match([{ id: child_champs.first.id, value: type_de_champ_child_value }, { id: child_champs.second.id, value: type_de_champ_child_value2 }])
+      it "builds an array of [champ, attributes] pairs matching the given params" do
+        expect(prefill_champs_array).to match([[child_champs.first, { value: type_de_champ_child_value }], [child_champs.second, { value: type_de_champ_child_value2 }]])
       end
     end
 
@@ -208,8 +208,8 @@ RSpec.describe PrefillChamps do
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => [{ "champ_#{type_de_champ_child.to_typed_id_for_query}" => type_de_champ_child_value }, { "champ_#{type_de_champ_child.to_typed_id_for_query}" => type_de_champ_child_value2 }] } }
 
-      it "builds an array of hash(id, value) matching the given params" do
-        expect(prefill_champs_array).to match([{ id: child_champs.first.id, value: type_de_champ_child_value }, { id: child_champs.second.id, value: type_de_champ_child_value2 }])
+      it "builds an array of [champ, attributes] pairs matching the given params" do
+        expect(prefill_champs_array).to match([[child_champs.first, { value: type_de_champ_child_value }], [child_champs.second, { value: type_de_champ_child_value2 }]])
       end
     end
 

--- a/spec/models/types_de_champ/prefill_address_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_address_type_de_champ_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe TypesDeChamp::PrefillAddressTypeDeChamp do
 
     context 'when the value is present' do
       let(:value) { 'hello' }
-      it { is_expected.to match({ id: champ.id, value: 'hello', external_id: 'hello' }) }
+      it { is_expected.to match({ value: 'hello', external_id: 'hello' }) }
     end
   end
 end

--- a/spec/models/types_de_champ/prefill_commune_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_commune_type_de_champ_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe TypesDeChamp::PrefillCommuneTypeDeChamp do
     context 'when the value is an array of one element' do
       context 'when the first element is a valid postal code' do
         let(:value) { ['01540'] }
-        it { is_expected.to match({ id: champ.id, code_postal: '01540' }) }
+        it { is_expected.to match({ code_postal: '01540' }) }
       end
 
       context 'when the first element is not a valid postal code' do
@@ -65,7 +65,7 @@ RSpec.describe TypesDeChamp::PrefillCommuneTypeDeChamp do
       context 'when the first element is a valid postal code' do
         context 'when the second element is a valid insee code' do
           let(:value) { ['01540', '01457'] }
-          it { is_expected.to match({ id: champ.id, code_postal: '01540', external_id: '01457' }) }
+          it { is_expected.to match({ code_postal: '01540', external_id: '01457' }) }
         end
 
         context 'when the second element is not a valid insee code' do
@@ -84,7 +84,7 @@ RSpec.describe TypesDeChamp::PrefillCommuneTypeDeChamp do
       context 'when the first element is a valid postal code' do
         context 'when the second element is a valid insee code' do
           let(:value) { ['01540', '01457', 'hello'] }
-          it { is_expected.to match({ id: champ.id, code_postal: '01540', external_id: '01457' }) }
+          it { is_expected.to match({ code_postal: '01540', external_id: '01457' }) }
         end
 
         context 'when the second element is not a valid insee code' do

--- a/spec/models/types_de_champ/prefill_epci_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_epci_type_de_champ_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe TypesDeChamp::PrefillEpciTypeDeChamp do
     subject(:to_assignable_attributes) { described_class.build(type_de_champ, procedure.active_revision).to_assignable_attributes(champ, value) }
 
     shared_examples "a transformation to" do |code_departement, value|
-      it { is_expected.to match({ code_departement: code_departement, value: value, id: champ.id }) }
+      it { is_expected.to match({ code_departement: code_departement, value: value }) }
     end
 
     context 'when the value is nil' do

--- a/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
@@ -80,13 +80,13 @@ RSpec.describe TypesDeChamp::PrefillRepetitionTypeDeChamp, type: :model do
     context 'when the value is an array with some wrong keys' do
       let(:value) { [{ "champ_#{text_repetition.to_typed_id_for_query}" => "value", "blabla" => "value2" }, { "champ_#{integer_repetition.to_typed_id_for_query}" => "value3" }, { "blabla" => "false" }] }
 
-      it { is_expected.to match([[{ id: text_repetition_champs.first.id, value: "value" }], [{ id: integer_repetition_champs.second.id, value: "value3" }]]) }
+      it { is_expected.to match([[text_repetition_champs.first, { value: "value" }], [integer_repetition_champs.second, { value: "value3" }]]) }
     end
 
     context 'when the value is an array with right keys' do
       let(:value) { [{ "champ_#{text_repetition.to_typed_id_for_query}" => "value" }, { "champ_#{text_repetition.to_typed_id_for_query}" => "value2" }] }
 
-      it { is_expected.to match([[{ id: text_repetition_champs.first.id, value: "value" }], [{ id: text_repetition_champs.second.id, value: "value2" }]]) }
+      it { is_expected.to match([[text_repetition_champs.first, { value: "value" }], [text_repetition_champs.second, { value: "value2" }]]) }
     end
   end
 end

--- a/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_type_de_champ_spec.rb
@@ -159,6 +159,6 @@ RSpec.describe TypesDeChamp::PrefillTypeDeChamp, type: :model do
     let(:value) { "any@email.org" }
     subject(:to_assignable_attributes) { described_class.build(type_de_champ, procedure.active_revision).to_assignable_attributes(champ, value) }
 
-    it { is_expected.to match({ id: champ.id, value: value }) }
+    it { is_expected.to match({ value: value }) }
   end
 end


### PR DESCRIPTION
## Contexte

Le pré-remplissage était le seul code utilisant le writer `champs_attributes=` généré par `accepts_nested_attributes_for :champs`.

## Changements

- `PrefillChamps#to_a` retourne des paires `[champ, attributes]` (plus de clé `id:` dans `to_assignable_attributes`)
- `prefill!` assigne et sauvegarde chaque champ directement, comme le fait déjà `DossierEditConcern` partout ailleurs — le `reload` n'est plus nécessaire
- L'association garde `autosave: true` explicitement : c'était implicite via `accepts_nested_attributes_for`, et c'est nécessaire pour remonter les erreurs de validation des champs sur le dossier (contextes `champs_public_value` / `champs_private_value`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)