### PR TITLE
correctif: ETQ usager, les icons dans le sidemenu on un espace de plus

### DIFF
--- a/app/components/dsfr/sidemenu_component/sidemenu_component.html.erb
+++ b/app/components/dsfr/sidemenu_component/sidemenu_component.html.erb
@@ -18,7 +18,7 @@
           <li class="<%= "fr-sidemenu__item fr-sidemenu__item#{active?(link.url) ? '--active' : ''}" %>">
             <%= link_to link.url, class: 'fr-sidemenu__link', 'aria-current': (active?(link.url) ? 'page' : nil), target: '_self' do %>
               <% if link.icon.present? %>
-                <span class="<%= link.icon %>"></span>
+                <span class="<%= link.icon %>">&nbsp;</span>
               <% end %>
 
               <%= link.name %>


### PR DESCRIPTION
mini fix visuel suite a mon agent qui a merdé


avant:
<img width="222" height="92" alt="Capture d’écran 2026-07-06 à 5 27 02 PM" src="https://github.com/user-attachments/assets/c76fb807-b0cf-411e-9413-c45c06f2eec3" />


apres:
> <img width="261" height="159" alt="Capture d’écran 2026-07-06 à 5 20 41 PM" src="https://github.com/user-attachments/assets/eb8c710f-b657-47b2-8875-cdede3b6d4dd" />
