### PR TITLE
Tech: valide des instances de champs projetées dans les specs

### DIFF
--- a/app/jobs/migrations/batch_update_pays_values_job.rb
+++ b/app/jobs/migrations/batch_update_pays_values_job.rb
@@ -80,7 +80,7 @@ class Migrations::BatchUpdatePaysValuesJob < ApplicationJob
       # orphaned champs (stable_id no longer in the dossier revision) can not
       # be validated: resolving their type_de_champ raises
       next unless pays_champ.dossier.stable_id_in_revision?(pays_champ.stable_id)
-      next if pays_champ.valid?(:champ_value)
+      next if valid_country?(pays_champ)
       code = APIGeoService.country_code(pays_champ.value)
       value = if code.present?
         APIGeoService.country_name(code)
@@ -93,5 +93,17 @@ class Migrations::BatchUpdatePaysValuesJob < ApplicationJob
         pays_champ.update_columns(value: value, external_id: associated_country_code)
       end
     end
+  end
+
+  private
+
+  # same check as the :champ_value validations on Champs::PaysChamp, without
+  # instantiating a projected champ (these are raw, possibly historical, records)
+  def valid_country?(champ)
+    country_names = APIGeoService.countries.pluck(:name)
+    country_codes = APIGeoService.countries.pluck(:code)
+
+    (champ.value.nil? || champ.value.in?(country_names)) &&
+      (champ.external_id.nil? || champ.external_id.in?(country_codes))
   end
 end

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -499,6 +499,7 @@ module DossierChampsConcern
     reset_champs_cache
 
     champ.save!
+    champ.type_de_champ = type_de_champ
     champ
   end
 

--- a/spec/models/champs/commune_champ_spec.rb
+++ b/spec/models/champs/commune_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::CommuneChamp do
   let(:types_de_champ_public) { [{ type: :communes }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champ_data.first }
+  let(:champ) { dossier.project_champs_public.first }
 
   let(:code_insee) { '63102' }
   let(:code_postal) { '63290' }

--- a/spec/models/champs/date_champ_spec.rb
+++ b/spec/models/champs/date_champ_spec.rb
@@ -69,7 +69,7 @@ describe Champs::DateChamp do
   end
 
   context 'when the value is not in the past' do
-    let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
     subject { champ.validate(:champ_value) }
 
     context 'all dates are accepted' do
@@ -90,7 +90,7 @@ describe Champs::DateChamp do
   end
 
   context 'when there is a range' do
-    let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
     subject { champ.validate(:champ_value) }
 
     before { champ.type_de_champ.update(options: { range_date: '1', start_date: '2017-11-30', end_date: '2017-12-31' }) }
@@ -145,7 +145,7 @@ describe Champs::DateChamp do
   end
 
   context 'when birthdate option is enabled' do
-    let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
     subject { champ.validate(:champ_value) }
 
     before { champ.type_de_champ.update(options: { birthdate: "1" }) }

--- a/spec/models/champs/datetime_champ_spec.rb
+++ b/spec/models/champs/datetime_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::DatetimeChamp do
   let(:types_de_champ_public) { [{ type: :datetime }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:datetime_champ) { dossier.champ_data.first }
+  let(:datetime_champ) { dossier.project_champs_public.first }
 
   describe '#normalizes' do
     it 'preserves nil' do
@@ -104,7 +104,7 @@ describe Champs::DatetimeChamp do
   end
 
   context 'when there is a range' do
-    let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
     subject { champ.validate(:champ_value) }
 
     before { champ.type_de_champ.update(options: { range_date: '1', start_date: '2017-11-30', end_date: '2017-12-31' }) }

--- a/spec/models/champs/decimal_number_champ_spec.rb
+++ b/spec/models/champs/decimal_number_champ_spec.rb
@@ -5,7 +5,7 @@ describe Champs::DecimalNumberChamp do
   let(:types_de_champ_private) { [] }
   let(:procedure) { create(:procedure, types_de_champ_public:, types_de_champ_private:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
   let(:value) { nil }
 
   describe 'validation' do
@@ -127,6 +127,7 @@ describe Champs::DecimalNumberChamp do
     context 'when the champ is private and the value is invalid' do
       let(:types_de_champ_public) { [] }
       let(:types_de_champ_private) { [{ type: :decimal_number }] }
+      let(:champ) { dossier.project_champs_private.first.tap { _1.update(value:) } }
       let(:value) { '2.6666' }
 
       it { is_expected.to be_falsey }

--- a/spec/models/champs/departement_champ_spec.rb
+++ b/spec/models/champs/departement_champ_spec.rb
@@ -3,7 +3,7 @@
 describe Champs::DepartementChamp, type: :model do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :departements }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champ_data.first.tap { _1.update_columns(value:, external_id:) } }
+  let(:champ) { dossier.project_champs_public.first.tap { _1.update_columns(value:, external_id:) } }
   let(:value) { nil }
   let(:external_id) { nil }
 

--- a/spec/models/champs/dossier_link_champ_spec.rb
+++ b/spec/models/champs/dossier_link_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::DossierLinkChamp, type: :model do
   let(:types_de_champ_public) { [{ type: :dossier_link, mandatory: }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, :en_construction, procedure:) }
-  let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
   let(:value) { nil }
   let(:mandatory) { false }
 

--- a/spec/models/champs/drop_down_list_champ_spec.rb
+++ b/spec/models/champs/drop_down_list_champ_spec.rb
@@ -6,7 +6,7 @@ describe Champs::DropDownListChamp do
   let(:dossier) { create(:dossier, procedure:) }
   let(:referentiel) { nil }
   let(:drop_down_mode) { nil }
-  let(:champ) { dossier.champ_data.first.tap { _1.update(value:, other:) } }
+  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:, other:) } }
   let(:value) { nil }
   let(:other) { nil }
 

