### PR TITLE
ETQ usager, je peux déposer mon dossier même si la vérification du SIRET est temporairement indisponible

### DIFF
--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -78,12 +78,13 @@ module Dsfr
       case @champ.type_de_champ.type_champ
       when TypeDeChamp.type_champs[:siret]
         # TODO: use fetched? after T20251029backfillChampSiretExternalStateTask
-        if @champ.etablissement && @champ.etablissement.entreprise_capital_social.present?
+        if @champ.degraded?
+          # Submission is blocked when the champ feeds a condition: no reassuring message then.
+          { state: :info, text: t('.siret.technical_error') } if !@champ.dependent_conditions?
+        elsif @champ.etablissement && @champ.etablissement.entreprise_capital_social.present?
           { state: :info, text: t('.siret.fetched_with_capital', raison_sociale_or_name: displayable_raison_sociale_or_name(@champ.etablissement), forme_juridique: @champ.etablissement.entreprise_forme_juridique, capital_sociale: pretty_currency(@champ.etablissement.entreprise_capital_social)) }
         elsif @champ.etablissement && @champ.etablissement.entreprise_capital_social.blank?
           { state: :info, text: t('.siret.fetched', raison_sociale_or_name: displayable_raison_sociale_or_name(@champ.etablissement), forme_juridique: @champ.etablissement.entreprise_forme_juridique) }
-        elsif @champ.external_error?
-          { state: :warning, text: t('.siret.error', value: pretty_siret(@champ.external_id)) }
         elsif @champ.pending?
           { state: :info, text: t('.siret.pending', value: pretty_siret(@champ.external_id)) }
         end

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
@@ -9,10 +9,10 @@ en:
     pending: "RNF verification pending"
     success: "This RNF matches: %{title}, %{address}"
   siret:
+    technical_error: "Automatic verification is temporarily unavailable. You can continue submitting; the information will be retrieved as soon as possible."
     pending: "Search in progress for SIRET %{value}…"
     fetched_with_capital: "%{raison_sociale_or_name} %{forme_juridique} with a share capital of %{capital_sociale}"
     fetched: "%{raison_sociale_or_name} %{forme_juridique}"
-    error: "An error occurred while retrieving SIRET information."
   referentiel:
     not_configured: "This field has not been configured by the administrator yet."
     fetching: "Search in progress."

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
@@ -9,10 +9,10 @@ fr:
     pending: "Vérification du RNF en cours"
     success: "Ce RNF correspond à : %{title}, %{address}"
   siret:
+    technical_error: "La vérification automatique est temporairement indisponible. Vous pouvez poursuivre le dépôt ; les informations seront récupérées dès que possible."
     pending: "Recherche en cours pour le SIRET %{value}…"
     fetched_with_capital: "%{raison_sociale_or_name} %{forme_juridique} au capital social de %{capital_sociale}"
     fetched: "%{raison_sociale_or_name} %{forme_juridique}"
-    error: "Une erreur est survenue lors de la récupération des informations SIRET."
   referentiel:
     not_configured: "Ce champ n’est pas encore configuré par l’administrateur."
     fetching: "Recherche en cours."

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -215,7 +215,7 @@ module Users
       end
 
       case APIEntrepriseService.create_etablissement_with_fallback(@dossier, sanitized_siret, current_user.id)
-      in Success
+      in Success | Failure(degraded: true, **)
         current_user.update!(siret: sanitized_siret)
         @dossier.update!(autorisation_donnees: true, last_champ_updated_at: Time.zone.now)
         redirect_to etablissement_dossier_path

--- a/app/jobs/champ_fetch_external_data_job.rb
+++ b/app/jobs/champ_fetch_external_data_job.rb
@@ -6,7 +6,12 @@ class ChampFetchExternalDataJob < ApplicationJob
 
   retry_on RetryableFetchError, attempts: 3, wait: :polynomially_longer do |job, err|
     champ = job.arguments.first
-    champ.handle_exhausted_external_data_retries!
+    begin
+      champ.handle_exhausted_external_data_retries!
+    rescue StandardError => e
+      # Never let this escape: the champ would stay stuck in waiting_for_job.
+      Sentry.capture_exception(e)
+    end
 
     # Don't raise, otherwise it will pop forever as "working" queue without doing anything
     Sentry.capture_exception(err.cause)

--- a/app/jobs/champ_fetch_external_data_job.rb
+++ b/app/jobs/champ_fetch_external_data_job.rb
@@ -6,7 +6,7 @@ class ChampFetchExternalDataJob < ApplicationJob
 
   retry_on RetryableFetchError, attempts: 3, wait: :polynomially_longer do |job, err|
     champ = job.arguments.first
-    champ.external_data_error!
+    champ.handle_exhausted_external_data_retries!
 
     # Don't raise, otherwise it will pop forever as "working" queue without doing anything
     Sentry.capture_exception(err.cause)

--- a/app/jobs/cron/backfill_siret_degraded_mode_job.rb
+++ b/app/jobs/cron/backfill_siret_degraded_mode_job.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# TODO: remove this job in a few days once all failed etablissements are queued as separate jobs
 class Cron::BackfillSiretDegradedModeJob < Cron::CronJob
   self.schedule_expression = "every 2 hour"
 

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -74,10 +74,6 @@ class ChampData < ApplicationRecord
   # look like it was edited. Revert blank-equivalent JSON columns before saving.
   before_save :nullify_blank_json_columns
 
-  def permissive_external_data_validation?
-    false
-  end
-
   def type_de_champ
     @type_de_champ ||= dossier.revision
       .type_de_champs

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -74,6 +74,10 @@ class ChampData < ApplicationRecord
   # look like it was edited. Revert blank-equivalent JSON columns before saving.
   before_save :nullify_blank_json_columns
 
+  def permissive_external_data_validation?
+    false
+  end
+
   def type_de_champ
     @type_de_champ ||= dossier.revision
       .type_de_champs

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -9,8 +9,14 @@ class Champs::SiretChamp < ChampData
     true
   end
 
+  # A condition based on one of this champ's columns (value_json) cannot be
+  # evaluated until the data is fetched: restore the blocking validation.
   def permissive_external_data_validation?
-    true
+    !external_data_required_for_conditions?
+  end
+
+  def external_data_required_for_conditions?
+    dependent_conditions?
   end
 
   def focusable_input_id(attribute = :value)
@@ -67,6 +73,7 @@ class Champs::SiretChamp < ChampData
   # SIRET controller creates an etablissement in degraded mode
   def validate_etablissement
     return if external_id.blank?
+
     return if etablissement.present?
     return if pending?
     return if external_error?

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -12,11 +12,7 @@ class Champs::SiretChamp < ChampData
   # A condition based on one of this champ's columns (value_json) cannot be
   # evaluated until the data is fetched: restore the blocking validation.
   def permissive_external_data_validation?
-    !external_data_required_for_conditions?
-  end
-
-  def external_data_required_for_conditions?
-    dependent_conditions?
+    !dependent_conditions?
   end
 
   def focusable_input_id(attribute = :value)
@@ -44,15 +40,23 @@ class Champs::SiretChamp < ChampData
 
   def fetch_external_data
     case APIEntrepriseService.create_etablissement_with_fallback(self, external_id.delete(" "), dossier.user&.id)
-    in Success(etablissement) if etablissement.as_degraded_mode?
-      Failure(retryable: true, error: StandardError.new("API Entreprise: degraded mode"), code: 503)
     in Success(etablissement)
       Success(etablissement:, value: external_id)
+    in Failure(degraded: true, etablissement:, type:, code:)
+      Failure(degraded: true, etablissement:, value: external_id,
+        error: StandardError.new("API Entreprise: #{type}"), code:)
     in Failure(type: :not_found, **)
       Failure(retryable: false, error: StandardError.new('NotFound'), code: 404)
     in Failure(type:, code:, retryable:, **)
       Failure(retryable:, error: StandardError.new("API Entreprise: #{type}"), code:)
     end
+  end
+
+  def handle_exhausted_external_data_retries!
+    etablissement = APIEntrepriseService.create_etablissement_as_degraded_mode(self, external_id.delete(" "), dossier.user&.id)
+
+    handle_result(Failure(degraded: true, etablissement:, value: external_id,
+      error: StandardError.new('API Entreprise: retries exhausted'), code: 504))
   end
 
   def search_terms
@@ -75,8 +79,9 @@ class Champs::SiretChamp < ChampData
     return if external_id.blank?
 
     return if etablissement.present?
-    return if pending?
-    return if external_error?
+    # Once a fetch has been attempted, blocking is ExternalDataChampValidator's
+    # job; this validation only covers the synchronous format-check path.
+    return unless idle?
 
     validator = ActiveModel::Validations::SiretValidator.new(attributes: { value: true })
 

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -9,6 +9,10 @@ class Champs::SiretChamp < ChampData
     true
   end
 
