### PR TITLE
Tech: déplace les constantes et helpers de stream dans des concerns dédiés

### DIFF
--- a/app/components/dossiers/champ_updated_component.rb
+++ b/app/components/dossiers/champ_updated_component.rb
@@ -30,7 +30,7 @@ class Dossiers::ChampUpdatedComponent < ApplicationComponent
   end
 
   def instructeur?
-    source_stream == Champ::INSTRUCTEUR_BUFFER_STREAM
+    source_stream == Dossier::INSTRUCTEUR_BUFFER_STREAM
   end
 
   def tooltip_id

--- a/app/components/dossiers/champs_rows_show_component.rb
+++ b/app/components/dossiers/champs_rows_show_component.rb
@@ -26,7 +26,7 @@ class Dossiers::ChampsRowsShowComponent < ApplicationComponent
   end
 
   def updated_by(champ)
-    if usager? && champ.source_stream == Champ::INSTRUCTEUR_BUFFER_STREAM && champ.procedure.hide_instructeurs_email?
+    if usager? && champ.instructeur_buffer_source_stream? && champ.procedure.hide_instructeurs_email?
       nil
     else
       champ.updated_by

--- a/app/components/editable_champ/editable_champ_component.rb
+++ b/app/components/editable_champ/editable_champ_component.rb
@@ -100,7 +100,7 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
   def turbo_poll_url_value
     if @champ.private?
       annotation_instructeur_dossier_path(@champ.dossier.procedure, @champ.dossier, @champ.stable_id, row_id: @champ.row_id)
-    elsif @champ.dossier.stream == Champ::INSTRUCTEUR_BUFFER_STREAM
+    elsif @champ.dossier.instructeur_buffer_stream?
       champ_instructeur_dossier_path(@champ.dossier.procedure, @champ.dossier, @champ.stable_id, row_id: @champ.row_id)
     else
       champ_dossier_path(@champ.dossier, @champ.stable_id, row_id: @champ.row_id)

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -73,7 +73,7 @@ class AttachmentsController < ApplicationController
   end
 
   def instructeur_changing_an_attachment?
-    (champ&.private? || champ&.stream == Champ::INSTRUCTEUR_BUFFER_STREAM) && current_user.instructeur? && current_instructeur.in?(champ.dossier.groupe_instructeur.instructeurs)
+    (champ&.private? || champ&.instructeur_buffer_stream?) && current_user.instructeur? && current_instructeur.in?(champ.dossier.groupe_instructeur.instructeurs)
   end
 
   def admin_changing_its_procedure?

--- a/app/jobs/migrations/backfill_stable_id_job.rb
+++ b/app/jobs/migrations/backfill_stable_id_job.rb
@@ -6,7 +6,7 @@ class Migrations::BackfillStableIdJob < ApplicationJob
   DEFAULT_LIMIT = 50_000
 
   def perform(iteration, limit = DEFAULT_LIMIT)
-    sql = "UPDATE champs SET stable_id = t.stable_id, stream = 'main'
+    sql = "UPDATE champs SET stable_id = t.stable_id, stream = '#{Dossier::MAIN_STREAM}'
       FROM types_de_champ t
         WHERE champs.type_de_champ_id = t.id
         AND champs.id IN (SELECT id FROM champs WHERE champs.stable_id IS NULL LIMIT ?);"

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -5,6 +5,7 @@ class Champ < ApplicationRecord
   include ChampValidateConcern
   include ChampRevisionConcern
   include ChampExternalDataConcern
+  include ChampStreamConcern
 
   self.ignored_columns += [:type_de_champ_id, :parent_id]
 
@@ -265,7 +266,7 @@ class Champ < ApplicationRecord
     deep_clone(only: champ_attributes + value_attributes, include: relationships, validate: true) do |original, kopy|
       if original.is_a?(Champ)
         kopy.write_attribute(:stable_id, original.stable_id)
-        kopy.write_attribute(:stream, 'main')
+        kopy.write_attribute(:stream, Dossier::MAIN_STREAM)
         # TODO: overwrite row_id "N" with nil
         kopy.write_attribute(:row_id, kopy.row_id)
       end
@@ -283,32 +284,6 @@ class Champ < ApplicationRecord
 
   def html_id
     type_de_champ.html_id(row_id)
-  end
-
-  MAIN_STREAM = 'main'
-  USER_BUFFER_STREAM = 'user:buffer'
-  INSTRUCTEUR_BUFFER_STREAM = 'instructeur:buffer'
-  USER_HISTORY_STREAM = 'user:history'
-  HISTORY_STREAM = 'history:'
-
-  def main_stream?
-    stream == MAIN_STREAM
-  end
-
-  def user_buffer_stream?
-    stream == USER_BUFFER_STREAM
-  end
-
-  def instructeur_buffer_stream?
-    stream == INSTRUCTEUR_BUFFER_STREAM
-  end
-
-  def history_stream?
-    stream.start_with?(HISTORY_STREAM)
-  end
-
-  def buffer_stream?
-    persisted? && (user_buffer_stream? || instructeur_buffer_stream?)
   end
 
   def clear

--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -100,7 +100,7 @@ class Champs::ReferentielChamp < Champ
   private
 
   def prefillable_types_de_champ
