### PR TITLE
Tech: optimiser les tests de gallery_item_component_spec.rb

### DIFF
--- a/spec/components/attachment/gallery_item_component_spec.rb
+++ b/spec/components/attachment/gallery_item_component_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Attachment::GalleryItemComponent, type: :component do
-  let(:instructeur) { create(:instructeur) }
-  let(:procedure) { create(:procedure, :published, types_de_champ_public:, types_de_champ_private:) }
-  let(:types_de_champ_public) { [{ type: :piece_justificative }] }
-  let(:types_de_champ_private) { [{ type: :piece_justificative }] }
+  let_it_be(:instructeur) { create(:instructeur) }
+  let_it_be(:types_de_champ_public) { [{ type: :piece_justificative }] }
+  let_it_be(:types_de_champ_private) { [{ type: :piece_justificative }] }
+  let_it_be(:procedure) { create(:procedure, :published, types_de_champ_public:, types_de_champ_private:) }
   let(:dossier) { create(:dossier, :accepte, :with_populated_champs, :with_populated_annotations, :with_attestation_acceptation, procedure:) }
   let(:filename) { attachment.blob.filename.to_s }
 


### PR DESCRIPTION
# Probleme

Tests lents dans `spec/components/attachment/gallery_item_component_spec.rb` — temps baseline : 4.94s (mediane locale, 3 runs).

# Solution

Skill [`/test-optimization`](https://github.com/mfo/night-shift/blob/main/.claude/skills/test-optimization/SKILL.md)

### Techniques appliquees

| Technique | Avant | Apres | Gain |
|-----------|-------|-------|------|
| T08 — let_it_be | 4.94s | 3.48s | -29.5% |

### Techniques tentees sans succes

| Technique | Raison |
|-----------|--------|
| T09 — aggregate_failures | Gain marginal (2%, sous le seuil de 5% / 0.5s). Le setup economise (touch(:depose_at)) est trop leger. |
| T01 — create→build | Tous les `create` ont besoin de persistance DB (FK, associations, fichiers). |
| T04 — setup inutile | Aucun `let!` superflu ; chaque objet est utilise par au moins un test. |
| T10 — let!→let | Aucun `let!` dans le fichier. |
| T11 — factory_default | La procedure est deja partagee via `let_it_be`. Ajout de factory_default necessiterait des changements dans spec_helper.rb pour un gain marginal. |
| T12 — split | Fichier < 1000 lignes (172 lignes). |

**Resultat final : 4.94s → 3.48s (gain total 29.5%)**

Coverage : 41.09% → 41.09% (maintenue)

Generated with [Claude Code](https://claude.com/claude-code)