+  def permissive_external_data_validation?
+    true
+  end
+
   def focusable_input_id(attribute = :value)
     [input_id, :value].compact.join('-')
   end
@@ -65,6 +69,7 @@ class Champs::SiretChamp < ChampData
     return if external_id.blank?
     return if etablissement.present?
     return if pending?
+    return if external_error?
 
     validator = ActiveModel::Validations::SiretValidator.new(attributes: { value: true })
 

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -109,6 +109,10 @@ module ChampExternalDataConcern
     in Success(hash)
       update_external_data!(hash)
       external_data_fetched!
+    in Failure(degraded: true, error:, code:, **data)
+      update_external_data!(data)
+      save_external_error(error, code)
+      external_data_degraded!
     in Failure(retryable: true, error:, code:)
       save_external_error(error, code)
       retry!

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -58,6 +58,7 @@ module ChampExternalDataConcern
       end
 
       event :external_data_degraded do
+        # waiting_for_job: reached from the retry_on exhaustion block
         transitions from: [:fetching, :waiting_for_job], to: :degraded
       end
 
@@ -77,9 +78,14 @@ module ChampExternalDataConcern
 
   def pending? = waiting_for_job? || fetching?
   def done? = fetched? || degraded? || external_error?
-  def external_data_not_found? = external_error? && fetch_external_data_exceptions&.last&.not_found?
+  # Only the most recent exception is conclusive, and legacy rows can sit in
+  # external_error with none recorded at all.
+  def last_external_data_exception = external_error? ? fetch_external_data_exceptions&.last : nil
+  def external_data_not_found? = last_external_data_exception&.not_found?
 
   def has_async_external_data? = false
+
+  def permissive_external_data_validation? = false
 
   def external_data_needed_for_validation? = has_async_external_data?
 
@@ -124,8 +130,9 @@ module ChampExternalDataConcern
     end
   end
 
+  # Clears the exception list unless the caller passes its own.
   def update_external_data!(hash)
-    update!(hash.merge(fetch_external_data_exceptions: []))
+    update!({ fetch_external_data_exceptions: [] }.merge(hash))
   end
 
   def save_external_error(error, code)

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -16,6 +16,11 @@ module ChampExternalDataConcern
   # fetching -> external_error
   # if the data is fetched successfully, the external_data_fetched event is triggered
   # fetching -> fetched
+  # if the data is unavailable but a usable fallback was built, the
+  # external_data_degraded event is triggered
+  # fetching -> degraded
+  # the champ leaves degraded once a backfill job completes the data
+  # degraded -> fetched
 
   included do
     include AASM
@@ -28,6 +33,7 @@ module ChampExternalDataConcern
       waiting_for_job: 'waiting_for_job',
       fetching: 'fetching',
       fetched: 'fetched',
+      degraded: 'degraded',
       external_error: 'external_error',
     }
 
@@ -36,6 +42,7 @@ module ChampExternalDataConcern
       state :waiting_for_job
       state :fetching
       state :fetched
+      state :degraded
       state :external_error
 
       event :fetch_later, after_commit: :fetch_external_data_later do
@@ -47,7 +54,11 @@ module ChampExternalDataConcern
       end
 
       event :external_data_fetched do
-        transitions from: [:fetching], to: :fetched
+        transitions from: [:fetching, :degraded], to: :fetched
+      end
+
+      event :external_data_degraded do
+        transitions from: [:fetching, :waiting_for_job], to: :degraded
       end
 
       event :external_data_error do
@@ -59,18 +70,22 @@ module ChampExternalDataConcern
       end
 
       event :reset_external_data, after: :after_reset_external_data do
-        transitions from: [:idle, :waiting_for_job, :fetching, :fetched, :external_error], to: :idle
+        transitions from: [:idle, :waiting_for_job, :fetching, :fetched, :degraded, :external_error], to: :idle
       end
     end
   end
 
   def pending? = waiting_for_job? || fetching?
-  def done? = fetched? || external_error?
+  def done? = fetched? || degraded? || external_error?
   def external_data_not_found? = external_error? && fetch_external_data_exceptions&.last&.not_found?
 
   def has_async_external_data? = false
 
   def external_data_needed_for_validation? = has_async_external_data?
+
+  def handle_exhausted_external_data_retries!
+    external_data_error!
+  end
 
   private
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -639,7 +639,7 @@ class Dossier < ApplicationRecord
 
   def any_etablissement_as_degraded_mode?
     return true if etablissement&.as_degraded_mode?
-    return true if filled_champs_public.any? { _1.etablissement&.as_degraded_mode? }
+    return true if filled_champs.any? { _1.etablissement&.as_degraded_mode? }
 
     false
   end

--- a/app/models/external_data_exception.rb
+++ b/app/models/external_data_exception.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class ExternalDataException
+  # The API answered about this identifier and will not answer differently
+  # later: nonexistent (404), unprocessable (422), non-diffusible (451).
+  DEFINITIVE_CODES = [404, 422, 451].freeze
+
   attr_accessor :error, :code
 
   def initialize(error:, code:)
@@ -10,5 +14,9 @@ class ExternalDataException
 
   def not_found?
     code == 404
+  end
+
+  def definitive?
+    code.in?(DEFINITIVE_CODES)
   end
 end

--- a/app/models/types_de_champ/siret_type_de_champ.rb
+++ b/app/models/types_de_champ/siret_type_de_champ.rb
@@ -12,7 +12,8 @@ class TypesDeChamp::SiretTypeDeChamp < TypeDeChamp
     FILL_DURATION_MEDIUM
   end
 
-  def typed_champ_blank_or_invalid?(champ) = Siret.new(siret: champ.value).invalid?
+  # A syntactically valid external_id satisfies the mandatory check; blocking on the fetch result belongs to ExternalDataChampValidator.
+  def typed_champ_blank_or_invalid?(champ) = Siret.new(siret: champ.external_id).invalid?
 
   def columns(procedure_id:, displayable: true, prefix: nil)
     super

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class APIEntrepriseService
-  DEGRADED_CODES = [401, 403, 409].freeze
+  CREDENTIALS_CODES = [401, 403].freeze
 
   class << self
     include Dry::Monads[:result]
@@ -58,8 +58,11 @@ class APIEntrepriseService
         degraded(dossier_or_champ, siret, user_id, type:, code:)
       in Failure(type:, code:, retryable: true, **) if !APIEntreprise::HealthChecker.provider_up?(:insee_sirene)
         degraded(dossier_or_champ, siret, user_id, type:, code:)
-      in Failure(type:, code:, **) if DEGRADED_CODES.include?(code)
-        Sentry.capture_message("API Entreprise: #{type}", level: :error, extra: { siret:, code: }) if code.in?([401, 403])
+      in Failure(type:, code:, **) => result if code.in?(CREDENTIALS_CODES)
+        report_error(result.failure, siret:)
+        degraded(dossier_or_champ, siret, user_id, type:, code:)
+      in Failure(type:, code: 409 => code, **)
+        # Conflict: nothing we can fix, and no retry would help.
         degraded(dossier_or_champ, siret, user_id, type:, code:)
       in result
         result
@@ -74,6 +77,11 @@ class APIEntrepriseService
         champ = etablissement.champ_data
         champ.external_data_fetched! if champ&.may_external_data_fetched?
         etablissement
+      in Failure(type:, code:, **) => result if code.in?(CREDENTIALS_CODES)
+        # Our own credentials: no retry converges, the champ would stay degraded forever.
+        Rails.logger.error("API Entreprise backfill blocked: etablissement=#{etablissement.id} type=#{type} code=#{code}")
+        report_error(result.failure, siret: etablissement.siret, etablissement_id: etablissement.id)
+        nil
       else
         nil
       end

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class APIEntrepriseService
+  DEGRADED_CODES = [401, 403, 409].freeze
+
   class << self
     include Dry::Monads[:result]
 
@@ -55,6 +57,9 @@ class APIEntrepriseService
       in Failure(type: :rate_limited => type, code:, **)
         degraded(dossier_or_champ, siret, user_id, type:, code:)
       in Failure(type:, code:, retryable: true, **) if !APIEntreprise::HealthChecker.provider_up?(:insee_sirene)
+        degraded(dossier_or_champ, siret, user_id, type:, code:)
+      in Failure(type:, code:, **) if DEGRADED_CODES.include?(code)
+        Sentry.capture_message("API Entreprise: #{type}", level: :error, extra: { siret:, code: }) if code.in?([401, 403])
         degraded(dossier_or_champ, siret, user_id, type:, code:)
       in result
         result

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -42,15 +42,20 @@ class APIEntrepriseService
 
     # Tries to create an etablissement; falls back to degraded mode if API is unavailable.
     #
