### PR TITLE
Perf: fix un N+1 dans le job de publication sur datagouv du descriptif de démarches

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -21,7 +21,12 @@ module Types
     field :demarches_publiques, DemarcheDescriptorType.connection_type, null: false, internal: true
 
     def demarches_publiques
-      Procedure.publiques.includes(:procedure_paths, draft_revision: :procedure, published_revision: :procedure)
+      Procedure.publiques.includes(
+        :procedure_paths,
+        published_revision: {
+          revision_types_de_champ: :type_de_champ,
+        }
+      )
     end
 
     def demarche_descriptor(demarche:)


### PR DESCRIPTION
Suite à l'abaissement du seuil de nb de dossiers minimums pour qu'une procédure rentre dans le scope (https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/13363/changes/462735e29c8d52d80c5eabe1c1eb235d797ba9c0), on a sujet perf qui pop : https://demarches-simplifiees.sentry.io/issues/7601642237/?project=1429550&query=is%3Aunresolved%20datagouv&referrer=issue-stream