### PR TITLE
Tech: linter, apostrophe, ajoute le support devant une interpolation

### DIFF
--- a/app/components/account_dropdown_component/account_dropdown_component.en.yml
+++ b/app/components/account_dropdown_component/account_dropdown_component.en.yml
@@ -8,4 +8,5 @@ en:
   profile: 'See my profile'
   logout: 'Log out'
   my_account: 'My profile'
+  via_france_connect: 'via FranceConnect'
   connected_as: 'connected as %{profile}'

--- a/app/components/account_dropdown_component/account_dropdown_component.fr.yml
+++ b/app/components/account_dropdown_component/account_dropdown_component.fr.yml
@@ -8,4 +8,5 @@ fr:
   profile: 'Voir mon profil'
   logout: 'Se déconnecter'
   my_account: 'Mon profil'
-  connected_as: 'connecté en tant qu’%{profile}'
+  via_france_connect: 'via FranceConnect'
+  connected_as: "connecté en tant qu'%{profile}"

--- a/app/components/account_dropdown_component/account_dropdown_component.fr.yml
+++ b/app/components/account_dropdown_component/account_dropdown_component.fr.yml
@@ -9,4 +9,4 @@ fr:
   logout: 'Se déconnecter'
   my_account: 'Mon profil'
   via_france_connect: 'via FranceConnect'
-  connected_as: "connecté en tant qu'%{profile}"
+  connected_as: "connecté en tant qu’%{profile}"

--- a/app/components/account_dropdown_component/account_dropdown_component.html.erb
+++ b/app/components/account_dropdown_component/account_dropdown_component.html.erb
@@ -13,7 +13,7 @@
       <span class="fr-mr-1w"><%= current_email %></span>
 
       <%- if france_connected? -%>
-        <span>&nbsp;via FranceConnect</span>
+        <span>&nbsp;<%= t('.via_france_connect') %></span>
       <%- end -%>
 
       <%- if show_profile_badge? -%>

--- a/lib/tasks/apostrophe_lint.rake
+++ b/lib/tasks/apostrophe_lint.rake
@@ -13,7 +13,8 @@ namespace :lint do
     # Common french elision patterns where apostrophes are used
     # These patterns match a letter followed by an incorrect apostrophe followed by a vowel or 'h'
     # which indicates a french elision (l'exemple, d'abord, n'est, etc.)
-    vowels_and_h = "aeiouyàâäéèêëïîôùûüœæAEIOUYÀÂÄÉÈÊËÏÎÔÙÛÜŒÆhH"
+    # % is included to catch elisions before YAML interpolation variables (e.g. qu'%{profile})
+    vowels_and_h = "aeiouyàâäéèêëïîôùûüœæAEIOUYÀÂÄÉÈÊËÏÎÔÙÛÜŒÆhH%"
 
     elision_patterns = [
       # Single letter elisions: l', d', n', s', c', j', m', t'


### PR DESCRIPTION
# Probleme

Textes francais en dur dans `app/mailers/super_admin_mailer.rb` — bloque l'internationalisation.

# Solution

Aucun texte hardcode trouve. Le mailer est une classe vide sans methode ni sujet ni template associe.

### Validation visuelle — RESULTAT

Aucun rendu a capturer — le mailer ne definit aucune action email.

### Validation technique

- [x] Aucun texte hardcode dans le fichier
- [x] Aucun template de vue associe
- [x] Preview mailer vide (aucune action)

Generated with [Claude Code](https://claude.com/claude-code)

---

# Probleme

Texte francais en dur dans `account_dropdown_component.html.erb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 1 cle i18n vers `app/components/account_dropdown_component/account_dropdown_component.yml`.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `via_france_connect` | "via FranceConnect" | "via FranceConnect" |

### Validation visuelle — RESULTAT

**Screenshots non disponibles** — permissions Playwright en attente.

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante
- [x] Apostrophes typographiques verifiees
- [x] Tests passes (8 exemples, 0 echecs)
- [x] Rubocop OK

Generated with [Claude Code](https://claude.com/claude-code)

---

# Probleme

Textes francais en dur dans `app/components/application_component.rb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Aucun texte hardcode trouve dans ce fichier — classe de base pure sans strings.

### Validation technique

- [x] Aucun texte francais en dur identifie

Generated with [Claude Code](https://claude.com/claude-code)