### PR TITLE
ETQ usager, transforme le bandeau « en attente de réponse » en notice

### DIFF
--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
@@ -39,7 +39,7 @@
                     <% c.with_desc { t(".communes_warning_desc_html") } %>
 
                     <% c.with_link do %>
-                      <%= button_tag(t(".communes_info_link"), type: :button, class: "fr-pl-0 fr-link fr-text-default--warning fr-mt-1w",
+                      <%= button_tag(t(".communes_info_link"), type: :button, class: "fr-pl-0 fr-notice__link fr-text-default--warning fr-mt-1w",
                         data: { "fr-opened" => "false", "turbo-frame" => "api-champ-columns", action: "lazy-modal#load", href: 'style' },
                         src: commune_info_admin_procedure_path(id: procedure.id, stable_id: type_de_champ.stable_id),
                         "aria-controls" => "api-champ-columns-modal",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -619,7 +619,7 @@ en:
           no_result_search_back_link: "go back to your files list"
           new_message:
             title: "New message from the administration"
-            body_html: 'Check your <a href="%{link}" class="fr-link">messages</a>.'
+            body_html: 'Check your <a href="%{link}" class="fr-notice__link">messages</a>.'
           pending_correction:
             title: "Warning"
             body_html: 'Consult the corrections to be made to your file in the <a href="%{link}" class="fr-notice__link">messaging system<span class="fr-sr-only"> of file number %{id}</span></a>.'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -644,7 +644,7 @@ fr:
             this_procedure: cette démarche
           new_message:
             title: "Nouveau message de l’administration"
-            body_html: 'Consultez la <a href="%{link}" class="fr-link">messagerie</a>.'
+            body_html: 'Consultez la <a href="%{link}" class="fr-notice__link">messagerie</a>.'
           pending_correction:
             title: "Attention"
             body_html: 'Consultez les corrections à apporter à votre dossier dans la <a href="%{link}" class="fr-notice__link">messagerie<span class="fr-sr-only"> du dossier numéro %{id}</span></a>.'

--- a/spec/views/users/dossiers/show/_status_overview.html.erb_spec.rb
+++ b/spec/views/users/dossiers/show/_status_overview.html.erb_spec.rb
@@ -61,6 +61,19 @@ describe 'users/dossiers/show/_status_overview', type: :view do
         expect(rendered).to have_link(href: messagerie_dossier_path(dossier))
       end
     end
+
+    context 'with a pending response' do
+      let(:dossier) do
+        create(:dossier, :en_construction).tap { create(:dossier_pending_response, dossier: it) }
+      end
+
+      it 'renders the "en attente de réponse" notice (warning, not an alert)' do
+        expect(rendered).to have_selector('.fr-notice.fr-notice--warning')
+        expect(rendered).not_to have_selector('.fr-alert')
+        expect(rendered).to have_text("répondez à l'administration")
+        expect(rendered).to have_link(href: messagerie_dossier_path(dossier))
+      end
+    end
   end
 
   context 'when en construction on a brouillon procedure (EN TEST) without estimation' do


### PR DESCRIPTION
Uniformise l'affichage des dossiers « en attente de réponse » de l'usager avec le bandeau « à corriger ».

- Le bandeau « en attente de réponse » passe d'une grosse alerte (titre `card-title`) à une **notice warning compacte** (« Attention … »), cohérente avec le bandeau « à corriger ». Appliqué sur la carte « Mes dossiers » et la page de suivi du dossier.
- Les liens des notices utilisent désormais `fr-notice__link` au lieu de `fr-link` : le lien prend la teinte du bandeau au lieu du bleu, conformément à la [doc DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bandeau-d-information-importante/design-du-bandeau-d-information-importante). Concerne les notices « en attente de réponse », « à corriger », « nouveau message » et l'info communes de l'éditeur de champs.

> Basée sur `worktree-vast-wishing-koala` (PR #13456).

Avant
<img width="2304" height="750" alt="pr-before-list" src="https://github.com/user-attachments/assets/426a4286-8b08-48da-aa36-cd00a39422b0" />

<img width="2304" height="718" alt="pr-before-show" src="https://github.com/user-attachments/assets/ff050037-a6a0-4bb3-81cf-1fb206977d4a" />

Après
<img width="2304" height="696" alt="pr-after-show" src="https://github.com/user-attachments/assets/b1be70ac-b723-4a82-aa8b-caf4e385ea41" />
<img width="2304" height="728" alt="pr-after-list" src="https://github.com/user-attachments/assets/b71bc883-562b-406d-b88e-3a00b583ccc6" />
