### PR TITLE
Correctif : ETQ instructeur, je peux utiliser « nom original du fichier » sur plusieurs pièces jointes d'un export zip personnalisé

### DIFF
--- a/app/services/downloadable_file_service.rb
+++ b/app/services/downloadable_file_service.rb
@@ -5,6 +5,8 @@ class DownloadableFileService
   EXPORT_DIRNAME = 'export'
 
   def self.download_and_zip(procedure, attachments, filename, &block)
+    attachments = deduplicate_paths(attachments)
+
     Dir.mktmpdir(nil, ARCHIVE_CREATION_DIR) do |tmp_dir|
       export_dir = File.join(tmp_dir, EXPORT_DIRNAME)
       zip_path = File.join(ARCHIVE_CREATION_DIR, "#{filename}.zip")
@@ -23,6 +25,25 @@ class DownloadableFileService
         FileUtils.remove_entry_secure(export_dir) if Dir.exist?(export_dir)
         File.delete(zip_path) if File.exist?(zip_path)
       end
+    end
+  end
+
+  # attachments with the same path (ex: same original filename) would silently
+  # overwrite each other in the export dir: suffix duplicates before download
+  def self.deduplicate_paths(attachments)
+    used_paths = Set.new
+
+    attachments.map do |attachment, path|
+      deduplicated_path = path
+      counter = 1
+
+      until used_paths.add?(deduplicated_path)
+        counter += 1
+        extension = File.extname(path)
+        deduplicated_path = "#{path.delete_suffix(extension)}-#{counter}#{extension}"
+      end
+
+      [attachment, deduplicated_path]
     end
   end
 end

--- a/app/validators/export_template_validator.rb
+++ b/app/validators/export_template_validator.rb
@@ -54,8 +54,10 @@ class ExportTemplateValidator < ActiveModel::Validator
   end
 
   def validate_different_templates(export_template)
+    # templates containing the original filename tag resolve to a different name per attachment
     templates = [export_template.export_pdf, *export_template.pjs]
       .filter(&:enabled?)
+      .reject { mentions(_1.template).include?('original-filename') }
       .map(&:template_string)
 
     return if templates.uniq.size == templates.size

--- a/spec/services/downloadable_file_service_spec.rb
+++ b/spec/services/downloadable_file_service_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe DownloadableFileService do
+  include ZipHelpers
+
   let(:procedure) { create(:procedure, :published) }
   let(:service) { ProcedureArchiveService.new(procedure) }
 
@@ -39,6 +41,36 @@ describe DownloadableFileService do
         expect(File.exist?(expected_zip_path)).to be_truthy
       end
       expect(File.exist?(expected_zip_path)).to be_falsey
+    end
+
+    context 'when attachments target the same path' do
+      def fake_attachment(content, id)
+        ActiveStorage::FakeAttachment.new(
+          file: StringIO.new(content),
+          filename: 'test.pdf',
+          name: 'pdf_export_for_instructeur',
+          id:,
+          created_at: Time.zone.now
+        )
+      end
+
+      let(:attachments) do
+        [
+          [fake_attachment('fichier 1', 1), 'dossier-1/test.pdf'],
+          [fake_attachment('fichier 2', 2), 'dossier-1/test.pdf'],
+          [fake_attachment('fichier 3', 3), 'dossier-1/test.pdf'],
+        ]
+      end
+
+      it 'deduplicates paths so no file is overwritten' do
+        DownloadableFileService.download_and_zip(procedure, attachments, filename) do |zip_path|
+          entries = read_zip_entries(zip_path)
+          expect(entries).to include('export/dossier-1/test.pdf', 'export/dossier-1/test-2.pdf', 'export/dossier-1/test-3.pdf')
+          expect(read_zip_file_content(zip_path, 'export/dossier-1/test.pdf')).to eq('fichier 1')
+          expect(read_zip_file_content(zip_path, 'export/dossier-1/test-2.pdf')).to eq('fichier 2')
+          expect(read_zip_file_content(zip_path, 'export/dossier-1/test-3.pdf')).to eq('fichier 3')
+        end
+      end
     end
   end
 end

--- a/spec/validators/export_template_validator_spec.rb
+++ b/spec/validators/export_template_validator_spec.rb
@@ -77,5 +77,29 @@ describe ExportTemplateValidator do
 
       it { expect(errors(export_template)).to eq([[:base, "Les fichiers doivent avoir des noms différents"]]) }
     end
+
+    context 'with multiple pjs using the original filename tag' do
+      def original_filename_template(stable_id:)
+        {
+          template: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "mention", attrs: { id: 'original-filename', label: 'nom original du fichier' } }],
+              },
+            ],
+          },
+          enabled: true,
+          stable_id:,
+        }
+      end
+
+      let(:export_template) do
+        build(:export_template, pjs: [original_filename_template(stable_id: 3), original_filename_template(stable_id: 4)])
+      end
+
+      it { expect(export_template.errors.count).to eq(0) }
+    end
   end
 end


### PR DESCRIPTION
## Contexte

Dans un modèle d'export zip, sélectionner la balise « nom original du fichier » pour plusieurs champs pièce justificative provoquait l'erreur « Les fichiers doivent avoir des noms différents » à l'enregistrement. Et lorsque deux pièces jointes portent le même nom d'origine, l'une écrasait silencieusement l'autre dans le zip généré.

## Correctifs

**Validation** : `ExportTemplateValidator#validate_different_templates` compare les modèles de noms **sans substitutions** : la balise « nom original du fichier » est alors rendue sous sa forme brute, identique pour tous les champs, alors qu'à l'export elle est remplacée par le nom propre de chaque fichier. Les modèles contenant cette balise sont désormais exclus du contrôle d'unicité.

**Export zip** : deux pièces jointes pouvaient produire le même chemin dans l'archive (ex. deux fichiers homonymes avec cette balise) ; le second téléchargement écrasait le premier. Les chemins en double sont maintenant suffixés (`-2`, `-3`, …) avant téléchargement dans `DownloadableFileService`.