### PR TITLE
Tech: seeds partagées dev/test avec Oaken

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,10 +241,12 @@ Controllers are organized by user role:
 
 ## Testing Philosophy
 
-
 - Use TDD as much as possible.
 - Prefer system specs for user-facing features
-- Use factories (FactoryBot) in `spec/factories/`
+- **Prefer Oaken seeds over factories.** The whole world in `db/seeds/` (users, procedures, dossiers) is seeded once per suite via `oaken/rspec_setup`; labeled accessors (`users.usager`, `administrateurs.default`, `procedures.individual`, `dossiers.en_construction`, …) are available in every example, and per-example mutations roll back. Reach for a seeded record first; only fall back to a factory when the spec needs attributes the seeds don't provide.
+- Scenario seeds in `db/seeds/cases/` (avis, champs, entreprise, messagerie, sva, …) load per group with `before_all { seed "cases/avis" }` — add a new case file when several specs need the same non-trivial setup.
+- **When touching a spec that builds generic records with factories, migrate it to seeds if a seeded record (or a new case seed) fits** — it makes the suite faster and the setup shared. Keep FactoryBot (`spec/factories/`) for records whose attributes are the point of the test.
+- Seed-safety: never assert global counts or unparameterized scopes (`Procedure.all`, raw SQL over a table) — scope queries to the spec's records, or declare `empty_seeds Model` at the top of the group (see `spec/support/oaken.rb`). Specs about an admin's own aggregate state should use the seeded `administrateurs.blank`.
 - Use `let_it_be` (test-prof) for shared setup where possible
 - Support files in `spec/support/`
 - RSpec helper: `rails_helper.rb` (includes Rails), `spec_helper.rb` (no Rails)
@@ -272,4 +274,4 @@ Controllers are organized by user role:
 User support is handled via **Crisp** integration.
 
 
-Last updated: July 6, 2026.
+Last updated: July 20, 2026.

--- a/Gemfile
+++ b/Gemfile
@@ -171,6 +171,7 @@ group :development, :test do
   gem 'graphql-schema_comparator'
   gem 'irb'
   gem 'mina', require: false # Deploy
+  gem 'oaken' # Seed data shared between development and test
   gem 'rspec-rails'
   gem 'simple_xlsx_reader'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -550,6 +550,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-musl)
       racc (~> 1.4)
+    oaken (1.0.0)
     oauth2 (2.0.19)
       auth-sanitizer (~> 0.1)
       faraday (>= 0.17.3, < 4.0)
@@ -1096,6 +1097,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
+  oaken
   oauth2
   omniauth
   omniauth-rails_csrf_protection

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,12 +10,13 @@
 # - db/seeds/development/    — development-only records (super-admin, fixer instructeur)
 # - db/seeds/cases/          — scenario-specific data (expert avis, messagerie, …)
 #
-# In specs, tag an example group with :oaken to load these seeds and access the
-# labeled records (users.usager, procedures.individual, dossiers.en_construction, …).
-# Scenario seeds are loaded per spec with e.g. `before { seed "cases/avis" }`.
+# In specs, these seeds load once per suite (see spec/support/oaken.rb) and the
+# labeled records (users.usager, procedures.individual, dossiers.en_construction, …)
+# are available in every example.
+# Scenario seeds are loaded per spec group with e.g. `before_all { seed "cases/avis" }`.
 #
-# Seeds assume an empty database and are not re-runnable: specs load them in
-# rolled-back transactions, and a development database is refreshed with
+# Seeds assume an empty database and are not re-runnable: specs replant once
+# per suite, and a development database is refreshed with
 # `bin/rails db:seed:replant` (truncate + reseed).
 Oaken.seed :users, :procedures, :dossiers
 Oaken.seed :cases if Rails.env.development?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,28 +1,21 @@
 # frozen_string_literal: true
 
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-
+# Seed data is managed with Oaken (https://github.com/kaspth/oaken) and shared
+# between development and test:
 #
-# Create an initial user who can use all roles
+# - db/seeds/setup.rb        — helpers and defaults (loaded automatically)
+# - db/seeds/users.rb        — usager / administrateur / instructeur personas
+# - db/seeds/procedures.rb   — a published demo procedure with common types de champ
+# - db/seeds/dossiers.rb     — dossiers in various states on the individual procedure
+# - db/seeds/development/    — development-only records (super-admin, fixer instructeur)
+# - db/seeds/cases/          — scenario-specific data (expert avis, messagerie, …)
 #
-
-default_user = "test@exemple.fr"
-default_password = "this is a very complicated password !"
-
-puts "Create test user '#{default_user}'"
-SuperAdmin.create!(email: default_user, password: default_password)
-user = User.create!(
-  email: default_user,
-  password: default_password,
-  confirmed_at: Time.zone.now,
-  email_verified_at: Time.zone.now
-)
-user.create_instructeur!
-user.create_administrateur!
-
-user_fixer = User.create(email: ENV.fetch('DEFAULT_INSTRUCTEUR_EMAIL') { CONTACT_EMAIL },
-  password: Random.srand,
-  confirmed_at: Time.zone.now,
-  email_verified_at: Time.zone.now)
-user_fixer.create_instructeur!
+# In specs, tag an example group with :oaken to load these seeds and access the
+# labeled records (users.usager, procedures.individual, dossiers.en_construction, …).
+# Scenario seeds are loaded per spec with e.g. `before { seed "cases/avis" }`.
+#
+# Seeds assume an empty database and are not re-runnable: specs load them in
+# rolled-back transactions, and a development database is refreshed with
+# `bin/rails db:seed:replant` (truncate + reseed).
+Oaken.seed :users, :procedures, :dossiers
+Oaken.seed :cases if Rails.env.development?

--- a/db/seeds/cases/avis.rb
+++ b/db/seeds/cases/avis.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# An expert invited on the individual procedure, with a pending avis requested by the
+# default instructeur on the en_instruction dossier. Load in a spec with
+# `seed "cases/avis"`.
+
+expert_user = users.create :expert, email: "expert@exemple.fr"
+expert_user.create_expert!
+experts.label default: expert_user.expert
+
+experts_procedure = experts_procedures.create(expert: experts.default, procedure: procedures.individual)
+experts_procedures.label default: experts_procedure
+
+pending_avis = avis.create(
+  dossier: dossiers.en_instruction,
+  claimant: instructeurs.default,
+  experts_procedure:,
+  confidentiel: false,
+  introduction: "Bonjour, merci de me donner votre avis sur ce dossier."
+)
+avis.label pending: pending_avis

--- a/db/seeds/cases/avis.rb
+++ b/db/seeds/cases/avis.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # An expert invited on the individual procedure, with a pending avis requested by the
-# default instructeur on the en_instruction dossier. Load in a spec with
-# `seed "cases/avis"`.
+# default instructeur on the en_instruction dossier and an answered avis on the
+# accepte dossier. Load in a spec with `seed "cases/avis"`.
 
 expert_user = users.create :expert, email: "expert@exemple.fr"
 expert_user.create_expert!
@@ -19,3 +19,13 @@ pending_avis = avis.create(
   introduction: "Bonjour, merci de me donner votre avis sur ce dossier."
 )
 avis.label pending: pending_avis
+
+answered_avis = avis.create(
+  dossier: dossiers.accepte,
+  claimant: instructeurs.default,
+  experts_procedure:,
+  confidentiel: false,
+  introduction: "Bonjour, merci de me donner votre avis sur ce dossier.",
+  answer: "La demande semble pertinente et le demandeur remplit les conditions."
+)
+avis.label answered: answered_avis

--- a/db/seeds/cases/champs.rb
+++ b/db/seeds/cases/champs.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# A draft procedure carrying one champ of every type (public) and one
+# annotation of every type (private), mirroring the factory traits
+# :with_all_champs / :with_all_annotations (same libelles: the type name,
+# except drop_down_list which is labeled simple_drop_down_list). The
+# repetition has two children, and a brouillon dossier is seeded with its
+# default champs. Load in a spec with `seed "cases/champs"`.
+
+ActiveRecord::Base.transaction do
+  procedure = Procedure.new(
+    libelle: "Démarche avec tous les types de champ",
+    description: "Une démarche de démonstration avec un champ de chaque type.",
+    cadre_juridique: "https://www.legifrance.gouv.fr/",
+    duree_conservation_dossiers_dans_ds: 3,
+    max_duree_conservation_dossiers_dans_ds: Procedure::OLD_MAX_DUREE_CONSERVATION,
+    for_individual: true,
+    administrateurs: [administrateurs.default]
+  )
+  procedure.draft_revision = procedure.revisions.build
+  procedure.save!
+  instructeurs.default.assign_to_procedure(procedure)
+
+  # .beta.gouv.fr domains must be explicitly allowed via
+  # ALLOWED_API_DOMAINS_FROM_FRONTEND; plain .gouv.fr domains always are.
+  referentiel_domain = ENV.fetch("ALLOWED_API_DOMAINS_FROM_FRONTEND", "").split(",").grep(/rnb-api.beta.gouv/).first || "https://rnb-api.data.gouv.fr"
+  referentiel = Referentiels::APIReferentiel.create!(
+    mode: "exact_match",
+    url_tiptap: {
+      "type" => "doc",
+      "content" => [
+        {
+          "type" => "paragraph",
+          "content" => [
+            { "type" => "text", "text" => "#{referentiel_domain}/api/alpha/buildings/" },
+            { "type" => "mention", "attrs" => { "id" => "{query}", "label" => "Valeur saisie par l'usager" } },
+          ],
+        },
+      ],
+    },
+    test_data_tiptap: { "{query}" => "PG46YY6YWCX8" }
+  )
+
+  extra_params_by_type = {
+    "drop_down_list" => { libelle: "simple_drop_down_list", drop_down_options: ["val1", "val2", "val3"] },
+    "multiple_drop_down_list" => { drop_down_options: ["val1", "val2", "val3"] },
+    "linked_drop_down_list" => { drop_down_options: ["--primary--", "secondary"] },
+    "referentiel" => { referentiel:, mandatory: true },
+  }
+
+  # Build all coordinates in memory and save the revision once: one champ of
+  # every type per list, faster than one add_type_de_champ call per champ.
+  revision = procedure.draft_revision
+
+  build_type_de_champ = lambda do |params, private_champ, position|
+    type_de_champ = TypeDeChamp.new(private: private_champ, libelle: params[:type_champ], **params)
+    revision.revision_types_de_champ.build(type_de_champ:, position:)
+
+    if type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:piece_justificative) && type_de_champ.nature.blank?
+      type_de_champ.piece_justificative_template.attach(
+        io: StringIO.new("toto"),
+        filename: "toto.txt",
+        content_type: "text/plain",
+        metadata: { virus_scan_result: ActiveStorage::VirusScanner::SAFE }
+      )
+    end
+  end
+
+  [false, true].each do |private_champ|
+    TypeDeChamp.type_champs.each_value.with_index do |type_champ, position|
+      build_type_de_champ.call({ type_champ:, **extra_params_by_type.fetch(type_champ, {}) }, private_champ, position)
+    end
+  end
+
+  # titre_identite is a piece_justificative nature, not a type_champ
+  build_type_de_champ.call(
+    { type_champ: "piece_justificative", nature: "titre_identite", libelle: "titre_identité" },
+    false,
+    TypeDeChamp.type_champs.size
+  )
+
+  revision.save!
+
+  repetition_coordinate = revision.revision_types_de_champ.find { it.type_de_champ.repetition? && !it.type_de_champ.private? }
+  [
+    { type_champ: "text", libelle: "sub type de champ" },
+    { type_champ: "integer_number", libelle: "sub type de champ2" },
+  ].each_with_index do |params, position|
+    revision.revision_types_de_champ.create!(type_de_champ: TypeDeChamp.create!(params), parent: repetition_coordinate, position:)
+  end
+
+  procedures.label tous_champs: procedure
+
+  dossier = Dossier.create!(
+    user: users.usager,
+    revision: procedure.active_revision,
+    groupe_instructeur: procedure.defaut_groupe_instructeur,
+    individual: Individual.new(gender: "Mme", nom: "Dupont", prenom: "Jeanne", birthdate: Date.new(1985, 3, 12)),
+    autorisation_donnees: true
+  )
+  dossier.build_default_values
+  dossiers.label tous_champs: dossier
+end

--- a/db/seeds/cases/entreprise.rb
+++ b/db/seeds/cases/entreprise.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# A published procedure for entreprises (for_individual: false) with an
+# en_construction dossier carrying a fully populated etablissement.
+# Load in a spec with `seed "cases/entreprise"`.
+
+procedure = Procedure.new(
+  libelle: "Démarche de démonstration (entreprises)",
+  description: "Une démarche de démonstration réservée aux entreprises.",
+  cadre_juridique: "https://www.legifrance.gouv.fr/",
+  lien_site_web: "https://www.exemple.fr",
+  duree_conservation_dossiers_dans_ds: 3,
+  max_duree_conservation_dossiers_dans_ds: Procedure::OLD_MAX_DUREE_CONSERVATION,
+  for_individual: false,
+  administrateurs: [administrateurs.default]
+)
+procedure.draft_revision = procedure.revisions.build
+procedure.save!
+
+[
+  { type_champ: "text", libelle: "Nom du projet", mandatory: true },
+  { type_champ: "textarea", libelle: "Description du projet" },
+].reduce(nil) do |previous, params|
+  type_de_champ = procedure.draft_revision.add_type_de_champ(**params, after_stable_id: previous&.stable_id)
+  raise type_de_champ.errors.full_messages.to_sentence if type_de_champ.errors.any?
+  type_de_champ
+end
+
+procedure.publish_or_reopen!(administrateurs.default, "demarche-demo-entreprise")
+instructeurs.default.assign_to_procedure(procedure)
+
+procedures.label entreprise: procedure
+
+dossier = Dossier.create!(
+  user: users.usager,
+  revision: procedure.active_revision,
+  groupe_instructeur: procedure.defaut_groupe_instructeur,
+  autorisation_donnees: true,
+  etablissement: Etablissement.new(
+    siret: "44011762001530",
+    siege_social: true,
+    naf: "4950Z",
+    libelle_naf: "Transports par conduites",
+    adresse: "GRTGAZ\r IMMEUBLE BORA\r 6 RUE RAOUL NORDLING\r 92270 BOIS COLOMBES\r",
+    numero_voie: "6",
+    type_voie: "RUE",
+    nom_voie: "RAOUL NORDLING",
+    complement_adresse: "IMMEUBLE BORA",
+    code_postal: "92270",
+    localite: "BOIS COLOMBES",
+    code_insee_localite: "92009",
+    entreprise_siren: "440117620",
+    entreprise_capital_social: 537_100_000,
+    entreprise_numero_tva_intracommunautaire: "FR27440117620",
+    entreprise_forme_juridique: "SA à conseil d’administration (s.a.i.)",
+    entreprise_forme_juridique_code: "5599",
+    entreprise_nom_commercial: "GRTGAZ",
+    entreprise_raison_sociale: "GRTGAZ",
+    entreprise_siret_siege_social: "44011762001530",
+    entreprise_code_effectif_entreprise: "51",
+    entreprise_date_creation: Date.new(1990, 4, 24),
+    entreprise_etat_administratif: :actif,
+    entreprise_effectif_mensuel: 100.5,
+    entreprise_effectif_mois: "03",
+    entreprise_effectif_annee: "2020",
+    diffusable_commercialement: true
+  )
+)
+dossier.build_default_values
+dossier.state = Dossier.states.fetch(:en_construction)
+processed_at = DossierWithReferenceDate.assign(dossier, reference_date: 1.day.ago)
+dossier.traitements.passer_en_construction(processed_at:)
+dossier.submitted_revision_id = dossier.revision_id
+dossier.save!
+
+dossiers.label avec_siret: dossier

--- a/db/seeds/cases/messagerie.rb
+++ b/db/seeds/cases/messagerie.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# A message sent by the default instructeur on the en_construction dossier.
+# Load in a spec with `seed "cases/messagerie"`.
+
+message = commentaires.create(
+  dossier: dossiers.en_construction,
+  instructeur: instructeurs.default,
+  email: users.instructeur.email,
+  body: "Bonjour, pouvez-vous préciser la date de début de votre projet ?"
+)
+commentaires.label from_instructeur: message

--- a/db/seeds/cases/sva.rb
+++ b/db/seeds/cases/sva.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Published procedures configured for SVA / SVR decisions (silence vaut
+# accord / rejet). Load in a spec with `seed "cases/sva"`.
+
+["sva", "svr"].each do |decision|
+  procedure = Procedure.new(
+    libelle: "Démarche de démonstration (#{decision.upcase})",
+    description: "Une démarche de démonstration en décision automatique #{decision.upcase}.",
+    cadre_juridique: "https://www.legifrance.gouv.fr/",
+    lien_site_web: "https://www.exemple.fr",
+    duree_conservation_dossiers_dans_ds: 3,
+    max_duree_conservation_dossiers_dans_ds: Procedure::OLD_MAX_DUREE_CONSERVATION,
+    for_individual: true,
+    administrateurs: [administrateurs.default],
+    sva_svr: SVASVRConfiguration.new(decision:).attributes
+  )
+  procedure.draft_revision = procedure.revisions.build
+  procedure.save!
+
+  type_de_champ = procedure.draft_revision.add_type_de_champ(type_champ: "text", libelle: "Nom du projet", mandatory: true)
+  raise type_de_champ.errors.full_messages.to_sentence if type_de_champ.errors.any?
+
+  procedure.publish_or_reopen!(administrateurs.default, "demarche-demo-#{decision}")
+  instructeurs.default.assign_to_procedure(procedure)
+
+  procedures.label(decision.to_sym => procedure)
+end

--- a/db/seeds/development/users.rb
+++ b/db/seeds/development/users.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Super-admin account for the manager interface, sharing the admin user's credentials.
+SuperAdmin.create!(email: users.admin.email, password: users.default_password)
+
+# Default instructeur automatically assigned by the platform (see DEFAULT_INSTRUCTEUR_EMAIL).
+fixer = users.create email: ENV.fetch('DEFAULT_INSTRUCTEUR_EMAIL') { CONTACT_EMAIL },
+  password: SecureRandom.base58(24)
+fixer.create_instructeur!

--- a/db/seeds/dossiers.rb
+++ b/db/seeds/dossiers.rb
@@ -7,7 +7,7 @@ labels = %w[brouillon en_construction en_instruction accepte refuse].to_h do |st
     user: users.usager,
     revision: procedure.active_revision,
     groupe_instructeur: procedure.defaut_groupe_instructeur,
-    individual: Individual.new,
+    individual: Individual.new(gender: "Mme", nom: "Dupont", prenom: "Jeanne", birthdate: Date.new(1985, 3, 12)),
     autorisation_donnees: true
   )
   dossier.build_default_values

--- a/db/seeds/dossiers.rb
+++ b/db/seeds/dossiers.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+procedure = procedures.individual
+
+labels = %w[brouillon en_construction en_instruction accepte refuse].to_h do |state|
+  dossier = Dossier.create!(
+    user: users.usager,
+    revision: procedure.active_revision,
+    groupe_instructeur: procedure.defaut_groupe_instructeur,
+    individual: Individual.new,
+    autorisation_donnees: true
+  )
+  dossier.build_default_values
+
+  if state != Dossier.states.fetch(:brouillon)
+    dossier.state = state
+    processed_at = DossierWithReferenceDate.assign(dossier)
+
+    case state
+    when Dossier.states.fetch(:en_construction)
+      dossier.traitements.passer_en_construction(processed_at:)
+    when Dossier.states.fetch(:en_instruction)
+      dossier.traitements.passer_en_instruction(processed_at:)
+    when Dossier.states.fetch(:accepte)
+      dossier.traitements.accepter(motivation: "Dossier complet.", processed_at:)
+    when Dossier.states.fetch(:refuse)
+      dossier.traitements.refuser(motivation: "Dossier incomplet.", processed_at:)
+    end
+
+    dossier.submitted_revision_id = dossier.revision_id
+    dossier.save!
+  end
+
+  [state.to_sym, dossier]
+end
+
+dossiers.label(**labels)

--- a/db/seeds/dossiers.rb
+++ b/db/seeds/dossiers.rb
@@ -14,7 +14,9 @@ labels = %w[brouillon en_construction en_instruction accepte refuse].to_h do |st
 
   if state != Dossier.states.fetch(:brouillon)
     dossier.state = state
-    processed_at = DossierWithReferenceDate.assign(dossier)
+    # Deposited dossiers are backdated so that specs freezing time to earlier
+    # today still see the seeded traitements in the past.
+    processed_at = DossierWithReferenceDate.assign(dossier, reference_date: 1.day.ago)
 
     case state
     when Dossier.states.fetch(:en_construction)

--- a/db/seeds/procedures.rb
+++ b/db/seeds/procedures.rb
@@ -29,6 +29,19 @@ end
 procedure.publish_or_reopen!(administrateurs.default, "demarche-demo")
 instructeurs.default.assign_to_procedure(procedure)
 
