### PR TITLE
ETQ admin, Simpliscore me propose d'activer la lecture automatique des justificatifs (domicile, RIB, avis d'impôt)

### DIFF
--- a/app/components/llm/improve_types_item_component.html.erb
+++ b/app/components/llm/improve_types_item_component.html.erb
@@ -2,7 +2,7 @@
   <div class="fr-checkbox-group fr-my-1v">
     <%= checkbox do %>
       <span class="fr-badge fr-badge--sm">
-        <%= original_type_champ_label %>
+        <%= original_badge_label %>
       </span>
 
       <span
@@ -11,7 +11,7 @@
       ></span>
 
       <span class="fr-badge fr-badge--sm fr-badge--green-emeraude">
-        <%= new_type_champ_label %>
+        <%= new_badge_label %>
       </span>
 
       <% if options_summary.present? %>

--- a/app/components/llm/improve_types_item_component.rb
+++ b/app/components/llm/improve_types_item_component.rb
@@ -13,12 +13,26 @@ class LLM::ImproveTypesItemComponent < LLM::SuggestionItemComponent
     I18n.t(type_champ, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])
   end
 
-  def new_type_champ_label
-    type_champ_label(payload['type_champ'])
+  def nature_label(nature)
+    I18n.t(nature, scope: [:activerecord, :attributes, :type_de_champ, :natures])
   end
 
-  def original_type_champ_label
-    type_champ_label(original_tdc.type_champ)
+  # Le type reste piece_justificative quand seule la lecture automatique du document change :
+  # afficher la nature plutôt qu'une transition de type identique
+  def nature_change?
+    payload['nature'].present? && payload['type_champ'] == original_tdc.type_champ
+  end
+
+  def new_badge_label
+    nature_change? ? nature_label(payload['nature']) : type_champ_label(payload['type_champ'])
+  end
+
+  def original_badge_label
+    if nature_change?
+      nature_label(original_tdc.nature || TypeDeChamp.natures.fetch(:non_specifie))
+    else
+      type_champ_label(original_tdc.type_champ)
+    end
   end
 
   def options_summary

--- a/app/models/concerns/revision_describable_to_llm_concern.rb
+++ b/app/models/concerns/revision_describable_to_llm_concern.rb
@@ -19,12 +19,19 @@ module RevisionDescribableToLLMConcern
           parent_id: rtdc.parent&.stable_id,
           header_section_level: (rtdc.type_de_champ.header_section_level_value if rtdc.type_de_champ.header_section?),
           display_condition: rtdc.type_de_champ.condition.present?,
+          nature: nature_for_llm(rtdc.type_de_champ),
           options: options_for_llm(rtdc.type_de_champ),
         }.compact.reject { |k, _v| reject.include?(k) }
       end
   end
 
   private
+
+  def nature_for_llm(tdc)
+    return nil unless tdc.piece_justificative?
+
+    tdc.nature || TypeDeChamp.natures.fetch(:non_specifie)
+  end
 
   def options_for_llm(tdc)
     return nil unless TYPES_WITH_OPTIONS.include?(tdc.type_champ)

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -311,10 +311,11 @@ class ProcedureRevision < ApplicationRecord
           end
         end
       elsif payload.key?(:type_champ) # TypesImprover: type change
-        stable_id, type_champ, options = payload.values_at(:stable_id, :type_champ, :options)
+        stable_id, type_champ, nature, options = payload.values_at(:stable_id, :type_champ, :nature, :options)
 
         tdc = find_and_ensure_exclusive_use(stable_id)
         update_params = { type_champ: }
+        update_params[:nature] = nature if nature.present?
         update_params[:options] = tdc.options.merge(options) if options.present?
         tdc.update(update_params)
       else # LabelImprover: mise à jour contenu

