### PR TITLE
Tech: navigation en arbre des champs (sections et répétitions)

### DIFF
--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
@@ -1,12 +1,19 @@
 <% each_champ do |champ| %>
   <% if champ.repetition? %>
-    <% types_de_champ = champ.type_de_champ.flat_children(champ.dossier.revision) %>
-    <% champ.row_ids.each.with_index(1) do |row_id, row_number| %>
-      <div class="fr-background-alt--grey fr-p-2w fr-my-3w fr-ml-2w champ-repetition">
-        <%= tag.send(repetition_heading_tag, t(".repetition_heading", libelle: champ.libelle, row_number: row_number), class: "fr-h6 fr-text--bold") %>
-        <%= render ViewableChamp::SectionComponent.new(dossier: champ.dossier, types_de_champ:, row_id:, demande_seen_at: seen_at, profile:) %>
-      </div>
-    <% end %>
+    <div id="<%= champ.html_id %>">
+      <% champ.rows.each do |row| %>
+        <div
+          id="<%= champ.type_de_champ.html_id(row.id) %>"
+          class="
+            fr-background-alt--grey fr-p-2w fr-my-3w fr-ml-2w
+            champ-repetition
+          "
+        >
+          <%= tag.send(repetition_heading_tag, t(".repetition_heading", libelle: champ.libelle, row_number: row.index), class: "fr-h6 fr-text--bold") %>
+          <%= render ViewableChamp::SectionComponent.new(dossier: champ.dossier, champs: row.champs, demande_seen_at: seen_at, profile:) %>
+        </div>
+      <% end %>
+    </div>
   <% else %>
     <%= render row_show_component(champ) do |c| %>
       <% if champ.blank? %>

--- a/app/components/dossiers/errors_full_messages_component.rb
+++ b/app/components/dossiers/errors_full_messages_component.rb
@@ -34,27 +34,27 @@ class Dossiers::ErrorsFullMessagesComponent < ApplicationComponent
   end
 
   def parent_prefix(model)
-    return "" if !model.child?
+    return "" if !model.in_repetition?
 