+# A published procedure without a service is nagged about on every admin page.
+procedure.update!(service: Service.create!(
+  nom: "Service de démonstration",
+  administrateur: administrateurs.default,
+  organisme: "Organisme de démonstration",
+  type_organisme: Service.type_organismes.fetch(:administration_centrale),
+  email: "contact@exemple.fr",
+  telephone: "0102030405",
+  horaires: "Du lundi au vendredi, de 9 h à 18 h",
+  adresse: "20 avenue de Ségur, 75007 Paris",
+  siret: "13002526500013"
+))
+
 procedures.label individual: procedure
 
 brouillon_procedure = Procedure.new(

--- a/db/seeds/procedures.rb
+++ b/db/seeds/procedures.rb
@@ -30,3 +30,16 @@ procedure.publish_or_reopen!(administrateurs.default, "demarche-demo")
 instructeurs.default.assign_to_procedure(procedure)
 
 procedures.label individual: procedure
+
+brouillon_procedure = Procedure.new(
+  libelle: "Démarche de démonstration (brouillon)",
+  description: "Une démarche de démonstration encore en brouillon.",
+  cadre_juridique: "https://www.legifrance.gouv.fr/",
+  duree_conservation_dossiers_dans_ds: 3,
+  max_duree_conservation_dossiers_dans_ds: Procedure::OLD_MAX_DUREE_CONSERVATION,
+  administrateurs: [administrateurs.default]
+)
+brouillon_procedure.draft_revision = brouillon_procedure.revisions.build
+brouillon_procedure.save!
+
+procedures.label brouillon: brouillon_procedure

--- a/db/seeds/procedures.rb
+++ b/db/seeds/procedures.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+procedure = Procedure.new(
+  libelle: "Démarche de démonstration",
+  description: "Une démarche de démonstration avec les types de champ les plus courants.",
+  cadre_juridique: "https://www.legifrance.gouv.fr/",
+  lien_site_web: "https://www.exemple.fr",
+  duree_conservation_dossiers_dans_ds: 3,
+  max_duree_conservation_dossiers_dans_ds: Procedure::OLD_MAX_DUREE_CONSERVATION,
+  for_individual: true,
+  administrateurs: [administrateurs.default]
+)
+procedure.draft_revision = procedure.revisions.build
+procedure.save!
+
+[
+  { type_champ: "text", libelle: "Nom du projet", mandatory: true },
+  { type_champ: "textarea", libelle: "Description du projet", mandatory: true },
+  { type_champ: "date", libelle: "Date de début" },
+  { type_champ: "drop_down_list", libelle: "Type de projet", drop_down_options: ["Association", "Entreprise", "Collectivité"] },
+  { type_champ: "checkbox", libelle: "Le projet bénéficie d'un financement public" },
+  { type_champ: "piece_justificative", libelle: "Justificatif" },
+].reduce(nil) do |previous, params|
+  type_de_champ = procedure.draft_revision.add_type_de_champ(**params, after_stable_id: previous&.stable_id)
+  raise type_de_champ.errors.full_messages.to_sentence if type_de_champ.errors.any?
+  type_de_champ
+end
+
+procedure.publish_or_reopen!(administrateurs.default, "demarche-demo")
+instructeurs.default.assign_to_procedure(procedure)
+
+procedures.label individual: procedure

--- a/db/seeds/setup.rb
+++ b/db/seeds/setup.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+def users.default_password = "this is a very complicated password !"
+
+users.defaults password: users.default_password,
+  confirmed_at: Time.zone.now,
+  email_verified_at: Time.zone.now

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+users.create :usager, email: "usager@exemple.fr"
+
+admin = users.create :admin, email: "admin@exemple.fr"
+admin.create_instructeur!
+admin.create_administrateur!
+
+instructeur = users.create :instructeur, email: "instructeur@exemple.fr"
+instructeur.create_instructeur!
+
+administrateurs.label default: admin.administrateur
+instructeurs.label default: instructeur.instructeur

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -3,11 +3,18 @@
 users.create :usager, email: "usager@exemple.fr"
 
 admin = users.create :admin, email: "admin@exemple.fr"
-admin.create_instructeur!
+admin.create_instructeur!(bypass_email_login_token: true)
 admin.create_administrateur!
 
 instructeur = users.create :instructeur, email: "instructeur@exemple.fr"
 instructeur.create_instructeur!
 
-administrateurs.label default: admin.administrateur
-instructeurs.label default: instructeur.instructeur
+# An administrateur guaranteed to own nothing — no procedures, no services, no
+# API tokens. For specs whose subject is the admin's own aggregate state
+# (deletion, merge, unused, token scoping); seeds must never attach anything
+# to it.
+blank_admin = users.create :blank_admin, email: "blank-admin@exemple.fr"
+blank_admin.create_administrateur!
+
+administrateurs.label default: admin.administrateur, blank: blank_admin.administrateur
+instructeurs.label default: instructeur.instructeur, admin: admin.instructeur

--- a/spec/components/dossiers/message_component_spec.rb
+++ b/spec/components/dossiers/message_component_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
   end
 
   describe 'groupe_gestionnaire' do
-    let(:commentaire) { create(:commentaire_groupe_gestionnaire, sender: administrateurs(:default_admin)) }
+    let(:commentaire) { create(:commentaire_groupe_gestionnaire, sender: administrateurs.default) }
     let(:groupe_gestionnaire) { commentaire.groupe_gestionnaire }
     let(:connected_user) { commentaire.sender }
     subject { render_inline(component).to_html }
@@ -405,7 +405,7 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
 
     context 'with an gestionnaire message' do
       let(:gestionnaire) { create(:gestionnaire) }
-      let(:commentaire) { create(:commentaire_groupe_gestionnaire, sender: administrateurs(:default_admin), gestionnaire: gestionnaire, body: 'Second message') }
+      let(:commentaire) { create(:commentaire_groupe_gestionnaire, sender: administrateurs.default, gestionnaire: gestionnaire, body: 'Second message') }
 
       it 'should display gestionnaire’s email' do
         is_expected.to have_text(gestionnaire.email)
@@ -420,7 +420,7 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
         end
 
         context 'when commentaire had been written by connected gestionnaire and discarded' do
-          let(:commentaire) { create(:commentaire_groupe_gestionnaire, sender: administrateurs(:default_admin), gestionnaire: gestionnaire, body: 'Second message', discarded_at: 2.days.ago) }
+          let(:commentaire) { create(:commentaire_groupe_gestionnaire, sender: administrateurs.default, gestionnaire: gestionnaire, body: 'Second message', discarded_at: 2.days.ago) }
 
           it do
             is_expected.not_to have_selector("form[action=\"#{form_url}\"]")
@@ -429,7 +429,7 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
         end
 
         context 'on a procedure where commentaire had been written another gestionnaire' do
-          let(:commentaire) { create(:commentaire_groupe_gestionnaire, sender: administrateurs(:default_admin), gestionnaire: create(:gestionnaire), body: 'Second message') }
+          let(:commentaire) { create(:commentaire_groupe_gestionnaire, sender: administrateurs.default, gestionnaire: create(:gestionnaire), body: 'Second message') }
 
           it { is_expected.not_to have_selector("form[action=\"#{form_url}\"]") }
         end
@@ -446,7 +446,7 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
       let(:present_date) { Time.zone.local(2018, 9, 2, 10, 5, 0) }
       let(:creation_date) { present_date }
       let(:commentaire) do
-        travel_to(creation_date) { create(:commentaire_groupe_gestionnaire, sender: administrateurs(:default_admin)) }
+        travel_to(creation_date) { create(:commentaire_groupe_gestionnaire, sender: administrateurs.default) }
       end
 
       subject do

--- a/spec/components/instructeurs/procedure_summary_component_spec.rb
+++ b/spec/components/instructeurs/procedure_summary_component_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Instructeurs::ProcedureSummaryComponent, type: :component do
   include Rails.application.routes.url_helpers
 
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let(:procedure) { create(:procedure) }
-  let(:instructeur) { instructeurs(:default_instructeur_admin) }
+  let(:instructeur) { instructeurs.admin }
 
   # Default empty counters, using Hash.new(0) for simplicity
   let(:component) { described_class.new(procedure:) }

--- a/spec/components/procedures/card/annotations_component_spec.rb
+++ b/spec/components/procedures/card/annotations_component_spec.rb
@@ -2,7 +2,7 @@
 
 describe Procedure::Card::AnnotationsComponent, type: :component do
   describe 'render' do
-    let(:procedure) { create(:procedure, id: 1, types_de_champ_private:, types_de_champ_public:) }
+    let(:procedure) { create(:procedure, types_de_champ_private:, types_de_champ_public:) }
     let(:types_de_champ_private) { [] }
     let(:types_de_champ_public) { [] }
     before { procedure.validate(:publication) }

--- a/spec/components/procedures/card/champs_component_spec.rb
+++ b/spec/components/procedures/card/champs_component_spec.rb
@@ -2,7 +2,7 @@
 
 describe Procedure::Card::ChampsComponent, type: :component do
   describe 'render' do
-    let(:procedure) { create(:procedure, id: 1, types_de_champ_private:, types_de_champ_public:) }
+    let(:procedure) { create(:procedure, types_de_champ_private:, types_de_champ_public:) }
     let(:types_de_champ_private) { [] }
     let(:types_de_champ_public) { [] }
     before { procedure.validate(:publication) }

--- a/spec/components/procedures/errors_summary_spec.rb
+++ b/spec/components/procedures/errors_summary_spec.rb
@@ -48,7 +48,7 @@ describe Procedure::ErrorsSummary, type: :component do
     include Logic
 
     let(:procedure) do
-      create(:procedure, id: 1, types_de_champ_public: [
+      create(:procedure, types_de_champ_public: [
         { libelle: 'repetition requires children', type: :repetition, children: [] },
         { libelle: 'drop down list requires options', type: :drop_down_list, options: [] },
         { libelle: 'invalid condition', type: :text, condition: ds_eq(constant(true), constant(1)) },

--- a/spec/components/types_de_champ_editor/editor_component_spec.rb
+++ b/spec/components/types_de_champ_editor/editor_component_spec.rb
@@ -2,7 +2,7 @@
 
 describe TypesDeChampEditor::EditorComponent, type: :component do
   let(:revision) { procedure.draft_revision }
-  let(:procedure) { create(:procedure, id: 1, types_de_champ_private:, types_de_champ_public:) }
+  let(:procedure) { create(:procedure, types_de_champ_private:, types_de_champ_public:) }
   let(:types_de_champ_private) { [{ type: :repetition, children: [], libelle: 'private' }] }
   let(:types_de_champ_public) { [{ type: :repetition, children: [], libelle: 'public' }] }
 

--- a/spec/controllers/administrateurs/api_tokens_controller_spec.rb
+++ b/spec/controllers/administrateurs/api_tokens_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Administrateurs::APITokensController, type: :controller do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:procedure) { create(:procedure, administrateur: admin) }
 
   before { sign_in(admin.user) }
@@ -167,6 +167,9 @@ describe Administrateurs::APITokensController, type: :controller do
   end
 
   describe 'remove_procedure' do
+    # a full-access token materializes all the admin's procedures on removal:
+    # use the seeded blank administrateur, who is guaranteed to own nothing
+    let(:admin) { administrateurs.blank }
     let!(:procedure1) { create(:procedure, administrateurs: [admin]) }
     let!(:procedure2) { create(:procedure, administrateurs: [admin]) }
     let(:token) { APIToken.generate(admin).first }

--- a/spec/controllers/administrateurs/archives_controller_spec.rb
+++ b/spec/controllers/administrateurs/archives_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Administrateurs::ArchivesController, type: :controller do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:procedure) { create :procedure, groupe_instructeurs: [groupe_instructeur1, groupe_instructeur2] }
   let(:groupe_instructeur1) { create(:groupe_instructeur) }
   let(:groupe_instructeur2) { create(:groupe_instructeur) }

--- a/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Administrateurs::AttestationTemplateV2sController, type: :controller do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:attestation_acceptation_template) { build(:attestation_template, :v2) }
   let(:procedure) { create(:procedure, :published, administrateur: admin, attestation_acceptation_template:, libelle: "Ma démarche") }
   let(:logo) { fixture_file_upload('spec/fixtures/files/white.png', 'image/png') }

--- a/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Administrateurs::AttestationTemplatesController, type: :controller do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:attestation_template) { build(:attestation_template) }
   let(:procedure) { create(:procedure, administrateur: admin, attestation_acceptation_template: attestation_template) }
   let(:logo) { fixture_file_upload('spec/fixtures/files/white.png', 'image/png') }

--- a/spec/controllers/administrateurs/contact_informations_controller_spec.rb
+++ b/spec/controllers/administrateurs/contact_informations_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Administrateurs::ContactInformationsController, type: :controller do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:procedure) { create(:procedure, administrateurs: [admin]) }
   let(:groupe_instructeur) { procedure.defaut_groupe_instructeur }
 

--- a/spec/controllers/administrateurs/dossier_submitted_messages_controller_spec.rb
+++ b/spec/controllers/administrateurs/dossier_submitted_messages_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Administrateurs::DossierSubmittedMessagesController, type: :controller do
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let(:tiptap_body) { { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello' }] }] }.to_json }
 
   before { sign_in(administrateur.user) }

--- a/spec/controllers/administrateurs/experts_procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/experts_procedures_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Administrateurs::ExpertsProceduresController, type: :controller do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:procedure) { create :procedure, administrateur: admin }
 
   before do

--- a/spec/controllers/administrateurs/exports_controller_spec.rb
+++ b/spec/controllers/administrateurs/exports_controller_spec.rb
@@ -2,7 +2,7 @@
 
 describe Administrateurs::ExportsController, type: :controller do
   describe '#download' do
-    let(:administrateur) { administrateurs(:default_admin) }
+    let(:administrateur) { administrateurs.default }
     before { sign_in(administrateur.user) }
 
     subject do

--- a/spec/controllers/administrateurs/groupe_gestionnaire_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_gestionnaire_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Administrateurs::GroupeGestionnaireController, type: :controller do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
 
   describe "#show" do
     subject { get :show }

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -4,7 +4,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
   render_views
   include Logic
 
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:procedure) { create(:procedure, :routee, :published, :for_individual, administrateurs: [admin]) }
 
   let!(:gi_1_1) { procedure.defaut_groupe_instructeur }

--- a/spec/controllers/administrateurs/jetons_controller_spec.rb
+++ b/spec/controllers/administrateurs/jetons_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Administrateurs::JetonsController, type: :controller do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:procedure) { create(:procedure, administrateur: admin) }
 
   context 'API Entreprise' do

--- a/spec/controllers/administrateurs/labels_controller_spec.rb
+++ b/spec/controllers/administrateurs/labels_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Administrateurs::LabelsController, type: :controller do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:procedure) { create(:procedure, administrateur: admin) }
   let(:admin_2) { create(:administrateur) }
   let(:procedure_2) { create(:procedure, administrateur: admin_2) }

--- a/spec/controllers/administrateurs/mail_templates_controller_spec.rb
+++ b/spec/controllers/administrateurs/mail_templates_controller_spec.rb
@@ -4,7 +4,7 @@ describe Administrateurs::MailTemplatesController, type: :controller do
   render_views
   let(:procedure) { create :procedure }
 
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
 
   before do
     sign_in(procedure.administrateurs.first.user)

--- a/spec/controllers/administrateurs/procedure_administrateurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedure_administrateurs_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Administrateurs::ProcedureAdministrateursController, type: :controller do
-  let(:signed_in_admin) { administrateurs(:default_admin).tap { _1.user.update(last_sign_in_at: Time.zone.now) } }
+  let(:signed_in_admin) { administrateurs.default.tap { it.user.update(last_sign_in_at: Time.zone.now) } }
   let(:other_admin) { create(:administrateur).tap { _1.user.update(last_sign_in_at: Time.zone.now) } }
   let!(:administrateurs_procedure) { create(:administrateurs_procedure, administrateur: signed_in_admin, procedure: procedure, manager: manager) }
   let!(:procedure) { create(:procedure, administrateurs: [other_admin]) }
@@ -14,7 +14,7 @@ describe Administrateurs::ProcedureAdministrateursController, type: :controller 
   describe '#create' do
     context 'as manager' do
       let(:manager) { true }
-      subject { post :create, params: { procedure_id: procedure.id, administrateur: { email: administrateurs(:default_admin).email } }, format: :turbo_stream }
+      subject { post :create, params: { procedure_id: procedure.id, administrateur: { email: administrateurs.default.email } }, format: :turbo_stream }
       it { is_expected.to have_http_status(:forbidden) }
     end
   end

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -3,7 +3,7 @@
 describe Administrateurs::ProceduresController, type: :controller do
   include Logic
 
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:administrateur_2) { create(:administrateur) }
   let(:administrateur_3) { create(:administrateur) }
   let(:instructeur_2) { create(:instructeur) }
@@ -384,8 +384,9 @@ describe Administrateurs::ProceduresController, type: :controller do
         expect(assigns(:admins)).not_to include(admin2)
         expect(assigns(:admins)).not_to include(admin4)
         expect(assigns(:admins)).not_to include(admin3)
-        expect(assigns(:admins)[0].procedures).not_to include(published_procedure)
-        expect(assigns(:admins)[0].procedures).to include(antoher_published_procedure_for_admin1)
+        assigned_admin1 = assigns(:admins).find { it.id == admin1.id }
+        expect(assigned_admin1.procedures).not_to include(published_procedure)
+        expect(assigned_admin1.procedures).to include(antoher_published_procedure_for_admin1)
       end
     end
   end
@@ -988,7 +989,7 @@ describe Administrateurs::ProceduresController, type: :controller do
     end
 
     context 'when procedure has invalid fields' do
-      let(:admin_2) { administrateurs(:default_admin) }
+      let(:admin_2) { administrateurs.default }
       let(:path) { 'spec/fixtures/files/invalid_file_format.json' }
 
       before do

--- a/spec/controllers/administrateurs/services_controller_spec.rb
+++ b/spec/controllers/administrateurs/services_controller_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 describe Administrateurs::ServicesController, type: :controller do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:procedure) { create(:procedure, administrateur: admin) }
 
   describe '#new' do
-    let(:admin) { administrateurs(:default_admin) }
+    let(:admin) { administrateurs.default }
     let(:procedure) { create(:procedure, administrateur: admin) }
 
     before do
@@ -352,7 +352,7 @@ describe Administrateurs::ServicesController, type: :controller do
   end
 
   describe "#index" do
-    let(:admin) { administrateurs(:default_admin) }
+    let(:admin) { administrateurs.default }
 
     before do
       sign_in(admin.user)

--- a/spec/controllers/api/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/v1/dossiers_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe API::V1::DossiersController do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:token) { APIToken.generate(admin)[1] }
   let(:procedure) { create(:procedure, :with_type_de_champ, :with_type_de_champ_private, administrateur: admin) }
   let(:wrong_procedure) { create(:procedure, :new_administrateur) }

--- a/spec/controllers/api/v2/base_controller_spec.rb
+++ b/spec/controllers/api/v2/base_controller_spec.rb
@@ -2,7 +2,7 @@
 
 describe API::V2::BaseController, type: :controller do
   describe 'ensure_authorized_network and token_is_not_expired' do
-    let(:admin) { administrateurs(:default_admin) }
+    let(:admin) { administrateurs.default }
     let(:token_bearer_couple) { APIToken.generate(admin) }
     let(:token) { token_bearer_couple[0] }
     let(:bearer) { token_bearer_couple[1] }

--- a/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe API::V2::GraphqlController do
-  let_it_be(:admin) { administrateurs(:default_admin) }
+  let_it_be(:admin) { administrateurs.default }
   let_it_be(:generated_token) { APIToken.generate(admin) }
   let(:token) { generated_token.second }
   let_it_be(:procedure) { create(:procedure, :published, :for_individual, :with_service, administrateurs: [admin], types_de_champ_public: [{}, { type: :piece_justificative }, { type: :siret }, { type: :repetition, mandatory: true, children: [{}, { type: :piece_justificative }, { type: :siret }] }]) }

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe API::V2::GraphqlController do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:generated_token) { APIToken.generate(admin) }
   let(:api_token) { generated_token.first }
   let(:token) { generated_token.second }

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe API::V2::GraphqlController do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:generated_token) { APIToken.generate(admin) }
   let(:api_token) { generated_token.first }
   let(:token) { generated_token.second }

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -43,7 +43,7 @@ describe APIController, type: :controller do
   end
 
   describe 'ensure_authorized_network and token is not expired' do
-    let(:admin) { administrateurs(:default_admin) }
+    let(:admin) { administrateurs.default }
     let(:token_bearer_couple) { APIToken.generate(admin) }
     let(:token) { token_bearer_couple[0] }
     let(:bearer) { token_bearer_couple[1] }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -74,7 +74,7 @@ describe ApplicationController, type: :controller do
     context 'when someone is logged as a user, instructeur, administrateur and super_admin' do
       let(:current_user) { create(:user) }
       let(:current_instructeur) { create(:instructeur) }
-      let(:current_administrateur) { administrateurs(:default_admin) }
+      let(:current_administrateur) { administrateurs.default }
       let(:current_super_admin) { create(:super_admin) }
 
       it "configure sentry user" do
@@ -300,7 +300,7 @@ describe ApplicationController, type: :controller do
     end
 
     context 'when an administrateur is logged in' do
-      let(:administrateur) { administrateurs(:default_admin) }
+      let(:administrateur) { administrateurs.default }
 
       before do
         allow(@controller).to receive(:current_user).and_return(administrateur.user)

--- a/spec/controllers/data_sources/chorus_controller_spec.rb
+++ b/spec/controllers/data_sources/chorus_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe DataSources::ChorusController do
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
 
   render_views
 

--- a/spec/controllers/gestionnaires/groupe_gestionnaire_administrateurs_controller_spec.rb
+++ b/spec/controllers/gestionnaires/groupe_gestionnaire_administrateurs_controller_spec.rb
@@ -53,7 +53,7 @@ describe Gestionnaires::GroupeGestionnaireAdministrateursController, type: :cont
     end
 
     context 'when administrateur has some procedure' do
-      let(:administrateur_with_procedure) { administrateurs(:default_admin) }
+      let(:administrateur_with_procedure) { administrateurs.default }
       let!(:procedure) { create(:procedure_with_dossiers, administrateur: administrateur_with_procedure) }
       before do
         groupe_gestionnaire.administrateurs << administrateur_with_procedure
@@ -67,7 +67,7 @@ describe Gestionnaires::GroupeGestionnaireAdministrateursController, type: :cont
     end
 
     context 'when administrateur is not in the groupe_gestionnaire' do
-      let(:other_administrateur) { administrateurs(:default_admin) }
+      let(:other_administrateur) { administrateurs.default }
 
       it 'does not disclose the unrelated administrateur email' do
         expect { destroy(other_administrateur) }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/controllers/gestionnaires/groupe_gestionnaire_commentaires_controller_spec.rb
+++ b/spec/controllers/gestionnaires/groupe_gestionnaire_commentaires_controller_spec.rb
@@ -2,7 +2,7 @@
 
 describe Gestionnaires::GroupeGestionnaireCommentairesController, type: :controller do
   let(:gestionnaire) { create(:gestionnaire).tap { _1.user.update(last_sign_in_at: Time.zone.now) } }
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let(:groupe_gestionnaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire], administrateurs: [administrateur]) }
   let!(:commentaire) { create(:commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire, sender: administrateur) }
 

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -746,8 +746,13 @@ describe Instructeurs::ProceduresController, type: :controller do
         let!(:dossier_2) { create(:dossier, :en_construction, procedure:, groupe_instructeur: gi_2) }
         let(:statut) { 'tous' }
         let(:label_id) { procedure.find_column(label: 'Labels') }
-        let!(:procedure_presentation) do
-          ProcedurePresentation.create!(assign_to: AssignTo.first)
+        # the instructeur belongs to several groupes of the procedure and the
+        # controller resolves its AssignTo with an unordered find_by: create a
+        # presentation on every AssignTo so the resolution order can't matter
+        let!(:procedure_presentations) do
+          AssignTo.joins(:groupe_instructeur)
+            .where(instructeur:, groupe_instructeurs: { procedure_id: procedure.id })
+            .map { ProcedurePresentation.create!(assign_to: it) }
         end
         render_views
 
@@ -756,9 +761,7 @@ describe Instructeurs::ProceduresController, type: :controller do
           DossierLabel.create(dossier_id: dossier.id, label_id: dossier.procedure.labels.second.id)
           DossierLabel.create(dossier_id: dossier_2.id, label_id: dossier.procedure.labels.last.id)
 
-          procedure_presentation.update(displayed_columns: [
-            label_id.id,
-          ])
+          procedure_presentations.each { it.update(displayed_columns: [label_id.id]) }
 
           subject
         end

--- a/spec/controllers/manager/administrateurs_controller_spec.rb
+++ b/spec/controllers/manager/administrateurs_controller_spec.rb
@@ -2,7 +2,7 @@
 
 describe Manager::AdministrateursController, type: :controller do
   let(:super_admin) { create(:super_admin) }
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
 
   before do
     sign_in super_admin
@@ -62,6 +62,8 @@ describe Manager::AdministrateursController, type: :controller do
   end
 
   describe '#delete' do
+    # deletion needs an admin who owns nothing, not the shared default one
+    let(:administrateur) { administrateurs.blank }
     subject { delete :delete, params: { id: administrateur.id } }
 
     it 'deletes the admin' do

--- a/spec/controllers/manager/procedures_controller_spec.rb
+++ b/spec/controllers/manager/procedures_controller_spec.rb
@@ -3,7 +3,7 @@
 describe Manager::ProceduresController, type: :controller do
   let(:super_admin) { create :super_admin }
   let(:administrateur) { create(:administrateur, email: super_admin.email) }
-  let(:autre_administrateur) { administrateurs(:default_admin) }
+  let(:autre_administrateur) { administrateurs.default }
   before { sign_in super_admin }
 
   describe '#whitelist' do

--- a/spec/controllers/root_controller_spec.rb
+++ b/spec/controllers/root_controller_spec.rb
@@ -36,7 +36,7 @@ describe RootController, type: :controller do
 
   context 'when Administrateur is connected' do
     before do
-      sign_in(administrateurs(:default_admin).user)
+      sign_in(administrateurs.default.user)
     end
 
     it { expect(subject).to redirect_to(admin_procedures_path) }

--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -71,6 +71,8 @@ describe StatsController, type: :controller do
   end
 
   describe '#cumulative_hash' do
+    empty_seeds Dossier, Procedure
+
     before do
       travel_to(Time.zone.local(2016, 10, 2))
       create(:procedure, created_at: 55.days.ago, updated_at: 43.days.ago)

--- a/spec/controllers/users/activate_controller_spec.rb
+++ b/spec/controllers/users/activate_controller_spec.rb
@@ -99,7 +99,7 @@ describe Users::ActivateController, type: :controller do
     end
 
     context 'when the token is ok and user is admin' do
-      let(:admin) { administrateurs(:default_admin) }
+      let(:admin) { administrateurs.default }
       let!(:user) { admin.user }
 
       it 'trusts the device because admin has an instructeur profile' do

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -234,12 +234,12 @@ describe Users::CommencerController, type: :controller do
 
         shared_examples 'a prefilled brouillon dossier creator' do
           it 'creates a dossier' do
-            subject
-            expect(Dossier.count).to eq(1)
-            expect(session[:prefill_token]).to eq(Dossier.last.prefill_token)
+            expect { subject }.to change { published_procedure.dossiers.count }.by(1)
+            dossier = published_procedure.dossiers.last
+            expect(session[:prefill_token]).to eq(dossier.prefill_token)
             expect(session[:prefill_params_digest]).to eq(PrefillChamps.digest({ "champ_#{type_de_champ_text.to_typed_id}" => "blabla" }))
-            expect(Dossier.last.champ_data.where(stable_id: type_de_champ_text.stable_id).first.value).to eq("blabla")
-            expect(Dossier.last.individual.nom).to eq("Dupont")
+            expect(dossier.champ_data.where(stable_id: type_de_champ_text.stable_id).first.value).to eq("blabla")
+            expect(dossier.individual.nom).to eq("Dupont")
           end
         end
 
@@ -252,7 +252,7 @@ describe Users::CommencerController, type: :controller do
 
           it_behaves_like 'a prefilled brouillon dossier creator'
 
-          it { expect { subject }.to change { Dossier.last&.user }.from(nil).to(user) }
+          it { expect { subject }.to change { published_procedure.dossiers.last&.user }.from(nil).to(user) }
 
           it 'sends the notify_new_draft email and enqueues AMI notification' do
             allow(Ami::CreateNotificationService).to receive(:call)