--- a/app/services/llm/base_improver.rb
+++ b/app/services/llm/base_improver.rb
@@ -237,6 +237,7 @@ module LLM
           - parent_id : stable_id du champ parent, ou null s’il n’y a pas de parent (donc ce champ est un enfant d’une répétition)
           - header_section_level : le niveau de section si le champ est de type header_section
           - display_condition : une condition d'affichage, optionnelle, dépendant de valeurs saisies préalablement par l'usager. Si cette condition est vraie le champ sera affiché, sinon il sera masqué, même s'il est obligatoire.
+          - nature : pour les champs piece_justificative uniquement, le document attendu (non_specifie, titre_identite, rib, justificatif_domicile, avis_impot). « non_specifie » signifie qu'aucune lecture automatique n'est activée.
 
           Les types de champ utilisés dans ce formulaire sont :
           %<field_types>s

--- a/app/services/llm/types_improver.rb
+++ b/app/services/llm/types_improver.rb
@@ -132,6 +132,37 @@ module LLM
           "justification": "Interface standard de case à cocher pour les attestations et consentements, obligeant l'usager à confirmer explicitement son engagement."
         }
 
+        **Exemple 6 : Lecture automatique d'un justificatif (ACCEPTÉ)**
+
+        Champ actuel :
+        { stable_id: 60, libelle: "Justificatif de domicile de moins de 3 mois", type: "piece_justificative", nature: "non_specifie" }
+
+        Analyse :
+        - Le libellé désigne UN document précis et connu : un justificatif de domicile
+        - Nature actuelle : "non_specifie" (le fichier est stocké tel quel, aucune donnée exploitable)
+        - Nature recommandée : "justificatif_domicile"
+        - GAIN : si le document porte un cachet 2D-Doc, le bénéficiaire, l'adresse et la date d'émission sont extraits et transmis à l'instructeur
+        - CONTREPARTIE ACCEPTABLE : le champ est limité à 1 fichier et aux formats document texte / scan, ce qui correspond à ce document
+        - DÉCISION : Proposer le changement de nature (le type reste piece_justificative)
+
+        Tool call :
+        {
+          "update": { "stable_id": 60, "type_champ": "piece_justificative", "nature": "justificatif_domicile" },
+          "justification": "Lecture automatique du cachet 2D-Doc : le nom du bénéficiaire, l'adresse et la date d'émission sont transmis à l'instructeur."
+        }
+
+        **Exemple 7 : Pièce jointe générique (REJETÉ)**
+
+        Champ actuel :
+        { stable_id: 70, libelle: "Pièces complémentaires à votre demande", type: "piece_justificative", nature: "non_specifie" }
+
+        Analyse :
+        - Le libellé ne désigne AUCUN document précis : l'usager peut déposer n'importe quoi
+        - Tentation : activer une nature pour bénéficier de la lecture automatique
+        - PROBLÈME : activer une nature limite le champ à 1 SEUL fichier et aux formats document texte / scan
+        - L'usager ne pourrait plus déposer plusieurs pièces → régression fonctionnelle
+        - DÉCISION : NE PAS changer la nature
+
         ## MÉTHODOLOGIE OBLIGATOIRE EN 2 PHASES :
 
         PHASE 1 - AUDIT (mental, pas de tool call) :
@@ -144,6 +175,10 @@ module LLM
         - Le champ attend-il des DONNÉES STANDARDISÉES connues ?
           - email, phone, siret, iban, date, etc.
           - SI OUI : marquer pour transformation PRIORITÉ 1
+
+        - Le champ est-il une piece_justificative attendant UN document à LECTURE AUTOMATIQUE ?
+          - justificatif de domicile, RIB, avis d'imposition
+          - SI OUI et nature == "non_specifie" : marquer pour changement de nature PRIORITÉ 1
 
         - Le champ bénéficierait-il d'AUTO-COMPLÉTION via référentiel ?
           - address, communes, départements, regions, rna, rnf, annuaire_education
@@ -205,6 +240,27 @@ module LLM
 
         - annuaire_education : Identifiant établissement + données complètes
           OK "Établissement scolaire" (text) → annuaire_education