-    if stream == Champ::MAIN_STREAM
+    if main_stream?
       dossier.revision.types_de_champ
     else
       dossier.types_de_champ_public_all

--- a/app/models/concerns/champ_stream_concern.rb
+++ b/app/models/concerns/champ_stream_concern.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ChampStreamConcern
+  extend ActiveSupport::Concern
+
+  def main_stream?
+    stream == Dossier::MAIN_STREAM
+  end
+
+  def user_buffer_stream?
+    stream == Dossier::USER_BUFFER_STREAM
+  end
+
+  def instructeur_buffer_stream?
+    stream == Dossier::INSTRUCTEUR_BUFFER_STREAM
+  end
+
+  def history_stream?
+    stream.start_with?(Dossier::HISTORY_STREAM)
+  end
+
+  def buffer_stream?
+    persisted? && (user_buffer_stream? || instructeur_buffer_stream?)
+  end
+
+  def instructeur_buffer_source_stream?
+    source_stream == Dossier::INSTRUCTEUR_BUFFER_STREAM
+  end
+end

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -183,35 +183,35 @@ module DossierChampsConcern
   end
 
   def merge_user_buffer_stream!
-    buffer_ids, changed_ids = changed_champ_ids_for_merge(Champ::USER_BUFFER_STREAM)
+    buffer_ids, changed_ids = changed_champ_ids_for_merge(Dossier::USER_BUFFER_STREAM)
 
     return if buffer_ids.blank?
 
-    merge_buffer_champs(buffer_ids, changed_ids, Champ::USER_BUFFER_STREAM)
+    merge_buffer_champs(buffer_ids, changed_ids, Dossier::USER_BUFFER_STREAM)
   end
 
   def merge_instructeur_buffer_stream!
-    buffer_ids, changed_ids = changed_champ_ids_for_merge(Champ::INSTRUCTEUR_BUFFER_STREAM)
+    buffer_ids, changed_ids = changed_champ_ids_for_merge(Dossier::INSTRUCTEUR_BUFFER_STREAM)
 
     return if buffer_ids.blank?
 
-    merge_buffer_champs(buffer_ids, changed_ids, Champ::INSTRUCTEUR_BUFFER_STREAM)
+    merge_buffer_champs(buffer_ids, changed_ids, Dossier::INSTRUCTEUR_BUFFER_STREAM)
   end
 
   def reset_user_buffer_stream!
-    champ_data.where(stream: Champ::USER_BUFFER_STREAM).destroy_all
+    champ_data.where(stream: Dossier::USER_BUFFER_STREAM).destroy_all
 
     # update loaded champ instances
-    association(:champ_data).target = champ_data.filter { _1.stream != Champ::USER_BUFFER_STREAM }
+    association(:champ_data).target = champ_data.reject(&:user_buffer_stream?)
 
     reset_champs_cache
   end
 
   def reset_instructeur_buffer_stream!
-    champ_data.where(stream: Champ::INSTRUCTEUR_BUFFER_STREAM).destroy_all
+    champ_data.where(stream: Dossier::INSTRUCTEUR_BUFFER_STREAM).destroy_all
 
     # update loaded champ instances
-    association(:champ_data).target = champ_data.filter { _1.stream != Champ::INSTRUCTEUR_BUFFER_STREAM }
+    association(:champ_data).target = champ_data.reject(&:instructeur_buffer_stream?)
 
     reset_champs_cache
   end
@@ -222,49 +222,6 @@ module DossierChampsConcern
 
   def instructeur_buffer_changes?
     champs_on_instructeur_buffer_stream.present?
-  end
-
-  def can_update_as_user?(user)
-    return false unless en_construction?
-    user.owns_or_invite?(self)
-  end
-
-  def can_update_as_instructeur?(user)
-    return false unless en_construction?
-    return false unless procedure.instructeurs_can_edit_dossiers?
-    return false unless user.instructeur?
-    return false if can_update_as_user?(user)
-    groupe_instructeur.instructeurs.include?(user.instructeur)
-  end
-
-  def with_update_stream(user, &block)
-    if can_update_as_user?(user)
-      with_stream(Champ::USER_BUFFER_STREAM, &block)
-    elsif can_update_as_instructeur?(user)
-      with_stream(Champ::INSTRUCTEUR_BUFFER_STREAM, &block)
-    else
-      with_stream(Champ::MAIN_STREAM, &block)
-    end
-  end
-
-  def with_main_stream(&block)
-    with_stream(Champ::MAIN_STREAM, &block)
-  end
-
-  def with_instructeur_buffer_stream(&block)
-    with_stream(Champ::INSTRUCTEUR_BUFFER_STREAM, &block)
-  end
-
-  def with_user_history_stream(&block)
-    with_stream(Champ::USER_HISTORY_STREAM, &block)
-  end
-
-  def with_champ_stream(champ, &block)
-    with_stream(champ.stream, &block)
-  end
-
-  def stream
-    @stream || Champ::MAIN_STREAM
   end
 
   def history
@@ -308,7 +265,7 @@ module DossierChampsConcern
 
     return [[], []] if stream_h.empty?
 