@@ -275,8 +275,7 @@ describe Users::CommencerController, type: :controller do
           let!(:dossier) { create(:dossier, :prefilled, procedure:, prefill_token: "token") }
 
           it "does not create a new dossier" do
-            subject
-            expect(Dossier.count).to eq(1)
+            expect { subject }.not_to change(Dossier, :count)
             expect(assigns(:prefilled_dossier)).to eq(dossier)
           end
         end
@@ -297,8 +296,7 @@ describe Users::CommencerController, type: :controller do
           let!(:dossier) { create(:dossier, :prefilled, prefill_token: "token") }
 
           it "does not create a new dossier" do
-            subject
-            expect(Dossier.count).to eq(1)
+            expect { subject }.not_to change(Dossier, :count)
             expect(assigns(:prefilled_dossier)).to eq(dossier)
           end
         end

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -3,7 +3,7 @@
 describe Users::DossiersController, type: :controller do
   include ActiveSupport::Testing::TimeHelpers
 
-  let(:user) { users(:default_user) }
+  let(:user) { users.usager }
 
   describe 'before_actions' do
     it 'are present' do

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -7,7 +7,7 @@ describe WebhookController, type: :controller do
         "event" => "message:send",
         "data" => {
           "from" => "user",
-          "user" => { "user_id" => "default_user@user.com" },
+          "user" => { "user_id" => "usager@exemple.fr" },
         },
       }
     end

--- a/spec/factories/administrateurs_procedure.rb
+++ b/spec/factories/administrateurs_procedure.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :administrateurs_procedure do
-    administrateur { Administrateur.find_by(user: { email: "default_admin@admin.com" }) }
+    administrateur { Administrateur.find_by(user: { email: "admin@exemple.fr" }) }
     association :procedure
   end
 end

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
     end
 
     transient do
-      administrateur { Administrateur.find_by(user: { email: "default_admin@admin.com" }) }
+      administrateur { Administrateur.find_by(user: { email: "admin@exemple.fr" }) }
       instructeurs { [] }
       types_de_champ_public { [] }
       types_de_champ_private { [] }
@@ -85,7 +85,7 @@ FactoryBot.define do
       end
 
       after(:create) do |procedure, evaluator|
-        user = User.find_by(email: "default_user@user.com")
+        user = User.find_by(email: "usager@exemple.fr")
         create_list(:dossier, evaluator.dossiers_count, procedure: procedure, user: user)
       end
     end

--- a/spec/fixtures/administrateurs.yml
+++ b/spec/fixtures/administrateurs.yml
@@ -1,2 +1,0 @@
-default_admin:
-  user: default_user_admin

--- a/spec/fixtures/instructeurs.yml
+++ b/spec/fixtures/instructeurs.yml
@@ -1,3 +1,0 @@
-default_instructeur_admin:
-  user: default_user_admin
-  bypass_email_login_token: true

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,9 +1,0 @@
-default_user:
-  email: default_user@user.com
-  encrypted_password: <%= Devise::Encryptor.digest(User, '{My-$3cure-p4ssWord}') %>
-  confirmed_at: <%= Time.current.to_s %>
-
-default_user_admin:
-  email: default_admin@admin.com
-  encrypted_password: <%= Devise::Encryptor.digest(User, '{My-$3cure-p4ssWord}') %>
-  confirmed_at: <%= Time.current.to_s %>

--- a/spec/graphql/annotation_spec.rb
+++ b/spec/graphql/annotation_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Mutations::DossierModifierAnnotations, type: :graphql do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:procedure) { create(:procedure, :published, :for_individual, types_de_champ_private:, administrateurs: [admin]) }
   let(:types_de_champ_private) do
     [

--- a/spec/graphql/demarche_spec.rb
+++ b/spec/graphql/demarche_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Types::DemarcheType, type: :graphql do
-  let(:admin) { administrateurs(:default_admin) }
+  let(:admin) { administrateurs.default }
   let(:admin_2) { create(:administrateur) }
   let(:query) { '' }
   let(:context) { { administrateur_id: admin.id, procedure_ids: admin.procedure_ids, write_access: true, remote_ip: '192.168.1.23' } }

--- a/spec/jobs/bulk_route_job_spec.rb
+++ b/spec/jobs/bulk_route_job_spec.rb
@@ -3,7 +3,7 @@
 describe BulkRouteJob, type: :job do
   include Logic
   describe 'perform' do
-    let(:admin) { administrateurs(:default_admin) }
+    let(:admin) { administrateurs.default }
     let!(:procedure) do
       create(:procedure,
              types_de_champ_public: [

--- a/spec/jobs/crisp_mattermost_tech_notification_job_spec.rb
+++ b/spec/jobs/crisp_mattermost_tech_notification_job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CrispMattermostTechNotificationJob, type: :job do
-  let(:user) { users(:default_user) }
+  let(:user) { users.usager }
   let(:session_id) { "session_310b13c9-f115-42f5-bd83-f5e22b8e50dd" }
   let(:website_id) { "test-website-id" }
   let(:inbox_id) { "123-456" }

--- a/spec/jobs/crisp_update_people_data_job_spec.rb
+++ b/spec/jobs/crisp_update_people_data_job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CrispUpdatePeopleDataJob, type: :job do
-  let(:user) { users(:default_user) }
+  let(:user) { users.usager }
   let(:session_id) { "session_d57cb2d9-4607-42fe-a6be-000001112222" }
   let(:email) { nil }
   let(:job) { described_class.new(session_id, email) }

--- a/spec/jobs/cron/administrateur_activate_before_expiration_job_spec.rb
+++ b/spec/jobs/cron/administrateur_activate_before_expiration_job_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Cron::AdministrateurActivateBeforeExpirationJob, type: :job do
   describe 'perform' do
-    let(:administrateur) { administrateurs(:default_admin) }
+    let(:administrateur) { administrateurs.default }
     let(:user) { administrateur.user }
     let(:mailer_double) { double('mailer', deliver_later: true) }
 

--- a/spec/jobs/cron/send_api_entreprise_token_expiration_notice_job_spec.rb
+++ b/spec/jobs/cron/send_api_entreprise_token_expiration_notice_job_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Cron::SendAPIEntrepriseTokenExpirationNoticeJob, type: :job do
   describe 'perform' do
-    let(:administrateur) { administrateurs(:default_admin) }
+    let(:administrateur) { administrateurs.default }
     let(:expires_at) { 6.months.from_now }
     let(:token) { JWT.encode({ exp: expires_at.to_i }, nil, 'none') }
     let!(:procedure) { create(:procedure, administrateurs: [administrateur], api_entreprise_token: token) }

--- a/spec/jobs/cron/send_api_token_expiration_notice_job_spec.rb
+++ b/spec/jobs/cron/send_api_token_expiration_notice_job_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Cron::SendAPITokenExpirationNoticeJob, type: :job do
   describe 'perform' do
-    let(:administrateur) { administrateurs(:default_admin) }
+    let(:administrateur) { administrateurs.default }
     let!(:token) { APIToken.generate(administrateur).first }
     let(:mailer_double) { double('mailer', deliver_later: true) }
     let(:today) { Date.new(2018, 01, 01) }

--- a/spec/lib/active_storage/downloadable_file_spec.rb
+++ b/spec/lib/active_storage/downloadable_file_spec.rb
@@ -2,7 +2,7 @@
 
 describe ActiveStorage::DownloadableFile do
   let(:dossier) { create(:dossier, :en_construction) }
-  let(:user_profile) { administrateurs(:default_admin) }
+  let(:user_profile) { administrateurs.default }
   let(:dossiers) { Dossier.where(id: dossier.id) }
   subject(:list) { ActiveStorage::DownloadableFile.create_list_from_dossiers(user_profile:, dossiers:) }
 

--- a/spec/lib/recovery/dossier_life_cycle_spec.rb
+++ b/spec/lib/recovery/dossier_life_cycle_spec.rb
@@ -68,18 +68,17 @@ describe 'Dossier::Recovery::LifeCycle' do
 
     after { cleanup_export_file }
     it 'reloads the full grappe', :slow do
-      expect(Dossier.count).to eq(1)
-      expect(Dossier.first.champ_data.count).not_to be(0)
+      expect(dossier.champ_data.count).not_to be(0)
 
-      @dossier_ids = Dossier.ids
+      @dossier_ids = [dossier.id]
 
       Recovery::Exporter.new(dossier_ids: @dossier_ids, file_path: fp).dump
       Dossier.where(id: @dossier_ids).destroy_all
       Recovery::Importer.new(file_path: fp).load
 
-      expect(Dossier.count).to eq(1)
+      expect(Dossier.exists?(dossier.id)).to be(true)
 
-      reloaded_dossier = Dossier.first
+      reloaded_dossier = Dossier.find(dossier.id)
 
       expect(reloaded_dossier.champ_data.count).not_to be(0)
 
@@ -128,22 +127,21 @@ describe 'Dossier::Recovery::LifeCycle' do
       parent.destroy
       Recovery::Importer.new(file_path: fp).load
 
-      expect(Dossier.count).to eq(1)
+      expect(Dossier.exists?(dossier.id)).to be(true)
+      expect(Dossier.exists?(parent.id)).to be(false)
     end
 
     it 'does not insert follow when instructeur does not exists any more', :slow do
-      expect(Dossier.count).to eq(1)
-
-      @dossier_ids = Dossier.ids
+      @dossier_ids = [dossier.id]
 
       Recovery::Exporter.new(dossier_ids: @dossier_ids, file_path: fp).dump
       Dossier.where(id: @dossier_ids).destroy_all
       instructeur.destroy
       Recovery::Importer.new(file_path: fp).load
 
-      expect(Dossier.count).to eq(1)
+      expect(Dossier.exists?(dossier.id)).to be(true)
 
-      reloaded_dossier = Dossier.first
+      reloaded_dossier = Dossier.find(dossier.id)
 
       expect(reloaded_dossier.followers_instructeurs).to match_array([])
     end

--- a/spec/lib/tasks/clean_services_spec.rb
+++ b/spec/lib/tasks/clean_services_spec.rb
@@ -26,7 +26,7 @@ describe 'service tasks' do
   describe 'service:notify_no_siret' do
     let(:task) { 'service:email_no_siret' }
     let!(:procedure_without_siret_service) { create(:procedure, :published, service: service, administrateur: administrateur) }
-    let(:administrateur) { administrateurs(:default_admin) }
+    let(:administrateur) { administrateurs.default }
     let(:service) do
       s = build(:service, siret: nil, administrateur: administrateur)
       s.save(validate: false)

--- a/spec/lib/tasks/support_spec.rb
+++ b/spec/lib/tasks/support_spec.rb
@@ -11,8 +11,9 @@ describe 'support' do
     end
     after { rake_task.reenable }
 
-    # the admin to remove
-    let(:admin) { administrateurs(:default_admin) }
+    # the admin to remove: the seeded blank administrateur, who is guaranteed
+    # to own nothing
+    let(:admin) { administrateurs.blank }
 
     # the super admin doing the removal
     let(:super_admin) { create(:super_admin) }

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe NotificationMailer, type: :mailer do
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let(:user) { create(:user) }
   let(:procedure) { create(:simple_procedure, :with_service) }
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     context 'administrateur' do
-      let(:role) { administrateurs(:default_admin) }
+      let(:role) { administrateurs.default }
       it 'sends email with correct links to administrateur' do
         expect(subject.to).to eq([role.user.email])
         expect(subject.body).to have_link('Consulter mes archives', href: admin_procedure_archives_url(procedure))
@@ -141,7 +141,7 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     context 'when perform_later is called' do
-      let(:role) { administrateurs(:default_admin) }
+      let(:role) { administrateurs.default }
       let(:custom_queue) { 'default' }
       it 'enqueues email is custom queue for non critical delivery' do
         expect { subject.deliver_later }.to have_enqueued_job.on_queue(custom_queue)

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -15,7 +15,7 @@ describe Administrateur, type: :model do
     subject { administrateur.can_be_deleted? }
 
     context "when the administrateur's procedures have other administrateurs" do
-      let!(:administrateur) { administrateurs(:default_admin) }
+      let!(:administrateur) { administrateurs.blank }
       let!(:autre_administrateur) { create(:administrateur) }
       let!(:procedure) { create(:procedure, administrateurs: [administrateur, autre_administrateur]) }
 
@@ -23,14 +23,14 @@ describe Administrateur, type: :model do
     end
 
     context "when the administrateur has a procedure with dossiers where they is the only admin" do
-      let!(:administrateur) { administrateurs(:default_admin) }
+      let!(:administrateur) { administrateurs.blank }
       let!(:procedure) { create(:procedure_with_dossiers, :published, administrateurs: [administrateur]) }
 
       it { is_expected.to be false }
     end
 
     context "when the administrateur has a procedure with dossiers and with other admins" do
-      let!(:administrateur) { administrateurs(:default_admin) }
+      let!(:administrateur) { administrateurs.blank }
       let!(:administrateur2) { create(:administrateur) }
       let!(:procedure) { create(:procedure_with_dossiers, :published, administrateurs: [administrateur, administrateur2]) }
 
@@ -38,21 +38,21 @@ describe Administrateur, type: :model do
     end
 
     context "when the administrateur has a discarded procedure with dossiers" do
-      let!(:administrateur) { administrateurs(:default_admin) }
+      let!(:administrateur) { administrateurs.blank }
       let!(:procedure) { create(:procedure_with_dossiers, :closed, :discarded, administrateurs: [administrateur]) }
 
       it { is_expected.to be false }
     end
 
     context "when the administrateur has a procedure without dossiers" do
-      let!(:administrateur) { administrateurs(:default_admin) }
+      let!(:administrateur) { administrateurs.blank }
       let!(:procedure) { create(:procedure, :published, administrateurs: [administrateur]) }
 
       it { is_expected.to be true }
     end
 
     context "when the administrateur has no non-draft procedure" do
-      let!(:administrateur) { administrateurs(:default_admin) }
+      let!(:administrateur) { administrateurs.blank }
       let!(:procedure) { create(:procedure_with_dossiers, :draft, administrateurs: [administrateur]) }
 
       it { is_expected.to be true }
@@ -60,7 +60,9 @@ describe Administrateur, type: :model do
   end
 
   describe '#merge' do
-    let(:new_admin) { administrateurs(:default_admin) }
+    # merge semantics depend on the admin's own records: use the seeded blank
+    # administrateur, who is guaranteed to own nothing
+    let(:new_admin) { administrateurs.blank }
     let(:old_admin) { create(:administrateur) }
 
     subject { new_admin.merge(old_admin) }
@@ -188,7 +190,7 @@ describe Administrateur, type: :model do
   describe 'unused' do
     subject { Administrateur.unused }
 
-    let(:new_admin) { administrateurs(:default_admin) }
+    let(:new_admin) { administrateurs.blank }
     let(:unused_admin) { create(:administrateur, :with_api_token) }
 
     before do
@@ -240,7 +242,7 @@ describe Administrateur, type: :model do
   end
 
   describe 'zones' do
-    let(:admin) { administrateurs(:default_admin) }
+    let(:admin) { administrateurs.default }
     let(:zone1) { create(:zone) }
     let(:zone2) { create(:zone) }
     let!(:procedure) { create(:procedure, administrateurs: [admin], zones: [zone1, zone2]) }
@@ -253,7 +255,7 @@ describe Administrateur, type: :model do
   describe "#unread_commentaires?" do
     context "commentaire_seen_at is nil" do
       let(:gestionnaire) { create(:gestionnaire) }
-      let(:administrateur) { administrateurs(:default_admin) }
+      let(:administrateur) { administrateurs.default }
       let(:groupe_gestionnaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
       let!(:commentaire_groupe_gestionnaire) { create(:commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire, sender: administrateur, gestionnaire: gestionnaire, created_at: 12.hours.ago) }
 
@@ -288,7 +290,7 @@ describe Administrateur, type: :model do
   describe "#mark_commentaire_as_seen" do
     let(:now) { Time.zone.now.beginning_of_minute }
     let(:gestionnaire) { create(:gestionnaire) }
-    let(:administrateur) { administrateurs(:default_admin) }
+    let(:administrateur) { administrateurs.default }
     let(:groupe_gestionnaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
     let!(:commentaire_groupe_gestionnaire) { create(:commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire, sender: administrateur, created_at: 12.hours.ago) }
 

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 describe APIToken, type: :model do
-  let(:administrateur) { administrateurs(:default_admin) }
+  # Tokens expose all the admin's procedures: use the seeded blank
+  # administrateur, who is guaranteed to own nothing.
+  let(:administrateur) { administrateurs.blank }
 
   describe '#generate' do
     let(:api_token_and_packed_token) { APIToken.generate(administrateur) }

--- a/spec/models/avis_spec.rb
+++ b/spec/models/avis_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Avis, :oaken, type: :model do
-  before { seed "cases/avis" }
+  before_all { seed "cases/avis" }
 
   describe '#email_to_display' do
     context 'when expert is known' do

--- a/spec/models/avis_spec.rb
+++ b/spec/models/avis_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Avis, :oaken, type: :model do
+RSpec.describe Avis, type: :model do
   before_all { seed "cases/avis" }
 
   describe '#email_to_display' do

--- a/spec/models/avis_spec.rb
+++ b/spec/models/avis_spec.rb
@@ -1,145 +1,109 @@
 # frozen_string_literal: true
 
-RSpec.describe Avis, type: :model do
-  let(:claimant) { create(:instructeur) }
+RSpec.describe Avis, :oaken, type: :model do
+  before { seed "cases/avis" }
 
   describe '#email_to_display' do
-    let(:invited_email) { 'invited@avis.com' }
-    let(:expert) { create(:expert) }
-    let(:procedure) { create(:procedure) }
-    let(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: procedure) }
-
-    subject { avis.email_to_display }
-
     context 'when expert is known' do
-      let!(:avis) { create(:avis, claimant: claimant, dossier: create(:dossier), experts_procedure: experts_procedure) }
-
-      it { is_expected.to eq(avis.expert.email) }
+      it { expect(avis.pending.email_to_display).to eq(experts.default.email) }
     end
   end
 
   describe '.by_latest' do
-    context 'with 3 avis' do
-      let!(:avis) { create(:avis) }
-      let!(:avis2) { create(:avis, updated_at: 4.hours.ago) }
-      let!(:avis3) { create(:avis, updated_at: 3.hours.ago) }
+    context 'with 3 avis on the same dossier' do
+      let!(:avis2) { create(:avis, dossier: dossiers.en_instruction, experts_procedure: experts_procedures.default, updated_at: 4.hours.ago) }
+      let!(:avis3) { create(:avis, dossier: dossiers.en_instruction, experts_procedure: experts_procedures.default, updated_at: 3.hours.ago) }
 
-      subject { Avis.by_latest }
+      subject { Avis.where(dossier: dossiers.en_instruction).by_latest }
 
-      it { expect(subject).to eq([avis, avis3, avis2]) }
+      it { is_expected.to eq([avis.pending, avis3, avis2]) }
     end
   end
 
-  describe "an avis is linked to an expert_procedure" do
-    let(:procedure) { create(:procedure) }
-    let(:expert) { create(:expert) }
-    let(:experts_procedure) { create(:experts_procedure, procedure: procedure, expert: expert) }
-
-    context 'an avis is linked to an experts_procedure' do
-      let!(:avis) { create(:avis, experts_procedure: experts_procedure) }
-
-      before do
-        avis.reload
-      end
-      it do
-        expect(avis.valid?).to be_truthy
-        expect(avis.experts_procedure).to eq(experts_procedure)
-      end
+  describe "an avis is linked to an experts_procedure" do
+    it do
+      expect(avis.pending.valid?).to be_truthy
+      expect(avis.pending.experts_procedure).to eq(experts_procedures.default)
     end
   end
 
   describe ".revoke_by!" do
-    let(:claimant) { create(:instructeur) }
-
     context "when no answer" do
-      let(:avis) { create(:avis, claimant: claimant) }
-
       it "supprime l’avis" do
-        avis.revoke_by!(claimant)
-        expect(avis).to be_destroyed
-        expect(Avis.count).to eq 0
+        pending_avis = avis.pending
+        expect { pending_avis.revoke_by!(instructeurs.default) }.to change { Avis.exists?(pending_avis.id) }.from(true).to(false)
+        expect(pending_avis).to be_destroyed
       end
     end
 
     context "with answer" do
-      let(:avis) { create(:avis, :with_answer, claimant: claimant) }
-
       it "revoque l’avis" do
-        avis.revoke_by!(claimant)
-        expect(avis).not_to be_destroyed
-        expect(avis).to be_revoked
+        answered_avis = avis.answered
+        answered_avis.revoke_by!(instructeurs.default)
+        expect(answered_avis).not_to be_destroyed
+        expect(answered_avis).to be_revoked
       end
     end
 
     context "by an instructeur who can't revoke" do
-      let(:avis) { create(:avis, :with_answer, claimant: claimant) }
-      let(:expert) { create(:instructeur) }
+      let(:other_instructeur) { create(:instructeur) }
 
       it "doesn't revoke avis and returns false" do
-        result = avis.revoke_by!(expert)
-        expect(result).to be_falsey
-        expect(avis).not_to be_destroyed
-        expect(avis).not_to be_revoked
+        answered_avis = avis.answered
+        expect(answered_avis.revoke_by!(other_instructeur)).to be_falsey
+        expect(answered_avis).not_to be_destroyed
+        expect(answered_avis).not_to be_revoked
       end
     end
   end
 
   describe "revokable_by?" do
-    let(:instructeur) { create(:instructeur) }
-    let(:instructeurs) { [instructeur] }
-    let(:procedure) { create(:procedure, :published, instructeurs: instructeurs) }
-    let(:dossier) { create(:dossier, :en_instruction, procedure: procedure) }
+    let(:instructeur) { instructeurs.default }
     let(:claimant_expert) { create(:instructeur) }
-    let(:expert) { create(:expert) }
-    let(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: procedure) }
     let(:another_expert) { create(:expert) }
+    let(:dossier) { dossiers.en_instruction }
 
     context "when avis claimed by an expert" do
-      let(:avis) { create(:avis, dossier: dossier, claimant: claimant_expert, experts_procedure: experts_procedure) }
-      let(:another_avis) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure) }
+      let(:claimed_avis) { create(:avis, dossier:, claimant: claimant_expert, experts_procedure: experts_procedures.default) }
+
       it "is revokable by this expert or any instructeurs of the dossier" do
-        expect(avis.revokable_by?(claimant_expert)).to be_truthy
-        expect(avis.revokable_by?(another_expert)).to be_falsy
-        expect(avis.revokable_by?(instructeur)).to be_truthy
+        expect(claimed_avis.revokable_by?(claimant_expert)).to be_truthy
+        expect(claimed_avis.revokable_by?(another_expert)).to be_falsy
+        expect(claimed_avis.revokable_by?(instructeur)).to be_truthy
       end
     end
 
     context "when avis claimed by an instructeur" do
-      let(:expert) { create(:expert) }
-      let(:expert_2) { create(:expert) }
-      let!(:procedure) { create(:procedure, :published, instructeurs: instructeurs) }
-      let(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: procedure) }
-      let(:experts_procedure_2) { create(:experts_procedure, expert: expert_2, procedure: procedure) }
-      let(:avis) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure) }
-      let(:another_avis) { create(:avis, dossier: dossier, claimant: expert, experts_procedure: experts_procedure_2) }
       let(:another_instructeur) { create(:instructeur) }
-      let(:instructeurs) { [instructeur, another_instructeur] }
+      let(:claimed_avis) { create(:avis, dossier:, claimant: instructeur, experts_procedure: experts_procedures.default) }
+
+      before { another_instructeur.assign_to_procedure(procedures.individual) }
 
       it "is revokable by any instructeur of the dossier, not by an expert" do
-        expect(avis.revokable_by?(instructeur)).to be_truthy
-        expect(avis.revokable_by?(another_expert)).to be_falsy
-        expect(avis.revokable_by?(another_instructeur)).to be_truthy
+        expect(claimed_avis.revokable_by?(instructeur)).to be_truthy
+        expect(claimed_avis.revokable_by?(another_expert)).to be_falsy
+        expect(claimed_avis.revokable_by?(another_instructeur)).to be_truthy
       end
     end
   end
 
   describe "question_label cleanup" do
     it "nullify empty" do
-      avis = create(:avis, question_label: " ")
-      expect(avis.question_label).to be_nil
+      created_avis = create(:avis, question_label: " ", dossier: dossiers.en_construction, experts_procedure: experts_procedures.default, claimant: instructeurs.default)
+      expect(created_avis.question_label).to be_nil
     end
 
     it "strip" do
-      avis = create(:avis, question_label: "my question ")
-      expect(avis.question_label).to eq("my question")
+      created_avis = create(:avis, question_label: "my question ", dossier: dossiers.en_construction, experts_procedure: experts_procedures.default, claimant: instructeurs.default)
+      expect(created_avis.question_label).to eq("my question")
     end
   end
 
   describe 'normalization' do
     it 'removes non-printable characters from answer (ASCII control character "End of Transmission Block), seen in pdf' do