-    "#{[is_in_fieldset?(model) ? "[#{row_number(model)}]" : nil, model.parent.libelle].compact.join(" ")} - "
+    "#{[is_in_fieldset?(model) ? "[#{row_number(model)}]" : nil, model.repetition.libelle].compact.join(" ")} - "
   end
 
   def row_number_prefix(model)
-    return "" if !model.child? || is_in_fieldset?(model)
+    return "" if !model.in_repetition? || is_in_fieldset?(model)
 
     "[#{row_number(model)}] "
   end
 
   def row_number(model)
-    return 1 if !model.child?
+    return 1 if !model.in_repetition?
 
-    model.dossier.repetition_row_ids(model.parent).index(model.row_id) + 1
+    model.repetition.row_ids.index(model.row_id) + 1
   end
 
   def is_in_fieldset?(model)
-    return 0 if !model.child?
+    return 0 if !model.in_repetition?
 
-    model.parent.flat_children(model.dossier.revision).size > 1
+    model.repetition.type_de_champ.flat_children(model.dossier.revision).size > 1
   end
 
   def render?

--- a/app/components/editable_champ/editable_champ_base_component.rb
+++ b/app/components/editable_champ/editable_champ_base_component.rb
@@ -26,7 +26,7 @@ class EditableChamp::EditableChampBaseComponent < ApplicationComponent
   end
 
   def labelledby_id_attr(label_id = nil)
-    return {} if !@champ.child?
+    return {} if !@champ.in_repetition?
 
     { labelledby: labelledby_id(label_id) }
   end
@@ -48,7 +48,7 @@ class EditableChamp::EditableChampBaseComponent < ApplicationComponent
   private
 
   def labelledby_id(label_id = nil)
-    return nil if !@champ.child?
+    return nil if !@champ.in_repetition?
 
     labelledby = []
     # in repetition, aria_labelledby_prefix is the fieldset legend id

--- a/app/components/editable_champ/editable_champ_component.rb
+++ b/app/components/editable_champ/editable_champ_component.rb
@@ -17,11 +17,11 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
   end
 
   def parent_fieldset_legend_id
-    "#{@champ.parent.html_id}-legend"
+    "#{@champ.repetition.html_id}-legend"
   end
 
   def fieldset_legend_id
-    "#{@champ.parent.html_id(@champ.row_id)}-legend"
+    "#{@champ.repetition.type_de_champ.html_id(@champ.row_id)}-legend"
   end
 
   def aria_labelledby_prefix
@@ -31,19 +31,15 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
   end
 
   def number_of_siblings_if_in_repetition
-    return if !@champ.child?
+    return if !@champ.in_repetition?
 
-    @number_of_siblings_if_in_repetition ||= @champ.parent.flat_children(@champ.dossier.revision).count
+    @number_of_siblings_if_in_repetition ||= @champ.repetition.type_de_champ.flat_children(@champ.dossier.revision).count
   end
 
   def row_number_if_in_repetition
-    return if !@champ.child? || number_of_siblings_if_in_repetition > 1
+    return if !@champ.in_repetition? || number_of_siblings_if_in_repetition > 1
 
-    @row_number_if_in_repetition ||= begin
-      parent = @champ.parent
-      row_ids = @champ.dossier.repetition_row_ids(parent)
-      row_ids.find_index(@champ.row_id)&.+ 1
-    end
+    @row_number_if_in_repetition ||= @champ.repetition.row_ids.find_index(@champ.row_id)&.+ 1
   end
 
   private

--- a/app/components/editable_champ/repetition_component/repetition_component.html.erb
+++ b/app/components/editable_champ/repetition_component/repetition_component.html.erb
@@ -46,8 +46,8 @@
     id="<%= dom_id(@champ, :rows) %>"
     data-repetition-toggle-all-target="rowsContainer"
   >
-    <% @champ.row_ids.each.with_index(1) do |row_id, row_number| %>
-      <%= render EditableChamp::RepetitionRowComponent.new(form: @form, dossier: @champ.dossier, champ: @champ, row_id: row_id, row_number: row_number, seen_at: @seen_at, expanded: expand_row?(row_id, @champ.row_ids.count)) %>
+    <% @champ.rows.each do |row| %>
+      <%= render EditableChamp::RepetitionRowComponent.new(form: @form, dossier: @champ.dossier, champ: @champ, row:, seen_at: @seen_at, expanded: expand_row?(row.id, @champ.row_ids.count)) %>
     <% end %>
   </div>
 

--- a/app/components/editable_champ/repetition_row_component.rb
+++ b/app/components/editable_champ/repetition_row_component.rb
@@ -3,13 +3,14 @@
 class EditableChamp::RepetitionRowComponent < ApplicationComponent
   include ChampAriaLabelledbyHelper
 
-  def initialize(form:, dossier:, champ:, row_id:, row_number:, expanded: false, seen_at: nil)
-    @form, @dossier, @champ, @row_id, @row_number, @expanded, @seen_at = form, dossier, champ, row_id, row_number, expanded, seen_at
+  def initialize(form:, dossier:, champ:, row:, expanded: false, seen_at: nil)
+    @form, @dossier, @champ, @row, @expanded, @seen_at = form, dossier, champ, row, expanded, seen_at
     @type_de_champ = champ.type_de_champ
     @types_de_champ = @type_de_champ.flat_children(dossier.revision)
   end
 
-  attr_reader :row_id, :row_number
+  def row_id = @row.id
+  def row_number = @row.index
 
   def has_fieldset?
     @types_de_champ.size > 1
@@ -18,7 +19,7 @@ class EditableChamp::RepetitionRowComponent < ApplicationComponent
   private
 
   def section_component
-    EditableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: @types_de_champ, row_id:, row_number: @row_number)
+    EditableChamp::SectionComponent.new(dossier: @dossier, champs: @row.champs, row_number:)
   end
 
   def delete_button

--- a/app/components/editable_champ/section_component.rb
+++ b/app/components/editable_champ/section_component.rb
@@ -2,34 +2,30 @@
 
 class EditableChamp::SectionComponent < ApplicationComponent
   include ApplicationHelper
-  include TreeableConcern
 
-  def initialize(dossier:, types_de_champ: nil, header_section: nil, row_id: nil, row_number: nil)
-    @dossier, @header_section, @row_id, @row_number = dossier, header_section, row_id, row_number
-    @nodes = types_de_champ ? to_tree_roots(types_de_champ:) : header_section.children(dossier.revision)
+  def initialize(dossier:, champs:, header_section: nil, row_number: nil)
+    @dossier, @champs, @header_section, @row_number = dossier, champs, header_section, row_number
   end
+
+  attr_reader :header_section
 
   def render_within_fieldset?
-    @header_section.present?
-  end
-
-  def header_section
-    @dossier.project_champ(@header_section, row_id: @row_id) if @header_section
+    header_section.present?
   end
 
   def splitted_tail
-    @nodes.map { split_section_champ(it) }
+    @champs.map { split_section_champ(it) }
   end
 
   def tag_for_depth
     "h#{header_section.level + 1}"
   end
 
-  def split_section_champ(type_de_champ)
-    if type_de_champ.header_section?
-      [EditableChamp::SectionComponent.new(dossier: @dossier, header_section: type_de_champ, row_id: @row_id), nil]
+  def split_section_champ(champ)
+    if champ.header_section?
+      [EditableChamp::SectionComponent.new(dossier: @dossier, champs: champ.children, header_section: champ), nil]
     else
-      [nil, @dossier.project_champ(type_de_champ, row_id: @row_id)]
+      [nil, champ]
     end
   end
 end

--- a/app/components/manager/dossier_champ_row_component.rb
+++ b/app/components/manager/dossier_champ_row_component.rb
@@ -33,13 +33,13 @@ class Manager::DossierChampRowComponent < ApplicationComponent
     class_names(
       'cell-data': true,
       'cell-disabled': !row.visible?,
-      'fr-pl-16v': cell == :label && row.child?
+      'fr-pl-16v': cell == :label && row.in_repetition?
     )
   end
 
   def nested_rows
     if row.respond_to?(:rows)
-      row.rows
+      row.rows.map(&:flat_champs)
     else
       []
     end

--- a/app/components/viewable_champ/header_sections_summary_component.rb
+++ b/app/components/viewable_champ/header_sections_summary_component.rb
@@ -1,22 +1,45 @@
 # frozen_string_literal: true
 
 class ViewableChamp::HeaderSectionsSummaryComponent < ApplicationComponent
-  attr_reader :header_sections
+  Entry = Data.define(:libelle, :anchor_id, :level)
 
   def initialize(dossier:, is_private:)
     @dossier = dossier
     @is_private = is_private
-
-    @header_sections = if is_private
-      dossier.revision.root_types_de_champ_private
-    else
-      dossier.revision.root_types_de_champ_public
-    end.filter(&:header_section?)
   end
 
-  def render? = header_sections.any?
+  # Visible header sections, repetitions and their rows in document order.
+  # Sections hidden by a condition are excluded.
+  def sections
+    @sections ||= flatten_sections(root_champs, 1)
+  end
 
-  def href(header_section) # used by viewable champs to anchor elements
-    "##{header_section.html_id}"
+  def render? = sections.any?
+
+  private
+
+  def root_champs
+    @is_private ? @dossier.champs_private : @dossier.champs_public
+  end
+
+  def flatten_sections(champs, depth)
+    champs.filter { (it.header_section? || it.repetition?) && it.visible? }.flat_map do |champ|
+      children = if champ.header_section?
+        flatten_sections(champ.children, depth + 1)
+      else
+        row_entries(champ, depth + 1)
+      end
+      [Entry.new(libelle: champ.libelle, anchor_id: champ.html_id, level: depth), *children]
+    end
+  end
+
+  # Each row of a repetition is listed with its own sections beneath it.
+  def row_entries(champ, depth)
+    champ.rows.flat_map do |row|
+      [
+        Entry.new(libelle: "#{champ.libelle} #{row.index}", anchor_id: champ.type_de_champ.html_id(row.id), level: depth),
+        *flatten_sections(row.champs, depth + 1),
+      ]
+    end
   end
 end

--- a/app/components/viewable_champ/header_sections_summary_component/header_sections_summary_component.html.haml
+++ b/app/components/viewable_champ/header_sections_summary_component/header_sections_summary_component.html.haml
@@ -1,10 +1,9 @@
 #summary.fr-col-12.fr-col-xl-3
   %nav.fr-sidemenu.sticky.fr-hidden.fr-unhidden-xl{ "aria-labelledby" => "fr-summary-title", role: "navigation" }
     %ul.fr-sidemenu__list
-      - header_sections.each do |header_section|
+      - sections.each do |section|
         %li.fr-sidemenu__item
-          - level = header_section.header_section_level_value.to_i
-          - if level == 1
-            %a.fr-sidemenu__link{ href: href(header_section) }= header_section.libelle
+          - if section.level == 1
+            %a.fr-sidemenu__link{ href: "##{section.anchor_id}" }= section.libelle
           - else
-            %a.fr-sidemenu__link{ class: level >= 3 ? 'custom-link-grey': '', href: href(header_section) }= "-- #{header_section.libelle}"
+            %a.fr-sidemenu__link{ class: section.level >= 3 ? 'custom-link-grey': '', href: "##{section.anchor_id}" }= "-- #{section.libelle}"

--- a/app/components/viewable_champ/section_component.rb
+++ b/app/components/viewable_champ/section_component.rb
@@ -2,38 +2,25 @@
 
 class ViewableChamp::SectionComponent < ApplicationComponent
   include ApplicationHelper
-  include TreeableConcern
 
-  def initialize(dossier:, nodes: nil, types_de_champ: nil, row_id: nil, demande_seen_at:, profile:)
-    @dossier, @demande_seen_at, @profile, @row_id = dossier, demande_seen_at, profile, row_id
-    nodes ||= to_tree(types_de_champ:)
-    @nodes = to_sections(nodes:)
+  def initialize(dossier:, champs:, header_section: nil, demande_seen_at:, profile:)
+    @dossier, @header_section = dossier, header_section
+    @demande_seen_at, @profile = demande_seen_at, profile
+    @section_champs, @champs = champs.partition(&:header_section?)
   end
 
   private
+
+  attr_reader :header_section, :champs
 
   def section_id
     @section_id ||= header_section ? dom_id(header_section, :content) : SecureRandom.uuid
   end
 
-  def header_section
-    node = @nodes.first
-    @dossier.project_champ(node, row_id: @row_id) if node.is_a?(TypeDeChamp) && node.header_section?
-  end
-
-  def champs
-    tail.filter_map { _1.is_a?(TypeDeChamp) ? @dossier.project_champ(_1, row_id: @row_id) : nil }
-  end
-
   def sections
-    tail.filter { _1.is_a?(ViewableChamp::SectionComponent) }
-  end
-
-  def tail
-    return @nodes if header_section.nil?
-    _, *rest_of_champ = @nodes
-
-    rest_of_champ
+    @sections ||= @section_champs.map do |champ|
+      ViewableChamp::SectionComponent.new(dossier: @dossier, champs: champ.children, header_section: champ, demande_seen_at: @demande_seen_at, profile: @profile)
+    end
   end
 
   def reset_tag_for_depth
@@ -52,11 +39,5 @@ class ViewableChamp::SectionComponent < ApplicationComponent
     relative_level = header_section ? header_section.level : 1
     # there are 2 levels of heading before the repetition heading
     [relative_level + 2, 6].min
-  end
-
-  private
-
-  def to_sections(nodes:)
-    nodes.map { _1.is_a?(Array) ? ViewableChamp::SectionComponent.new(dossier: @dossier, nodes: _1, demande_seen_at: @demande_seen_at, profile: @profile, row_id: @row_id) : _1 }
   end
 end

--- a/app/controllers/champs/repetition_controller.rb
+++ b/app/controllers/champs/repetition_controller.rb
@@ -2,9 +2,9 @@
 
 class Champs::RepetitionController < Champs::ChampController
   def add
-    @row_id = @champ.add_row(updated_by: current_user.email)
+    row_id = @champ.add_row(updated_by: current_user.email)
+    @row = @champ.rows.find { it.id == row_id }
     @first_champ_id = @champ.focusable_input_id
-    @row_number = @row_id.nil? ? 0 : @champ.row_ids.find_index(@row_id) + 1
     @champ.update_timestamps
   end
 

--- a/app/controllers/concerns/turbo_champs_concern.rb
+++ b/app/controllers/concerns/turbo_champs_concern.rb
@@ -22,7 +22,7 @@ module TurboChampsConcern
   end
 
   def champs_to_toggle(champs, to_update)
-    champs.filter { it.conditional? || it.child? }
+    champs.filter { it.conditional? || it.in_repetition? }
       .partition(&:visible?)
       .map { champs_to_one_selector(it - to_update) }
   end

--- a/app/graphql/types/champs/repetition_champ_type.rb
+++ b/app/graphql/types/champs/repetition_champ_type.rb
@@ -13,7 +13,7 @@ module Types::Champs
     field :rows, [Row], null: false
 
     def champs
-      object.rows.flat_map { _1.filter(&:visible?) }
+      object.rows.flat_map { it.flat_champs.filter(&:visible?) }
     end
 
     def rows
@@ -21,8 +21,8 @@ module Types::Champs
         .rows
         .map do
           {
-            id: GraphQL::Schema::UniqueWithinType.encode('Row', _1.first.row_id),
-            champs: _1.filter(&:visible?),
+            id: GraphQL::Schema::UniqueWithinType.encode('Row', it.id),
+            champs: it.flat_champs.filter(&:visible?),
           }
         end
     end

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -147,15 +147,18 @@ class ChampData < ApplicationRecord
     data&.dig("prefilled_from_france_connect_information") == true
   end
 
-  def child?
-    row_id.present? && !is_type?(TypeDeChamp.type_champs.fetch(:repetition))
+  # Sections and repetitions above this champ in the tree, outermost first.
+  # Ancestors inside the repetition share the champ's row_id.
+  def ancestors
+    type_de_champ.ancestors(dossier.revision).map { project_ancestor(it) }
   end
 
-  def parent
-    return nil if row_id.blank?
+  def parent = project_ancestor(type_de_champ.parent(dossier.revision))
+  def section = project_ancestor(type_de_champ.section(dossier.revision))
+  def repetition = project_ancestor(type_de_champ.repetition(dossier.revision))
 
-    dossier.revision.repetition_of(type_de_champ)
-  end
+  def in_repetition? = repetition.present?
+  def in_section? = section.present?
 
   def row?
     row_id.present? && is_type?(TypeDeChamp.type_champs.fetch(:repetition))
@@ -357,6 +360,14 @@ class ChampData < ApplicationRecord
   end
 
   private
+
+  # Ancestors inside the champ's repetition are projected on its row.
+  def project_ancestor(ancestor_type_de_champ)
+    return if ancestor_type_de_champ.nil?
+
+    row = ancestor_type_de_champ.in_repetition?(dossier.revision) ? row_id : nil
+    dossier.project_champ(ancestor_type_de_champ, row_id: row)
+  end
 
   def nullify_blank_json_columns
     [:value_json, :data].each do |column|

--- a/app/models/champ_presentations/repetition_presentation.rb
+++ b/app/models/champ_presentations/repetition_presentation.rb
@@ -10,8 +10,8 @@ class ChampPresentations::RepetitionPresentation < ChampPresentations::BasePrese
   end
 
   def to_s
-    ([libelle] + rows.map do |champs|
-      champs.map do |champ|
+    ([libelle] + rows.map do |row|
+      row.flat_champs.map do |champ|
         "#{champ.libelle} : #{champ}"
       end.join("\n")
     end).join("\n\n")
@@ -21,13 +21,13 @@ class ChampPresentations::RepetitionPresentation < ChampPresentations::BasePrese
     {
       type: 'orderedList',
       attrs: { class: 'tdc-repetition' },
-      content: rows.map do |champs|
+      content: rows.map do |row|
         {
           type: 'listItem',
           content: [
             {
               type: 'descriptionList',
-              content: champs.map do |champ|
+              content: row.flat_champs.map do |champ|
                 [
                   {
                     type: 'descriptionTerm',

--- a/app/models/champs/header_section_champ.rb
+++ b/app/models/champs/header_section_champ.rb
@@ -8,4 +8,16 @@ class Champs::HeaderSectionChamp < ChampData
   def level
     type_de_champ.level(dossier.revision)
   end
+
+  # Direct children of the section, as projected champs (sharing the section's
+  # row_id when the section is inside a repetition).
+  def children
+    type_de_champ.children(dossier.revision).map { dossier.project_champ(it, row_id:) }
+  end
+
+  # Every champ below the section in document order, as projected champs; a
+  # nested repetition is a boundary (included, its rows' content excluded).
+  def flat_children
+    type_de_champ.flat_children(dossier.revision).map { dossier.project_champ(it, row_id:) }
+  end
 end

--- a/app/models/champs/repetition_champ.rb
+++ b/app/models/champs/repetition_champ.rb
@@ -29,7 +29,7 @@ class Champs::RepetitionChamp < ChampData
   end
 
   def focusable_input_id(attribute = :value)
-    rows.last&.first&.focusable_input_id(attribute)
+    rows.last&.flat_champs&.first&.focusable_input_id(attribute)
   end
 
   def discarded?
@@ -58,7 +58,7 @@ class Champs::RepetitionChamp < ChampData
     return if !type_de_champ.limit_repetitions?
     # Only skip validation when no rows have been filled AND no minimum is required.
     # When a minimum is configured, always validate so that submitting with 0 rows is caught.
-    return if type_de_champ.min_repetitions.blank? && rows.none? { |row| row.any? { _1.value.present? } }
+    return if type_de_champ.min_repetitions.blank? && rows.none? { |row| row.flat_champs.any? { it.value.present? } }
 
     count = row_ids.count
     min = type_de_champ.min_repetitions.to_i
@@ -70,27 +70,6 @@ class Champs::RepetitionChamp < ChampData
 
     if type_de_champ.max_repetitions.present? && count > max
       errors.add(:value, :repetition_too_many, max: max, libelle: type_de_champ.libelle)
-    end
-  end
-
-  class Row < Hashie::Dash
-    property :index
-    property :row_id
-    property :dossier
-
-    def dossier_id
-      dossier.id.to_s
-    end
-
-    def read_attribute_for_serialization(attribute)
-      self[attribute]
-    end
-
-    def spreadsheet_columns(types_de_champ, export_template: nil, format:)
-      [
-        ['Dossier ID', :dossier_id],
-        ['Ligne', :index],
-      ] + dossier.champ_values_for_export(types_de_champ, row_id:, export_template:, format:)
     end
   end
 end

--- a/app/models/concerns/champ_conditional_concern.rb
+++ b/app/models/concerns/champ_conditional_concern.rb
@@ -52,16 +52,10 @@ module ChampConditionalConcern
 
   def parent_hidden?
     # if there is no row_id, it always has been a root champ
-    return false if !child?
+    return false if !in_repetition?
 
     # otherwise maybe the champ has been moved outside a repetition
-    parent_tdc = dossier.revision.repetition_of(type_de_champ)
-
-    return false if parent_tdc.nil?
-
-    parent = dossier.champs
-      .find { it.type_de_champ == parent_tdc }
-
-    !parent.visible?
+    parent = repetition
+    parent.present? && !parent.visible?
   end
 end

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -7,10 +7,7 @@ module DossierChampsConcern
     check_valid_row_id_on_read?(type_de_champ, row_id)
     data = champ_data_by_public_id[type_de_champ.public_id(row_id)]
     if data.nil? || !data.is_type?(type_de_champ.type_champ)
-      value = type_de_champ.champ_blank?(data) ? nil : data.value
-      updated_at = data&.updated_at || depose_at || created_at
-      rebased_at = data&.rebased_at
-      type_de_champ.build_champ(dossier: self, row_id:, updated_at:, rebased_at:, value:, stream:)
+      projected_champ(type_de_champ, row_id:, champ_data: data)
     else
       data.type_de_champ = type_de_champ
       data
@@ -26,13 +23,24 @@ module DossierChampsConcern
   end
 
   def champs
-    root_champs_public + root_champs_private
+    flat_champs_public + flat_champs_private
+  end
+
+  # Entry points to navigate champs as a tree: first-level champs and top-level
+  # header sections. Navigate deeper with Champs::HeaderSectionChamp#children
+  # and Champs::RepetitionChamp#rows.
+  def champs_public
+    @champs_public ||= revision.types_de_champ_public.map { project_champ(it) }
+  end
+
+  def champs_private
+    @champs_private ||= revision.types_de_champ_private.map { project_champ(it) }
   end
 
   def filled_champs_public
     @filled_champs_public ||= root_champs_public.flat_map do |champ|
       if champ.repetition?
-        champ.rows.flatten.filter { _1.persisted? && _1.fillable? }
+        champ.rows.flat_map(&:flat_champs).filter { it.persisted? && it.fillable? }
       elsif champ.persisted? && champ.fillable?
         champ
       else
@@ -44,7 +52,7 @@ module DossierChampsConcern
   def filled_champs_private
     @filled_champs_private ||= root_champs_private.flat_map do |champ|
       if champ.repetition?
-        champ.rows.flatten.filter { _1.persisted? && _1.fillable? }
+        champ.rows.flat_map(&:flat_champs).filter { it.persisted? && it.fillable? }
       elsif champ.persisted? && champ.fillable?
         champ
       else
@@ -61,7 +69,7 @@ module DossierChampsConcern
     @flat_champs_public ||= revision.root_types_de_champ_public.flat_map do |type_de_champ|
       champ = project_champ(type_de_champ)
       if type_de_champ.repetition?
-        [champ] + project_rows_for(type_de_champ).flatten
+        [champ] + project_rows_for(type_de_champ).flat_map(&:flat_champs)
       else
         champ
       end
@@ -72,7 +80,7 @@ module DossierChampsConcern
     @flat_champs_private ||= revision.root_types_de_champ_private.flat_map do |type_de_champ|
       champ = project_champ(type_de_champ)
       if type_de_champ.repetition?
-        [champ] + project_rows_for(type_de_champ).flatten
+        [champ] + project_rows_for(type_de_champ).flat_map(&:flat_champs)
       else
         champ
       end
@@ -82,11 +90,8 @@ module DossierChampsConcern
   def project_rows_for(type_de_champ)
     return [] if !type_de_champ.repetition?
 
-    children = type_de_champ.flat_children(revision)
-    row_ids = repetition_row_ids(type_de_champ)
-
-    row_ids.map do |row_id|
-      children.map { project_champ(_1, row_id:) }
+    repetition_row_ids(type_de_champ).map.with_index(1) do |row_id, index|
+      RepetitionRow.new(id: row_id, index:, dossier: self, type_de_champ:)
     end
   end
 
@@ -142,12 +147,6 @@ module DossierChampsConcern
     stable_id, row_id = public_id.split('-')
     type_de_champ = find_type_de_champ_by_stable_id(stable_id, :private)
     champ_for_update(type_de_champ, row_id:, updated_by:)
-  end
-
-  def repetition_rows_for_export(type_de_champ)
-    repetition_row_ids(type_de_champ).map.with_index(1) do |row_id, index|
-      Champs::RepetitionChamp::Row.new(index:, row_id:, dossier: self)
-    end
   end
 
   def repetition_row_ids(type_de_champ)
@@ -331,6 +330,27 @@ module DossierChampsConcern
     @champ_data_by_public_id ||= champ_data_on_stream.index_by(&:public_id)
   end
 
+  # Champs built for types de champ without a persisted champ are memoized so
+  # repeated projections of the same public_id return the same instance.
+  def projected_champ(type_de_champ, row_id:, champ_data:)
+    public_id = type_de_champ.public_id(row_id)
+    projected = champs_by_public_id[public_id]
+    if projected.nil? || !projected.is_type?(type_de_champ.type_champ)
+      value = type_de_champ.champ_blank?(champ_data) ? nil : champ_data.value
+      updated_at = champ_data&.updated_at || depose_at || created_at
+      rebased_at = champ_data&.rebased_at
+      projected = type_de_champ.build_champ(dossier: self, row_id:, updated_at:, rebased_at:, value:, stream:)
+      champs_by_public_id[public_id] = projected
+    else
+      projected.type_de_champ = type_de_champ
+    end
+    projected
+  end
+
+  def champs_by_public_id
+    @champs_by_public_id ||= {}
+  end
+
   def discarded_champ_data_by_public_id
     @discarded_champ_data_by_public_id ||= discarded_champ_data_on_main_stream.index_by(&:public_id)
   end
@@ -474,11 +494,14 @@ module DossierChampsConcern
 
   def reset_champs_cache
     @champ_data_by_public_id = nil
+    @champs_by_public_id = nil
     @discarded_champ_data_by_public_id = nil
     @filled_champs_public = nil
     @filled_champs_private = nil
     @root_champs_public = nil
     @root_champs_private = nil
+    @champs_public = nil
+    @champs_private = nil
     @flat_champs_public = nil
     @flat_champs_private = nil
     @repetition_row_ids = nil

--- a/app/models/repetition_row.rb
+++ b/app/models/repetition_row.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class RepetitionRow < Hashie::Dash
+  property :id
+  property :index
+  property :dossier
+  property :type_de_champ
+
+  # All the champs of the row, including champs nested in header sections.
+  def flat_champs
+    type_de_champ.flat_children(dossier.revision).map { dossier.project_champ(it, row_id: id) }
+  end
+
+  # Entry points to navigate the row's champs as a tree: first-level champs and
+  # top-level header sections. Navigate deeper with
+  # Champs::HeaderSectionChamp#children.
+  def champs
+    type_de_champ.children(dossier.revision).map { dossier.project_champ(it, row_id: id) }
+  end
+
+  def dossier_id
+    dossier.id.to_s
+  end
+
+  def read_attribute_for_serialization(attribute)
+    self[attribute]
+  end
+
+  def spreadsheet_columns(types_de_champ, export_template: nil, format:)
+    [
+      ['Dossier ID', :dossier_id],
+      ['Ligne', :index],
+    ] + dossier.champ_values_for_export(types_de_champ, row_id: id, export_template:, format:)
+  end
+end

--- a/app/serializers/champ_serializer.rb
+++ b/app/serializers/champ_serializer.rb
@@ -48,7 +48,7 @@ class ChampSerializer < ActiveModel::Serializer
   end
 
   def rows
-    object.rows.map.with_index(1) { |champs, index| Row.new(index:, champs:) }
+    object.rows.map { Row.new(index: it.index, champs: it.flat_champs) }
   end
 
   def include_etablissement?

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -342,7 +342,7 @@ class PiecesJustificativesService
   # # # pj_champ_5 (stable_id: 2)
   # it returns { pj_0.id => 0, pj_1.id => 1, pj_2.id => 0, pj_3.id => 0, pj_4.id => 1, pj_5.id => 1 }
   def compute_champ_id_row_index(champs)
-    champs.filter(&:child?).group_by(&:dossier_id).values.each_with_object({}) do |children_for_dossier, hash|
+    champs.filter(&:in_repetition?).group_by(&:dossier_id).values.each_with_object({}) do |children_for_dossier, hash|
       children_for_dossier.group_by(&:stable_id).values.each do |champs_for_stable_id|
         champs_for_stable_id.sort_by(&:row_id).each.with_index { |c, index| hash[c.id] = index }
       end

--- a/app/services/procedure_export_service.rb
+++ b/app/services/procedure_export_service.rb
@@ -117,7 +117,7 @@ class ProcedureExportService
       .repetition
       .filter_map do |type_de_champ_repetition|
         types_de_champ = procedure.all_revisions_types_de_champ(parent: type_de_champ_repetition).to_a
-        rows = dossiers.flat_map { _1.repetition_rows_for_export(type_de_champ_repetition) }
+        rows = dossiers.flat_map { it.project_rows_for(type_de_champ_repetition) }
 
         if types_de_champ.present? && rows.present?
           {

--- a/app/services/procedure_export_service/xlsx_export.rb
+++ b/app/services/procedure_export_service/xlsx_export.rb
@@ -176,7 +176,7 @@ class ProcedureExportService::XlsxExport
 
     def collect_repetitions(dossier, export_template)
       repetition_tdcs.each do |tdc|
-        rows = dossier.repetition_rows_for_export(tdc)
+        rows = dossier.project_rows_for(tdc)
         next if rows.empty?
 
         children_tdcs = repetition_children_tdcs[tdc.stable_id]

--- a/app/views/champs/repetition/add.turbo_stream.erb
+++ b/app/views/champs/repetition/add.turbo_stream.erb
@@ -1,6 +1,6 @@
-<% if @row_id.present? %>
+<% if @row.present? %>
   <%= fields_for @champ.input_name, @champ do |form| %>
-    <%= turbo_stream.append dom_id(@champ, :rows), render(EditableChamp::RepetitionRowComponent.new(form: form, dossier: @champ.dossier, champ: @champ, row_id: @row_id, row_number: @row_number, expanded: true)) %>
+    <%= turbo_stream.append dom_id(@champ, :rows), render(EditableChamp::RepetitionRowComponent.new(form:, dossier: @champ.dossier, champ: @champ, row: @row, expanded: true)) %>
 
     <% if @first_champ_id %>
       <%= turbo_stream.focus(@first_champ_id, delay: 50) %>

--- a/app/views/champs/repetition/remove.turbo_stream.erb
+++ b/app/views/champs/repetition/remove.turbo_stream.erb
@@ -3,9 +3,9 @@
 <% end %>
 
 <%= turbo_stream.update dom_id(@champ, :rows) do %>
-  <% @champ.row_ids.each.with_index(1) do |row_id, row_number| %>
+  <% @champ.rows.each do |row| %>
     <%= fields_for @champ.input_name, @champ do |form| %>
-      <%= render EditableChamp::RepetitionRowComponent.new(form: form, dossier: @champ.dossier, champ: @champ, row_id: row_id, row_number: row_number, seen_at: nil, expanded: row_number == 1) %>
+      <%= render EditableChamp::RepetitionRowComponent.new(form:, dossier: @champ.dossier, champ: @champ, row:, seen_at: nil, expanded: row.index == 1) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -313,7 +313,7 @@ def add_champs(pdf, champs)
     elsif champ.repetition?
       pdf.indent(current_indent) do
         champ.rows.each do |row|
-          row.each do |inner_champ|
+          row.flat_champs.each do |inner_champ|
             add_single_champ(pdf, inner_champ)
           end
         end

--- a/app/views/instructeurs/dossiers/print.html.haml
+++ b/app/views/instructeurs/dossiers/print.html.haml
@@ -15,15 +15,13 @@
 
 %h2 Formulaire
 
-- types_de_champ_public = @dossier.revision.root_types_de_champ_public
-- if types_de_champ_public.any? || @dossier.procedure.routing_enabled?
-  = render ViewableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: types_de_champ_public, demande_seen_at: nil, profile: 'instructeur')
+- if @dossier.revision.root_types_de_champ_public.any? || @dossier.procedure.routing_enabled?
+  = render ViewableChamp::SectionComponent.new(dossier: @dossier, champs: @dossier.champs_public, demande_seen_at: nil, profile: 'instructeur')
 
 %h2 Annotations privées
 
-- types_de_champ_private = @dossier.revision.root_types_de_champ_private
-- if types_de_champ_private.any?
-  = render ViewableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: types_de_champ_private, demande_seen_at: nil, profile: 'instructeur')
+- if @dossier.revision.root_types_de_champ_private.any?
+  = render ViewableChamp::SectionComponent.new(dossier: @dossier, champs: @dossier.champs_private, demande_seen_at: nil, profile: 'instructeur')
 - else
   Aucune annotation privée
 

--- a/app/views/instructeurs/dossiers/show_submitted_revision.html.erb
+++ b/app/views/instructeurs/dossiers/show_submitted_revision.html.erb
@@ -34,7 +34,7 @@
         data-clipboard2-copy-text-value="<%= t('clipboard.copy') %>"
         data-clipboard2-copied-text-value="<%= t('clipboard.copied') %>"
       >
-        <%= render ViewableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: @dossier.revision.root_types_de_champ_public, demande_seen_at: @demande_seen_at, profile: 'instructeur') %>
+        <%= render ViewableChamp::SectionComponent.new(dossier: @dossier, champs: @dossier.champs_public, demande_seen_at: @demande_seen_at, profile: 'instructeur') %>
       </div>
     </div>
   </div>

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -33,7 +33,7 @@
 
     %form.form
       = form_for @dossier, url: '', html: { class: 'form' } do |f|
-        = render EditableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: @dossier.revision.root_types_de_champ_public)
+        = render EditableChamp::SectionComponent.new(dossier: @dossier, champs: @dossier.champs_public)
 
         .editable-champ.editable-champ-text
           %label Mot de passe

--- a/app/views/shared/dossiers/_demande.html.erb
+++ b/app/views/shared/dossiers/_demande.html.erb
@@ -121,9 +121,7 @@
     <% end %>
   <% end %>
 
-  <% types_de_champ = dossier.revision.root_types_de_champ_public %>
-
-  <% if types_de_champ.any? || dossier.procedure.routing_enabled? %>
-    <%= render ViewableChamp::SectionComponent.new(dossier:, types_de_champ:, demande_seen_at:, profile:) %>
+  <% if dossier.revision.root_types_de_champ_public.any? || dossier.procedure.routing_enabled? %>
+    <%= render ViewableChamp::SectionComponent.new(dossier:, champs: dossier.champs_public, demande_seen_at:, profile:) %>
   <% end %>
 </div>

--- a/app/views/shared/dossiers/_edit.html.erb
+++ b/app/views/shared/dossiers/_edit.html.erb
@@ -50,7 +50,7 @@
     <h2 class="fr-sr-only">Formulaire</h2>
 
     <fieldset class="fr-fieldset">
-      <%= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.root_types_de_champ_public) %>
+      <%= render EditableChamp::SectionComponent.new(dossier:, champs: dossier.champs_public) %>
     </fieldset>
 
     <%= render Dossiers::PendingCorrectionCheckboxComponent.new(dossier:) %>

--- a/app/views/shared/dossiers/_edit_annotations.html.erb
+++ b/app/views/shared/dossiers/_edit_annotations.html.erb
@@ -5,7 +5,7 @@
 
       <%= form_for dossier, url: annotations_instructeur_dossier_path(dossier.procedure, dossier), html: { class: 'form', multipart: true } do |f| %>
         <fieldset class="fr-fieldset">
-          <%= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.root_types_de_champ_private) %>
+          <%= render EditableChamp::SectionComponent.new(dossier:, champs: dossier.champs_private) %>
         </fieldset>
       <% end %>
 

--- a/app/views/shared/dossiers/_edit_instructeur.html.erb
+++ b/app/views/shared/dossiers/_edit_instructeur.html.erb
@@ -21,7 +21,7 @@
     </header>
 
     <fieldset class="fr-fieldset">
-      <%= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.root_types_de_champ_public) %>
+      <%= render EditableChamp::SectionComponent.new(dossier:, champs: dossier.champs_public) %>
     </fieldset>
   <% end %>
 

--- a/spec/components/champ_header_sections_summary_component_spec.rb
+++ b/spec/components/champ_header_sections_summary_component_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewableChamp::HeaderSectionsSummaryComponent, type: :component do
+  include Logic
+
   subject { render_inline(component).to_html }
 
   let(:is_private) { false }
@@ -14,15 +16,57 @@ RSpec.describe ViewableChamp::HeaderSectionsSummaryComponent, type: :component d
       { type: :text },
     ]
   end
-  let(:procedure) { build(:procedure, types_de_champ_public: types_de_champ, types_de_champ_private: types_de_champ) }
-  let(:dossier) { build(:dossier, procedure:) }
+  let(:procedure) { create(:procedure, types_de_champ_public: types_de_champ, types_de_champ_private: types_de_champ) }
+  let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
   let(:component) { described_class.new(dossier:, is_private:) }
   let(:types_de_champ_public) { dossier.revision.root_types_de_champ_public.filter(&:header_section?) }
   let(:types_de_champ_private) { dossier.revision.root_types_de_champ_private.filter(&:header_section?) }
+  let(:repetition_tdc) { dossier.revision.root_types_de_champ_public.find(&:repetition?) }
+  let(:section_in_repetition) { repetition_tdc.flat_children(dossier.revision).find(&:header_section?) }
 
   context 'public' do
     it do
       types_de_champ_public.each { expect(subject).to have_selector("a[href='##{_1.html_id}']") }
+    end
+
+    it 'anchors the repetition, each of its rows and their sections' do
+      row_ids = dossier.repetition_row_ids(repetition_tdc)
+      expect(row_ids.size).to eq(2)
+      expect(subject).to have_selector("a[href='##{repetition_tdc.html_id}']")
+      row_ids.each.with_index(1) do |row_id, row_number|
+        expect(subject).to have_selector("a[href='##{repetition_tdc.html_id(row_id)}']", text: "#{repetition_tdc.libelle} #{row_number}")
+        expect(subject).to have_selector("a[href='##{section_in_repetition.html_id(row_id)}']")
+      end
+    end
+
+    context 'when the repetition has no rows' do
+      let(:types_de_champ) do
+        [{ type: :repetition, mandatory: false, children: [{ type: :text }, { type: :header_section, level: 1 }] }]
+      end
+      let(:dossier) { create(:dossier, procedure:) }
+
+      it 'lists the repetition but not its content' do
+        expect(subject).to have_selector("a[href='##{repetition_tdc.html_id}']", count: 1)
+      end
+    end
+
+    context 'when sections are hidden by a condition' do
+      let(:procedure) { create(:procedure, types_de_champ_public: types_de_champ) }
+      let(:types_de_champ) do
+        [
+          { type: :yes_no, stable_id: 42 },
+          { type: :header_section, level: 1, libelle: 'visible section' },
+          { type: :header_section, level: 1, libelle: 'hidden section', condition: ds_eq(champ_value(42), constant(true)) },
+          { type: :repetition, mandatory: false, libelle: 'hidden repetition', condition: ds_eq(champ_value(42), constant(true)), children: [{ type: :text }] },
+        ]
+      end
+      let(:dossier) { create(:dossier, procedure:) }
+
+      it 'excludes hidden sections and repetitions from the summary' do
+        expect(subject).to have_text('visible section')
+        expect(subject).not_to have_text('hidden section')
+        expect(subject).not_to have_text('hidden repetition')
+      end
     end
   end
 

--- a/spec/components/dossiers/errors_full_messages_component_spec.rb
+++ b/spec/components/dossiers/errors_full_messages_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Dossiers::ErrorsFullMessagesComponent, type: :component do
       context 'when champ is repetition' do
         let(:champ_repetition) { dossier.champ_data.first }
         let(:rows) { champ_repetition.rows }
-        let(:champ_child) { rows.first.first }
+        let(:champ_child) { rows.first.champs.first }
 
         let(:types_de_champ_public) { [{ libelle: "Champ parent", type: :repetition, children: [{ libelle: "Champ enfant", type: :text }] }] }
 

--- a/spec/components/editable_champ/drop_down_list_component_spec.rb
+++ b/spec/components/editable_champ/drop_down_list_component_spec.rb
@@ -54,7 +54,7 @@ describe EditableChamp::DropDownListComponent, type: :component do
         let(:fieldset) { page.find('fieldset fieldset') }
 
         let(:repetition_champ) { dossier.root_champs_public.first }
-        let(:drop_down_list_champ) { repetition_champ.rows.first.first }
+        let(:drop_down_list_champ) { repetition_champ.rows.first.champs.first }
 
         it do
           render

--- a/spec/components/editable_champ/editable_champ_component_spec.rb
+++ b/spec/components/editable_champ/editable_champ_component_spec.rb
@@ -76,7 +76,7 @@ describe EditableChamp::EditableChampComponent, type: :component do
         [{ type: :repetition, children: [{ type: :text }, { type: :text }] }]
       end
 
-      let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.first.first }
+      let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.first.champs.first }
 
       it "returns nil (because the number of the row is on the fieldset legend)" do
         expect(subject).to be_nil