-    main_h = champ_data.where(stream: Champ::MAIN_STREAM, stable_id: revision_stable_ids)
+    main_h = champ_data.where(stream: Dossier::MAIN_STREAM, stable_id: revision_stable_ids)
       .pluck(:stable_id, :row_id, :id)
       .to_h { |(stable_id, row_id, id)| [TypeDeChamp.public_id(stable_id, row_id), id] }
 
@@ -325,7 +282,7 @@ module DossierChampsConcern
       .pluck(:row_id)
 
     if discarded_row_ids.present?
-      changed_ids += champ_data.where(stream: Champ::MAIN_STREAM, row_id: discarded_row_ids).pluck(:id)
+      changed_ids += champ_data.where(stream: Dossier::MAIN_STREAM, row_id: discarded_row_ids).pluck(:id)
     end
 
     [stream_ids, changed_ids]
@@ -333,21 +290,21 @@ module DossierChampsConcern
 
   def merge_buffer_champs(buffer_ids, changed_ids, stream)
     now = Time.zone.now
-    history_stream = "#{Champ::HISTORY_STREAM}#{now}"
+    history_stream = "#{Dossier::HISTORY_STREAM}#{now}"
     buffer_champs = champ_data.filter { buffer_ids.member?(it.id) }
 
     transaction do
       # if merging user buffer, discard any instructeur made changes
-      if stream == Champ::USER_BUFFER_STREAM
+      if stream == Dossier::USER_BUFFER_STREAM
         champ_data.where(id: buffer_ids, stream:).pluck(:stable_id, :row_id).each do |(stable_id, row_id)|
-          champ_data.where(stream: Champ::INSTRUCTEUR_BUFFER_STREAM, stable_id:, row_id:).destroy_all
+          champ_data.where(stream: Dossier::INSTRUCTEUR_BUFFER_STREAM, stable_id:, row_id:).destroy_all
         end
       end
 
       # move champ_data with changes from "main" to "history" stream
-      champ_data.where(id: changed_ids, stream: Champ::MAIN_STREAM).update_all(stream: history_stream)
+      champ_data.where(id: changed_ids, stream: Dossier::MAIN_STREAM).update_all(stream: history_stream)
       # move champ_data from "buffer" to "main"
-      champ_data.where(id: buffer_ids, stream:).update_all(stream: Champ::MAIN_STREAM, updated_at: now, checkpoint: history_stream)
+      champ_data.where(id: buffer_ids, stream:).update_all(stream: Dossier::MAIN_STREAM, updated_at: now, checkpoint: history_stream)
       update_champs_timestamps(buffer_champs, stream)
     end
 
@@ -356,7 +313,7 @@ module DossierChampsConcern
       if champ.id.in?(changed_ids)
         champ.stream = history_stream
       elsif champ.id.in?(buffer_ids)
-        champ.stream = Champ::MAIN_STREAM
+        champ.stream = Dossier::MAIN_STREAM
         champ.checkpoint = history_stream
       end
     end
@@ -370,22 +327,6 @@ module DossierChampsConcern
     history_stream
   end
 
-  def with_stream(stream)
-    if block_given?
-      previous_stream = @stream
-      @stream = stream
-      reset_champs_cache
-      result = yield
-      @stream = previous_stream
-      reset_champs_cache
-      result
-    else
-      @stream = stream
-      reset_champs_cache
-      self
-    end
-  end
-
   def champs_by_public_id
     @champs_by_public_id ||= champs_on_stream.index_by(&:public_id)
   end
@@ -395,12 +336,11 @@ module DossierChampsConcern
   end
 
   def champs_on_stream
-    @champs_on_stream ||= case stream
-    when Champ::USER_BUFFER_STREAM
+    @champs_on_stream ||= if user_buffer_stream?
       (champs_on_user_buffer_stream + champs_on_main_stream).uniq(&:public_id)
-    when Champ::INSTRUCTEUR_BUFFER_STREAM
+    elsif instructeur_buffer_stream?
       (champs_on_instructeur_buffer_stream + champs_on_main_stream).uniq(&:public_id)
-    when Champ::USER_HISTORY_STREAM
+    elsif user_history_stream?
       champ_data
         # only "main" and "history"
         .reject(&:buffer_stream?)
@@ -480,8 +420,8 @@ module DossierChampsConcern
     if champ.class != type_de_champ.champ_class
       champ = champ.becomes!(type_de_champ.champ_class)
       champ.assign_attributes(value: nil, value_json: nil, external_id: nil, data: nil)
-    elsif stream != Champ::MAIN_STREAM && champ.previously_new_record?
-      main_stream_champ = champ_data.find_by(stable_id: type_de_champ.stable_id, row_id:, stream: Champ::MAIN_STREAM)
+    elsif !main_stream? && champ.previously_new_record?
+      main_stream_champ = champ_data.find_by(stable_id: type_de_champ.stable_id, row_id:, stream: Dossier::MAIN_STREAM)
       champ.clone_value_from(main_stream_champ) if main_stream_champ.present?
     end
 
@@ -505,10 +445,10 @@ module DossierChampsConcern
 
   def check_valid_stream_on_write?(type_de_champ)
     if type_de_champ.private?
-      if stream != Champ::MAIN_STREAM
+      if !main_stream?
         raise "Can not write a private champ to \"#{stream}\" stream"
       end