+
+        - nature d'une piece_justificative : lecture automatique du document déposé
+          Le type reste "piece_justificative", seule la "nature" change. Répète toujours "type_champ": "piece_justificative".
+          Ne proposer QUE si la nature actuelle est "non_specifie" ET que le libellé désigne UN document précis.
+
+          - justificatif_domicile : décode le cachet 2D-Doc → bénéficiaire, adresse, date d'émission
+            OK "Justificatif de domicile" (nature non_specifie) → justificatif_domicile
+            OK "Facture d'électricité, de gaz ou d'eau de moins de 3 mois" → justificatif_domicile
+            OK "Quittance de loyer" → justificatif_domicile
+
+          - rib : extrait titulaire, IBAN, BIC, nom de la banque
+            OK "RIB" (nature non_specifie) → rib
+            OK "Relevé d'identité bancaire" → rib
+
+          - avis_impot : décode le cachet 2D-Doc → déclarants, revenu fiscal de référence, nombre de parts, référence d'avis
+            OK "Avis d'imposition" (nature non_specifie) → avis_impot
+            OK "Dernier avis d'impôt sur le revenu" → avis_impot
+
+          KO "Pièces complémentaires" / "Autres documents" → NE PAS changer (aucun document précis)
+          KO Champ où l'usager dépose plusieurs documents → NE PAS changer (la nature limite à 1 fichier)
+          KO nature déjà renseignée (rib, justificatif_domicile, avis_impot, titre_identite) → NE PAS changer
 
         PRIORITÉ 2 : AUTO-COMPLÉTION VIA RÉFÉRENTIELS
 
@@ -305,6 +361,9 @@ module LLM
         - NE PAS utiliser "pays" pour pays de naissance ou nationalité (manque pays historiques)
         - NE PAS transformer "address" en "communes" si l'adresse complète est nécessaire
         - NE PAS sur-spécialiser : un champ text libre doit rester text
+        - NE PAS renseigner une "nature" sur une pièce justificative générique (limite à 1 fichier et aux formats document texte / scan)
+        - NE PAS proposer "titre_identite" comme nature : ce choix relève de l'administration, pas d'une optimisation
+        - NE PAS renseigner "nature" sur un type autre que "piece_justificative"
 
         >> Il vaut mieux ne faire AUCUNE proposition que de proposer une transformation inappropriée.
 
@@ -316,6 +375,7 @@ module LLM
         ## Concentre-toi sur les gains concrets :
         - Validation automatique (email, iban, siret)
         - Enrichissement de données (siret → données entreprise, address → commune/département/région)
+        - Lecture automatique des documents déposés (justificatif de domicile, RIB, avis d'imposition → données transmises à l'instructeur)
         - Simplification pour l'usager (UX adaptée pour chaque champ, meilleure accessibilité)
 
         Utilise l'outil #{TOOL_DEFINITION.dig(:function, :name)} pour chaque proposition (un appel par changement).

