### PR TITLE
Tech: supprime Champ::NULL_ROW_ID et le code de migration associé

### DIFF
--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -141,13 +141,6 @@ class Champ < ApplicationRecord
     row_id.present? && is_type?(TypeDeChamp.type_champs.fetch(:repetition))
   end
 
-  NULL_ROW_ID = 'N'
-
-  def row_id
-    row_id_or_null = super
-    row_id_or_null == Champ::NULL_ROW_ID ? nil : row_id_or_null
-  end
-
   # used for the `required` html attribute
   # check visibility to avoid hidden required input
   # which prevent the form from being sent.
@@ -267,8 +260,6 @@ class Champ < ApplicationRecord
       if original.is_a?(Champ)
         kopy.write_attribute(:stable_id, original.stable_id)
         kopy.write_attribute(:stream, Dossier::MAIN_STREAM)
-        # TODO: overwrite row_id "N" with nil
-        kopy.write_attribute(:row_id, kopy.row_id)
       end
       ClonePiecesJustificativesService.clone_attachments(original, kopy) if !private?
     end

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -402,9 +402,6 @@ module DossierChampsConcern
     check_valid_stream_on_write?(type_de_champ)
     check_valid_row_id_on_write?(type_de_champ, row_id)
 
-    # FIXME: This is a temporary on-demand migration. It will be removed once the full migration is over.
-    Champ.where(dossier_id: id, row_id: Champ::NULL_ROW_ID).update_all(row_id: nil)
-
     # FIXME: Try to find the champ in memory before querying the database
     champ = champ_data.find { _1.stream == stream && _1.public_id == type_de_champ.public_id(row_id) }
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -875,7 +875,7 @@ class TypeDeChamp < ApplicationRecord
 
   class << self
     def public_id(stable_id, row_id)
-      if row_id.blank? || row_id == Champ::NULL_ROW_ID
+      if row_id.blank?
         stable_id.to_s
       else
         "#{stable_id}-#{row_id}"

--- a/app/tasks/maintenance/t20250526_nullify_row_id_task.rb
+++ b/app/tasks/maintenance/t20250526_nullify_row_id_task.rb
@@ -17,7 +17,7 @@ module Maintenance
 
     def process(dossier)
       with_nil_row_id, with_null_row_id = dossier.champ_data
-        .where(row_id: [nil, Champ::NULL_ROW_ID])
+        .where(row_id: [nil, 'N'])
         .pluck(:row_id, :stream, :stable_id, :id, :updated_at)
         .partition { _1.first == nil }
         .map { _1.index_by { |(_, stream, stable_id)| [stream, stable_id] } }

--- a/app/tasks/maintenance/t20250605fix_conflictual_row_id_during_mep_task.rb
+++ b/app/tasks/maintenance/t20250605fix_conflictual_row_id_during_mep_task.rb
@@ -17,17 +17,17 @@ module Maintenance
     end
 
     def process(dossier)
-      duplicated_champ_ids = dossier.champ_data.where(row_id: [Champ::NULL_ROW_ID, nil])
+      duplicated_champ_ids = dossier.champ_data.where(row_id: ['N', nil])
         .order(updated_at: :desc)
         .select(:id, :stream, :stable_id, :row_id)
-        .group_by { "#{_1.stream}-#{_1.public_id}" }
+        .group_by { "#{_1.stream}-#{_1.stable_id}" }
         .values
         .flat_map { _1[1..].map(&:id) }
       Dossier.transaction do
         if duplicated_champ_ids.present?
           Dossier.no_touching { dossier.champ_data.where(id: duplicated_champ_ids).destroy_all }
         end
-        dossier.champ_data.where(row_id: Champ::NULL_ROW_ID).update_all(row_id: nil)
+        dossier.champ_data.where(row_id: 'N').update_all(row_id: nil)
       end
     end
   end

--- a/spec/tasks/maintenance/t20250526_nullify_row_id_task_spec.rb
+++ b/spec/tasks/maintenance/t20250526_nullify_row_id_task_spec.rb
@@ -8,10 +8,10 @@ module Maintenance
       subject(:process) { described_class.process(dossier) }
       let(:procedure) { create(:procedure, types_de_champ_public: [{}, { type: :repetition, children: [{ type: :text }] }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champs_with_null_row_id) { dossier.champ_data.where(row_id: [nil, Champ::NULL_ROW_ID]) }
+      let(:champs_with_null_row_id) { dossier.champ_data.where(row_id: [nil, 'N']) }
 
       before do
-        dossier.champ_data.where(row_id: nil).update_all(row_id: Champ::NULL_ROW_ID)
+        dossier.champ_data.where(row_id: nil).update_all(row_id: 'N')
       end
 
       def null_row_id_counts
@@ -26,7 +26,7 @@ module Maintenance
 
       context 'deal with conflicts' do
         before do
-          attributes = dossier.champ_data.where(row_id: Champ::NULL_ROW_ID).first.attributes
+          attributes = dossier.champ_data.where(row_id: 'N').first.attributes
           dossier.champ_data.create(attributes.merge(row_id: nil, id: nil))
         end
         it 'nullify row_id' do

--- a/spec/tasks/maintenance/t20250605fix_conflictual_row_id_during_mep_task_spec.rb
+++ b/spec/tasks/maintenance/t20250605fix_conflictual_row_id_during_mep_task_spec.rb
@@ -11,14 +11,14 @@ module Maintenance
       let(:type_de_champ) { dossier.revision.types_de_champ_public.first }
 
       before {
-        dossier.champ_data.create(**type_de_champ.params_for_champ.merge(row_id: Champ::NULL_ROW_ID))
+        dossier.champ_data.create(**type_de_champ.params_for_champ.merge(row_id: 'N'))
       }
 
       it { expect { subject }.not_to change { dossier.reload.updated_at } }
       it { expect { subject }.not_to change { dossier.champ_data.order(id: :desc).first.id } }
       it { expect { subject }.to change { dossier.champ_data.order(:id).first.id } }
       it { expect { subject }.to change { dossier.champ_data.count }.by(-1) }
-      it { expect { subject }.to change { dossier.champ_data.where(row_id: Champ::NULL_ROW_ID).count }.from(1).to(0) }
+      it { expect { subject }.to change { dossier.champ_data.where(row_id: 'N').count }.from(1).to(0) }
     end
   end
 end


### PR DESCRIPTION
## Résumé

La base de production ne contient plus de valeurs `row_id = 'N'`. Cette PR supprime donc :

- la constante `Champ::NULL_ROW_ID` et la surcharge de `Champ#row_id` qui normalisait `'N'` en `nil` ;
- le cas particulier dans `TypeDeChamp.public_id` ;
- la migration à la volée dans `champ_upsert_by!` (`DossierChampsConcern`) ;
- la ligne de normalisation dans `Champ#clone` (le `row_id` est déjà copié par `deep_clone`).

Les deux tâches de maintenance ponctuelles (T20250526, T20250605) sont conservées et restent exécutables : le littéral `'N'` y est inliné, et le regroupement des doublons dans T20250605 utilise désormais `stream`/`stable_id` (équivalent, puisque tous les champs sélectionnés ont un `row_id` dans `['N', nil]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)