-    # Returns Success(etablissement) on success or degraded fallback
-    # Returns Failure(type: :not_found, ...) if SIRET not found
-    # Returns Failure(type:, code:, retryable:, raw_response:) on non-recoverable errors
+    # Returns Success(etablissement) when the data is complete
+    # Returns Failure(degraded: true, etablissement:, type:, code:) when only a
+    #   stub could be built: the caller can carry on, a backfill completes it later
+    # Returns Failure(type:, code:, retryable:, raw_response:) on a plain failure
     def create_etablissement_with_fallback(dossier_or_champ, siret, user_id = nil)
       case create_etablissement(dossier_or_champ, siret, user_id)
-      in Failure(type: :rate_limited, **)
-        Success(create_etablissement_as_degraded_mode(dossier_or_champ, siret, user_id))
-      in Failure(retryable: true, **) if !APIEntreprise::HealthChecker.provider_up?(:insee_sirene)
-        Success(create_etablissement_as_degraded_mode(dossier_or_champ, siret, user_id))
+      in Success(etablissement) if etablissement.as_degraded_mode?
+        Failure(degraded: true, etablissement:, type: :incomplete_payload, code: 200)
+      in Success(etablissement)
+        Success(etablissement)
+      in Failure(type: :rate_limited => type, code:, **)
+        degraded(dossier_or_champ, siret, user_id, type:, code:)
+      in Failure(type:, code:, retryable: true, **) if !APIEntreprise::HealthChecker.provider_up?(:insee_sirene)
+        degraded(dossier_or_champ, siret, user_id, type:, code:)
       in result
         result
       end
@@ -84,6 +89,11 @@ class APIEntrepriseService
       end
 
       APIEntreprise::AttestationFiscaleJob.set(wait:).perform_later(etablissement.id, procedure_id, user_id)
+    end
+
+    def degraded(dossier_or_champ, siret, user_id, type:, code:)
+      Failure(degraded: true, type:, code:,
+        etablissement: create_etablissement_as_degraded_mode(dossier_or_champ, siret, user_id))
     end
 
     def report_error(failure, extra = {})

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -61,6 +61,8 @@ class APIEntrepriseService
       in Success(etablissement_params) if etablissement_params.present?
         etablissement.update!(etablissement_params)
         etablissement.update_champ_value_json!
+        champ = etablissement.champ_data
+        champ.external_data_fetched! if champ&.may_external_data_fetched?
         etablissement
       else
         nil

--- a/app/validators/external_data_champ_validator.rb
+++ b/app/validators/external_data_champ_validator.rb
@@ -3,6 +3,9 @@
 class ExternalDataChampValidator < ActiveModel::Validator
   # Required checks are delegated to Champ#validate_completed (:champ_completeness context).
   def validate(record)
+    # Skip before permissive_external_data_validation? scans the revision.
+    return if record.idle? || record.fetched?
+
     if record.permissive_external_data_validation?
       permissive_validate(record)
     else
@@ -17,14 +20,15 @@ class ExternalDataChampValidator < ActiveModel::Validator
       record.errors.add(:external_id, :api_response_pending)
     elsif record.external_error?
       # User filled the field, but background job failed.
-      record.errors.add(:external_id, error_key_for(record, record.fetch_external_data_exceptions&.last))
+      record.errors.add(:external_id, error_key_for(record, record.last_external_data_exception))
     end
   end
 
   def permissive_validate(record)
-    return unless record.external_data_not_found?
+    exception = record.last_external_data_exception
+    return unless exception&.definitive?
 
-    record.errors.add(:value, error_key_for(record, record.fetch_external_data_exceptions.last))
+    record.errors.add(:value, error_key_for(record, exception))
   end
 
   def error_key_for(record, exception)

--- a/app/validators/external_data_champ_validator.rb
+++ b/app/validators/external_data_champ_validator.rb
@@ -3,22 +3,35 @@
 class ExternalDataChampValidator < ActiveModel::Validator
   # Required checks are delegated to Champ#validate_completed (:champ_completeness context).
   def validate(record)
-    if record.pending?
-      # User filled the field, but background job is still running.
-      record.errors.add(:external_id, :api_response_pending)
-    elsif record.external_error?
-      # User filled the field, but background job failed.
-      record.errors.add(:external_id, error_key_for_api_response_code(record))
+    if record.permissive_external_data_validation?
+      permissive_validate(record)
+    else
+      strict_validate(record)
     end
   end
 
   private
 
-  def error_key_for_api_response_code(record)
-    first_exception = record.fetch_external_data_exceptions&.first
-    return :code_unknown if first_exception.nil?
+  def strict_validate(record)
+    if record.pending?
+      # User filled the field, but background job is still running.
+      record.errors.add(:external_id, :api_response_pending)
+    elsif record.external_error?
+      # User filled the field, but background job failed.
+      record.errors.add(:external_id, error_key_for(record, record.fetch_external_data_exceptions&.last))
+    end
+  end
 
-    http_status = first_exception.code
+  def permissive_validate(record)
+    return unless record.external_data_not_found?
+
+    record.errors.add(:value, error_key_for(record, record.fetch_external_data_exceptions.last))
+  end
+
+  def error_key_for(record, exception)
+    return :code_unknown if exception.nil?
+
+    http_status = exception.code
     error_key = :"code_#{http_status}"
 
     if http_status && translation_exists_for?(error_key, record)

--- a/app/validators/external_data_champ_validator.rb
+++ b/app/validators/external_data_champ_validator.rb
@@ -13,8 +13,7 @@ class ExternalDataChampValidator < ActiveModel::Validator
   private
 
   def strict_validate(record)
-    if record.pending?
-      # User filled the field, but background job is still running.
+    if record.pending? || record.degraded?
       record.errors.add(:external_id, :api_response_pending)
     elsif record.external_error?
       # User filled the field, but background job failed.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -774,6 +774,8 @@ en:
         code_400: 'Invalid request. Please check your information.'
         code_403: 'Access denied. You do not have the necessary permissions.'
         code_401: 'Unauthorized. Please log in to continue.'
+        code_422: 'The information provided could not be processed. Please check the number you entered.'
+        code_451: 'This information cannot be disclosed for legal reasons.'
         code_unknown: 'The external service is not responding correctly. Please try again later.'
       models:
         attestation_template:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -787,6 +787,8 @@ fr:
         code_400: 'Demande incorrecte. Vérifiez vos informations.'
         code_403: 'Accès refusé. Vous n’avez pas les droits nécessaires.'
         code_401: 'Non autorisé. Connectez-vous pour continuer.'
+        code_422: 'Les informations transmises n’ont pas pu être traitées. Vérifiez le numéro saisi.'
+        code_451: 'Ces informations ne peuvent pas être communiquées pour des raisons légales.'
         code_unknown: 'Le service externe ne répond pas correctement. Réessayez plus tard.'
       models:
         attestation_template:

--- a/spec/components/input_status_message_component_spec.rb
+++ b/spec/components/input_status_message_component_spec.rb
@@ -277,6 +277,25 @@ RSpec.describe Dsfr::InputStatusMessageComponent, type: :component do
         end
       end
 
+      context "when the champ is in degraded state (API Entreprise was down at fetch time)" do
+        before do
+          champ.update!(value: '44011762001530', external_id: '44011762001530', etablissement: Etablissement.new(siret: '44011762001530'))
+          champ.update_columns(external_state: 'degraded')
+        end
+
+        it "renders an info message explaining verification is postponed" do
+          expect(subject).to have_css(".fr-message--info", text: "La vérification automatique est temporairement indisponible")
+        end
+
+        context "when the champ feeds a condition (submission is blocked until backfill)" do
+          before { allow(champ).to receive(:dependent_conditions?).and_return(true) }
+
+          it "does not render the 'you can continue' message" do
+            expect(subject).not_to have_css(".fr-message--info")
+          end
+        end
+      end
+
       context "when etablissement is non-diffusible (diffusable_commercialement: false)" do
         before do
           etablissement = create(:etablissement, :non_diffusable, entreprise_raison_sociale: "SECRET EI", entreprise_forme_juridique: "Entrepreneur individuel")

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -560,7 +560,11 @@ describe Users::DossiersController, type: :controller do
         let(:api_etablissement_status) { 200 }
         let(:token_expired) { true }
 
-        it_behaves_like 'the request fails with an error', I18n.t('errors.messages.siret.network_error')
+        it 'creates an etablissement in degraded mode instead of blocking the user' do
+          dossier.reload
+          expect(dossier.etablissement.siret).to eq(siret)
+          expect(dossier.etablissement).to be_as_degraded_mode
+        end
       end
 
       context 'when all API informations available' do

