### PR TITLE
ETQ invité, voir ProConnect et création de compte sur la page de connexion

### DIFF
--- a/app/controllers/targeted_user_links_controller.rb
+++ b/app/controllers/targeted_user_links_controller.rb
@@ -9,7 +9,8 @@ class TargetedUserLinksController < ApplicationController
     targeted_user_link.target_email
     if targeted_user_link.invalid_signed_in_user?(current_user)
       if !user_signed_in?
-        authenticate_user!
+        flash[:alert] = t('views.users.sessions.new_invite.flash_alert')
+        redirect_to new_user_session_path(context: 'invite')
       else
         render
       end

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -1,5 +1,8 @@
 = content_for(:page_id, 'auth')
 = content_for(:title, t('metas.signin.title'))
+- invite_context = params[:context] == 'invite'
+- if invite_context
+  = content_for(:hide_header_signin, true)
 
 #session-new.auth-form.sign-in-form
   = form_for resource, url: user_session_path, html: { class: "fr-py-5w" } do |f|
@@ -7,7 +10,7 @@
     %h1.fr-h2= t('views.users.sessions.new.sign_in', application_name: Current.application_name)
 
     = render partial: 'shared/france_connect_login', locals: { url: france_connect_path }
-    - if params[:with_proconnect]
+    - if invite_context || params[:with_proconnect]
       = render ProConnectLoginComponent.new
 
     %p.fr-hr-or= t('views.shared.france_connect_login.separator')
@@ -40,3 +43,8 @@
 
       .fr-fieldset__element.fr-mt-1w
         .fr-btns-group= f.submit t('views.users.sessions.new.connection'), class: "fr-btn"
+
+    - if invite_context
+      %h2.fr-h6.fr-mt-4w= t('views.users.sessions.new_invite.no_account')
+      .fr-btns-group
+        = link_to t('views.shared.account.create', application_name: Current.application_name), new_user_registration_path, class: "fr-btn fr-btn--secondary"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -693,6 +693,9 @@ en:
           connection: Sign in
           find_procedure: Find your procedure
           subtitle: "Sign in with your email"
+        new_invite:
+          flash_alert: "You must sign in or create an account to continue."
+          no_account: "Don't have an account?"
         link_sent:
           consult_help_page_html: If you're seeing this page too often, <a target="_blank" rel="noopener noreferrer" href="%{href}">please consult our help page</a>.
           email_cta_html: "We have to validate your email address <strong>%{email}</strong>."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -703,6 +703,9 @@ fr:
           connection: Se connecter
           find_procedure: Trouvez votre démarche
           subtitle: "Se connecter avec son adresse électronique"
+        new_invite:
+          flash_alert: "Vous devez vous connecter ou créer un compte pour continuer."
+          no_account: "Vous n’avez pas de compte"
         link_sent:
           consult_help_page_html: Si vous voyez cette page trop souvent, <a target="_blank" rel="noopener noreferrer" href="%{href}">consultez notre aide</a>.
           email_cta_html: "Nous avons besoin de vérifier votre adresse électronique <strong>%{email}</strong>."

--- a/spec/controllers/targeted_user_links_controller_spec.rb
+++ b/spec/controllers/targeted_user_links_controller_spec.rb
@@ -88,8 +88,8 @@ describe TargetedUserLinksController, type: :controller do
       context 'when invite user does not exists' do
         let(:user) { nil }
         before { get :show, params: { id: targeted_user_link.id } }
-        it 'requires authentication before exposing the invite' do
-          expect(response).to redirect_to(new_user_session_path)
+        it 'redirects to invite sign-in page and stores location' do
+          expect(response).to redirect_to(new_user_session_path(context: 'invite'))
           expect(controller.stored_location_for(:user)).to eq(controller.request.fullpath)
         end
       end
@@ -146,8 +146,8 @@ describe TargetedUserLinksController, type: :controller do
       context 'when invite user does not exists' do
         let(:user) { nil }
         before { get :show, params: { id: targeted_user_link.id } }