-    elsif stream == Champ::MAIN_STREAM && en_construction?
+    elsif main_stream? && en_construction?
       raise 'Can not write to "main" stream on a dossier "en construction"'
     end
   end

--- a/app/models/concerns/dossier_state_concern.rb
+++ b/app/models/concerns/dossier_state_concern.rb
@@ -391,14 +391,14 @@ module DossierStateConcern
   private
 
   def remove_not_in_revision_champs!
-    champ_data.where.not(stable_id: revision_stable_ids).where(stream: Champ::MAIN_STREAM).destroy_all
+    champ_data.where.not(stable_id: revision_stable_ids).where(stream: Dossier::MAIN_STREAM).destroy_all
   end
 
   def remove_discarded_rows!
     row_to_remove_ids = champ_data.filter { _1.row? && _1.discarded? }.map(&:row_id)
 
     return if row_to_remove_ids.empty?
-    champ_data.where(row_id: row_to_remove_ids, stream: Champ::MAIN_STREAM).destroy_all
+    champ_data.where(row_id: row_to_remove_ids, stream: Dossier::MAIN_STREAM).destroy_all
   end
 
   def remove_not_visible_or_empty_repetitions!
@@ -407,7 +407,7 @@ module DossierStateConcern
       .flat_map(&:row_ids)
 
     return if row_to_remove_ids.empty?
-    champ_data.where(row_id: row_to_remove_ids, stream: Champ::MAIN_STREAM).destroy_all
+    champ_data.where(row_id: row_to_remove_ids, stream: Dossier::MAIN_STREAM).destroy_all
   end
 
   def clear_not_visible_or_empty_champs!
@@ -415,7 +415,7 @@ module DossierStateConcern
       .reject(&:repetition?)
       .filter { _1.blank? || !_1.visible? }
 
-    champ_data.where(id: champs_to_clear, stream: Champ::MAIN_STREAM).find_each(&:clear)
+    champ_data.where(id: champs_to_clear, stream: Dossier::MAIN_STREAM).find_each(&:clear)
   end
 
   def clear_france_connect_champs_piece_justificatives!
@@ -462,7 +462,7 @@ module DossierStateConcern
 
     return if champ_to_remove_ids.empty?
 
-    champ_data.where(id: champ_to_remove_ids, stream: Champ::MAIN_STREAM).destroy_all
+    champ_data.where(id: champ_to_remove_ids, stream: Dossier::MAIN_STREAM).destroy_all
   end
 
   def enqueue_ami_notification(trigger: :dossier_state_change, state: nil)

--- a/app/models/concerns/dossier_stream_concern.rb
+++ b/app/models/concerns/dossier_stream_concern.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module DossierStreamConcern
+  extend ActiveSupport::Concern
+
+  MAIN_STREAM = 'main'
+  USER_BUFFER_STREAM = 'user:buffer'
+  INSTRUCTEUR_BUFFER_STREAM = 'instructeur:buffer'
+  USER_HISTORY_STREAM = 'user:history'
+  HISTORY_STREAM = 'history:'
+
+  def stream
+    @stream || MAIN_STREAM
+  end
+
+  def main_stream?
+    stream == MAIN_STREAM
+  end
+
+  def user_buffer_stream?
+    stream == USER_BUFFER_STREAM
+  end
+
+  def instructeur_buffer_stream?
+    stream == INSTRUCTEUR_BUFFER_STREAM
+  end
+
+  def user_history_stream?
+    stream == USER_HISTORY_STREAM
+  end
+
+  def with_update_stream(user, &block)
+    if can_update_as_user?(user)
+      with_stream(USER_BUFFER_STREAM, &block)
+    elsif can_update_as_instructeur?(user)
+      with_stream(INSTRUCTEUR_BUFFER_STREAM, &block)
+    else
+      with_stream(MAIN_STREAM, &block)
+    end
+  end
+
+  def with_main_stream(&block)
+    with_stream(MAIN_STREAM, &block)
+  end
+
+  def with_instructeur_buffer_stream(&block)
+    with_stream(INSTRUCTEUR_BUFFER_STREAM, &block)
+  end
+
+  def with_user_history_stream(&block)
+    with_stream(USER_HISTORY_STREAM, &block)
+  end
+
+  def with_champ_stream(champ, &block)
+    with_stream(champ.stream, &block)
+  end
+
+  def can_update_as_user?(user)
+    return false unless en_construction?
+    user.owns_or_invite?(self)
+  end
+
+  def can_update_as_instructeur?(user)
+    return false unless en_construction?
+    return false unless procedure.instructeurs_can_edit_dossiers?
+    return false unless user.instructeur?
+    return false if can_update_as_user?(user)
+    groupe_instructeur.instructeurs.include?(user.instructeur)
+  end
+
+  private
+
+  def with_stream(stream)
+    if block_given?
+      previous_stream = @stream
+      @stream = stream
+      reset_champs_cache
+      result = yield
+      @stream = previous_stream
+      reset_champs_cache
+      result
+    else
+      @stream = stream
+      reset_champs_cache
+      self
+    end
+  end
+end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -13,6 +13,7 @@ class Dossier < ApplicationRecord
   include DossierSearchableConcern
   include DossierSectionsConcern
   include DossierStateConcern
