### PR TITLE
ETQ usager, nouveau style de bandeau pour l’alerte « en attente de réponse »

### DIFF
--- a/app/views/users/dossiers/_dossiers_list.html.erb
+++ b/app/views/users/dossiers/_dossiers_list.html.erb
@@ -35,16 +35,9 @@
       <% end %>
 
       <% if dossier.pending_response? %>
-        <%= render Dsfr::AlertComponent.new(state: :warning, size: :sm, extra_class_names: "fr-mb-2w") do |c| %>
-          <% c.with_body do %>
-            <h3 class="card-title fr-mb-1v">
-              <%= t('views.users.dossiers.dossiers_list.pending_response.title') %>
-            </h3>
-
-            <p>
-              <%= t('views.users.dossiers.dossiers_list.pending_response.message_html', link: messagerie_dossier_path(dossier), id: number_with_html_delimiter(dossier.id)).html_safe %>
-            </p>
-          <% end %>
+        <%= render Dsfr::NoticeComponent.new(state: 'warning', extra_class_names: "fr-mb-2w") do |c| %>
+          <% c.with_title { t('views.users.dossiers.dossiers_list.pending_response.title') } %>
+          <% c.with_desc { t('views.users.dossiers.dossiers_list.pending_response.message_html', link: messagerie_dossier_path(dossier), id: number_with_html_delimiter(dossier.id)) } %>
         <% end %>
       <% end %>
 

--- a/app/views/users/dossiers/show/_status_overview.html.erb
+++ b/app/views/users/dossiers/show/_status_overview.html.erb
@@ -55,16 +55,9 @@
           <% end %>
 
           <% if dossier.awaiting_response.present? %>
-            <%= render Dsfr::AlertComponent.new(state: :warning, size: :sm, extra_class_names: "fr-mb-2w") do |c| %>
-              <% c.with_body do %>
-                <h4 class="card-title fr-mb-1v">
-                  <%= t('views.users.dossiers.dossiers_list.pending_response.title') %>
-                </h4>
-
-                <p>
-                  <%= t('views.users.dossiers.dossiers_list.pending_response.message_html', link: messagerie_dossier_path(dossier), id: number_with_html_delimiter(dossier.id)).html_safe %>
-                </p>
-              <% end %>
+            <%= render Dsfr::NoticeComponent.new(state: 'warning', extra_class_names: "fr-mb-2w") do |c| %>
+              <% c.with_title { t('views.users.dossiers.dossiers_list.pending_response.title') } %>
+              <% c.with_desc { t('views.users.dossiers.dossiers_list.pending_response.message_html', link: messagerie_dossier_path(dossier), id: number_with_html_delimiter(dossier.id)) } %>
             <% end %>
           <% end %>
 
@@ -81,16 +74,9 @@
       <% elsif dossier.en_instruction? %>
         <div class="en-instruction">
           <% if dossier.awaiting_response.present? %>
-            <%= render Dsfr::AlertComponent.new(state: :warning, size: :sm, extra_class_names: "fr-mb-2w") do |c| %>
-              <% c.with_body do %>
-                <h4 class="card-title fr-mb-1v">
-                  <%= t('views.users.dossiers.dossiers_list.pending_response.title') %>
-                </h4>
-
-                <p>
-                  <%= t('views.users.dossiers.dossiers_list.pending_response.message_html', link: messagerie_dossier_path(dossier), id: number_with_html_delimiter(dossier.id)).html_safe %>
-                </p>
-              <% end %>
+            <%= render Dsfr::NoticeComponent.new(state: 'warning', extra_class_names: "fr-mb-2w") do |c| %>
+              <% c.with_title { t('views.users.dossiers.dossiers_list.pending_response.title') } %>
+              <% c.with_desc { t('views.users.dossiers.dossiers_list.pending_response.message_html', link: messagerie_dossier_path(dossier), id: number_with_html_delimiter(dossier.id)) } %>
             <% end %>
           <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -620,10 +620,10 @@ en:
           no_result_search_back_link: "go back to your files list"
           pending_correction:
             title: "Warning"
-            body_html: 'Consult the corrections to be made to your file in the <a href="%{link}" class="fr-link">messaging system<span class="fr-sr-only"> of file number %{id}</span></a>.'
+            body_html: 'Consult the corrections to be made to your file in the <a href="%{link}" class="fr-notice__link">messaging system<span class="fr-sr-only"> of file number %{id}</span></a>.'
           pending_response:
             title: "Warning"
