### PR TITLE
Tech: trace l'origine des appels HTTP sortants dans les logs du proxy

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -25,7 +25,7 @@ class ApplicationJob < ActiveJob::Base
 
   around_perform do |job, block|
     Rails.logger.info("#{job.class.name} started at #{Time.zone.now}")
-    Current.set(request_id: job.request_id) do
+    Current.set(request_id: job.request_id, job_id: job.job_id) do
       block.call
     end
     Rails.logger.info("#{job.class.name} ended at #{Time.zone.now}")

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -6,6 +6,7 @@ class Current < ActiveSupport::CurrentAttributes
   attribute :browser
   attribute :contact_email
   attribute :host
+  attribute :job_id
   attribute :no_reply_email
   attribute :request_id
   attribute :user

--- a/lib/core_ext/ethon.rb
+++ b/lib/core_ext/ethon.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Expose libcurl's CURLOPT_PROXYHEADER, missing from Ethon: headers sent only
+# on the CONNECT request to a proxy, never to the target server.
+Ethon::Curls::Options.option(:easy, :proxyheader, :ffipointer, 228)
+
+module Ethon
+  class Easy
+    module ProxyHeaders
+      attr_reader :proxy_headers
+
+      # Same slist handling as Ethon::Easy::Header#headers=
+      def proxy_headers=(headers)
+        @proxy_headers = headers
+        list = nil
+        headers.each do |k, v|
+          list = Curl.slist_append(list, Util.escape_zero_byte("#{k}: #{v}"))
+        end
+        Curl.set_option(:proxyheader, list, handle)
+
+        @proxy_header_list = list && FFI::AutoPointer.new(list, Curl.method(:slist_free_all))
+      end
+    end
+
+    include ProxyHeaders
+  end
+end

--- a/lib/core_ext/typhoeus.rb
+++ b/lib/core_ext/typhoeus.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Send tracing headers on the CONNECT request to the outbound proxy (squid),
+# so its access log can tie each call back to a web request or a job.
+# Headers are set on the easy handle rather than in request.options, so the
+# Typhoeus cache key stays stable across requests.
+module Typhoeus
+  class EasyFactory
+    module ProxyTracingHeaders
+      def get
+        super.tap do |easy|
+          headers = {
+            'X-Request-Id' => Current.request_id,
+            'X-Job-Id' => Current.job_id,
+          }.compact
+
+          easy.proxy_headers = headers if headers.present?
+        end
+      end
+    end
+
+    prepend ProxyTracingHeaders
+  end
+end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -13,9 +13,21 @@ RSpec.describe ApplicationJob, type: :job do
       expect(Rails.logger).to have_received(:info).with(/started at/).once
       expect(Rails.logger).to have_received(:info).with(/ended at/).once
     end
+
+    it 'exposes the job_id in Current during perform' do
+      job = ChildJob.perform_later
+      perform_enqueued_jobs
+      expect(ChildJob.current_job_id).to eq(job.job_id)
+    end
   end
 
   class ChildJob < ApplicationJob
-    def perform; end
+    class << self
+      attr_accessor :current_job_id
+    end
+
+    def perform
+      self.class.current_job_id = Current.job_id
+    end
   end
 end

--- a/spec/lib/core_ext/typhoeus_spec.rb
+++ b/spec/lib/core_ext/typhoeus_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Typhoeus::EasyFactory do
+  describe 'proxy tracing headers' do
+    let(:request) { Typhoeus::Request.new('http://example.com') }
+
+    subject(:easy) { described_class.new(request).get }
+
+    it 'sets X-Request-Id and X-Job-Id from Current on the easy handle' do
+      Current.set(request_id: 'req-123', job_id: 'job-456') do
+        expect(easy.proxy_headers).to eq({ 'X-Request-Id' => 'req-123', 'X-Job-Id' => 'job-456' })
+      end
+    end
+
+    it 'omits headers without value' do
+      Current.set(request_id: 'req-123') do
+        expect(easy.proxy_headers).to eq({ 'X-Request-Id' => 'req-123' })
+      end
+    end
+
+    it 'sets no proxy headers outside of a request or job context' do
+      expect(easy.proxy_headers).to be_nil
+    end
+
+    it 'does not alter the request options, keeping the cache key stable' do
+      cache_key = Typhoeus::Request.new('http://example.com').cache_key
+
+      Current.set(request_id: 'req-123') do
+        easy
+        expect(request.cache_key).to eq(cache_key)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Tous les appels HTTP sortants passent par un proxy squid. Pour pouvoir relier chaque appel à son origine dans l'access log du proxy, on envoie deux headers sur la requête `CONNECT` :

- `X-Request-Id` : le request_id de la requête web d'origine (déjà propagé aux jobs via `serialize`)
- `X-Job-Id` : le job_id ActiveJob (le même que dans les logs applicatifs)

## Comment

- `lib/core_ext/ethon.rb` : expose `CURLOPT_PROXYHEADER` de libcurl, absent d'Ethon — des headers envoyés uniquement au proxy, jamais au serveur cible (vérifié avec un tunnel local).
- `lib/core_ext/typhoeus.rb` : un prepend sur `Typhoeus::EasyFactory#get` pose les headers depuis `Current` sur chaque requête (directe ou Hydra). Ils sont posés sur le handle easy et non dans `request.options`, pour ne pas invalider la clé du cache Typhoeus.
- `ApplicationJob` renseigne `Current.job_id` pendant le perform.

## Limites connues

- Couvre les appels Typhoeus (tous les clients métier). Excon (object storage), Faraday (openid_connect, oauth2, LLM) et Net::HTTP ne supportent pas de headers sur le CONNECT.
- Les appels en `http://` clair n'émettent pas de CONNECT (mais squid voit alors l'URL complète).

Côté squid, ajouter `%{X-Request-Id}>h %{X-Job-Id}>h` au `logformat` pour les logger.