--- a/spec/models/champs/email_champ_spec.rb
+++ b/spec/models/champs/email_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::EmailChamp do
   describe 'validation' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{}, { type: :email }, {}]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champ_data.second }
+    let(:champ) { dossier.project_champs_public.second }
     let(:value) { nil }
     before { champ.value = value }
     subject { champ.validate(:champ_value) }

--- a/spec/models/champs/engagement_juridique_champ_spec.rb
+++ b/spec/models/champs/engagement_juridique_champ_spec.rb
@@ -5,7 +5,7 @@ describe Champs::EngagementJuridiqueChamp do
     let(:types_de_champ_public) { [{ type: :engagement_juridique }] }
     let(:procedure) { create(:procedure, types_de_champ_public:) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
     let(:value) { nil }
 
     subject { champ.validate(:champ_value) }

--- a/spec/models/champs/epci_champ_spec.rb
+++ b/spec/models/champs/epci_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::EpciChamp, type: :model do
   let(:types_de_champ_public) { [{ type: :epci }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champ_data.first.tap { _1.code_departement = code_departement } }
+  let(:champ) { dossier.project_champs_public.first.tap { _1.code_departement = code_departement } }
   let(:code_departement) { nil }
 
   describe 'validations' do

--- a/spec/models/champs/formatted_champ_spec.rb
+++ b/spec/models/champs/formatted_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::FormattedChamp do
   let(:types_de_champ_public) { [tdc_definition] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champ_data.first }
+  let(:champ) { dossier.project_champs_public.first }
 
   before do
     champ.value = value

--- a/spec/models/champs/iban_champ_spec.rb
+++ b/spec/models/champs/iban_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::IbanChamp do
   let(:types_de_champ_public) { [{ type: :iban }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champ_data.first }
+  let(:champ) { dossier.project_champs_public.first }
 
   describe '#valid?' do
     def with_value(value)

--- a/spec/models/champs/integer_number_champ_spec.rb
+++ b/spec/models/champs/integer_number_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::IntegerNumberChamp do
   let(:types_de_champ_public) { [{ type: :integer_number }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
   let(:value) { nil }
   subject { champ.validate(:champ_value) }
 

--- a/spec/models/champs/multiple_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/multiple_drop_down_list_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::MultipleDropDownListChamp do
   let(:types_de_champ_public) { [{ type: :multiple_drop_down_list, options: ["val1", "val2", "val3", "[brackets] val4"] }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
   let(:value) { nil }
 
   describe 'validations' do

--- a/spec/models/champs/phone_champ_spec.rb
+++ b/spec/models/champs/phone_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::PhoneChamp do
   let(:types_de_champ_public) { [{ type: :phone }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champ_data.first }
+  let(:champ) { dossier.project_champs_public.first }
 
   describe '#validate' do
     it do

--- a/spec/models/champs/piece_justificative_champ_spec.rb
+++ b/spec/models/champs/piece_justificative_champ_spec.rb
@@ -7,7 +7,7 @@ describe Champs::PieceJustificativeChamp do
 
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.champ_data.first }
+  let(:champ) { dossier.project_champs_public.first }
 
   describe "validations" do
     subject { champ }
@@ -86,7 +86,7 @@ describe Champs::PieceJustificativeChamp do
     context 'titre_identite nature' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: 'titre_identite' }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ) { dossier.champ_data.first }
+      let(:champ) { dossier.project_champs_public.first }
 
       it 'accepts jpeg under 20MB' do
         champ.piece_justificative_file.purge
@@ -119,7 +119,7 @@ describe Champs::PieceJustificativeChamp do
       context "#{ocr_nature} nature" do
         let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: ocr_nature }]) }
         let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-        let(:champ) { dossier.champ_data.first }
+        let(:champ) { dossier.project_champs_public.first }
 
         it 'accepts pdf' do
           champ.piece_justificative_file.purge
@@ -139,7 +139,7 @@ describe Champs::PieceJustificativeChamp do
     context 'pj_limit_formats with document_texte' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, pj_limit_formats: '1', pj_format_families: ['document_texte'] }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ) { dossier.champ_data.first }