-            message_html: 'Consult the <a href="%{link}" class="fr-link">messaging system<span class="fr-sr-only"> of file number %{id}</span></a> and respond to the administration.'
+            message_html: 'Consult the <a href="%{link}" class="fr-notice__link">messaging system<span class="fr-sr-only"> of file number %{id}</span></a> and respond to the administration.'
           depose_at: First submission on %{date}
           created_at: Created at %{date}
           updated_at: updated at %{date}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -622,7 +622,7 @@ en:
             title: "Warning"
             body_html: 'Consult the corrections to be made to your file in the <a href="%{link}" class="fr-link">messaging system<span class="fr-sr-only"> of file number %{id}</span></a>.'
           pending_response:
-            title: "This file is waiting for your response"
+            title: "Warning"
             message_html: 'Consult the <a href="%{link}" class="fr-link">messaging system<span class="fr-sr-only"> of file number %{id}</span></a> and respond to the administration.'
           depose_at: First submission on %{date}
           created_at: Created at %{date}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -647,7 +647,7 @@ fr:
             title: "Attention"
             body_html: 'Consultez les corrections à apporter à votre dossier dans la <a href="%{link}" class="fr-link">messagerie<span class="fr-sr-only"> du dossier numéro %{id}</span></a>.'
           pending_response:
-            title: "Ce dossier attend votre réponse"
+            title: "Attention"
             message_html: 'Consultez la <a href="%{link}" class="fr-link">messagerie<span class="fr-sr-only"> du dossier numéro %{id}</span></a> et répondez à l''administration.'
           depose_at: Déposé le %{date}
           created_at: Créé le %{date}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -645,10 +645,10 @@ fr:
             this_procedure: cette démarche
           pending_correction:
             title: "Attention"
-            body_html: 'Consultez les corrections à apporter à votre dossier dans la <a href="%{link}" class="fr-link">messagerie<span class="fr-sr-only"> du dossier numéro %{id}</span></a>.'
+            body_html: 'Consultez les corrections à apporter à votre dossier dans la <a href="%{link}" class="fr-notice__link">messagerie<span class="fr-sr-only"> du dossier numéro %{id}</span></a>.'
           pending_response:
             title: "Attention"
-            message_html: 'Consultez la <a href="%{link}" class="fr-link">messagerie<span class="fr-sr-only"> du dossier numéro %{id}</span></a> et répondez à l''administration.'
+            message_html: 'Consultez la <a href="%{link}" class="fr-notice__link">messagerie<span class="fr-sr-only"> du dossier numéro %{id}</span></a> et répondez à l''administration.'
           depose_at: Déposé le %{date}
           created_at: Créé le %{date}
           updated_at: modifié le %{date}


### PR DESCRIPTION
Ref #13018

Aligne le bandeau **« en attente de réponse »** sur le nouveau design du ticket : passage du composant **alerte** au **bandeau d’information importante** (`Dsfr::NoticeComponent`, type *warning*), avec le titre **Attention**. Il rejoint ainsi le bandeau « à corriger », déjà migré. S’applique sur la carte de la liste des dossiers et sur la page dossier (états *en construction* et *en instruction*).

Corrige aussi la couleur des liens dans les deux bandeaux (« en attente de réponse » **et** « à corriger ») : `fr-link` (bleu) → `fr-notice__link`, pour que le lien hérite de la couleur *warning* du bandeau, conformément au [bandeau d’information importante du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bandeau-d-information-importante).

## Avant / Après

_Page dossier_

Avant
<img width="1400" height="1400" alt="show" src="https://github.com/user-attachments/assets/a6aba665-7ab9-406f-8bb8-e7f4146ec8e9" />

Après
<img width="1400" height="1400" alt="show" src="https://github.com/user-attachments/assets/9b5297f4-ea9c-4b5e-87ea-b0271214ca3e" />

_Carte dans la liste_

Avant
<img width="1400" height="1400" alt="list" src="https://github.com/user-attachments/assets/62c05e73-a647-48e3-b429-fd9448b5d258" />

Après
<img width="1400" height="1400" alt="list" src="https://github.com/user-attachments/assets/01fffbe6-bb91-401b-8ae4-3f2fe5867111" />