--- a/spec/jobs/champ_fetch_external_data_job_spec.rb
+++ b/spec/jobs/champ_fetch_external_data_job_spec.rb
@@ -66,5 +66,49 @@ RSpec.describe ChampFetchExternalDataJob, type: :job do
         expect(champ.fetch_external_data_exceptions.size).to eq(3)
       end
     end
+
+    context 'when retries are exhausted on a siret champ' do
+      let(:procedure) { create(:procedure, :published, public_type_de_champs: [{ type: :siret }]) }
+      let(:dossier) { create(:dossier, procedure:) }
+      let(:external_id) { '41816609600051' }
+
+      before do
+        champ.update_columns(external_id:, external_state: 'waiting_for_job')
+        allow_any_instance_of(Champs::SiretChamp).to receive(:fetch_external_data).and_return(failure)
+      end
+
+      it 'converges to the degraded state instead of external_error' do
+        described_class.perform_later(champ, external_id)
+
+        3.times do
+          perform_enqueued_jobs(only: ChampFetchExternalDataJob)
+        rescue StandardError
+        end
+
+        champ.reload
+
+        expect(champ).to be_degraded
+        expect(champ.etablissement).to be_as_degraded_mode
+        expect(champ.fetch_external_data_exceptions.last.code).to eq(504)
+      end
+
+      context 'and the exhaustion handler itself raises' do
+        let(:boom) { StandardError.new('champ was reset meanwhile') }
+
+        before do
+          allow_any_instance_of(Champs::SiretChamp)
+            .to receive(:handle_exhausted_external_data_retries!).and_raise(boom)
+        end
+
+        it 'reports it to Sentry instead of letting the exception escape' do
+          expect(Sentry).to receive(:capture_exception).with(boom)
+          expect(Sentry).to receive(:capture_exception).with(error)
+
+          described_class.perform_later(champ, external_id)
+
+          expect { 3.times { perform_enqueued_jobs(only: ChampFetchExternalDataJob) } }.not_to raise_error
+        end
+      end
+    end
   end
 end

--- a/spec/jobs/cron/backfill_siret_degraded_mode_job_spec.rb
+++ b/spec/jobs/cron/backfill_siret_degraded_mode_job_spec.rb
@@ -24,11 +24,16 @@ RSpec.describe Cron::BackfillSiretDegradedModeJob, type: :job do
 
       before do
         champ_siret
-        champ_siret.update_column(:etablissement_id, etablissement.id)
+        champ_siret.update_columns(etablissement_id: etablissement.id, external_state: 'degraded')
       end
       it 'works' do
         allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params).and_return(Dry::Monads::Success({ adresse: new_adresse }))
         expect { Cron::BackfillSiretDegradedModeJob.perform_now }.to change { etablissement.reload.adresse }.from(nil).to(new_adresse)
+      end
+
+      it 'gets the champ out of the degraded state' do
+        allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params).and_return(Dry::Monads::Success({ adresse: new_adresse }))
+        expect { Cron::BackfillSiretDegradedModeJob.perform_now }.to change { champ_siret.reload.external_state }.from('degraded').to('fetched')
       end
     end
   end

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -46,8 +46,8 @@ describe Champs::SiretChamp do
 
       before { champ.update_columns(external_state: 'waiting_for_job') }
 
-      it 'adds a pending error on external_id' do
-        expect(subject.errors[:external_id]).to include(I18n.t('activerecord.errors.messages.api_response_pending'))
+      it 'does not block submission (pending is non-blocking)' do
+        expect(subject.errors).to be_empty
       end
     end
 
@@ -62,9 +62,69 @@ describe Champs::SiretChamp do
         )
       end
 
-      it 'adds the external error on external_id only' do
-        expect(subject.errors[:external_id]).to include(I18n.t('activerecord.errors.messages.code_404'))
-        expect(subject.errors[:value]).to be_empty
+      it 'adds the external error on value only' do
+        expect(subject.errors[:value]).to include(I18n.t('activerecord.errors.messages.code_404'))
+        expect(subject.errors[:external_id]).to be_empty
+      end
+    end
+
+    context 'when external fetch failed with a technical error' do
+      let(:external_id) { "12345678901245" }
+      let(:exception) { ExternalDataException.new(error: 'API down', code: 503) }
+
+      before do
+        champ.update_columns(
+          external_state: 'external_error',
+          fetch_external_data_exceptions: [exception]
+        )
+      end
+
+      it 'does not block submission (technical error is non-blocking)' do
+        expect(subject.errors).to be_empty
+      end
+    end
+
+    context 'with a degraded-mode etablissement and no depending condition' do
+      let(:external_id) { "12345678901245" }
+      let(:etablissement) { Etablissement.new(siret: external_id) }
+
+      it { is_expected.to be_valid }
+    end
+
+  end
+
+  describe '#mandatory_blank?' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :siret, mandatory: true }]) }
+    let(:external_id) { "12345678901245" }
+
+    context 'when the fetch is pending' do
+      before { champ.update_columns(external_state: 'waiting_for_job') }
+
+      it 'is not mandatory_blank (a syntactically valid SIRET is enough while pending)' do
+        expect(champ.mandatory_blank?).to be false
+      end
+    end
+
+    context 'when the fetch failed with a technical error' do
+      let(:exception) { ExternalDataException.new(error: 'API down', code: 503) }
+
+      before do
+        champ.update_columns(
+          external_state: 'external_error',
+          fetch_external_data_exceptions: [exception]
+        )
+      end
+
+      it 'is not mandatory_blank (a syntactically valid SIRET is enough despite the technical error)' do
+        expect(champ.mandatory_blank?).to be false
+      end
+    end
+
+    context 'when the format is invalid' do
+      let(:external_id) { "12345" }
+
+      it 'is mandatory_blank' do
+        expect(champ.mandatory_blank?).to be true
       end
     end
   end
@@ -147,6 +207,39 @@ describe Champs::SiretChamp do
         expect(champ.reload.etablissement.entreprise_raison_sociale).to eq("DIRECTION INTERMINISTERIELLE DU NUMERIQUE")
       end
     end
+  end
+
+  describe '#fetch_external_data (result mapping)' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :siret }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+    before { champ.update_column(:external_id, '12345678901234') }
+
+    context 'when API returns not_found' do
+      before do
+        allow(APIEntrepriseService).to receive(:create_etablissement_with_fallback)
+          .and_return(Dry::Monads::Failure(type: :not_found, code: 404, retryable: false))
+      end
+
+      it 'wraps as a non-retryable 404 failure' do
+        result = champ.fetch_external_data
+        expect(result).to be_failure
+        expect(result.failure[:code]).to eq(404)
+        expect(result.failure[:retryable]).to be_falsey
+      end
+    end
+
+    context 'when API returns a generic technical failure' do
+      before do
+        allow(APIEntrepriseService).to receive(:create_etablissement_with_fallback)
+          .and_return(Dry::Monads::Failure(type: :network, code: 503, retryable: true))
+      end
+
+      it 'keeps the failure code' do
+        expect(champ.fetch_external_data.failure[:code]).to eq(503)
+      end
+    end
+
   end
 
   describe '#reset_external_data!' do

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -271,6 +271,22 @@ describe Champs::SiretChamp do
       end
     end
 
+    [422, 451].each do |status|
+      context "when API returns #{status}" do
+        let(:api_failure) { Dry::Monads::Failure(type: :unprocessable, code: status, retryable: false, raw_response: nil) }
+        before do
+          allow(APIEntrepriseService).to receive(:create_etablissement_with_fallback).and_return(api_failure)
+        end
+
+        it 'blocks submission instead of degrading' do
+          result = champ.fetch_external_data
+          expect(result).to be_failure
+          expect(result.failure[:degraded]).to be_nil
+          expect(result.failure[:code]).to eq(status)
+        end
+      end
+    end
+
     context 'when the service falls back to degraded mode' do
       let(:etablissement) { instance_double(Etablissement) }
       before do
@@ -307,26 +323,6 @@ describe Champs::SiretChamp do
       champ.reload
       expect(champ).to be_degraded
       expect(champ.etablissement).to be_as_degraded_mode
-    end
-  end
-
-  describe '#external_data_required_for_conditions?' do
-    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :siret }, { type: :text }]) }
-    let(:siret_tdc) { procedure.draft_revision.type_de_champs_for(scope: :public).first }
-    let(:text_tdc) { procedure.draft_revision.type_de_champs_for(scope: :public).second }
-    let(:champ) { dossier.champ_data.find(&:siret?) }
-
-    context 'when no other champ has a condition based on the siret champ' do
-      it { expect(champ.external_data_required_for_conditions?).to be false }
-    end
-
-    context 'when another champ has a condition based on a column of the siret champ' do
-      before do
-        naf_column = siret_tdc.columns(procedure_id: procedure.id).find { _1.label.match?(/NAF/i) }
-        text_tdc.update!(condition: ds_eq(champ_column_value(naf_column), constant('4950Z')))
-      end
-
-      it { expect(champ.external_data_required_for_conditions?).to be true }
     end
   end
 

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -198,9 +198,18 @@ describe Champs::SiretChamp do
 
       it { expect { fetch_external_data }.to change { Etablissement.count }.by(1) }
 