--- a/app/services/llm/types_improver.rb
+++ b/app/services/llm/types_improver.rb
@@ -15,7 +15,14 @@ module LLM
               description: 'Changement de type',
               properties: {
                 stable_id: { type: 'integer', description: 'Identifiant du champ à modifier.' },
-                type_champ: { type: 'string', description: 'Nouveau type du champ.' },
+                type_champ: { type: 'string', description: 'Nouveau type du champ. Répéter le type actuel si seule la nature change.' },
+                nature: {
+                  type: 'string',
+                  description: <<~DESC.squish,
+                    Nature de la pièce, uniquement pour type_champ "piece_justificative".
+                    Une des valeurs : non_specifie, titre_identite, rib, justificatif_domicile, avis_impot.
+                  DESC
+                },
                 options: {
                   type: 'object',
                   description: <<~DESC.squish,
@@ -328,16 +335,19 @@ module LLM
 
       stable_id = data['stable_id']
       type_champ = data['type_champ']
+      nature = data['nature']
 
       return if stable_id.nil? || type_champ.blank?
       return unless valid_type_champ?(type_champ)
+      return if nature.present? && !valid_nature?(type_champ, nature)
 
       original_tdc = tdc_index[stable_id]
-      return if original_tdc && original_tdc.type_champ == type_champ
+      return if original_tdc && unchanged?(original_tdc, type_champ, nature)
 
       options = sanitize_options(type_champ, data['options'])
 
       payload = { 'stable_id' => stable_id, 'type_champ' => type_champ }
+      payload['nature'] = nature if nature.present?
       payload['options'] = options if options.present?
 
       {
@@ -351,6 +361,19 @@ module LLM
 
     def valid_type_champ?(type_champ)
       TypeDeChamp.type_champs.key?(type_champ.to_s)
+    end
+
+    def valid_nature?(type_champ, nature)
+      type_champ.to_s == TypeDeChamp.type_champs.fetch(:piece_justificative) &&
+        TypeDeChamp.natures.key?(nature.to_s)
+    end
+
+    def unchanged?(original_tdc, type_champ, nature)
+      return false if original_tdc.type_champ != type_champ
+      return true if nature.blank?
+
+      current_nature = original_tdc.nature || TypeDeChamp.natures.fetch(:non_specifie)
+      current_nature == nature
     end
 
     def sanitize_options(type_champ, options)

--- a/spec/components/llm/improve_types_item_component_spec.rb
+++ b/spec/components/llm/improve_types_item_component_spec.rb
@@ -87,5 +87,24 @@ RSpec.describe LLM::ImproveTypesItemComponent, type: :component do
         expect(subject).to have_text("entre 0 et 100")
       end
     end
+
+    context 'with nature change on a piece_justificative' do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, libelle: "Justificatif de domicile", stable_id: 10 }]) }
+
+      before do
+        create(:llm_rule_suggestion_item,
+          llm_rule_suggestion:,
+          op_kind: 'update',
+          stable_id: 10,
+          payload: { 'stable_id' => 10, 'type_champ' => 'piece_justificative', 'nature' => 'justificatif_domicile' },
+          justification: 'Lecture automatique du cachet 2D-Doc')
+      end
+
+      it 'renders the nature transition instead of the unchanged type' do
+        expect(subject).to have_css('.fr-badge', text: "Non spécifié")
+        expect(subject).to have_css('.fr-badge.fr-badge--green-emeraude', text: "Justificatif de domicile")
+        expect(subject).not_to have_css('.fr-badge', text: "Pièce justificative")
+      end
+    end
   end
 end

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -1432,6 +1432,31 @@ describe ProcedureRevision do
         expect { revision.schema_to_llm }.not_to raise_error
       end
     end
+
+    context 'when a type_de_champ is a piece_justificative' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :piece_justificative, libelle: "Justificatif de domicile", stable_id: 10 },
+          { type: :text, libelle: "Nom", stable_id: 11 },
+        ])
+      end
+      let(:revision) { procedure.draft_revision }
+
+      it 'exposes nature, defaulting to non_specifie' do
+        pj, text = revision.schema_to_llm
+
+        expect(pj[:nature]).to eq('non_specifie')
+        expect(text).not_to have_key(:nature)
+      end
+
+      it 'exposes the nature already set' do
+        revision.types_de_champ_public.first.update!(nature: 'justificatif_domicile')
+
+        pj, _text = revision.reload.schema_to_llm
+
+        expect(pj[:nature]).to eq('justificatif_domicile')
+      end
+    end
   end
 
   describe "#apply_llm_rule_suggestion_items" do
@@ -1514,6 +1539,27 @@ describe ProcedureRevision do
           expect(tdc.options['special_characters_accepted']).to eq(false)
           expect(tdc.options['min_character_length']).to eq(5)
           expect(tdc.options['max_character_length']).to eq(5)
