### PR TITLE
ETQ usager, reformuler le message de fin de dépôt

### DIFF
--- a/app/views/users/dossiers/_merci.html.erb
+++ b/app/views/users/dossiers/_merci.html.erb
@@ -20,26 +20,7 @@
         </h1>
 
         <p class="fr-my-2w">
-          <%= t('views.users.dossiers.merci.dossier_acces_l1') %>
-
-          <strong>
-            <%= t('views.users.dossiers.merci.dossier_acces_l2') %>
-          </strong>
-        </p>
-
-        <p class="fr-my-2w">
-          <%= t('views.users.dossiers.merci.dossier_edit_l1') %>
-
-          <% if !dossier&.read_only? && !procedure.declarative_accepte? && !procedure.sva_svr_enabled? %>
-            <strong>
-              <%= t('views.users.dossiers.merci.dossier_edit_l2') %>
-            </strong>
-            <%= t('views.users.dossiers.merci.dossier_edit_l3') %>
-          <% end %>
-
-          <strong>
-            <%= t('views.users.dossiers.merci.dossier_edit_l4') %>
-          </strong>
+          <%= t('views.users.dossiers.merci.dossier_acces_html') %>
         </p>
 
         <% dsm = local_assigns[:dossier_submitted_message] || procedure.active_dossier_submitted_message %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -498,12 +498,7 @@ en:
         merci:
           thanks: Thank you!
           dossier_success: Your file has been submitted on the procedure “%{libelle}”.
-          dossier_acces_l1: You have now access to your
-          dossier_acces_l2: online file.
-          dossier_edit_l1: You can
-          dossier_edit_l2: edit it
-          dossier_edit_l3: and
-          dossier_edit_l4: talk with an instructor.
+          dossier_acces_html: You now have access to your <strong>online file</strong> to track its progress and, if needed, exchange with the administration through the messaging system.
           download_dossier: Download your file
           download_attestation: Download your attestation
           acces_dossier: Access your file

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -508,12 +508,7 @@ fr:
         merci:
           thanks: Merci !
           dossier_success: Votre dossier a bien été déposé sur la démarche “%{libelle}”.
-          dossier_acces_l1: Vous avez désormais accès à votre
-          dossier_acces_l2: dossier en ligne.
-          dossier_edit_l1: Vous pouvez
-          dossier_edit_l2: le modifier
-          dossier_edit_l3: et
-          dossier_edit_l4: échanger avec un instructeur.
+          dossier_acces_html: Vous avez désormais accès à votre <strong>dossier en ligne</strong> pour suivre son traitement et échanger si besoin avec l’administration par la messagerie.
           download_dossier: Télécharger mon dossier
           download_attestation: Télécharger mon attestation
           acces_dossier: Accéder au dossier


### PR DESCRIPTION
https://mattermost.incubateur.net/betagouv/pl/g57ucbritbd38gbygj1m87d65e

Sur la page de confirmation après dépôt d'un dossier, remplace les deux paragraphes fragmentés ( par une phrase unique, commune à tous les cas possible (déclarative, …) :

> Vous avez désormais accès à votre **dossier en ligne** pour suivre son traitement et échanger si besoin avec l'administration par la messagerie.