-      it 'returns a retryable failure to trigger job retry' do
-        expect(fetch_external_data).to be_failure
-        expect(fetch_external_data.failure[:retryable]).to be true
+      it 'returns a degraded failure carrying the stub (no retry loop, backfill jobs are scheduled)' do
+        result = fetch_external_data
+        expect(result).to be_failure
+        expect(result.failure[:degraded]).to be true
+        expect(result.failure[:etablissement]).to be_as_degraded_mode
+      end
+
+      it 'puts the champ in the degraded state' do
+        champ.update_columns(external_state: 'fetching')
+        champ.send(:handle_result, fetch_external_data)
+
+        expect(champ.reload).to be_degraded
       end
     end
 
@@ -260,6 +269,44 @@ describe Champs::SiretChamp do
       it 'keeps the failure code' do
         expect(champ.fetch_external_data.failure[:code]).to eq(503)
       end
+    end
+
+    context 'when the service falls back to degraded mode' do
+      let(:etablissement) { instance_double(Etablissement) }
+      before do
+        allow(APIEntrepriseService).to receive(:create_etablissement_with_fallback)
+          .and_return(Dry::Monads::Failure(degraded: true, etablissement:, type: :service_unavailable, code: 503))
+      end
+
+      it 'forwards the stub as a degraded failure (data will be backfilled later)' do
+        result = champ.fetch_external_data
+        expect(result).to be_failure
+        expect(result.failure[:degraded]).to be true
+        expect(result.failure[:etablissement]).to eq(etablissement)
+      end
+    end
+  end
+
+  describe '#handle_exhausted_external_data_retries!' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :siret }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+
+    before do
+      champ.update_columns(
+        external_id: '41816609600051',
+        external_state: 'waiting_for_job',
+        fetch_external_data_exceptions: [ExternalDataException.new(error: 'boom', code: 503)]
+      )
+    end
+
+    it 'converges to the degraded state instead of external_error' do
+      expect { champ.handle_exhausted_external_data_retries! }
+        .to have_enqueued_job(APIEntreprise::EtablissementJob)
+
+      champ.reload
+      expect(champ).to be_degraded
+      expect(champ.etablissement).to be_as_degraded_mode
     end
   end
 

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe Champs::SiretChamp do
+  include Logic
+
   let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :siret }]) }
   let(:dossier) { create(:dossier, procedure:) }
   let(:champ) { dossier.root_champs_public.first.tap { _1.update(external_id:, etablissement:) } }
@@ -88,9 +90,29 @@ describe Champs::SiretChamp do
       let(:external_id) { "12345678901245" }
       let(:etablissement) { Etablissement.new(siret: external_id) }
 
+      before { champ.update_columns(external_state: 'fetched') }
+
       it { is_expected.to be_valid }
     end
 
+    context 'in degraded state when the champ feeds a condition' do
+      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :siret }, { type: :text }]) }
+      let(:champ) { dossier.champ_data.find(&:siret?).tap { _1.update(external_id:, etablissement:) } }
+      let(:external_id) { "12345678901245" }
+      let(:etablissement) { Etablissement.new(siret: external_id) }
+
+      before do
+        champ.update_columns(external_state: 'degraded')
+        siret_tdc = procedure.draft_revision.type_de_champs_for(scope: :public).first
+        text_tdc = procedure.draft_revision.type_de_champs_for(scope: :public).second
+        naf_column = siret_tdc.columns(procedure_id: procedure.id).find { _1.label.match?(/NAF/i) }
+        text_tdc.update!(condition: ds_eq(champ_column_value(naf_column), constant('4950Z')))
+      end
+
+      it 'blocks submission until the backfill completes the etablissement' do
+        expect(subject.errors[:external_id]).to include(I18n.t('activerecord.errors.messages.api_response_pending'))
+      end
+    end
   end
 
   describe '#mandatory_blank?' do
@@ -239,7 +261,48 @@ describe Champs::SiretChamp do
         expect(champ.fetch_external_data.failure[:code]).to eq(503)
       end
     end
+  end
 
+  describe '#external_data_required_for_conditions?' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :siret }, { type: :text }]) }
+    let(:siret_tdc) { procedure.draft_revision.type_de_champs_for(scope: :public).first }
+    let(:text_tdc) { procedure.draft_revision.type_de_champs_for(scope: :public).second }
+    let(:champ) { dossier.champ_data.find(&:siret?) }
+
+    context 'when no other champ has a condition based on the siret champ' do
+      it { expect(champ.external_data_required_for_conditions?).to be false }
+    end
+
+    context 'when another champ has a condition based on a column of the siret champ' do
+      before do
+        naf_column = siret_tdc.columns(procedure_id: procedure.id).find { _1.label.match?(/NAF/i) }
+        text_tdc.update!(condition: ds_eq(champ_column_value(naf_column), constant('4950Z')))
+      end
+
+      it { expect(champ.external_data_required_for_conditions?).to be true }
+    end
+  end
+
+  describe '#permissive_external_data_validation?' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :siret }, { type: :text }]) }
+    let(:champ) { dossier.champ_data.find(&:siret?) }
+
+    it 'is permissive by default' do
+      expect(champ.permissive_external_data_validation?).to be true
+    end
+
+    context 'when another champ has a condition based on a column of the siret champ' do
+      before do
+        siret_tdc = procedure.draft_revision.type_de_champs_for(scope: :public).first
+        text_tdc = procedure.draft_revision.type_de_champs_for(scope: :public).second
+        naf_column = siret_tdc.columns(procedure_id: procedure.id).find { _1.label.match?(/NAF/i) }
+        text_tdc.update!(condition: ds_eq(champ_column_value(naf_column), constant('4950Z')))
+      end
+
+      it 'restores the blocking validation' do
+        expect(champ.permissive_external_data_validation?).to be false
+      end
+    end
   end
 
   describe '#reset_external_data!' do

--- a/spec/models/concerns/champ_external_data_concern_spec.rb
+++ b/spec/models/concerns/champ_external_data_concern_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe ChampExternalDataConcern do
 
       it { expect(champ).not_to be_external_data_not_found }
     end
+
+    context 'in external_error without any recorded exception' do
+      let(:external_state) { 'external_error' }
+      let(:exceptions) { [] }
+
+      it { expect(champ).not_to be_external_data_not_found }
+    end
   end
 
   describe 'the state machine' do
@@ -197,6 +204,64 @@ RSpec.describe ChampExternalDataConcern do
           expect(champ).to have_received(:after_reset_external_data)
         end
       end
+
+      context 'from degraded' do
+        before do
+          champ.update_column(:external_state, 'degraded')
+
+          allow(champ).to receive(:after_reset_external_data)
+          champ.reset_external_data!
+        end
+
+        it do
+          expect(champ).to be_idle
+          expect(champ).to have_received(:after_reset_external_data)
+        end
+      end
+    end
+
+    describe 'external_data_degraded' do
+      context 'from fetching' do
+        before do
+          allow(champ).to receive(:ready_for_external_call?).and_return(true)
+          champ.fetch_later!
+          champ.update_column(:external_state, 'fetching')
+          champ.external_data_degraded!
+        end
+
+        it { expect(champ.reload).to be_degraded }
+      end
+
+      # retry! has already moved the champ back to waiting_for_job.
+      context 'from waiting_for_job' do
+        before do
+          allow(champ).to receive(:ready_for_external_call?).and_return(true)
+          champ.fetch_later!
+          champ.external_data_degraded!
+        end
+
+        it { expect(champ.reload).to be_degraded }
+      end
+    end
+
+    describe 'external_data_fetched from degraded' do
+      before do
+        champ.update_column(:external_state, 'degraded')
+        champ.external_data_fetched!
+      end
+
+      it { expect(champ.reload).to be_fetched }
+    end
+  end
+
+  describe '#done?' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :rnf }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+
+    it 'is true in degraded' do
+      champ.external_state = 'degraded'
+      expect(champ).to be_done
     end
   end
 end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -2086,6 +2086,21 @@ describe Dossier, type: :model do
         expect(dossier_ok.may_accepter?(instructeur:, motivation:)).to be_truthy
       end
     end