@@ -89,7 +89,7 @@ describe EditableChamp::EditableChampComponent, type: :component do
       end
 
       context "on the first row" do
-        let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.first.first }
+        let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.first.champs.first }
 
         it do
           expect(component.row_number_if_in_repetition).to eq(1)
@@ -97,7 +97,7 @@ describe EditableChamp::EditableChampComponent, type: :component do
       end
 
       context "when the champ is in the second row" do
-        let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.last.first }
+        let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.last.champs.first }
 
         it do
           expect(component.row_number_if_in_repetition).to eq(2)

--- a/spec/components/editable_champ/section_component_spec.rb
+++ b/spec/components/editable_champ/section_component_spec.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 describe EditableChamp::SectionComponent, type: :component do
-  include TreeableConcern
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:types_de_champ_public) { [] }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:types_de_champ) { dossier.revision.root_types_de_champ_public }
-  let(:component) { described_class.new(types_de_champ:, dossier:) }
+  let(:component) { described_class.new(champs: dossier.champs_public, dossier:) }
   before { render_inline(component).to_html }
 
   context 'list of champs without an header_section' do

--- a/spec/controllers/api/public/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/dossiers_controller_spec.rb
@@ -102,9 +102,7 @@ RSpec.describe API::Public::V1::DossiersController, type: :controller do
               expect { create_request }.not_to raise_error
               dossier = Dossier.last
 
