### PR TITLE
Tech: corrige un test flaky sur les proxy headers Typhoeus

### DIFF
--- a/lib/core_ext/ethon.rb
+++ b/lib/core_ext/ethon.rb
@@ -20,8 +20,18 @@ module Ethon
 
         @proxy_header_list = list && FFI::AutoPointer.new(list, Curl.method(:slist_free_all))
       end
+
+      # Ethon::Easy#reset clears the libcurl handle (curl_easy_reset) but not our
+      # ivars. Handles are pooled and reused (Typhoeus::Pool.release calls reset),
+      # so keep the mirror in sync, otherwise a recycled handle reports stale
+      # proxy_headers even though libcurl no longer sends them.
+      def reset
+        super
+        @proxy_headers = nil
+        @proxy_header_list = nil
+      end
     end
 
-    include ProxyHeaders
+    prepend ProxyHeaders
   end
 end


### PR DESCRIPTION
## Problème

Le test `spec/lib/core_ext/typhoeus_spec.rb:23` ("sets no proxy headers outside of a request or job context") échouait de façon intermittente en CI ([run](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/29234780732/job/86766826319)).

## Cause

Les handles `Ethon::Easy` sont recyclés via un pool global (`Typhoeus::Pool`). Au `release`, `easy.reset` appelle `curl_easy_reset`, qui réinitialise le handle libcurl **mais pas** les ivars `@proxy_headers`/`@proxy_header_list` ajoutés par notre monkey-patch (`lib/core_ext/ethon.rb`).

Un handle recyclé pouvait donc renvoyer via le reader `easy.proxy_headers` les headers d'une requête précédente, alors que libcurl ne les envoie plus. Le test, qui lit ce reader, échouait selon l'ordre d'exécution.

Aucun impact production : le code applicatif écrit `proxy_headers` mais ne le lit jamais. C'est une incohérence du miroir Ruby, qui ne se manifeste qu'au test.

## Correction

Surcharge de `reset` pour remettre les ivars à `nil` (via `prepend` pour passer devant `Ethon::Easy#reset`), gardant le miroir Ruby cohérent avec l'état libcurl après un reset.