### PR TITLE
ETQ Super admin : je veux voir facilement les procédures nouvelles les plus actives

### DIFF
--- a/app/controllers/manager/top_activity_procedures_controller.rb
+++ b/app/controllers/manager/top_activity_procedures_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Manager
+  class TopActivityProceduresController < Manager::ApplicationController
+    def index
+      raw_resources = TopActivityProcedure.all
+      resources = Kaminari.paginate_array(raw_resources).page(params[:_page]).per(records_per_page)
+      page = Administrate::Page::Collection.new(dashboard)
+
+      render locals: {
+        resources: resources,
+        page: page,
+        show_search_bar: false,
+        search_term: nil,
+        filters: {},
+      }
+    end
+  end
+end

--- a/app/dashboards/top_activity_procedure_dashboard.rb
+++ b/app/dashboards/top_activity_procedure_dashboard.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "administrate/base_dashboard"
+
+class TopActivityProcedureDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    libelle: Field::String,
+    published_at: Field::DateTime,
+    dossiers_7_jours: Field::Number,
+    dossiers_total: Field::Number,
+  }.freeze
+
+  COLLECTION_ATTRIBUTES = [
+    :id,
+    :libelle,
+    :published_at,
+    :dossiers_7_jours,
+    :dossiers_total,
+  ].freeze
+
+  COLLECTION_FILTERS = {}.freeze
+  SHOW_PAGE_ATTRIBUTES = {}
+end

--- a/app/models/top_activity_procedure.rb
+++ b/app/models/top_activity_procedure.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class TopActivityProcedure
+  extend ActiveModel::Naming
+  extend ActiveModel::Translation
+
+  attr_accessor :id,
+                :libelle,
+                :published_at,
+                :dossiers_7_jours,
+                :dossiers_total
+
+  def persisted?
+    false
+  end
+
+  def self.all
+    procedures_with_activity_sql = Procedure
+      .publiees
+      .where(published_at: 1.month.ago..)
+      .select(
+        <<~SQL.squish
+          procedures.id,
+          procedures.libelle,
+          procedures.published_at,
+          procedures.estimated_dossiers_count AS dossiers_total,
+          COUNT(dossiers.id) AS dossiers_7_jours
+        SQL
+      )
+      .joins(:dossiers)
+      .where(dossiers: { depose_at: 7.days.ago.. })
+      .group("procedures.id")
+      .order(dossiers_7_jours: :desc)
+      .limit(20)
+      .to_sql
+
+    ActiveRecord::Base.connection.execute(procedures_with_activity_sql).map do |procedure|
+      p = TopActivityProcedure.new
+      p.id = procedure["id"]
+      p.libelle = procedure["libelle"]
+      p.published_at = procedure["published_at"]
+      p.dossiers_7_jours = procedure["dossiers_7_jours"]
+      p.dossiers_total = procedure["dossiers_total"]
+      p
+    end
+  end
+end

--- a/app/views/manager/top_activity_procedures/_collection.html.erb
+++ b/app/views/manager/top_activity_procedures/_collection.html.erb
@@ -1,0 +1,77 @@
+<%#
+  # Collection
+
+  This partial is used on the `index` and `show` pages
+  to display a collection of resources in an HTML table.
+
+  ## Local variables:
+
+  - `collection_presenter`:
+  An instance of [Administrate::Page::Collection][1].
+  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
+  the columns displayed in the table
+  - `resources`:
+  An ActiveModel::Relation collection of resources to be displayed in the table.
+  By default, the number of resources is limited by pagination
+  or by a hard limit to prevent excessive page load times
+
+  [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<table aria-labelledby="<%= table_title %>">
+  <thead>
+    <tr>
+      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <th
+          class="
+            cell-label
+            cell-label--<%= attr_type.html_class %>
+            cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
+            cell-label--<%= "#{collection_presenter.resource_name}_#{attr_name}" %>
+          "
+          scope="col"
+          aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>"
+        >
+          <%= t(
+          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+          default: resource_class.human_attribute_name(attr_name).titleize,
+        ) %>
+
+          <% if collection_presenter.ordered_by?(attr_name) %>
+            <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+              <svg aria-hidden="true">
+                <use xlink:href="#icon-up-caret" />
+              </svg>
+            </span>
+          <% end %>
+        </th>
+      <% end %>
+
+      <%= render(
+        "collection_header_actions",
+        collection_presenter: collection_presenter,
+        page: page,
+        resources: resources,
+        table_title: "page-title"
+      ) %>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% resources.each do |resource| %>
+      <tr class="js-table-row">
+        <% collection_presenter.attributes_for(resource).each do |attribute| %>
+          <td class="cell-data cell-data--<%= attribute.html_class %>">
+            <a
+              href="<%= manager_procedure_url(resource.id) -%>"
+              tabindex="-1"
+              class="action-show"
+            >
+              <%= render_field attribute %>
+            </a>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/manager/top_activity_procedures/_index_header.html.erb
+++ b/app/views/manager/top_activity_procedures/_index_header.html.erb
@@ -1,0 +1,17 @@
+<% content_for(:title) do %>
+  <%= display_resource_name(page.resource_name) %>
+<% end %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title" id="page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <% if show_search_bar %>
+    <%= render(
+      "search",
+      search_term: search_term,
+      resource_name: display_resource_name(page.resource_name)
+    ) %>
+  <% end %>
+</header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,7 @@ Rails.application.routes.draw do
     resources :dubious_procedures, only: [:index]
     resources :published_procedures, only: [:index]
     resources :safe_mailers, only: [:index, :edit, :update, :destroy, :new, :create, :show]
+    resources :top_activity_procedures, only: [:index]
 
     authenticate :super_admin do
       mount Flipper::UI.app(-> { Flipper.instance }) => "/features", as: :flipper


### PR DESCRIPTION
issue : http://github.com/demarche-numerique/demarche.numerique.gouv.fr/issues/13438

Nouvel onglet dans le manager, permettant de visualiser le top 20 des démarches publiées sur le dernier mois glissant, par nombre de dossiers déposés sur les 7 derniers jours glissants.

Exemple ici (une seule démarche en local)
<img width="1421" height="199" alt="Capture d’écran 2026-07-07 à 19 25 54" src="https://github.com/user-attachments/assets/8f42c056-6c29-492a-a0f7-3c619148052d" />