-      avis = build(:avis, answer: "Valid\x17Answer")
-      avis.validate
-      expect(avis.answer).to eq("ValidAnswer")
+      built_avis = build(:avis, answer: "Valid\x17Answer", dossier: dossiers.en_construction, experts_procedure: experts_procedures.default)
+      built_avis.validate
+      expect(built_avis.answer).to eq("ValidAnswer")
     end
   end
 end

--- a/spec/models/columns/linked_drop_down_column_spec.rb
+++ b/spec/models/columns/linked_drop_down_column_spec.rb
@@ -7,7 +7,7 @@ describe Columns::LinkedDropDownColumn do
     let(:kept_dossier) { create(:dossier, procedure: procedure) }
     let(:discarded_dossier) { create(:dossier, procedure: procedure) }
 
-    subject { column.filtered_ids(Dossier.all, { operator: 'match', value: search_terms }) }
+    subject { column.filtered_ids(procedure.dossiers, { operator: 'match', value: search_terms }) }
 
     context "when search_terms is an empty string" do
       let(:column) { procedure.find_column(label: 'linked') }
@@ -26,7 +26,7 @@ describe Columns::LinkedDropDownColumn do
 
     context "when filter value is missing" do
       let(:column) { procedure.find_column(label: 'linked') }
-      subject { column.filtered_ids(Dossier.all, { operator: 'match' }) }
+      subject { column.filtered_ids(procedure.dossiers, { operator: 'match' }) }
       before { kept_dossier; discarded_dossier }
 
       it { is_expected.to match_array([kept_dossier.id, discarded_dossier.id]) }

--- a/spec/models/commentaire_groupe_gestionnaire_spec.rb
+++ b/spec/models/commentaire_groupe_gestionnaire_spec.rb
@@ -13,7 +13,7 @@ describe CommentaireGroupeGestionnaire, type: :model do
     let(:commentaire_groupe_gestionnaire) { create :commentaire_groupe_gestionnaire, sender: sender, gestionnaire: gestionnaire }
 
     context 'when created by an administrateur' do
-      let(:sender) { administrateurs(:default_admin) }
+      let(:sender) { administrateurs.default }
       let(:gestionnaire) { nil }
       it 'set correctly sender_email and gestionnaire_email' do
         expect(commentaire_groupe_gestionnaire.sender_email).to eq(sender.email)
@@ -22,7 +22,7 @@ describe CommentaireGroupeGestionnaire, type: :model do
     end
 
     context 'when answer by a gestionnaire' do
-      let(:sender) { administrateurs(:default_admin) }
+      let(:sender) { administrateurs.default }
       let(:gestionnaire) { create(:gestionnaire) }
 
       it 'set correctly sender_email and gestionnaire_email' do
@@ -38,7 +38,7 @@ describe CommentaireGroupeGestionnaire, type: :model do
     let(:commentaire_groupe_gestionnaire) { build :commentaire_groupe_gestionnaire, sender: sender, gestionnaire: gestionnaire }
 
     context 'with a commentaire_groupe_gestionnaire created by an administrateur deleted by administrateur' do
-      let(:sender) { administrateurs(:default_admin) }
+      let(:sender) { administrateurs.default }
       let(:user) { sender }
       let(:gestionnaire) { nil }
 
@@ -46,7 +46,7 @@ describe CommentaireGroupeGestionnaire, type: :model do
     end
 
     context 'with a commentaire_groupe_gestionnaire created by an administrateur deleted by gestionnaire' do
-      let(:sender) { administrateurs(:default_admin) }
+      let(:sender) { administrateurs.default }
       let(:user) { create(:gestionnaire) }
       let(:gestionnaire) { nil }
 
@@ -63,7 +63,7 @@ describe CommentaireGroupeGestionnaire, type: :model do
 
     context 'with a commentaire_groupe_gestionnaire created by an gestionnaire deleted by administrateur' do
       let(:sender) { create(:gestionnaire) }
-      let(:user) { administrateurs(:default_admin) }
+      let(:user) { administrateurs.default }
       let(:gestionnaire) { sender }
 
       it { is_expected.to be_falsy }
@@ -76,14 +76,14 @@ describe CommentaireGroupeGestionnaire, type: :model do
     let(:commentaire_groupe_gestionnaire) { build :commentaire_groupe_gestionnaire, sender: sender }
 
     context 'with a commentaire_groupe_gestionnaire created by an administrateur so sent by administrateur' do
-      let(:sender) { administrateurs(:default_admin) }
+      let(:sender) { administrateurs.default }
       let(:user) { sender }
 
       it { is_expected.to be_truthy }
     end
 
     context 'with a commentaire_groupe_gestionnaire created by an administrateur so not sent by gestionnaire' do
-      let(:sender) { administrateurs(:default_admin) }
+      let(:sender) { administrateurs.default }
       let(:user) { create(:gestionnaire) }
 
       it { is_expected.to be_falsy }
@@ -98,7 +98,7 @@ describe CommentaireGroupeGestionnaire, type: :model do
 
     context 'with a commentaire_groupe_gestionnaire created by an gestionnaire so not sent by administrateur' do
       let(:sender) { create(:gestionnaire) }
-      let(:user) { administrateurs(:default_admin) }
+      let(:user) { administrateurs.default }
 
       it { is_expected.to be_falsy }
     end

--- a/spec/models/concerns/initiation_procedure_concern_spec.rb
+++ b/spec/models/concerns/initiation_procedure_concern_spec.rb
@@ -2,7 +2,7 @@
 
 describe InitiationProcedureConcern do
   describe '.create_initiation_procedure' do
-    let(:administrateur) { administrateurs(:default_admin) }
+    let(:administrateur) { administrateurs.default }
     subject { Procedure.create_initiation_procedure(administrateur) }
 
     it "returns a new procedure" do

--- a/spec/models/dossier_notification_spec.rb
+++ b/spec/models/dossier_notification_spec.rb
@@ -222,6 +222,8 @@ RSpec.describe DossierNotification, type: :model do
     let(:instructeur) { create(:instructeur) }
 
     context "when notification_type is dossier_depose" do
+      empty_seeds Dossier
+
       let(:notification_type) { :dossier_depose }
       let!(:dossier_to_notify) { create(:dossier, state: :en_construction, follows: []) }
       let!(:dossier_not_to_notify_1) { create(:dossier, :en_construction) }

--- a/spec/models/dossier_pending_response_spec.rb
+++ b/spec/models/dossier_pending_response_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe DossierPendingResponse, :oaken do
+describe DossierPendingResponse do
   before_all { seed "cases/messagerie" }
 
   let(:dossier) { dossiers.en_construction }

--- a/spec/models/dossier_pending_response_spec.rb
+++ b/spec/models/dossier_pending_response_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe DossierPendingResponse, :oaken do
-  before { seed "cases/messagerie" }
+  before_all { seed "cases/messagerie" }
 
   let(:dossier) { dossiers.en_construction }
   let(:instructeur) { instructeurs.default }

--- a/spec/models/dossier_pending_response_spec.rb
+++ b/spec/models/dossier_pending_response_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-describe DossierPendingResponse do
-  let(:dossier) { create(:dossier, :en_construction) }
-  let(:instructeur) { create(:instructeur) }
-  let(:commentaire) { create(:commentaire, dossier: dossier, instructeur: instructeur) }
+describe DossierPendingResponse, :oaken do
+  before { seed "cases/messagerie" }
+
+  let(:dossier) { dossiers.en_construction }
+  let(:instructeur) { instructeurs.default }
+  let(:commentaire) { commentaires.from_instructeur }
 
   describe '#pending?' do
     context 'when responded_at is nil' do

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -354,14 +354,14 @@ describe Dossier, :oaken, type: :model do
   describe "#extend_conservation" do
     subject { dossier.extend_conservation(1.month) }
 
-    let(:dossier) { create(:dossier, :en_construction) }
+    let(:dossier) { dossiers.en_construction }
 
     context "when the dossier has a dossier_expirant notification" do
       let!(:notification_expirant) { create(:dossier_notification, dossier:, notification_type: :dossier_expirant) }
 
       it "destroys dossier_expirant notification" do
         subject
-        expect(DossierNotification.count).to eq(0)
+        expect(DossierNotification.where(dossier:).count).to eq(0)
       end
     end
   end
@@ -369,17 +369,17 @@ describe Dossier, :oaken, type: :model do
   describe "#restore" do
     subject { dossier.restore(author) }
 
-    let(:dossier) { create(:dossier, :en_construction, :with_individual, hidden_by_administration_at: 1.hour.ago) }
+    let(:dossier) { dossiers.en_construction.tap { it.update_columns(hidden_by_administration_at: 1.hour.ago) } }
 
     context "when an instructeur restore the dossier" do
-      let(:author) { create(:instructeur) }
+      let(:author) { instructeurs.default }
 
       context "when there is a dossier_suppression notification" do
         let!(:notification_suppression) { create(:dossier_notification, dossier:, notification_type: :dossier_suppression) }
 
         it "destroys the notification" do
           subject
-          expect(DossierNotification.count).to eq(0)
+          expect(DossierNotification.where(dossier:).count).to eq(0)
         end
       end
     end
@@ -577,8 +577,8 @@ describe Dossier, :oaken, type: :model do
     end
 
     describe '#last_booked_rdv' do
-      let(:dossier) { create(:dossier) }
-      let(:instructeur) { create(:instructeur) }
+      let(:dossier) { dossiers.brouillon }
+      let(:instructeur) { instructeurs.default }
 
       context 'when there are no booked RDVs' do
         it 'returns nil' do
@@ -599,13 +599,12 @@ describe Dossier, :oaken, type: :model do
   end
 
   context 'when dossier is followed' do
-    let(:procedure) { create(:procedure, :with_type_de_champ, :with_type_de_champ_private) }
-    let(:instructeur) { create(:instructeur) }
+    let(:instructeur) { instructeurs.default }
     let(:date1) { 1.day.ago }
     let(:date2) { 1.hour.ago }
     let(:date3) { 1.minute.ago }
     let(:dossier) do
-      d = create(:dossier, :with_entreprise, user: user, procedure: procedure)
+      d = dossiers.brouillon
       travel_to(date1)
       d.passer_en_construction!
       travel_to(date2)
@@ -649,13 +648,15 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '#avis_for' do
-    let_it_be(:instructeur) { create(:instructeur) }
-    let_it_be(:expert_1) { create(:expert) }
+    before_all { seed "cases/avis" }
+
+    let(:instructeur) { instructeurs.default }
+    let(:expert_1) { experts.default }
+    let(:procedure) { procedures.individual }
+    let(:dossier) { dossiers.en_construction }
+    let(:experts_procedure) { experts_procedures.default }
     let_it_be(:expert_2) { create(:expert) }
-    let_it_be(:procedure) { create(:procedure, :published, instructeurs: [instructeur]) }
-    let_it_be(:dossier) { create(:dossier, procedure:, state: Dossier.states.fetch(:en_construction)) }
-    let_it_be(:experts_procedure) { create(:experts_procedure, expert: expert_1, procedure:) }
-    let_it_be(:experts_procedure_2) { create(:experts_procedure, expert: expert_2, procedure:) }
+    let_it_be(:experts_procedure_2) { create(:experts_procedure, expert: expert_2, procedure: procedures.individual) }
 
     context 'when there is a public advice asked from the dossiers instructeur' do
       let!(:avis) { create(:avis, dossier: dossier, claimant: instructeur, experts_procedure: experts_procedure, confidentiel: false) }
@@ -724,16 +725,16 @@ describe Dossier, :oaken, type: :model do
     end
 
     context 'when they are a advice published on another dossier' do
-      let!(:avis) { create(:avis, dossier: create(:dossier, procedure: procedure), claimant: instructeur, experts_procedure: experts_procedure, confidentiel: false, created_at: Time.zone.parse('9/01/2010')) }
+      let!(:avis) { create(:avis, dossier: dossiers.brouillon, claimant: instructeur, experts_procedure: experts_procedure, confidentiel: false, created_at: Time.zone.parse('9/01/2010')) }
 
       it { expect(dossier.avis_for_expert(expert_1)).to match([]) }
     end
   end
 
   describe '#update_state_dates' do
-    let(:dossier) { create(:dossier, :brouillon, :with_individual) }
+    let(:dossier) { dossiers.brouillon }
     let(:beginning_of_day) { Time.zone.now.beginning_of_day }
-    let(:instructeur) { create(:instructeur) }
+    let(:instructeur) { instructeurs.default }
 
     before { travel_to(beginning_of_day) }
 
@@ -804,8 +805,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     context 'when dossier is en_instruction' do
-      let(:dossier) { create(:dossier, :en_construction, :with_individual) }
-      let(:instructeur) { create(:instructeur) }
+      let(:dossier) { dossiers.en_construction }
 
       before do
         dossier.passer_en_instruction!(instructeur: instructeur)
@@ -834,7 +834,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     context 'when dossier is accepte' do
-      let(:dossier) { create(:dossier, :en_instruction, :with_individual) }
+      let(:dossier) { dossiers.en_instruction }
 
       before do
         dossier.accepter!(instructeur: instructeur)
@@ -851,7 +851,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     context 'when dossier is refuse' do
-      let(:dossier) { create(:dossier, :en_instruction, :with_individual) }
+      let(:dossier) { dossiers.en_instruction }
 
       before do
         dossier.refuser!(instructeur: instructeur)
@@ -868,7 +868,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     context 'when dossier is sans_suite' do
-      let(:dossier) { create(:dossier, :en_instruction, :with_individual) }
+      let(:dossier) { dossiers.en_instruction }
 
       before do
         dossier.classer_sans_suite!(instructeur: instructeur)
@@ -886,11 +886,11 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '.with_unread_messages_for_user' do
-    let(:dossier_with_unread_instructeur) { create(:dossier, :en_construction) }
-    let(:dossier_with_read_instructeur) { create(:dossier, :en_construction) }
-    let(:dossier_with_unread_expert) { create(:dossier, :en_construction) }
-    let(:dossier_with_only_usager_message) { create(:dossier, :en_construction) }
-    let(:dossier_with_discarded_unread) { create(:dossier, :en_construction) }
+    let(:dossier_with_unread_instructeur) { create(:dossier, :en_construction, procedure: procedures.individual) }
+    let(:dossier_with_read_instructeur) { create(:dossier, :en_construction, procedure: procedures.individual) }
+    let(:dossier_with_unread_expert) { create(:dossier, :en_construction, procedure: procedures.individual) }
+    let(:dossier_with_only_usager_message) { create(:dossier, :en_construction, procedure: procedures.individual) }
+    let(:dossier_with_discarded_unread) { create(:dossier, :en_construction, procedure: procedures.individual) }
 
     before do
       create(:commentaire, dossier: dossier_with_unread_instructeur, instructeur: create(:instructeur), seen_by_recipient_at: nil)
@@ -1052,11 +1052,11 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe "#unfollow_stale_instructeurs" do
-    let(:procedure) { create(:procedure, :published, :for_individual) }
+    let(:procedure) { procedures.individual }
     let(:instructeur) { create(:instructeur) }
     let(:new_groupe_instructeur) { create(:groupe_instructeur, procedure: procedure) }
     let(:instructeur2) { create(:instructeur, groupe_instructeurs: [procedure.defaut_groupe_instructeur, new_groupe_instructeur]) }
-    let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure: procedure) }
+    let(:dossier) { dossiers.en_construction }
     let(:last_operation) { DossierOperationLog.last }
 
     before do
@@ -1091,9 +1091,8 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe "#send_dossier_received" do
-    let(:procedure) { create(:procedure) }
-    let(:dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction)) }
-    let(:instructeur) { create(:instructeur) }
+    let(:dossier) { dossiers.en_construction }
+    let(:instructeur) { instructeurs.default }
 
     before do
       allow(NotificationMailer).to receive(:send_en_instruction_notification).and_return(double(deliver_later: nil))
@@ -1208,7 +1207,7 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe 'updated_at' do
-    let!(:dossier) { create(:dossier) }
+    let!(:dossier) { dossiers.en_construction }
     let(:modif_date) { Time.zone.parse('01/01/2100') }
 
     before { travel_to(modif_date) }
@@ -1227,13 +1226,13 @@ describe Dossier, :oaken, type: :model do
     end
 
     context 'when a commentaire is modified' do
-      before { dossier.commentaires << create(:commentaire) }
+      before { create(:commentaire, dossier:) }
 
       it { is_expected.to eq(modif_date) }
     end
 
     context 'when an avis is modified' do
-      before { dossier.avis << create(:avis) }
+      before { create(:avis, dossier:) }
 
       it { is_expected.to eq(modif_date) }
     end
@@ -1256,15 +1255,14 @@ describe Dossier, :oaken, type: :model do
     end
 
     context 'when there is an individual' do
-      let(:procedure) { create(:procedure, :for_individual) }
-      let(:dossier) { create(:dossier, :with_individual, procedure: procedure) }
+      let(:dossier) { dossiers.brouillon }
 
       it { is_expected.to eq("#{dossier.individual.nom} #{dossier.individual.prenom}") }
     end
   end
 
   describe "#hide_and_keep_track!" do
-    let(:dossier) { create(:dossier, :en_construction) }
+    let(:dossier) { dossiers.en_construction }
     let(:user) { dossier.user }
     let(:last_operation) { dossier.dossier_operation_logs.last }
     let(:reason) { :user_request }
@@ -1276,7 +1274,7 @@ describe Dossier, :oaken, type: :model do
     subject! { dossier.hide_and_keep_track!(user, reason) }
 
     context 'brouillon' do
-      let(:dossier) { create(:dossier) }
+      let(:dossier) { dossiers.brouillon }
 
       it 'hide the dossier' do
         expect(dossier.reload.hidden_by_user_at).to be_present
@@ -1307,7 +1305,7 @@ describe Dossier, :oaken, type: :model do
       end
 
       context 'when dossier is brouillon' do
-        let(:dossier) { create(:dossier) }
+        let(:dossier) { dossiers.brouillon }
         it 'do not notifies the procedure administrateur' do
           expect(DossierMailer).not_to have_received(:notify_en_construction_deletion_to_administration)
         end
@@ -1326,10 +1324,9 @@ describe Dossier, :oaken, type: :model do
       end
 
       context 'notifications to administration (en_construction)' do
-        let(:procedure) { create(:procedure) }
-        let(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur]) }
-        let(:dossier) { create(:dossier, :en_construction, groupe_instructeur:, procedure:) }
-        let(:instructeur) { create(:instructeur) }
+        let(:procedure) { procedures.individual }
+        let(:dossier) { dossiers.en_construction }
+        let(:instructeur) { create(:instructeur, groupe_instructeurs: [procedure.defaut_groupe_instructeur]) }
 
         context 'when the instructeur is not follower' do
           let!(:ip) { create(:instructeurs_procedure, instructeur:, procedure:, instant_email_dossier_deletion: true) }
@@ -1372,7 +1369,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     context 'termine' do
-      let(:dossier) { create(:dossier, state: "accepte", hidden_by_administration_at: 1.hour.ago) }
+      let(:dossier) { dossiers.accepte.tap { it.update_columns(hidden_by_administration_at: 1.hour.ago) } }
       before { subject }
 
       it 'affect the right deletion reason to the dossier' do
@@ -1380,27 +1377,26 @@ describe Dossier, :oaken, type: :model do
       end
 
       context "when the instructeur hide the dossier" do
-        let(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [create(:instructeur)]) }
         let(:user) { create(:instructeur) }
         let(:reason) { :instructeur_request }
 
         context "when the dossier is already hidden by user" do
-          let(:dossier) { create(:dossier, state: "accepte", groupe_instructeur:, hidden_by_user_at: Time.zone.yesterday) }
+          let(:dossier) { dossiers.accepte.tap { it.update_columns(hidden_by_user_at: Time.zone.yesterday) } }
 
           it "creates dossier_suppression notification with correct delay" do
             subject
-            expect(DossierNotification.count).to eq(1)
+            notifications = DossierNotification.where(dossier:)
+            expect(notifications.count).to eq(1)
 
-            notification = DossierNotification.last
-            expect(notification.dossier_id).to eq(dossier.id)
-            expect(notification.instructeur_id).to eq(groupe_instructeur.instructeur_ids.first)
+            notification = notifications.first
+            expect(notification.instructeur_id).to eq(dossier.groupe_instructeur.instructeur_ids.first)
             expect(notification.notification_type).to eq("dossier_suppression")
             expect(notification.display_at.to_date).to eq(Time.zone.now.to_date)
           end
         end
 
         context "when the dossier is not hidden by user" do
-          let(:dossier) { create(:dossier, state: "accepte", groupe_instructeur:) }
+          let(:dossier) { dossiers.accepte }
 
           it "does not create dossier_suppression notification" do
             expect { subject }.not_to change { DossierNotification.count }
@@ -1409,25 +1405,23 @@ describe Dossier, :oaken, type: :model do
       end
 
       context "when the user hide the dossier" do
-        let(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [create(:instructeur)]) }
-
         context "when the dossier is already hidden by administration" do
-          let(:dossier) { create(:dossier, state: "accepte", groupe_instructeur:, hidden_by_administration_at: Time.zone.yesterday) }
+          let(:dossier) { dossiers.accepte.tap { it.update_columns(hidden_by_administration_at: Time.zone.yesterday) } }
 
           it "creates dossier_suppression notification with correct delay" do
             subject
-            expect(DossierNotification.count).to eq(1)
+            notifications = DossierNotification.where(dossier:)
+            expect(notifications.count).to eq(1)
 
-            notification = DossierNotification.last
-            expect(notification.dossier_id).to eq(dossier.id)
-            expect(notification.instructeur_id).to eq(groupe_instructeur.instructeur_ids.first)
+            notification = notifications.first
+            expect(notification.instructeur_id).to eq(dossier.groupe_instructeur.instructeur_ids.first)
             expect(notification.notification_type).to eq("dossier_suppression")
             expect(notification.display_at.to_date).to eq(Time.zone.now.to_date)
           end
         end
 
         context "when the dossier is not hidden by administration" do
-          let(:dossier) { create(:dossier, state: "accepte", groupe_instructeur:) }
+          let(:dossier) { dossiers.accepte }
 
           it "does not create dossier_suppression notification" do
             expect { subject }.not_to change { DossierNotification.count }
