### PR TITLE
ETQ usager, ne plus perdre le formulaire d'identité au rafraîchissement

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -132,10 +132,14 @@ module Users
 
       respond_to do |format|
         format.html do
-          @dossier.prefill_individual_from_france_connect if @dossier.identity_from_fc?
+          @dossier.prefill_individual_from_france_connect if @dossier.identity_from_fc? && !@dossier.for_tiers?
         end
         format.turbo_stream do
           @dossier.assign_for_tiers(params.dig(:dossier, :for_tiers) == 'true')
+
+          # Persist the persona choice so the identity form survives a page reload:
+          # `identity_updated_at` is what makes the form visible on the next GET.
+          @dossier.update_columns(for_tiers: @dossier.for_tiers, identity_updated_at: Time.zone.now)
         end
       end
     end

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -190,6 +190,41 @@ describe Users::DossiersController, type: :controller do
     end
   end
 
+  describe 'identite turbo_stream persists the persona choice' do
+    let(:procedure) { create(:procedure, :for_individual, for_tiers_enabled: true) }
+    let(:dossier) { create(:dossier, user:, procedure:) }
+    let(:now) { Time.zone.parse('01/01/2100') }
+
+    before { sign_in(user) }
+
+    subject do
+      travel_to(now) do
+        patch :identite, params: { id: dossier.id, dossier: { for_tiers: for_tiers_value } }, format: :turbo_stream
+      end
+    end
+
+    # The choice must be persisted so that the identity form does not disappear on a page reload.
+    context 'when choosing "pour vous"' do
+      let(:for_tiers_value) { 'false' }
+
+      it 'persists for_tiers and stamps identity_updated_at' do
+        subject
+        expect(dossier.reload.for_tiers).to be false
+        expect(dossier.identity_updated_at).to eq(now)
+      end
+    end
+
+    context 'when choosing "pour une autre personne"' do
+      let(:for_tiers_value) { 'true' }
+
+      it 'persists for_tiers and stamps identity_updated_at' do
+        subject
+        expect(dossier.reload.for_tiers).to be true
+        expect(dossier.identity_updated_at).to eq(now)
+      end
+    end
+  end
+
   describe 'update_identite' do
     let(:procedure) { create(:procedure, :for_individual) }
     let(:dossier) { create(:dossier, user: user, procedure: procedure) }


### PR DESCRIPTION
Remonté au support https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_72921c2f-460a-4aff-bb93-152a28d69c55/

Sur une démarche `for_tiers_enabled`, le formulaire nom/prénom de la page identité disparaissait au rafraîchissement tant que l'identité n'avait pas été soumise.

<img width="888" height="591" alt="image" src="https://github.com/user-attachments/assets/868ddf27-3c5a-475d-99ab-dbf8c787d50f" />


En cause : le choix de persona (« Pour vous » / « Pour une autre personne ») n'était assigné qu'en mémoire et injecté via turbo_stream. Au reload, le serveur re-rendait à zéro (`identity_updated_at` nil) et masquait le formulaire.

## Changements
- L'action `identite` (turbo_stream) persiste désormais le choix (`for_tiers` + `identity_updated_at`) via `update_columns`, ce qui fait retomber le reload dans la branche déjà gérée « identité renseignée ».
- La page ne repréremplit plus l'individu depuis FranceConnect lorsque le dossier est `for_tiers` (l'identité FC est celle du mandataire, pas du bénéficiaire).