### PR TITLE
ETQ instructeur, le formulaire « Demander une correction » n'est plus grisé

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -329,6 +329,13 @@ ul.dropdown-items {
       }
     }
 
+    // In a dropdown, `.inactive` only marks a non-clickable item (see `:not(.inactive)`
+    // above); it must not inherit the global `.inactive { opacity: .5 }` utility, which
+    // would fade the correction/completion form it wraps.
+    &.inactive {
+      opacity: 1;
+    }
+
     &.form-inside {
       background-color: $white;
       margin-top: -2px;


### PR DESCRIPTION
Le formulaire « Demander une correction » (et « Demander à compléter » en SVA/SVR) s'affichait à 50 % d'opacité : textarea, liens et boutons apparaissaient grisés, dans tous les navigateurs.

**Cause** : le `<li class="inactive form-inside">` qui enveloppe le formulaire n'utilise `inactive` que pour désactiver le survol du menu (`li:not(.inactive)`). L'introduction récente d'une utilité globale `.inactive { opacity: .5 }` (pour l'éditeur quotient familial) débordait sur cet item et grisait tout le formulaire.

**Correctif** : dans les dropdowns, `.inactive` ne réduit plus l'opacité (il ne sert qu'à neutraliser le survol).