+
+    context "when a SIRET annotation privee has etablissement in degraded mode" do
+      let(:procedure) { create(:procedure, private_type_de_champs: [{ type: :siret }]) }
+      let(:dossier_incomplete) { create(:dossier, :en_instruction, :with_populated_annotations, procedure:) }
+      let(:dossier_ok) { create(:dossier, :en_instruction, :with_populated_annotations, procedure:) }
+
+      before do
+        dossier_incomplete.champ_data.first.update(etablissement: Etablissement.new(siret: build(:etablissement).siret))
+      end
+
+      it "can't accepter" do
+        expect(dossier_incomplete.may_accepter?(instructeur:, motivation:)).to be_falsey
+        expect(dossier_ok.may_accepter?(instructeur:, motivation:)).to be_truthy
+      end
+    end
   end
 
   describe "can't transition to terminer when annotations privees are not valid" do
@@ -2144,7 +2159,7 @@ describe Dossier, type: :model do
       let(:champ_siret) { dossier.champ_data.first }
 
       before do
-        champ_siret.update(value: '44011762001530')
+        champ_siret.update(external_id: '44011762001530', value: '44011762001530', etablissement: build(:etablissement, siret: '44011762001530'))
       end
 
       it 'should not have errors' do
@@ -2153,7 +2168,7 @@ describe Dossier, type: :model do
 
       context "and invalid SIRET" do
         before do
-          champ_siret.update(value: "1234")
+          champ_siret.update(external_id: "1234", value: "1234")
           dossier.reload
         end
 

--- a/spec/models/external_data_exception_spec.rb
+++ b/spec/models/external_data_exception_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExternalDataException do
+  describe '#not_found?' do
+    it 'is true when code is 404' do
+      expect(described_class.new(error: 'boom', code: 404).not_found?).to be_truthy
+    end
+
+    it 'is false for a technical error code' do
+      expect(described_class.new(error: 'boom', code: 503).not_found?).to be_falsey
+    end
+
+    it 'is false without code' do
+      expect(described_class.new(error: 'boom', code: nil).not_found?).to be_falsey
+    end
+  end
+end

--- a/spec/models/external_data_exception_spec.rb
+++ b/spec/models/external_data_exception_spec.rb
@@ -16,4 +16,22 @@ RSpec.describe ExternalDataException do
       expect(described_class.new(error: 'boom', code: nil).not_found?).to be_falsey
     end
   end
+
+  describe '#definitive?' do
+    [404, 422, 451].each do |code|
+      it "is true for #{code}, the API will not answer differently later" do
+        expect(described_class.new(error: 'boom', code:).definitive?).to be_truthy
+      end
+    end
+
+    [429, 500, 503].each do |code|
+      it "is false for #{code}, a retry or a backfill can still succeed" do
+        expect(described_class.new(error: 'boom', code:).definitive?).to be_falsey
+      end
+    end
+
+    it 'is false without code' do
+      expect(described_class.new(error: 'boom', code: nil).definitive?).to be_falsey
+    end
+  end
 end

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -140,10 +140,11 @@ describe APIEntrepriseService do
         allow(APIEntreprise::HealthChecker).to receive(:provider_up?).with(:insee_sirene).and_return(false)
       end
 
-      it 'returns Success with degraded etablissement' do
-        expect(subject).to be_success
-        expect(subject.value!.siret).to eq(siret)
-        expect(subject.value!).to be_as_degraded_mode
+      it 'returns an explicit degraded Failure carrying the stub' do
+        expect(subject).to be_failure
+        expect(subject.failure[:degraded]).to be true
+        expect(subject.failure[:etablissement].siret).to eq(siret)
+        expect(subject.failure[:etablissement]).to be_as_degraded_mode
       end
     end
 
@@ -168,9 +169,9 @@ describe APIEntrepriseService do
 
       it 'falls back to degraded mode without checking provider health' do
         expect(APIEntreprise::HealthChecker).not_to receive(:provider_up?)
-        expect(subject).to be_success
-        expect(subject.value!.siret).to eq(siret)
-        expect(subject.value!).to be_as_degraded_mode
+        expect(subject).to be_failure
+        expect(subject.failure[:degraded]).to be true
+        expect(subject.failure[:etablissement]).to be_as_degraded_mode
       end
     end
 

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -187,6 +187,40 @@ describe APIEntrepriseService do
     end
   end
 
+  describe '#update_etablissement_from_degraded_mode' do
+    let(:procedure) { create(:procedure, :published, public_type_de_champs: [{ type: :siret }]) }
+    let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+    let(:etablissement) { create(:etablissement, adresse: nil, siret: '01234567891011') }
+
+    before do
+      allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params)
+        .and_return(Dry::Monads::Success(adresse: '7 rue du puits, coye la foret'))
+    end
+
+    context 'when the etablissement belongs to a degraded champ' do
+      before do
+        champ.update_columns(etablissement_id: etablissement.id, external_state: 'degraded')
+      end
+
+      it 'completes the data and leaves the degraded state' do
+        described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id)
+
+        expect(etablissement.reload.adresse).to eq('7 rue du puits, coye la foret')
+        expect(champ.reload).to be_fetched
+      end
+    end
+
+    context 'when the etablissement belongs to a dossier (no champ)' do
+      let!(:dossier_with_etablissement) { create(:dossier, :en_construction, etablissement:) }
+
+      it 'completes the data without raising' do
+        expect { described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id) }
+          .to change { etablissement.reload.adresse }.from(nil).to('7 rue du puits, coye la foret')
+      end
+    end
+  end
+
   describe '#report_error' do
     it 'sends a message to Sentry with context' do
       failure = { type: :server_error, code: 503, retryable: true, raw_response: nil }

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -175,6 +175,45 @@ describe APIEntrepriseService do
       end
     end
 
+    [401, 403, 409].each do |status|
+      context "when API returns #{status}" do
+        before do
+          stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)
+            .to_return(body: '', status:)
+        end
+
+        it 'falls back to degraded mode' do
+          expect(subject).to be_failure
+          expect(subject.failure[:degraded]).to be true
+          expect(subject.failure[:etablissement]).to be_as_degraded_mode
+        end
+      end
+    end
+
+    context 'when API returns 401 (our own credentials are broken)' do
+      before do
+        stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)
+          .to_return(body: '', status: 401)
+      end
+
+      it 'reports to Sentry' do
+        expect(Sentry).to receive(:capture_message).with(/API Entreprise/, hash_including(level: :error))
+        subject
+      end
+    end
+
+    context 'when API returns 409 (no Sentry, nothing we can fix)' do
+      before do
+        stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)
+          .to_return(body: '', status: 409)
+      end
+
+      it 'does not report to Sentry' do
+        expect(Sentry).not_to receive(:capture_message)
+        subject
+      end
+    end
+
     context 'when API returns 451' do
       before do
         stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -175,7 +175,8 @@ describe APIEntrepriseService do
       end
     end
 
-    [401, 403, 409].each do |status|
+    # 401/403 are our own broken credentials and deserve an alert; 409 is not.
+    { 401 => true, 403 => true, 409 => false }.each do |status, alerts|
       context "when API returns #{status}" do
         before do
           stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)
@@ -187,30 +188,16 @@ describe APIEntrepriseService do
           expect(subject.failure[:degraded]).to be true
           expect(subject.failure[:etablissement]).to be_as_degraded_mode
         end
-      end
-    end
 
-    context 'when API returns 401 (our own credentials are broken)' do
-      before do
-        stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)
-          .to_return(body: '', status: 401)
-      end
+        it "#{alerts ? 'alerts' : 'does not alert'} on Sentry" do
+          if alerts
+            expect(Sentry).to receive(:capture_message).with(/API Entreprise/, hash_including(level: :error))
+          else
+            expect(Sentry).not_to receive(:capture_message)
+          end
 
-      it 'reports to Sentry' do
-        expect(Sentry).to receive(:capture_message).with(/API Entreprise/, hash_including(level: :error))
-        subject
-      end
-    end
-
-    context 'when API returns 409 (no Sentry, nothing we can fix)' do
-      before do
-        stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)
-          .to_return(body: '', status: 409)
-      end
-
-      it 'does not report to Sentry' do
-        expect(Sentry).not_to receive(:capture_message)
-        subject
+          subject
+        end
       end
     end
 
@@ -257,6 +244,45 @@ describe APIEntrepriseService do
       it 'completes the data without raising' do
         expect { described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id) }
           .to change { etablissement.reload.adresse }.from(nil).to('7 rue du puits, coye la foret')