+  include DossierStreamConcern
   include DossierChampsConcern
   include DossierExportConcern
   include DossierValidateConcern
@@ -281,7 +282,7 @@ class Dossier < ApplicationRecord
   scope :hidden_by_administration_since, -> (since) { where('dossiers.hidden_by_administration_at IS NOT NULL AND dossiers.hidden_by_administration_at >= ?', since) }
   scope :hidden_since,                   -> (since) { hidden_by_user_since(since).or(hidden_by_administration_since(since)) }
 
-  scope :with_type_de_champ, -> (stable_id) { joins(:champ_data).where(champs: { stream: 'main', stable_id: }) }
+  scope :with_type_de_champ, -> (stable_id) { joins(:champ_data).where(champs: { stream: MAIN_STREAM, stable_id: }) }
   scope :without_type_de_champ, -> (stable_id) { where.not(id: with_type_de_champ(stable_id).select(:id)) }
 
   scope :with_unread_messages_for_user, -> {
@@ -1103,9 +1104,9 @@ class Dossier < ApplicationRecord
     return if changed_champs.empty?
     updated_at = Time.zone.now
     attributes = { updated_at: }
-    if stream == Champ::USER_BUFFER_STREAM
+    if stream == USER_BUFFER_STREAM
       attributes[:last_champ_updated_at] = updated_at
-    elsif stream == Champ::INSTRUCTEUR_BUFFER_STREAM
+    elsif stream == INSTRUCTEUR_BUFFER_STREAM
       attributes[:last_champ_instructeur_updated_at] = updated_at
     end
     update_columns(attributes)

--- a/app/models/geo_area.rb
+++ b/app/models/geo_area.rb
@@ -256,7 +256,7 @@ class GeoArea < ApplicationRecord
   end
 
   def set_default_uuid
-    if champ.stream == Champ::MAIN_STREAM
+    if champ.main_stream?
       self.uuid ||= SecureRandom.uuid
     end
   end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -317,7 +317,7 @@ class TypeDeChamp < ApplicationRecord
       private: private?,
       type: champ_class.name,
       stable_id:,
-      stream: Champ::MAIN_STREAM,
+      stream: Dossier::MAIN_STREAM,
     }
   end
 

--- a/app/services/dossier_projection_service.rb
+++ b/app/services/dossier_projection_service.rb
@@ -31,7 +31,7 @@ class DossierProjectionService
 
     champ_data_by_dossier_id = if champ_columns.any?
       stable_ids = champ_columns.map(&:stable_id)
-      Champ.where(dossier_id: dossiers_ids, stable_id: stable_ids, stream: 'main')
+      Champ.where(dossier_id: dossiers_ids, stable_id: stable_ids, stream: Dossier::MAIN_STREAM)
         .includes(:piece_justificative_file_attachments)
         .group_by(&:dossier_id)
     else

--- a/app/tasks/maintenance/t20260521_backfill_geo_area_uuid_task.rb
+++ b/app/tasks/maintenance/t20260521_backfill_geo_area_uuid_task.rb
@@ -12,7 +12,7 @@ module Maintenance
     # run_on_first_deploy
 
     def collection
-      GeoArea.joins(:champ).where(champs: { stream: Champ::MAIN_STREAM })
+      GeoArea.joins(:champ).where(champs: { stream: Dossier::MAIN_STREAM })
     end
 
     def process(geo_area)
@@ -21,7 +21,7 @@ module Maintenance
       champ = geo_area.champ
       GeoArea.joins(:champ)
         .where(geometry: geo_area.geometry, champs: { dossier_id: champ.dossier_id, stable_id: champ.stable_id, row_id: champ.row_id })
-        .where.not(champs: { stream: Champ::MAIN_STREAM })
+        .where.not(champs: { stream: Dossier::MAIN_STREAM })
         .update_all(uuid:)
     end
   end

--- a/app/views/shared/dossiers/_update_footer.turbo_stream.erb
+++ b/app/views/shared/dossiers/_update_footer.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.replace_all '.dossier-edit-footer' do %>
-  <% if dossier.stream == Champ::INSTRUCTEUR_BUFFER_STREAM %>
+  <% if dossier.instructeur_buffer_stream? %>
     <%= render Instructeurs::EditDossierFooterComponent.new(dossier:) %>
   <% else %>
     <%= render Dossiers::EditFooterComponent.new(dossier:, annotation: false) %>

--- a/spec/components/dossiers/champ_updated_component_spec.rb
+++ b/spec/components/dossiers/champ_updated_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Dossiers::ChampUpdatedComponent, type: :component do
   let(:updated_at) { Time.zone.local(2026, 5, 19, 10, 30) }
   let(:seen_at) { nil }
   let(:updated_by) { nil }
-  let(:source_stream) { Champ::MAIN_STREAM }
+  let(:source_stream) { Dossier::MAIN_STREAM }
 
   context 'when updated_at is nil' do
     let(:updated_at) { nil }
@@ -17,7 +17,7 @@ RSpec.describe Dossiers::ChampUpdatedComponent, type: :component do
   end
 
   context 'when updated on usager stream' do
-    let(:source_stream) { Champ::MAIN_STREAM }
+    let(:source_stream) { Dossier::MAIN_STREAM }
 
     it 'renders the usager source and no tooltip' do
       expect(subject).to have_content('usager')