@@ -1438,8 +1432,8 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe 'webhook' do
-    let(:dossier) { create(:dossier) }
-    let(:instructeur) { create(:instructeur) }
+    let(:dossier) { dossiers.brouillon }
+    let(:instructeur) { instructeurs.default }
 
     it 'should not call webhook' do
       expect {
@@ -1485,50 +1479,46 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe "#can_transition_to_en_construction?" do
-    let(:procedure) { create(:procedure, :published) }
-    let(:dossier) { create(:dossier, state: state, procedure: procedure) }
-
     subject { dossier.can_transition_to_en_construction? }
 
     context "dossier state is brouillon" do
-      let(:state) { Dossier.states.fetch(:brouillon) }
+      let(:dossier) { dossiers.brouillon }
       it { is_expected.to be true }
 
       context "procedure is closed" do
-        before { procedure.close! }
+        before { dossier.procedure.close! }
         it { is_expected.to be false }
       end
     end
 
     context "dossier state is en_construction" do
-      let(:state) { Dossier.states.fetch(:en_construction) }
+      let(:dossier) { dossiers.en_construction }
       it { is_expected.to be false }
     end
 
     context "dossier state is en_instruction" do
-      let(:state) { Dossier.states.fetch(:en_instruction) }
+      let(:dossier) { dossiers.en_instruction }
       it { is_expected.to be false }
     end
 
-    context "dossier state is en_instruction" do
-      let(:state) { Dossier.states.fetch(:accepte) }
+    context "dossier state is accepte" do
+      let(:dossier) { dossiers.accepte }
       it { is_expected.to be false }
     end
 
-    context "dossier state is en_instruction" do
-      let(:state) { Dossier.states.fetch(:refuse) }
+    context "dossier state is refuse" do
+      let(:dossier) { dossiers.refuse }
       it { is_expected.to be false }
     end
 
-    context "dossier state is en_instruction" do
-      let(:state) { Dossier.states.fetch(:sans_suite) }
+    context "dossier state is sans_suite" do
+      let(:dossier) { create(:dossier, state: Dossier.states.fetch(:sans_suite), procedure: procedures.individual) }
       it { is_expected.to be false }
     end
   end
 
   describe "#messagerie_available?" do
-    let(:procedure) { create(:procedure) }
-    let(:dossier) { create(:dossier, procedure: procedure) }
+    let(:dossier) { dossiers.brouillon }
 
     subject { dossier.messagerie_available? }
 
@@ -2984,7 +2974,7 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe 'update procedure dossiers count' do
-    let(:dossier) { create(:dossier, :brouillon, :with_individual) }
+    let(:dossier) { dossiers.brouillon }
 
     it 'update procedure dossiers count when passing to construction' do
       expect(dossier.procedure).to receive(:compute_dossiers_count)

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Dossier, type: :model do
+describe Dossier, :oaken, type: :model do
   include ActionView::Helpers::SanitizeHelper
 
   let(:user) { create(:user) }
@@ -22,21 +22,29 @@ describe Dossier, type: :model do
 
       subject { Dossier.all }
 
-      it { is_expected.to match_array([dossier]) }
+      it { is_expected.to include(dossier) }
     end
 
     describe '.without_followers' do
       let!(:dossier_with_follower) { create(:dossier, :followed, :with_entreprise, user: user) }
       let!(:dossier_without_follower) { create(:dossier, :with_entreprise, user: user) }
 
-      it { expect(Dossier.without_followers.to_a).to eq([dossier_without_follower]) }
+      it do
+        expect(Dossier.without_followers).to include(dossier_without_follower)
+        expect(Dossier.without_followers).not_to include(dossier_with_follower)
+      end
     end
 
     describe 'brouillons_recently_updated' do
       let!(:dossier_en_brouillon) { create(:dossier) }
       let!(:dossier_en_brouillon_2) { create(:dossier) }
 
-      it { expect(Dossier.brouillons_recently_updated).to eq([dossier_en_brouillon_2, dossier_en_brouillon]) }
+      it 'returns brouillons most recently updated first' do
+        recently_updated = Dossier.brouillons_recently_updated.to_a
+
+        expect(recently_updated).to include(dossier_en_brouillon_2, dossier_en_brouillon)
+        expect(recently_updated.index(dossier_en_brouillon_2)).to be < recently_updated.index(dossier_en_brouillon)
+      end
     end
 
     describe 'by_statut' do
@@ -137,7 +145,14 @@ describe Dossier, type: :model do
       end
 
       it 'returns only visible brouillon dossiers whose expiration notice period has passed' do
-        expect(Dossier.brouillon_expired_after_notice_grace).to contain_exactly(dossier_brouillon_expired_and_noticed_long_time_ago)
+        expect(Dossier.brouillon_expired_after_notice_grace).to include(dossier_brouillon_expired_and_noticed_long_time_ago)
+        expect(Dossier.brouillon_expired_after_notice_grace).not_to include(
+          dossier_brouillon_not_expired,
+          dossier_brouillon_expired_but_noticed_recently,
+          dossier_brouillon_expired_but_not_noticed_yet,
+          dossier_instruction_expired,
+          dossier_hidden
+        )
       end
     end
 
@@ -160,7 +175,9 @@ describe Dossier, type: :model do
 
       it 'returns only expired brouillons structurally outside the notice path' do
         expect(Dossier.brouillon_expired_without_notice)
-          .to contain_exactly(expired_on_closed, expired_on_draft, expired_preview)
+          .to include(expired_on_closed, expired_on_draft, expired_preview)
+        expect(Dossier.brouillon_expired_without_notice)
+          .not_to include(expired_on_published, not_expired_on_closed, hidden_on_closed, en_construction_on_closed)
       end
     end
   end
@@ -1535,11 +1552,11 @@ describe Dossier, type: :model do
   end
 
   describe '#accepter!' do
-    let(:procedure) { create(:procedure, :for_individual, :published) }
-    let(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure:) }
+    let(:procedure) { procedures.individual }
+    let(:dossier) { dossiers.en_instruction }
     let(:last_operation) { dossier.dossier_operation_logs.last }
     let(:operation_serialized) { last_operation.data }
-    let!(:instructeur) { create(:instructeur) }
+    let(:instructeur) { instructeurs.default }
     let!(:now) { Time.zone.parse('01/01/2100') }
     let!(:attestation_template) { create(:attestation_template, procedure:, kind: :acceptation, state: :published) }
 
@@ -1673,10 +1690,10 @@ describe Dossier, type: :model do
   end
 
   describe '#passer_en_instruction!' do
-    let(:dossier) { create(:dossier, :en_construction) }
+    let(:dossier) { dossiers.en_construction }
     let(:last_operation) { dossier.dossier_operation_logs.last }
     let(:operation_serialized) { last_operation.data }
-    let(:instructeur) { create(:instructeur) }
+    let(:instructeur) { instructeurs.default }
     let!(:correction) { create(:dossier_correction, dossier:) } # correction has a commentaire
 
     subject(:passer_en_instruction) { dossier.passer_en_instruction!(instructeur: instructeur) }
@@ -2317,12 +2334,22 @@ describe Dossier, type: :model do
   end
 
   describe '#repasser_en_instruction!' do
-    let(:dossier) { create(:dossier, :refuse, :with_attestation_acceptation, :with_justificatif, archived: true, termine_close_to_expiration_notice_sent_at: Time.zone.now, sva_svr_decision_on: 1.day.ago) }
-    let!(:instructeur) { create(:instructeur) }
+    let(:dossier) { dossiers.refuse }
+    let(:instructeur) { instructeurs.default }
     let(:last_operation) { dossier.dossier_operation_logs.last }
 
     before do
       freeze_time
+      create(:attestation_template, :refus, procedure: dossier.procedure, state: :published)
+      AttestationPdfGenerationJob.perform_now(dossier)
+      expect(dossier.reload.attestation).to be_present
+      dossier.justificatif_motivation.attach(
+        io: StringIO.new('Hello World'),
+        filename: 'hello.txt',
+        # we don't want to run virus scanner on this file
+        metadata: { virus_scan_result: ActiveStorage::VirusScanner::SAFE }
+      )
+      dossier.update!(archived: true, termine_close_to_expiration_notice_sent_at: Time.zone.now, sva_svr_decision_on: 1.day.ago)
       allow(NotificationMailer).to receive(:send_repasser_en_instruction_notification).and_return(double(deliver_later: true))
       dossier.repasser_en_instruction!(instructeur: instructeur)
       dossier.reload
@@ -2483,8 +2510,8 @@ describe Dossier, type: :model do
     end
 
     it do
-      expect(Dossier.en_brouillon_expired_to_delete.count).to eq(2)
-      expect(Dossier.en_construction_expired_to_delete.count).to eq(2)
+      expect(Dossier.en_brouillon_expired_to_delete.where(user:).count).to eq(2)
+      expect(Dossier.en_construction_expired_to_delete.where(user:).count).to eq(2)
     end
   end
 
@@ -2552,14 +2579,16 @@ describe Dossier, type: :model do
     let(:dossiers) { Dossier.with_notifiable_procedure(notify_on_closed: notify_on_closed) }
 
     it 'should find dossiers with notifiable procedure' do
-      expect(dossiers).to match_array([dossier_on_published_procedure, dossier_on_unpublished_procedure])
+      expect(dossiers).to include(dossier_on_published_procedure, dossier_on_unpublished_procedure)
+      expect(dossiers).not_to include(dossier_on_test_procedure, dossier_on_closed_procedure)
     end
 
     context 'when notify on closed is true' do
       let(:notify_on_closed) { true }
 
       it 'should find dossiers with notifiable procedure' do
-        expect(dossiers).to match_array([dossier_on_published_procedure, dossier_on_closed_procedure, dossier_on_unpublished_procedure])
+        expect(dossiers).to include(dossier_on_published_procedure, dossier_on_closed_procedure, dossier_on_unpublished_procedure)
+        expect(dossiers).not_to include(dossier_on_test_procedure)
       end
     end
   end
@@ -2815,35 +2844,32 @@ describe Dossier, type: :model do
 
   describe '#archivable_in_month' do
     let(:dossier_accepte_at) { DateTime.new(2022, 3, 31, 12, 0) }
-    before do
-      travel_to(dossier_accepte_at) do
-        dossier = create(:dossier, :accepte)
-      end
-    end
+    let!(:dossier) { travel_to(dossier_accepte_at) { create(:dossier, :accepte) } }
 
     context 'given a date' do
       let(:archive_date) { Date.new(2022, 3, 1) }
       it 'includes a dossier processed_at at last day of month' do
-        expect(Dossier.archivable_in_month(archive_date).count).to eq(1)
+        expect(Dossier.archivable_in_month(archive_date)).to include(dossier)
       end
     end
 
     context 'given a datetime' do
       let(:archive_date) { DateTime.new(2022, 3, 1, 12, 0) }
       it 'includes a dossier processed_at at last day of month' do
-        expect(Dossier.archivable_in_month(archive_date).count).to eq(1)
+        expect(Dossier.archivable_in_month(archive_date)).to include(dossier)
       end
     end
 
     context 'with a dossier hidden by administration' do
-      before do
+      let!(:hidden_dossier) do
         travel_to(dossier_accepte_at) do
           create(:dossier, :accepte, :hidden_by_administration)
         end
       end
 
       it 'excludes hidden dossiers' do
-        expect(Dossier.archivable_in_month(Date.new(2022, 3, 1)).count).to eq(1)
+        expect(Dossier.archivable_in_month(Date.new(2022, 3, 1))).to include(dossier)
+        expect(Dossier.archivable_in_month(Date.new(2022, 3, 1))).not_to include(hidden_dossier)
       end
     end
   end
@@ -3012,13 +3038,19 @@ describe Dossier, type: :model do
 
     subject { Dossier.never_touched_brouillon_expired }
 
-    it { is_expected.to contain_exactly(dossier) }
+    it do
+      is_expected.to include(dossier)
+      is_expected.not_to include(dossier_2, dossier_with_champ_updated, dossier_en_construction)
+    end
 
     context 'when the dossier has been cloned' do
       let!(:cloned_dossier) { travel_to(3.weeks.ago) { dossier.clone } }
       let!(:cloned_dossier_2) { travel_to(3.weeks.ago) { dossier_with_champ_updated.clone } }
 
-      it { is_expected.to contain_exactly(dossier) }
+      it do
+        is_expected.to include(dossier)
+        is_expected.not_to include(cloned_dossier, cloned_dossier_2)
+      end
     end
 
     context 'when the dossier has an etablissement' do

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -3,7 +3,7 @@
 describe Dossier, :oaken, type: :model do
   include ActionView::Helpers::SanitizeHelper
 
-  before_all { seed "cases/entreprise" }
+  before_all { seed "cases/entreprise", "cases/sva" }
 
   let(:user) { create(:user) }
 
@@ -48,7 +48,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     describe 'by_statut' do
-      let_it_be(:procedure) { create(:procedure) }
+      let_it_be(:procedure) { procedures.brouillon }
       let_it_be(:dossier_en_construction) { create(:dossier, :en_construction, procedure:) }
       let_it_be(:dossier_en_instruction) { create(:dossier, :en_instruction, procedure:) }
       let_it_be(:dossier_accepte) { create(:dossier, :accepte, procedure:) }
@@ -184,7 +184,7 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe 'validations' do
-    let(:procedure) { create(:procedure, :for_individual) }
+    let(:procedure) { procedures.individual }
     subject(:dossier) { create(:dossier, procedure: procedure) }
 
     it 'validates presence of required attributes' do
@@ -935,7 +935,7 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe "#assign_to_groupe_instructeur" do
-    let(:procedure) { create(:procedure) }
+    let(:procedure) { procedures.brouillon }
     let(:new_groupe_instructeur_new_procedure) { create(:groupe_instructeur) }
     let(:new_instructeur) { create(:instructeur) }
     let(:new_groupe_instructeur) { create(:groupe_instructeur, procedure: procedure, instructeurs: [new_instructeur]) }
@@ -952,7 +952,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     context "when the groupe instructeur change" do
-      let(:procedure) { create(:procedure) }
+      let(:procedure) { procedures.brouillon }
       let(:instructeur) { create(:instructeur) }
       let(:new_instructeur) { create(:instructeur) }
       let(:previous_groupe_instructeur) { create(:groupe_instructeur, procedure:, instructeurs: [instructeur]) }
@@ -1012,7 +1012,7 @@ describe Dossier, :oaken, type: :model do
         let(:new_groupe_instructeur) { create(:groupe_instructeur, procedure:, instructeurs: [new_instructeur]) }
 
         context "when notification is dossier_expirant" do
-          let(:procedure) { create(:procedure) }
+          let(:procedure) { procedures.brouillon }
           let(:dossier) { create(:dossier, :accepte, procedure:) }
           before { dossier.update(expired_at: 1.week.from_now) }
 
@@ -1247,7 +1247,7 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '#owner_name' do
-    let(:procedure) { create(:procedure) }
+    let(:procedure) { procedures.brouillon }
     subject { dossier.owner_name }
 
     context 'when there is no entreprise or individual' do
@@ -1627,7 +1627,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     context 'as sva procedure' do
-      let_it_be(:procedure) { create(:procedure, :for_individual, :published, :sva) }
+      let(:procedure) { procedures.sva }
       let(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure:, sva_svr_decision_on: Date.current, en_instruction_at: DateTime.new(2021, 5, 1, 12)) }
       let!(:attestation_template) { create(:attestation_template, procedure:, kind: :acceptation, state: :published) }
 
@@ -1650,7 +1650,7 @@ describe Dossier, :oaken, type: :model do
   describe '#refuser_automatiquement' do
     context 'as svr procedure' do
       let(:last_operation) { dossier.dossier_operation_logs.last }
-      let_it_be(:procedure) { create(:procedure, :for_individual, :published, :svr) }
+      let(:procedure) { procedures.svr }
       let(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure:, sva_svr_decision_on: Date.current, en_instruction_at: DateTime.new(2021, 5, 1, 12)) }
 
       before {
@@ -1748,7 +1748,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     context "via procedure sva" do
-      let_it_be(:procedure) { create(:procedure, :sva, :published, :for_individual) }
+      let(:procedure) { procedures.sva }
       let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure:, sva_svr_decision_on: 10.days.from_now) }
       let(:sva_svr_decision_on) { SVASVRDecisionDateCalculatorService.new(dossier, procedure).decision_date }
 
@@ -1784,7 +1784,7 @@ describe Dossier, :oaken, type: :model do
     it { expect(dossier.can_repasser_en_construction?).to be_truthy }
 
     context 'when procedure is sva' do
-      let(:dossier) { create(:dossier, :en_instruction, procedure: create(:procedure, :sva)) }
+      let(:dossier) { create(:dossier, :en_instruction, procedure: procedures.sva) }
 
       it { expect(dossier.can_repasser_en_construction?).to be_falsey }
     end
@@ -1871,7 +1871,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     context 'when procedure has sva or svr enabled' do
-      let(:procedure) { create(:procedure, :published, :sva) }
+      let(:procedure) { procedures.sva }
       let(:dossier) { create(:dossier, :en_construction, procedure:) }
 
       it { expect(dossier.can_passer_automatiquement_en_instruction?).to be_truthy }
@@ -2490,7 +2490,7 @@ describe Dossier, :oaken, type: :model do
   describe 'brouillon_expired and en_construction_expired' do
     empty_seeds Dossier
 
-    let(:administrateur) { administrateurs(:default_admin) }
+    let(:administrateur) { administrateurs.default }
     let(:user) { administrateur.user }
     let(:reason) { DeletedDossier.reasons.fetch(:user_request) }
 
@@ -2812,20 +2812,20 @@ describe Dossier, :oaken, type: :model do
     it { expect(dossier.spreadsheet_columns(types_de_champ: [])).to include(["État du dossier", "Brouillon"]) }
 
     context 'procedure sva' do
-      let(:dossier) { build(:dossier, :en_instruction, procedure: create(:procedure, :sva)) }
+      let(:dossier) { build(:dossier, :en_instruction, procedure: procedures.sva) }
 
       it { expect(dossier.spreadsheet_columns(types_de_champ: [])).to include(["Date décision SVA", :sva_svr_decision_on]) }
     end
 
     context 'procedure svr' do
-      let(:dossier) { build(:dossier, :en_instruction, procedure: create(:procedure, :svr)) }
+      let(:dossier) { build(:dossier, :en_instruction, procedure: procedures.svr) }
 
       it { expect(dossier.spreadsheet_columns(types_de_champ: [])).to include(["Date décision SVR", :sva_svr_decision_on]) }
     end
   end
 
   describe '#archivable' do
-    let(:procedure) { create(:procedure, :published) }
+    let(:procedure) { procedures.individual }
 
     it 'includes visible termine dossiers' do
       dossier = create(:dossier, :accepte, procedure:)
@@ -3005,7 +3005,7 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '#update_champs_timestamps' do
-    let(:procedure) { create(:procedure, types_de_champ_public: [{}, { type: :piece_justificative }, { type: :piece_justificative, nature: 'titre_identite' }]) }
+    let_it_be(:procedure) { create(:procedure, types_de_champ_public: [{}, { type: :piece_justificative }, { type: :piece_justificative, nature: 'titre_identite' }]) }
     let(:dossier) { create(:dossier, procedure:, brouillon_close_to_expiration_notice_sent_at: 10.days.ago) }
     let(:changed_champs) { dossier.champ_data.filter(&:text?) }
 
@@ -3092,7 +3092,7 @@ describe Dossier, :oaken, type: :model do
 
   describe "#skip_user_notification_email?" do
     context "when the dossier is brouillon for a declarative procedure" do
-      let(:procedure) { create(:procedure, :published, declarative_with_state: :en_instruction) }
+      let(:procedure) { procedures.individual.tap { it.update!(declarative_with_state: :en_instruction) } }
       let(:dossier) { create(:dossier, :brouillon, procedure:) }
 
       it "allows the email to be sent (bug fix  06/2026)" do

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -20,33 +20,31 @@ describe Dossier, :oaken, type: :model do
 
   describe 'scopes' do
     describe '.default_scope' do
+      empty_seeds Dossier
+
       let!(:dossier) { create(:dossier) }
 
       subject { Dossier.all }
 
-      it { is_expected.to include(dossier) }
+      it { is_expected.to match_array([dossier]) }
     end
 
     describe '.without_followers' do
+      empty_seeds Dossier
+
       let!(:dossier_with_follower) { create(:dossier, :followed, :with_entreprise, user:, procedure: procedures.entreprise) }
       let!(:dossier_without_follower) { create(:dossier, :with_entreprise, user:, procedure: procedures.entreprise) }
 
-      it do
-        expect(Dossier.without_followers).to include(dossier_without_follower)
-        expect(Dossier.without_followers).not_to include(dossier_with_follower)
-      end
+      it { expect(Dossier.without_followers.to_a).to eq([dossier_without_follower]) }
     end
 
     describe 'brouillons_recently_updated' do
+      empty_seeds Dossier
+
       let!(:dossier_en_brouillon) { create(:dossier) }
       let!(:dossier_en_brouillon_2) { create(:dossier) }
 
-      it 'returns brouillons most recently updated first' do
-        recently_updated = Dossier.brouillons_recently_updated.to_a
-
-        expect(recently_updated).to include(dossier_en_brouillon_2, dossier_en_brouillon)
-        expect(recently_updated.index(dossier_en_brouillon_2)).to be < recently_updated.index(dossier_en_brouillon)
-      end
+      it { expect(Dossier.brouillons_recently_updated).to eq([dossier_en_brouillon_2, dossier_en_brouillon]) }
     end
 
     describe 'by_statut' do
@@ -97,12 +95,15 @@ describe Dossier, :oaken, type: :model do
     end
 
     describe '.brouillon_expired_after_notice_grace' do
+      empty_seeds Dossier
+
       let(:interval_between_first_and_second_expiration) { Dossier::MONTHS_AFTER_EXPIRATION.months + Dossier::DAYS_AFTER_EXPIRATION.days }
 
       let!(:dossier_brouillon_expired_and_noticed_long_time_ago) do
         travel_to(5.months.ago) do
           create(:dossier,
             state: :brouillon,
+            procedure: procedures.individual,
             brouillon_close_to_expiration_notice_sent_at: 1.day.ago)
         end
       end
@@ -110,7 +111,8 @@ describe Dossier, :oaken, type: :model do
       let!(:dossier_brouillon_not_expired) do
         travel_to(1.month.ago) do
           create(:dossier,
-            state: :brouillon)
+            state: :brouillon,
+            procedure: procedures.individual)
         end
       end
 
@@ -118,6 +120,7 @@ describe Dossier, :oaken, type: :model do
         travel_to(5.months.ago) do
           create(:dossier,
             state: :brouillon,
+            procedure: procedures.individual,
             brouillon_close_to_expiration_notice_sent_at: (4.months + 20.days).from_now)
         end
       end
@@ -125,7 +128,8 @@ describe Dossier, :oaken, type: :model do
       let!(:dossier_brouillon_expired_but_not_noticed_yet) do
         travel_to(5.months.ago) do
           create(:dossier,
-            state: :brouillon)
+            state: :brouillon,
+            procedure: procedures.individual)
         end
       end
 
@@ -133,6 +137,7 @@ describe Dossier, :oaken, type: :model do
         travel_to(5.months.ago) do
           create(:dossier,
             state: :en_instruction,
+            procedure: procedures.individual,
             brouillon_close_to_expiration_notice_sent_at: 1.day.ago)
         end
       end
@@ -141,27 +146,23 @@ describe Dossier, :oaken, type: :model do
         travel_to(5.months.ago) do
           create(:dossier,
             state: :brouillon,
+            procedure: procedures.individual,
             brouillon_close_to_expiration_notice_sent_at: 1.day.ago,
             hidden_by_user_at: Time.zone.now)
         end
       end
 
       it 'returns only visible brouillon dossiers whose expiration notice period has passed' do
-        expect(Dossier.brouillon_expired_after_notice_grace).to include(dossier_brouillon_expired_and_noticed_long_time_ago)
-        expect(Dossier.brouillon_expired_after_notice_grace).not_to include(
-          dossier_brouillon_not_expired,
-          dossier_brouillon_expired_but_noticed_recently,
-          dossier_brouillon_expired_but_not_noticed_yet,
-          dossier_instruction_expired,
-          dossier_hidden
-        )
+        expect(Dossier.brouillon_expired_after_notice_grace).to contain_exactly(dossier_brouillon_expired_and_noticed_long_time_ago)
       end
     end
 
     describe '.brouillon_expired_without_notice' do