+      end
+    end
+
+    context 'when the backfill cannot converge' do
+      before { champ.update_columns(etablissement_id: etablissement.id, external_state: 'degraded') }
+
+      [401, 403].each do |code|
+        context "on a credentials failure (#{code})" do
+          before do
+            allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params)
+              .and_return(Dry::Monads::Failure(type: :token_expired, code:, retryable: false, raw_response: nil))
+          end
+
+          it 'alerts and leaves the champ degraded' do
+            expect(Rails.logger).to receive(:error).with(/API Entreprise backfill blocked/)
+            expect(Sentry).to receive(:capture_message).with(
+              'API Entreprise error: token_expired',
+              level: :error,
+              extra: hash_including(code:, siret: etablissement.siret)
+            )
+
+            expect(described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id)).to be_nil
+            expect(champ.reload).to be_degraded
+          end
+        end
+      end
+
+      context 'on any other failure' do
+        before do
+          allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params)
+            .and_return(Dry::Monads::Failure(type: :server_error, code: 503, retryable: true, raw_response: nil))
+        end
+
+        it 'stays silent: the cron will retry' do
+          expect(Sentry).not_to receive(:capture_message)
+
+          expect(described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id)).to be_nil
+          expect(champ.reload).to be_degraded
+        end
       end
     end
   end

--- a/spec/types/external_data_exception_type_spec.rb
+++ b/spec/types/external_data_exception_type_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExternalDataExceptionType do
+  let(:type) { described_class.new }
+
+  describe '#cast' do
+    it 'returns nil for nil' do
+      expect(type.cast(nil)).to be_nil
+    end
+
+    it 'parses a JSON string' do
+      json = '{"code":500,"error":"boom"}'
+      result = type.cast(json)
+      expect(result.error).to eq('boom')
+      expect(result.code).to eq(500)
+    end
+
+    it 'parses a hash' do
+      result = type.cast(error: 'x', code: 503)
+      expect(result.error).to eq('x')
+      expect(result.code).to eq(503)
+    end
+
+    it 'parses a legacy hash with reason instead of error' do
+      result = type.cast(reason: 'x', code: 503)
+      expect(result.error).to eq('x')
+    end
+  end
+
+  describe '#serialize' do
+    it 'serializes error and code' do
+      ex = ExternalDataException.new(error: 'x', code: 404)
+      expect(JSON.parse(type.serialize(ex))).to eq('code' => 404, 'error' => 'x')
+    end
+  end
+end

--- a/spec/validators/external_data_champ_validator_spec.rb
+++ b/spec/validators/external_data_champ_validator_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExternalDataChampValidator do
+  let(:champ) { Champs::SiretChamp.new }
+  let(:validator) { described_class.new(attributes: {}) }
+
+  before { champ.errors.clear }
+
+  shared_examples 'no error added' do
+    it { expect { validator.validate(champ) }.not_to change { champ.errors.size } }
+  end
+
+  shared_examples 'adds a permissive error' do
+    it { expect { validator.validate(champ) }.to change { champ.errors[:value].size }.by(1) }
+  end
+
+  context 'fetched' do
+    before { allow(champ).to receive_messages(pending?: false, external_error?: false) }
+    include_examples 'no error added'
+  end
+
+  context 'pending' do
+    before do
+      allow(champ).to receive_messages(pending?: true, external_error?: false)
+    end
+    include_examples 'no error added'
+  end
+
+  context 'external_error 404 (not found)' do
+    before do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        fetch_external_data_exceptions: [ExternalDataException.new(error: 'NF', code: 404)]
+      )
+    end
+    include_examples 'adds a permissive error'
+  end
+
+  context 'external_error with a technical code' do
+    before do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        fetch_external_data_exceptions: [ExternalDataException.new(error: 'boom', code: 503)]
+      )
+    end
+    include_examples 'no error added'
+  end
+
+  context 'external_error with a technical retry followed by a 404 (exceptions accumulate)' do
+    before do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        fetch_external_data_exceptions: [
+          ExternalDataException.new(error: 'boom', code: 503),
+          ExternalDataException.new(error: 'NF', code: 404),
+        ]
+      )
+    end
+    include_examples 'adds a permissive error'
+
+    it 'uses the error key of the most recent exception' do
+      validator.validate(champ)
+      expect(champ.errors.map(&:type)).to include(:code_404)
+    end
+  end
+
+  context 'external_error with a non-404 code and no translation' do
+    before do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        fetch_external_data_exceptions: [ExternalDataException.new(error: 'old', code: 500)]
+      )
+    end
+    include_examples 'no error added'
+  end
+end

--- a/spec/validators/external_data_champ_validator_spec.rb
+++ b/spec/validators/external_data_champ_validator_spec.rb
@@ -16,42 +16,81 @@ RSpec.describe ExternalDataChampValidator do
     it { expect { validator.validate(champ) }.to change { champ.errors[:value].size }.by(1) }
   end
 
+  shared_examples 'adds a strict error' do
+    it { expect { validator.validate(champ) }.to change { champ.errors[:external_id].size }.by(1) }
+  end
+
   context 'fetched' do
-    before { allow(champ).to receive_messages(pending?: false, external_error?: false) }
+    before { allow(champ).to receive_messages(pending?: false, external_error?: false, external_data_required_for_conditions?: false) }
     include_examples 'no error added'
   end
 
-  context 'pending' do
+  context 'pending and not required for conditions' do
     before do
-      allow(champ).to receive_messages(pending?: true, external_error?: false)
+      allow(champ).to receive_messages(pending?: true, external_error?: false, external_data_required_for_conditions?: false)
     end
     include_examples 'no error added'
   end
 
-  context 'external_error 404 (not found)' do
+  context 'pending and required for conditions' do
+    before do
+      allow(champ).to receive_messages(pending?: true, external_error?: false, external_data_required_for_conditions?: true)
+    end
+    include_examples 'adds a strict error'
+  end
+
+  context 'degraded and not required for conditions' do
+    before do
+      allow(champ).to receive_messages(pending?: false, degraded?: true, external_error?: false, external_data_required_for_conditions?: false)
+    end
+    include_examples 'no error added'
+  end
+
+  context 'degraded and required for conditions' do
+    before do
+      allow(champ).to receive_messages(pending?: false, degraded?: true, external_error?: false, external_data_required_for_conditions?: true)
+    end
+    include_examples 'adds a strict error'
+  end
+
+  context 'external_error 404 (not found) and not required for conditions' do
     before do
       allow(champ).to receive_messages(
         pending?: false, external_error?: true,
+        external_data_required_for_conditions?: false,
         fetch_external_data_exceptions: [ExternalDataException.new(error: 'NF', code: 404)]
       )
     end
     include_examples 'adds a permissive error'
   end
 
-  context 'external_error with a technical code' do
+  context 'external_error with a technical code and not required for conditions' do
     before do
       allow(champ).to receive_messages(
         pending?: false, external_error?: true,
+        external_data_required_for_conditions?: false,
         fetch_external_data_exceptions: [ExternalDataException.new(error: 'boom', code: 503)]
       )
     end
     include_examples 'no error added'
   end
 