@@ -35,7 +35,7 @@ RSpec.describe Dossiers::ChampUpdatedComponent, type: :component do
   end
 
   context 'when updated on instructeur buffer stream' do
-    let(:source_stream) { Champ::INSTRUCTEUR_BUFFER_STREAM }
+    let(:source_stream) { Dossier::INSTRUCTEUR_BUFFER_STREAM }
 
     it 'renders the instructeur source' do
       expect(subject).to have_content('instructeur')
@@ -68,7 +68,7 @@ RSpec.describe Dossiers::ChampUpdatedComponent, type: :component do
   end
 
   describe 'new badge styling' do
-    let(:source_stream) { Champ::MAIN_STREAM }
+    let(:source_stream) { Dossier::MAIN_STREAM }
 
     context 'when updated_at is after seen_at' do
       let(:seen_at) { updated_at - 1.hour }

--- a/spec/controllers/instructeurs/champs_controller_spec.rb
+++ b/spec/controllers/instructeurs/champs_controller_spec.rb
@@ -44,7 +44,7 @@ describe Instructeurs::ChampsController, type: :controller do
       is_expected.to redirect_to(instructeur_dossier_path(procedure, dossier))
       expect(flash[:notice]).to end_with("ont bien été modifiées.")
 
-      mains, others = Champ.where(stable_id: champ.stable_id, row_id: champ.row_id).partition { it.stream == 'main' }
+      mains, others = Champ.where(stable_id: champ.stable_id, row_id: champ.row_id).partition(&:main_stream?)
       expect((mains + others).count).to eq(2)
 
       main = mains.first
@@ -52,7 +52,7 @@ describe Instructeurs::ChampsController, type: :controller do
       expect(main.external_state).to eq('fetched')
 
       history_champ = others.first
-      expect(history_champ.stream).to start_with('history:')
+      expect(history_champ.stream).to start_with(Dossier::HISTORY_STREAM)
     end
 
     context 'when the public_id points to a public champ that is not a RIB' do
@@ -75,7 +75,7 @@ describe Instructeurs::ChampsController, type: :controller do
       it 'rejects the request and does not overwrite the address champ' do
         expect { cross_type_request }.to raise_error(ActiveRecord::RecordNotFound)
 
-        main_address = Champ.find_by!(dossier_id: dossier.id, stable_id: address_champ.stable_id, stream: Champ::MAIN_STREAM)
+        main_address = Champ.find_by!(dossier_id: dossier.id, stable_id: address_champ.stable_id, stream: Dossier::MAIN_STREAM)
         expect(main_address.value_json).not_to have_key('rib')
         expect(main_address.value_json).to include('label' => original_address['label'])
         expect(main_address.type).to eq('Champs::AddressChamp')

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1555,7 +1555,7 @@ describe Users::DossiersController, type: :controller do
         subject
         dossier.reload
         expect(dossier.user_buffer_changes?).to be_truthy
-        expect(first_champ_user_buffer.stream).to eq(Champ::USER_BUFFER_STREAM)
+        expect(first_champ_user_buffer.stream).to eq(Dossier::USER_BUFFER_STREAM)
         expect(first_champ_user_buffer.value).to eq('beautiful value')
         expect(first_champ_user_buffer.updated_at).to eq(now)
       end
@@ -1571,7 +1571,7 @@ describe Users::DossiersController, type: :controller do
           subject
           dossier.reload
           expect(dossier.user_buffer_changes?).to be_truthy
-          expect(piece_justificative_champ_user_buffer.stream).to eq(Champ::USER_BUFFER_STREAM)
+          expect(piece_justificative_champ_user_buffer.stream).to eq(Dossier::USER_BUFFER_STREAM)
           expect(piece_justificative_champ_user_buffer.piece_justificative_file).to be_attached
         end
       end
@@ -1792,7 +1792,7 @@ describe Users::DossiersController, type: :controller do
         dossier.reload
         annotation = dossier.project_champs_private.find { it.stable_id == 100 }
         expect(annotation.value).to eq(suggestion_data[:finess])
-        expect(annotation.stream).to eq(Champ::MAIN_STREAM)
+        expect(annotation.stream).to eq(Dossier::MAIN_STREAM)
       end
     end
 

--- a/spec/factories/champ.rb
+++ b/spec/factories/champ.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :champ_do_not_use, class: 'Champ' do
-    stream { 'main' }
+    stream { Dossier::MAIN_STREAM }
     add_attribute(:private) { false }
 
     factory :champ_do_not_use_text, class: 'Champs::TextChamp' do

--- a/spec/models/champ_blank_json_not_touched_spec.rb
+++ b/spec/models/champ_blank_json_not_touched_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'A blank champ must not be touched when another champ is correcte
   let(:user) { dossier.user }
 
   def second_champ
-    dossier.reload.champ_data.find { _1.stream == Champ::MAIN_STREAM && _1.stable_id == 100 }
+    dossier.reload.champ_data.find { _1.stream == Dossier::MAIN_STREAM && _1.stable_id == 100 }
   end
 
   # Reproduces the usager correction flow: edit only the text champ on the user

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -631,7 +631,7 @@ describe Champ do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
     let(:dossier) { create(:dossier, procedure:) }
     let(:source_champ) { dossier.champ_data.first }