-              first_row = dossier.root_champs_public.first.rows.first
-              second_row = dossier.root_champs_public.first.rows.last
-              expect(dossier.root_champs_public.first.rows.flatten.map(&:value)).to match_array(['Texte court', 'Texte court'])
+              expect(dossier.root_champs_public.first.rows.flat_map(&:champs).map(&:value)).to match_array(['Texte court', 'Texte court'])
             end
           end
         end

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -1360,7 +1360,7 @@ describe Instructeurs::DossiersController, type: :controller do
     let(:now) { Time.zone.parse('01/01/2100') }
 
     let(:champ_repetition) { dossier.root_champs_private.fourth }
-    let(:champ_text) { champ_repetition.rows.first.first }
+    let(:champ_text) { champ_repetition.rows.first.champs.first }
     let(:champ_multiple_drop_down_list) { dossier.root_champs_private.first }
     let(:champ_linked_drop_down_list) { dossier.root_champs_private.second }
     let(:champ_datetime) { dossier.root_champs_private.third }
@@ -1442,7 +1442,7 @@ describe Instructeurs::DossiersController, type: :controller do
         context 'repetition' do
           let(:champs_private_attributes) do
             {
-              champ_repetition.rows.first.first.public_id => {
+              champ_repetition.rows.first.champs.first.public_id => {
                 value: 'text',
               },
             }
@@ -1476,7 +1476,7 @@ describe Instructeurs::DossiersController, type: :controller do
             end
             let(:champs_private_attributes) do
               {
-                champ_repetition.rows.first.first.public_id => {
+                champ_repetition.rows.first.champs.first.public_id => {
                   external_id: 'text',
                 },
               }

--- a/spec/graphql/annotation_spec.rb
+++ b/spec/graphql/annotation_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe Mutations::DossierModifierAnnotations, type: :graphql do
     end
 
     context 'with rows' do
-      let(:annotation) { champs_private.find(&:repetition?).rows.first.first }
-      let(:other_annotation) { champs_private.find(&:repetition?).rows.second.first }
+      let(:annotation) { champs_private.find(&:repetition?).rows.first.champs.first }
+      let(:other_annotation) { champs_private.find(&:repetition?).rows.second.champs.first }
 
       it 'update champ' do
         expect(data).to eq(dossierModifierAnnotationText: {
@@ -169,8 +169,8 @@ RSpec.describe Mutations::DossierModifierAnnotations, type: :graphql do
     end
 
     context 'with rows' do
-      let(:annotation) { champs_private.find(&:repetition?).rows.first.find(&:decimal_number?) }
-      let(:other_annotation) { champs_private.find(&:repetition?).rows.second.find(&:decimal_number?) }
+      let(:annotation) { champs_private.find(&:repetition?).rows.first.champs.find(&:decimal_number?) }
+      let(:other_annotation) { champs_private.find(&:repetition?).rows.second.champs.find(&:decimal_number?) }
 
       it 'update champ' do
         expect(data).to eq(dossierModifierAnnotationDecimalNumber: {
@@ -247,8 +247,8 @@ RSpec.describe Mutations::DossierModifierAnnotations, type: :graphql do
     end
 
     context 'with rows' do
-      let(:annotation) { champs_private.find(&:repetition?).rows.first.find(&:decimal_number?) }
-      let(:other_annotation) { champs_private.find(&:repetition?).rows.second.find(&:decimal_number?) }
+      let(:annotation) { champs_private.find(&:repetition?).rows.first.champs.find(&:decimal_number?) }
+      let(:other_annotation) { champs_private.find(&:repetition?).rows.second.champs.find(&:decimal_number?) }
 
       it 'update annotation' do
         expect(data).to eq(dossierModifierAnnotations: {

--- a/spec/graphql/dossier_spec.rb
+++ b/spec/graphql/dossier_spec.rb
@@ -340,8 +340,8 @@ RSpec.describe Types::DossierType, type: :graphql do
     let(:variables) { { number: dossier.id } }
 
     let(:rows) do
-      dossier.root_champs_public.first.rows.map do |champs|
-        { champs: champs.map { { id: _1.to_typed_id } } }
+      dossier.root_champs_public.first.rows.map do |row|
+        { champs: row.champs.map { { id: it.to_typed_id } } }
       end
     end
 

--- a/spec/lib/recovery/dossier_life_cycle_spec.rb
+++ b/spec/lib/recovery/dossier_life_cycle_spec.rb
@@ -82,7 +82,7 @@ describe 'Dossier::Recovery::LifeCycle' do
 
       expect(reloaded_dossier.champ_data.count).not_to be(0)
 
-      expect(repetition(reloaded_dossier).rows.flatten.map(&:type)).to match_array(["Champs::PieceJustificativeChamp", "Champs::PieceJustificativeChamp", "Champs::PieceJustificativeChamp"])
+      expect(repetition(reloaded_dossier).rows.flat_map(&:champs).map(&:type)).to match_array(["Champs::PieceJustificativeChamp", "Champs::PieceJustificativeChamp", "Champs::PieceJustificativeChamp"])
       expect(pj_champ(reloaded_dossier).piece_justificative_file).to be_attached
       expect(carte(reloaded_dossier).geo_areas).to be_present
 

--- a/spec/models/champ_data_spec.rb
+++ b/spec/models/champ_data_spec.rb
@@ -119,7 +119,7 @@ describe ChampData do
     let(:standalone_champ) { build(:champ, type_de_champ: build(:type_de_champ), dossier: build(:dossier)) }
     let(:public_sections) { dossier.root_champs_public.filter(&:header_section?) }
     let(:private_sections) { dossier.root_champs_private.filter(&:header_section?) }
-    let(:sections_in_repetition) { dossier.root_champs_public.find(&:repetition?).rows.flatten.filter(&:header_section?) }
+    let(:sections_in_repetition) { dossier.root_champs_public.find(&:repetition?).rows.flat_map(&:champs).filter(&:header_section?) }
 
     it 'returns the sibling sections of a champ' do
       expect(public_sections).not_to be_empty
@@ -616,14 +616,55 @@ describe ChampData do
     end
   end
 
-  describe "#parent" do
-    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, mandatory: false, children: [{ type: :text }] }]) }
+  describe "#ancestors, #parent, #section and #repetition" do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :text, libelle: 't0' },
+        { type: :header_section, level: 1, libelle: 's1' },
+        { type: :header_section, level: 2, libelle: 's1.1' },
+        {
+          type: :repetition, mandatory: false, libelle: 'rep', children: [
+            { type: :header_section, level: 1, libelle: 'rs1' },
+            { type: :text, libelle: 'rt1' },
+          ],
+        },
+      ])
+    end
     let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+    let(:champ) { dossier.filled_champs_public.find { it.libelle == 'rt1' } }
 
-    let(:champ) { dossier.champ_data.where(type: "Champs::TextChamp").first }
+    it "returns the projected champs above, outermost first" do
+      expect(champ.ancestors.map(&:libelle)).to eq(['s1', 's1.1', 'rep', 'rs1'])
+      expect(champ.ancestors.map(&:row_id)).to eq([nil, nil, nil, champ.row_id])
+    end
 
-    it "returns the parent" do
-      expect(champ.parent).to eq(TypeDeChamp.find_by(type_champ: "repetition"))
+    it "projects each ancestor once per dossier" do
+      champ.ancestors.zip(champ.ancestors).each do |ancestor, reprojected|
+        expect(ancestor).to equal(reprojected)
+      end
+    end
+
+    it "exposes parent, section and repetition" do
+      expect(champ.parent.libelle).to eq('rs1')
+      expect(champ.parent.row_id).to eq(champ.row_id)
+      expect(champ.section.libelle).to eq('rs1')
+      expect(champ.repetition.libelle).to eq('rep')
+      expect(champ.repetition.row_id).to be_nil
+
+      root_champ = dossier.root_champs_public.find { it.libelle == 't0' }
+      expect(root_champ.ancestors).to eq([])
+      expect(root_champ.parent).to be_nil
+      expect(root_champ.section).to be_nil
+      expect(root_champ.repetition).to be_nil
+    end
+
+    it "exposes in_repetition? and in_section?" do
+      expect(champ.in_repetition?).to be(true)
+      expect(champ.in_section?).to be(true)
+
+      root_champ = dossier.root_champs_public.find { it.libelle == 't0' }
+      expect(root_champ.in_repetition?).to be(false)
+      expect(root_champ.in_section?).to be(false)
     end
   end
 

--- a/spec/models/champ_presentations/repetition_presentation_spec.rb
+++ b/spec/models/champ_presentations/repetition_presentation_spec.rb
@@ -20,7 +20,7 @@ describe ChampPresentations::RepetitionPresentation do
   before do
     champ_repetition.add_row(updated_by: 'test')
     champ_repetition.add_row(updated_by: 'test')
-    row1, row2, row3 = champ_repetition.rows
+    row1, row2, row3 = champ_repetition.rows.map(&:champs)
 
     nom, stars = row1
     champ_for_update(nom).update(value: "ruby")

--- a/spec/models/champs/header_section_champ_spec.rb
+++ b/spec/models/champs/header_section_champ_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+describe Champs::HeaderSectionChamp do
+  describe '#children' do
+    let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+
+    context 'at the root of the form' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :text, libelle: 't1' },
+          { type: :header_section, level: 2, libelle: 's1.1' },
+          { type: :text, libelle: 't1.1' },
+        ])
+      end
+      let(:champ) { dossier.root_champs_public.find { it.libelle == 's1' } }
+
+      it 'returns the projected champs of its direct children' do
+        expect(champ.children.map(&:libelle)).to eq(['t1', 's1.1'])
+        expect(champ.children).to all(have_attributes(row_id: nil))
+      end
+    end
+
+    context 'inside a repetition' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          {
+            type: :repetition, libelle: 'rep', children: [
+              { type: :header_section, level: 1, libelle: 'rs1' },
+              { type: :text, libelle: 'rt1' },
+            ],
+          },
+        ])
+      end
+      let(:repetition) { dossier.root_champs_public.find { it.libelle == 'rep' } }
+      let(:champ) { repetition.rows.first.champs.find { it.libelle == 'rs1' } }
+
+      it 'returns the projected champs of the same row' do
+        expect(champ.children.map(&:libelle)).to eq(['rt1'])
+        expect(champ.children).to all(have_attributes(row_id: champ.row_id))
+      end
+    end
+  end
+end