-      let(:published_procedure) { create(:procedure, :published) }
-      let(:closed_procedure)    { create(:procedure, :closed) }
-      let(:draft_procedure)     { create(:procedure, :draft) }
+      empty_seeds Dossier
+
+      let(:published_procedure) { procedures.individual }
+      let_it_be(:closed_procedure) { create(:procedure, :closed) }
+      let_it_be(:draft_procedure)  { create(:procedure, :draft) }
 
       # targets: expired + structurally never notified
       let!(:expired_on_closed) { create(:dossier, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
@@ -177,9 +178,7 @@ describe Dossier, :oaken, type: :model do
 
       it 'returns only expired brouillons structurally outside the notice path' do
         expect(Dossier.brouillon_expired_without_notice)
-          .to include(expired_on_closed, expired_on_draft, expired_preview)
-        expect(Dossier.brouillon_expired_without_notice)
-          .not_to include(expired_on_published, not_expired_on_closed, hidden_on_closed, en_construction_on_closed)
+          .to contain_exactly(expired_on_closed, expired_on_draft, expired_preview)
       end
     end
   end
@@ -402,7 +401,7 @@ describe Dossier, :oaken, type: :model do
       end
 
       context 'when the dossier belongs to a procedure for individuals' do
-        let(:procedure) { create(:procedure, for_individual: true) }
+        let(:procedure) { procedures.individual }
 
         it 'creates a default individual' do
           subject
@@ -435,7 +434,7 @@ describe Dossier, :oaken, type: :model do
       end
 
       context 'when the dossier belongs to a procedure for moral personas' do
-        let(:procedure) { create(:procedure, for_individual: false) }
+        let(:procedure) { procedures.entreprise }
 
         it 'doesn’t create a individual' do
           subject
@@ -445,7 +444,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     describe '#prefill_champs_from_france_connect' do
-      let(:procedure) { create(:procedure, :for_individual, types_de_champ_public: [{ type: :date }]) }
+      let_it_be(:procedure) { create(:procedure, :for_individual, types_de_champ_public: [{ type: :date }]) }
       let(:user) { create(:user, france_connect_informations: [build(:france_connect_information)]) }
       let(:dossier) { create(:dossier, procedure:, user:) }
       let(:tdc) { procedure.active_revision.root_types_de_champ_public.first }
@@ -515,9 +514,8 @@ describe Dossier, :oaken, type: :model do
     end
 
     describe '#update_for_tiers' do
-      let(:procedure) { create(:procedure, :for_individual) }
       let(:individual) { build(:individual, nom: 'Dupont', prenom: 'Jean', gender: Individual::GENDER_MALE, birthdate: Date.new(1980, 1, 1)) }
-      let(:dossier) { create(:dossier, procedure:, user:, individual:) }
+      let(:dossier) { create(:dossier, procedure: procedures.individual, user:, individual:) }
 
       context 'when user is connected via FranceConnect with one identity' do
         let(:user) { create(:user, france_connect_informations: [build(:france_connect_information)]) }
@@ -888,13 +886,13 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '.with_unread_messages_for_user' do
-    let(:dossier_with_unread_instructeur) { create(:dossier, :en_construction, procedure: procedures.individual) }
-    let(:dossier_with_read_instructeur) { create(:dossier, :en_construction, procedure: procedures.individual) }
-    let(:dossier_with_unread_expert) { create(:dossier, :en_construction, procedure: procedures.individual) }
-    let(:dossier_with_only_usager_message) { create(:dossier, :en_construction, procedure: procedures.individual) }
-    let(:dossier_with_discarded_unread) { create(:dossier, :en_construction, procedure: procedures.individual) }
+    let_it_be(:dossier_with_unread_instructeur) { create(:dossier, :en_construction, procedure: procedures.individual) }
+    let_it_be(:dossier_with_read_instructeur) { create(:dossier, :en_construction, procedure: procedures.individual) }
+    let_it_be(:dossier_with_unread_expert) { create(:dossier, :en_construction, procedure: procedures.individual) }
+    let_it_be(:dossier_with_only_usager_message) { create(:dossier, :en_construction, procedure: procedures.individual) }
+    let_it_be(:dossier_with_discarded_unread) { create(:dossier, :en_construction, procedure: procedures.individual) }
 
-    before do
+    before_all do
       create(:commentaire, dossier: dossier_with_unread_instructeur, instructeur: create(:instructeur), seen_by_recipient_at: nil)
       create(:commentaire, dossier: dossier_with_read_instructeur, instructeur: create(:instructeur), seen_by_recipient_at: 1.day.ago)
       create(:commentaire, dossier: dossier_with_unread_expert, expert: create(:expert), seen_by_recipient_at: nil)
@@ -1112,22 +1110,30 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe "#unspecified_attestation_champs" do
-    let(:procedure) { create(:procedure, attestation_acceptation_template:, types_de_champ_public:, types_de_champ_private:) }
-    let(:dossier) { create(:dossier, :en_instruction, procedure:) }
+    def types_de_champ_public
+      [
+        { libelle: "specified champ-in-title" },
+        { libelle: "unspecified champ-in-title" },
+        { libelle: "specified champ-in-body" },
+        { libelle: "unspecified champ-in-body" },
+      ]
+    end
 
-    let(:types_de_champ_public) { [tdc_1, tdc_2, tdc_3, tdc_4] }
-    let(:types_de_champ_private) { [tdc_5, tdc_6, tdc_7, tdc_8] }
+    def types_de_champ_private
+      [
+        { libelle: "specified annotation privée-in-title" },
+        { libelle: "unspecified annotation privée-in-title" },
+        { libelle: "specified annotation privée-in-body" },
+        { libelle: "unspecified annotation privée-in-body" },
+      ]
+    end
 
-    let(:tdc_1) { { libelle: "specified champ-in-title" } }
-    let(:tdc_2) { { libelle: "unspecified champ-in-title" } }
-    let(:tdc_3) { { libelle: "specified champ-in-body" } }
-    let(:tdc_4) { { libelle: "unspecified champ-in-body" } }
-    let(:tdc_5) { { libelle: "specified annotation privée-in-title" } }
-    let(:tdc_6) { { libelle: "unspecified annotation privée-in-title" } }
-    let(:tdc_7) { { libelle: "specified annotation privée-in-body" } }
-    let(:tdc_8) { { libelle: "unspecified annotation privée-in-body" } }
+    let_it_be(:procedure, reload: true) { create(:procedure, types_de_champ_public:, types_de_champ_private:) }
+    let_it_be(:dossier, reload: true) { create(:dossier, :en_instruction, procedure:) }
 
     before do
+      procedure.attestation_acceptation_template = attestation_acceptation_template if attestation_acceptation_template
+
       (dossier.root_champs_public + dossier.root_champs_private)
         .filter { |c| c.libelle.match?(/^specified/) }
         .each { |c| c.update_attribute(:value, "specified") }
@@ -1586,7 +1592,7 @@ describe Dossier, :oaken, type: :model do
   describe '#accepter_automatiquement!' do
     let(:last_operation) { dossier.dossier_operation_logs.last }
     let!(:now) { Time.zone.parse('01/01/2100') }
-    let(:procedure) { create(:procedure, :for_individual, :published) }
+    let(:procedure) { procedures.individual }
     let!(:attestation_template) { create(:attestation_template, procedure:, kind: :acceptation, state: :published) }
 
     before do
@@ -1621,7 +1627,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     context 'as sva procedure' do
-      let(:procedure) { create(:procedure, :for_individual, :published, :sva) }
+      let_it_be(:procedure) { create(:procedure, :for_individual, :published, :sva) }
       let(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure:, sva_svr_decision_on: Date.current, en_instruction_at: DateTime.new(2021, 5, 1, 12)) }
       let!(:attestation_template) { create(:attestation_template, procedure:, kind: :acceptation, state: :published) }
 
@@ -1644,7 +1650,7 @@ describe Dossier, :oaken, type: :model do
   describe '#refuser_automatiquement' do
     context 'as svr procedure' do
       let(:last_operation) { dossier.dossier_operation_logs.last }
-      let(:procedure) { create(:procedure, :for_individual, :published, :svr) }
+      let_it_be(:procedure) { create(:procedure, :for_individual, :published, :svr) }
       let(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure:, sva_svr_decision_on: Date.current, en_instruction_at: DateTime.new(2021, 5, 1, 12)) }
 
       before {
@@ -1722,7 +1728,7 @@ describe Dossier, :oaken, type: :model do
     let(:instructeur) { create(:instructeur) }
 
     context "via procedure declarative en instruction" do
-      let(:dossier) { create(:dossier, :en_construction, :with_declarative_en_instruction) }
+      let(:dossier) { create(:dossier, :en_construction, :with_declarative_en_instruction, procedure: procedures.individual) }
 
       subject do
         dossier.process_declarative!
@@ -1742,7 +1748,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     context "via procedure sva" do
-      let(:procedure) { create(:procedure, :sva, :published, :for_individual) }
+      let_it_be(:procedure) { create(:procedure, :sva, :published, :for_individual) }
       let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure:, sva_svr_decision_on: 10.days.from_now) }
       let(:sva_svr_decision_on) { SVASVRDecisionDateCalculatorService.new(dossier, procedure).decision_date }
 
@@ -2047,10 +2053,9 @@ describe Dossier, :oaken, type: :model do
 
   describe "can't transition to terminer when annotations privees are not valid" do
     let(:instructeur) { create(:instructeur) }
-    let(:procedure) { create(:procedure, types_de_champ_private:) }
+    let_it_be(:procedure) { create(:procedure, types_de_champ_private: [{ type: :text, mandatory: true }]) }
     let(:dossier_incomplete) { create(:dossier, :en_instruction, procedure:) }
     let(:dossier_ok) { create(:dossier, :en_instruction, :with_populated_annotations, procedure:) }
-    let(:types_de_champ_private) { [{ type: :text, mandatory: true }] }
 
     context "when dossier is en_instruction" do
       it "can't accepter" do
@@ -2483,6 +2488,8 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe 'brouillon_expired and en_construction_expired' do
+    empty_seeds Dossier
+
     let(:administrateur) { administrateurs(:default_admin) }
     let(:user) { administrateur.user }
     let(:reason) { DeletedDossier.reasons.fetch(:user_request) }
@@ -2509,8 +2516,8 @@ describe Dossier, :oaken, type: :model do
     end
 
     it do
-      expect(Dossier.en_brouillon_expired_to_delete.where(user:).count).to eq(2)
-      expect(Dossier.en_construction_expired_to_delete.where(user:).count).to eq(2)
+      expect(Dossier.en_brouillon_expired_to_delete.count).to eq(2)
+      expect(Dossier.en_construction_expired_to_delete.count).to eq(2)
     end
   end
 
@@ -2564,6 +2571,8 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe "with_notifiable_procedure" do
+    empty_seeds Dossier
+
     let_it_be(:test_procedure) { create(:procedure) }
     let_it_be(:published_procedure) { create(:procedure, :published) }
     let_it_be(:closed_procedure) { create(:procedure, :closed) }
@@ -2578,16 +2587,14 @@ describe Dossier, :oaken, type: :model do
     let(:dossiers) { Dossier.with_notifiable_procedure(notify_on_closed: notify_on_closed) }
 
     it 'should find dossiers with notifiable procedure' do
-      expect(dossiers).to include(dossier_on_published_procedure, dossier_on_unpublished_procedure)
-      expect(dossiers).not_to include(dossier_on_test_procedure, dossier_on_closed_procedure)
+      expect(dossiers).to match_array([dossier_on_published_procedure, dossier_on_unpublished_procedure])
     end
 
     context 'when notify on closed is true' do
       let(:notify_on_closed) { true }
 
       it 'should find dossiers with notifiable procedure' do
-        expect(dossiers).to include(dossier_on_published_procedure, dossier_on_closed_procedure, dossier_on_unpublished_procedure)
-        expect(dossiers).not_to include(dossier_on_test_procedure)
+        expect(dossiers).to match_array([dossier_on_published_procedure, dossier_on_closed_procedure, dossier_on_unpublished_procedure])
       end
     end
   end
@@ -2874,10 +2881,10 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '#archivable_by_month' do
-    let(:procedure) { create(:procedure, :published, groupe_instructeurs: [groupe_instructeurs]) }
-    let(:groupe_instructeurs) { create(:groupe_instructeur) }
+    let_it_be(:groupe_instructeurs) { create(:groupe_instructeur) }
+    let_it_be(:procedure) { create(:procedure, :published, groupe_instructeurs: [groupe_instructeurs]) }
 
-    before do
+    before_all do
       create_dossier_for_month(procedure, 2021, 3)
       create_dossier_for_month(procedure, 2021, 3)
       create_archived_dossier_for_month(procedure, 2021, 3)

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -3,6 +3,8 @@
 describe Dossier, :oaken, type: :model do
   include ActionView::Helpers::SanitizeHelper
 
+  before_all { seed "cases/entreprise" }
+
   let(:user) { create(:user) }
 
   describe 'has_many preloaded_commentaires' do
@@ -26,8 +28,8 @@ describe Dossier, :oaken, type: :model do
     end
 
     describe '.without_followers' do
-      let!(:dossier_with_follower) { create(:dossier, :followed, :with_entreprise, user: user) }
-      let!(:dossier_without_follower) { create(:dossier, :with_entreprise, user: user) }
+      let!(:dossier_with_follower) { create(:dossier, :followed, :with_entreprise, user:, procedure: procedures.entreprise) }
+      let!(:dossier_without_follower) { create(:dossier, :with_entreprise, user:, procedure: procedures.entreprise) }
 
       it do
         expect(Dossier.without_followers).to include(dossier_without_follower)
@@ -924,12 +926,12 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '.ordered_for_export' do
-    let(:procedure) { create(:procedure) }
+    let(:procedure) { procedures.entreprise }
     let!(:dossier2) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_construction), depose_at: Time.zone.parse('03/01/2010')) }
     let!(:dossier3) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_instruction), depose_at: Time.zone.parse('01/01/2010')) }
     let!(:dossier4) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_instruction), archived: true, depose_at: Time.zone.parse('02/01/2010')) }
 
-    subject { procedure.dossiers.ordered_for_export }
+    subject { procedure.dossiers.where(id: [dossier2, dossier3, dossier4]).ordered_for_export }
 
     it { is_expected.to match([dossier3, dossier4, dossier2]) }
   end
@@ -1249,7 +1251,7 @@ describe Dossier, :oaken, type: :model do
     end
 
     context 'when there is entreprise' do
-      let(:dossier) { create(:dossier, :with_entreprise, procedure: procedure) }
+      let(:dossier) { dossiers.avec_siret }
 
       it { is_expected.to eq(dossier.etablissement.entreprise_raison_sociale) }
     end
@@ -1998,8 +2000,8 @@ describe Dossier, :oaken, type: :model do
     let(:motivation) { 'motivation' }
 
     context "when dossier is en_instruction" do
-      let(:dossier_incomplete) { create(:dossier, :en_instruction, :with_entreprise, as_degraded_mode: true) }
-      let(:dossier_ok) { create(:dossier, :en_instruction, :with_entreprise, as_degraded_mode: false) }
+      let(:dossier_incomplete) { create(:dossier, :en_instruction, :with_entreprise, as_degraded_mode: true, procedure: procedures.entreprise) }
+      let(:dossier_ok) { create(:dossier, :en_instruction, :with_entreprise, as_degraded_mode: false, procedure: procedures.entreprise) }
 
       it "can't accepter" do
         expect(dossier_incomplete.may_accepter?(instructeur:, motivation:)).to be_falsey
@@ -2018,8 +2020,8 @@ describe Dossier, :oaken, type: :model do
     end
 
     context "when dossier is en_construction" do
-      let(:dossier_incomplete) { create(:dossier, :en_construction, :with_entreprise, :with_declarative_accepte, as_degraded_mode: true) }
-      let(:dossier_ok) { create(:dossier, :en_construction, :with_entreprise, :with_declarative_accepte, as_degraded_mode: false) }
+      let(:dossier_incomplete) { create(:dossier, :en_construction, :with_entreprise, :with_declarative_accepte, as_degraded_mode: true, procedure: procedures.entreprise) }
+      let(:dossier_ok) { create(:dossier, :en_construction, :with_entreprise, :with_declarative_accepte, as_degraded_mode: false, procedure: procedures.entreprise) }
 
       it "can't accepter_automatiquement" do
         expect(dossier_incomplete.may_accepter_automatiquement?(instructeur:, motivation:)).to be_falsey
@@ -2420,7 +2422,7 @@ describe Dossier, :oaken, type: :model do
         )
       end
 
-      let(:dossier) { create(:dossier, :with_entreprise) }
+      let(:dossier) { dossiers.avec_siret }
       let(:result) { { lat: etablissement_geo_adresse_lat, lon: etablissement_geo_adresse_lon, zoom: zoom } }
 
       it 'should geolocate' do

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1772,7 +1772,7 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '#can_repasser_en_construction?' do
-    let(:dossier) { create(:dossier, :en_instruction) }
+    let(:dossier) { dossiers.en_instruction }
     it { expect(dossier.can_repasser_en_construction?).to be_truthy }
 
     context 'when procedure is sva' do
@@ -1783,7 +1783,7 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '#can_passer_en_instruction?' do
-    let(:dossier) { create(:dossier, :en_construction) }
+    let(:dossier) { dossiers.en_construction }
 
     it { expect(dossier.can_passer_en_instruction?).to be_truthy }
 
@@ -1812,7 +1812,11 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '#can_passer_automatiquement_en_instruction?' do
-    let(:dossier) { create(:dossier, :en_construction, declarative_triggered_at: declarative_triggered_at) }
+    let(:dossier) do
+      dossiers.en_construction.tap do |d|
+        d.update_columns(declarative_triggered_at:) if declarative_triggered_at
+      end
+    end
     let(:declarative_triggered_at) { nil }
 
     it { expect(dossier.can_passer_automatiquement_en_instruction?).to be_falsey }
@@ -1873,7 +1877,11 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '#can_accepter_automatiquement?' do
-    let(:dossier) { create(:dossier, state: initial_state, declarative_triggered_at: declarative_triggered_at) }
+    let(:dossier) do
+      dossiers.send(initial_state).tap do |d|
+        d.update_columns(declarative_triggered_at:) if declarative_triggered_at
+      end
+    end
     let(:initial_state) { :en_construction }
     let(:declarative_triggered_at) { nil }
 
@@ -1911,7 +1919,7 @@ describe Dossier, :oaken, type: :model do
       end
 
       context 'when dossier has pending correction' do
-        let(:dossier) { create(:dossier, :en_construction) }
+        let(:dossier) { dossiers.en_construction }
         let!(:dossier_correction) { create(:dossier_correction, dossier:) }
 
         it { expect(dossier.can_accepter_automatiquement?).to be_falsey }
@@ -1932,7 +1940,7 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '#can_refuser_automatiquement?' do
-    let(:dossier) { create(:dossier, state: initial_state) }
+    let(:dossier) { dossiers.send(initial_state) }
     let(:initial_state) { :en_instruction }
 
     it { expect(dossier.can_refuser_automatiquement?).to be_falsey }
@@ -1964,7 +1972,7 @@ describe Dossier, :oaken, type: :model do
         end
 
         context 'when dossier has pending correction' do
-          let(:dossier) { create(:dossier, :en_construction) }
+          let(:dossier) { dossiers.en_construction }
           let!(:dossier_correction) { create(:dossier_correction, dossier:) }
 
           it { expect(dossier.can_refuser_automatiquement?).to be_falsey }
@@ -2395,7 +2403,7 @@ describe Dossier, :oaken, type: :model do
     let(:etablissement_geo_adresse_lon) { "-74.0059731" }
 
     let(:result) { { lat: lat, lon: lon, zoom: zoom } }
-    let(:dossier) { create(:dossier) }
+    let(:dossier) { dossiers.brouillon }
 
     it 'should geolocate' do
       expect(dossier.geo_position).to eq(result)
@@ -2462,15 +2470,13 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe 'dossier_operation_log after dossier deletion' do
-    let(:dossier) { create(:dossier) }
+    let(:dossier) { dossiers.brouillon }
     let(:dossier_operation_log) { create(:dossier_operation_log, dossier: dossier) }
 
     it 'should nullify dossier link' do
       expect(dossier_operation_log.dossier).to eq(dossier)
-      expect(DossierOperationLog.count).to eq(1)
-      dossier.destroy
+      expect { dossier.destroy }.not_to change { DossierOperationLog.count }
       expect(dossier_operation_log.reload.dossier).to be_nil
-      expect(DossierOperationLog.count).to eq(1)
     end
   end
 
@@ -2480,22 +2486,23 @@ describe Dossier, :oaken, type: :model do
     let(:reason) { DeletedDossier.reasons.fetch(:user_request) }
 
     before do
-      create(:dossier, user: user)
-      create(:dossier, :en_construction, user: user)
-      create(:dossier, user: user).hide_and_keep_track!(user, reason)
-      create(:dossier, :en_construction, user: user).hide_and_keep_track!(user, reason)
+      create(:dossier, user:, procedure: procedures.individual)
+      create(:dossier, :en_construction, user:, procedure: procedures.individual)
+      create(:dossier, user:, procedure: procedures.individual).hide_and_keep_track!(user, reason)
+      create(:dossier, :en_construction, user:, procedure: procedures.individual).hide_and_keep_track!(user, reason)
 
       travel_to(2.months.ago) do
-        create(:dossier, user: user).hide_and_keep_track!(user, reason)
-        create(:dossier, :en_construction, user: user).hide_and_keep_track!(user, reason)
+        create(:dossier, user:, procedure: procedures.individual).hide_and_keep_track!(user, reason)
+        create(:dossier, :en_construction, user:, procedure: procedures.individual).hide_and_keep_track!(user, reason)
 
-        create(:dossier, user: user).procedure.discard_and_keep_track!(administrateur)
+        # These two procedures get discarded, so they can't share procedures.individual
+        create(:dossier, user:).procedure.discard_and_keep_track!(administrateur)
         create(:dossier, :en_construction, user: user).procedure.discard_and_keep_track!(administrateur)
       end
 
       travel_to(2.weeks.ago) do
-        create(:dossier, user: user).hide_and_keep_track!(user, reason)
-        create(:dossier, :en_construction, user: user).hide_and_keep_track!(user, reason)
+        create(:dossier, user:, procedure: procedures.individual).hide_and_keep_track!(user, reason)
+        create(:dossier, :en_construction, user:, procedure: procedures.individual).hide_and_keep_track!(user, reason)
       end
     end
 
@@ -2734,7 +2741,7 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '#log_api_entreprise_job_exception' do
-    let(:dossier) { create(:dossier) }
+    let(:dossier) { dossiers.brouillon }
 
     context "add execption to the log" do
       before do
@@ -2772,20 +2779,20 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe "#spreadsheet_columns" do
-    let(:dossier) { create(:dossier) }
+    let(:dossier) { dossiers.brouillon }
 
     context 'user france connected' do
-      let(:dossier) { build(:dossier, user: build(:user, france_connect_informations: [build(:france_connect_information)])) }
+      let(:dossier) { build(:dossier, user: build(:user, france_connect_informations: [build(:france_connect_information)]), procedure: procedures.individual) }
       it { expect(dossier.spreadsheet_columns(types_de_champ: [])).to include(["FranceConnect ?", true]) }
     end
 
     context 'user not france connected' do
-      let(:dossier) { build(:dossier) }
+      let(:dossier) { build(:dossier, procedure: procedures.individual) }
       it { expect(dossier.spreadsheet_columns(types_de_champ: [])).to include(["FranceConnect ?", false]) }
     end
 
     context 'for_individual' do
-      let(:dossier) { create(:dossier, procedure: create(:procedure, :for_individual)) }
+      let(:dossier) { dossiers.brouillon }
       it do
         expect(dossier.spreadsheet_columns(types_de_champ: [])).to include(["Dépôt pour un tiers", :for_tiers])
         expect(dossier.spreadsheet_columns(types_de_champ: [])).to include(['Nom du mandataire', :mandataire_last_name])
@@ -2905,7 +2912,7 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe 'BatchOperation' do
-    subject { build(:dossier) }
+    subject { build(:dossier, procedure: procedures.individual) }
     it { is_expected.to belong_to(:batch_operation).optional }
   end
 
@@ -2914,13 +2921,13 @@ describe Dossier, :oaken, type: :model do
 
     context 'when the dossier is prefilled' do
       context 'when the dossier has a user' do
-        let(:dossier) { build(:dossier, :prefilled) }
+        let(:dossier) { build(:dossier, :prefilled, procedure: procedures.individual) }
 
         it { expect(orphan).to be_falsey }
       end
 
       context 'when the dossier does not have a user' do
-        let(:dossier) { build(:dossier, :prefilled, user: nil) }
+        let(:dossier) { build(:dossier, :prefilled, user: nil, procedure: procedures.individual) }
 
         it { expect(orphan).to be_truthy }
       end
@@ -2928,13 +2935,13 @@ describe Dossier, :oaken, type: :model do
 
     context 'when the dossier is not prefilled' do
       context 'when the dossier has a user' do
-        let(:dossier) { build(:dossier) }
+        let(:dossier) { build(:dossier, procedure: procedures.individual) }
 
         it { expect(orphan).to be_falsey }
       end
 
       context 'when the dossier does not have a user' do
-        let(:dossier) { build(:dossier, user: nil) }
+        let(:dossier) { build(:dossier, user: nil, procedure: procedures.individual) }
 
         it { expect(orphan).to be_falsey }
       end
@@ -2945,28 +2952,28 @@ describe Dossier, :oaken, type: :model do
     subject(:owned_by) { dossier.owned_by?(user) }
 
     context 'when the dossier is orphan' do
-      let(:dossier) { build(:dossier, user: nil) }
+      let(:dossier) { build(:dossier, user: nil, procedure: procedures.individual) }
       let(:user) { build(:user) }
 
       it { expect(owned_by).to be_falsey }
     end
 
     context 'when the given user is nil' do
-      let(:dossier) { build(:dossier) }
+      let(:dossier) { build(:dossier, procedure: procedures.individual) }
       let(:user) { nil }
 
       it { expect(owned_by).to be_falsey }
     end
 
     context 'when the dossier has a user and it is not the given user' do
-      let(:dossier) { build(:dossier) }
+      let(:dossier) { build(:dossier, procedure: procedures.individual) }
       let(:user) { build(:user) }
 
       it { expect(owned_by).to be_falsey }
     end
 
     context 'when the dossier has a user and it is the given user' do
-      let(:dossier) { build(:dossier, user: user) }
+      let(:dossier) { build(:dossier, user:, procedure: procedures.individual) }
       let(:user) { build(:user) }
 
       it { expect(owned_by).to be_truthy }
@@ -2983,7 +2990,7 @@ describe Dossier, :oaken, type: :model do
   end
 
   describe '#sva_svr_decision_in_days' do
-    let(:dossier) { create(:dossier, :en_instruction, sva_svr_decision_on: 10.days.from_now) }
+    let(:dossier) { dossiers.en_instruction.tap { it.update_columns(sva_svr_decision_on: 10.days.from_now) } }
 
     it { expect(dossier.sva_svr_decision_in_days).to eq 10 }
   end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Dossier, :oaken, type: :model do
+describe Dossier, type: :model do
   include ActionView::Helpers::SanitizeHelper
 
   before_all { seed "cases/entreprise", "cases/sva" }

--- a/spec/models/experts_procedure_spec.rb
+++ b/spec/models/experts_procedure_spec.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
-RSpec.describe ExpertsProcedure, type: :model do
+RSpec.describe ExpertsProcedure, :oaken, type: :model do
+  before { seed "cases/avis" }
+
   describe '#invited_expert_emails' do