-    let(:target_champ) { source_champ.dup.tap { it.stream = Champ::USER_BUFFER_STREAM } }
+    let(:target_champ) { source_champ.dup.tap { it.stream = Dossier::USER_BUFFER_STREAM } }
 
     before do
       source_champ.update_columns(external_state: 'fetched')

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -374,7 +374,7 @@ RSpec.describe DossierChampsConcern do
         it {
           expect(subject.persisted?).to be_truthy
           expect(subject.is_a?(Champs::CarteChamp)).to be_truthy
-          expect(subject.stream).to eq(Champ::MAIN_STREAM)
+          expect(subject.stream).to eq(Dossier::MAIN_STREAM)
           expect(subject.geo_areas.size).to eq(0)
         }
 
@@ -394,7 +394,7 @@ RSpec.describe DossierChampsConcern do
           it {
             expect(subject.persisted?).to be_truthy
             expect(subject.is_a?(Champs::CarteChamp)).to be_truthy
-            expect(subject.stream).to eq(Champ::USER_BUFFER_STREAM)
+            expect(subject.stream).to eq(Dossier::USER_BUFFER_STREAM)
             expect(subject.geo_areas.size).to eq(2)
             expect(subject.geo_areas.size).to eq(main_champ.geo_areas.size)
             expect(subject.geo_areas.first.id).not_to eq(main_champ.geo_areas.first.id)
@@ -671,18 +671,18 @@ RSpec.describe DossierChampsConcern do
 
         expect(dossier.user_buffer_changes?).to be_truthy
 
-        expect(main_champ_99.stream).to eq(Champ::MAIN_STREAM)
-        expect(main_champ_991.stream).to eq(Champ::MAIN_STREAM)
-        expect(main_champ_994.stream).to eq(Champ::MAIN_STREAM)
+        expect(main_champ_99.stream).to eq(Dossier::MAIN_STREAM)
+        expect(main_champ_991.stream).to eq(Dossier::MAIN_STREAM)
+        expect(main_champ_994.stream).to eq(Dossier::MAIN_STREAM)
         expect(main_champ_99.source_stream).to be_nil
 
         expect(main_champ_99.value).to be_nil
         expect(main_champ_991.value).to be_nil
         expect(main_champ_994.value).to be_nil
 
-        expect(draft_champ_99.stream).to eq(Champ::USER_BUFFER_STREAM)
-        expect(draft_champ_991.stream).to eq(Champ::USER_BUFFER_STREAM)
-        expect(draft_champ_994.stream).to eq(Champ::USER_BUFFER_STREAM)
+        expect(draft_champ_99.stream).to eq(Dossier::USER_BUFFER_STREAM)
+        expect(draft_champ_991.stream).to eq(Dossier::USER_BUFFER_STREAM)
+        expect(draft_champ_994.stream).to eq(Dossier::USER_BUFFER_STREAM)
 
         expect(draft_champ_99.value).to eq("Hello")
         expect(draft_champ_991.value).to eq("World")
@@ -727,9 +727,9 @@ RSpec.describe DossierChampsConcern do
           subject
           dossier.save!
 
-          expect(draft_champ_99.stream).to eq(Champ::USER_BUFFER_STREAM)
-          expect(draft_champ_991.stream).to eq(Champ::USER_BUFFER_STREAM)
-          expect(draft_champ_994.stream).to eq(Champ::USER_BUFFER_STREAM)
+          expect(draft_champ_99.stream).to eq(Dossier::USER_BUFFER_STREAM)
+          expect(draft_champ_991.stream).to eq(Dossier::USER_BUFFER_STREAM)
+          expect(draft_champ_994.stream).to eq(Dossier::USER_BUFFER_STREAM)
 
           expect(draft_champ_99.value).to eq("Hello")
           expect(draft_champ_991.value).to eq("World")
@@ -926,17 +926,17 @@ RSpec.describe DossierChampsConcern do
 
         expect(dossier.instructeur_buffer_changes?).to be_truthy
 
-        expect(main_champ_99.stream).to eq(Champ::MAIN_STREAM)
-        expect(main_champ_991.stream).to eq(Champ::MAIN_STREAM)
-        expect(main_champ_994.stream).to eq(Champ::MAIN_STREAM)
+        expect(main_champ_99.stream).to eq(Dossier::MAIN_STREAM)
+        expect(main_champ_991.stream).to eq(Dossier::MAIN_STREAM)
+        expect(main_champ_994.stream).to eq(Dossier::MAIN_STREAM)
 
         expect(main_champ_99.value).to eq('Bonjour')
         expect(main_champ_991.value).to eq('Au revoir')
         expect(main_champ_994.value).to be_nil
 
-        expect(draft_champ_99.stream).to eq(Champ::INSTRUCTEUR_BUFFER_STREAM)
-        expect(draft_champ_991.stream).to eq(Champ::INSTRUCTEUR_BUFFER_STREAM)
-        expect(draft_champ_994.stream).to eq(Champ::INSTRUCTEUR_BUFFER_STREAM)
+        expect(draft_champ_99.stream).to eq(Dossier::INSTRUCTEUR_BUFFER_STREAM)
+        expect(draft_champ_991.stream).to eq(Dossier::INSTRUCTEUR_BUFFER_STREAM)
+        expect(draft_champ_994.stream).to eq(Dossier::INSTRUCTEUR_BUFFER_STREAM)
 
         expect(draft_champ_99.value).to eq("Hello")
         expect(draft_champ_991.value).to eq("World")
@@ -1017,9 +1017,9 @@ RSpec.describe DossierChampsConcern do
         expect(user_history_champ_991.value).to eq("World")
         expect(user_history_champ_994.value).to eq("Greer")
 
-        expect(user_history_champ_99.source_stream).to eq(Champ::USER_BUFFER_STREAM)
-        expect(user_history_champ_991.source_stream).to eq(Champ::INSTRUCTEUR_BUFFER_STREAM)
-        expect(user_history_champ_994.source_stream).to eq(Champ::INSTRUCTEUR_BUFFER_STREAM)
+        expect(user_history_champ_99.source_stream).to eq(Dossier::USER_BUFFER_STREAM)
+        expect(user_history_champ_991.source_stream).to eq(Dossier::INSTRUCTEUR_BUFFER_STREAM)
+        expect(user_history_champ_994.source_stream).to eq(Dossier::INSTRUCTEUR_BUFFER_STREAM)
       }
     end
   end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -2977,7 +2977,7 @@ describe Dossier, type: :model do
     let(:dossier) { create(:dossier, procedure:, brouillon_close_to_expiration_notice_sent_at: 10.days.ago) }
     let(:changed_champs) { dossier.champ_data.filter(&:text?) }
 