--- a/spec/models/champs/referentiel_champ_cast_value_spec.rb
+++ b/spec/models/champs/referentiel_champ_cast_value_spec.rb
@@ -652,7 +652,7 @@ describe Champs::ReferentielChamp, type: :model do
           ]
         end
         let(:repetition_champ) { dossier.champ_data.find(&:repetition?) }
-        let(:referentiel_champ) { repetition_champ.rows.first.find(&:referentiel?) }
+        let(:referentiel_champ) { repetition_champ.rows.first.champs.find(&:referentiel?) }
 
         context 'when mapping and data are arrays' do
           let(:referentiel_mapping) do
@@ -664,7 +664,7 @@ describe Champs::ReferentielChamp, type: :model do
 
           it 'update current row' do
             expect { subject }.not_to change { repetition_champ.reload.rows.size }
-            champs = repetition_champ.rows.first
+            champs = repetition_champ.rows.first.champs
             expect(champs.find(&:text?).value).to eq('Jeanne')
           end
         end

--- a/spec/models/champs/repetition_champ_spec.rb
+++ b/spec/models/champs/repetition_champ_spec.rb
@@ -101,7 +101,7 @@ describe Champs::RepetitionChamp do
       let(:max_rep) { nil }
 
       before do
-        champ_for_update(champ.rows.first.first).update(value: "rb")
+        champ_for_update(champ.rows.first.champs.first).update(value: "rb")
       end
 
       it "adds a repetition_too_few error" do
