### PR TITLE
Correctif : ETQ instructeur, le bouton « Modifier le dossier » ne s'affiche plus quand la fonction n'est pas activée sur la démarche

### DIFF
--- a/app/components/instructeurs/edit_dossier_button_component.rb
+++ b/app/components/instructeurs/edit_dossier_button_component.rb
@@ -7,6 +7,10 @@ class Instructeurs::EditDossierButtonComponent < ApplicationComponent
     @dossier = dossier
   end
 
+  def render?
+    dossier.procedure.instructeurs_can_edit_dossiers?
+  end
+
   def title
     if dossier.en_instruction?
       t('.title.en_instruction')

--- a/spec/components/instructeurs/edit_dossier_button_component_spec.rb
+++ b/spec/components/instructeurs/edit_dossier_button_component_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe Instructeurs::EditDossierButtonComponent, type: :component do
+  let(:procedure) { create(:procedure, :published, instructeurs: [instructeur], instructeurs_can_edit_dossiers:) }
+  let(:instructeur) { create(:instructeur) }
+  let(:dossier) { create(:dossier, :en_construction, procedure:) }
+  let(:instructeurs_can_edit_dossiers) { true }
+
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(instructeur.user)
+  end
+
+  subject do
+    with_request_url "/procedures/#{procedure.id}/dossiers/#{dossier.id}" do
+      render_inline(described_class.new(dossier:))
+    end
+  end
+
+  context "when the procedure does not allow instructeurs to edit dossiers" do
+    let(:instructeurs_can_edit_dossiers) { false }
+
+    it "renders nothing" do
+      expect(subject.to_html).to be_empty
+    end
+  end
+
+  context "when the instructeur can edit the dossier" do
+    it "renders the edit link" do
+      expect(subject).to have_link("Modifier le dossier")
+    end
+  end
+
+  context "when the dossier is en instruction" do
+    let(:dossier) { create(:dossier, :en_instruction, procedure:) }
+
+    it "renders a disabled button" do
+      expect(subject).to have_button("Modifier le dossier", disabled: true)
+    end
+  end
+
+  context "when the instructeur owns the dossier" do
+    let(:dossier) { create(:dossier, :en_construction, procedure:, user: instructeur.user) }
+
+    it "renders a disabled button" do
+      expect(subject).to have_button("Modifier le dossier", disabled: true)
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Retour au support : le bouton « Modifier le dossier » grisé était affiché côté instructeur sur tous les dossiers, même lorsque l'administrateur n'avait pas activé la modification des dossiers par les instructeurs sur la démarche. L'infobulle affichée (« dossier déposé par le même compte ») prêtait en plus à confusion.

## Correction

Le composant `Instructeurs::EditDossierButtonComponent` ne se rend plus du tout (`render?`) quand `instructeurs_can_edit_dossiers` est désactivé sur la démarche. Le bouton grisé avec infobulle reste affiché uniquement quand la fonction est activée, pour les cas où elle est indisponible : dossier déposé par l'instructeur lui-même, dossier en instruction, dossier terminé.