### PR TITLE
ETQ usager, notice « bientôt supprimé » dans la corbeille

### DIFF
--- a/app/views/users/dossiers/_dossiers_list.html.erb
+++ b/app/views/users/dossiers/_dossiers_list.html.erb
@@ -84,6 +84,22 @@
       <% end %>
 
       <% if @statut == "dossiers-supprimes" %>
+        <%= render Dsfr::NoticeComponent.new(state: 'warning', extra_class_names: "fr-mb-2w") do |c| %>
+          <% c.with_title { t('views.users.dossiers.dossiers_list.soon_deleted.title') } %>
+
+          <% c.with_desc do %>
+            <% if dossier.hidden_by_reason != 'expired' %>
+              <%= t('views.users.dossiers.dossiers_list.soon_deleted.restore') %>
+            <% elsif dossier.expiration_can_be_extended? %>
+              <%= t('views.users.dossiers.dossiers_list.soon_deleted.restore_and_extend') %>
+            <% else %>
+              <%= t('views.users.dossiers.dossiers_list.soon_deleted.download') %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% if @statut == "dossiers-supprimes" %>
         <div class="flex justify-end no-flex-xs">
           <% if dossier.hidden_by_reason != 'expired' %>
             <%= link_to restore_dossier_path(dossier.id), method: :patch, class: "fr-btn fr-btn--sm" do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -627,6 +627,11 @@ en:
           pending_response:
             title: "Warning"
             message_html: 'Consult the <a href="%{link}" class="fr-notice__link">messaging system<span class="fr-sr-only"> of file number %{id}</span></a> and respond to the administration.'
+          soon_deleted:
+            title: "Warning"
+            restore: If you want to keep this file, you can restore it before it is permanently deleted.
+            restore_and_extend: If you want to keep this file, you can restore it and extend its retention period before it is permanently deleted.
+            download: If you want to keep a record of this file, you can download it before it is permanently deleted.
           depose_at: First submission on %{date}
           created_at: Created at %{date}
           updated_at: updated at %{date}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -652,6 +652,11 @@ fr:
           pending_response:
             title: "Attention"
             message_html: 'Consultez la <a href="%{link}" class="fr-notice__link">messagerie<span class="fr-sr-only"> du dossier numéro %{id}</span></a> et répondez à l''administration.'
+          soon_deleted:
+            title: "Attention"
+            restore: Si vous souhaitez conserver ce dossier, vous pouvez le restaurer avant qu’il ne soit supprimé définitivement.
+            restore_and_extend: Si vous souhaitez conserver ce dossier, vous pouvez le restaurer et étendre sa durée de conservation avant qu’il ne soit supprimé définitivement.
+            download: Si vous souhaitez conserver une trace de ce dossier, vous pouvez le télécharger avant qu’il ne soit supprimé définitivement.
           depose_at: Déposé le %{date}
           created_at: Créé le %{date}
           updated_at: modifié le %{date}

--- a/spec/system/users/list_dossiers_spec.rb
+++ b/spec/system/users/list_dossiers_spec.rb
@@ -136,6 +136,27 @@ describe 'user dossiers list', js: true do
       expect(page).not_to have_button(text: /Filtrer les dossiers/i)
     end
 
+    it 'shows a "bientôt supprimé" warning notice whose content depends on the trash context' do
+      by_user = create(:dossier, :accepte, :hidden_by_user, user: user)
+      expired_brouillon = create(:dossier, :brouillon, :hidden_by_expired, user: user)
+      expired_termine   = create(:dossier, :accepte, :hidden_by_expired, user: user)
+
+      visit trash_path
+
+      within("#dossier_#{by_user.id}") do
+        expect(page).to have_css('.fr-notice.fr-notice--warning')
+        expect(page).to have_text('vous pouvez le restaurer avant qu’il ne soit supprimé définitivement')
+      end
+
+      within("#dossier_#{expired_brouillon.id}") do
+        expect(page).to have_text('vous pouvez le restaurer et étendre sa durée de conservation')
+      end
+
+      within("#dossier_#{expired_termine.id}") do
+        expect(page).to have_text('vous pouvez le télécharger avant qu’il ne soit supprimé définitivement')
+      end
+    end
+
     it 'links to the deleted dossiers history page' do
       create(:dossier, :en_construction, :hidden_by_user, user: user)
       create(:deleted_dossier, user_id: user.id)


### PR DESCRIPTION
Dans la corbeille (`/corbeille`), un dossier est définitivement supprimé 2 semaines après sa mise à la corbeille, sans qu'aucun avertissement ne le signale à l'usager.

Cette PR ajoute, sur chaque dossier de la corbeille, une notice DSFR « warning » (« Attention ») dont le contenu s'adapte au contexte de mise à la corbeille, **en cohérence avec l'action disponible sous la notice** :

- **Mise à la corbeille par l'usager** (quel que soit l'état) → l'inviter à le **restaurer**
- **Expiration — brouillon** → l'inviter à le **restaurer et étendre sa durée de conservation**
- **Expiration — dossier traité** → l'inviter à le **télécharger** (non restaurable)

Suite de l'issue #13018 (évolution des bandeaux de notification des dossiers usager).

> Basée sur `future-notice-demande-reponse` (PR #13468).

<img width="910" height="654" alt="image" src="https://github.com/user-attachments/assets/44ed8ab0-fd8c-4f00-add8-9a820a8d14f8" />
