### PR TITLE
Tech: optimiser les tests de champ_header_sections_summary_component_spec

### DIFF
--- a/spec/components/champ_header_sections_summary_component_spec.rb
+++ b/spec/components/champ_header_sections_summary_component_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe ViewableChamp::HeaderSectionsSummaryComponent, type: :component d
       { type: :text },
     ]
   end
-  let(:procedure) { create(:procedure, types_de_champ_public: types_de_champ, types_de_champ_private: types_de_champ) }
-  let(:dossier) { create(:dossier, procedure:) }
+  let(:procedure) { build(:procedure, types_de_champ_public: types_de_champ, types_de_champ_private: types_de_champ) }
+  let(:dossier) { build(:dossier, procedure:) }
   let(:component) { described_class.new(dossier:, is_private:) }
   let(:types_de_champ_public) { dossier.revision.types_de_champ_public.filter(&:header_section?) }
   let(:types_de_champ_private) { dossier.revision.types_de_champ_private.filter(&:header_section?) }


### PR DESCRIPTION
# Probleme

Tests lents dans `spec/components/champ_header_sections_summary_component_spec.rb` — temps baseline : 1.31s (médiane locale, 3 runs).

# Solution

Skill [`/test-optimization`](https://github.com/mfo/night-shift/blob/main/.claude/skills/test-optimization/SKILL.md)

### Techniques appliquées

| Technique | Avant | Après | Gain |
|-----------|-------|-------|------|
| T01 — create→build | 1.31s | 0.50s | -62% |

Le composant testé ne fait que lire `dossier.revision.types_de_champ_public` et générer du HTML — aucune requête DB ni persistance n'est nécessaire. Le remplacement de `create(:procedure)` et `create(:dossier)` par `build(...)` supprime les appels à la base de données.

### Techniques tentées sans succès

| Technique | Raison |
|-----------|--------|
| T08 — let_it_be | Le spec utilise `build` (pas de persistance DB), donc let_it_be n'apporte aucun gain |
| T09 — aggregate_failures | Seulement 2 exemples avec un setup déjà réduit à 0.50s — gain marginal |

**Résultat final : 1.31s → 0.50s (gain total -62%)**

Coverage : ~36% → ~34% (maintenue, variation due au chargement Rails)

Generated with [Claude Code](https://claude.com/claude-code)