-    subject { -> { dossier.update_champs_timestamps(changed_champs, Champ::USER_BUFFER_STREAM) } }
+    subject { -> { dossier.update_champs_timestamps(changed_champs, Dossier::USER_BUFFER_STREAM) } }
 
     it do
       is_expected.to change(dossier, :last_champ_updated_at)

--- a/spec/system/instructeurs/edit_dossier_spec.rb
+++ b/spec/system/instructeurs/edit_dossier_spec.rb
@@ -8,7 +8,7 @@ describe 'Editing a dossier as an instructeur:', js: true do
 
   def buffered_value(dossier, stable_id)
     dossier.reload.champ_data
-      .find { _1.stream == Champ::INSTRUCTEUR_BUFFER_STREAM && _1.stable_id == stable_id }
+      .find { _1.stream == Dossier::INSTRUCTEUR_BUFFER_STREAM && _1.stable_id == stable_id }
       &.value
   end
 
@@ -16,7 +16,7 @@ describe 'Editing a dossier as an instructeur:', js: true do
   # the buffered champ as the new main one, so we must look it up by stream.
   def main_value(dossier, stable_id)
     dossier.reload.champ_data
-      .find { _1.stream == Champ::MAIN_STREAM && _1.stable_id == stable_id }
+      .find { _1.stream == Dossier::MAIN_STREAM && _1.stable_id == stable_id }
       &.value
   end
 
@@ -124,7 +124,7 @@ describe 'Editing a dossier as an instructeur:', js: true do
 
     def buffered_pj(stable_id)
       dossier.reload.champ_data
-        .find { _1.stream == Champ::INSTRUCTEUR_BUFFER_STREAM && _1.stable_id == stable_id }
+        .find { _1.stream == Dossier::INSTRUCTEUR_BUFFER_STREAM && _1.stable_id == stable_id }
         &.piece_justificative_file
     end
 

--- a/spec/tasks/maintenance/t20260521_backfill_geo_area_uuid_task_spec.rb
+++ b/spec/tasks/maintenance/t20260521_backfill_geo_area_uuid_task_spec.rb
@@ -32,7 +32,7 @@ module Maintenance
       context 'when a matching geo_area exists in another stream' do
         let(:buffer_champ) do
           champ = main_champ.dup
-          champ.stream = Champ::USER_BUFFER_STREAM
+          champ.stream = Dossier::USER_BUFFER_STREAM
           champ.save!(validate: false)
           champ
         end
@@ -47,7 +47,7 @@ module Maintenance
       context 'when a geo_area in another stream has a different geometry' do
         let(:buffer_champ) do
           champ = main_champ.dup
-          champ.stream = Champ::USER_BUFFER_STREAM
+          champ.stream = Dossier::USER_BUFFER_STREAM
           champ.save!(validate: false)
           champ
         end


### PR DESCRIPTION
## Résumé

- Ajoute `DossierStreamConcern` (constantes de stream, contexte `with_*_stream` et prédicats sur `Dossier`) et `ChampStreamConcern` (prédicats sur `Champ`)
- Les constantes vivent désormais sur `Dossier` (`Dossier::MAIN_STREAM` au lieu de `Champ::MAIN_STREAM`)
- Les comparaisons `dossier.stream == Champ::*_STREAM` / `champ.stream == ...` utilisent les helpers (`instructeur_buffer_stream?`, `main_stream?`, etc.), avec un nouveau `instructeur_buffer_source_stream?` pour `source_stream`
- Remplace les noms de stream codés en dur (`'main'`, `'history:'`) par les constantes

Refactoring pur, aucun changement de comportement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)