+        end
+      end
+
+      context 'with nature update' do
+        let(:types_de_champ_public) { [{ type: :piece_justificative, libelle: "Justificatif de domicile", stable_id: 10 }] }
+
+        it "can update nature on an unchanged piece_justificative" do
+          llm_rule_suggestion = create(:llm_rule_suggestion, procedure_revision: revision, rule: 'improve_types', schema_hash:)
+          create(:llm_rule_suggestion_item,
+            llm_rule_suggestion:,
+            verify_status: 'accepted',
+            stable_id: 10,
+            op_kind: 'update',
+            payload: { 'stable_id' => 10, 'type_champ' => 'piece_justificative', 'nature' => 'justificatif_domicile' })
+
+          revision.apply_llm_rule_suggestion_items(llm_rule_suggestion.changes_to_apply)
+          revision.reload
+
+          tdc = revision.types_de_champ_public.find { |t| t.stable_id == 10 }
+          expect(tdc.type_champ).to eq('piece_justificative')
+          expect(tdc.nature).to eq('justificatif_domicile')
         end
       end
     end

--- a/spec/services/llm/types_improver_spec.rb
+++ b/spec/services/llm/types_improver_spec.rb
@@ -215,5 +215,51 @@ RSpec.describe LLM::TypesImprover do
         )
       end
     end
+
+    context 'with nature' do
+      let(:types_de_champ) do
+        [
+          double('tdc4', stable_id: 4, type_champ: 'piece_justificative', nature: 'non_specifie'),
+          double('tdc5', stable_id: 5, type_champ: 'piece_justificative', nature: 'rib'),
+        ]
+      end
+
+      def tool_calls_for(update)
+        calls = [{ name: rule, arguments: { 'update' => update, 'justification' => 'Test' } }]
+        runner = double()
+        allow(runner).to receive(:call).with(anything).and_return([calls, usage])
+
+        described_class.new(runner:).generate_for(suggestion).first
+      end
+
+      it 'keeps a nature change on an unchanged piece_justificative' do
+        tool_calls = tool_calls_for({ 'stable_id' => 4, 'type_champ' => 'piece_justificative', 'nature' => 'justificatif_domicile' })
+
+        expect(tool_calls.size).to eq(1)
+        expect(tool_calls.first[:payload]).to include(
+          'stable_id' => 4,
+          'type_champ' => 'piece_justificative',
+          'nature' => 'justificatif_domicile'
+        )
+      end
+
+      it 'filters update when nature unchanged' do
+        tool_calls = tool_calls_for({ 'stable_id' => 5, 'type_champ' => 'piece_justificative', 'nature' => 'rib' })
+
+        expect(tool_calls).to be_empty
+      end
+
+      it 'filters invalid nature values' do
+        tool_calls = tool_calls_for({ 'stable_id' => 4, 'type_champ' => 'piece_justificative', 'nature' => 'invalid_nature' })
+
+        expect(tool_calls).to be_empty
+      end
+
+      it 'filters nature on a type that is not a piece_justificative' do
+        tool_calls = tool_calls_for({ 'stable_id' => 1, 'type_champ' => 'email', 'nature' => 'justificatif_domicile' })
+
+        expect(tool_calls).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
Les recommandations Simpliscore savent désormais proposer d'activer la lecture automatique des documents déposés : justificatif de domicile, RIB et avis d'impôt.

Ces documents sont déjà lus automatiquement quand la « nature » de la pièce justificative est renseignée (décodage du cachet 2D-Doc → bénéficiaire, adresse, date d'émission…), mais l'administrateur devait le savoir et le faire à la main. L'improver ne pouvait pas le suggérer : il ne transportait que le type de champ et ses options, alors que la nature est un attribut distinct.

**Deux commits :**

1. `tech:` la plomberie — la nature est exposée au LLM, acceptée dans le tool call, validée puis appliquée.
2. `feat:` les prompts et l'affichage de la suggestion.

**Point d'attention pour la relecture :** activer une nature restreint le champ à **un seul fichier** et aux formats document texte / scan. Le prompt ne propose donc le changement que si le libellé désigne un document précis, jamais sur une pièce jointe générique (« Pièces complémentaires ») où ce serait une régression. `titre_identite` est également exclu des propositions : ce choix relève de l'administration.

La suggestion s'affiche « Non spécifié → Justificatif de domicile » plutôt qu'une transition de type identique.
