### PR TITLE
Tech: log de la procédure et des URLs appelées dans ProcedureExternalURLCheckJob

### DIFF
--- a/app/jobs/procedure_external_url_check_job.rb
+++ b/app/jobs/procedure_external_url_check_job.rb
@@ -7,24 +7,28 @@ class ProcedureExternalURLCheckJob < ApplicationJob
     if procedure.lien_notice.present?
       error = procedure.errors.find { _1.attribute == :lien_notice }
 
-      procedure.lien_notice_error = check_for_error(error, procedure.lien_notice)
+      procedure.lien_notice_error = check_for_error(procedure, error, procedure.lien_notice)
       procedure.save!(validate: false) # others errors may prevent save if validate
     end
 
     if procedure.lien_dpo.present? && !procedure.lien_dpo_email?
       error = procedure.errors.find { _1.attribute == :lien_dpo }
 
-      procedure.lien_dpo_error = check_for_error(error, procedure.lien_dpo)
+      procedure.lien_dpo_error = check_for_error(procedure, error, procedure.lien_dpo)
       procedure.save!(validate: false)
     end
   end
 
   private
 
-  def check_for_error(error, url)
+  def check_for_error(procedure, error, url)
     return error.message if error.present?
 
     response = Typhoeus.get(url, followlocation: true)
+
+    log = "ProcedureExternalURLCheckJob: procedure #{procedure.id}, GET #{url}"
+    log += " (redirected to #{response.effective_url})" if response.redirect_count > 0
+    Rails.logger.info(log)
 
     return if response.success?
 

--- a/spec/jobs/procedure_external_url_check_job_spec.rb
+++ b/spec/jobs/procedure_external_url_check_job_spec.rb
@@ -10,8 +10,8 @@ describe ProcedureExternalURLCheckJob do
   let(:procedure) { create(:procedure, lien_dpo:, lien_dpo_error:, lien_notice:) }
 
   before do
-    allow(Typhoeus).to receive(:get).with("https://example.com/dpo", followlocation: true).and_return(Typhoeus::Response.new(code: dpo_code, mock: true))
-    allow(Typhoeus).to receive(:get).with("https://example.com/notice", followlocation: true).and_return(Typhoeus::Response.new(code: notice_code, mock: true))
+    allow(Typhoeus).to receive(:get).with("https://example.com/dpo", followlocation: true).and_return(Typhoeus::Response.new(code: dpo_code, redirect_count: 0, mock: true))
+    allow(Typhoeus).to receive(:get).with("https://example.com/notice", followlocation: true).and_return(Typhoeus::Response.new(code: notice_code, redirect_count: 0, mock: true))
   end
 
   context 'with valid links' do


### PR DESCRIPTION
Ajoute un log (id de procédure + URL appelée) à chaque vérification d'URL externe (`lien_notice`, `lien_dpo`). En cas de redirection, l'URL finale est aussi loggée via `effective_url`.

Les mocks Typhoeus de la spec sont complétés avec `redirect_count: 0` pour refléter une vraie réponse libcurl.