-    let!(:procedure) { create(:procedure, :published) }
-    let(:claimant) { create(:instructeur) }
-    let(:expert) { create(:expert) }
+    let(:procedure) { procedures.individual }
+    let(:claimant) { instructeurs.default }
+    let(:expert) { experts.default }
     let(:expert2) { create(:expert) }
     let(:expert3) { create(:expert) }
-    let(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: procedure) }
+    let(:experts_procedure) { experts_procedures.default }
     let(:experts_procedure2) { create(:experts_procedure, expert: expert2, procedure: procedure) }
     let(:experts_procedure3) { create(:experts_procedure, expert: expert3, procedure: procedure) }
     subject { procedure.experts_procedures }
 
     context 'when there is one dossier' do
-      let!(:dossier) { create(:dossier, procedure: procedure) }
+      let(:dossier) { dossiers.en_construction }
 
       context 'when a procedure has one avis and known instructeur' do
         let!(:avis) { create(:avis, dossier: dossier, claimant: claimant, experts_procedure: experts_procedure) }
@@ -38,8 +40,8 @@ RSpec.describe ExpertsProcedure, type: :model do
     end
 
     context 'when there are two dossiers' do
-      let!(:dossier) { create(:dossier, procedure: procedure) }
-      let!(:dossier2) { create(:dossier, procedure: procedure) }
+      let(:dossier) { dossiers.en_construction }
+      let(:dossier2) { dossiers.en_instruction }
 
       context 'and each one has an avis from 3 different experts' do
         let!(:avis) { create(:avis, dossier: dossier, experts_procedure: experts_procedure) }

--- a/spec/models/experts_procedure_spec.rb
+++ b/spec/models/experts_procedure_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe ExpertsProcedure, :oaken, type: :model do
-  before { seed "cases/avis" }
+  before_all { seed "cases/avis" }
 
   describe '#invited_expert_emails' do
     let(:procedure) { procedures.individual }

--- a/spec/models/experts_procedure_spec.rb
+++ b/spec/models/experts_procedure_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe ExpertsProcedure, :oaken, type: :model do
+RSpec.describe ExpertsProcedure, type: :model do
   before_all { seed "cases/avis" }
 
   describe '#invited_expert_emails' do

--- a/spec/models/gestionnaire_spec.rb
+++ b/spec/models/gestionnaire_spec.rb
@@ -87,18 +87,18 @@ describe Gestionnaire, type: :model do
   describe "#unread_commentaires?" do
     context "over three different groupe_gestionnaire" do
       let(:gestionnaire) { create(:gestionnaire) }
-      let(:administrateur) { administrateurs(:default_admin) }
+      let(:administrateur) { administrateurs.default }
       let(:groupe_gestionnaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
       let!(:commentaire_groupe_gestionnaire) { create(:commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire, sender: administrateur, created_at: 12.hours.ago) }
       let!(:follow_commentaire_groupe_gestionnaire) { create(:follow_commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire, gestionnaire: gestionnaire, sender: administrateur, commentaire_seen_at: Time.zone.now) }
 
       let(:gestionnaire_unread_commentaire_cause_never_seen) { create(:gestionnaire) }
-      let(:administrateur_unread_commentaire_cause_never_seen) { administrateurs(:default_admin) }
+      let(:administrateur_unread_commentaire_cause_never_seen) { administrateurs.default }
       let(:groupe_gestionnaire_unread_commentaire_cause_never_seen) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire_unread_commentaire_cause_never_seen]) }
       let!(:commentaire_groupe_gestionnaire_unread_commentaire_cause_never_seen) { create(:commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire_unread_commentaire_cause_never_seen, sender: administrateur_unread_commentaire_cause_never_seen, created_at: 12.hours.ago) }
 
       let(:gestionnaire_unread_commentaire_cause_seen_at_before_last_commentaire) { create(:gestionnaire) }
-      let(:administrateur_unread_commentaire_cause_seen_at_before_last_commentaire) { administrateurs(:default_admin) }
+      let(:administrateur_unread_commentaire_cause_seen_at_before_last_commentaire) { administrateurs.default }
       let(:groupe_gestionnaire_unread_commentaire_cause_seen_at_before_last_commentaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire_unread_commentaire_cause_seen_at_before_last_commentaire]) }
       let!(:commentaire_groupe_gestionnaire_unread_commentaire_cause_seen_at_before_last_commentaire) { create(:commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire_unread_commentaire_cause_seen_at_before_last_commentaire, sender: administrateur_unread_commentaire_cause_seen_at_before_last_commentaire, created_at: 12.hours.ago) }
       let!(:follow_commentaire_groupe_gestionnaire_unread_commentaire_cause_seen_at_before_last_commentaire) { create(:follow_commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire_unread_commentaire_cause_seen_at_before_last_commentaire, gestionnaire: gestionnaire_unread_commentaire_cause_seen_at_before_last_commentaire, sender: administrateur_unread_commentaire_cause_seen_at_before_last_commentaire, commentaire_seen_at: 1.day.ago) }
@@ -114,7 +114,7 @@ describe Gestionnaire, type: :model do
       let(:gestionnaire) { create(:gestionnaire) }
       let(:gestionnaire_unread_commentaire_cause_never_seen) { create(:gestionnaire) }
       let(:gestionnaire_unread_commentaire_cause_seen_at_before_last_commentaire) { create(:gestionnaire) }
-      let(:administrateur) { administrateurs(:default_admin) }
+      let(:administrateur) { administrateurs.default }
       let(:groupe_gestionnaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire, gestionnaire_unread_commentaire_cause_never_seen, gestionnaire_unread_commentaire_cause_seen_at_before_last_commentaire]) }
       let!(:commentaire_groupe_gestionnaire) { create(:commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire, sender: administrateur, created_at: 12.hours.ago) }
 
@@ -132,7 +132,7 @@ describe Gestionnaire, type: :model do
   describe "#commentaire_seen_at" do
     context "when already seen commentaire" do
       let(:gestionnaire) { create(:gestionnaire) }
