### PR TITLE
Tech: borne l'URL de retour Devise pour éviter le CookieOverflow

### DIFF
--- a/config/initializers/devise_store_location_cap.rb
+++ b/config/initializers/devise_store_location_cap.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Devise persists the "return to" URL after an authentication failure into the
+# session cookie (`user_return_to`, `super_admin_return_to`, ...). Our session
+# store is a 4 KB cookie (:cookie_store), so an oversized URL — a prefill /
+# `commencer` link carrying many champ query params, or a bot hammering
+# /manager with a giant query string — overflows the cookie and raises
+# ActionDispatch::Cookies::CookieOverflow (see Sentry RAILS-JYR).
+#
+# We cap the stored location: anything larger than MAX_STORED_LOCATION_BYTES is
+# not stored, so the user simply lands on the default post-login page instead of
+# crashing the request (or getting their whole session wiped by
+# CookieOverflowHandler). Prepending onto the shared StoreLocation module covers
+# both application controllers and Devise::FailureApp.
+#
+# 1024 is chosen so two concurrent *_return_to keys plus the rest of the session
+# still fit the ~2.7 KB plaintext budget that the encrypted cookie leaves us.
+module Devise
+  module Controllers
+    module StoreLocationCap
+      MAX_STORED_LOCATION_BYTES = 1024
+
+      def store_location_for(resource_or_scope, location)
+        return if location && location.to_s.bytesize > MAX_STORED_LOCATION_BYTES
+
+        super
+      end
+    end
+  end
+end
+
+Devise::Controllers::StoreLocation.prepend(Devise::Controllers::StoreLocationCap)

--- a/config/initializers/devise_store_location_cap.rb
+++ b/config/initializers/devise_store_location_cap.rb
@@ -21,7 +21,11 @@ module Devise
       MAX_STORED_LOCATION_BYTES = 1024
 
       def store_location_for(resource_or_scope, location)
-        return if location && location.to_s.bytesize > MAX_STORED_LOCATION_BYTES
+        if location && location.to_s.bytesize > MAX_STORED_LOCATION_BYTES
+          scope = Devise::Mapping.find_scope!(resource_or_scope)
+          Rails.logger.info("[StoreLocationCap] skipped oversized return-to for #{scope} (#{location.to_s.bytesize} bytes > #{MAX_STORED_LOCATION_BYTES})")
+          return
+        end
 
         super
       end

--- a/spec/controllers/devise/store_location_cap_spec.rb
+++ b/spec/controllers/devise/store_location_cap_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe "Devise store_location_for byte cap", type: :controller do
+  controller(ActionController::Base) do
+    include Devise::Controllers::StoreLocation
+  end
+
+  let(:max) { Devise::Controllers::StoreLocationCap::MAX_STORED_LOCATION_BYTES }
+
+  it "stores a normal-size location" do
+    subject.store_location_for(:user, "/dossiers?statut=en-cours")
+
+    expect(subject.session["user_return_to"]).to eq("/dossiers?statut=en-cours")
+  end
+
+  it "does not store a location larger than the cap" do
+    huge = "/commencer/ma-demarche?" + ("champ_Z=valeur&" * 200)
+    expect(huge.bytesize).to be > max
+
+    subject.store_location_for(:user, huge)
+
+    expect(subject.session["user_return_to"]).to be_nil
+  end
+end

--- a/spec/controllers/devise/store_location_cap_spec.rb
+++ b/spec/controllers/devise/store_location_cap_spec.rb
@@ -21,4 +21,28 @@ RSpec.describe "Devise store_location_for byte cap", type: :controller do
 
     expect(subject.session["user_return_to"]).to be_nil
   end
+
+  it "logs the scope and size when skipping (without the URL)" do
+    sentinel = "SENSITIVE_CHAMP_VALUE"
+    huge = "/commencer/x?#{sentinel}=" + ("a" * max)
+
+    expect(Rails.logger).to receive(:info)
+      .with(a_string_including("user", huge.bytesize.to_s))
+      .and_call_original
+
+    subject.store_location_for(:user, huge)
+  end
+
+  it "never logs the URL content" do
+    sentinel = "SENSITIVE_CHAMP_VALUE"
+    huge = "/commencer/x?#{sentinel}=" + ("a" * max)
+
+    logged = nil
+    allow(Rails.logger).to receive(:info) { |msg| logged = msg }
+
+    subject.store_location_for(:user, huge)
+
+    expect(logged).to be_present
+    expect(logged).not_to include(sentinel)
+  end
 end

--- a/spec/requests/cookie_overflow_prevention_spec.rb
+++ b/spec/requests/cookie_overflow_prevention_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe "Cookie overflow prevention on auth failure", type: :request do
+  # An unauthenticated GET to an authenticate_user!-protected route with a huge
+  # query string makes Devise::FailureApp try to store `user_return_to` = the
+  # full attempted path. Without the size cap that overflows the 4 KB session
+  # cookie; with it, the oversized location is skipped and the request stays clean.
+  it "redirects to sign in without storing an oversized return_to" do
+    huge_query = "x=#{'a' * 4000}"
+
+    get "/profil?#{huge_query}"
+
+    expect(response).to redirect_to(new_user_session_path)
+    expect(session["user_return_to"]).to be_nil
+  end
+
+  it "still stores a normal-size return_to" do
+    get "/profil?statut=en-cours"
+
+    expect(response).to redirect_to(new_user_session_path)
+    expect(session["user_return_to"]).to eq("/profil?statut=en-cours")
+  end
+end


### PR DESCRIPTION
Sentry [`RAILS-JYR`](https://demarches-simplifiees.sentry.io/issues/RAILS-JYR) : ~1400 `CookieOverflow` sur `_DS_session`. Sur échec d'auth, Devise stocke l'URL tentée dans le cookie de session (4 Ko) sous `<scope>_return_to` ; une URL trop longue le fait déborder. Source dominante réelle : `user_return_to` sur des liens de préremplissage chargés de query params (jusqu'à ~6,5 Ko), pas le coupable affiché `Manager::AdministrateursController#index`.

**Fix** : cap à 1 Ko de l'URL stockée, via un `prepend` sur `Devise::Controllers::StoreLocation` — couvre les contrôleurs **et** le `FailureApp`. Au-delà, l'URL n'est pas stockée (log scope + taille, sans l'URL). `CookieOverflowHandler` reste en filet de sécurité.

Dégradation gracieuse : un usager suivant un lien de préremplissage à très longue query atterrit sur la page par défaut après login au lieu de crasher. 

Autre possibilité à discuter : passer le session store sur Redis (supprime la limite 4 Ko).

Fixes RAILS-JYR