+      let(:champ) { dossier.project_champs_public.first }
 
       it 'accepts pdf' do
         champ.piece_justificative_file.purge
@@ -164,7 +164,7 @@ describe Champs::PieceJustificativeChamp do
     context 'pj_limit_formats enabled with empty families' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, pj_limit_formats: '1', pj_format_families: [] }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ) { dossier.champ_data.first }
+      let(:champ) { dossier.project_champs_public.first }
 
       it 'accepts pdf' do
         champ.piece_justificative_file.purge

--- a/spec/models/champs/referentiel_champ_spec.rb
+++ b/spec/models/champs/referentiel_champ_spec.rb
@@ -9,7 +9,7 @@ describe Champs::ReferentielChamp, type: :model do
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
   let(:referentiel_champ) { dossier.champ_data.find(&:referentiel?) }
-  let(:champ) { referentiel_champ }
+  let(:champ) { dossier.project_champs_public.find(&:referentiel?) }
 
   describe '#valid?' do
     context 'when the champ is pending' do

--- a/spec/models/champs/region_champ_spec.rb
+++ b/spec/models/champs/region_champ_spec.rb
@@ -3,7 +3,7 @@
 describe Champs::RegionChamp, type: :model do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :regions }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champ_data.first.tap { _1.update(value:, external_id:) } }
+  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:, external_id:) } }
   let(:value) { nil }
   let(:external_id) { nil }
 

