### PR TITLE
ETQ usager, mon compte est conservé si je me suis connecté récemment

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -196,6 +196,15 @@ class User < ApplicationRecord
     last_sign_in_at.present?
   end
 
+  # Devise Trackable calls this on every active authentication (password,
+  # FranceConnect, ProConnect, remember-me, session re-auth), never on a plain
+  # per-request session fetch. Clearing the pending-deletion notice here ensures
+  # a returning user is never deleted without a fresh notice.
+  def update_tracked_fields(request)
+    super
+    self.inactive_close_to_expiration_notice_sent_at = nil
+  end
+
   def administrateur?
     administrateur.present?
   end

--- a/app/services/expired.rb
+++ b/app/services/expired.rb
@@ -3,7 +3,7 @@
 module Expired
   # User is considered inactive after two years of idleness regarding
   #   when he does not have a dossier en instruction
-  #   or when his users.last_signed_in_at is smaller than two years ago
+  #   or when his users.current_sign_in_at is smaller than two years ago
   INACTIVE_USER_RETATION_IN_YEAR = 2
 
   # Dossier are automatically destroyed after a period (it's configured per Procedure)

--- a/app/services/expired/users_deletion_service.rb
+++ b/app/services/expired/users_deletion_service.rb
@@ -59,7 +59,7 @@ class Expired::UsersDeletionService < Expired::MailRateLimiter
   def expired_users
     User.unscoped
       .where.missing(:expert, :instructeur, :administrateur)
-      .where(last_sign_in_at: ..Expired::INACTIVE_USER_RETATION_IN_YEAR.years.ago)
+      .where(current_sign_in_at: ..Expired::INACTIVE_USER_RETATION_IN_YEAR.years.ago)
   end
   # rubocop:enable DS/Unscoped
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -322,6 +322,16 @@ describe User, type: :model do
     end
   end
 
+  describe '#update_tracked_fields' do
+    it 'resets inactive_close_to_expiration_notice_sent_at on sign in' do
+      user = create(:user, inactive_close_to_expiration_notice_sent_at: 1.week.ago)
+
+      user.update_tracked_fields!(instance_double(ActionDispatch::Request, remote_ip: '127.0.0.1'))
+
+      expect(user.reload.inactive_close_to_expiration_notice_sent_at).to be_nil
+    end
+  end
+
   describe '#crisp_segments' do
     it 'returns user roles or usager by default' do
       user = create(:user)

--- a/spec/services/expired/expired_users_deletion_service_spec.rb
+++ b/spec/services/expired/expired_users_deletion_service_spec.rb
@@ -21,7 +21,7 @@ describe Expired::UsersDeletionService do
       let(:dossier) { create(:dossier, user:, created_at: last_signed_in_expired) }
 
       context 'when user was not notified' do
-        let(:user) { create(:user, last_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: before_close_to_expiration) }
+        let(:user) { create(:user, current_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: before_close_to_expiration) }
 
         it 'update user.inactive_close_to_expiration_notice_sent_at ' do
           expect(UserMailer).to receive(:notify_inactive_close_to_deletion).with(user).and_return(mail_double)
@@ -32,7 +32,7 @@ describe Expired::UsersDeletionService do
       end
 
       context 'user has been notified 1 week ago' do
-        let(:user) { create(:user, last_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: notified_close_to_expiration) }
+        let(:user) { create(:user, current_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: notified_close_to_expiration) }
 
         it 'do nothing' do
           expect { subject }.not_to change { Dossier.count }
@@ -41,7 +41,7 @@ describe Expired::UsersDeletionService do
       end
 
       context 'user has been notified 3 weeks ago' do
-        let(:user) { create(:user, last_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: due_close_to_expiration) }
+        let(:user) { create(:user, current_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: due_close_to_expiration) }
 
         it 'destroys user and dossier' do
           expect { subject }.to change { Dossier.count }.by(-1)
@@ -86,7 +86,7 @@ describe Expired::UsersDeletionService do
       let(:dossier) { nil }
 
       context 'when user was not notified' do
-        let(:user) { create(:user, last_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: before_close_to_expiration) }
+        let(:user) { create(:user, current_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: before_close_to_expiration) }
 
         it 'update user.inactive_close_to_expiration_notice_sent_at ' do
           expect(UserMailer).to receive(:notify_inactive_close_to_deletion).with(user).and_return(mail_double)
@@ -97,7 +97,7 @@ describe Expired::UsersDeletionService do
       end
 
       context 'when user has been notified 1 week ago' do