-        it 'requires authentication before exposing the invite' do
-          expect(response).to redirect_to(new_user_session_path)
+        it 'redirects to invite sign-in page and stores location' do
+          expect(response).to redirect_to(new_user_session_path(context: 'invite'))
           expect(controller.stored_location_for(:user)).to eq(controller.request.fullpath)
         end
       end
@@ -177,9 +177,9 @@ describe TargetedUserLinksController, type: :controller do
         expect(response).not_to redirect_to(invite_path(invite, email: invite_email))
       end
 
-      it 'requires authentication and stores the location for return after sign-in' do
+      it 'redirects to invite sign-in page and stores the location for return after sign-in' do
         anonymous_show
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to redirect_to(new_user_session_path(context: 'invite'))
         expect(controller.stored_location_for(:user)).to eq(controller.request.fullpath)
       end
     end

--- a/spec/system/users/invite_spec.rb
+++ b/spec/system/users/invite_spec.rb
@@ -27,7 +27,12 @@ describe 'Invitations' do
     context 'when inviting someone without an existing account' do
       let(:invite) { create(:invite, dossier: dossier, user: nil) }
 
-      scenario 'an invited user receiving the targeted_user_link is asked to authenticate first', js: true do
+      before do
+        allow(FranceConnectService).to receive(:enabled?).and_return(true)
+        allow(ProConnectService).to receive(:enabled?).and_return(true)
+      end
+
+      scenario 'an invited user receiving the targeted_user_link sees all sign-in options', js: true do
         log_in(owner)
         navigate_to_brouillon(dossier)
 
@@ -45,7 +50,10 @@ describe 'Invitations' do
 
         page.reset_session!
         visit URI.parse(targeted_user_link_url(targeted_user_link)).request_uri
-        expect(page).to have_current_path("/users/sign_in")
+        expect(page).to have_current_path("/users/sign_in?context=invite")
+        expect(page).to have_content('FranceConnect')
+        expect(page).to have_content('ProConnect')
+        expect(page).to have_link(I18n.t('views.shared.account.create', application_name: Current.application_name))
       end
     end
 
@@ -70,7 +78,7 @@ describe 'Invitations' do
 
         page.reset_session!
         visit URI.parse(targeted_user_link_url(targeted_user_link)).request_uri
-        expect(page).to have_current_path("/users/sign_in")
+        expect(page).to have_current_path("/users/sign_in?context=invite")
       end
     end
 


### PR DESCRIPTION
## Problème

Quand un invité clique sur le lien d'invitation reçu par email, il est redirigé vers la page de connexion standard `/users/sign_in`. Cette page :
- **masque ProConnect** (derrière un paramètre `with_proconnect`)
- **ne propose pas de créer un compte**
- affiche un message flash générique

Résultat : les invités sans compte sont perdus et génèrent des tickets support.

Closes https://github.com/demarche-numerique/demarche.numerique.gouv.fr/issues/13450

## Solution

Ajout d'un paramètre `?context=invite` sur la page de connexion existante qui active :

1. **ProConnect** (affiché sans condition)
2. **Lien vers la création de compte** en bas de page
3. **Flash explicite** : *"Vous devez vous connecter ou créer un compte pour continuer."*

Pas de nouvelle page, pas de nouvelle route — juste un flag sur la page standard.

Le `TargetedUserLinksController` redirige vers `/users/sign_in?context=invite` au lieu d'`authenticate_user!`.

## Diff visuel

### Avant (page standard `/users/sign_in`)

![before-current-state.png](https://gist.githubusercontent.com/mfo/1d573882b2aaba1d1bbbaad0a89fee04/raw/before-current-state.png)

### Après (`/users/sign_in?context=invite`)

![after-invite-page.png](https://gist.githubusercontent.com/mfo/1d573882b2aaba1d1bbbaad0a89fee04/raw/after-invite-page.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)