### PR TITLE
ETQ instructeur, l'erreur de motivation manquante s'affiche au format DSFR

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -181,7 +181,7 @@
 
 [data-fr-theme='dark'] .dropdown-items {
   li {
-    &:not(.inactive) {
+    &:not(.form-inside) {
       &:hover,
       &.selected {
         background: var(--background-action-low-blue-france-hover);
@@ -320,20 +320,13 @@ ul.dropdown-items {
       }
     }
 
-    &:not(.inactive) {
+    &:not(.form-inside) {
       cursor: pointer;
 
       &:hover,
       &.selected {
         background: $light-grey;
       }
-    }
-
-    // In a dropdown, `.inactive` only marks a non-clickable item (see `:not(.inactive)`
-    // above); it must not inherit the global `.inactive { opacity: .5 }` utility, which
-    // would fade the correction/completion form it wraps.
-    &.inactive {
-      opacity: 1;
     }
 
     &.form-inside {

--- a/app/components/instructeurs/en_construction_menu_component/en_construction_menu_component.html.haml
+++ b/app/components/instructeurs/en_construction_menu_component/en_construction_menu_component.html.haml
@@ -23,7 +23,7 @@
           - else
             Le délai du #{sva_svr_human_decision} reprendra lorsqu’il déclarera avoir corrigé le dossier.
 
-  - menu.with_item(class: "inactive form-inside fr-pt-1v", data: { panels_target: 'panel', panels_name: 'pending_correction' }) do
+  - menu.with_item(class: "form-inside fr-pt-1v", data: { panels_target: 'panel', panels_name: 'pending_correction' }) do
     = render partial: 'instructeurs/dossiers/dropdown_motivation_form',
       locals: { form_path: pending_correction_instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut]),
         placeholder: 'Expliquez au demandeur quelle(s) correction(s) sont attendues',
@@ -42,7 +42,7 @@
           %h4= t('.request_completion')
           L’usager sera informé que son dossier est incomplet. Le délai du #{sva_svr_human_decision} sera réinitialisé lorque il déclarera avoir complété le dossier.
 
-    - menu.with_item(class: "inactive form-inside fr-pt-1v", data: { panels_target: 'panel', panels_name: 'pending_completion' }) do
+    - menu.with_item(class: "form-inside fr-pt-1v", data: { panels_target: 'panel', panels_name: 'pending_completion' }) do
       = render partial: 'instructeurs/dossiers/dropdown_motivation_form',
         locals: { form_path: pending_correction_instructeur_dossier_path(dossier.procedure, dossier, reason: :incomplete),
           placeholder: 'Expliquez au demandeur comment compléter son dossier',

--- a/app/controllers/instructeurs/batch_operations_controller.rb
+++ b/app/controllers/instructeurs/batch_operations_controller.rb
@@ -6,6 +6,14 @@ module Instructeurs
     before_action :ensure_ownership!
 
     def create
+      operation = params.dig(:batch_operation, :operation)
+      motivation = params.dig(:batch_operation, :motivation)
+
+      if operation.in?(%w[refuser classer_sans_suite]) && motivation.blank?
+        flash.alert = t('instructeurs.dossiers.motivation_missing_error')
+        return redirect_back_or_to(instructeur_procedure_url(@procedure.id))
+      end
+
       batch = BatchOperation.safe_create!(batch_operation_params)
       flash[:alert] = "Le traitement de masse n’a pas été lancé. Vérifiez que l’action demandée est possible pour les dossiers sélectionnés" if batch.blank?
       redirect_back_or_to(instructeur_procedure_url(@procedure.id))

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -259,6 +259,11 @@ module Instructeurs
       motivation = params[:dossier] && params[:dossier][:motivation]
       justificatif = params[:dossier] && params[:dossier][:justificatif_motivation]
 
+      if params[:process_action] != "accepter" && motivation.blank?
+        flash.alert = t('instructeurs.dossiers.motivation_missing_error')
+        return redirect_back_or_to(instructeur_dossier_path(dossier.procedure, dossier))
+      end
+
       h = { instructeur: current_instructeur, motivation: motivation, justificatif: justificatif }
 
       begin

--- a/app/javascript/controllers/motivation_justificatif_controller.ts
+++ b/app/javascript/controllers/motivation_justificatif_controller.ts
@@ -20,7 +20,11 @@ export class MotivationJustificatifController extends ApplicationController {
 
   showImport() {
     show(this.importTarget);
+    // move focus off the button before hiding it so it does not fall back to
+    // the document body, then open the native file picker
+    this.inputTarget.focus();
     hide(this.suggestTarget);
+    this.inputTarget.click();
   }
 
   fileSelected() {

--- a/app/javascript/new_design/form-validation.ts
+++ b/app/javascript/new_design/form-validation.ts
@@ -1,3 +1,5 @@
+import { isFormInputElement } from 'coldwired/utils';
+
 import { delegate } from '@utils';
 
 delegate('blur keydown', 'input, textarea', ({ target }) => {
@@ -18,4 +20,52 @@ function touch(target: EventTarget | null) {
   if (target instanceof Element) {
     target.classList.add('touched');
   }
+}
+
+// DSFR error rendering for forms opting in with data-dsfr-validation: native
+// constraint validation still blocks submission, but its bubble is replaced by
+// the DSFR error pattern rendered by the server (a hidden `#<input id>-error`
+// element next to the input).
+let dsfrInvalidForm: HTMLFormElement | null = null;
+
+document.addEventListener(
+  'invalid',
+  (event) => {
+    const input = event.target;
+    if (!isFormInputElement(input)) return;
+    if (!input.form?.hasAttribute('data-dsfr-validation')) return;
+
+    event.preventDefault();
+    toggleDsfrError(input);
+
+    // focus the first invalid input of the validation run
+    if (dsfrInvalidForm != input.form) {
+      dsfrInvalidForm = input.form;
+      queueMicrotask(() => (dsfrInvalidForm = null));
+      input.focus();
+    }
+  },
+  true // `invalid` does not bubble
+);
+
+delegate(
+  'input change',
+  'form[data-dsfr-validation] .fr-input--error',
+  ({ target }) => {
+    if (isFormInputElement(target)) {
+      toggleDsfrError(target);
+    }
+  }
+);
+
+function toggleDsfrError(
+  input: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+) {
+  const group = input.closest('.fr-input-group');
+  const error = document.getElementById(`${input.id}-error`);
+  const invalid = !input.validity.valid;
+
+  group?.classList.toggle('fr-input-group--error', invalid);
+  input.classList.toggle('fr-input--error', invalid);
+  error?.classList.toggle('hidden', !invalid);
 }

--- a/app/views/instructeurs/dossiers/_dropdown_motivation_form.html.haml
+++ b/app/views/instructeurs/dossiers/_dropdown_motivation_form.html.haml
@@ -11,7 +11,7 @@
       required: required
 
     .optional-justificatif{ id: "justificatif_motivation_suggest_#{popup_class}", data: { motivation_justificatif_target: 'suggest' } }
-      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-attachment-line.fr-ml-0{ type: 'button', data: { action: 'motivation-justificatif#showImport' } }
+      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-btn--align-on-content.fr-icon-attachment-line{ type: 'button', data: { action: 'motivation-justificatif#showImport' } }
         = button_justificatif_label
 
     .hidden{ id: "justificatif_motivation_import_#{popup_class}", data: { motivation_justificatif_target: 'import' } }
@@ -21,7 +21,7 @@
         data: { motivation_justificatif_target: 'input', action: 'change->motivation-justificatif#fileSelected' }
 
     .hidden{ id: "delete_motivation_import_#{popup_class}", data: { motivation_justificatif_target: 'delete' } }
-      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line.fr-ml-0.fr-mt-1w{
+      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-btn--align-on-content.fr-icon-delete-line.fr-mt-1w{
         type: 'button',
         data: { action: 'motivation-justificatif#delete' }
       }

--- a/app/views/instructeurs/dossiers/_instruction_motivation_fields.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_motivation_fields.html.haml
@@ -2,6 +2,7 @@
   .motivation{ class: "#{opt[:operation]}", data: { controller: 'motivation-justificatif' } }
 
     - field_id = "motivation_#{opt[:operation]}"
+    - required = opt[:operation] != 'accept'
 
     - if batch
       .fr-input-group{ id: "motivation-group-#{opt[:operation]}" }
@@ -14,7 +15,11 @@
         = form.text_area :motivation,
           id: field_id,
           class: "fr-input js_batch_operation_motivation_#{opt[:operation]}",
-          required: opt[:operation] != 'accept'
+          required: required,
+          aria: { describedby: required ? "#{field_id}-error" : nil }
+
+        - if required
+          %p.fr-error-text.hidden{ id: "#{field_id}-error" }= t('instructeurs.dossiers.motivation_missing_error')
 
     - else
       .fr-input-group{ id: "motivation-group-#{opt[:operation]}" }
@@ -26,7 +31,11 @@
         = text_area_tag "dossier[motivation]", nil,
           id: field_id,
           class: "fr-input",
-          required: opt[:operation] != 'accept'
+          required: required,
+          aria: { describedby: required ? "#{field_id}-error" : nil }
+
+        - if required
+          %p.fr-error-text.hidden{ id: "#{field_id}-error" }= t('instructeurs.dossiers.motivation_missing_error')
 
     / Justificatif
     .optional-justificatif{ id: "justificatif_motivation_suggest_#{opt[:operation]}", data: { motivation_justificatif_target: 'suggest' } }

--- a/app/views/instructeurs/dossiers/_instruction_motivation_fields.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_motivation_fields.html.haml
@@ -39,7 +39,7 @@
 
     / Justificatif
     .optional-justificatif{ id: "justificatif_motivation_suggest_#{opt[:operation]}", data: { motivation_justificatif_target: 'suggest' } }
-      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-attachment-line{
+      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-btn--align-on-content.fr-icon-attachment-line{
         type: "button",
         data: { action: 'motivation-justificatif#showImport' }
       }
@@ -58,7 +58,7 @@
           data: { motivation_justificatif_target: 'input', action: 'change->motivation-justificatif#fileSelected' }
 
     .hidden{ id: "delete_motivation_import_#{opt[:operation]}", data: { motivation_justificatif_target: 'delete' } }
-      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-icon-delete-line{
+      %button.fr-btn.fr-btn--tertiary-no-outline.fr-btn--icon-left.fr-btn--align-on-content.fr-icon-delete-line{
         type: "button",
         data: { action: 'motivation-justificatif#delete' }
       }

--- a/app/views/instructeurs/dossiers/_instruction_motivation_fields.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_motivation_fields.html.haml
@@ -4,27 +4,29 @@
     - field_id = "motivation_#{opt[:operation]}"
 
     - if batch
-      %label.fr-label{ for: field_id }
-        = opt[:label]
-        - if opt[:hint].present?
+      .fr-input-group{ id: "motivation-group-#{opt[:operation]}" }
+        %label.fr-label{ for: field_id }
+          = opt[:label]
+          - if opt[:hint].present?
+            %span.fr-hint-text
+              = opt[:hint]
+
+        = form.text_area :motivation,
+          id: field_id,
+          class: "fr-input js_batch_operation_motivation_#{opt[:operation]}",
+          required: opt[:operation] != 'accept'
+
+    - else
+      .fr-input-group{ id: "motivation-group-#{opt[:operation]}" }
+        = label_tag field_id, class: "fr-label" do
+          = opt[:label]
           %span.fr-hint-text
             = opt[:hint]
 
-      = form.text_area :motivation,
-        id: field_id,
-        class: "fr-input js_batch_operation_motivation_#{opt[:operation]}",
-        required: opt[:operation] != 'accept'
-
-    - else
-      = label_tag field_id, class: "fr-label" do
-        = opt[:label]
-        %span.fr-hint-text
-          = opt[:hint]
-
-      = text_area_tag "dossier[motivation]", nil,
-        id: field_id,
-        class: "fr-input",
-        required: opt[:operation] != 'accept'
+        = text_area_tag "dossier[motivation]", nil,
+          id: field_id,
+          class: "fr-input",
+          required: opt[:operation] != 'accept'
 
     / Justificatif
     .optional-justificatif{ id: "justificatif_motivation_suggest_#{opt[:operation]}", data: { motivation_justificatif_target: 'suggest' } }

--- a/app/views/instructeurs/dossiers/_instruction_selected_form.html.haml
+++ b/app/views/instructeurs/dossiers/_instruction_selected_form.html.haml
@@ -5,7 +5,7 @@
   - attestation_context = instruction_attestation_context(operation: operation, batch: batch, procedure: procedure, dossier: dossier)
 
   - if batch
-    = form_for BatchOperation.new, url: instructeur_batch_operations_path(procedure_id: procedure.id), method: :post, html: { id: "batch-instruction-form", multipart: true } do |form|
+    = form_for BatchOperation.new, url: instructeur_batch_operations_path(procedure_id: procedure.id), method: :post, html: { id: "batch-instruction-form", multipart: true, data: { dsfr_validation: true } } do |form|
       = hidden_field_tag "batch_operation[operation]", opt[:action]
 
       - dossier_ids.each do |id|
@@ -14,7 +14,7 @@
       = render "instructeurs/dossiers/instruction_motivation_fields", opt: opt, form: form, batch: true, attestation_context: attestation_context, visible: true
 
   - else
-    = form_tag(terminer_instructeur_dossier_path(dossier.procedure, dossier, statut: current_statut), method: :post, multipart: true, id: "instruction-form", data: { turbo: true }) do
+    = form_tag(terminer_instructeur_dossier_path(dossier.procedure, dossier, statut: current_statut), method: :post, multipart: true, id: "instruction-form", data: { turbo: true, dsfr_validation: true }) do
       = hidden_field_tag :process_action, opt[:action]
 
       = render "instructeurs/dossiers/instruction_motivation_fields", opt: opt, batch: false, attestation_context: attestation_context, dossier: dossier, visible: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1084,6 +1084,7 @@ en:
       unspecified_champs_group: User form
       unspecified_annotations_group: Private annotations
       add_justificatif: Add a supporting document (optional)
+      motivation_missing_error: '"Motivation" must be filled in'
     avis:
       revoquer:
         revoked: "%{email} can no longer give their opinion on this file."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1091,6 +1091,7 @@ fr:
       unspecified_champs_group: Formulaire usager
       unspecified_annotations_group: Annotations privées
       add_justificatif: Ajouter un justificatif (facultatif)
+      motivation_missing_error: « Motivation » doit être rempli
     avis:
       revoquer:
         revoked: "%{email} ne peut plus donner son avis sur ce dossier."

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -362,7 +362,7 @@ describe Instructeurs::DossiersController, type: :controller do
       end
 
       context 'simple refusal' do
-        subject { post :terminer, params: { process_action: "refuser", procedure_id: procedure.id, dossier_id: dossier.id, statut: 'a-suivre' }, format: :turbo_stream }
+        subject { post :terminer, params: { process_action: "refuser", procedure_id: procedure.id, dossier_id: dossier.id, dossier: { motivation: "Motif du refus" }, statut: 'a-suivre' }, format: :turbo_stream }
 
         it 'change state to refuse' do
           subject
@@ -386,7 +386,7 @@ describe Instructeurs::DossiersController, type: :controller do
       end
 
       context 'refusal with a justificatif' do
-        subject { post :terminer, params: { process_action: "refuser", procedure_id: procedure.id, dossier_id: dossier.id, dossier: { justificatif_motivation: fake_justificatif }, statut: 'a-suivre' }, format: :turbo_stream }
+        subject { post :terminer, params: { process_action: "refuser", procedure_id: procedure.id, dossier_id: dossier.id, dossier: { justificatif_motivation: fake_justificatif, motivation: "Motif du refus" }, statut: 'a-suivre' }, format: :turbo_stream }
 
         it 'attachs a justificatif' do
           subject
@@ -401,7 +401,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
       context 'when the dossier does not have any attestation' do
         it 'Notification email is sent' do
-          subject { post :terminer, params: { process_action: "refuser", procedure_id: procedure.id, dossier_id: dossier.id, statut: 'a-suivre' }, format: :turbo_stream }
+          subject { post :terminer, params: { process_action: "refuser", procedure_id: procedure.id, dossier_id: dossier.id, dossier: { motivation: "Motif du refus" }, statut: 'a-suivre' }, format: :turbo_stream }
           subject
         end
       end
@@ -414,7 +414,7 @@ describe Instructeurs::DossiersController, type: :controller do
           allow_any_instance_of(Dossier).to receive(:build_attestation).and_return(attestation)
         end
 
-        subject { post :terminer, params: { process_action: "refuser", procedure_id: procedure.id, dossier_id: dossier.id, statut: 'a-suivre' }, format: :turbo_stream }
+        subject { post :terminer, params: { process_action: "refuser", procedure_id: procedure.id, dossier_id: dossier.id, dossier: { motivation: "Motif du refus" }, statut: 'a-suivre' }, format: :turbo_stream }
 
         it 'The instructeur is sent back to the dossier page' do
           subject
@@ -456,7 +456,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
       context 'with dossier in batch_operation' do
         let!(:batch_operation) { create(:batch_operation, operation: :archiver, dossiers: [dossier], instructeur: instructeur) }
-        subject { post :terminer, params: { process_action: "refuser", procedure_id: procedure.id, dossier_id: dossier.id, statut: 'a-suivre' }, format: :turbo_stream }
+        subject { post :terminer, params: { process_action: "refuser", procedure_id: procedure.id, dossier_id: dossier.id, dossier: { motivation: "Motif du refus" }, statut: 'a-suivre' }, format: :turbo_stream }
 
         it do
           expect { subject }.not_to change { dossier.reload.state }
@@ -475,7 +475,7 @@ describe Instructeurs::DossiersController, type: :controller do
         sign_in(instructeur.user)
       end
       context 'without continuation' do
-        subject { post :terminer, params: { process_action: "classer_sans_suite", procedure_id: procedure.id, dossier_id: dossier_for_tiers.id, statut: 'a-suivre' }, format: :turbo_stream }
+        subject { post :terminer, params: { process_action: "classer_sans_suite", procedure_id: procedure.id, dossier_id: dossier_for_tiers.id, dossier: { motivation: "Motif du classement sans suite" }, statut: 'a-suivre' }, format: :turbo_stream }
 
         it 'Notification email is sent' do
           expect(NotificationMailer).to receive(:send_sans_suite_notification)
@@ -501,7 +501,7 @@ describe Instructeurs::DossiersController, type: :controller do
         sign_in(instructeur.user)
       end
       context 'without continuation' do
-        subject { post :terminer, params: { process_action: "classer_sans_suite", procedure_id: procedure.id, dossier_id: dossier_for_tiers_without_notif.id, statut: 'a-suivre' }, format: :turbo_stream }
+        subject { post :terminer, params: { process_action: "classer_sans_suite", procedure_id: procedure.id, dossier_id: dossier_for_tiers_without_notif.id, dossier: { motivation: "Motif du classement sans suite" }, statut: 'a-suivre' }, format: :turbo_stream }
 
         it 'Notification email is sent' do
           expect(NotificationMailer).to receive(:send_sans_suite_notification)
@@ -527,7 +527,7 @@ describe Instructeurs::DossiersController, type: :controller do
         sign_in(instructeur.user)
       end
       context 'with classer_sans_suite' do
-        subject { post :terminer, params: { process_action: "classer_sans_suite", procedure_id: procedure_accuse_lecture.id, dossier_id: dossier_accuse_lecture.id, statut: 'a-suivre' }, format: :turbo_stream }
+        subject { post :terminer, params: { process_action: "classer_sans_suite", procedure_id: procedure_accuse_lecture.id, dossier_id: dossier_accuse_lecture.id, dossier: { motivation: "Motif du classement sans suite" }, statut: 'a-suivre' }, format: :turbo_stream }
 
         it 'Notification accuse de lecture email is sent and not the others' do
           expect(NotificationMailer).to receive(:send_accuse_lecture_notification)
@@ -555,7 +555,7 @@ describe Instructeurs::DossiersController, type: :controller do
         sign_in(instructeur.user)
       end
       context 'without attachment' do
-        subject { post :terminer, params: { process_action: "classer_sans_suite", procedure_id: procedure.id, dossier_id: dossier.id, statut: 'a-suivre' }, format: :turbo_stream }
+        subject { post :terminer, params: { process_action: "classer_sans_suite", procedure_id: procedure.id, dossier_id: dossier.id, dossier: { motivation: "Motif du classement sans suite" }, statut: 'a-suivre' }, format: :turbo_stream }
 
         it 'change state to sans_suite' do
           subject
@@ -580,7 +580,7 @@ describe Instructeurs::DossiersController, type: :controller do
       end
 
       context 'with attachment' do
-        subject { post :terminer, params: { process_action: "classer_sans_suite", procedure_id: procedure.id, dossier_id: dossier.id, statut: 'a-suivre', dossier: { justificatif_motivation: fake_justificatif } }, format: :turbo_stream }
+        subject { post :terminer, params: { process_action: "classer_sans_suite", procedure_id: procedure.id, dossier_id: dossier.id, statut: 'a-suivre', dossier: { justificatif_motivation: fake_justificatif, motivation: "Motif du classement sans suite" } }, format: :turbo_stream }
 
         it 'change state to sans_suite' do
           subject

--- a/spec/system/instructeurs/batch_operation_spec.rb
+++ b/spec/system/instructeurs/batch_operation_spec.rb
@@ -551,7 +551,19 @@ describe 'BatchOperation a dossier:', js: true do
     click_on "Refuser les dossiers"
 
     expect(page).to have_field("motivation_refuse")
+
+    # le confirm se déclenche avant la validation (statu quo produit),
+    # puis la validation cliente bloque la soumission vide
+    expect(page).to have_selector('button[data-confirm="Êtes-vous sûr de vouloir appliquer cette décision aux dossiers sélectionnés ?"]')
+    page.execute_script('window.confirm = () => true')
+    click_on "Valider la décision"
+
+    expect(page).to have_css(".fr-input-group--error")
+    expect(page).to have_css('#motivation_refuse-error:not(.hidden)', text: "« Motivation » doit être rempli")
+    expect(BatchOperation.count).to eq(0)
+
     fill_in("motivation_refuse", with: "Refus batch avec justificatif")
+    expect(page).to have_no_css(".fr-input-group--error")
 
     within(".motivation.refuse") do
       find('input[type="file"]', visible: :all).attach_file(

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -103,6 +103,31 @@ describe 'Instructing a dossier:', js: true do
     expect(page).not_to have_button('Repasser en instruction')
   end
 
+  scenario 'shows DSFR error when motivation is missing before refusing a dossier' do
+    dossier.passer_en_instruction!(instructeur: instructeur)
+    login_as(instructeur.user, scope: :user)
+
+    visit instructeur_dossier_path(procedure, dossier)
+    click_on 'Rendre une décision'
+
+    within('.instruction-button') { find_link('Refuser').click }
+
+    expect(page).to have_field('motivation_refuse')
+    find('button', text: 'Valider la décision').click
+
+    expect(page).to have_css('.fr-input-group--error')
+    expect(page).to have_css('#motivation_refuse-error:not(.hidden)', text: '« Motivation » doit être rempli')
+    expect(dossier.reload.state).to eq(Dossier.states.fetch(:en_instruction))
+
+    fill_in('motivation_refuse', with: 'dossier irrecevable')
+    expect(page).to have_no_css('.fr-input-group--error')
+
+    find('button', text: 'Valider la décision').click
+
+    expect(page).to have_text('Le dossier a bien été traité')
+    expect(dossier.reload.state).to eq(Dossier.states.fetch(:refuse))
+  end
+
   scenario 'A instructeur can follow/unfollow a dossier and request an export' do
     login_as(instructeur.user, scope: :user)
     visit instructeur_procedures_path

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -128,6 +128,22 @@ describe 'Instructing a dossier:', js: true do
     expect(dossier.reload.state).to eq(Dossier.states.fetch(:refuse))
   end
 
+  scenario 'moves focus to the justificatif file input when adding a justificatif' do
+    dossier.passer_en_instruction!(instructeur: instructeur)
+    login_as(instructeur.user, scope: :user)
+
+    visit instructeur_dossier_path(procedure, dossier)
+    click_on 'Rendre une décision'
+
+    within('.instruction-button') { find_link('Refuser').click }
+    expect(page).to have_field('motivation_refuse')
+
+    within('.refuse.motivation') { click_on 'Ajouter un justificatif' }
+
+    expect(page).to have_css('#dossier_justificatif_motivation_refuse:focus')
+    expect(page).to have_no_css('#motivation_refuse:focus')
+  end
+
   scenario 'A instructeur can follow/unfollow a dossier and request an export' do
     login_as(instructeur.user, scope: :user)
     visit instructeur_procedures_path


### PR DESCRIPTION
Suite des retours UX du parcours d'instruction, pages 4 , 5, 8

## Contexte

Dans la modale « Rendre une décision » (unitaire et lot), une motivation obligatoire manquante était signalée par la bulle native du navigateur, hors charte DSFR.

## Ce que fait cette PR

- La validation native continue de bloquer la soumission, mais sa bulle est remplacée par le pattern d'erreur DSFR : les formulaires optent via `data-dsfr-validation`, le serveur rend le message d'erreur masqué à côté du champ, et le module global `form-validation.ts` bascule les classes DSFR depuis l'événement `invalid` (focus sur le champ en erreur, effacement dès que la saisie redevient valide). Mécanisme opt-in, réutilisable tel quel par d'autres formulaires.
- Filet serveur : les deux endpoints de décision rejettent désormais une motivation vide (flash + redirect) — il n'existait aucune validation serveur.

## Pourquoi pas un traitement de formulaire classique ?

Le round-trip serveur avec re-rendu du formulaire en erreur a été prototypé puis écarté : re-rendre la modale détruit l'état client du direct upload du justificatif et oblige à restructurer le formulaire batch imbriqué — environ deux fois plus de code pour la même promesse UX. Ici, l'erreur est instantanée, aucune requête ne part tant que le formulaire est invalide, et l'état de la modale (justificatif compris) n'est jamais perturbé.

## Retours UX complémentaires

Trois ajustements sur le même flux de décision, suite à relecture :

- **Alignement du bouton « Ajouter un justificatif »** : son contenu était rentré par rapport au bord gauche du textarea, à cause du padding horizontal du bouton DSFR tertiary. Corrigé avec la classe DSFR dédiée `fr-btn--align-on-content`, qui aligne le contenu du bouton sur le champ (en remplacement d'un `fr-ml-0` inopérant côté menu déroulant).
- **Formulaire de motivation « en construction » grisé** :  alternative au [fix déjà mergé, vu après coup](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/13465) le `<li>` du menu portait la classe `inactive` pour neutraliser le survol des items du menu, mais cette classe déclenche aussi l'utilitaire globale `opacity: 0.5` — le formulaire, pourtant pleinement interactif, s'affichait à moitié transparent. L'exclusion du survol s'appuie désormais sur `form-inside`, ce qui supprime l'opacité parasite sans toucher à l'utilitaire globale. Le contournement CSS de #13465 (`&.inactive { opacity: 1 }`) est retiré au passage.
- **Ouverture du sélecteur de fichier au clic sur « Ajouter un justificatif »** : le bouton se contentait de révéler l'`input[type=file]` (bouton « Parcourir »), et le focus était perdu lorsque le bouton qui le portait était masqué. Le contrôleur Stimulus `motivation-justificatif` (arrivé sur main entre temps) déplace désormais le focus sur l'input fichier avant de masquer le bouton, puis ouvre directement le sélecteur natif.

<img width="871" height="638" alt="Capture d’écran 2026-07-13 à 18 49 16" src="https://github.com/user-attachments/assets/34bce8e2-2002-4d2f-a0c6-a6bed5c6fc7a" />


