### PR TITLE
Tech: stabiliser le test flaky de typhoeus_spec

### DIFF
--- a/spec/lib/core_ext/typhoeus_spec.rb
+++ b/spec/lib/core_ext/typhoeus_spec.rb
@@ -2,6 +2,8 @@
 
 RSpec.describe Typhoeus::EasyFactory do
   describe 'proxy tracing headers' do
+    before { ActiveSupport::CurrentAttributes.reset_all }
+
     let(:request) { Typhoeus::Request.new('http://example.com') }
 
     subject(:easy) { described_class.new(request).get }


### PR DESCRIPTION
# Probleme

Le fichier `spec/lib/core_ext/typhoeus_spec.rb` echoue de maniere intermittente en CI.

### Evidence CI

| Signal | Count | Signification |
|--------|-------|---------------|
| Merge queue | 2 echecs | Pas de changement de code → preuve forte de flakiness |
| Retries | 0 passes au retry | Le test est instable |

Branches concernees : `bettera11ycomboselect`, `auto/haml-migration/batch-beb37214`, `gh-readonly-queue/main/pr-13406-...`, `gh-readonly-queue/main/pr-13421-...`
Jobs : [`Unit tests (0)`](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/29081907643/job/86326470994), [`Unit tests (1)`](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/29078096196/job/86314240355), [`Unit tests (2)`](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/28947782676/job/85886075221)

Tests concernes :
- `sets no proxy headers outside of a request or job context`

# Solution

Skill [`/flaky-test-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/flaky-test-fix/SKILL.md)

### Causes identifiees et fixes

| Cause | Scope | Fix | Pourquoi ca resout |
|-------|-------|-----|--------------------|
| `CurrentAttributes` non reset entre les exemples RSpec — `Current.request_id` fuite depuis les controller specs qui le positionnent via `before_action` | test | `before { ActiveSupport::CurrentAttributes.reset_all }` dans le describe block | Garantit un etat propre de Current avant chaque exemple, quel que soit l'ordre aleatoire |

### Preuve de stabilite

| Test | Runs | Resultat | Type |
|------|------|----------|------|
| `sets no proxy headers outside of a request or job context` | 50/50 | ✅ STABLE | unit |

Script : [`verify-flaky.sh`](https://github.com/mfo/night-shift/blob/main/.claude/skills/flaky-test-fix/verify-flaky.sh) (50 runs unit, random seed a chaque run)

Generated with [Claude Code](https://claude.com/claude-code)