-      let(:administrateur) { administrateurs(:default_admin) }
+      let(:administrateur) { administrateurs.default }
       let(:groupe_gestionnaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
       let!(:commentaire_groupe_gestionnaire) { create(:commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire, sender: administrateur, created_at: 12.hours.ago) }
       let!(:follow_commentaire_groupe_gestionnaire) { create(:follow_commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire, gestionnaire: gestionnaire, sender: administrateur, commentaire_seen_at: Time.zone.now) }
@@ -142,7 +142,7 @@ describe Gestionnaire, type: :model do
 
     context "when never seen commentaire" do
       let(:gestionnaire) { create(:gestionnaire) }
-      let(:administrateur) { administrateurs(:default_admin) }
+      let(:administrateur) { administrateurs.default }
       let(:groupe_gestionnaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
       let!(:commentaire_groupe_gestionnaire) { create(:commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire, sender: administrateur, created_at: 12.hours.ago) }
 
@@ -154,7 +154,7 @@ describe Gestionnaire, type: :model do
     context "when already seen commentaire" do
       let(:now) { Time.zone.now.beginning_of_minute }
       let(:gestionnaire) { create(:gestionnaire) }
-      let(:administrateur) { administrateurs(:default_admin) }
+      let(:administrateur) { administrateurs.default }
       let(:groupe_gestionnaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
       let!(:commentaire_groupe_gestionnaire) { create(:commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire, sender: administrateur, created_at: 12.hours.ago) }
       let!(:follow_commentaire_groupe_gestionnaire) { create(:follow_commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire, gestionnaire: gestionnaire, sender: administrateur, commentaire_seen_at: 12.hours.ago) }
@@ -174,7 +174,7 @@ describe Gestionnaire, type: :model do
     context "when never seen commentaire" do
       let(:now) { Time.zone.now.beginning_of_minute }
       let(:gestionnaire) { create(:gestionnaire) }
-      let(:administrateur) { administrateurs(:default_admin) }
+      let(:administrateur) { administrateurs.default }
       let(:groupe_gestionnaire) { create(:groupe_gestionnaire, gestionnaires: [gestionnaire]) }
       let!(:commentaire_groupe_gestionnaire) { create(:commentaire_groupe_gestionnaire, groupe_gestionnaire: groupe_gestionnaire, sender: administrateur, created_at: 12.hours.ago) }
 

--- a/spec/models/groupe_gestionnaire_spec.rb
+++ b/spec/models/groupe_gestionnaire_spec.rb
@@ -25,7 +25,7 @@ describe GroupeGestionnaire, type: :model do
   describe "#add_administrateur" do
     let(:groupe_gestionnaire) { create(:groupe_gestionnaire) }
     let(:gestionnaire) { create(:gestionnaire) }
-    let(:administrateur) { administrateurs(:default_admin) }
+    let(:administrateur) { administrateurs.default }
 
     subject { groupe_gestionnaire.add_administrateur(administrateur) }
 

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -416,7 +416,7 @@ describe Instructeur, type: :model do
     subject { instructeur.can_be_deleted? }
 
     context 'when the instructeur is an administrateur' do
-      let!(:administrateur) { administrateurs(:default_admin) }
+      let!(:administrateur) { administrateurs.default }
       let(:instructeur) { administrateur.instructeur }
 
       it { is_expected.to be false }
@@ -719,7 +719,7 @@ describe Instructeur, type: :model do
     end
 
     context 'when the old instructeur is on on admin list' do
-      let(:administrateur) { administrateurs(:default_admin) }
+      let(:administrateur) { administrateurs.default }
 
       before do
         administrateur.instructeurs << old_instructeur
@@ -732,7 +732,7 @@ describe Instructeur, type: :model do
     end
 
     context 'when both are on the same admin list' do
-      let(:administrateur) { administrateurs(:default_admin) }
+      let(:administrateur) { administrateurs.default }
 
       before do
         administrateur.instructeurs << old_instructeur

--- a/spec/models/procedure_path_spec.rb
+++ b/spec/models/procedure_path_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ProcedurePath, type: :model do
     context 'when it is the only path' do
       it 'prevents destruction' do
         expect { procedure.procedure_paths.first.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
-        expect { procedure.procedure_paths.first.destroy }.not_to change(ProcedurePath, :count).from(1)
+        expect { procedure.procedure_paths.first.destroy }.not_to change { procedure.procedure_paths.count }.from(1)
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe ProcedurePath, type: :model do
       let!(:procedure_path1) { create(:procedure_path, procedure: procedure) }
 
       it 'allows destruction' do
-        expect { procedure_path1.destroy }.to change(ProcedurePath, :count).from(2).to(1)
+        expect { procedure_path1.destroy }.to change { procedure.procedure_paths.count }.from(2).to(1)
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe ProcedurePath, type: :model do
 
       it 'prevents destruction' do
         expect { procedure_path.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
-        expect { procedure_path.destroy }.not_to change(ProcedurePath, :count)
+        expect { procedure_path.destroy }.not_to change { procedure.procedure_paths.count }
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe ProcedurePath, type: :model do
       let!(:procedure_path) { create(:procedure_path, procedure: procedure, path: '123e4567-e89b-12d3-a456-426614174000') }
 
       it 'allows destruction' do
-        expect { procedure.destroy }.to change(ProcedurePath, :count).from(2).to(0)
+        expect { procedure.destroy }.to change { ProcedurePath.where(procedure:).count }.from(2).to(0)
       end
     end
   end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -298,7 +298,10 @@ describe Procedure do
 
     describe 'default_scope' do
       subject { Procedure.all }
-      it { is_expected.to match_array([procedure]) }
+      it 'excludes discarded procedures' do
+        is_expected.to include(procedure)
+        is_expected.not_to include(discarded_procedure)
+      end
     end
   end
 
@@ -1408,7 +1411,6 @@ describe Procedure do
       let(:hidden_at) { nil }
 
       it do
-        expect(Procedure.count).to eq(1)
         expect(Procedure.all).to include(procedure)
       end
     end
@@ -1417,7 +1419,7 @@ describe Procedure do
       let(:hidden_at) { 2.days.ago }
 
       it do
-        expect(Procedure.count).to eq(0)
+        expect(Procedure.all).not_to include(procedure)
         expect { Procedure.find(procedure.id) }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -2,7 +2,7 @@
 
 describe Service, type: :model do
   describe 'validation' do
-    let(:administrateur) { administrateurs(:default_admin) }
+    let(:administrateur) { administrateurs.default }
     let(:params) do
       {
         nom: 'service des jardins',

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -24,6 +24,9 @@ describe Stat, type: :model do
   end
 
   describe '.dossiers_states' do
+    # the metric is a global aggregate: run it against an empty dossiers table
+    empty_seeds Dossier
+
     let(:procedure) { create(:procedure, :published) }
     before do
       create_list(:dossier, 2, :en_construction, depose_at: 10.days.ago, procedure:)

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -2,14 +2,16 @@
 
 describe TypeDeChamp do
   describe 'validation' do
-    context 'type' do
+    context 'type', :oaken do
+      before_all { seed "cases/champs" }
+
       it do
         is_expected.not_to allow_value(nil).for(:type_champ)
         is_expected.not_to allow_value('').for(:type_champ)
       end
 
-      let(:procedure) { create(:procedure, :with_all_champs) }
-      let(:dossier) { create(:dossier, procedure:) }
+      let(:procedure) { procedures.tous_champs }
+      let(:dossier) { dossiers.tous_champs }
 
       it do
         dossier.revision.root_types_de_champ_public.each do |type_de_champ|

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -2,7 +2,7 @@
 
 describe TypeDeChamp do
   describe 'validation' do
-    context 'type', :oaken do
+    context 'type' do
       before_all { seed "cases/champs" }
 
       it do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -125,7 +125,7 @@ describe User, type: :model do
       end
 
       context 'with an administrateur' do
-        let(:admins) { [administrateurs(:default_admin)] }
+        let(:admins) { [administrateurs.default] }
 
         it do
           user = subject
@@ -144,7 +144,7 @@ describe User, type: :model do
       end
 
       context 'with an existing instructeur' do
-        let(:old_admins) { [administrateurs(:default_admin)] }
+        let(:old_admins) { [administrateurs.default] }
         let(:admins) { [create(:administrateur)] }
         let!(:instructeur) { create(:instructeur, email: 'i@mail.com', administrateurs: old_admins) }
 
@@ -277,7 +277,7 @@ describe User, type: :model do
 
   describe 'invite_administrateur!' do
     let(:super_admin) { create(:super_admin) }
-    let(:administrateur) { administrateurs(:default_admin) }
+    let(:administrateur) { administrateurs.default }
     let(:user) { administrateur.user }
 
     let(:mailer_double) { double('mailer', deliver_later: true) }
@@ -345,7 +345,7 @@ describe User, type: :model do
 
   describe '#can_be_deleted?' do
     let(:user) { create(:user) }
-    let(:administrateur) { administrateurs(:default_admin) }
+    let(:administrateur) { administrateurs.default }
     let(:instructeur) { create(:instructeur) }
     let(:expert) { create(:expert) }
 
@@ -464,7 +464,7 @@ describe User, type: :model do
     end
 
     context 'for administrateurs' do
-      let(:user) { build(:user, email: 'admin@exemple.fr', password: password, administrateur: build(:administrateur, user: nil)) }
+      let(:user) { build(:user, email: 'nouvel-admin@exemple.fr', password: password, administrateur: build(:administrateur, user: nil)) }
 
       context 'when the password is too short' do
         let(:password) { 's' * (PASSWORD_MIN_LENGTH - 1) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,14 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+# Required after Rails so test-prof registers its ActiveRecord let_it_be
+# modifiers (reload:, refind:, freeze:).
+require 'test_prof/recipes/rspec/let_it_be'
+
+TestProf::BeforeAll.configure do |config|
+  config.setup_fixtures = true
+end
+
 require 'axe-rspec'
 require 'devise'
 require 'shoulda-matchers'
@@ -61,8 +69,6 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
-
-  config.global_fixtures = :administrateurs, :instructeurs, :users
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/services/administrateur_deletion_service_spec.rb
+++ b/spec/services/administrateur_deletion_service_spec.rb
@@ -2,7 +2,9 @@
 
 describe AdministrateurDeletionService do
   let(:super_admin) { create(:super_admin) }
-  let(:admin) { administrateurs(:default_admin) }
+  # This service destroys the admin and their procedures: use the seeded blank
+  # administrateur, who is guaranteed to own nothing.
+  let(:admin) { administrateurs.blank }
   let(:service) { create(:service, administrateur: admin) }
   let(:other_admin) { create(:administrateur) }
   let(:procedure) { create(:procedure, service: service, administrateurs: [admin, other_admin]) }

--- a/spec/services/crisp/user_data_builder_spec.rb
+++ b/spec/services/crisp/user_data_builder_spec.rb
@@ -3,13 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe Crisp::UserDataBuilder do
-  let(:user) { users(:default_user) }
+  let(:user) { users.usager }
   let(:builder) { described_class.new(user) }
 
   subject(:build) { builder.build_data }
 
   describe '#build_data' do
     context 'without instructeur' do
+      before { user.update!(email_verified_at: nil) }
+
       it 'retourne les liens de base' do
         data = build
 

--- a/spec/services/crisp/webhook_processor_spec.rb
+++ b/spec/services/crisp/webhook_processor_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Crisp::WebhookProcessor do
-  let!(:user) { users(:default_user) }
+  let!(:user) { users.usager }
   let(:event) { "message:send" }
   let(:email) { user.email }
   let(:session_id) { "session_d57cb2d9-4607-42fe-a6be-000001112222" }

--- a/spec/services/expired/expired_dossiers_deletion_service_spec.rb
+++ b/spec/services/expired/expired_dossiers_deletion_service_spec.rb
@@ -110,6 +110,8 @@ describe Expired::DossiersDeletionService do
     subject { service.process_never_touched_dossiers_brouillon }
 
     context 'with never touched brouillon dossiers' do
+      empty_seeds Dossier
+
       let!(:never_touched_brouillon) { travel_to(20.days.ago) { create(:dossier, procedure: procedure, last_champ_updated_at: nil) } }
       let!(:never_touched_brouillon_2) { travel_to(7.days.ago) { create(:dossier, procedure: procedure, last_champ_updated_at: nil) } }
       let!(:never_touched_en_construction) { travel_to(20.days.ago) { create(:dossier, :en_construction, procedure: procedure, last_champ_updated_at: nil) } }

--- a/spec/services/expired/expired_users_deletion_service_spec.rb
+++ b/spec/services/expired/expired_users_deletion_service_spec.rb
@@ -146,12 +146,12 @@ describe Expired::UsersDeletionService do
     end
 
     context 'when user is expired and has an admin' do
-      let(:user) { create(:user, administrateur: administrateurs(:default_admin), current_sign_in_at: signed_in_expired) }
+      let(:user) { create(:user, administrateur: administrateurs.default, current_sign_in_at: signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
 
     context 'when user is expired but have a dossier' do
-      let(:user) { users(:default_user_admin).tap { _1.update(current_sign_in_at: signed_in_expired) } }
+      let(:user) { users.admin.tap { it.update(current_sign_in_at: signed_in_expired) } }
       let(:dossier) { create(:dossier, :brouillon, user:, created_at: signed_in_expired) }
       it { is_expected.not_to include(user) }
     end
@@ -217,7 +217,7 @@ describe Expired::UsersDeletionService do
 
     context 'when user is expired and has an admin' do
       let(:dossier) { create(:dossier, user:, created_at: signed_in_expired) }
-      let(:user) { users(:default_user_admin).tap { _1.update(current_sign_in_at: signed_in_expired) } }
+      let(:user) { users.admin.tap { it.update(current_sign_in_at: signed_in_expired) } }
       it { is_expected.not_to include(user) }
     end
   end

--- a/spec/services/instructeur_procedures_counters_service_spec.rb
+++ b/spec/services/instructeur_procedures_counters_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe InstructeursProceduresCountersService do
-  let(:instructeur) { instructeurs(:default_instructeur_admin) }
+  let(:instructeur) { instructeurs.admin }
 
   describe '#call' do
     subject { described_class.new(instructeur:, procedures: instructeur.procedures.kept).call }

--- a/spec/services/procedure_archive_service_spec.rb
+++ b/spec/services/procedure_archive_service_spec.rb
@@ -5,7 +5,7 @@ describe ProcedureArchiveService do
 
   let(:procedure) { create(:procedure, :published, administrateurs: [administrateur]) }
   let(:instructeur) { create(:instructeur) }
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let(:service) { ProcedureArchiveService.new(procedure) }
   let(:year) { 2020 }
   let(:month) { 3 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,12 +22,6 @@
 #
 require 'simplecov' if ENV["CI"] || ENV["COVERAGE"] # see config in .simplecov file
 
-require 'test_prof/recipes/rspec/let_it_be'
-
-TestProf::BeforeAll.configure do |config|
-  config.setup_fixtures = true
-end
-
 require 'rspec/retry'
 
 SECURE_PASSWORD = '{My-$3cure-p4ssWord}'

--- a/spec/support/oaken.rb
+++ b/spec/support/oaken.rb
@@ -1,34 +1,12 @@
 # frozen_string_literal: true
 
-require 'test_prof/recipes/rspec/before_all'
-
-# Oaken seeds (db/seeds/) are opt-in: tag an example group with :oaken to load
-# the shared seed data once per group (via test-prof's before_all transaction)
-# and access the labeled records (users.usager, procedures.individual,
-# dossiers.en_construction, …). Scenario seeds (db/seeds/cases/) load with
-# `before_all { seed "cases/avis" }`; per-example mutations of seeded records
-# roll back to the group snapshot after each example.
-module OakenSupport
-  # The global fixtures (config.global_fixtures) define `users`, `instructeurs`
-  # and `administrateurs` accessors directly on each example group, shadowing
-  # Oaken's. Prepend to route no-arg calls to Oaken; calls with fixture names
-  # (e.g. `users(:default_user)`) still reach the fixture accessor via super.
-  [:users, :instructeurs, :administrateurs].each do |name|
-    define_method(name) do |*fixture_names|
-      fixture_names.empty? ? Oaken::Seeds.public_send(name) : super(*fixture_names)
-    end
-  end
-end
-
-RSpec.shared_context 'with oaken seeds' do
-  before_all { Oaken.loader.seed :users, :procedures, :dossiers }
-end
-
-RSpec.configure do |config|
-  config.include Oaken.loader.context, :oaken
-  config.prepend OakenSupport, :oaken
-  config.include_context 'with oaken seeds', :oaken
-end
+# Oaken seeds (db/seeds/) replace ActiveRecord fixtures. oaken/rspec_setup
+# replants them (truncate + load users, procedures, dossiers) once per suite
+# and includes the labeled-record accessors (users.usager, procedures.individual,
+# dossiers.en_construction, …) in every example; per-example mutations roll
+# back via transactional fixtures. Scenario seeds (db/seeds/cases/) still load
+# per group with `before_all { seed "cases/avis" }`.
+require 'oaken/rspec_setup'
 
 # Specs asserting on global aggregates or unparameterized scopes (raw SQL over
 # a whole table, `Dossier.some_scope`, `Procedure.all`) can't scope their

--- a/spec/support/oaken.rb
+++ b/spec/support/oaken.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
+require 'test_prof/recipes/rspec/before_all'
+
 # Oaken seeds (db/seeds/) are opt-in: tag an example group with :oaken to load
-# the shared seed data inside the example's transaction and access the labeled
-# records (users.usager, procedures.individual, dossiers.en_construction, …).
+# the shared seed data once per group (via test-prof's before_all transaction)
+# and access the labeled records (users.usager, procedures.individual,
+# dossiers.en_construction, …). Scenario seeds (db/seeds/cases/) load with
+# `before_all { seed "cases/avis" }`; per-example mutations of seeded records
+# roll back to the group snapshot after each example.
 module OakenSupport
   # The global fixtures (config.global_fixtures) define `users`, `instructeurs`
   # and `administrateurs` accessors directly on each example group, shadowing
@@ -15,8 +20,37 @@ module OakenSupport
   end
 end
 
+RSpec.shared_context 'with oaken seeds' do
+  before_all { Oaken.loader.seed :users, :procedures, :dossiers }
+end
+
 RSpec.configure do |config|
   config.include Oaken.loader.context, :oaken
   config.prepend OakenSupport, :oaken
-  config.prepend_before(:each, :oaken) { Oaken.loader.seed :users, :procedures, :dossiers }
+  config.include_context 'with oaken seeds', :oaken
+end
+
+# Specs asserting on global aggregates or unparameterized scopes (raw SQL over
+# a whole table, `Dossier.some_scope`, `Procedure.all`) can't scope their
+# queries to spec-created records. Declare the models whose tables must start
+# empty at the top of the group, before any `let_it_be`:
+#
+#   describe '.dossiers_states' do
+#     empty_seeds Dossier
+#
+# All rows of the given models are destroyed once per group, inside the
+# group's before_all transaction: examples start from an empty table and the
+# seeded world comes back when the group's transaction rolls back. List
+# dependents before their parents (e.g. `empty_seeds Dossier, Procedure` —
+# procedures restrict deletion while dossiers exist). Seed accessors for the
+# wiped models (dossiers.en_construction, …) must not be used in the group.
+module EmptySeeds
+  def empty_seeds(*models)
+    # unscoped: the wipe must also remove rows hidden by default scopes (discarded procedures)
+    before_all { models.each { it.unscoped.destroy_all } } # rubocop:disable DS/Unscoped
+  end
+end
+
+RSpec.configure do |config|
+  config.extend EmptySeeds
 end

--- a/spec/support/oaken.rb
+++ b/spec/support/oaken.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Oaken seeds (db/seeds/) are opt-in: tag an example group with :oaken to load
+# the shared seed data inside the example's transaction and access the labeled
+# records (users.usager, procedures.individual, dossiers.en_construction, …).
+module OakenSupport
+  # The global fixtures (config.global_fixtures) define `users`, `instructeurs`
+  # and `administrateurs` accessors directly on each example group, shadowing
+  # Oaken's. Prepend to route no-arg calls to Oaken; calls with fixture names
+  # (e.g. `users(:default_user)`) still reach the fixture accessor via super.
+  [:users, :instructeurs, :administrateurs].each do |name|
+    define_method(name) do |*fixture_names|
+      fixture_names.empty? ? Oaken::Seeds.public_send(name) : super(*fixture_names)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Oaken.loader.context, :oaken
+  config.prepend OakenSupport, :oaken
+  config.prepend_before(:each, :oaken) { Oaken.loader.seed :users, :procedures, :dossiers }
+end

--- a/spec/system/administrateurs/api_referentiel_spec.rb
+++ b/spec/system/administrateurs/api_referentiel_spec.rb
@@ -196,7 +196,7 @@ describe 'Referentiel API:' do
 
             # check we can create a dossier
             click_on("Déposer le dossier")
-            wait_until { Dossier.en_construction.count == 1 }
+            wait_until { procedure.dossiers.en_construction.count == 1 }
 
             created_dossier = Dossier.last
             # check data is also visible on demande page as an usager
@@ -310,7 +310,7 @@ describe 'Referentiel API:' do
           expect(page).to have_content("GEORGES GIRERD")
 
           click_on("Déposer le dossier")
-          wait_until { Dossier.en_construction.count == 1 }
+          wait_until { procedure.dossiers.en_construction.count == 1 }
 
           created_dossier = Dossier.last
 
@@ -508,7 +508,7 @@ describe 'Referentiel API:' do
 
           # check we can create a dossier
           click_on("Déposer le dossier")
-          wait_until { Dossier.en_construction.count == 1 }
+          wait_until { procedure.dossiers.en_construction.count == 1 }
         end
       end
     end

--- a/spec/system/administrateurs/groupe_instructeur_signature_spec.rb
+++ b/spec/system/administrateurs/groupe_instructeur_signature_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'Groupe instructeur signature upload', js: true do
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let(:procedure) { create(:procedure, administrateur:) }
   let(:groupe_instructeur) { procedure.defaut_groupe_instructeur }
 

--- a/spec/system/administrateurs/procedure_administrateurs_spec.rb
+++ b/spec/system/administrateurs/procedure_administrateurs_spec.rb
@@ -5,7 +5,7 @@ require 'system/administrateurs/procedure_spec_helper'
 describe 'Administrateurs can manage administrateurs', js: true do
   include ProcedureSpecHelper
 
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let(:procedure) { create(:procedure) }
   let(:manager) { false }
   before do

--- a/spec/system/administrateurs/procedure_archive_and_export_spec.rb
+++ b/spec/system/administrateurs/procedure_archive_and_export_spec.rb
@@ -5,7 +5,7 @@ require 'system/administrateurs/procedure_spec_helper'
 describe 'Creating a new procedure', js: true do
   include ProcedureSpecHelper
 
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let(:procedure) do
     create(:procedure, :with_service, :with_instructeur,
       aasm_state: :publiee,

--- a/spec/system/administrateurs/procedure_attestation_template_spec.rb
+++ b/spec/system/administrateurs/procedure_attestation_template_spec.rb
@@ -5,7 +5,7 @@ require 'system/administrateurs/procedure_spec_helper'
 describe 'As an administrateur, I want to manage the procedure’s attestation', js: true do
   include ProcedureSpecHelper
 
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
 
   before do
     login_as(administrateur.user, scope: :user)

--- a/spec/system/administrateurs/procedure_cloning_spec.rb
+++ b/spec/system/administrateurs/procedure_cloning_spec.rb
@@ -5,7 +5,9 @@ require 'system/administrateurs/procedure_spec_helper'
 describe 'As an administrateur I wanna clone a procedure', js: true do
   include ProcedureSpecHelper
 
-  let(:administrateur) { administrateurs(:default_admin) }
+  # procedure counts are asserted per admin: use the seeded blank
+  # administrateur, who is guaranteed to own nothing
+  let(:administrateur) { administrateurs.blank }
 
   before do
     create(:procedure, :with_service, :with_instructeur, :with_zone,
@@ -32,8 +34,10 @@ describe 'As an administrateur I wanna clone a procedure', js: true do
       end
 
       expect(page).to have_content(Procedure.last.libelle)
-      find('.button_to>button').click
-      click_on 'Cloner'
+      # the platform-wide list also shows seeded procedures: scope to our row
+      # (re-found after the detail toggle re-renders it)
+      within(find('tr', text: 'libellé de la procédure')) { find('.button_to>button').click }
+      within(find('tr', text: 'libellé de la procédure')) { click_on 'Cloner' }
       check 'Instructeurs', allow_label_click: true
       click_on 'Cloner la démarche'
       visit admin_procedures_path(statut: "brouillons")

--- a/spec/system/administrateurs/procedure_closing_spec.rb
+++ b/spec/system/administrateurs/procedure_closing_spec.rb
@@ -5,7 +5,7 @@ require 'system/administrateurs/procedure_spec_helper'
 describe 'Closing a procedure', js: true do
   include ProcedureSpecHelper
 
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let!(:procedure) do
     create(:procedure_with_dossiers,
       :published,

--- a/spec/system/administrateurs/procedure_creation_spec.rb
+++ b/spec/system/administrateurs/procedure_creation_spec.rb
@@ -5,7 +5,7 @@ require 'system/administrateurs/procedure_spec_helper'
 describe 'Creating a new procedure', js: true do
   include ProcedureSpecHelper
 
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
 
   before do
     login_as administrateur.user, scope: :user

--- a/spec/system/administrateurs/procedure_groupe_instructeur_spec.rb
+++ b/spec/system/administrateurs/procedure_groupe_instructeur_spec.rb
@@ -5,7 +5,7 @@ require 'system/administrateurs/procedure_spec_helper'
 describe 'Manage procedure instructeurs', js: true do
   include ProcedureSpecHelper
 
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let(:procedure) { create(:procedure) }
   let(:manager) { false }
   before do

--- a/spec/system/administrateurs/procedure_informations_upload_spec.rb
+++ b/spec/system/administrateurs/procedure_informations_upload_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'Administrateurs can upload files on procedure informations', js: true do
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let(:procedure) { create(:procedure, administrateur:) }
 
   before do

--- a/spec/system/administrateurs/procedure_locked_spec.rb
+++ b/spec/system/administrateurs/procedure_locked_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'procedure locked' do
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
 
   before do
     login_as administrateur.user, scope: :user

--- a/spec/system/administrateurs/procedure_publish_spec.rb
+++ b/spec/system/administrateurs/procedure_publish_spec.rb
@@ -5,7 +5,7 @@ require 'system/administrateurs/procedure_spec_helper'
 describe 'Publishing a procedure', js: true do
   include ProcedureSpecHelper
 
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let(:other_administrateur) { create(:administrateur) }
 
   let(:instructeurs) { [administrateur.user.instructeur] }

--- a/spec/system/administrateurs/procedure_update_spec.rb
+++ b/spec/system/administrateurs/procedure_update_spec.rb
@@ -5,7 +5,7 @@ require 'system/administrateurs/procedure_spec_helper'
 describe 'Administrateurs can edit procedures', js: true do
   include ProcedureSpecHelper
 
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let!(:procedure) do
     create(:procedure_with_dossiers,
       :published,

--- a/spec/system/forgery_spec.rb
+++ b/spec/system/forgery_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 describe 'Protecting against request forgeries:', :allow_forgery_protection, :show_exception_pages do
-  let(:user) { users(:default_user) }
-  let(:password) { SECURE_PASSWORD }
+  let(:user) { users.usager }
+  let(:password) { users.default_password }
   let(:assert_text) { "Mes dossiers" }
 
   before do

--- a/spec/system/instructeurs/batch_operation_spec.rb
+++ b/spec/system/instructeurs/batch_operation_spec.rb
@@ -6,7 +6,7 @@ describe 'BatchOperation a dossier:', js: true do
 
   let(:password) { 'demarches-simplifiees' }
   let(:instructeur) { create(:instructeur, password: password) }
-  let(:procedure) { create(:simple_procedure, :published, instructeurs: [instructeur], administrateurs: [administrateurs(:default_admin)]) }
+  let(:procedure) { create(:simple_procedure, :published, instructeurs: [instructeur], administrateurs: [administrateurs.default]) }
 
   context 'with an instructeur' do
     scenario 'create a BatchOperation', chrome: true do

--- a/spec/system/patron_spec.rb
+++ b/spec/system/patron_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'Accessing the /patron page:' do
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   before { sign_in administrateur.user }
 
   scenario 'I can display a page with all form fields and UI elements' do

--- a/spec/system/playground_spec.rb
+++ b/spec/system/playground_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'the playground', js: true do
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let!(:procedure) { create(:procedure, administrateurs: [administrateur]) }
   before { sign_in administrateur.user }
 

--- a/spec/system/users/dossier_prefill_get_spec.rb
+++ b/spec/system/users/dossier_prefill_get_spec.rb
@@ -122,7 +122,7 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
     end
 
     it "should not create a new dossier" do
-      expect(Dossier.count).to eq(1)
+      expect(procedure.dossiers.count).to eq(1)
       expect(dossier.reload.user).to eq(user)
 
       expect(page).to have_current_path(brouillon_dossier_path(dossier))

--- a/spec/system/users/managing_password_spec.rb
+++ b/spec/system/users/managing_password_spec.rb
@@ -31,7 +31,7 @@ describe 'Managing password:', js: true do
   end
 
   context 'for admins' do
-    let(:administrateur) { administrateurs(:default_admin) }
+    let(:administrateur) { administrateurs.default }
     let(:user) { administrateur.user }
     let(:weak_password) { '000000000000' }
     let(:strong_password) { 'a new, long, and complicated password!' }

--- a/spec/system/users/sign_out_spec.rb
+++ b/spec/system/users/sign_out_spec.rb
@@ -2,7 +2,7 @@
 
 describe 'Sign out' do
   context 'when a user is logged in' do
-    let(:user) { administrateurs(:default_admin).user }
+    let(:user) { administrateurs.default.user }
 
     before { login_as user, scope: :user }
 

--- a/spec/tasks/maintenance/destroy_procedure_without_administrateur_and_without_dossier_task_spec.rb
+++ b/spec/tasks/maintenance/destroy_procedure_without_administrateur_and_without_dossier_task_spec.rb
@@ -6,17 +6,17 @@ module Maintenance
   RSpec.describe DestroyProcedureWithoutAdministrateurAndWithoutDossierTask do
     describe "#process" do
       subject(:process) { described_class.process(procedure) }
-      let(:procedure) { create(:procedure) }
+      let(:administrateur) { administrateurs.blank }
+      let!(:procedure) { create(:procedure, administrateurs: [administrateur]) }
 
       before do
-        administrateur = procedure.administrateurs.first
         AdministrateursProcedure.where(administrateur_id: administrateur.id).delete_all
         administrateur.destroy
       end
 
       it "destroys procedure" do
         subject
-        expect(Procedure.count).to eq 0
+        expect(Procedure.with_discarded.exists?(procedure.id)).to be(false)
       end
     end
   end

--- a/spec/tasks/maintenance/t20250415remove_misplaced_autodestruction_header_task_spec.rb
+++ b/spec/tasks/maintenance/t20250415remove_misplaced_autodestruction_header_task_spec.rb
@@ -86,7 +86,7 @@ module Maintenance
 
             expect(TaskLog.count).to eq(1)
             expect(TaskLog.last.data).to eq({
-              "email" => "default_user@user.com",
+              "email" => "usager@exemple.fr",
               "state" => "lost",
               "blob_key" => blob.key,
               "dossier_id" => dossier.id,

--- a/spec/tasks/maintenance/t20250522_re_route_procedure_task_spec.rb
+++ b/spec/tasks/maintenance/t20250522_re_route_procedure_task_spec.rb
@@ -7,7 +7,7 @@ module Maintenance
     include Logic
 
     describe "#process" do
-      let(:admin) { administrateurs(:default_admin) }
+      let(:admin) { administrateurs.default }
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :departements, libelle: 'Votre département' }], administrateurs: [admin]) }
       let(:dossier1) { create(:dossier, :en_construction, :with_populated_champs, procedure: procedure) }
       let!(:dossier2) { create(:dossier, :en_construction, :with_populated_champs, procedure: procedure) }

--- a/spec/tasks/maintenance/t20250522reset_forced_group_instructeur_task_spec.rb
+++ b/spec/tasks/maintenance/t20250522reset_forced_group_instructeur_task_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Maintenance
   RSpec.describe T20250522resetForcedGroupInstructeurTask do
     describe "#process" do
-      let(:admin) { administrateurs(:default_admin) }
+      let(:admin) { administrateurs.default }
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :departements, libelle: 'Votre département' }], administrateurs: [admin]) }
       let(:dossier1) { create(:dossier, :en_construction, :with_populated_champs, procedure: procedure, forced_groupe_instructeur: true) }
       let!(:dossier2) { create(:dossier, :en_construction, :with_populated_champs, procedure: procedure) }

--- a/spec/tasks/maintenance/t20250721destroy_orphan_follows_task_spec.rb
+++ b/spec/tasks/maintenance/t20250721destroy_orphan_follows_task_spec.rb
@@ -11,6 +11,9 @@ module Maintenance
       let(:instructeur) { create(:instructeur) }
       let!(:valid_follow) { create(:follow, dossier:, instructeur:) }
 
+      let(:missing_instructeur_id) { Instructeur.maximum(:id).to_i + 1000 }
+      let(:missing_dossier_id) { Dossier.maximum(:id).to_i + 1000 }
+
       # Following the insertion of constraints into the database by #11970,
       # these must be bypassed in order to create orphan follows.
       before do
@@ -18,12 +21,12 @@ module Maintenance
 
         Follow.connection.execute <<~SQL.squish
           INSERT INTO follows (instructeur_id, dossier_id, annotations_privees_seen_at, avis_seen_at, demande_seen_at, messagerie_seen_at, created_at, updated_at)
-          VALUES (9999, #{valid_follow.dossier_id}, NOW(), NOW(), NOW(), NOW(), NOW(), NOW())
+          VALUES (#{missing_instructeur_id}, #{valid_follow.dossier_id}, NOW(), NOW(), NOW(), NOW(), NOW(), NOW())
         SQL
 
         Follow.connection.execute <<~SQL.squish
           INSERT INTO follows (instructeur_id, dossier_id, annotations_privees_seen_at, avis_seen_at, demande_seen_at, messagerie_seen_at, created_at, updated_at)
-          VALUES (#{valid_follow.instructeur_id}, 9999, NOW(), NOW(), NOW(), NOW(), NOW(), NOW())
+          VALUES (#{valid_follow.instructeur_id}, #{missing_dossier_id}, NOW(), NOW(), NOW(), NOW(), NOW(), NOW())
         SQL
 
         Follow.connection.execute("ALTER TABLE follows ENABLE TRIGGER ALL")
@@ -34,8 +37,8 @@ module Maintenance
 
         expect(result.count).to eq(2)
         expect(result).not_to include(valid_follow)
-        expect(result.map(&:instructeur_id)).to include(9999)
-        expect(result.map(&:dossier_id)).to include(9999)
+        expect(result.map(&:instructeur_id)).to include(missing_instructeur_id)
+        expect(result.map(&:dossier_id)).to include(missing_dossier_id)
       end
     end
 

--- a/spec/tasks/maintenance/t20251112backfill_champ_siret_external_state_with_etablissement_but_no_value_or_external_id_task_spec.rb
+++ b/spec/tasks/maintenance/t20251112backfill_champ_siret_external_state_with_etablissement_but_no_value_or_external_id_task_spec.rb
@@ -10,7 +10,7 @@ module Maintenance
       let(:champ1) { dossier1.root_champs_public.first }
       let(:etablissement1) { create(:etablissement, siret: "12345678901234") }
 
-      subject(:process) { described_class.process(Champs::SiretChamp.first) }
+      subject(:process) { described_class.process(champ1) }
       before do
         champ1.update(etablissement: etablissement1, external_state: 'fetched', external_id: nil, value: nil)
       end

--- a/spec/tasks/maintenance/t20251118destroy_instructeurs_procedure_of_instructeurs_removed_from_procedure_task_spec.rb
+++ b/spec/tasks/maintenance/t20251118destroy_instructeurs_procedure_of_instructeurs_removed_from_procedure_task_spec.rb
@@ -13,6 +13,8 @@ module Maintenance
     let!(:groupe_instructeur_2_1) { create(:groupe_instructeur, procedure: procedure_2, instructeurs: [instructeur_2]) }
 
     describe "#collection" do
+      empty_seeds Dossier, Procedure
+
       subject(:collection) { described_class.collection }
 
       it "returns instructeur_ids group by procedure_id" do

--- a/spec/tasks/maintenance/t20251208backfill_unique_and_valid_routing_rule_in_groupe_instructeurs_task_spec.rb
+++ b/spec/tasks/maintenance/t20251208backfill_unique_and_valid_routing_rule_in_groupe_instructeurs_task_spec.rb
@@ -7,7 +7,7 @@ module Maintenance
     include Logic
 
     let(:procedure) { create(:procedure, routing_enabled: true, administrateur: admin) }
-    let(:admin) { administrateurs(:default_admin) }
+    let(:admin) { administrateurs.default }
     let(:stable_id) { procedure.published_revision.root_types_de_champ_public.last.stable_id }
 
     before do

--- a/spec/tasks/maintenance/t20260601_nullify_en_construction_expired_at_task_spec.rb
+++ b/spec/tasks/maintenance/t20260601_nullify_en_construction_expired_at_task_spec.rb
@@ -7,6 +7,8 @@ module Maintenance
     let(:procedure) { create(:procedure, :published) }
 
     describe "#collection" do
+      empty_seeds Dossier
+
       let!(:en_construction_with_expired_at) { create(:dossier, :en_construction, procedure:) }
       let!(:en_construction_clean) do
         create(:dossier, :en_construction, procedure:).tap { it.update_column(:expired_at, nil) }

--- a/spec/views/administrateurs/procedures/zones.html.haml_spec.rb
+++ b/spec/views/administrateurs/procedures/zones.html.haml_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'administrateurs/procedures/zones', type: :view do
-  let(:administrateur) { administrateurs(:default_admin) }
+  let(:administrateur) { administrateurs.default }
   let(:procedure) { create(:procedure, published_at: Time.zone.parse('2022-07-20')) } # Définir une date de publication de la procédure plus tardive
   let!(:zone1) { create(:zone, acronym: 'MTEI', labels: [{ designated_on: '2022-05-18', name: "Ministère du Travail" }]) }
   let!(:zone2) { create(:zone, acronym: 'MEP', labels: [{ designated_on: '2022-05-18', name: "Ministère des vacances" }]) }

--- a/spec/views/instructeur/dossiers/_expiration_banner.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/_expiration_banner.html.haml_spec.rb
@@ -5,7 +5,6 @@ describe 'instructeur/dossiers/expiration_banner', type: :view do
   let(:duree_conservation_dossiers_dans_ds) { 3 }
   let(:dossier) do
     create(:dossier, state, attributes.merge(
-                              id: 1,
                               state: state,
                               procedure: create(:procedure, duree_conservation_dossiers_dans_ds: duree_conservation_dossiers_dans_ds)
                             ))

--- a/spec/views/instructeur/procedures/_tabs.html.haml_spec.rb
+++ b/spec/views/instructeur/procedures/_tabs.html.haml_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'instructeurs/procedures/_tabs', type: :view do
-  let(:procedure) { create(:procedure, id: 1) }
+  let(:procedure) { create(:procedure) }
 
   before { allow(view).to receive(:current_instructeur).and_return(create(:instructeur)) }
 

--- a/spec/views/users/dossiers/_expiration_banner.html.haml_spec.rb
+++ b/spec/views/users/dossiers/_expiration_banner.html.haml_spec.rb
@@ -5,7 +5,6 @@ describe 'users/dossiers/expiration_banner', type: :view do
   let(:duree_conservation_dossiers_dans_ds) { 3 }
   let(:dossier) do
     create(:dossier, state, attributes.merge(
-                              id: 1,
                               state: state,
                               conservation_extension: 1,
                               procedure: create(:procedure, duree_conservation_dossiers_dans_ds: duree_conservation_dossiers_dans_ds)


### PR DESCRIPTION
## Quoi

Remplace les fixtures ActiveRecord par des seeds [Oaken](https://github.com/kaspth/oaken) partagées entre développement et test, chargées **une fois par suite**.

- personas (`users.usager` / `admin` / `instructeur`), démarches de démonstration (publiée — avec service —, brouillon, entreprise, SVA/SVR, tous types de champ), dossiers dans chaque état, et scénarios (`cases/avis`, `cases/messagerie`, `cases/entreprise`, `cases/sva`, `cases/champs`)
- `administrateurs.blank` : un admin seedé qui ne possède rien (ni démarche, ni service, ni token) — pour les specs dont le sujet est l'état propre de l'admin (suppression, merge, `unused`, scoping de tokens). À l'inverse, `administrateurs.default` possède les démarches seedées.
- les seeds ne sont **pas idempotentes** : elles supposent une base vide et se lisent comme du `create!` déclaratif, sans gardes `find_or_create_by`. Les specs replantent (truncate + seed) une fois par suite ; en développement, on rafraîchit avec `bin/rails db:seed:replant`. Les enregistrements dev-only (super-admin, instructeur « fixer ») sont dans `db/seeds/development/`

## Côté specs

- `spec/support/oaken.rb` : `require "oaken/rspec_setup"` — truncate + seed (~1,8 s) une fois par suite, accesseurs labellisés (`procedures.individual`, `dossiers.en_construction`, …) disponibles dans chaque exemple, isolation par rollback transactionnel. Le tag `:oaken` disparaît.
- macro `empty_seeds Dossier[, Procedure]` pour les specs qui testent des agrégats globaux ou des scopes non paramétrés (`Stat.dossiers_states`, `Dossier.without_followers`, `Procedure.all`, …) : vide les tables des modèles donnés dans la transaction `before_all` du groupe, ce qui préserve les assertions exactes (`contain_exactly`, comptes absolus) ; le monde seedé revient au rollback du groupe
- Les seeds de scénario restent chargées par groupe : `before_all { seed "cases/avis" }`
- le `require` de test-prof passe de `spec_helper.rb` à `rails_helper.rb` (après le boot de Rails) : test-prof n'enregistre ses modificateurs ActiveRecord (`reload:`, `refind:`, `freeze:`) que si ActiveRecord est chargé au moment du require — ils étaient silencieusement indisponibles jusqu'ici
- Specs migrées sur les seeds : `avis_spec` (-45 %), `dossier_spec` (**~52 s → ~33 s, -38 %**), `experts_procedure`, `dossier_pending_response`, le contexte tous-types de `type_de_champ_spec`
- ~30 fichiers rendus « seed-safe » (un commit par fichier) : requêtes scopées aux enregistrements de la spec quand l'API s'y prête, `empty_seeds` pour les agrégats globaux, admins dédiés là où le sujet est l'admin, ids codés en dur supprimés (ils collisionnent avec les ids 1-2 pris par les seeds sur une base fraîche), `wait_until { Dossier.en_construction.count == 1 }` scopés à la démarche

## Points d'attention pour la review

- La démarche seedée publiée a un service : sans lui, toutes les pages admin affichent l'alerte « démarches sans service associé »
- Les dossiers seedés sont antidatés d'un jour (specs qui gèlent le temps) ; le dossier `en_construction` seedé a un `expired_at` non nul
- Le contrat de `administrateurs.blank` (ne possède rien) est documenté dans `db/seeds/users.rb` — ne jamais lui rattacher de seed
- `empty_seeds` se déclare en tête de groupe, avant tout `let_it_be`, dépendants d'abord (`Dossier` avant `Procedure`) ; ne pas utiliser les accesseurs seedés des modèles vidés dans le groupe

🤖 Generated with [Claude Code](https://claude.com/claude-code)
