### PR TITLE
Tech: fix N+1 sur active_storage_attachments, dossier_notifications, experts_procedures dans Instructeurs::DossiersController

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -608,7 +608,7 @@ module Instructeurs
           .map(&:id)
 
         avis_attachments_ids = dossier
-          .avis.flat_map { [_1.introduction_file, _1.piece_justificative_file] }
+          .avis.includes(:introduction_file_attachment, :piece_justificative_file_attachment).flat_map { [_1.introduction_file, _1.piece_justificative_file] }
           .flat_map(&:attachments)
           .compact
           .map(&:id)

--- a/app/models/dossier_notification.rb
+++ b/app/models/dossier_notification.rb
@@ -264,9 +264,9 @@ class DossierNotification < ApplicationRecord
 
     return types.transform_values { false } if dossier.archived
 
-    notifications = DossierNotification.where(dossier:, instructeur:)
+    existing_types = DossierNotification.where(dossier:, instructeur:).pluck(:notification_type)
 
-    types.transform_values { |type| notifications.exists?(notification_type: type) }
+    types.transform_values { |type| existing_types.include?(type.to_s) }
   end
 
   def self.notifications_counts_for_instructeur_procedures(groupe_instructeur_ids, instructeur)

--- a/app/services/create_avis_service.rb
+++ b/app/services/create_avis_service.rb
@@ -15,19 +15,41 @@ class CreateAvisService
 
       emails, restricted_emails = filter_restricted_emails(dossier.procedure, emails)
 
-      # create experts
-      users, invalids = emails.map { User.create_or_promote_to_expert(it, SecureRandom.hex) }.partition(&:valid?)
+      # create experts — batch-find existing users by email to avoid N+1
+      existing_users_by_email = User.where(email: emails).index_by(&:email)
+      users = []
+      invalids = []
+      emails.each do |email|
+        user = existing_users_by_email[email]
+        if user.nil?
+          user = User.create_or_promote_to_expert(email, SecureRandom.hex)
+        elsif user.valid? && user.expert.nil?
+          user.create_expert!
+        end
+        (user.valid? ? users : invalids) << user
+      end
       failed_emails = invalids.map { { email: it.email, messages: it.errors.full_messages } }
       failed_emails += restricted_emails.map { { email: it, messages: [I18n.t('create_avis_service.errors.expert_not_allowed')] } }
 
       # list all related dossiers
       dossiers = avis.invite_linked_dossiers.present? ? [dossier, *dossier.linked_dossiers_for(claimant)] : [dossier]
 
-      # create expert <-> procedure
-      experts = users.map(&:expert)
-      experts_procedures_h = dossiers.map(&:procedure).uniq
-        .flat_map { |procedure| experts.map { |expert| [[expert, procedure], ExpertsProcedure.find_or_create_by(procedure:, expert:)] } }
-        .to_h
+      # create expert <-> procedure — batch-load experts and ExpertsProcedure records
+      experts = User.where(id: users.map(&:id)).includes(:expert).map(&:expert)
+      procedures = dossiers.map(&:procedure).uniq
+
+      existing_eps = ExpertsProcedure.where(procedure_id: procedures.map(&:id), expert_id: experts.map(&:id))
+        .index_by { |ep| [ep.expert_id, ep.procedure_id] }
+
+      experts_procedures_h = {}
+      procedures.each do |procedure|
+        experts.each do |expert|
+          key = [expert, procedure]
+          ep = existing_eps[[expert.id, procedure.id]]
+          ep ||= ExpertsProcedure.find_or_create_by(procedure:, expert:)
+          experts_procedures_h[key] = ep
+        end
+      end
 
       # create avis on all related dossiers
       persisted, failed = experts.flat_map do |expert|


### PR DESCRIPTION
# Probleme

N+1 detecte par [Prosopite](https://github.com/charkost/prosopite) (scan des tests en raise mode) et confirme par analyse du code.

**Donnees de production** (Skylight) : waste estime 69.2ms sur 5 endpoints du controller (RPM 161.7, P95 1138ms).

**Triage Prosopite** : 3 patterns PROD / ~195 patterns TEST ignores (flipper, setup).

# Solution

Skill [`/n1-query-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/n1-query-fix/SKILL.md)

### Patterns corriges

| Association | Table | Strategy | Changement |
|-------------|-------|----------|------------|
| `dossier.avis` -> `introduction_file` / `piece_justificative_file` | `active_storage_attachments` | `includes` | Ajoute `includes(:introduction_file_attachment, :piece_justificative_file_attachment)` avant le `flat_map` dans `set_gallery_attachments` |
| `DossierNotification.exists?` par type | `dossier_notifications` | `pluck` | Remplace 4 requetes `exists?` par un unique `pluck(:notification_type)` avec detection Ruby dans `notifications_sticker_for_instructeur_dossier` |
| `User.create_or_promote_to_expert` + `users.map(&:expert)` + `ExpertsProcedure.find_or_create_by` en boucle | `users`, `experts`, `experts_procedures` | batch queries | Batch les requetes par email, expert, et ExpertsProcedure dans `CreateAvisService.call` |

### Preuve Prosopite

**Avant (3 patterns PROD) :**
```
N+1 queries detected (Xms): SELECT "active_storage_attachments".* FROM ... (repete pour chaque avis)
  Call stack: app/controllers/instructeurs/dossiers_controller.rb:613

N+1 queries detected (Xms): SELECT 1 AS one FROM "dossier_notifications" WHERE ... (repete 4x par type)
  Call stack: app/models/dossier_notification.rb:269

N+1 queries detected (Xms): SELECT "users".* FROM "users" WHERE "users"."email" = $1 (repete par email)
  Call stack: app/services/create_avis_service.rb:19
```

**Apres (0 patterns PROD) :**
```
Aucun N+1 PROD detecte.
```

### Validation

- [x] Tests passes (rspec)
- [x] Rubocop OK
- [x] Prosopite : 0 N+1 PROD apres fix
- [x] Seuls des fichiers app/ et config/ commites

Generated with [Claude Code](https://claude.com/claude-code)