### PR TITLE
Tech: stabiliser les tests flaky de spec/graphql/annotation_spec.rb

### DIFF
--- a/spec/graphql/annotation_spec.rb
+++ b/spec/graphql/annotation_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Mutations::DossierModifierAnnotations, type: :graphql do
     end
 
     context 'with not found annotation' do
-      let(:annotation_id) { GraphQL::Schema::UniqueWithinType.encode('Champ', 123) }
+      let(:annotation_id) { GraphQL::Schema::UniqueWithinType.encode('Champ', Float::INFINITY) }
       let(:annotations) { [{ id: annotation_id, value: { text: '' } }] }
 
       it 'returns error' do


### PR DESCRIPTION
# Probleme

Le fichier `spec/graphql/annotation_spec.rb` echoue de maniere intermittente en CI.

### Evidence CI

| Signal | Count | Signification |
|--------|-------|---------------|
| Merge queue | 1 echec | Pas de changement de code → preuve forte de flakiness |
| Retries | 0 passes au retry | Le test est instable |

Branches concernees : `gh-readonly-queue/main/pr-13433-08d4c674116a58aac94e04c152ff15a764b4c914`, `auto/i18n-hardcoded/batch-539aa2ae`
Jobs : [`Unit tests (0)`](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/28869467188/job/85628085397), [`Unit tests (1)`](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/28663100511/job/85008172126)

Tests concernes :
- `returns error` (line 218, `dossierModifierAnnotations` / `with not found annotation`)

# Solution

Skill [`/flaky-test-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/flaky-test-fix/SKILL.md)

### Cause identifiee et fix

| Cause | Scope | Fix | Pourquoi ca resout |
|-------|-------|-----|--------------------|
| ID `123` en dur dans `encode('Champ', 123)` entre en collision avec un `TypeDeChamp` reel dont l'ID sequence atteint 123 | test | `Float::INFINITY` au lieu de `123` | `TypeDeChamp#populate_stable_id` copie l'ID dans `stable_id`. Quand la sequence DB produit 123, `find_type_de_champ_by_stable_id('123')` trouve un type reel et la mutation reussit au lieu d'erreur. `Float::INFINITY` ne peut jamais etre un ID DB. |

### Preuve de stabilite

| Test | Runs | Resultat | Type |
|------|------|----------|------|
| `returns error` (line 218) | 50/50 | ✅ STABLE | unit |

Script : [`verify-flaky.sh`](https://github.com/mfo/night-shift/blob/main/.claude/skills/flaky-test-fix/verify-flaky.sh) (50 runs, random seed a chaque run)

Generated with [Claude Code](https://claude.com/claude-code)