@@ -130,7 +130,7 @@ describe Champs::RepetitionChamp do
       let(:max_rep) { 1 }
 
       before do
-        champ_for_update(champ.rows.first.first).update(value: "rb")
+        champ_for_update(champ.rows.first.champs.first).update(value: "rb")
         champ.add_row(updated_by: "test")
         champ.add_row(updated_by: "test")
       end
@@ -146,7 +146,7 @@ describe Champs::RepetitionChamp do
       let(:max_rep) { 3 }
 
       before do
-        champ_for_update(champ.rows.first.first).update(value: "rb")
+        champ_for_update(champ.rows.first.champs.first).update(value: "rb")
       end
 
       it "does not add any errors" do
@@ -158,7 +158,7 @@ describe Champs::RepetitionChamp do
 
   describe "#for_tag" do
     before do
-      champ_for_update(champ.rows.first.first).update(value: "rb")
+      champ_for_update(champ.rows.first.champs.first).update(value: "rb")
     end
 
     it "can render as string" do

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -66,6 +66,37 @@ RSpec.describe DossierChampsConcern do
     it { is_expected.to be_truthy }
   end
 
+  describe "#champs_public and #champs_private" do
+    let(:types_de_champ_public) do
+      [
+        { type: :text, libelle: "t1" },
+        { type: :repetition, libelle: "rep", children: [{ type: :text, libelle: "rt1" }] },
+        { type: :header_section, level: 1, libelle: "s1" },
+        { type: :text, libelle: "t2" },
+        { type: :header_section, level: 2, libelle: "s1.1" },
+        { type: :text, libelle: "t3" },
+      ]
+    end
+    let(:types_de_champ_private) do
+      [
+        { type: :header_section, level: 1, libelle: "ps1" },
+        { type: :text, libelle: "pt1" },
+      ]
+    end
+
+    it "returns first-level champs and top-level header sections" do
+      expect(dossier.champs_public.map(&:libelle)).to eq(["t1", "rep", "s1"])
+      expect(dossier.champs_private.map(&:libelle)).to eq(["ps1"])
+    end
+
+    it "composes with children and rows to navigate the tree" do
+      _, repetition, section = dossier.champs_public
+      expect(repetition.rows.flat_map(&:champs).map(&:libelle)).to eq(["rt1"])
+      expect(section.children.map(&:libelle)).to eq(["t2", "s1.1"])
+      expect(section.children.last.children.map(&:libelle)).to eq(["t3"])
+    end
+  end
+
   describe "#project_champ" do
     let(:type_de_champ_repetition) { dossier.find_type_de_champ_by_stable_id(993) }
     let(:type_de_champ_public) { dossier.find_type_de_champ_by_stable_id(99) }