--- a/spec/models/champs/rna_champ_spec.rb
+++ b/spec/models/champs/rna_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::RNAChamp do
   let(:types_de_champ_public) { [{ type: :rna }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champ_data.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
   let(:value) { "W182736273" }
 
   def with_external_id(external_id)

--- a/spec/models/champs/rnf_champ_spec.rb
+++ b/spec/models/champs/rnf_champ_spec.rb
@@ -11,7 +11,7 @@ describe Champs::RNFChamp, type: :model do
   describe '#valid?' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champ_data.find(&:rnf?) }
+    let(:champ) { dossier.project_champs_public.find(&:rnf?) }
 
     def with_state(external_id:, data:, fetch_external_data_exceptions: [])
       champ.tap do
@@ -86,7 +86,7 @@ describe Champs::RNFChamp, type: :model do
   describe 'format validation' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.champ_data.find(&:rnf?) }
+    let(:champ) { dossier.project_champs_public.find(&:rnf?) }
 
     before { champ.update_columns(external_id:) }
 

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -3,7 +3,7 @@
 describe Champs::SiretChamp do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champ_data.first.tap { _1.update(external_id:, etablissement:) } }
+  let(:champ) { dossier.project_champs_public.first.tap { _1.update(external_id:, etablissement:) } }
   let(:external_id) { "" }
   let(:etablissement) { nil }
 

--- a/spec/models/concerns/champ_conditional_concern_spec.rb
+++ b/spec/models/concerns/champ_conditional_concern_spec.rb
@@ -5,8 +5,8 @@ describe ChampConditionalConcern do
 
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :decimal_number, stable_id: 99 }, { type: :decimal_number, stable_id: 999, condition: }]) }
   let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.champ_data.find { _1.stable_id == 99 }.tap { _1.update_column(:value, '1.1234') } }
-  let(:last_champ) { dossier.champ_data.find { _1.stable_id == 999 }.tap { _1.update_column(:value, '1.1234') } }
+  let(:champ) { dossier.project_champs_public.find { _1.stable_id == 99 }.tap { _1.update_column(:value, '1.1234') } }
+  let(:last_champ) { dossier.project_champs_public.find { _1.stable_id == 999 }.tap { _1.update_column(:value, '1.1234') } }
   let(:condition) { nil }
 
   describe '#dependent_conditions?' do

--- a/spec/services/attachment/piece_justificative_service_spec.rb
+++ b/spec/services/attachment/piece_justificative_service_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Attachment::PieceJustificativeService do
   let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.champ_data.first }
+  let(:champ) { dossier.project_champs_public.first }
 
   let(:blob_1) { ActiveStorage::Blob.create_and_upload!(io: StringIO.new("file1"), filename: "file1.pdf", content_type: "application/pdf") }
   let(:blob_2) { ActiveStorage::Blob.create_and_upload!(io: StringIO.new("file2"), filename: "file2.pdf", content_type: "application/pdf") }
@@ -20,8 +20,8 @@ RSpec.describe Attachment::PieceJustificativeService do
 
     context 'with concurrent uploads (simulated stale state)' do
       it 'preserves all attachments' do
-        champ_a = Champ.find(champ.id)
-        champ_b = Champ.find(champ.id)
+        champ_a = Dossier.find(dossier.id).project_champs_public.first
+        champ_b = Dossier.find(dossier.id).project_champs_public.first
 
         # Force-load the blobs association on both instances before either attaches.
         # This simulates two concurrent requests that both read blobs = [] at the same time.


### PR DESCRIPTION
## Contexte

Les champs sont désormais validés dans leur état projeté. Certaines specs et un job de migration validaient encore des enregistrements bruts (`champ_data` / `Champ.find`) avec le contexte `:champ_value`.

## Changements

- Les specs obtiennent le champ à valider via l'API de projection du dossier (`project_champs_public` / `project_champs_private`, etc.) au lieu d'enregistrements bruts
- `BatchUpdatePaysValuesJob` vérifie directement les valeurs contre le référentiel pays au lieu de valider des enregistrements bruts
- `champ_for_update` assigne `type_de_champ` sur le champ retourné, comme le fait la projection

🤖 Generated with [Claude Code](https://claude.com/claude-code)