### PR TITLE
Tech: spec vérifiant qu'un invité peut modifier les geo_areas d'un champ carte sur un dossier en construction

### DIFF
--- a/spec/controllers/champs/carte_controller_spec.rb
+++ b/spec/controllers/champs/carte_controller_spec.rb
@@ -181,6 +181,85 @@ describe Champs::CarteController, type: :controller do
       end
     end
 
+    describe 'as an invited user on a dossier en_construction' do
+      let(:invited_user) { create(:user) }
+      let(:dossier) { create(:dossier, :en_construction, user: user, procedure: procedure) }
+
+      before do
+        create(:invite, dossier: dossier, user: invited_user, email: invited_user.email)
+        sign_in invited_user
+      end
+
+      describe 'POST #create' do
+        let(:params) do
+          {
+            dossier_id: champ.dossier_id,
+            stable_id: champ.stable_id,
+            feature: feature,
+            source: GeoArea.sources.fetch(:selection_utilisateur),
+          }
+        end
+
+        subject { post :create, params: params }
+
+        it 'creates the geo area' do
+          expect { subject }.to change { GeoArea.count }.by(1)
+          expect(response).to have_http_status(:created)
+        end
+      end
+
+      describe 'PATCH #update' do
+        let(:params) do
+          {
+            dossier_id: champ.dossier_id,
+            stable_id: champ.stable_id,
+            id: geo_area.to_feature[:properties][:id],
+            feature: feature,
+          }
+        end
+
+        subject { patch :update, params: params }
+
+        context 'geometry' do
+          let(:feature) { attributes_for(:geo_area, :point) }
+
+          it 'updates the geo area' do
+            subject
+            expect(response).to have_http_status(:no_content)
+            expect(GeoArea.where("geometry->>'type' = 'Point'")).to exist
+          end
+        end
+
+        context 'description' do
+          let(:feature) { { properties: { description: 'un point' } } }
+
+          it 'updates the geo area' do
+            subject
+            expect(response).to have_http_status(:no_content)
+          end
+        end
+      end
+
+      describe 'DELETE #destroy' do
+        let(:params) do
+          {
+            dossier_id: champ.dossier_id,
+            stable_id: champ.stable_id,
+            id: geo_area.to_feature[:properties][:id],
+          }
+        end
+
+        before { geo_area }
+
+        subject { delete :destroy, params: params }
+
+        it 'destroys the geo area' do
+          subject
+          expect(response).to have_http_status(:no_content)
+        end
+      end
+    end
+
     describe 'GET #index' do
       render_views
 


### PR DESCRIPTION
Suite à un signalement utilisateur suspect indiquant que le backend rejetterait les modifications de zones (geo_areas) d'un champ carte faites par un invité sur un dossier en construction, cette PR ajoute des specs contrôleur couvrant ce scénario (création, mise à jour de géométrie et de description, suppression).

Les specs passent sans modification du code applicatif : le backend autorise bien ces opérations (`ChampPolicy#update?` → `owns_or_invite?`). À noter : en construction, les modifications vont dans le buffer stream et `last_champ_updated_at` n'est volontairement pas mis à jour tant que les modifications ne sont pas déposées — le signalement vient probablement de là (modifications « invisibles » plutôt que rejetées), ou du côté client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)