@@ -102,6 +133,12 @@ RSpec.describe DossierChampsConcern do
           expect(subject.is_a?(Champs::TextChamp)).to be_truthy
           expect(subject.updated_at).not_to be_nil
         }
+
+        it "memoizes the built champ" do
+          expect(subject).to equal(dossier.project_champ(type_de_champ_public, row_id:))
+          dossier.reload
+          expect(subject).not_to equal(dossier.project_champ(type_de_champ_public, row_id:))
+        end
 
         context "in repetition" do
           let(:type_de_champ_public) { dossier.find_type_de_champ_by_stable_id(994) }
@@ -248,7 +285,13 @@ RSpec.describe DossierChampsConcern do
 
     it do
       expect(subject.size).to eq(1)
-      expect(subject.first.size).to eq(1)
+      expect(subject.first.index).to eq(1)
+      expect(subject.first.id).to be_present
+      expect(subject.first.champs.size).to eq(1)
+    end
+
+    it "projects the same champ instances across rows built separately" do
+      expect(subject.first.champs.first).to equal(dossier.project_rows_for(type_de_champ_repetition).first.champs.first)
     end
   end
 

--- a/spec/models/concerns/dossier_clone_concern_spec.rb
+++ b/spec/models/concerns/dossier_clone_concern_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe DossierCloneConcern do
           let(:cloned_champ_repetition) { new_dossier.root_champs_public.find(&:repetition?) }
 
           it do
-            expect(cloned_champ_repetition.rows.flatten.count).to eq(4)
-            expect(cloned_champ_repetition.rows.flatten.map(&:id)).not_to eq(champ_repetition.rows.flatten.map(&:id))
+            expect(cloned_champ_repetition.rows.flat_map(&:champs).count).to eq(4)
+            expect(cloned_champ_repetition.rows.flat_map(&:champs).map(&:id)).not_to eq(champ_repetition.rows.flat_map(&:champs).map(&:id))
             expect(cloned_champ_repetition.row_ids).to eq(champ_repetition.row_ids)
           end
         end

--- a/spec/models/concerns/dossier_rebase_concern_spec.rb
+++ b/spec/models/concerns/dossier_rebase_concern_spec.rb
@@ -189,8 +189,8 @@ describe DossierRebaseConcern do
         expect(dossier.root_champs_public.size).to eq(5)
         expect(dossier.champ_data.count(&:public?)).to eq(6)
         expect(repetition_champ.rows.size).to eq(2)
-        expect(repetition_champ.rows[0].size).to eq(1)
-        expect(repetition_champ.rows[1].size).to eq(1)
+        expect(repetition_champ.rows[0].champs.size).to eq(1)
+        expect(repetition_champ.rows[1].champs.size).to eq(1)
 
         procedure.publish_revision!(procedure.administrateurs.first)
         perform_enqueued_jobs
@@ -206,14 +206,14 @@ describe DossierRebaseConcern do
         expect(rebased_datetime_champ.type_champ).to eq(TypeDeChamp.type_champs.fetch(:date))
         expect(rebased_datetime_champ.value).to be_nil
         expect(rebased_repetition_champ.rows.size).to eq(2)
-        expect(rebased_repetition_champ.rows[0].size).to eq(2)
-        expect(rebased_repetition_champ.rows[1].size).to eq(2)
+        expect(rebased_repetition_champ.rows[0].champs.size).to eq(2)
+        expect(rebased_repetition_champ.rows[1].champs.size).to eq(2)
         expect(rebased_text_champ.rebased_at).not_to be_nil
         expect(rebased_datetime_champ.rebased_at).not_to be_nil
         expect(rebased_number_champ.rebased_at).to be_nil
         expect(rebased_new_repetition_champ).not_to be_nil
         expect(rebased_new_repetition_champ.rows.size).to eq(1)
-        expect(rebased_new_repetition_champ.rows[0].size).to eq(2)
+        expect(rebased_new_repetition_champ.rows[0].champs.size).to eq(2)
 
         dossier.passer_en_construction!
         procedure.draft_revision.find_and_ensure_exclusive_use(private_text_type_de_champ.stable_id).update(type_champ: TypeDeChamp.type_champs.fetch(:textarea))

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -234,7 +234,7 @@ describe TagsSubstitutionConcern, type: :model do
       before do
         repetition = dossier.root_champs_public.find(&:repetition?)
         repetition.add_row(updated_by: 'test')