+  context 'external_error with a technical code and required for conditions' do
+    before do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        external_data_required_for_conditions?: true,
+        fetch_external_data_exceptions: [ExternalDataException.new(error: 'boom', code: 503)]
+      )
+    end
+    include_examples 'adds a strict error'
+  end
+
   context 'external_error with a technical retry followed by a 404 (exceptions accumulate)' do
     before do
       allow(champ).to receive_messages(
         pending?: false, external_error?: true,
+        external_data_required_for_conditions?: false,
         fetch_external_data_exceptions: [
           ExternalDataException.new(error: 'boom', code: 503),
           ExternalDataException.new(error: 'NF', code: 404),
@@ -66,10 +105,30 @@ RSpec.describe ExternalDataChampValidator do
     end
   end
 
-  context 'external_error with a non-404 code and no translation' do
+  context 'external_error with accumulated exceptions and required for conditions (strict path)' do
     before do
       allow(champ).to receive_messages(
         pending?: false, external_error?: true,
+        external_data_required_for_conditions?: true,
+        fetch_external_data_exceptions: [
+          ExternalDataException.new(error: 'boom', code: 503),
+          ExternalDataException.new(error: 'NF', code: 404),
+        ]
+      )
+    end
+    include_examples 'adds a strict error'
+
+    it 'uses the error key of the most recent exception' do
+      validator.validate(champ)
+      expect(champ.errors.map(&:type)).to include(:code_404)
+    end
+  end
+
+  context 'external_error with a non-404 code and no translation (no condition)' do
+    before do
+      allow(champ).to receive_messages(
+        pending?: false, external_error?: true,
+        external_data_required_for_conditions?: false,
         fetch_external_data_exceptions: [ExternalDataException.new(error: 'old', code: 500)]
       )
     end

--- a/spec/validators/external_data_champ_validator_spec.rb
+++ b/spec/validators/external_data_champ_validator_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe ExternalDataChampValidator do
   let(:champ) { Champs::SiretChamp.new }
   let(:validator) { described_class.new(attributes: {}) }
 
-  before { champ.errors.clear }
+  # Every context below is about a champ whose fetch has been attempted;
+  # the early return in #validate only skips idle and fetched champs.
+  before { allow(champ).to receive_messages(idle?: false, fetched?: false) }
 
   shared_examples 'no error added' do
     it { expect { validator.validate(champ) }.not_to change { champ.errors.size } }
@@ -21,34 +23,34 @@ RSpec.describe ExternalDataChampValidator do
   end
 
   context 'fetched' do
-    before { allow(champ).to receive_messages(pending?: false, external_error?: false, external_data_required_for_conditions?: false) }
+    before { allow(champ).to receive_messages(fetched?: true) }
     include_examples 'no error added'
   end
 
   context 'pending and not required for conditions' do
     before do
-      allow(champ).to receive_messages(pending?: true, external_error?: false, external_data_required_for_conditions?: false)
+      allow(champ).to receive_messages(pending?: true, external_error?: false, permissive_external_data_validation?: true)
     end
     include_examples 'no error added'
   end
 
   context 'pending and required for conditions' do
     before do
-      allow(champ).to receive_messages(pending?: true, external_error?: false, external_data_required_for_conditions?: true)
+      allow(champ).to receive_messages(pending?: true, external_error?: false, permissive_external_data_validation?: false)
     end
     include_examples 'adds a strict error'
   end
 
   context 'degraded and not required for conditions' do
     before do
-      allow(champ).to receive_messages(pending?: false, degraded?: true, external_error?: false, external_data_required_for_conditions?: false)
+      allow(champ).to receive_messages(pending?: false, degraded?: true, external_error?: false, permissive_external_data_validation?: true)
     end
     include_examples 'no error added'
   end
 
   context 'degraded and required for conditions' do
     before do
-      allow(champ).to receive_messages(pending?: false, degraded?: true, external_error?: false, external_data_required_for_conditions?: true)
+      allow(champ).to receive_messages(pending?: false, degraded?: true, external_error?: false, permissive_external_data_validation?: false)
     end
     include_examples 'adds a strict error'
   end
@@ -57,18 +59,36 @@ RSpec.describe ExternalDataChampValidator do
     before do
       allow(champ).to receive_messages(
         pending?: false, external_error?: true,
-        external_data_required_for_conditions?: false,
+        permissive_external_data_validation?: true,
         fetch_external_data_exceptions: [ExternalDataException.new(error: 'NF', code: 404)]
       )
     end
     include_examples 'adds a permissive error'
   end
 
+  [422, 451].each do |code|
+    context "external_error #{code} (definitive answer) and not required for conditions" do
+      before do
+        allow(champ).to receive_messages(
+          pending?: false, external_error?: true,
+          permissive_external_data_validation?: true,
+          fetch_external_data_exceptions: [ExternalDataException.new(error: 'definitive', code:)]
+        )
+      end
+      include_examples 'adds a permissive error'
+
+      it 'uses the code-specific message' do
+        validator.validate(champ)
+        expect(champ.errors.map(&:type)).to include(:"code_#{code}")
+      end
+    end
+  end
+
   context 'external_error with a technical code and not required for conditions' do
     before do
       allow(champ).to receive_messages(
         pending?: false, external_error?: true,
-        external_data_required_for_conditions?: false,
+        permissive_external_data_validation?: true,
         fetch_external_data_exceptions: [ExternalDataException.new(error: 'boom', code: 503)]
       )
     end
@@ -79,7 +99,7 @@ RSpec.describe ExternalDataChampValidator do
     before do
       allow(champ).to receive_messages(
         pending?: false, external_error?: true,
-        external_data_required_for_conditions?: true,
+        permissive_external_data_validation?: false,
         fetch_external_data_exceptions: [ExternalDataException.new(error: 'boom', code: 503)]
       )
     end
@@ -90,7 +110,7 @@ RSpec.describe ExternalDataChampValidator do
     before do
       allow(champ).to receive_messages(
         pending?: false, external_error?: true,
-        external_data_required_for_conditions?: false,
+        permissive_external_data_validation?: true,
         fetch_external_data_exceptions: [
           ExternalDataException.new(error: 'boom', code: 503),
           ExternalDataException.new(error: 'NF', code: 404),
@@ -109,7 +129,7 @@ RSpec.describe ExternalDataChampValidator do
     before do
       allow(champ).to receive_messages(
         pending?: false, external_error?: true,
-        external_data_required_for_conditions?: true,
+        permissive_external_data_validation?: false,
         fetch_external_data_exceptions: [
           ExternalDataException.new(error: 'boom', code: 503),
           ExternalDataException.new(error: 'NF', code: 404),
@@ -128,7 +148,7 @@ RSpec.describe ExternalDataChampValidator do
     before do
       allow(champ).to receive_messages(
         pending?: false, external_error?: true,
-        external_data_required_for_conditions?: false,
+        permissive_external_data_validation?: true,
         fetch_external_data_exceptions: [ExternalDataException.new(error: 'old', code: 500)]
       )
     end


### PR DESCRIPTION
Voir #12997 (périmètre SIRET)

Objectif : une panne d'API Entreprise ne doit plus bloquer l'usager au dépôt, sans pour autant laisser un instructeur accepter un dossier aux données incomplètes.

- **Nouvel état `degraded`** dans la machine à états des champs à données externes.
  C'est un état stable dont on ne sort que par le backfill, qui repasse le champ en `fetched`.

- **Le routage des échecs API Entreprise est centralisé** dans
  `APIEntrepriseService.create_etablissement_with_fallback`, qui renvoie désormais un `Failure(degraded: true, etablissement:, …)` explicite. Convergent vers `degraded` : 429, 5xx quand le  HealthChecker signale l'INSEE indisponible, 200 incomplet, retries épuisés, et (nouveau) 401/403/409, avec alerte Sentry sur 401/403 où le problème vient des  identifiants de l'administration.

- **La validation du champ SIRET devient permissive** : seuls les codes suivants bloquent le dépôt :  404 (SIRET inexistant), 422 (Unprocessable Entity) et 451 (Unavailable For Legal Reasons). Un fetch en cours ou une erreur technique laissent passer, avec un message informatif sous le champ.

- **Exception** : si une condition s'appuie sur une colonne du champ SIRET, elle n'est  pas évaluable tant que les données manquent — la validation bloquante historique est conservée dans ce cas.

- `any_etablissement_as_degraded_mode?` couvre aussi les annotations privées.

## Point d'attention

Changement de comportement volontaire : un token API Entreprise expiré (401) ne renvoie
plus une erreur réseau sur la page SIRET, il crée un etablissement dégradé. L'usager
n'est plus bloqué, et l'alerte Sentry prend le relais côté équipe.

## Pour tester

- Si nécessaire, ajouter une clé `API_ENTREPRISE_KEY` à votre `.env`

- Créer une démarche avec un champ siret, puis commencer un nouveau dossier

Deux options pour produire un dossier en erreur technique, qui pourra être déposé :

- Couper l'accès à l'API en ajoutant `127.0.0.1 entreprise.api.gouv.fr` dans
  `/etc/hosts`. Saisir un SIRET valide, puis attendre ~2 minutes (3 tentatives du job
  avec backoff : ~3 s, ~18 s, ~83 s). À l'épuisement, le hook converge vers le
  dégradé. Penser à retirer la ligne de `/etc/hosts` ensuite.
- Ou en console :
  ```ruby
  champ = Dossier.find(ID).champs.find(&:siret?)
  champ.update_columns(external_id: NUMERO_DU_SIRET, external_state: 'waiting_for_job')
  champ.handle_exhausted_external_data_retries!

Pour reproduire un dossier en erreur 404, qui ne peut pas être déposé :
```
champ.update_columns(
  value: NUMERO_DU_SIRET,
  external_id: NUMERO_DU_SIRET,
  etablissement_id: nil,
  external_state: 'external_error',
  fetch_external_data_exceptions: [ExternalDataException.new(error: 'not found'
)
```
Ce qu'on doit observer pour un dossier en erreur technique

1. Usager : le message « La vérification automatique est temporairement
   indisponible. Vous pouvez poursuivre le dépôt… » s'affiche sous le champ, et
   dépôt fonctionne.
2. Base : le champ est en external_state: 'degraded', avec un etablissement ne
   portant que le siret (as_degraded_mode? → true).
3. Instructeur : le dossier passe en instruction, mais accepter / refuser / classer
   sans suite sont refusés (can_terminer? → false tant qu'un etablissement est
   dégradé, y compris sur une annotation privée).
4. Rattrapage : une fois l'API rétablie, les données arrivent via le job planifié à
   +30 min — ou immédiatement en console avec
   APIEntreprise::EtablissementJob.perform_now(etablissement.id, procedure.id). Le
   champ repasse alors en fetched et l'acceptation redevient possible.