-        let(:user) { create(:user, last_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: notified_close_to_expiration) }
+        let(:user) { create(:user, current_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: notified_close_to_expiration) }
 
         it 'do nothing' do
           expect { subject }.not_to change { Dossier.count }
@@ -106,7 +106,7 @@ describe Expired::UsersDeletionService do
       end
 
       context 'when user has been notified 3 weeks ago' do
-        let(:user) { create(:user, last_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: due_close_to_expiration) }
+        let(:user) { create(:user, current_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: due_close_to_expiration) }
 
         it 'destroys user and dossier' do
           subject
@@ -121,44 +121,49 @@ describe Expired::UsersDeletionService do
     subject { Expired::UsersDeletionService.new.send(:expired_users_without_dossiers) }
 
     context 'when user last_sign_in_at is 1 year ago and has no dossier' do
-      let(:user) { create(:user, last_sign_in_at: last_signed_in_not_expired) }
+      let(:user) { create(:user, current_sign_in_at: last_signed_in_not_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user last_sign_in_at is 3 year ago and has no dossier' do
-      let(:user) { create(:user, last_sign_in_at: last_signed_in_expired) }
+      let(:user) { create(:user, current_sign_in_at: last_signed_in_expired) }
       it { is_expected.to include(user) }
     end
 
+    context 'when user signed in once recently but last_sign_in_at is still old (regression #13260)' do
+      let(:user) { create(:user, last_sign_in_at: last_signed_in_expired, current_sign_in_at: last_signed_in_not_expired) }
+      it { is_expected.not_to include(user) }
+    end
+
     context 'when user is expired and has an expert' do
-      let(:user) { create(:user, expert: create(:expert), last_sign_in_at: last_signed_in_expired) }
+      let(:user) { create(:user, expert: create(:expert), current_sign_in_at: last_signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired and has an instructeur' do
-      let(:user) { create(:user, instructeur: create(:instructeur), last_sign_in_at: last_signed_in_expired) }
+      let(:user) { create(:user, instructeur: create(:instructeur), current_sign_in_at: last_signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired and has an admin' do
-      let(:user) { create(:user, administrateur: administrateurs(:default_admin), last_sign_in_at: last_signed_in_expired) }
+      let(:user) { create(:user, administrateur: administrateurs(:default_admin), current_sign_in_at: last_signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired but have a dossier' do
-      let(:user) { users(:default_user_admin).tap { _1.update(last_sign_in_at: last_signed_in_expired) } }
+      let(:user) { users(:default_user_admin).tap { _1.update(current_sign_in_at: last_signed_in_expired) } }
       let(:dossier) { create(:dossier, :brouillon, user:, created_at: last_signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
   end
 
   describe '#expired_users_with_dossiers' do
-    let(:user) { create(:user, last_sign_in_at: last_signed_in_expired) }
+    let(:user) { create(:user, current_sign_in_at: last_signed_in_expired) }
     let(:dossier) { create(:dossier, :brouillon, user:, created_at: last_signed_in_expired) }
     subject { Expired::UsersDeletionService.new.send(:expired_users_with_dossiers) }
 
     context 'when user is not expired' do
-      let(:user) { create(:user, last_sign_in_at: last_signed_in_not_expired) }
+      let(:user) { create(:user, current_sign_in_at: last_signed_in_not_expired) }
       it { is_expected.not_to include(user) }
     end
 
@@ -200,19 +205,19 @@ describe Expired::UsersDeletionService do
 
     context 'when user is expired and has an expert' do
       let(:dossier) { create(:dossier, user:, created_at: last_signed_in_expired) }
-      let(:user) { create(:user, expert: create(:expert), last_sign_in_at: last_signed_in_expired) }
+      let(:user) { create(:user, expert: create(:expert), current_sign_in_at: last_signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired and has an instructeur' do
       let(:dossier) { create(:dossier, user:, created_at: last_signed_in_expired) }
-      let(:user) { create(:user, instructeur: create(:instructeur), last_sign_in_at: last_signed_in_expired) }
+      let(:user) { create(:user, instructeur: create(:instructeur), current_sign_in_at: last_signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired and has an admin' do
       let(:dossier) { create(:dossier, user:, created_at: last_signed_in_expired) }
-      let(:user) { users(:default_user_admin).tap { _1.update(last_sign_in_at: last_signed_in_expired) } }
+      let(:user) { users(:default_user_admin).tap { _1.update(current_sign_in_at: last_signed_in_expired) } }
       it { is_expected.not_to include(user) }
     end
   end

--- a/spec/services/expired/expired_users_deletion_service_spec.rb
+++ b/spec/services/expired/expired_users_deletion_service_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 describe Expired::UsersDeletionService do
-  let(:last_signed_in_not_expired) { (Expired::INACTIVE_USER_RETATION_IN_YEAR - 1).years.ago }
-  let(:last_signed_in_expired) { (Expired::INACTIVE_USER_RETATION_IN_YEAR + 1).years.ago }
+  let(:signed_in_not_expired) { (Expired::INACTIVE_USER_RETATION_IN_YEAR - 1).years.ago }
+  let(:signed_in_expired) { (Expired::INACTIVE_USER_RETATION_IN_YEAR + 1).years.ago }
   let(:before_close_to_expiration) { nil }
   let(:notified_close_to_expiration) { (Expired::REMAINING_WEEKS_BEFORE_EXPIRATION - 1).weeks.ago }
   let(:due_close_to_expiration) { (Expired::REMAINING_WEEKS_BEFORE_EXPIRATION + 1).weeks.ago }
@@ -18,10 +18,10 @@ describe Expired::UsersDeletionService do
     subject { Expired::UsersDeletionService.new.process_expired }
 
     context 'when user is expirable and have a dossier' do
-      let(:dossier) { create(:dossier, user:, created_at: last_signed_in_expired) }
+      let(:dossier) { create(:dossier, user:, created_at: signed_in_expired) }
 
       context 'when user was not notified' do
-        let(:user) { create(:user, current_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: before_close_to_expiration) }
+        let(:user) { create(:user, current_sign_in_at: signed_in_expired, inactive_close_to_expiration_notice_sent_at: before_close_to_expiration) }
 
         it 'update user.inactive_close_to_expiration_notice_sent_at ' do
           expect(UserMailer).to receive(:notify_inactive_close_to_deletion).with(user).and_return(mail_double)
@@ -32,7 +32,7 @@ describe Expired::UsersDeletionService do
       end
 
       context 'user has been notified 1 week ago' do
-        let(:user) { create(:user, current_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: notified_close_to_expiration) }
+        let(:user) { create(:user, current_sign_in_at: signed_in_expired, inactive_close_to_expiration_notice_sent_at: notified_close_to_expiration) }
 
         it 'do nothing' do
           expect { subject }.not_to change { Dossier.count }
@@ -41,7 +41,7 @@ describe Expired::UsersDeletionService do
       end
 
       context 'user has been notified 3 weeks ago' do
-        let(:user) { create(:user, current_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: due_close_to_expiration) }
+        let(:user) { create(:user, current_sign_in_at: signed_in_expired, inactive_close_to_expiration_notice_sent_at: due_close_to_expiration) }
 
         it 'destroys user and dossier' do
           expect { subject }.to change { Dossier.count }.by(-1)
@@ -49,7 +49,7 @@ describe Expired::UsersDeletionService do
         end
 
         context 'when dossier brouillon' do
-          let(:dossier) { create(:dossier, :brouillon, user:, created_at: last_signed_in_expired) }
+          let(:dossier) { create(:dossier, :brouillon, user:, created_at: signed_in_expired) }
           it 'destroys user and dossier' do
             expect { subject }.to change { Dossier.count }.by(-1)
             expect { user.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -57,7 +57,7 @@ describe Expired::UsersDeletionService do
         end
 
         context 'when dossier en_construction' do
-          let(:dossier) { create(:dossier, :en_construction, user:, created_at: last_signed_in_expired) }
+          let(:dossier) { create(:dossier, :en_construction, user:, created_at: signed_in_expired) }
           it 'destroys user and dossier' do
             expect { subject }.to change { Dossier.count }.by(-1)
             expect { user.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -65,7 +65,7 @@ describe Expired::UsersDeletionService do
         end
 
         context 'when dossier en_instruction' do
-          let(:dossier) { create(:dossier, :en_instruction, user:, created_at: last_signed_in_expired) }
+          let(:dossier) { create(:dossier, :en_instruction, user:, created_at: signed_in_expired) }
           it 'does not do anything' do
             expect { subject }.not_to change { Dossier.count }
             expect { user.reload }.not_to raise_error
@@ -73,7 +73,7 @@ describe Expired::UsersDeletionService do
         end
 
         context 'when dossier termine' do
-          let(:dossier) { create(:dossier, :accepte, user:, created_at: last_signed_in_expired) }
+          let(:dossier) { create(:dossier, :accepte, user:, created_at: signed_in_expired) }
           it 'marks dossier as hidden by user due to user_removal and remove user' do
             expect { subject }.to change { dossier.reload.hidden_by_user_at }.from(nil).to(anything)
             expect { user.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -86,7 +86,7 @@ describe Expired::UsersDeletionService do
       let(:dossier) { nil }
 
       context 'when user was not notified' do
-        let(:user) { create(:user, current_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: before_close_to_expiration) }
+        let(:user) { create(:user, current_sign_in_at: signed_in_expired, inactive_close_to_expiration_notice_sent_at: before_close_to_expiration) }
 
         it 'update user.inactive_close_to_expiration_notice_sent_at ' do
           expect(UserMailer).to receive(:notify_inactive_close_to_deletion).with(user).and_return(mail_double)
@@ -97,7 +97,7 @@ describe Expired::UsersDeletionService do
       end
 
       context 'when user has been notified 1 week ago' do
-        let(:user) { create(:user, current_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: notified_close_to_expiration) }
+        let(:user) { create(:user, current_sign_in_at: signed_in_expired, inactive_close_to_expiration_notice_sent_at: notified_close_to_expiration) }
 
         it 'do nothing' do
           expect { subject }.not_to change { Dossier.count }
@@ -106,7 +106,7 @@ describe Expired::UsersDeletionService do
       end
 
       context 'when user has been notified 3 weeks ago' do
-        let(:user) { create(:user, current_sign_in_at: last_signed_in_expired, inactive_close_to_expiration_notice_sent_at: due_close_to_expiration) }
+        let(:user) { create(:user, current_sign_in_at: signed_in_expired, inactive_close_to_expiration_notice_sent_at: due_close_to_expiration) }
 
         it 'destroys user and dossier' do
           subject
@@ -120,104 +120,104 @@ describe Expired::UsersDeletionService do
     let(:dossier) { nil }
     subject { Expired::UsersDeletionService.new.send(:expired_users_without_dossiers) }
 
-    context 'when user last_sign_in_at is 1 year ago and has no dossier' do
-      let(:user) { create(:user, current_sign_in_at: last_signed_in_not_expired) }
+    context 'when user current_sign_in_at is 1 year ago and has no dossier' do
+      let(:user) { create(:user, current_sign_in_at: signed_in_not_expired) }
       it { is_expected.not_to include(user) }
     end
 
-    context 'when user last_sign_in_at is 3 year ago and has no dossier' do
-      let(:user) { create(:user, current_sign_in_at: last_signed_in_expired) }
+    context 'when user current_sign_in_at is 3 year ago and has no dossier' do
+      let(:user) { create(:user, current_sign_in_at: signed_in_expired) }
       it { is_expected.to include(user) }
     end
 
     context 'when user signed in once recently but last_sign_in_at is still old (regression #13260)' do
-      let(:user) { create(:user, last_sign_in_at: last_signed_in_expired, current_sign_in_at: last_signed_in_not_expired) }
+      let(:user) { create(:user, last_sign_in_at: signed_in_expired, current_sign_in_at: signed_in_not_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired and has an expert' do
-      let(:user) { create(:user, expert: create(:expert), current_sign_in_at: last_signed_in_expired) }
+      let(:user) { create(:user, expert: create(:expert), current_sign_in_at: signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired and has an instructeur' do
-      let(:user) { create(:user, instructeur: create(:instructeur), current_sign_in_at: last_signed_in_expired) }
+      let(:user) { create(:user, instructeur: create(:instructeur), current_sign_in_at: signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired and has an admin' do
-      let(:user) { create(:user, administrateur: administrateurs(:default_admin), current_sign_in_at: last_signed_in_expired) }
+      let(:user) { create(:user, administrateur: administrateurs(:default_admin), current_sign_in_at: signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired but have a dossier' do
-      let(:user) { users(:default_user_admin).tap { _1.update(current_sign_in_at: last_signed_in_expired) } }
-      let(:dossier) { create(:dossier, :brouillon, user:, created_at: last_signed_in_expired) }
+      let(:user) { users(:default_user_admin).tap { _1.update(current_sign_in_at: signed_in_expired) } }
+      let(:dossier) { create(:dossier, :brouillon, user:, created_at: signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
   end
 
   describe '#expired_users_with_dossiers' do
-    let(:user) { create(:user, current_sign_in_at: last_signed_in_expired) }
-    let(:dossier) { create(:dossier, :brouillon, user:, created_at: last_signed_in_expired) }
+    let(:user) { create(:user, current_sign_in_at: signed_in_expired) }
+    let(:dossier) { create(:dossier, :brouillon, user:, created_at: signed_in_expired) }
     subject { Expired::UsersDeletionService.new.send(:expired_users_with_dossiers) }
 
     context 'when user is not expired' do
-      let(:user) { create(:user, current_sign_in_at: last_signed_in_not_expired) }
+      let(:user) { create(:user, current_sign_in_at: signed_in_not_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired and has a dossier brouillon' do
-      let(:dossier) { create(:dossier, :brouillon, user:, created_at: last_signed_in_expired) }
+      let(:dossier) { create(:dossier, :brouillon, user:, created_at: signed_in_expired) }
       it { is_expected.to include(user) }
     end
 
     context 'when user is expired and has a many dossier brouillon' do
       before do
-        create(:dossier, :brouillon, user:, created_at: last_signed_in_expired)
-        create(:dossier, :brouillon, user:, created_at: last_signed_in_expired)
+        create(:dossier, :brouillon, user:, created_at: signed_in_expired)
+        create(:dossier, :brouillon, user:, created_at: signed_in_expired)
       end
       it { is_expected.to eq([user]) }
     end
 
     context 'when user is expired and has a dossier en_construction' do
-      let(:dossier) { create(:dossier, :en_construction, user:, created_at: last_signed_in_expired) }
+      let(:dossier) { create(:dossier, :en_construction, user:, created_at: signed_in_expired) }
       it { is_expected.to include(user) }
     end
 
     context 'when user is expired and has a dossier en_instruction' do
-      let(:dossier) { create(:dossier, :en_instruction, user:, created_at: last_signed_in_expired) }
+      let(:dossier) { create(:dossier, :en_instruction, user:, created_at: signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired and has a dossier en_instruction plus another one brouillon' do
       before do
-        create(:dossier, :en_instruction, user:, created_at: last_signed_in_expired)
-        create(:dossier, :brouillon, user:, created_at: last_signed_in_expired)
+        create(:dossier, :en_instruction, user:, created_at: signed_in_expired)
+        create(:dossier, :brouillon, user:, created_at: signed_in_expired)
       end
       it { is_expected.to eq([]) }
     end
 
     context 'when user is expired and has a dossier termine' do
-      let(:dossier) { create(:dossier, :accepte, user:, created_at: last_signed_in_expired) }
+      let(:dossier) { create(:dossier, :accepte, user:, created_at: signed_in_expired) }
       it { is_expected.to include(user) }
     end
 
     context 'when user is expired and has an expert' do
-      let(:dossier) { create(:dossier, user:, created_at: last_signed_in_expired) }
-      let(:user) { create(:user, expert: create(:expert), current_sign_in_at: last_signed_in_expired) }
+      let(:dossier) { create(:dossier, user:, created_at: signed_in_expired) }
+      let(:user) { create(:user, expert: create(:expert), current_sign_in_at: signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired and has an instructeur' do
-      let(:dossier) { create(:dossier, user:, created_at: last_signed_in_expired) }
-      let(:user) { create(:user, instructeur: create(:instructeur), current_sign_in_at: last_signed_in_expired) }
+      let(:dossier) { create(:dossier, user:, created_at: signed_in_expired) }
+      let(:user) { create(:user, instructeur: create(:instructeur), current_sign_in_at: signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired and has an admin' do
-      let(:dossier) { create(:dossier, user:, created_at: last_signed_in_expired) }
-      let(:user) { users(:default_user_admin).tap { _1.update(current_sign_in_at: last_signed_in_expired) } }
+      let(:dossier) { create(:dossier, user:, created_at: signed_in_expired) }
+      let(:user) { users(:default_user_admin).tap { _1.update(current_sign_in_at: signed_in_expired) } }
       it { is_expected.not_to include(user) }
     end
   end


### PR DESCRIPTION
Corrige #13260 : `Cron::ExpiredUsersDeletionJob` notifiait puis supprimait à tort des comptes récemment actifs (~10% des suppressions).

**Cause** : la recherche des comptes inactifs se basait sur `users.last_sign_in_at`, qui — sémantique Devise Trackable — contient l'**avant-dernière** connexion, pas la dernière. Un usager qui se reconnecte une seule fois après une longue absence conserve un `last_sign_in_at` ancien et passait pour inactif depuis plus de 2 ans.

**Correctifs**
- La recherche se base désormais sur `current_sign_in_at` (la connexion la plus récente, toujours ≥ `last_sign_in_at`).
- `inactive_close_to_expiration_notice_sent_at` est remis à zéro à chaque ré-authentification (`User#update_tracked_fields`, couvre mot de passe / FranceConnect / ProConnect / « se souvenir de moi ») : un usager qui revient ne peut plus être supprimé sans nouveau rappel de 2 semaines.

Closes #13260