-        paul_champs, pierre_champs = repetition.rows
+        paul_champs, pierre_champs = repetition.rows.map(&:champs)
 
         champ_for_update(paul_champs.first).update(value: 'Paul')
         champ_for_update(paul_champs.last).update(value: 'Chavard')

--- a/spec/models/dossier_preloader_spec.rb
+++ b/spec/models/dossier_preloader_spec.rb
@@ -12,7 +12,7 @@ describe DossierPreloader do
   let(:dossier) { create(:dossier, procedure: procedure) }
   let(:repetition) { subject.root_champs_public.second }
   let(:repetition_optional) { subject.root_champs_public.third }
-  let(:first_child) { repetition.rows.first.first }
+  let(:first_child) { repetition.rows.first.champs.first }
 
   describe 'all' do
     subject { DossierPreloader.load_one(dossier, pj_template: true) }
@@ -40,7 +40,7 @@ describe DossierPreloader do
         expect(subject.champ_data.find(&:public?).conditional?).to eq(false)
         expect(subject.root_champs_public.first.conditional?).to eq(false)
 
-        expect(repetition.rows.first.first.public_id).to eq(first_child.public_id)
+        expect(repetition.rows.first.champs.first.public_id).to eq(first_child.public_id)
         expect(repetition_optional.row_ids).to be_empty
       end
 

--- a/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe TypesDeChamp::PrefillRepetitionTypeDeChamp, type: :model do
   let(:text_repetition) { prefillable_subchamps.first }
   let(:integer_repetition) { prefillable_subchamps.second }
   let(:region_repetition) { prefillable_subchamps.third }
-  let(:text_repetition_champs) { champ.rows.flat_map(&:first) }
-  let(:integer_repetition_champs) { champ.rows.flat_map(&:second) }
+  let(:text_repetition_champs) { champ.rows.map { it.champs.first } }
+  let(:integer_repetition_champs) { champ.rows.map { it.champs.second } }
 
   describe 'ancestors' do
     subject { described_class.build(type_de_champ, procedure.active_revision) }

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -65,8 +65,8 @@ describe PiecesJustificativesService do
     end
 
     context 'with a repetition' do
-      let(:first_champ) { champ_for_update(repetition(dossier).rows.first.first) }
-      let(:second_champ) { champ_for_update(repetition(dossier).rows.second.first) }
+      let(:first_champ) { champ_for_update(repetition(dossier).rows.first.champs.first) }
+      let(:second_champ) { champ_for_update(repetition(dossier).rows.second.champs.first) }
 
       before do
         repetition(dossier).add_row(updated_by: 'test')
@@ -558,15 +558,15 @@ describe PiecesJustificativesService do
     it do
       champs = dossier_1.root_champs_public
       repet_0 = champs[0]
-      pj_0 = repet_0.rows.first.first
-      pj_1 = repet_0.rows.second.first
+      pj_0 = repet_0.rows.first.champs.first
+      pj_1 = repet_0.rows.second.champs.first
 
       repet_1 = champs[1]
-      pj_2 = repet_1.rows.first.first
-      pj_3 = repet_1.rows.first.second
+      pj_2 = repet_1.rows.first.champs.first
+      pj_3 = repet_1.rows.first.champs.second
 
-      pj_4 = repet_1.rows.second.first
-      pj_5 = repet_1.rows.second.second
+      pj_4 = repet_1.rows.second.champs.first
+      pj_5 = repet_1.rows.second.champs.second
 
       is_expected.to eq({ pj_0.id => 0, pj_1.id => 1, pj_2.id => 0, pj_3.id => 0, pj_4.id => 1, pj_5.id => 1 })
     end

--- a/spec/services/procedure_export_service_zip_spec.rb
+++ b/spec/services/procedure_export_service_zip_spec.rb
@@ -18,11 +18,11 @@ describe ProcedureExportService do
       attach_file_to_champ(pj_champ(dossier))
 
       repetition(dossier).add_row(updated_by: 'test')
-      attach_file_to_champ(repetition(dossier).rows.first.first)
-      attach_file_to_champ(repetition(dossier).rows.first.first)
+      attach_file_to_champ(repetition(dossier).rows.first.champs.first)
+      attach_file_to_champ(repetition(dossier).rows.first.champs.first)
 
       repetition(dossier).add_row(updated_by: 'test')
-      attach_file_to_champ(repetition(dossier).rows.second.first)
+      attach_file_to_champ(repetition(dossier).rows.second.champs.first)
     end
 
     allow_any_instance_of(ActiveStorage::Attachment).to receive(:url).and_return("https://opengraph.githubassets.com/d0e7862b24d8026a3c03516d865b28151eb3859029c6c6c2e86605891fbdcd7a/socketry/async-io")

--- a/spec/system/administrateurs/api_referentiel_spec.rb
+++ b/spec/system/administrateurs/api_referentiel_spec.rb
@@ -663,11 +663,11 @@ describe 'Referentiel API:' do
           dossier = Dossier.last
 
           # wait until selected key had been submitted to backend
-          wait_until { dossier.reload.flat_champs_private.find(&:repetition?).rows.first.find(&:referentiel?).value&.match?(/010002699 CENTRE MEDICAL REGINA/) }
+          wait_until { dossier.reload.flat_champs_private.find(&:repetition?).rows.first.champs.find(&:referentiel?).value&.match?(/010002699 CENTRE MEDICAL REGINA/) }
 
           # wait until refreshed with prefilled values
           expect(page).to have_content("Donnée remplie automatiquement.", count: 2)
-          expect(dossier.reload.flat_champs_private.find(&:repetition?).rows.first.map(&:value)).to include("010002699")
+          expect(dossier.reload.flat_champs_private.find(&:repetition?).rows.first.champs.map(&:value)).to include("010002699")
         end
       end
     end

--- a/spec/views/shared/dossiers/_champs.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_champs.html.haml_spec.rb
@@ -6,7 +6,6 @@ describe 'shared/dossiers/champs', type: :view do
   let(:profile) { "instructeur" }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:types_de_champ) { dossier.revision.root_types_de_champ_public }
 
   before do
     view.extend DossierHelper
@@ -17,7 +16,7 @@ describe 'shared/dossiers/champs', type: :view do
     end
   end
 
-  subject { render ViewableChamp::SectionComponent.new(types_de_champ:, dossier:, demande_seen_at:, profile:) }
+  subject { render ViewableChamp::SectionComponent.new(champs: dossier.champs_public, dossier:, demande_seen_at:, profile:) }
 
   context "there are some champs" do
     let(:types_de_champ_public) { [{ type: :checkbox }, { type: :header_section }, { type: :explication }, { type: :dossier_link }, { type: :textarea }, { type: :integer_number }] }


### PR DESCRIPTION
> [!NOTE]
> PR empilée sur #13503 (API arbre des types de champ) — à merger d'abord ; la base de cette PR est `push-zzkoqkonzsqu`.

## Résumé

Étend l'API de navigation en arbre (#13503) au côté champs (champs projetés d'un dossier), puis l'utilise dans les composants existants.

### API

- `Champ#children` / `#ancestors` / `#parent` / `#section` / `#repetition` / `#in_repetition?` / `#in_section?` — équivalents côté champs de l'API des types de champ : délégation à celle-ci, plus la projection de ligne (les ancêtres à l'intérieur d'une répétition partagent le `row_id` du champ)
- `Dossier#champs_public` / `#champs_private` — points d'entrée de l'arbre des champs projetés
- `RepetitionRow` (ex `Champs::RepetitionChamp::Row`) : `RepetitionChamp#rows` retourne des instances avec `id`, `index`, `flat_champs` (tous les champs de la ligne) et `champs` (points d'entrée de l'arbre de la ligne) — objets valeur reconstruits à la demande
- `Dossier#project_champ` mémoïse les champs construits : deux projections du même public_id retournent la même instance (`champs_by_public_id`), invalidée par `reset_champs_cache`
- ⚠️ `Champ#parent` change de sémantique : retournait le TypeDeChamp de la répétition parente, retourne maintenant le conteneur le plus proche (champ projeté) ; les anciens appelants utilisent `Champ#repetition`

### Refactors

- Sommaire du dossier (`ViewableChamp::HeaderSectionsSummaryComponent`) : construit sur l'arbre des champs, il exclut les sections et répétitions masquées par une condition (`visible?`), liste chaque ligne d'une répétition avec ses sections, et ancre chaque ligne sur son bloc dans la vue
- `ViewableChamp::SectionComponent` / `EditableChamp::SectionComponent` : rendus via l'arbre de champs, suppression du plumbing `row_id` ; `RepetitionRowComponent` reçoit directement la `RepetitionRow`
- `ChampConditionalConcern#parent_hidden?` simplifié via `Champ#repetition`

### Revue commit par commit

1. **modèles** — l'API arbre des champs (`RepetitionRow`, navigation, mémoïsation des projections, `champs_public`/`champs_private`)
2. **code applicatif** — contrôleurs, GraphQL, serializers, services et vues
3. **specs** — mise à jour des specs (hors composants)
4. **composants editable_champ** (+ leurs specs)
5. **sommaire du dossier** (+ specs) — le changement visible instructeur
6. **composants d'affichage du dossier** (+ specs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)