### PR TITLE
Tech: renomme les accesseurs de champs et de types de champ

### DIFF
--- a/app/components/conditions/routing_rules_component.rb
+++ b/app/components/conditions/routing_rules_component.rb
@@ -8,7 +8,7 @@ class Conditions::RoutingRulesComponent < Conditions::ConditionsComponent
     @condition = groupe_instructeur.routing_rule || empty_operator(empty, empty)
     @procedure = groupe_instructeur.procedure
     @procedure_id = @procedure.id
-    @source_tdcs = @procedure.active_revision.types_de_champ_public
+    @source_tdcs = @procedure.active_revision.root_types_de_champ_public
     @champ_value_in_condition = @procedure.champ_value_in_condition?
   end
 

--- a/app/components/types_de_champ_editor/estimated_fill_duration_component.rb
+++ b/app/components/types_de_champ_editor/estimated_fill_duration_component.rb
@@ -17,7 +17,7 @@ class TypesDeChampEditor::EstimatedFillDurationComponent < ApplicationComponent
   end
 
   def show?
-    !annotations? && @revision.types_de_champ_public.present?
+    !annotations? && @revision.root_types_de_champ_public.present?
   end
 
   def estimated_fill_duration_minutes

--- a/app/components/viewable_champ/header_sections_summary_component.rb
+++ b/app/components/viewable_champ/header_sections_summary_component.rb
@@ -8,9 +8,9 @@ class ViewableChamp::HeaderSectionsSummaryComponent < ApplicationComponent
     @is_private = is_private
 
     @header_sections = if is_private
-      dossier.revision.types_de_champ_private
+      dossier.revision.root_types_de_champ_private
     else
-      dossier.revision.types_de_champ_public
+      dossier.revision.root_types_de_champ_public
     end.filter(&:header_section?)
   end
 

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -380,7 +380,7 @@ module Instructeurs
 
       respond_to do |format|
         format.turbo_stream do
-          @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_attributes_params(:private), dossier.project_champs_private_all)
+          @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_attributes_params(:private), dossier.flat_champs_private)
         end
       end
     end
@@ -398,7 +398,7 @@ module Instructeurs
 
       respond_to do |format|
         format.turbo_stream do
-          @to_show, @to_hide, @to_update = champ_to_turbo_update(annotation, dossier.project_champs_private_all)
+          @to_show, @to_hide, @to_update = champ_to_turbo_update(annotation, dossier.flat_champs_private)
 
           render :update_annotations, layout: false
         end

--- a/app/controllers/instructeurs/edit_controller.rb
+++ b/app/controllers/instructeurs/edit_controller.rb
@@ -21,7 +21,7 @@ module Instructeurs
 
       respond_to do |format|
         format.turbo_stream do
-          @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_attributes_params(:public), dossier.project_champs_public_all)
+          @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_attributes_params(:public), dossier.flat_champs_public)
           render layout: false
         end
       end
@@ -59,7 +59,7 @@ module Instructeurs
 
       respond_to do |format|
         format.turbo_stream do
-          @to_show, @to_hide, @to_update = champ_to_turbo_update(champ, dossier.project_champs_public_all)
+          @to_show, @to_hide, @to_update = champ_to_turbo_update(champ, dossier.flat_champs_public)
           render :update, layout: false
         end
       end

--- a/app/controllers/prefill_type_de_champs_controller.rb
+++ b/app/controllers/prefill_type_de_champs_controller.rb
@@ -14,7 +14,7 @@ class PrefillTypeDeChampsController < ApplicationController
   end
 
   def set_prefill_type_de_champ
-    type_de_champ = @procedure.active_revision.types_de_champ_public.filter(&:fillable?).find { _1.stable_id == params[:id].to_i }
+    type_de_champ = @procedure.active_revision.root_types_de_champ_public.filter(&:fillable?).find { _1.stable_id == params[:id].to_i }
     raise ActiveRecord::RecordNotFound if type_de_champ.blank?
     @type_de_champ = TypesDeChamp::PrefillTypeDeChamp.build(type_de_champ, @procedure.active_revision)
   end

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -337,7 +337,7 @@ module Users
 
       respond_to do |format|
         format.turbo_stream do
-          @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_attributes_params(:public), dossier.project_champs_public_all)
+          @to_show, @to_hide, @to_update = champs_to_turbo_update(champs_attributes_params(:public), dossier.flat_champs_public)
           render :update, layout: false
         end
       end
@@ -357,7 +357,7 @@ module Users
       champ.validate(:champ_value) if champ.done?
       respond_to do |format|
         format.turbo_stream do
-          @to_show, @to_hide, @to_update = champ_to_turbo_update(champ, dossier.project_champs_public_all)
+          @to_show, @to_hide, @to_update = champ_to_turbo_update(champ, dossier.flat_champs_public)
 
           render :update, layout: false
         end

--- a/app/dashboards/dossier_dashboard.rb
+++ b/app/dashboards/dossier_dashboard.rb
@@ -24,7 +24,7 @@ class DossierDashboard < Administrate::BaseDashboard
     en_construction_at: Field::DateTime,
     en_instruction_at: Field::DateTime,
     processed_at: Field::DateTime,
-    project_champs_public: ChampCollectionField,
+    root_champs_public: ChampCollectionField,
     groupe_instructeur: Field::BelongsTo,
   }.freeze
 
@@ -48,7 +48,7 @@ class DossierDashboard < Administrate::BaseDashboard
     :state,
     :procedure,
     :groupe_instructeur,
-    :project_champs_public,
+    :root_champs_public,
     :created_at,
     :updated_at,
     :hidden_by_user_at,

--- a/app/graphql/types/dossier_type.rb
+++ b/app/graphql/types/dossier_type.rb
@@ -168,17 +168,17 @@ module Types
 
     def champs(id: nil)
       if id.present?
-        find_record_by_typed_id(object.project_champs_public, id, attribute: :stable_id)
+        find_record_by_typed_id(object.root_champs_public, id, attribute: :stable_id)
       else
-        object.project_champs_public.filter(&:visible?)
+        object.root_champs_public.filter(&:visible?)
       end
     end
 
     def annotations(id: nil)
       if id.present?
-        find_record_by_typed_id(object.project_champs_private, id, attribute: :stable_id)
+        find_record_by_typed_id(object.root_champs_private, id, attribute: :stable_id)
       else
-        object.project_champs_private.filter(&:visible?)
+        object.root_champs_private.filter(&:visible?)
       end
     end
 

--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -57,9 +57,9 @@ class Champs::ReferentielChamp < Champ
   def prefillable_champs
     elligible_stable_ids = prefillable_stable_ids
     if public?
-      dossier.project_champs_public
+      dossier.root_champs_public
     else
-      dossier.project_champs_private
+      dossier.root_champs_private
     end.filter do |champ|
       if champ.repetition?
         dossier.revision.children_of(champ.type_de_champ).any? { _1.stable_id.in?(elligible_stable_ids) }

--- a/app/models/changed_column.rb
+++ b/app/models/changed_column.rb
@@ -16,7 +16,7 @@ class ChangedColumn
     def columns(revision, champs, reference_champs)
       row_ids = champs.values.map(&:row_id).compact.uniq.sort
 
-      revision.types_de_champ_public.flat_map do |type_de_champ|
+      revision.root_types_de_champ_public.flat_map do |type_de_champ|
         if type_de_champ.repetition?
           prefix = type_de_champ.libelle
           types_de_champ = revision.children_of(type_de_champ)

--- a/app/models/concerns/champ_conditional_concern.rb
+++ b/app/models/concerns/champ_conditional_concern.rb
@@ -59,7 +59,7 @@ module ChampConditionalConcern
 
     return false if parent_tdc.nil?
 
-    parent = dossier.project_champs
+    parent = dossier.champs
       .find { it.type_de_champ == parent_tdc }
 
     !parent.visible?

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -17,20 +17,20 @@ module DossierChampsConcern
     end
   end
 
-  def project_champs_public
-    @project_champs_public ||= revision.types_de_champ_public.map { project_champ(_1) }
+  def root_champs_public
+    @root_champs_public ||= revision.root_types_de_champ_public.map { project_champ(_1) }
   end
 
-  def project_champs_private
-    @project_champs_private ||= revision.types_de_champ_private.map { project_champ(_1) }
+  def root_champs_private
+    @root_champs_private ||= revision.root_types_de_champ_private.map { project_champ(_1) }
   end
 
-  def project_champs
-    project_champs_public + project_champs_private
+  def champs
+    root_champs_public + root_champs_private
   end
 
   def filled_champs_public
-    @filled_champs_public ||= project_champs_public.flat_map do |champ|
+    @filled_champs_public ||= root_champs_public.flat_map do |champ|
       if champ.repetition?
         champ.rows.flatten.filter { _1.persisted? && _1.fillable? }
       elsif champ.persisted? && champ.fillable?
@@ -42,7 +42,7 @@ module DossierChampsConcern
   end
 
   def filled_champs_private
-    @filled_champs_private ||= project_champs_private.flat_map do |champ|
+    @filled_champs_private ||= root_champs_private.flat_map do |champ|
       if champ.repetition?
         champ.rows.flatten.filter { _1.persisted? && _1.fillable? }
       elsif champ.persisted? && champ.fillable?
@@ -57,8 +57,8 @@ module DossierChampsConcern
     filled_champs_public + filled_champs_private
   end
 
-  def project_champs_public_all
-    @project_champs_public_all ||= revision.types_de_champ_public.flat_map do |type_de_champ|
+  def flat_champs_public
+    @flat_champs_public ||= revision.root_types_de_champ_public.flat_map do |type_de_champ|
       champ = project_champ(type_de_champ)
       if type_de_champ.repetition?
         [champ] + project_rows_for(type_de_champ).flatten
@@ -68,8 +68,8 @@ module DossierChampsConcern
     end
   end
 
-  def project_champs_private_all
-    @project_champs_private_all ||= revision.types_de_champ_private.flat_map do |type_de_champ|
+  def flat_champs_private
+    @flat_champs_private ||= revision.root_types_de_champ_private.flat_map do |type_de_champ|
       champ = project_champ(type_de_champ)
       if type_de_champ.repetition?
         [champ] + project_rows_for(type_de_champ).flatten
@@ -229,7 +229,7 @@ module DossierChampsConcern
   end
 
   def set_default_value_for_france_connect_champs(user_email)
-    revision.types_de_champ_public.filter(&:france_connect?).each do |type_de_champ|
+    revision.root_types_de_champ_public.filter(&:france_connect?).each do |type_de_champ|
       existing_champ_on_main_stream = champs_on_main_stream.any? { _1.stable_id == type_de_champ.stable_id }
 
       next if existing_champ_on_main_stream && en_construction?
@@ -475,10 +475,10 @@ module DossierChampsConcern
     @discarded_champs_by_public_id = nil
     @filled_champs_public = nil
     @filled_champs_private = nil
-    @project_champs_public = nil
-    @project_champs_private = nil
-    @project_champs_public_all = nil
-    @project_champs_private_all = nil
+    @root_champs_public = nil
+    @root_champs_private = nil
+    @flat_champs_public = nil
+    @flat_champs_private = nil
     @repetition_row_ids = nil
     @revision_stable_ids = nil
     @champs_on_stream = nil

--- a/app/models/concerns/dossier_france_connect_prefill_concern.rb
+++ b/app/models/concerns/dossier_france_connect_prefill_concern.rb
@@ -32,7 +32,7 @@ module DossierFranceConnectPrefillConcern
     fc_info = user.france_connect_informations.first
     return if fc_info.birthdate.blank?
 
-    revision.types_de_champ_public.each do |tdc|
+    revision.root_types_de_champ_public.each do |tdc|
       next if !tdc.date?
       next if !tdc.prefill_with_france_connect_information?
 
@@ -50,7 +50,7 @@ module DossierFranceConnectPrefillConcern
   def reset_champs_from_france_connect(updated_by:)
     return if !for_tiers?
 
-    revision.types_de_champ_public.filter(&:prefill_with_france_connect_information?).each do |tdc|
+    revision.root_types_de_champ_public.filter(&:prefill_with_france_connect_information?).each do |tdc|
       champ = champ_for_update(tdc, updated_by:)
       next if !champ.prefilled_from_france_connect_information?
 

--- a/app/models/concerns/dossier_searchable_concern.rb
+++ b/app/models/concerns/dossier_searchable_concern.rb
@@ -18,7 +18,7 @@ module DossierSearchableConcern
 
     search_terms = [
       user&.email,
-      *project_champs_public.flat_map(&:search_terms),
+      *root_champs_public.flat_map(&:search_terms),
       *etablissement&.search_terms,
       individual&.nom,
       individual&.prenom,
@@ -26,7 +26,7 @@ module DossierSearchableConcern
       mandataire_last_name,
     ].compact_blank.join(' ')
 
-    private_search_terms = project_champs_private.flat_map(&:search_terms).compact_blank.join(' ')
+    private_search_terms = root_champs_private.flat_map(&:search_terms).compact_blank.join(' ')
 
     sql = "UPDATE dossiers SET search_terms = :search_terms, private_search_terms = :private_search_terms WHERE id = :id"
     sanitized_sql = self.class.sanitize_sql_array([sql, search_terms:, private_search_terms:, id:])

--- a/app/models/concerns/dossier_sections_concern.rb
+++ b/app/models/concerns/dossier_sections_concern.rb
@@ -7,9 +7,9 @@ module DossierSectionsConcern
     @sections = Hash.new do |hash, parent|
       case parent
       when :public
-        hash[parent] = revision.types_de_champ_public.filter(&:header_section?)
+        hash[parent] = revision.root_types_de_champ_public.filter(&:header_section?)
       when :private
-        hash[parent] = revision.types_de_champ_private.filter(&:header_section?)
+        hash[parent] = revision.root_types_de_champ_private.filter(&:header_section?)
       else
         hash[parent] = revision.children_of(parent).filter(&:header_section?)
       end
@@ -24,7 +24,7 @@ module DossierSectionsConcern
   end
 
   def index_for_section_header(header)
-    types_de_champ = header.private? ? revision.types_de_champ_private : revision.types_de_champ_public
+    types_de_champ = header.private? ? revision.root_types_de_champ_private : revision.root_types_de_champ_public
     counters = []
 
     types_de_champ

--- a/app/models/concerns/dossier_state_concern.rb
+++ b/app/models/concerns/dossier_state_concern.rb
@@ -402,7 +402,7 @@ module DossierStateConcern
   end
 
   def remove_not_visible_or_empty_repetitions!
-    row_to_remove_ids = project_champs_public
+    row_to_remove_ids = root_champs_public
       .filter { _1.repetition? && (_1.blank? || !_1.visible?) }
       .flat_map(&:row_ids)
 
@@ -411,7 +411,7 @@ module DossierStateConcern
   end
 
   def clear_not_visible_or_empty_champs!
-    champs_to_clear = project_champs_public_all
+    champs_to_clear = flat_champs_public
       .reject(&:repetition?)
       .filter { _1.blank? || !_1.visible? }
 
@@ -419,7 +419,7 @@ module DossierStateConcern
   end
 
   def clear_france_connect_champs_piece_justificatives!
-    champs_to_clear = project_champs_public.filter(&:france_connect?)
+    champs_to_clear = root_champs_public.filter(&:france_connect?)
 
     return if champs_to_clear.empty?
     champ_data.where(id: champs_to_clear).find_each(&:clear_piece_justificative)

--- a/app/models/concerns/dossier_validate_concern.rb
+++ b/app/models/concerns/dossier_validate_concern.rb
@@ -10,24 +10,24 @@ module DossierValidateConcern
 
   def champs_public_valid?
     validate(:champs_public_value)
-    check_mandatory_and_visible_champs_for(project_champs_public)
+    check_mandatory_and_visible_champs_for(root_champs_public)
     errors.blank?
   end
 
   def champs_private_valid?
     validate(:champs_private_value)
-    check_mandatory_and_visible_champs_for(project_champs_private)
+    check_mandatory_and_visible_champs_for(root_champs_private)
     errors.blank?
   end
 
   private
 
   def validate_champs_public_value
-    validate_projected_champs(project_champs_public_all)
+    validate_projected_champs(flat_champs_public)
   end
 
   def validate_champs_private_value
-    validate_projected_champs(project_champs_private_all)
+    validate_projected_champs(flat_champs_private)
   end
 
   def validate_projected_champs(champs)

--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -123,7 +123,7 @@ module ProcedureCloneConcern
     procedure.labels = [] if !options[:clone_labels]
 
     if !same_admin?(admin) || options[:cloned_from_library]
-      procedure.draft_revision.types_de_champ_public.each { |tdc| tdc.options&.delete(:old_pj) }
+      procedure.draft_revision.root_types_de_champ_public.each { |tdc| tdc.options&.delete(:old_pj) }
     end
 
     new_defaut_groupe = procedure.groupe_instructeurs

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -392,12 +392,12 @@ module TagsSubstitutionConcern
   end
 
   def champ_public_tags(dossier: nil)
-    types_de_champ = (dossier || procedure.active_revision).types_de_champ_public
+    types_de_champ = (dossier || procedure.active_revision).root_types_de_champ_public
     types_de_champ_tags(types_de_champ, Dossier::SOUMIS)
   end
 
   def champ_private_tags(dossier: nil)
-    types_de_champ = (dossier || procedure.active_revision).types_de_champ_private
+    types_de_champ = (dossier || procedure.active_revision).root_types_de_champ_private
     types_de_champ_tags(types_de_champ, Dossier::INSTRUCTION_COMMENCEE)
   end
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -168,7 +168,7 @@ class Dossier < ApplicationRecord
   has_one :attestation_acceptation_template, through: :procedure
   has_one :attestation_refus_template, through: :procedure
 
-  delegate :types_de_champ_public, :types_de_champ_private, :has_france_connect_type_de_champ?, to: :revision
+  delegate :root_types_de_champ_public, :root_types_de_champ_private, :has_france_connect_type_de_champ?, to: :revision
 
   belongs_to :transfer, class_name: 'DossierTransfer', foreign_key: 'dossier_transfer_id', optional: true, inverse_of: :dossiers
   has_many :transfer_logs, class_name: 'DossierTransferLog', dependent: :destroy
@@ -1090,7 +1090,7 @@ class Dossier < ApplicationRecord
   end
 
   def has_annotations?
-    revision.types_de_champ_private.present?
+    revision.root_types_de_champ_private.present?
   end
 
   def hide_info_with_accuse_lecture?
@@ -1153,8 +1153,8 @@ class Dossier < ApplicationRecord
   end
 
   def build_default_champs
-    build_default_champs_for(revision.types_de_champ_public) if !champ_data.any?(&:public?)
-    build_default_champs_for(revision.types_de_champ_private) if !champ_data.any?(&:private?)
+    build_default_champs_for(revision.root_types_de_champ_public) if !champ_data.any?(&:public?)
+    build_default_champs_for(revision.root_types_de_champ_private) if !champ_data.any?(&:private?)
   end
 
   def build_default_champs_for(types_de_champ)

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -150,7 +150,7 @@ class GroupeInstructeur < ApplicationRecord
   private
 
   def routing_rule_matches_tdc?(rule)
-    tdcs = procedure.active_revision.types_de_champ_public
+    tdcs = procedure.active_revision.root_types_de_champ_public
     rule.errors(tdcs).blank?
   end
 

--- a/app/models/prefill_description.rb
+++ b/app/models/prefill_description.rb
@@ -51,7 +51,7 @@ class PrefillDescription < SimpleDelegator
   private
 
   def active_fillable_public_types_de_champ
-    active_revision.types_de_champ_public.filter(&:fillable?)
+    active_revision.root_types_de_champ_public.filter(&:fillable?)
   end
 
   def prefilled_champs_as_params

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -35,10 +35,10 @@ class Procedure < ApplicationRecord
   has_many :deleted_dossiers, dependent: :destroy
   has_many :llm_rule_suggestions, through: :revisions
 
-  def draft_types_de_champ_public = draft_revision&.types_de_champ_public || []
-  def draft_types_de_champ_private = draft_revision&.types_de_champ_private || []
-  def published_types_de_champ_public = published_revision&.types_de_champ_public || []
-  def published_types_de_champ_private = published_revision&.types_de_champ_private || []
+  def draft_types_de_champ_public = draft_revision&.root_types_de_champ_public || []
+  def draft_types_de_champ_private = draft_revision&.root_types_de_champ_private || []
+  def published_types_de_champ_public = published_revision&.root_types_de_champ_public || []
+  def published_types_de_champ_private = published_revision&.root_types_de_champ_private || []
 
   has_one :published_dossier_submitted_message, dependent: :destroy, through: :published_revision, source: :dossier_submitted_message
   has_one :draft_dossier_submitted_message, dependent: :destroy, through: :draft_revision, source: :dossier_submitted_message

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -14,8 +14,8 @@ class ProcedureRevision < ApplicationRecord
   def revision_types_de_champ_public = revision_types_de_champ.filter { _1.root? && _1.public? }.sort_by(&:position)
   def revision_types_de_champ_private = revision_types_de_champ.filter { _1.root? && _1.private? }.sort_by(&:position)
   def types_de_champ = revision_types_de_champ.map(&:type_de_champ)
-  def types_de_champ_public = revision_types_de_champ_public.map(&:type_de_champ)
-  def types_de_champ_private = revision_types_de_champ_private.map(&:type_de_champ)
+  def root_types_de_champ_public = revision_types_de_champ_public.map(&:type_de_champ)
+  def root_types_de_champ_private = revision_types_de_champ_private.map(&:type_de_champ)
 
   has_one :draft_procedure, -> { with_discarded }, class_name: 'Procedure', foreign_key: :draft_revision_id, dependent: :nullify, inverse_of: :draft_revision
   has_one :published_procedure, -> { with_discarded }, class_name: 'Procedure', foreign_key: :published_revision_id, dependent: :nullify, inverse_of: :published_revision
@@ -215,7 +215,7 @@ class ProcedureRevision < ApplicationRecord
   def dependent_conditions(tdc)
     stable_id = tdc.stable_id
 
-    (tdc.public? ? types_de_champ_public : types_de_champ_private).filter do |other_tdc|
+    (tdc.public? ? root_types_de_champ_public : root_types_de_champ_private).filter do |other_tdc|
       next if !other_tdc.condition?
 
       other_tdc.condition.sources.include?(stable_id)
@@ -236,11 +236,11 @@ class ProcedureRevision < ApplicationRecord
   end
 
   def carte?
-    types_de_champ_public.any?(&:carte?)
+    root_types_de_champ_public.any?(&:carte?)
   end
 
   def has_france_connect_type_de_champ?
-    types_de_champ_public.any?(&:france_connect?)
+    root_types_de_champ_public.any?(&:france_connect?)
   end
 
   def coordinate_and_tdc(stable_id)
@@ -254,7 +254,7 @@ class ProcedureRevision < ApplicationRecord
   end
 
   def simple_routable_types_de_champ
-    types_de_champ_public.filter(&:simple_routable?)
+    root_types_de_champ_public.filter(&:simple_routable?)
   end
 
   def conditionable_types_de_champ
@@ -334,7 +334,7 @@ class ProcedureRevision < ApplicationRecord
   private
 
   def compute_estimated_fill_duration
-    types_de_champ_public.sum do |tdc|
+    root_types_de_champ_public.sum do |tdc|
       next tdc.estimated_read_duration unless tdc.fillable?
 
       duration = tdc.estimated_read_duration + tdc.estimated_fill_duration(self)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -581,7 +581,7 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def current_section_level(revision)
-    tdcs = private? ? revision.types_de_champ_private.to_a : revision.types_de_champ_public.to_a
+    tdcs = private? ? revision.root_types_de_champ_private.to_a : revision.root_types_de_champ_public.to_a
 
     previous_section_level(tdcs.take(tdcs.find_index(self)))
   end

--- a/app/serializers/dossier_serializer.rb
+++ b/app/serializers/dossier_serializer.rb
@@ -32,7 +32,7 @@ class DossierSerializer < ActiveModel::Serializer
   has_many :champs, serializer: ChampSerializer
 
   def champs
-    champs = object.project_champs_public.reject { |c| c.type_de_champ.old_pj.present? }
+    champs = object.root_champs_public.reject { |c| c.type_de_champ.old_pj.present? }
 
     if object.expose_legacy_carto_api?
       champ_carte = champs.find do |champ|
@@ -53,7 +53,7 @@ class DossierSerializer < ActiveModel::Serializer
   end
 
   def champs_private
-    object.project_champs_private
+    object.root_champs_private
   end
 
   def cerfa
@@ -61,7 +61,7 @@ class DossierSerializer < ActiveModel::Serializer
   end
 
   def pieces_justificatives
-    object.project_champs_public.filter { |champ| champ.type_de_champ.old_pj }.map do |champ|
+    object.root_champs_public.filter { |champ| champ.type_de_champ.old_pj }.map do |champ|
       {
         created_at: champ.created_at&.in_time_zone('UTC'),
         type_de_piece_justificative_id: champ.type_de_champ.old_pj[:stable_id],

--- a/app/serializers/procedure_serializer.rb
+++ b/app/serializers/procedure_serializer.rb
@@ -46,11 +46,11 @@ class ProcedureSerializer < ActiveModel::Serializer
   end
 
   def types_de_champ
-    object.active_revision.types_de_champ_public.reject { |c| c.old_pj.present? }
+    object.active_revision.root_types_de_champ_public.reject { |c| c.old_pj.present? }
   end
 
   def types_de_champ_private
-    object.active_revision.types_de_champ_private
+    object.active_revision.root_types_de_champ_private
   end
 
   def types_de_piece_justificative

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -64,7 +64,7 @@ class PiecesJustificativesService
   end
 
   def self.serialize_types_de_champ_as_type_pj(revision)
-    tdcs = revision.types_de_champ_public.filter { |type_champ| type_champ.old_pj.present? }
+    tdcs = revision.root_types_de_champ_public.filter { |type_champ| type_champ.old_pj.present? }
     tdcs.map.with_index do |type_champ, order_place|
       description = type_champ.description
       if /^(?<original_description>.*?)(?:[\r\n]+)Récupérer le formulaire vierge pour mon dossier : (?<lien_demarche>http.*)$/m =~ description

--- a/app/tasks/maintenance/backfill_cloned_champs_private_piece_justificatives_task.rb
+++ b/app/tasks/maintenance/backfill_cloned_champs_private_piece_justificatives_task.rb
@@ -10,11 +10,11 @@ module Maintenance
     end
 
     def process(cloned_dossier)
-      cloned_dossier.project_champs_private
+      cloned_dossier.root_champs_private
         .filter { checkable_pj?(_1, cloned_dossier) }
         .map do |cloned_champ|
           parent_champ = cloned_dossier.parent_dossier
-            .project_champs_private
+            .root_champs_private
             .find { _1.stable_id == cloned_champ.stable_id }
 
           next if !parent_champ

--- a/app/tasks/maintenance/t20250825backfill_pj_external_state_task.rb
+++ b/app/tasks/maintenance/t20250825backfill_pj_external_state_task.rb
@@ -24,7 +24,7 @@ module Maintenance
     end
 
     def process(dossier)
-      pjs = dossier.project_champs_public
+      pjs = dossier.root_champs_public
         .filter { it.type == "Champs::PieceJustificativeChamp" && it.rib? == true }
 
       pjs.filter(&:idle?).each do |pj|

--- a/app/tasks/maintenance/update_conditions_based_on_commune_or_epci_champ_task.rb
+++ b/app/tasks/maintenance/update_conditions_based_on_commune_or_epci_champ_task.rb
@@ -15,7 +15,7 @@ module Maintenance
     def process(revision)
       tdc_to_update_ids = []
 
-      tdcs = TypeDeChamp.where(id: revision.types_de_champ_public)
+      tdcs = TypeDeChamp.where(id: revision.root_types_de_champ_public)
 
       tdcs.where.not(condition: nil).pluck(:condition, :id).each do |condition, id|
         if tdcs.where(stable_id: condition.sources, type_champ: ["communes", "epci"]).present?

--- a/app/tasks/maintenance/update_routing_rules_based_on_commune_or_epci_champ_task.rb
+++ b/app/tasks/maintenance/update_routing_rules_based_on_commune_or_epci_champ_task.rb
@@ -18,7 +18,7 @@ module Maintenance
       routing_rule = gi.routing_rule
 
       if routing_rule.present?
-        tdcs = TypeDeChamp.where(id: gi.procedure.active_revision.types_de_champ_public)
+        tdcs = TypeDeChamp.where(id: gi.procedure.active_revision.root_types_de_champ_public)
 
         if tdcs.where(stable_id: routing_rule.sources, type_champ: ["communes", "epci"]).present?
           if routing_rule.is_a?(And)

--- a/app/views/administrateurs/procedures/clone_settings.html.erb
+++ b/app/views/administrateurs/procedures/clone_settings.html.erb
@@ -47,7 +47,7 @@
           </div>
         <%- end -%>
 
-        <%- if @procedure.active_revision.types_de_champ_public.present? -%>
+        <%- if @procedure.active_revision.root_types_de_champ_public.present? -%>
           <div class="fr-fieldset__element">
             <div class="fr-checkbox-group">
               <%= fco.check_box 'champs', checked: true %>
@@ -56,7 +56,7 @@
                 <%= t('administrateurs.procedures.clone.types_de_champ_public') %>
 
                 <div class="fr-hint-text">
-                  <%= t('administrateurs.procedures.clone.types_de_champ_count', count: @procedure.active_revision.types_de_champ_public.count) %>
+                  <%= t('administrateurs.procedures.clone.types_de_champ_count', count: @procedure.active_revision.root_types_de_champ_public.count) %>
                 </div>
               <% end %>
             </div>
@@ -189,7 +189,7 @@
           </div>
         <%- end -%>
 
-        <%- if @procedure.active_revision.types_de_champ_private.present? -%>
+        <%- if @procedure.active_revision.root_types_de_champ_private.present? -%>
           <div class="fr-fieldset__element">
             <div class="fr-checkbox-group">
               <%= fco.check_box 'annotations', checked: true %>
@@ -198,7 +198,7 @@
                 <%= t('administrateurs.procedures.clone.types_de_champ_private') %>
 
                 <div class="fr-hint-text">
-                  <%= t('administrateurs.procedures.clone.types_de_champ_count', count: @procedure.active_revision.types_de_champ_private.count) %>
+                  <%= t('administrateurs.procedures.clone.types_de_champ_count', count: @procedure.active_revision.root_types_de_champ_private.count) %>
                 </div>
               <% end %>
             </div>

--- a/app/views/administrateurs/procedures/publication.html.haml
+++ b/app/views/administrateurs/procedures/publication.html.haml
@@ -7,7 +7,7 @@
 .fr-container
   .fr-grid-row
     .fr-col-12.fr-col-offset-md-2.fr-col-md-8
-      - dubious = TypeDeChamp.where(id: @procedure.draft_revision.types_de_champ_public).dubious
+      - dubious = TypeDeChamp.where(id: @procedure.draft_revision.root_types_de_champ_public).dubious
       - if dubious.present?
         = render Dsfr::AlertComponent.new(state: :warning, title: t('.dubious_fields'), extra_class_names: 'fr-mb-2w') do |c|
           - c.with_body do

--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -237,7 +237,7 @@ prawn_document(page_size: "A4") do |pdf|
 
   add_title(pdf, 'Formulaire')
   add_single_line(pdf, @procedure.description + "\n", 9, :italic) if @procedure.description.present?
-  add_champs(pdf, @revision, @revision.types_de_champ_public)
+  add_champs(pdf, @revision, @revision.root_types_de_champ_public)
   add_page_numbering(pdf)
   add_procedure(pdf, @procedure)
 end

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -463,11 +463,11 @@ prawn_document(page_size: "A4") do |pdf|
   end
 
   add_title(pdf, 'Formulaire')
-  add_champs(pdf, @dossier.project_champs_public)
+  add_champs(pdf, @dossier.root_champs_public)
 
   if @acls[:include_infos_administration] && @dossier.has_annotations?
     add_title(pdf, "Annotations privées")
-    add_champs(pdf, @dossier.project_champs_private)
+    add_champs(pdf, @dossier.root_champs_private)
   end
 
   if @acls[:include_infos_administration] && @dossier.avis.present?

--- a/app/views/instructeurs/dossiers/print.html.haml
+++ b/app/views/instructeurs/dossiers/print.html.haml
@@ -15,13 +15,13 @@
 
 %h2 Formulaire
 
-- types_de_champ_public = @dossier.revision.types_de_champ_public
+- types_de_champ_public = @dossier.revision.root_types_de_champ_public
 - if types_de_champ_public.any? || @dossier.procedure.routing_enabled?
   = render ViewableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: types_de_champ_public, demande_seen_at: nil, profile: 'instructeur')
 
 %h2 Annotations privées
 
-- types_de_champ_private = @dossier.revision.types_de_champ_private
+- types_de_champ_private = @dossier.revision.root_types_de_champ_private
 - if types_de_champ_private.any?
   = render ViewableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: types_de_champ_private, demande_seen_at: nil, profile: 'instructeur')
 - else

--- a/app/views/instructeurs/dossiers/show_submitted_revision.html.erb
+++ b/app/views/instructeurs/dossiers/show_submitted_revision.html.erb
@@ -34,7 +34,7 @@
         data-clipboard2-copy-text-value="<%= t('clipboard.copy') %>"
         data-clipboard2-copied-text-value="<%= t('clipboard.copied') %>"
       >
-        <%= render ViewableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: @dossier.revision.types_de_champ_public, demande_seen_at: @demande_seen_at, profile: 'instructeur') %>
+        <%= render ViewableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: @dossier.revision.root_types_de_champ_public, demande_seen_at: @demande_seen_at, profile: 'instructeur') %>
       </div>
     </div>
   </div>

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -33,7 +33,7 @@
 
     %form.form
       = form_for @dossier, url: '', html: { class: 'form' } do |f|
-        = render EditableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: @dossier.revision.types_de_champ_public)
+        = render EditableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: @dossier.revision.root_types_de_champ_public)
 
         .editable-champ.editable-champ-text
           %label Mot de passe
@@ -310,7 +310,7 @@
     %h1.fr-mt-4w Attachment::FileFieldComponent (single file)
     %span.fr-hint-text Note: direct upload, suppression ne marchent pas comme attendu ici.
 
-    - champ = @dossier.project_champs_public.find { _1.type_champ == TypeDeChamp.type_champs.fetch(:piece_justificative) }
+    - champ = @dossier.root_champs_public.find { _1.type_champ == TypeDeChamp.type_champs.fetch(:piece_justificative) }
     - tdc = champ.type_de_champ
     - avis = Avis.new
 

--- a/app/views/shared/dossiers/_demande.html.erb
+++ b/app/views/shared/dossiers/_demande.html.erb
@@ -121,7 +121,7 @@
     <% end %>
   <% end %>
 
-  <% types_de_champ = dossier.revision.types_de_champ_public %>
+  <% types_de_champ = dossier.revision.root_types_de_champ_public %>
 
   <% if types_de_champ.any? || dossier.procedure.routing_enabled? %>
     <%= render ViewableChamp::SectionComponent.new(dossier:, types_de_champ:, demande_seen_at:, profile:) %>

--- a/app/views/shared/dossiers/_edit.html.erb
+++ b/app/views/shared/dossiers/_edit.html.erb
@@ -50,7 +50,7 @@
     <h2 class="fr-sr-only">Formulaire</h2>
 
     <fieldset class="fr-fieldset">
-      <%= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.types_de_champ_public) %>
+      <%= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.root_types_de_champ_public) %>
     </fieldset>
 
     <%= render Dossiers::PendingCorrectionCheckboxComponent.new(dossier:) %>

--- a/app/views/shared/dossiers/_edit_annotations.html.erb
+++ b/app/views/shared/dossiers/_edit_annotations.html.erb
@@ -5,7 +5,7 @@
 
       <%= form_for dossier, url: annotations_instructeur_dossier_path(dossier.procedure, dossier), html: { class: 'form', multipart: true } do |f| %>
         <fieldset class="fr-fieldset">
-          <%= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.types_de_champ_private) %>
+          <%= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.root_types_de_champ_private) %>
         </fieldset>
       <% end %>
 

--- a/app/views/shared/dossiers/_edit_instructeur.html.erb
+++ b/app/views/shared/dossiers/_edit_instructeur.html.erb
@@ -21,7 +21,7 @@
     </header>
 
     <fieldset class="fr-fieldset">
-      <%= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.types_de_champ_public) %>
+      <%= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.root_types_de_champ_public) %>
     </fieldset>
   <% end %>
 

--- a/spec/components/champ_header_sections_summary_component_spec.rb
+++ b/spec/components/champ_header_sections_summary_component_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe ViewableChamp::HeaderSectionsSummaryComponent, type: :component d
   let(:procedure) { build(:procedure, types_de_champ_public: types_de_champ, types_de_champ_private: types_de_champ) }
   let(:dossier) { build(:dossier, procedure:) }
   let(:component) { described_class.new(dossier:, is_private:) }
-  let(:types_de_champ_public) { dossier.revision.types_de_champ_public.filter(&:header_section?) }
-  let(:types_de_champ_private) { dossier.revision.types_de_champ_private.filter(&:header_section?) }
+  let(:types_de_champ_public) { dossier.revision.root_types_de_champ_public.filter(&:header_section?) }
+  let(:types_de_champ_private) { dossier.revision.root_types_de_champ_private.filter(&:header_section?) }
 
   context 'public' do
     it do

--- a/spec/components/dossiers/champs_rows_show_component_spec.rb
+++ b/spec/components/dossiers/champs_rows_show_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Dossiers::ChampsRowsShowComponent, type: :component do
     ])
   end
   let(:dossier) { create(:dossier, procedure:, populate_champs: true) }
-  let(:champs) { dossier.project_champs_public }
+  let(:champs) { dossier.root_champs_public }
 
   before { render_inline(component).to_html }
 

--- a/spec/components/dossiers/referentiel_component_spec.rb
+++ b/spec/components/dossiers/referentiel_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Dossiers::ReferentielComponent, type: :component do
   let(:referentiel) { create(:api_referentiel, :exact_match) }
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :referentiel, referentiel: }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
 
   let(:pending) { false }
   let(:not_found) { false }

--- a/spec/components/editable_champ/date_component_spec.rb
+++ b/spec/components/editable_champ/date_component_spec.rb
@@ -3,7 +3,7 @@
 describe EditableChamp::DateComponent, type: :component do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :date, stable_id: 99 }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs.first }
+  let(:champ) { dossier.champs.first }
 
   let(:component) {
     described_class.new(form: instance_double(ActionView::Helpers::FormBuilder, object_name: "dossier[champs_public_attributes]"), champ:)

--- a/spec/components/editable_champ/datetime_component_spec.rb
+++ b/spec/components/editable_champ/datetime_component_spec.rb
@@ -3,7 +3,7 @@
 describe EditableChamp::DatetimeComponent, type: :component do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :datetime, stable_id: 99, mandatory: true }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs.first }
+  let(:champ) { dossier.champs.first }
 
   let(:component) {
     described_class.new(form: instance_double(ActionView::Helpers::FormBuilder, object_name: "dossier[champs_public_attributes]"), champ:)

--- a/spec/components/editable_champ/drop_down_list_component_spec.rb
+++ b/spec/components/editable_champ/drop_down_list_component_spec.rb
@@ -53,7 +53,7 @@ describe EditableChamp::DropDownListComponent, type: :component do
         # the first fieldset is for the repetition
         let(:fieldset) { page.find('fieldset fieldset') }
 
-        let(:repetition_champ) { dossier.project_champs_public.first }
+        let(:repetition_champ) { dossier.root_champs_public.first }
         let(:drop_down_list_champ) { repetition_champ.rows.first.first }
 
         it do

--- a/spec/components/editable_champ/editable_champ_component_spec.rb
+++ b/spec/components/editable_champ/editable_champ_component_spec.rb
@@ -5,7 +5,7 @@ describe EditableChamp::EditableChampComponent, type: :component do
   let(:types_de_champ_public) { [] }
   let(:types_de_champ_private) { [] }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:champ) { (dossier.project_champs_public + dossier.project_champs_private).first }
+  let(:champ) { (dossier.root_champs_public + dossier.root_champs_private).first }
 
   let(:component) { described_class.new(form: nil, champ:) }
 
@@ -76,7 +76,7 @@ describe EditableChamp::EditableChampComponent, type: :component do
         [{ type: :repetition, children: [{ type: :text }, { type: :text }] }]
       end
 
-      let(:champ) { dossier.project_champs_public.find(&:repetition?).rows.first.first }
+      let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.first.first }
 
       it "returns nil (because the number of the row is on the fieldset legend)" do
         expect(subject).to be_nil
@@ -89,7 +89,7 @@ describe EditableChamp::EditableChampComponent, type: :component do
       end
 
       context "on the first row" do
-        let(:champ) { dossier.project_champs_public.find(&:repetition?).rows.first.first }
+        let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.first.first }
 
         it do
           expect(component.row_number_if_in_repetition).to eq(1)
@@ -97,7 +97,7 @@ describe EditableChamp::EditableChampComponent, type: :component do
       end
 
       context "when the champ is in the second row" do
-        let(:champ) { dossier.project_champs_public.find(&:repetition?).rows.last.first }
+        let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.last.first }
 
         it do
           expect(component.row_number_if_in_repetition).to eq(2)

--- a/spec/components/editable_champ/explication_component/explication_component_spec.rb
+++ b/spec/components/editable_champ/explication_component/explication_component_spec.rb
@@ -3,7 +3,7 @@
 describe EditableChamp::ExplicationComponent, type: :component do
   let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
 
   let(:component) {
     described_class.new(form: instance_double(ActionView::Helpers::FormBuilder, object_name: "dossier[champs_public_attributes]"), champ:)

--- a/spec/components/editable_champ/pre_rempli_component_spec.rb
+++ b/spec/components/editable_champ/pre_rempli_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe EditableChamp::PreRempliComponent, type: :component do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :pre_rempli }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
   let(:form) do
     ActionView::Helpers::FormBuilder.new("dossier[champs_public_attributes]", champ, ActionController::Base.new.view_context, {})
   end

--- a/spec/components/editable_champ/quotient_familial_component_spec.rb
+++ b/spec/components/editable_champ/quotient_familial_component_spec.rb
@@ -3,7 +3,7 @@
 describe EditableChamp::QuotientFamilialComponent, type: :component do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :quotient_familial }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
 
   subject(:render) do
     component = nil

--- a/spec/components/editable_champ/referentiel_component_spec.rb
+++ b/spec/components/editable_champ/referentiel_component_spec.rb
@@ -6,7 +6,7 @@ describe EditableChamp::ReferentielComponent, type: :component do
   let(:types_de_champ_public) { [{ type: :referentiel, referentiel:, referentiel_mapping: {} }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
   let(:form) do
     ActionView::Helpers::FormBuilder.new("dossier[champs_public_attributes]", champ, ActionController::Base.new.view_context, {})
   end

--- a/spec/components/editable_champ/referentiel_display_component_spec.rb
+++ b/spec/components/editable_champ/referentiel_display_component_spec.rb
@@ -7,7 +7,7 @@ describe EditableChamp::ReferentielDisplayComponent, type: :component do
   let(:types_de_champ_public) { [{ type: :referentiel, referentiel:, referentiel_mapping: }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:champ) { (dossier.project_champs_public).first }
+  let(:champ) { (dossier.root_champs_public).first }
 
   let(:referentiel_mapping) { {} }
   subject { render_inline(described_class.new(champ:)) }

--- a/spec/components/editable_champ/section_component_spec.rb
+++ b/spec/components/editable_champ/section_component_spec.rb
@@ -5,7 +5,7 @@ describe EditableChamp::SectionComponent, type: :component do
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:types_de_champ_public) { [] }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:types_de_champ) { dossier.revision.types_de_champ_public }
+  let(:types_de_champ) { dossier.revision.root_types_de_champ_public }
   let(:component) { described_class.new(types_de_champ:, dossier:) }
   before { render_inline(component).to_html }
 
@@ -112,7 +112,7 @@ describe EditableChamp::SectionComponent, type: :component do
     end
 
     it 'contains as many text champ as repetition.rows' do
-      expect(page).to have_selector("fieldset fieldset input[type=text]", count: dossier.project_champs_public.find(&:repetition?).rows.size)
+      expect(page).to have_selector("fieldset fieldset input[type=text]", count: dossier.root_champs_public.find(&:repetition?).rows.size)
     end
   end
 
@@ -121,7 +121,7 @@ describe EditableChamp::SectionComponent, type: :component do
       let(:types_de_champ_public) { [{ type: :siret }] }
 
       it 'renders a persistent sr-only polite live region' do
-        champ = dossier.project_champs_public.first
+        champ = dossier.root_champs_public.first
         expect(page).to have_css("##{champ.focusable_input_id}-aria-live.fr-sr-only[aria-live='polite']", visible: :all)
       end
     end

--- a/spec/components/header_section_component_spec.rb
+++ b/spec/components/header_section_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TypesDeChampEditor::HeaderSectionComponent, type: :component do
   describe 'header_section_options_for_select' do
     context 'without upper tdc' do
       let(:types_de_champ_public) { [{ type: :header_section, level: 1 }] }
-      let(:tdc) { procedure.draft_revision.types_de_champ_public.first }
+      let(:tdc) { procedure.draft_revision.root_types_de_champ_public.first }
       let(:upper_tdcs) { [] }
 
       it 'allows up to level 1 header section' do
@@ -33,8 +33,8 @@ RSpec.describe TypesDeChampEditor::HeaderSectionComponent, type: :component do
           { type: :header_section, level: 2 },
         ]
       end
-      let(:tdc) { procedure.draft_revision.types_de_champ_public.last }
-      let(:upper_tdcs) { [procedure.draft_revision.types_de_champ_public.first] }
+      let(:tdc) { procedure.draft_revision.root_types_de_champ_public.last }
+      let(:upper_tdcs) { [procedure.draft_revision.root_types_de_champ_public.first] }
 
       it 'allows up to level 2 header section' do
         expect(subject).to have_selector("option", count: 2)
@@ -49,8 +49,8 @@ RSpec.describe TypesDeChampEditor::HeaderSectionComponent, type: :component do
           { type: :header_section, level: 3 },
         ]
       end
-      let(:tdc) { procedure.draft_revision.types_de_champ_public.third }
-      let(:upper_tdcs) { [procedure.draft_revision.types_de_champ_public.first, procedure.draft_revision.types_de_champ_public.second] }
+      let(:tdc) { procedure.draft_revision.root_types_de_champ_public.third }
+      let(:upper_tdcs) { [procedure.draft_revision.root_types_de_champ_public.first, procedure.draft_revision.root_types_de_champ_public.second] }
 
       it 'allows up to level 3 header section' do
         expect(subject).to have_selector("option", count: 3)
@@ -59,7 +59,7 @@ RSpec.describe TypesDeChampEditor::HeaderSectionComponent, type: :component do
 
     context 'with error' do
       let(:types_de_champ_public) { [{ type: :header_section, level: 2 }] }
-      let(:tdc) { procedure.draft_revision.types_de_champ_public.first }
+      let(:tdc) { procedure.draft_revision.root_types_de_champ_public.first }
       let(:upper_tdcs) { [] }
 
       it 'includes disabled levels' do
@@ -71,7 +71,7 @@ RSpec.describe TypesDeChampEditor::HeaderSectionComponent, type: :component do
 
   describe 'errors' do
     let(:types_de_champ_public) { [{ type: :header_section, level: 2 }] }
-    let(:tdc) { procedure.draft_revision.types_de_champ_public.first }
+    let(:tdc) { procedure.draft_revision.root_types_de_champ_public.first }
     let(:upper_tdcs) { [] }
 
     it 'returns errors' do

--- a/spec/components/instructeurs/clear_filter_buttons_component_spec.rb
+++ b/spec/components/instructeurs/clear_filter_buttons_component_spec.rb
@@ -14,7 +14,7 @@ describe Instructeurs::ClearFilterButtonsComponent, type: :component do
 
   describe "visible text" do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text }]) }
-    let(:first_type_de_champ) { procedure.active_revision.types_de_champ_public.first }
+    let(:first_type_de_champ) { procedure.active_revision.root_types_de_champ_public.first }
     let(:filter) { to_filter([first_type_de_champ.libelle, { operator: 'match', value: ['true'] }]) }
 
     context 'when type_de_champ text' do

--- a/spec/components/procedure/revision_changes_component_spec.rb
+++ b/spec/components/procedure/revision_changes_component_spec.rb
@@ -4,7 +4,7 @@ describe Procedure::RevisionChangesComponent, type: :component do
   describe 'dossier_link changes' do
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :dossier_link, libelle: 'Dossier lié' }]) }
     let(:new_revision) { procedure.create_new_revision }
-    let(:tdc) { procedure.active_revision.types_de_champ_public.first }
+    let(:tdc) { procedure.active_revision.root_types_de_champ_public.first }
 
     subject do
       render_inline(described_class.new(new_revision: new_revision.reload, previous_revision: procedure.active_revision))
@@ -81,7 +81,7 @@ describe Procedure::RevisionChangesComponent, type: :component do
   describe "repetition limits changes" do
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :repetition, libelle: "Bloc" }]) }
     let(:new_revision) { procedure.create_new_revision }
-    let(:tdc) { procedure.active_revision.types_de_champ_public.first }
+    let(:tdc) { procedure.active_revision.root_types_de_champ_public.first }
 
     subject do
       render_inline(described_class.new(new_revision: new_revision.reload, previous_revision: procedure.active_revision))

--- a/spec/components/procedures/errors_summary_spec.rb
+++ b/spec/components/procedures/errors_summary_spec.rb
@@ -60,7 +60,7 @@ describe Procedure::ErrorsSummary, type: :component do
     let(:validation_context) { :types_de_champ_public_editor }
 
     before do
-      drop_down_public = procedure.draft_revision.types_de_champ_public.find(&:any_drop_down_list?)
+      drop_down_public = procedure.draft_revision.root_types_de_champ_public.find(&:any_drop_down_list?)
       drop_down_public.update!(drop_down_options: [])
       subject
     end

--- a/spec/components/referentiels/autocomplete_configuration_component_spec.rb
+++ b/spec/components/referentiels/autocomplete_configuration_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Referentiels::AutocompleteConfigurationComponent, type: :componen
   let(:component) { described_class.new(referentiel:, type_de_champ:, procedure:) }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:types_de_champ_public) { [{ type: :referentiel, referentiel: }] }
-  let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+  let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public.first }
   let(:referentiel) { create(:api_referentiel, :autocomplete, last_response:) }
 
   describe 'render' do

--- a/spec/components/referentiels/configuration_error_component_spec.rb
+++ b/spec/components/referentiels/configuration_error_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Referentiels::ConfigurationErrorComponent, type: :component do
   let(:component) { described_class.new(referentiel:, type_de_champ:, procedure:) }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:types_de_champ_public) { [{ type: :referentiel, referentiel: }] }
-  let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+  let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public.first }
   let(:referentiel) { create(:api_referentiel, :exact_match) }
   before do
     render_inline(component)

--- a/spec/components/referentiels/mapping_form_component_spec.rb
+++ b/spec/components/referentiels/mapping_form_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Referentiels::MappingFormComponent, type: :component do
   let(:component) { described_class.new(referentiel:, type_de_champ:, procedure:) }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:types_de_champ_public) { [{ type: :referentiel, referentiel: }] }
-  let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+  let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public.first }
   let(:referentiel) { create(:api_referentiel, :exact_match) }
 
   describe 'render' do

--- a/spec/components/referentiels/new_form_component_spec.rb
+++ b/spec/components/referentiels/new_form_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Referentiels::NewFormComponent, type: :component do
     let(:component) { described_class.new(referentiel:, type_de_champ:, procedure:) }
     let(:procedure) { create(:procedure, types_de_champ_public:) }
     let(:types_de_champ_public) { [{ type: :referentiel }] }
-    let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+    let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public.first }
     before do
       render_inline(component)
     end
@@ -54,7 +54,7 @@ RSpec.describe Referentiels::NewFormComponent, type: :component do
 
       context 'with api was selected and procedure has yes_no and address champs' do
         let(:types_de_champ_public) { [{ type: :yes_no, libelle: 'Majeur' }, { type: :address, libelle: 'Adresse' }, { type: :checkbox, libelle: 'Checkbox' }, { type: :referentiel }] }
-        let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.last }
+        let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public.last }
         let(:referentiel) { type_de_champ.build_referentiel(type: "Referentiels::APIReferentiel") }
 
         it 'renders yes_no and address champs as tiptap tags' do

--- a/spec/components/referentiels/referentiel_display_component_spec.rb
+++ b/spec/components/referentiels/referentiel_display_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Referentiels::ReferentielDisplayComponent, type: :component do
   end
   let(:types_de_champ_public) { [{ type: :referentiel, referentiel: referentiel, referentiel_mapping: }] }
   let(:types_de_champ_private) { [] }
-  let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+  let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public.first }
   let(:referentiel) { create(:api_referentiel, :exact_match) }
 
   subject { render_inline(component) }
@@ -60,7 +60,7 @@ RSpec.describe Referentiels::ReferentielDisplayComponent, type: :component do
       context 'when the field is private' do
         let(:types_de_champ_public) { [] }
         let(:types_de_champ_private) { [{ type: :referentiel, referentiel: referentiel, referentiel_mapping: }] }
-        let(:type_de_champ) { procedure.draft_revision.types_de_champ_private.first }
+        let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_private.first }
 
         it 'hides the usager column' do
           expect(subject).to have_selector('th', text: 'Propriété')

--- a/spec/components/referentiels/stepper_component_spec.rb
+++ b/spec/components/referentiels/stepper_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Referentiels::StepperComponent, type: :component do
   subject(:rendered_component) { render_inline(described_class.new(step_component:)) }
 
   context 'when referentiel is private' do
-    let(:type_de_champ) { procedure.draft_revision.types_de_champ_private.first }
+    let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_private.first }
     let(:types_de_champ_private) { [{ type: :referentiel, referentiel: }] }
 
     it 'back links goes to annotations' do
@@ -26,7 +26,7 @@ RSpec.describe Referentiels::StepperComponent, type: :component do
   end
 
   context 'when referentiel is public' do
-    let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+    let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public.first }
     let(:types_de_champ_public) { [{ type: :referentiel, referentiel: }] }
 
     it 'back links goes to champs' do

--- a/spec/components/types_de_champ_editor/explication_component_spec.rb
+++ b/spec/components/types_de_champ_editor/explication_component_spec.rb
@@ -4,7 +4,7 @@ describe TypesDeChampEditor::ChampComponent, type: :component do
   describe 'render by type' do
     context 'explication' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :explication }]) }
-      let(:tdc) { procedure.active_revision.types_de_champ_public.first }
+      let(:tdc) { procedure.active_revision.root_types_de_champ_public.first }
       let(:coordinate) { procedure.draft_revision.coordinate_for(tdc) }
       let(:component) { described_class.new(coordinate: coordinate, upper_coordinates: []) }
 

--- a/spec/components/types_de_champ_editor/info_referentiel_component_spec.rb
+++ b/spec/components/types_de_champ_editor/info_referentiel_component_spec.rb
@@ -4,7 +4,7 @@ describe TypesDeChampEditor::InfoReferentielComponent, type: :component do
   describe 'render' do
     let(:component) { described_class.new(procedure:, type_de_champ:) }
     let(:types_de_champ_public) { [{ type: :referentiel }] }
-    let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+    let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public.first }
 
     before do
       referentiel

--- a/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_templates_controller_spec.rb
@@ -197,11 +197,11 @@ describe Administrateurs::AttestationTemplatesController, type: :controller do
           activated: true,
         }
       end
-      let(:type_de_champ) { procedure.draft_revision.types_de_champ_public[0] }
-      let(:removed_type_de_champ) { procedure.draft_revision.types_de_champ_public[1] }
-      let(:removed_and_published_type_de_champ) { procedure.draft_revision.types_de_champ_public[2] }
-      let(:new_type_de_champ) { procedure.draft_revision.types_de_champ_public.find { _1.libelle == 'new type de champ' } }
-      let(:draft_type_de_champ) { procedure.draft_revision.types_de_champ_public.find { _1.libelle == 'draft type de champ' } }
+      let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public[0] }
+      let(:removed_type_de_champ) { procedure.draft_revision.root_types_de_champ_public[1] }
+      let(:removed_and_published_type_de_champ) { procedure.draft_revision.root_types_de_champ_public[2] }
+      let(:new_type_de_champ) { procedure.draft_revision.root_types_de_champ_public.find { _1.libelle == 'new type de champ' } }
+      let(:draft_type_de_champ) { procedure.draft_revision.root_types_de_champ_public.find { _1.libelle == 'draft type de champ' } }
       let(:title) { 'title --numéro du dossier--' }
       let(:body) { "body --#{type_de_champ.libelle}-- et --#{new_type_de_champ.libelle}--" }
 
@@ -209,12 +209,12 @@ describe Administrateurs::AttestationTemplatesController, type: :controller do
         procedure.publish!(procedure.administrateurs.first)
         procedure.reload
         procedure.draft_revision.remove_type_de_champ(removed_and_published_type_de_champ.stable_id)
-        procedure.draft_revision.add_type_de_champ(libelle: 'new type de champ', type_champ: 'text', after_stable_id: procedure.draft_revision.types_de_champ_public.last.stable_id)
+        procedure.draft_revision.add_type_de_champ(libelle: 'new type de champ', type_champ: 'text', after_stable_id: procedure.draft_revision.root_types_de_champ_public.last.stable_id)
         procedure.publish_revision!(admin)
         procedure.reload
         procedure.draft_revision.remove_type_de_champ(removed_type_de_champ.stable_id)
         procedure.draft_revision.reload
-        procedure.draft_revision.add_type_de_champ(libelle: 'draft type de champ', type_champ: 'text', after_stable_id: procedure.draft_revision.types_de_champ_public.last.stable_id)
+        procedure.draft_revision.add_type_de_champ(libelle: 'draft type de champ', type_champ: 'text', after_stable_id: procedure.draft_revision.root_types_de_champ_public.last.stable_id)
 
         dossier
 

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -863,8 +863,8 @@ describe Administrateurs::ProceduresController, type: :controller do
           expect(Procedure.last.administrateurs).to include(administrateur_2)
           expect(Procedure.last.defaut_groupe_instructeur.instructeurs).to match_array([admin.instructeur, instructeur_2])
           expect(Procedure.last.instructeurs_self_management_enabled).to be_truthy
-          expect(Procedure.last.draft_revision.types_de_champ_public.count).to eq 1
-          expect(Procedure.last.draft_revision.types_de_champ_private.count).to eq 1
+          expect(Procedure.last.draft_revision.root_types_de_champ_public.count).to eq 1
+          expect(Procedure.last.draft_revision.root_types_de_champ_private.count).to eq 1
           expect(Procedure.last.attestation_acceptation_template).not_to be_nil
           expect(Procedure.last.attestation_refus_template).not_to be_nil
           expect(Procedure.last.zones).not_to be_blank
@@ -932,8 +932,8 @@ describe Administrateurs::ProceduresController, type: :controller do
           expect(Procedure.last.routing_enabled).to be_falsey
           expect(Procedure.last.defaut_groupe_instructeur.contact_information).to be_nil
           expect(Procedure.last.instructeurs_self_management_enabled).to be_falsey
-          expect(Procedure.last.draft_revision.types_de_champ_public.count).to eq 0
-          expect(Procedure.last.draft_revision.types_de_champ_private.count).to eq 0
+          expect(Procedure.last.draft_revision.root_types_de_champ_public.count).to eq 0
+          expect(Procedure.last.draft_revision.root_types_de_champ_private.count).to eq 0
           expect(Procedure.last.attestation_acceptation_template).to be_nil
           expect(Procedure.last.attestation_refus_template).to be_nil
           expect(Procedure.last.zones).to be_blank
@@ -1502,7 +1502,7 @@ describe Administrateurs::ProceduresController, type: :controller do
           expect(procedure.replaced_by_procedure_id).to be_nil
           expect(procedure.closing_notification_brouillon).to be_falsy
           expect(procedure.closing_notification_en_cours).to be_falsy
-          expect(procedure.published_revision.types_de_champ_public.first.libelle).to eq('libelle 1')
+          expect(procedure.published_revision.root_types_de_champ_public.first.libelle).to eq('libelle 1')
         end
       end
 

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -146,7 +146,7 @@ describe Administrateurs::TypesDeChampController, type: :controller do
     context 'with a dropdown list with a referentiel' do
       let(:referentiel_file) { fixture_file_upload('spec/fixtures/files/modele-import-referentiel.csv', 'text/csv') }
       let(:drop_down_list_type_de_champ) do
-        procedure.draft_revision.types_de_champ_public.third
+        procedure.draft_revision.root_types_de_champ_public.third
       end
 
       let(:params) do
@@ -276,7 +276,7 @@ describe Administrateurs::TypesDeChampController, type: :controller do
       end
       let(:referentiel_file) { fixture_file_upload('spec/fixtures/files/modele-import-referentiel.csv', 'text/csv') }
       let(:multiple_drop_down_list_type_de_champ) do
-        procedure.draft_revision.types_de_champ_public.first
+        procedure.draft_revision.root_types_de_champ_public.first
       end
       let(:coordinate) { procedure.draft_revision.revision_types_de_champ_public.first }
 
@@ -628,7 +628,7 @@ describe Administrateurs::TypesDeChampController, type: :controller do
       expect { subject }.to change { suggestion.reload.state }.from('completed').to('accepted')
       expect(response).to redirect_to(simplify_admin_procedure_types_de_champ_path(procedure, tunnel_id:, rule: 'improve_structure'))
 
-      libelles = procedure.draft_revision.reload.types_de_champ_public.map(&:libelle)
+      libelles = procedure.draft_revision.reload.root_types_de_champ_public.map(&:libelle)
       expect(libelles).to include('Nouveau')
       expect(libelles).not_to include('A')
 

--- a/spec/controllers/api/public/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/dossiers_controller_spec.rb
@@ -102,9 +102,9 @@ RSpec.describe API::Public::V1::DossiersController, type: :controller do
               expect { create_request }.not_to raise_error
               dossier = Dossier.last
 
-              first_row = dossier.project_champs_public.first.rows.first
-              second_row = dossier.project_champs_public.first.rows.last
-              expect(dossier.project_champs_public.first.rows.flatten.map(&:value)).to match_array(['Texte court', 'Texte court'])
+              first_row = dossier.root_champs_public.first.rows.first
+              second_row = dossier.root_champs_public.first.rows.last
+              expect(dossier.root_champs_public.first.rows.flatten.map(&:value)).to match_array(['Texte court', 'Texte court'])
             end
           end
         end

--- a/spec/controllers/api/v1/procedures_controller_spec.rb
+++ b/spec/controllers/api/v1/procedures_controller_spec.rb
@@ -54,7 +54,7 @@ describe API::V1::ProceduresController, type: :controller do
         describe 'type_de_champ' do
           subject { super()[:types_de_champ][0] }
 
-          let(:champ) { procedure.active_revision.types_de_champ_public.first }
+          let(:champ) { procedure.active_revision.root_types_de_champ_public.first }
 
           it do
             expect(subject[:id]).to eq(champ.id)

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -259,14 +259,14 @@ describe API::V2::GraphqlController do
             draftRevision: { id: procedure.draft_revision.to_typed_id },
             publishedRevision: {
               id: procedure.published_revision.to_typed_id,
-              champDescriptors: procedure.published_revision.types_de_champ_public.map { { __typename: format_type_champ(_1.type_champ) } },
+              champDescriptors: procedure.published_revision.root_types_de_champ_public.map { { __typename: format_type_champ(_1.type_champ) } },
             },
             service: {
               nom: procedure.service.nom,
               typeOrganisme: procedure.service.type_organisme,
               organisme: procedure.service.organisme,
             },
-            champDescriptors: procedure.active_revision.types_de_champ_public.map do |tdc|
+            champDescriptors: procedure.active_revision.root_types_de_champ_public.map do |tdc|
               {
                 id: tdc.to_typed_id,
                 label: tdc.libelle,
@@ -559,7 +559,7 @@ describe API::V2::GraphqlController do
             },
             revision: {
               id: dossier.revision.to_typed_id,
-              champDescriptors: dossier.types_de_champ_public.map do |tdc|
+              champDescriptors: dossier.root_types_de_champ_public.map do |tdc|
                 {
                   type: tdc.type_champ,
                 }
@@ -575,7 +575,7 @@ describe API::V2::GraphqlController do
             avis: []
           )
 
-          expected_champs = dossier.project_champs_public.map do |champ|
+          expected_champs = dossier.root_champs_public.map do |champ|
             {
               id: champ.to_typed_id,
               label: champ.libelle,
@@ -608,7 +608,7 @@ describe API::V2::GraphqlController do
           end
           expect(gql_data[:dossier][:messages]).to match_array(expected_messages)
 
-          expect(gql_data[:dossier][:champs][0][:id]).to eq(dossier.project_champs_public[0].type_de_champ.to_typed_id)
+          expect(gql_data[:dossier][:champs][0][:id]).to eq(dossier.root_champs_public[0].type_de_champ.to_typed_id)
         end
       end
 
@@ -749,8 +749,8 @@ describe API::V2::GraphqlController do
       context "champs" do
         let(:procedure) { create(:procedure, :published, :for_individual, administrateurs: [admin], types_de_champ_public: [{ type: :date }, { type: :datetime }]) }
         let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
-        let(:champ_date) { dossier.project_champs_public.first }
-        let(:champ_datetime) { dossier.project_champs_public.second }
+        let(:champ_date) { dossier.root_champs_public.first }
+        let(:champ_datetime) { dossier.root_champs_public.second }
 
         before do
           champ_date.update(value: '2019-07-10')
@@ -1402,7 +1402,7 @@ describe API::V2::GraphqlController do
             "mutation {
               dossierModifierAnnotationText(input: {
                 dossierId: \"#{dossier.to_typed_id}\",
-                annotationId: \"#{dossier.project_champs_private.find { |c| c.type == 'Champs::TextChamp' }.to_typed_id}\",
+                annotationId: \"#{dossier.root_champs_private.find { |c| c.type == 'Champs::TextChamp' }.to_typed_id}\",
                 instructeurId: \"#{instructeur.to_typed_id}\",
                 value: \"hello\"
               }) {
@@ -1439,7 +1439,7 @@ describe API::V2::GraphqlController do
             "mutation {
               dossierModifierAnnotationCheckbox(input: {
                 dossierId: \"#{dossier.to_typed_id}\",
-                annotationId: \"#{dossier.project_champs_private.find { |c| c.type_champ == 'checkbox' }.to_typed_id}\",
+                annotationId: \"#{dossier.root_champs_private.find { |c| c.type_champ == 'checkbox' }.to_typed_id}\",
                 instructeurId: \"#{instructeur.to_typed_id}\",
                 value: #{value}
               }) {
@@ -1490,7 +1490,7 @@ describe API::V2::GraphqlController do
             "mutation {
               dossierModifierAnnotationCheckbox(input: {
                 dossierId: \"#{dossier.to_typed_id}\",
-                annotationId: \"#{dossier.project_champs_private.find { |c| c.type_champ == 'yes_no' }.to_typed_id}\",
+                annotationId: \"#{dossier.root_champs_private.find { |c| c.type_champ == 'yes_no' }.to_typed_id}\",
                 instructeurId: \"#{instructeur.to_typed_id}\",
                 value: #{value}
               }) {
@@ -1540,7 +1540,7 @@ describe API::V2::GraphqlController do
             "mutation {
               dossierModifierAnnotationDate(input: {
                 dossierId: \"#{dossier.to_typed_id}\",
-                annotationId: \"#{dossier.project_champs_private.find { |c| c.type_champ == 'date' }.to_typed_id}\",
+                annotationId: \"#{dossier.root_champs_private.find { |c| c.type_champ == 'date' }.to_typed_id}\",
                 instructeurId: \"#{instructeur.to_typed_id}\",
                 value: \"#{1.day.from_now.to_date.iso8601}\"
               }) {
@@ -1560,7 +1560,7 @@ describe API::V2::GraphqlController do
 
               expect(gql_data).to eq(dossierModifierAnnotationDate: {
                 annotation: {
-                  stringValue: dossier.reload.project_champs_private.find { |c| c.type_champ == 'date' }.to_s,
+                  stringValue: dossier.reload.root_champs_private.find { |c| c.type_champ == 'date' }.to_s,
                 },
                 errors: nil,
               })
@@ -1575,7 +1575,7 @@ describe API::V2::GraphqlController do
             "mutation {
               dossierModifierAnnotationDatetime(input: {
                 dossierId: \"#{dossier.to_typed_id}\",
-                annotationId: \"#{dossier.project_champs_private.find { |c| c.type_champ == 'datetime' }.to_typed_id}\",
+                annotationId: \"#{dossier.root_champs_private.find { |c| c.type_champ == 'datetime' }.to_typed_id}\",
                 instructeurId: \"#{instructeur.to_typed_id}\",
                 value: \"#{1.day.from_now.iso8601}\"
               }) {
@@ -1596,7 +1596,7 @@ describe API::V2::GraphqlController do
 
               expect(gql_data).to eq(dossierModifierAnnotationDatetime: {
                 annotation: {
-                  stringValue: dossier.reload.project_champs_private.find { |c| c.type_champ == 'datetime' }.to_s,
+                  stringValue: dossier.reload.root_champs_private.find { |c| c.type_champ == 'datetime' }.to_s,
                 },
                 errors: nil,
               })
@@ -1612,7 +1612,7 @@ describe API::V2::GraphqlController do
             "mutation {
               dossierModifierAnnotationDropDownList(input: {
                 dossierId: \"#{dossier.to_typed_id}\",
-                annotationId: \"#{dossier.project_champs_private.find { |c| c.type_champ == 'drop_down_list' }.to_typed_id}\",
+                annotationId: \"#{dossier.root_champs_private.find { |c| c.type_champ == 'drop_down_list' }.to_typed_id}\",
                 instructeurId: \"#{instructeur.to_typed_id}\",
                 value: \"#{value}\"
               }) {
@@ -1633,7 +1633,7 @@ describe API::V2::GraphqlController do
 
               expect(gql_data).to eq(dossierModifierAnnotationDropDownList: {
                 annotation: {
-                  stringValue: dossier.reload.project_champs_private.find { |c| c.type_champ == 'drop_down_list' }.to_s,
+                  stringValue: dossier.reload.root_champs_private.find { |c| c.type_champ == 'drop_down_list' }.to_s,
                 },
                 errors: nil,
               })
@@ -1658,7 +1658,7 @@ describe API::V2::GraphqlController do
             "mutation {
               dossierModifierAnnotationIntegerNumber(input: {
                 dossierId: \"#{dossier.to_typed_id}\",
-                annotationId: \"#{dossier.project_champs_private.find { |c| c.type_champ == 'integer_number' }.to_typed_id}\",
+                annotationId: \"#{dossier.root_champs_private.find { |c| c.type_champ == 'integer_number' }.to_typed_id}\",
                 instructeurId: \"#{instructeur.to_typed_id}\",
                 value: 42
               }) {

--- a/spec/controllers/champs/carte_controller_spec.rb
+++ b/spec/controllers/champs/carte_controller_spec.rb
@@ -27,7 +27,7 @@ describe Champs::CarteController, type: :controller do
 
     context 'when the champ is not a carte' do
       let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :text }]) }
-      let(:champ) { dossier.project_champs_public.first }
+      let(:champ) { dossier.root_champs_public.first }
 
       it 'returns not found' do
         get :index, params: { dossier_id: champ.dossier_id, stable_id: champ.stable_id }, format: :turbo_stream

--- a/spec/controllers/champs/piece_justificative_controller_spec.rb
+++ b/spec/controllers/champs/piece_justificative_controller_spec.rb
@@ -4,12 +4,12 @@ describe Champs::PieceJustificativeController, type: :controller do
   let(:user) { create(:user) }
   let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }], types_de_champ_private: [{ type: :piece_justificative }]) }
   let(:dossier) { create(:dossier, user: user, procedure: procedure) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
 
   describe 'ensure_legitimate_access' do
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :text }]) }
     let(:dossier) { create(:dossier, user: user, procedure: procedure) }
-    let(:champ) { dossier.project_champs_public.first }
+    let(:champ) { dossier.root_champs_public.first }
 
     before { sign_in user }
 
@@ -24,7 +24,7 @@ describe Champs::PieceJustificativeController, type: :controller do
 
     context 'when the dossier is en_instruction' do
       let(:dossier) { create(:dossier, :en_instruction, user: user, procedure: procedure) }
-      let(:champ) { dossier.project_champs_public.first }
+      let(:champ) { dossier.root_champs_public.first }
 
       it 'returns not found' do
         put :update, params: { dossier_id: champ.dossier_id, stable_id: champ.stable_id }, format: :turbo_stream
@@ -34,7 +34,7 @@ describe Champs::PieceJustificativeController, type: :controller do
 
     context 'when the dossier is accepte' do
       let(:dossier) { create(:dossier, :accepte, user: user, procedure: procedure) }
-      let(:champ) { dossier.project_champs_public.first }
+      let(:champ) { dossier.root_champs_public.first }
 
       it 'returns not found' do
         put :update, params: { dossier_id: champ.dossier_id, stable_id: champ.stable_id }, format: :turbo_stream
@@ -48,7 +48,7 @@ describe Champs::PieceJustificativeController, type: :controller do
 
     context 'when a non-instructeur user tries to access a private champ' do
       let(:dossier) { create(:dossier, user: user, procedure: procedure) }
-      let(:champ) { dossier.project_champs_private.first }
+      let(:champ) { dossier.root_champs_private.first }
 
       it 'returns not found' do
         put :update, params: { dossier_id: champ.dossier_id, stable_id: champ.stable_id }, format: :turbo_stream
@@ -118,7 +118,7 @@ describe Champs::PieceJustificativeController, type: :controller do
       let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
       let(:instructeur) { create(:instructeur) }
       let!(:dossier) { create(:dossier, :en_construction, user: user, procedure: procedure) }
-      let!(:champ) { dossier.project_champs_private.first }
+      let!(:champ) { dossier.root_champs_private.first }
 
       before do
         instructeur.assign_to_procedure(procedure)
@@ -133,7 +133,7 @@ describe Champs::PieceJustificativeController, type: :controller do
     context 'when the champ is public and the dossier is en_construction' do
       let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
       let!(:dossier) { create(:dossier, :en_construction, user: user, procedure: procedure) }
-      let!(:champ) { dossier.project_champs_public.first }
+      let!(:champ) { dossier.root_champs_public.first }
 
       it 'renders the footer with submit button' do
         subject
@@ -159,7 +159,7 @@ describe Champs::PieceJustificativeController, type: :controller do
     context 'when the champ is a RIB whose content analysis is pending (#13104)' do
       let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative, nature: 'rib' }]) }
       let(:dossier) { create(:dossier, user: user, procedure: procedure) }
-      let(:champ) { dossier.project_champs_public.first }
+      let(:champ) { dossier.root_champs_public.first }
       let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
 
       before do

--- a/spec/controllers/champs/repetition_controller_spec.rb
+++ b/spec/controllers/champs/repetition_controller_spec.rb
@@ -5,12 +5,12 @@ describe Champs::RepetitionController, type: :controller do
 
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, mandatory: true, children: [{ libelle: 'Nom' }, { type: :integer_number, libelle: 'Age' }] }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:repetition) { dossier.project_champs_public.find(&:repetition?) }
+  let(:repetition) { dossier.root_champs_public.find(&:repetition?) }
 
   describe 'ensure_legitimate_access' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.project_champs_public.first }
+    let(:champ) { dossier.root_champs_public.first }
 
     it 'returns not found when the champ is not a repetition' do
       post :add, params: { dossier_id: dossier, stable_id: champ.stable_id }, format: :turbo_stream
@@ -22,7 +22,7 @@ describe Champs::RepetitionController, type: :controller do
       let(:gi) { create(:groupe_instructeur, instructeurs: [instructeur]) }
       let(:procedure) { create(:procedure, types_de_champ_private: [{ type: :repetition, children: [{ libelle: 'Nom' }] }], groupe_instructeurs: [gi]) }
       let(:dossier) { create(:dossier, :en_instruction, procedure:) }
-      let(:repetition) { dossier.project_champs_private.find(&:repetition?) }
+      let(:repetition) { dossier.root_champs_private.find(&:repetition?) }
       before { sign_in instructeur.user }
 
       it 'works' do
@@ -39,7 +39,7 @@ describe Champs::RepetitionController, type: :controller do
 
     context 'removes repetition' do
       it { expect { subject }.not_to change { dossier.reload.champ_data.size } }
-      it { expect { subject }.to change { dossier.reload; dossier.project_champs_public.find(&:repetition?).row_ids.size }.from(1).to(0) }
+      it { expect { subject }.to change { dossier.reload; dossier.root_champs_public.find(&:repetition?).row_ids.size }.from(1).to(0) }
       it { expect { subject }.to change { row.reload.discarded_at }.from(nil).to(Time) }
       it { expect { subject }.to change { dossier.reload.last_champ_updated_at } }
     end

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -542,7 +542,7 @@ describe Experts::AvisController, type: :controller do
         context 'when the expert also shares the linked dossiers' do
           context 'and the expert can access the linked dossiers' do
             let(:created_avis) { create(:avis, dossier: dossier, claimant: claimant) }
-            let(:linked_dossier) { Dossier.find_by(id: dossier.reload.project_champs_public.filter(&:dossier_link?).filter_map(&:value)) }
+            let(:linked_dossier) { Dossier.find_by(id: dossier.reload.root_champs_public.filter(&:dossier_link?).filter_map(&:value)) }
             let(:linked_avis) { create(:avis, dossier: linked_dossier, claimant: claimant) }
             let(:invite_linked_dossiers) { true }
 

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -1366,12 +1366,12 @@ describe Instructeurs::DossiersController, type: :controller do
     let(:another_instructeur) { create(:instructeur) }
     let(:now) { Time.zone.parse('01/01/2100') }
 
-    let(:champ_repetition) { dossier.project_champs_private.fourth }
+    let(:champ_repetition) { dossier.root_champs_private.fourth }
     let(:champ_text) { champ_repetition.rows.first.first }
-    let(:champ_multiple_drop_down_list) { dossier.project_champs_private.first }
-    let(:champ_linked_drop_down_list) { dossier.project_champs_private.second }
-    let(:champ_datetime) { dossier.project_champs_private.third }
-    let(:champ_drop_down_list) { dossier.project_champs_private.fifth }
+    let(:champ_multiple_drop_down_list) { dossier.root_champs_private.first }
+    let(:champ_linked_drop_down_list) { dossier.root_champs_private.second }
+    let(:champ_datetime) { dossier.root_champs_private.third }
+    let(:champ_drop_down_list) { dossier.root_champs_private.fifth }
 
     context 'when no invalid champs_public' do
       context "with new values for champs_private" do
@@ -1573,7 +1573,7 @@ describe Instructeurs::DossiersController, type: :controller do
         ]
       end
 
-      let(:champ_decimal_number) { dossier.project_champs_public.first }
+      let(:champ_decimal_number) { dossier.root_champs_public.first }
 
       let(:params) do
         {
@@ -1634,7 +1634,7 @@ describe Instructeurs::DossiersController, type: :controller do
       let(:types_de_champ_private) { [{ type: :pre_rempli }] }
       let(:types_de_champ_public) { [] }
       let(:dossier) { create(:dossier, :en_construction, :with_populated_annotations, procedure:) }
-      let(:pre_rempli_annotation) { dossier.project_champs_private.first }
+      let(:pre_rempli_annotation) { dossier.root_champs_private.first }
 
       before { pre_rempli_annotation.update_column(:value, 'original') }
 
@@ -1688,7 +1688,7 @@ describe Instructeurs::DossiersController, type: :controller do
       it 'recomputes visibility of conditional annotations after polling' do
         subject
 
-        explication_annotation = assigns(:dossier).project_champs_private_all
+        explication_annotation = assigns(:dossier).flat_champs_private
           .find { _1.type_de_champ.stable_id == explication_stable_id }
         expect(assigns(:to_show)).to include("##{explication_annotation.input_group_id}")
       end

--- a/spec/controllers/recherche_controller_spec.rb
+++ b/spec/controllers/recherche_controller_spec.rb
@@ -136,11 +136,11 @@ describe RechercheController, type: :controller do
 
     describe 'by champs' do
       before do
-        dossier.project_champs_public[0].value = "Name of district A"
-        dossier.project_champs_public[1].value = "75000"
+        dossier.root_champs_public[0].value = "Name of district A"
+        dossier.root_champs_public[1].value = "75000"
         dossier.save!
 
-        dossier_with_expert.project_champs_public[0].value = "Name of district B"
+        dossier_with_expert.root_champs_public[0].value = "Name of district B"
         dossier_with_expert.save!
 
         perform_enqueued_jobs(only: DossierIndexSearchTermsJob)
@@ -189,7 +189,7 @@ describe RechercheController, type: :controller do
       let(:query) { 'invalid' }
 
       before do
-        dossier_with_expert.project_champs_private[1].value = "Dossier B is invalid"
+        dossier_with_expert.root_champs_private[1].value = "Dossier B is invalid"
         dossier_with_expert.save!
 
         perform_enqueued_jobs(only: DossierIndexSearchTermsJob)

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -622,7 +622,7 @@ describe Users::DossiersController, type: :controller do
     let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
     let(:types_de_champ_public) { [{ type: :text, mandatory: false }] }
     let!(:dossier) { create(:dossier, user:, procedure:) }
-    let(:first_champ) { dossier.project_champs_public.first }
+    let(:first_champ) { dossier.root_champs_public.first }
     let(:value) { 'beautiful value' }
     let(:now) { Time.zone.parse('01/01/2100') }
     let(:payload) { { id: dossier.id } }
@@ -788,7 +788,7 @@ describe Users::DossiersController, type: :controller do
     let(:dossier) { create(:dossier, :en_construction, :with_individual, *dossier_traits, procedure:, user: owner).tap { _1.with_update_stream(_1.user) } }
     let(:now) { Time.zone.parse('01/01/2100') }
     let(:params) { { id: dossier.id } }
-    let(:champs) { dossier.project_champs_public }
+    let(:champs) { dossier.root_champs_public }
     let(:make_changes) do
       champ = champs.first
       if champ.present?
@@ -979,8 +979,8 @@ describe Users::DossiersController, type: :controller do
     let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
     let(:types_de_champ_public) { [{}, { type: :piece_justificative, mandatory: false }] }
     let(:dossier) { create(:dossier, user:, procedure:, brouillon_close_to_expiration_notice_sent_at: 10.days.ago) }
-    let(:first_champ) { dossier.project_champs_public.first }
-    let(:piece_justificative_champ) { dossier.project_champs_public.last }
+    let(:first_champ) { dossier.root_champs_public.first }
+    let(:piece_justificative_champ) { dossier.root_champs_public.last }
     let(:value) { 'beautiful value' }
     let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
     let(:now) { Time.zone.parse('01/01/2100') }
@@ -1025,7 +1025,7 @@ describe Users::DossiersController, type: :controller do
       end
 
       context 'with a valid value sent as string' do
-        before { procedure.active_revision.types_de_champ_public.first.update!(drop_down_mode: 'advanced', referentiel:) }
+        before { procedure.active_revision.root_types_de_champ_public.first.update!(drop_down_mode: 'advanced', referentiel:) }
 
         it 'updates the value' do
           subject
@@ -1057,7 +1057,7 @@ describe Users::DossiersController, type: :controller do
       end
 
       context 'with a valid value sent as string' do
-        before { procedure.active_revision.types_de_champ_public.first.update!(drop_down_mode: 'advanced', referentiel:) }
+        before { procedure.active_revision.root_types_de_champ_public.first.update!(drop_down_mode: 'advanced', referentiel:) }
 
         it 'updates the value' do
           subject
@@ -1291,8 +1291,8 @@ describe Users::DossiersController, type: :controller do
       render_views
 
       let(:types_de_champ_public) { [{ type: :text }, { type: :integer_number }] }
-      let(:text_champ) { dossier.project_champs_public.first }
-      let(:number_champ) { dossier.project_champs_public.last }
+      let(:text_champ) { dossier.root_champs_public.first }
+      let(:number_champ) { dossier.root_champs_public.last }
       let(:validate) { "true" }
       let(:submit_payload) do
         {
@@ -1402,7 +1402,7 @@ describe Users::DossiersController, type: :controller do
         dossier.reload
 
         # check data persistence
-        champs = dossier.project_champs
+        champs = dossier.champs
         champ_referentiel = champs.find(&:referentiel?)
         expect(champ_referentiel.value).to eq(suggestion_value)
         expect(champ_referentiel.data).to eq(champ_referentiel.send(:rewrap_selected_object_in_datasource, suggestion_data.with_indifferent_access))
@@ -1497,10 +1497,10 @@ describe Users::DossiersController, type: :controller do
     let(:types_de_champ_public) { [{}, { type: :piece_justificative }] }
     let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
     let!(:dossier) { create(:dossier, :en_construction, user:, procedure:) }
-    let(:first_champ) { dossier.project_champs_public.first }
-    let(:first_champ_user_buffer) { dossier.with_update_stream(dossier.user) { dossier.project_champs_public.first } }
-    let(:piece_justificative_champ) { dossier.project_champs_public.last }
-    let(:piece_justificative_champ_user_buffer) { dossier.with_update_stream(dossier.user) { dossier.project_champs_public.last } }
+    let(:first_champ) { dossier.root_champs_public.first }
+    let(:first_champ_user_buffer) { dossier.with_update_stream(dossier.user) { dossier.root_champs_public.first } }
+    let(:piece_justificative_champ) { dossier.root_champs_public.last }
+    let(:piece_justificative_champ_user_buffer) { dossier.with_update_stream(dossier.user) { dossier.root_champs_public.last } }
     let(:value) { 'beautiful value' }
     let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
     let(:now) { Time.zone.parse('01/01/2100') }
@@ -1536,7 +1536,7 @@ describe Users::DossiersController, type: :controller do
 
     context 'when champ is pre_rempli (read-only guard)' do
       let(:types_de_champ_public) { [{ type: :pre_rempli }] }
-      let(:pre_rempli_champ) { dossier.project_champs_public.first }
+      let(:pre_rempli_champ) { dossier.root_champs_public.first }
 
       before { pre_rempli_champ.update_column(:value, 'original') }
 
@@ -1780,17 +1780,17 @@ describe Users::DossiersController, type: :controller do
         subject
 
         dossier.reload
-        annotation = dossier.project_champs_private.find { it.stable_id == 100 }
+        annotation = dossier.root_champs_private.find { it.stable_id == 100 }
         expect(annotation.value).to be_nil
 
         dossier.with_update_stream(dossier.user) do
-          referentiel = dossier.project_champs_public.find { it.stable_id == referentiel_stable_id }
+          referentiel = dossier.root_champs_public.find { it.stable_id == referentiel_stable_id }
           expect(referentiel.data.deep_symbolize_keys).to eq(data: [suggestion_data])
         end
 
         dossier.merge_user_buffer_stream!
         dossier.reload
-        annotation = dossier.project_champs_private.find { it.stable_id == 100 }
+        annotation = dossier.root_champs_private.find { it.stable_id == 100 }
         expect(annotation.value).to eq(suggestion_data[:finess])
         expect(annotation.stream).to eq(Dossier::MAIN_STREAM)
       end
@@ -2608,7 +2608,7 @@ describe Users::DossiersController, type: :controller do
     context 'live announcement of a RIB status (polling anti-spam)' do
       render_views
       let(:types_de_champ_public) { [{ type: :piece_justificative, nature: 'rib', stable_id: }] }
-      let(:champ) { dossier.project_champs_public.first }
+      let(:champ) { dossier.root_champs_public.first }
       let(:region_id) { "#{champ.focusable_input_id}-aria-live" }
 
       def announced_region(body)
@@ -2688,7 +2688,7 @@ describe Users::DossiersController, type: :controller do
             get :champ, params: { id: dossier.id, stable_id: referentiel_stable_id }, format: :turbo_stream
 
             expect(assigns(:to_update).size).to eq(3)
-            expect(dossier.reload.project_champs.map(&:value)).to include('valeur préremplie')
+            expect(dossier.reload.champs.map(&:value)).to include('valeur préremplie')
             expect(response.body).to include('Donnée remplie automatiquement.')
             expect(response.body).to include('Jeanne')
             expect(response.body).to include('Bob')
@@ -2728,7 +2728,7 @@ describe Users::DossiersController, type: :controller do
         it 'recomputes visibility of conditional champs after polling' do
           subject
 
-          explication_champ = assigns(:dossier).project_champs_public_all
+          explication_champ = assigns(:dossier).flat_champs_public
             .find { _1.type_de_champ.stable_id == explication_stable_id }
           expect(assigns(:to_show)).to include("##{explication_champ.input_group_id}")
         end
@@ -2880,7 +2880,7 @@ describe Users::DossiersController, type: :controller do
 
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{}]) }
     let(:dossier) { create(:dossier, user:, procedure:) }
-    let(:champ) { dossier.project_champs_public.first }
+    let(:champ) { dossier.root_champs_public.first }
 
     subject { patch :revert_prefill, params: { id: dossier.id, stable_id: champ.stable_id }, format: :turbo_stream }
 
@@ -2917,7 +2917,7 @@ describe Users::DossiersController, type: :controller do
       it 'reverts on the buffer stream champ and responds with turbo_stream' do
         subject
         dossier.reload
-        buffer_champ = dossier.with_update_stream(user) { dossier.project_champs_public.first }
+        buffer_champ = dossier.with_update_stream(user) { dossier.root_champs_public.first }
         expect(buffer_champ.value).to eq('original')
         expect(buffer_champ.prefilled_original_value).to eq({ 'value' => 'original' })
         expect(response).to have_http_status(:success)

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -23,13 +23,13 @@ FactoryBot.define do
 
     after(:create) do |dossier, evaluator|
       if evaluator.populate_champs
-        dossier.revision.types_de_champ_public.each do |type_de_champ|
+        dossier.revision.root_types_de_champ_public.each do |type_de_champ|
           dossier_factory_create_champ_or_repetition(type_de_champ, dossier)
         end
       end
 
       if evaluator.populate_annotations
-        dossier.revision.types_de_champ_private.each do |type_de_champ|
+        dossier.revision.root_types_de_champ_private.each do |type_de_champ|
           dossier_factory_create_champ_or_repetition(type_de_champ, dossier)
         end
       end

--- a/spec/graphql/annotation_spec.rb
+++ b/spec/graphql/annotation_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Mutations::DossierModifierAnnotations, type: :graphql do
   end
   let(:dossiers) { [] }
   let(:instructeur) { create(:instructeur, followed_dossiers: dossiers) }
-  let(:champs_private) { dossier.project_champs_private }
+  let(:champs_private) { dossier.root_champs_private }
 
   let(:query) { '' }
   let(:context) { { administrateur_id: admin.id, procedure_ids: admin.procedure_ids, write_access: true } }

--- a/spec/graphql/demarche_spec.rb
+++ b/spec/graphql/demarche_spec.rb
@@ -33,14 +33,14 @@ RSpec.describe Types::DemarcheType, type: :graphql do
     let(:procedure_clone) { procedure.clone(admin:) }
     let(:query) { DEMARCHE_WITH_CHAMP_DESCRIPTORS_QUERY }
     let(:variables) { { number: procedure_clone.id } }
-    let(:champ_descriptor_id) { procedure.draft_revision.types_de_champ_public.first.to_typed_id }
+    let(:champ_descriptor_id) { procedure.draft_revision.root_types_de_champ_public.first.to_typed_id }
 
     it {
       expect(data[:demarche][:champDescriptors]).to eq(data[:demarche][:draftRevision][:champDescriptors])
       expect(data[:demarche][:champDescriptors][0][:id]).to eq(champ_descriptor_id)
       expect(data[:demarche][:draftRevision][:champDescriptors][0][:id]).to eq(champ_descriptor_id)
-      expect(procedure.draft_revision.types_de_champ_public.first.id).not_to eq(procedure_clone.draft_revision.types_de_champ_public.first.id)
-      expect(procedure.draft_revision.types_de_champ_public.first.stable_id).to eq(procedure_clone.draft_revision.types_de_champ_public.first.stable_id)
+      expect(procedure.draft_revision.root_types_de_champ_public.first.id).not_to eq(procedure_clone.draft_revision.root_types_de_champ_public.first.id)
+      expect(procedure.draft_revision.root_types_de_champ_public.first.stable_id).to eq(procedure_clone.draft_revision.root_types_de_champ_public.first.stable_id)
     }
   end
 

--- a/spec/graphql/dossier_spec.rb
+++ b/spec/graphql/dossier_spec.rb
@@ -146,8 +146,8 @@ RSpec.describe Types::DossierType, type: :graphql do
     end
 
     before do
-      dossier.project_champs_public.find { _1.type_champ == TypeDeChamp.type_champs.fetch(:address) }.update(value_json: address)
-      dossier.project_champs_public.find { _1.type_champ == TypeDeChamp.type_champs.fetch(:rna) }.update(data: rna)
+      dossier.root_champs_public.find { _1.type_champ == TypeDeChamp.type_champs.fetch(:address) }.update(value_json: address)
+      dossier.root_champs_public.find { _1.type_champ == TypeDeChamp.type_champs.fetch(:rna) }.update(data: rna)
     end
 
     it '', :slow do
@@ -156,7 +156,7 @@ RSpec.describe Types::DossierType, type: :graphql do
       expect(data[:dossier][:champs][1][:commune][:code]).to eq('75119')
       expect(data[:dossier][:champs][1][:commune][:postalCode]).to eq('75019')
       expect(data[:dossier][:champs][1][:departement][:code]).to eq('75')
-      expect(data[:dossier][:champs][2][:etablissement][:siret]).to eq dossier.project_champs_public[2].etablissement.siret
+      expect(data[:dossier][:champs][2][:etablissement][:siret]).to eq dossier.root_champs_public[2].etablissement.siret
 
       expect(data[:dossier][:revision][:champDescriptors].map { _1[:level] }).to eq([nil, nil, nil, nil, 1, nil])
       expect(data[:dossier][:revision][:champDescriptors].map { _1[:__typename] }).to eq ["CommuneChampDescriptor", "AddressChampDescriptor", "SiretChampDescriptor", "RNAChampDescriptor", "HeaderSectionChampDescriptor", "ExplicationChampDescriptor"]
@@ -177,7 +177,7 @@ RSpec.describe Types::DossierType, type: :graphql do
 
     context 'not in ban' do
       before do
-        dossier.project_champs_public.find(&:address?).update_columns(value_json: not_in_ban_address)
+        dossier.root_champs_public.find(&:address?).update_columns(value_json: not_in_ban_address)
       end
 
       it 'should return address', :slow do
@@ -190,7 +190,7 @@ RSpec.describe Types::DossierType, type: :graphql do
 
     context 'international' do
       before do
-        dossier.project_champs_public.find(&:address?).update_columns(value_json: international_address)
+        dossier.root_champs_public.find(&:address?).update_columns(value_json: international_address)
       end
 
       it 'should return address', :slow do
@@ -202,7 +202,7 @@ RSpec.describe Types::DossierType, type: :graphql do
     end
 
     context 'when etablissement is in degraded mode' do
-      let(:etablissement) { dossier.project_champs_public.third.etablissement }
+      let(:etablissement) { dossier.root_champs_public.third.etablissement }
       before do
         etablissement.update(adresse: nil)
       end
@@ -231,7 +231,7 @@ RSpec.describe Types::DossierType, type: :graphql do
     let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
     let(:query) { DOSSIER_WITH_SELECTED_CHAMP_QUERY }
     let(:variables) { { number: dossier.id, id: champ.to_typed_id } }
-    let(:champ) { dossier.project_champs_public.last }
+    let(:champ) { dossier.root_champs_public.last }
 
     context 'when champ exists' do
       it {
@@ -258,7 +258,7 @@ RSpec.describe Types::DossierType, type: :graphql do
     let(:checkbox_value) { 'true' }
 
     before do
-      dossier.project_champs_public.first.update(value: checkbox_value)
+      dossier.root_champs_public.first.update(value: checkbox_value)
     end
 
     context 'when checkbox is true' do
@@ -311,7 +311,7 @@ RSpec.describe Types::DossierType, type: :graphql do
     let(:variables) { { number: dossier.id } }
 
     before do
-      dossier.project_champs_public.first.update(value: linked_dossier.id)
+      dossier.root_champs_public.first.update(value: linked_dossier.id)
     end
 
     context 'en_construction' do
@@ -340,7 +340,7 @@ RSpec.describe Types::DossierType, type: :graphql do
     let(:variables) { { number: dossier.id } }
 
     let(:rows) do
-      dossier.project_champs_public.first.rows.map do |champs|
+      dossier.root_champs_public.first.rows.map do |champs|
         { champs: champs.map { { id: _1.to_typed_id } } }
       end
     end
@@ -361,7 +361,7 @@ RSpec.describe Types::DossierType, type: :graphql do
     let(:large_integer) { 3400936534933 }
 
     before do
-      integer_champ = dossier.project_champs_public.first
+      integer_champ = dossier.root_champs_public.first
       integer_champ.update(value: large_integer.to_s)
     end
 
@@ -510,8 +510,8 @@ RSpec.describe Types::DossierType, type: :graphql do
     let(:query) { DOSSIER_WITH_DATE_CHAMPS_QUERY }
     let(:variables) { { number: dossier.id } }
 
-    let(:champ_date) { dossier.project_champs_public.first }
-    let(:champ_datetime) { dossier.project_champs_public.second }
+    let(:champ_date) { dossier.root_champs_public.first }
+    let(:champ_datetime) { dossier.root_champs_public.second }
 
     before do
       champ_date.update(value: '2026-01-01')

--- a/spec/jobs/blob_processor_job_spec.rb
+++ b/spec/jobs/blob_processor_job_spec.rb
@@ -219,7 +219,7 @@ describe BlobProcessorJob, :external_deps, type: :job do
     let(:nature) { "rib" }
     let(:dossier) { create(:dossier, procedure:) }
     let(:analysis) { { "some" => "data" } }
-    let(:champ_pj) { dossier.project_champs_public.first }
+    let(:champ_pj) { dossier.root_champs_public.first }
 
     let(:blob) do
       pj = champ_pj.piece_justificative_file

--- a/spec/jobs/dossier_index_search_terms_job_spec.rb
+++ b/spec/jobs/dossier_index_search_terms_job_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe DossierIndexSearchTermsJob, type: :job do
   subject(:perform_job) { described_class.perform_now(dossier.reload) }
 
   before do
-    dossier.project_champs_public.first.update_column(:value, "un nouveau champ")
-    dossier.project_champs_private.first.update_column(:value, "private champ")
+    dossier.root_champs_public.first.update_column(:value, "un nouveau champ")
+    dossier.root_champs_private.first.update_column(:value, "private champ")
   end
 
   it "update search terms columns" do

--- a/spec/lib/recovery/dossier_life_cycle_spec.rb
+++ b/spec/lib/recovery/dossier_life_cycle_spec.rb
@@ -49,7 +49,7 @@ describe 'Dossier::Recovery::LifeCycle' do
       d
     end
 
-    def repetition(d) = d.project_champs_public.find(&:repetition?)
+    def repetition(d) = d.root_champs_public.find(&:repetition?)
     def pj_champ(d) = d.champ_data.find_by(type: "Champs::PieceJustificativeChamp")
     def carte(d) = d.champ_data.find_by(type: "Champs::CarteChamp")
     def siret(d) = d.champ_data.find_by(type: "Champs::SiretChamp")

--- a/spec/lib/recovery/revision_life_cycle_spec.rb
+++ b/spec/lib/recovery/revision_life_cycle_spec.rb
@@ -29,11 +29,11 @@ describe 'Recovery::Revision::LifeCycle' do
 
       it do
         expect { DossierPreloader.load_one(dossier) }.not_to raise_error
-        expect(dossier.project_champs_public.size).to eq(1)
+        expect(dossier.root_champs_public.size).to eq(1)
         expect(dossier.champ_data.size).to eq(2)
         importer.load
         expect { DossierPreloader.load_one(dossier) }.not_to raise_error
-        expect(dossier.project_champs_public.size).to eq(2)
+        expect(dossier.root_champs_public.size).to eq(2)
       end
     end
 

--- a/spec/models/attestation_template_spec.rb
+++ b/spec/models/attestation_template_spec.rb
@@ -73,11 +73,11 @@ describe AttestationTemplate, type: :model do
     end
 
     before do
-      dossier.project_champs_public
+      dossier.root_champs_public
         .find { |champ| champ.libelle == 'libelleA' }
         .update(value: 'libelle1')
 
-      dossier.project_champs_public
+      dossier.root_champs_public
         .find { |champ| champ.libelle == 'libelleB' }
         .update(value: 'libelle2')
     end
@@ -118,7 +118,7 @@ describe AttestationTemplate, type: :model do
 
       context 'when a tag value contains a < character' do
         before do
-          dossier.project_champs_public
+          dossier.root_champs_public
             .find { |champ| champ.libelle == 'libelleB' }
             .update(value: 'age < 18')
         end

--- a/spec/models/champ_presentations/repetition_presentation_spec.rb
+++ b/spec/models/champ_presentations/repetition_presentation_spec.rb
@@ -15,7 +15,7 @@ describe ChampPresentations::RepetitionPresentation do
   }
 
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ_repetition) { dossier.project_champs_public.first }
+  let(:champ_repetition) { dossier.root_champs_public.first }
 
   before do
     champ_repetition.add_row(updated_by: 'test')

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -33,7 +33,7 @@ describe Champ do
       context 'when repetition blank' do
         let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, mandatory: false, children: [{ type: :text }] }]) }
         let(:dossier) { create(:dossier, procedure:) }
-        let(:champ) { dossier.project_champs_public.find(&:repetition?) }
+        let(:champ) { dossier.root_champs_public.find(&:repetition?) }
 
         it { expect(champ.blank?).to be(true) }
       end
@@ -58,7 +58,7 @@ describe Champ do
     context 'when repetition not blank' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{ type: :text }] }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ) { dossier.project_champs_public.find(&:repetition?) }
+      let(:champ) { dossier.root_champs_public.find(&:repetition?) }
 
       it { expect(champ.blank?).to be(false) }
     end
@@ -87,8 +87,8 @@ describe Champ do
     let(:dossier) { create(:dossier) }
 
     it 'partition public and private' do
-      expect(dossier.project_champs_public.count).to eq(1)
-      expect(dossier.project_champs_private.count).to eq(1)
+      expect(dossier.root_champs_public.count).to eq(1)
+      expect(dossier.root_champs_private.count).to eq(1)
     end
 
     it do
@@ -100,11 +100,11 @@ describe Champ do
       it { expect(dossier.procedure.revisions.count).to eq(2) }
 
       it 'does not duplicate public champs' do
-        expect(dossier.project_champs_public.count).to eq(1)
+        expect(dossier.root_champs_public.count).to eq(1)
       end
 
       it 'does not duplicate private champs' do
-        expect(dossier.project_champs_private.count).to eq(1)
+        expect(dossier.root_champs_private.count).to eq(1)
       end
     end
   end
@@ -114,12 +114,12 @@ describe Champ do
       create(:procedure, types_de_champ_public: [{}, { type: :header_section }, { type: :repetition, mandatory: true, children: [{ type: :header_section }] }], types_de_champ_private: [{}, { type: :header_section }])
     end
     let(:dossier) { create(:dossier, procedure: procedure) }
-    let(:public_champ) { dossier.project_champs_public.first }
-    let(:private_champ) { dossier.project_champs_private.first }
+    let(:public_champ) { dossier.root_champs_public.first }
+    let(:private_champ) { dossier.root_champs_private.first }
     let(:standalone_champ) { build(:champ, type_de_champ: build(:type_de_champ), dossier: build(:dossier)) }
-    let(:public_sections) { dossier.project_champs_public.filter(&:header_section?) }
-    let(:private_sections) { dossier.project_champs_private.filter(&:header_section?) }
-    let(:sections_in_repetition) { dossier.project_champs_public.find(&:repetition?).rows.flatten.filter(&:header_section?) }
+    let(:public_sections) { dossier.root_champs_public.filter(&:header_section?) }
+    let(:private_sections) { dossier.root_champs_private.filter(&:header_section?) }
+    let(:sections_in_repetition) { dossier.root_champs_public.find(&:repetition?).rows.flatten.filter(&:header_section?) }
 
     it 'returns the sibling sections of a champ' do
       expect(public_sections).not_to be_empty

--- a/spec/models/champs/commune_champ_spec.rb
+++ b/spec/models/champs/commune_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::CommuneChamp do
   let(:types_de_champ_public) { [{ type: :communes }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
 
   let(:code_insee) { '63102' }
   let(:code_postal) { '63290' }

--- a/spec/models/champs/date_champ_spec.rb
+++ b/spec/models/champs/date_champ_spec.rb
@@ -35,7 +35,7 @@ describe Champs::DateChamp do
   end
 
   context 'when the value is not in the past' do
-    let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.root_champs_public.first.tap { _1.update(value:) } }
     subject { champ.validate(:champ_value) }
 
     context 'all dates are accepted' do
@@ -56,7 +56,7 @@ describe Champs::DateChamp do
   end
 
   context 'when there is a range' do
-    let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.root_champs_public.first.tap { _1.update(value:) } }
     subject { champ.validate(:champ_value) }
 
     before { champ.type_de_champ.update(options: { range_date: '1', start_date: '2017-11-30', end_date: '2017-12-31' }) }
@@ -111,7 +111,7 @@ describe Champs::DateChamp do
   end
 
   context 'when birthdate option is enabled' do
-    let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.root_champs_public.first.tap { _1.update(value:) } }
     subject { champ.validate(:champ_value) }
 
     before { champ.type_de_champ.update(options: { birthdate: "1" }) }

--- a/spec/models/champs/datetime_champ_spec.rb
+++ b/spec/models/champs/datetime_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::DatetimeChamp do
   let(:types_de_champ_public) { [{ type: :datetime }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:datetime_champ) { dossier.project_champs_public.first }
+  let(:datetime_champ) { dossier.root_champs_public.first }
 
   describe '#normalizes' do
     it 'preserves nil' do
@@ -104,7 +104,7 @@ describe Champs::DatetimeChamp do
   end
 
   context 'when there is a range' do
-    let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.root_champs_public.first.tap { _1.update(value:) } }
     subject { champ.validate(:champ_value) }
 
     before { champ.type_de_champ.update(options: { range_date: '1', start_date: '2017-11-30', end_date: '2017-12-31' }) }

--- a/spec/models/champs/decimal_number_champ_spec.rb
+++ b/spec/models/champs/decimal_number_champ_spec.rb
@@ -5,7 +5,7 @@ describe Champs::DecimalNumberChamp do
   let(:types_de_champ_private) { [] }
   let(:procedure) { create(:procedure, types_de_champ_public:, types_de_champ_private:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.root_champs_public.first.tap { _1.update(value:) } }
   let(:value) { nil }
 
   describe 'validation' do
@@ -127,7 +127,7 @@ describe Champs::DecimalNumberChamp do
     context 'when the champ is private and the value is invalid' do
       let(:types_de_champ_public) { [] }
       let(:types_de_champ_private) { [{ type: :decimal_number }] }
-      let(:champ) { dossier.project_champs_private.first.tap { _1.update(value:) } }
+      let(:champ) { dossier.root_champs_private.first.tap { _1.update(value:) } }
       let(:value) { '2.6666' }
 
       it { is_expected.to be_falsey }

--- a/spec/models/champs/departement_champ_spec.rb
+++ b/spec/models/champs/departement_champ_spec.rb
@@ -3,7 +3,7 @@
 describe Champs::DepartementChamp, type: :model do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :departements }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first.tap { _1.update_columns(value:, external_id:) } }
+  let(:champ) { dossier.root_champs_public.first.tap { _1.update_columns(value:, external_id:) } }
   let(:value) { nil }
   let(:external_id) { nil }
 

--- a/spec/models/champs/dossier_link_champ_spec.rb
+++ b/spec/models/champs/dossier_link_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::DossierLinkChamp, type: :model do
   let(:types_de_champ_public) { [{ type: :dossier_link, mandatory: }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, :en_construction, procedure:) }
-  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.root_champs_public.first.tap { _1.update(value:) } }
   let(:value) { nil }
   let(:mandatory) { false }
 

--- a/spec/models/champs/drop_down_list_champ_spec.rb
+++ b/spec/models/champs/drop_down_list_champ_spec.rb
@@ -6,7 +6,7 @@ describe Champs::DropDownListChamp do
   let(:dossier) { create(:dossier, procedure:) }
   let(:referentiel) { nil }
   let(:drop_down_mode) { nil }
-  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:, other:) } }
+  let(:champ) { dossier.root_champs_public.first.tap { _1.update(value:, other:) } }
   let(:value) { nil }
   let(:other) { nil }
 

--- a/spec/models/champs/email_champ_spec.rb
+++ b/spec/models/champs/email_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::EmailChamp do
   describe 'validation' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{}, { type: :email }, {}]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.project_champs_public.second }
+    let(:champ) { dossier.root_champs_public.second }
     let(:value) { nil }
     before { champ.value = value }
     subject { champ.validate(:champ_value) }

--- a/spec/models/champs/engagement_juridique_champ_spec.rb
+++ b/spec/models/champs/engagement_juridique_champ_spec.rb
@@ -5,7 +5,7 @@ describe Champs::EngagementJuridiqueChamp do
     let(:types_de_champ_public) { [{ type: :engagement_juridique }] }
     let(:procedure) { create(:procedure, types_de_champ_public:) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
+    let(:champ) { dossier.root_champs_public.first.tap { _1.update(value:) } }
     let(:value) { nil }
 
     subject { champ.validate(:champ_value) }

--- a/spec/models/champs/epci_champ_spec.rb
+++ b/spec/models/champs/epci_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::EpciChamp, type: :model do
   let(:types_de_champ_public) { [{ type: :epci }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first.tap { _1.code_departement = code_departement } }
+  let(:champ) { dossier.root_champs_public.first.tap { _1.code_departement = code_departement } }
   let(:code_departement) { nil }
 
   describe 'validations' do

--- a/spec/models/champs/formatted_champ_spec.rb
+++ b/spec/models/champs/formatted_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::FormattedChamp do
   let(:types_de_champ_public) { [tdc_definition] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
 
   before do
     champ.value = value

--- a/spec/models/champs/iban_champ_spec.rb
+++ b/spec/models/champs/iban_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::IbanChamp do
   let(:types_de_champ_public) { [{ type: :iban }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
 
   describe '#valid?' do
     def with_value(value)

--- a/spec/models/champs/integer_number_champ_spec.rb
+++ b/spec/models/champs/integer_number_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::IntegerNumberChamp do
   let(:types_de_champ_public) { [{ type: :integer_number }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.root_champs_public.first.tap { _1.update(value:) } }
   let(:value) { nil }
   subject { champ.validate(:champ_value) }
 

--- a/spec/models/champs/multiple_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/multiple_drop_down_list_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::MultipleDropDownListChamp do
   let(:types_de_champ_public) { [{ type: :multiple_drop_down_list, options: ["val1", "val2", "val3", "[brackets] val4"] }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.root_champs_public.first.tap { _1.update(value:) } }
   let(:value) { nil }
 
   describe 'validations' do

--- a/spec/models/champs/phone_champ_spec.rb
+++ b/spec/models/champs/phone_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::PhoneChamp do
   let(:types_de_champ_public) { [{ type: :phone }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
 
   describe '#validate' do
     it do

--- a/spec/models/champs/piece_justificative_champ_spec.rb
+++ b/spec/models/champs/piece_justificative_champ_spec.rb
@@ -7,7 +7,7 @@ describe Champs::PieceJustificativeChamp do
 
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
 
   describe "validations" do
     subject { champ }
@@ -86,7 +86,7 @@ describe Champs::PieceJustificativeChamp do
     context 'titre_identite nature' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: 'titre_identite' }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ) { dossier.project_champs_public.first }
+      let(:champ) { dossier.root_champs_public.first }
 
       it 'accepts jpeg under 20MB' do
         champ.piece_justificative_file.purge
@@ -119,7 +119,7 @@ describe Champs::PieceJustificativeChamp do
       context "#{ocr_nature} nature" do
         let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: ocr_nature }]) }
         let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-        let(:champ) { dossier.project_champs_public.first }
+        let(:champ) { dossier.root_champs_public.first }
 
         it 'accepts pdf' do
           champ.piece_justificative_file.purge
@@ -139,7 +139,7 @@ describe Champs::PieceJustificativeChamp do
     context 'pj_limit_formats with document_texte' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, pj_limit_formats: '1', pj_format_families: ['document_texte'] }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ) { dossier.project_champs_public.first }
+      let(:champ) { dossier.root_champs_public.first }
 
       it 'accepts pdf' do
         champ.piece_justificative_file.purge
@@ -164,7 +164,7 @@ describe Champs::PieceJustificativeChamp do
     context 'pj_limit_formats enabled with empty families' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, pj_limit_formats: '1', pj_format_families: [] }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:champ) { dossier.project_champs_public.first }
+      let(:champ) { dossier.root_champs_public.first }
 
       it 'accepts pdf' do
         champ.piece_justificative_file.purge

--- a/spec/models/champs/referentiel_champ_cast_value_spec.rb
+++ b/spec/models/champs/referentiel_champ_cast_value_spec.rb
@@ -44,7 +44,7 @@ describe Champs::ReferentielChamp, type: :model do
 
         it 'update the prefiiable stable_id with the jsonpath value of the external data' do
           expect { subject }
-            .to change { dossier.reload.project_champs.find(&:text?).value }.from(nil).to("ok")
+            .to change { dossier.reload.champs.find(&:text?).value }.from(nil).to("ok")
         end
       end
 
@@ -55,7 +55,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: "42" } }
           it 'casts and updates the integer_number with the jsonpath value as integer' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:integer_number?).value }.from(nil).to("42")
+              .to change { dossier.reload.champs.find(&:integer_number?).value }.from(nil).to("42")
           end
         end
 
@@ -63,7 +63,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 42 } }
           it 'casts and updates the integer_number with the jsonpath value as integer' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:integer_number?).value }.from(nil).to("42")
+              .to change { dossier.reload.champs.find(&:integer_number?).value }.from(nil).to("42")
           end
         end
 
@@ -71,7 +71,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 42.2 } }
           it 'casts and updates the integer_number with the jsonpath value as integer' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:integer_number?).value }.from(nil).to("42")
+              .to change { dossier.reload.champs.find(&:integer_number?).value }.from(nil).to("42")
           end
         end
 
@@ -79,7 +79,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: nil } }
           it 'casts and updates the integer_number with the jsonpath value as integer' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:integer_number?).value }
+              .not_to change { dossier.reload.champs.find(&:integer_number?).value }
           end
         end
 
@@ -87,7 +87,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: "" } }
           it 'casts and updates the integer_number with the jsonpath value as integer' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:integer_number?).value }
+              .not_to change { dossier.reload.champs.find(&:integer_number?).value }
           end
         end
       end
@@ -99,7 +99,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 3.14 } }
           it 'casts and updates the decimal_number with the jsonpath value as float' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:decimal_number?).value }.from(nil).to("3.14")
+              .to change { dossier.reload.champs.find(&:decimal_number?).value }.from(nil).to("3.14")
           end
         end
 
@@ -107,7 +107,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: "3.14" } }
           it 'casts and updates the decimal_number with the jsonpath value as float' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:decimal_number?).value }.from(nil).to("3.14")
+              .to change { dossier.reload.champs.find(&:decimal_number?).value }.from(nil).to("3.14")
           end
         end
 
@@ -115,7 +115,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 2 } }
           it 'casts and updates the decimal_number with the jsonpath value as float' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:decimal_number?).value }.from(nil).to("2.0")
+              .to change { dossier.reload.champs.find(&:decimal_number?).value }.from(nil).to("2.0")
           end
         end
 
@@ -123,7 +123,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: "2" } }
           it 'casts and updates the decimal_number with the jsonpath value as float' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:decimal_number?).value }.from(nil).to("2.0")
+              .to change { dossier.reload.champs.find(&:decimal_number?).value }.from(nil).to("2.0")
           end
         end
 
@@ -131,7 +131,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: nil } }
           it 'does not update the decimal_number value (remains nil)' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:decimal_number?).value }.from(nil)
+              .not_to change { dossier.reload.champs.find(&:decimal_number?).value }.from(nil)
           end
         end
 
@@ -139,7 +139,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: "" } }
           it 'does not update the decimal_number value (remains nil)' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:decimal_number?).value }.from(nil)
+              .not_to change { dossier.reload.champs.find(&:decimal_number?).value }.from(nil)
           end
         end
       end
@@ -151,7 +151,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: true } }
           it 'casts and updates the checkbox with the jsonpath value as "true"' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:checkbox?).value }.from(nil).to("true")
+              .to change { dossier.reload.champs.find(&:checkbox?).value }.from(nil).to("true")
           end
         end
 
@@ -159,7 +159,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: "true" } }
           it 'casts and updates the checkbox with the jsonpath value as "true"' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:checkbox?).value }.from(nil).to("true")
+              .to change { dossier.reload.champs.find(&:checkbox?).value }.from(nil).to("true")
           end
         end
 
@@ -167,7 +167,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 1 } }
           it 'casts and updates the checkbox with the jsonpath value as "true"' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:checkbox?).value }.from(nil).to("true")
+              .to change { dossier.reload.champs.find(&:checkbox?).value }.from(nil).to("true")
           end
         end
 
@@ -175,7 +175,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: "1" } }
           it 'casts and updates the checkbox with the jsonpath value as "true"' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:checkbox?).value }.from(nil).to("true")
+              .to change { dossier.reload.champs.find(&:checkbox?).value }.from(nil).to("true")
           end
         end
 
@@ -183,7 +183,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: nil } }
           it 'does not update the checkbox value (remains nil)' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:checkbox?).value }.from(nil)
+              .not_to change { dossier.reload.champs.find(&:checkbox?).value }.from(nil)
           end
         end
 
@@ -191,7 +191,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: "" } }
           it 'does not update the checkbox value (remains nil)' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:checkbox?).value }.from(nil)
+              .not_to change { dossier.reload.champs.find(&:checkbox?).value }.from(nil)
           end
         end
       end
@@ -203,7 +203,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: false } }
           it 'casts and updates the yes_no with the jsonpath value as "false"' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:yes_no?).value }.from(nil).to("false")
+              .to change { dossier.reload.champs.find(&:yes_no?).value }.from(nil).to("false")
           end
         end
 
@@ -211,7 +211,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: "false" } }
           it 'casts and updates the yes_no with the jsonpath value as "false"' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:yes_no?).value }.from(nil).to("false")
+              .to change { dossier.reload.champs.find(&:yes_no?).value }.from(nil).to("false")
           end
         end
 
@@ -219,7 +219,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 0 } }
           it 'casts and updates the yes_no with the jsonpath value as "false"' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:yes_no?).value }.from(nil).to("false")
+              .to change { dossier.reload.champs.find(&:yes_no?).value }.from(nil).to("false")
           end
         end
 
@@ -227,7 +227,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: "0" } }
           it 'casts and updates the yes_no with the jsonpath value as "false"' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:yes_no?).value }.from(nil).to("false")
+              .to change { dossier.reload.champs.find(&:yes_no?).value }.from(nil).to("false")
           end
         end
 
@@ -235,7 +235,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: nil } }
           it 'does not update the yes_no value (remains nil)' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:yes_no?).value }.from(nil)
+              .not_to change { dossier.reload.champs.find(&:yes_no?).value }.from(nil)
           end
         end
 
@@ -243,7 +243,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: "" } }
           it 'does not update the yes_no value (remains nil)' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:yes_no?).value }.from(nil)
+              .not_to change { dossier.reload.champs.find(&:yes_no?).value }.from(nil)
           end
         end
       end
@@ -255,7 +255,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: '2024-06-14' } }
           it 'casts and updates the date with the jsonpath value as ISO8601' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:date?).value }.from(nil).to('2024-06-14')
+              .to change { dossier.reload.champs.find(&:date?).value }.from(nil).to('2024-06-14')
           end
         end
 
@@ -264,7 +264,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: date.to_time.to_i } } # 2025-07-10T00:00:00Z
           it 'convert to ISO8601 date' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:date?).value }.from(nil).to(date.iso8601)
+              .to change { dossier.reload.champs.find(&:date?).value }.from(nil).to(date.iso8601)
           end
         end
 
@@ -273,7 +273,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: date.to_time.to_i.to_s } } # 2025-07-10T00:00:00Z
           it 'convert to ISO8601 date' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:date?).value }.from(nil).to(date.iso8601)
+              .to change { dossier.reload.champs.find(&:date?).value }.from(nil).to(date.iso8601)
           end
         end
 
@@ -281,7 +281,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 'not_a_timestamp' } }
           it 'noops' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:date?).value }.from(nil)
+              .not_to change { dossier.reload.champs.find(&:date?).value }.from(nil)
           end
         end
 
@@ -289,7 +289,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: '14/06/2024' } }
           it 'casts and updates the date with the jsonpath value as ISO8601' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:date?).value }.from(nil).to('2024-06-14')
+              .to change { dossier.reload.champs.find(&:date?).value }.from(nil).to('2024-06-14')
           end
         end
 
@@ -297,7 +297,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: '2024-13-14' } }
           it 'does not update the date value (remains nil)' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:date?).value }.from(nil)
+              .not_to change { dossier.reload.champs.find(&:date?).value }.from(nil)
           end
         end
       end
@@ -309,7 +309,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: '2024-06-14T12:34' } }
           it 'casts and updates the datetime with the jsonpath value as ISO8601' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:datetime?).value }.from(nil).to(Time.zone.parse('2024-06-14T12:34').iso8601)
+              .to change { dossier.reload.champs.find(&:datetime?).value }.from(nil).to(Time.zone.parse('2024-06-14T12:34').iso8601)
           end
         end
 
@@ -317,7 +317,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: '14/06/2024 12:34' } }
           it 'casts and updates the datetime with the jsonpath value as ISO8601' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:datetime?).value }.from(nil).to(Time.zone.parse('2024-06-14T12:34').iso8601)
+              .to change { dossier.reload.champs.find(&:datetime?).value }.from(nil).to(Time.zone.parse('2024-06-14T12:34').iso8601)
           end
         end
 
@@ -325,7 +325,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: '2024-06-14T25:00' } }
           it 'does not update the datetime value (remains nil)' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:datetime?).value }.from(nil)
+              .not_to change { dossier.reload.champs.find(&:datetime?).value }.from(nil)
           end
         end
 
@@ -334,7 +334,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: datetime.to_f } }
           it 'convert to ISO8601 datetime' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:datetime?).value }.from(nil).to(datetime.iso8601)
+              .to change { dossier.reload.champs.find(&:datetime?).value }.from(nil).to(datetime.iso8601)
           end
         end
 
@@ -343,7 +343,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: datetime.to_f.to_s } }
           it 'convert to ISO8601 datetime' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:datetime?).value }.from(nil).to(datetime.iso8601)
+              .to change { dossier.reload.champs.find(&:datetime?).value }.from(nil).to(datetime.iso8601)
           end
         end
 
@@ -351,7 +351,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 'not_a_timestamp' } }
           it 'noops' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:datetime?).value }.from(nil)
+              .not_to change { dossier.reload.champs.find(&:datetime?).value }.from(nil)
           end
         end
       end
@@ -364,7 +364,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 'valid' } }
           it 'casts and updates the drop_down_list with the jsonpath value as string' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:drop_down_list?).value }.from(nil).to('valid')
+              .to change { dossier.reload.champs.find(&:drop_down_list?).value }.from(nil).to('valid')
           end
         end
 
@@ -373,7 +373,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 'invalid' } }
           it 'does not cast' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:drop_down_list?).value }
+              .not_to change { dossier.reload.champs.find(&:drop_down_list?).value }
           end
         end
 
@@ -382,7 +382,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 'anything' } }
           it 'allows other' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:drop_down_list?).value }.from(nil).to('anything')
+              .to change { dossier.reload.champs.find(&:drop_down_list?).value }.from(nil).to('anything')
           end
         end
 
@@ -390,7 +390,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: nil } }
           it 'does not update the drop_down_list value (remains nil)' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:drop_down_list?).value }.from(nil)
+              .not_to change { dossier.reload.champs.find(&:drop_down_list?).value }.from(nil)
           end
         end
       end
@@ -400,10 +400,10 @@ describe Champs::ReferentielChamp, type: :model do
         let(:data) { { ok: '13002526500013' } }
         it 'casts and updates the siret champ' do
           expect { subject }
-            .to change { dossier.reload.project_champs.find(&:siret?).external_id }.from(nil).to('13002526500013')
+            .to change { dossier.reload.champs.find(&:siret?).external_id }.from(nil).to('13002526500013')
         end
         it 'enqueue job' do
-          expect { subject }.to have_enqueued_job(ChampFetchExternalDataJob).with(dossier.reload.project_champs.find(&:siret?), '13002526500013')
+          expect { subject }.to have_enqueued_job(ChampFetchExternalDataJob).with(dossier.reload.champs.find(&:siret?), '13002526500013')
         end
       end
 
@@ -413,10 +413,10 @@ describe Champs::ReferentielChamp, type: :model do
         let(:data) { { ok: 'champdapi' } }
         it 'casts and updates the siret champ' do
           expect { subject }
-            .to change { dossier.reload.project_champs.reverse.find(&:referentiel?).external_id }.from(nil).to('champdapi')
+            .to change { dossier.reload.champs.reverse.find(&:referentiel?).external_id }.from(nil).to('champdapi')
         end
         it 'enqueue job' do
-          expect { subject }.to have_enqueued_job(ChampFetchExternalDataJob).with(dossier.reload.project_champs.reverse.find(&:referentiel?), 'champdapi')
+          expect { subject }.to have_enqueued_job(ChampFetchExternalDataJob).with(dossier.reload.champs.reverse.find(&:referentiel?), 'champdapi')
         end
       end
 
@@ -428,7 +428,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: ['valid', 'valid_one'] } }
           it 'casts and updates the multiple_drop_down_list with the jsonpath value as JSON array' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:multiple_drop_down_list?).value }.from(nil).to(['valid', 'valid_one'].to_json)
+              .to change { dossier.reload.champs.find(&:multiple_drop_down_list?).value }.from(nil).to(['valid', 'valid_one'].to_json)
           end
         end
 
@@ -436,7 +436,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: [{ choice: '1' }, { choice: '2' }] } }
           it 'passthru' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:multiple_drop_down_list?).value }
+              .not_to change { dossier.reload.champs.find(&:multiple_drop_down_list?).value }
           end
         end
 
@@ -444,7 +444,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: nil } }
           it 'does not update the multiple_drop_down_list value (remains nil)' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:multiple_drop_down_list?).value }.from(nil)
+              .not_to change { dossier.reload.champs.find(&:multiple_drop_down_list?).value }.from(nil)
           end
         end
 
@@ -452,7 +452,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: ['valid', 'invalid_option'] } }
           it 'allows invalid value due to validation afterward' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:multiple_drop_down_list?).value }.from(nil).to(['valid', 'invalid_option'].to_json)
+              .to change { dossier.reload.champs.find(&:multiple_drop_down_list?).value }.from(nil).to(['valid', 'invalid_option'].to_json)
           end
         end
       end
@@ -462,7 +462,7 @@ describe Champs::ReferentielChamp, type: :model do
         let(:data) { { ok: 'texte <b>formaté</b>' } }
         it 'update le champ formatted avec la valeur string' do
           expect { subject }
-            .to change { dossier.reload.project_champs.find(&:formatted?).value }.from(nil).to('texte <b>formaté</b>')
+            .to change { dossier.reload.champs.find(&:formatted?).value }.from(nil).to('texte <b>formaté</b>')
         end
       end
 
@@ -473,7 +473,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 'Monsieur' } }
           it 'casts to "M."' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:civilite?).value }.from(nil).to("M.")
+              .to change { dossier.reload.champs.find(&:civilite?).value }.from(nil).to("M.")
           end
         end
 
@@ -481,7 +481,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 'M' } }
           it 'casts to "M."' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:civilite?).value }.from(nil).to("M.")
+              .to change { dossier.reload.champs.find(&:civilite?).value }.from(nil).to("M.")
           end
         end
 
@@ -489,7 +489,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 'male' } }
           it 'casts to "M."' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:civilite?).value }.from(nil).to("M.")
+              .to change { dossier.reload.champs.find(&:civilite?).value }.from(nil).to("M.")
           end
         end
 
@@ -497,7 +497,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 'Mme' } }
           it 'casts to "Mme"' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:civilite?).value }.from(nil).to("Mme")
+              .to change { dossier.reload.champs.find(&:civilite?).value }.from(nil).to("Mme")
           end
         end
 
@@ -505,7 +505,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 'Mademoiselle' } }
           it 'casts to "Mme" (CNIL conformity)' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:civilite?).value }.from(nil).to("Mme")
+              .to change { dossier.reload.champs.find(&:civilite?).value }.from(nil).to("Mme")
           end
         end
 
@@ -513,7 +513,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 'female' } }
           it 'casts to "Mme"' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:civilite?).value }.from(nil).to("Mme")
+              .to change { dossier.reload.champs.find(&:civilite?).value }.from(nil).to("Mme")
           end
         end
 
@@ -521,7 +521,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 'Dr' } }
           it 'does not update the civilite' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:civilite?).value }
+              .not_to change { dossier.reload.champs.find(&:civilite?).value }
           end
         end
 
@@ -529,7 +529,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: '' } }
           it 'does not update the civilite' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:civilite?).value }
+              .not_to change { dossier.reload.champs.find(&:civilite?).value }
           end
         end
       end
@@ -541,12 +541,12 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: '20 avenue de Segur Paris' } }
           it 'sets external_id on the address champ' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:address?).external_id }.from(nil).to("20 avenue de Segur Paris")
+              .to change { dossier.reload.champs.find(&:address?).external_id }.from(nil).to("20 avenue de Segur Paris")
           end
 
           it 'does not set value (stays nil until async BAN resolution)' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:address?).value }
+              .not_to change { dossier.reload.champs.find(&:address?).value }
           end
         end
 
@@ -554,7 +554,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: '' } }
           it 'does not update the address champ' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:address?).external_id }
+              .not_to change { dossier.reload.champs.find(&:address?).external_id }
           end
         end
 
@@ -562,7 +562,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: nil } }
           it 'does not update the address champ' do
             expect { subject }
-              .not_to change { dossier.reload.project_champs.find(&:address?).external_id }
+              .not_to change { dossier.reload.champs.find(&:address?).external_id }
           end
         end
       end
@@ -574,7 +574,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 'valeur' } }
           it 'casts to string' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:pre_rempli?).value }.from(nil).to('valeur')
+              .to change { dossier.reload.champs.find(&:pre_rempli?).value }.from(nil).to('valeur')
           end
         end
 
@@ -582,7 +582,7 @@ describe Champs::ReferentielChamp, type: :model do
           let(:data) { { ok: 42 } }
           it 'casts to string via to_s' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:pre_rempli?).value }.from(nil).to('42')
+              .to change { dossier.reload.champs.find(&:pre_rempli?).value }.from(nil).to('42')
           end
         end
       end
@@ -704,7 +704,7 @@ describe Champs::ReferentielChamp, type: :model do
 
           it 'update the prefiiable stable_id with the jsonpath value of the external data' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:text?).value }.from(nil).to("ok")
+              .to change { dossier.reload.champs.find(&:text?).value }.from(nil).to("ok")
           end
         end
       end
@@ -739,7 +739,7 @@ describe Champs::ReferentielChamp, type: :model do
 
           it 'update the prefiiable stable_id with the jsonpath value of the external data' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:text?).value }.from(nil).to("ok")
+              .to change { dossier.reload.champs.find(&:text?).value }.from(nil).to("ok")
           end
         end
       end
@@ -776,7 +776,7 @@ describe Champs::ReferentielChamp, type: :model do
 
           it 'update the prefiiable stable_id with the jsonpath value of the external data' do
             expect { subject }
-              .to change { dossier.reload.project_champs.find(&:text?).value }.from(nil).to("ok")
+              .to change { dossier.reload.champs.find(&:text?).value }.from(nil).to("ok")
           end
         end
       end

--- a/spec/models/champs/referentiel_champ_spec.rb
+++ b/spec/models/champs/referentiel_champ_spec.rb
@@ -9,7 +9,7 @@ describe Champs::ReferentielChamp, type: :model do
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
   let(:referentiel_champ) { dossier.champ_data.find(&:referentiel?) }
-  let(:champ) { dossier.project_champs_public.find(&:referentiel?) }
+  let(:champ) { dossier.root_champs_public.find(&:referentiel?) }
 
   describe '#valid?' do
     context 'when the champ is pending' do

--- a/spec/models/champs/region_champ_spec.rb
+++ b/spec/models/champs/region_champ_spec.rb
@@ -3,7 +3,7 @@
 describe Champs::RegionChamp, type: :model do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :regions }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:, external_id:) } }
+  let(:champ) { dossier.root_champs_public.first.tap { _1.update(value:, external_id:) } }
   let(:value) { nil }
   let(:external_id) { nil }
 

--- a/spec/models/champs/repetition_champ_spec.rb
+++ b/spec/models/champs/repetition_champ_spec.rb
@@ -11,7 +11,7 @@ describe Champs::RepetitionChamp do
       ])
   }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.find(&:repetition?) }
+  let(:champ) { dossier.root_champs_public.find(&:repetition?) }
 
   describe "#row_libelle" do
     context "with a single child (monochamp)" do
@@ -94,7 +94,7 @@ describe Champs::RepetitionChamp do
         ])
     end
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.project_champs_public.find(&:repetition?) }
+    let(:champ) { dossier.root_champs_public.find(&:repetition?) }
 
     context "when count is below min" do
       let(:min_rep) { 2 }
@@ -119,7 +119,7 @@ describe Champs::RepetitionChamp do
       end
 
       it "adds a repetition_too_few error even without any rows" do
-        fresh_champ = dossier.reload.project_champs_public.find(&:repetition?)
+        fresh_champ = dossier.reload.root_champs_public.find(&:repetition?)
         fresh_champ.valid?(:champ_value)
         expect(fresh_champ.errors.where(:value, :repetition_too_few)).to be_present
       end

--- a/spec/models/champs/rna_champ_spec.rb
+++ b/spec/models/champs/rna_champ_spec.rb
@@ -4,7 +4,7 @@ describe Champs::RNAChamp do
   let(:types_de_champ_public) { [{ type: :rna }] }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first.tap { _1.update(value:) } }
+  let(:champ) { dossier.root_champs_public.first.tap { _1.update(value:) } }
   let(:value) { "W182736273" }
 
   def with_external_id(external_id)

--- a/spec/models/champs/rnf_champ_spec.rb
+++ b/spec/models/champs/rnf_champ_spec.rb
@@ -11,7 +11,7 @@ describe Champs::RNFChamp, type: :model do
   describe '#valid?' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.project_champs_public.find(&:rnf?) }
+    let(:champ) { dossier.root_champs_public.find(&:rnf?) }
 
     def with_state(external_id:, data:, fetch_external_data_exceptions: [])
       champ.tap do
@@ -86,7 +86,7 @@ describe Champs::RNFChamp, type: :model do
   describe 'format validation' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.project_champs_public.find(&:rnf?) }
+    let(:champ) { dossier.root_champs_public.find(&:rnf?) }
 
     before { champ.update_columns(external_id:) }
 

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -3,7 +3,7 @@
 describe Champs::SiretChamp do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first.tap { _1.update(external_id:, etablissement:) } }
+  let(:champ) { dossier.root_champs_public.first.tap { _1.update(external_id:, etablissement:) } }
   let(:external_id) { "" }
   let(:etablissement) { nil }
 

--- a/spec/models/columns/linked_drop_down_column_spec.rb
+++ b/spec/models/columns/linked_drop_down_column_spec.rb
@@ -3,7 +3,7 @@
 describe Columns::LinkedDropDownColumn do
   describe '#filtered_ids' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :linked_drop_down_list, libelle: 'linked' }]) }
-    let(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }
+    let(:type_de_champ) { procedure.active_revision.root_types_de_champ_public.first }
     let(:kept_dossier) { create(:dossier, procedure: procedure) }
     let(:discarded_dossier) { create(:dossier, procedure: procedure) }
 
@@ -126,7 +126,7 @@ describe Columns::LinkedDropDownColumn do
 
   describe 'unpack_values' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :linked_drop_down_list, libelle: 'linked' }]) }
-    let(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }
+    let(:type_de_champ) { procedure.active_revision.root_types_de_champ_public.first }
     let(:column) { procedure.find_column(label: 'linked') }
     subject { column.send(:unpack_values, nil) }
 

--- a/spec/models/concerns/champ_conditional_concern_spec.rb
+++ b/spec/models/concerns/champ_conditional_concern_spec.rb
@@ -5,8 +5,8 @@ describe ChampConditionalConcern do
 
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :decimal_number, stable_id: 99 }, { type: :decimal_number, stable_id: 999, condition: }]) }
   let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
-  let(:champ) { dossier.project_champs_public.find { _1.stable_id == 99 }.tap { _1.update_column(:value, '1.1234') } }
-  let(:last_champ) { dossier.project_champs_public.find { _1.stable_id == 999 }.tap { _1.update_column(:value, '1.1234') } }
+  let(:champ) { dossier.root_champs_public.find { _1.stable_id == 99 }.tap { _1.update_column(:value, '1.1234') } }
+  let(:last_champ) { dossier.root_champs_public.find { _1.stable_id == 999 }.tap { _1.update_column(:value, '1.1234') } }
   let(:condition) { nil }
 
   describe '#dependent_conditions?' do

--- a/spec/models/concerns/champ_validate_concern_spec.rb
+++ b/spec/models/concerns/champ_validate_concern_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe ChampValidateConcern do
   let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:type_de_champ) { dossier.revision.types_de_champ_public.first }
+  let(:type_de_champ) { dossier.revision.root_types_de_champ_public.first }
   let(:public_id) { type_de_champ.public_id(nil) }
   let(:types_de_champ_public) { [{ type: :email }] }
 

--- a/spec/models/concerns/columns_concern_spec.rb
+++ b/spec/models/concerns/columns_concern_spec.rb
@@ -86,10 +86,10 @@ describe ColumnsConcern do
 
     context 'when the procedure can have a SIRET number' do
       let(:procedure) { create(:procedure, types_de_champ_public:, types_de_champ_private:) }
-      let(:tdc_1) { procedure.active_revision.types_de_champ_public[0] }
-      let(:tdc_2) { procedure.active_revision.types_de_champ_public[1] }
-      let(:tdc_private_1) { procedure.active_revision.types_de_champ_private[0] }
-      let(:tdc_private_2) { procedure.active_revision.types_de_champ_private[1] }
+      let(:tdc_1) { procedure.active_revision.root_types_de_champ_public[0] }
+      let(:tdc_2) { procedure.active_revision.root_types_de_champ_public[1] }
+      let(:tdc_private_1) { procedure.active_revision.root_types_de_champ_private[0] }
+      let(:tdc_private_2) { procedure.active_revision.root_types_de_champ_private[1] }
       let(:expected) {
         [
           { label: 'Dossier ID', table: 'self', column: 'id', displayable: true, type: :number, filterable: true },
@@ -137,10 +137,10 @@ describe ColumnsConcern do
         let(:types_de_champ_public) { Array.new(4) { { type: :text } } }
         let(:types_de_champ_private) { Array.new(4) { { type: :text } } }
         before do
-          procedure.active_revision.types_de_champ_public[2].update_attribute(:type_champ, TypeDeChamp.type_champs.fetch(:header_section))
-          procedure.active_revision.types_de_champ_public[3].update_attribute(:type_champ, TypeDeChamp.type_champs.fetch(:explication))
-          procedure.active_revision.types_de_champ_private[2].update_attribute(:type_champ, TypeDeChamp.type_champs.fetch(:header_section))
-          procedure.active_revision.types_de_champ_private[3].update_attribute(:type_champ, TypeDeChamp.type_champs.fetch(:explication))
+          procedure.active_revision.root_types_de_champ_public[2].update_attribute(:type_champ, TypeDeChamp.type_champs.fetch(:header_section))
+          procedure.active_revision.root_types_de_champ_public[3].update_attribute(:type_champ, TypeDeChamp.type_champs.fetch(:explication))
+          procedure.active_revision.root_types_de_champ_private[2].update_attribute(:type_champ, TypeDeChamp.type_champs.fetch(:header_section))
+          procedure.active_revision.root_types_de_champ_private[3].update_attribute(:type_champ, TypeDeChamp.type_champs.fetch(:explication))
         end
 
         it {

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -178,8 +178,8 @@ RSpec.describe DossierChampsConcern do
     end
   end
 
-  describe '#project_champs_public' do
-    subject { dossier.project_champs_public }
+  describe '#root_champs_public' do
+    subject { dossier.root_champs_public }
 
     it do
       expect(subject.size).to eq(4)
@@ -187,8 +187,8 @@ RSpec.describe DossierChampsConcern do
     end
   end
 
-  describe '#project_champs_private' do
-    subject { dossier.project_champs_private }
+  describe '#root_champs_private' do
+    subject { dossier.root_champs_private }
 
     it { expect(subject.size).to eq(1) }
   end
@@ -274,7 +274,7 @@ RSpec.describe DossierChampsConcern do
   end
 
   describe "#champ_values_for_export" do
-    subject { dossier.champ_values_for_export(dossier.revision.types_de_champ_public, format: :xlsx) }
+    subject { dossier.champ_values_for_export(dossier.revision.root_types_de_champ_public, format: :xlsx) }
 
     it do
       expect(subject.size).to eq(4)
@@ -1068,8 +1068,8 @@ RSpec.describe DossierChampsConcern do
           dossier.reload
           dossier.rebase!
 
-          @old_qf = dossier.project_champs_public.sort_by(&:stable_id).first
-          @new_qf = dossier.project_champs_public.sort_by(&:stable_id).last
+          @old_qf = dossier.root_champs_public.sort_by(&:stable_id).first
+          @new_qf = dossier.root_champs_public.sort_by(&:stable_id).last
 
           @fetched_instances = []
 
@@ -1117,8 +1117,8 @@ RSpec.describe DossierChampsConcern do
           dossier.reload
           dossier.rebase!
 
-          @old_qf = dossier.project_champs_public.sort_by(&:stable_id).first
-          @new_qf = dossier.project_champs_public.sort_by(&:stable_id).last
+          @old_qf = dossier.root_champs_public.sort_by(&:stable_id).first
+          @new_qf = dossier.root_champs_public.sort_by(&:stable_id).last
 
           @fetched_instances = []
 

--- a/spec/models/concerns/dossier_clone_concern_spec.rb
+++ b/spec/models/concerns/dossier_clone_concern_spec.rb
@@ -111,21 +111,21 @@ RSpec.describe DossierCloneConcern do
 
       context 'public are duplicated' do
         it do
-          expect(new_dossier.project_champs_public.count).to eq(dossier.project_champs_public.count)
-          expect(new_dossier.project_champs_public.map(&:id)).not_to eq(dossier.project_champs_public.map(&:id))
+          expect(new_dossier.root_champs_public.count).to eq(dossier.root_champs_public.count)
+          expect(new_dossier.root_champs_public.map(&:id)).not_to eq(dossier.root_champs_public.map(&:id))
         end
 
         it 'keeps champs.values' do
-          original_first_champ = dossier.project_champs_public.first
+          original_first_champ = dossier.root_champs_public.first
           original_first_champ.update!(value: 'kthxbye')
 
-          expect(new_dossier.project_champs_public.first.value).to eq(original_first_champ.value)
+          expect(new_dossier.root_champs_public.first.value).to eq(original_first_champ.value)
         end
 
         context 'for Champs::Repetition with rows, original_champ.repetition and rows are duped' do
           let(:types_de_champ_public) { [{ type: :repetition, children: [{}, {}] }] }
-          let(:champ_repetition) { dossier.project_champs_public.find(&:repetition?) }
-          let(:cloned_champ_repetition) { new_dossier.project_champs_public.find(&:repetition?) }
+          let(:champ_repetition) { dossier.root_champs_public.find(&:repetition?) }
+          let(:cloned_champ_repetition) { new_dossier.root_champs_public.find(&:repetition?) }
 
           it do
             expect(cloned_champ_repetition.rows.flatten.count).to eq(4)
@@ -184,13 +184,13 @@ RSpec.describe DossierCloneConcern do
         let(:types_de_champ_private) { [{}] }
 
         it 'reset champs private values' do
-          expect(new_dossier.project_champs_private.count).to eq(dossier.project_champs_private.count)
-          expect(new_dossier.project_champs_private.map(&:id)).not_to eq(dossier.project_champs_private.map(&:id))
-          original_first_champs_private = dossier.project_champs_private.first
+          expect(new_dossier.root_champs_private.count).to eq(dossier.root_champs_private.count)
+          expect(new_dossier.root_champs_private.map(&:id)).not_to eq(dossier.root_champs_private.map(&:id))
+          original_first_champs_private = dossier.root_champs_private.first
           original_first_champs_private.update!(value: 'kthxbye')
 
-          expect(new_dossier.project_champs_private.first.value).not_to eq(original_first_champs_private.value)
-          expect(new_dossier.project_champs_private.first.value).to eq(nil)
+          expect(new_dossier.root_champs_private.first.value).not_to eq(original_first_champs_private.value)
+          expect(new_dossier.root_champs_private.first.value).to eq(nil)
         end
       end
     end

--- a/spec/models/concerns/dossier_prefillable_concern_spec.rb
+++ b/spec/models/concerns/dossier_prefillable_concern_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe DossierPrefillableConcern do
         end
 
         it "doesn't change champs_public" do
-          expect { fill }.not_to change { dossier.project_champs_public.to_a }
+          expect { fill }.not_to change { dossier.root_champs_public.to_a }
         end
       end
 
@@ -52,15 +52,15 @@ RSpec.describe DossierPrefillableConcern do
           let(:types_de_champ_public) { [{ type: :text }, { type: :phone }] }
           let(:types_de_champ_private) { [{ type: :text }] }
 
-          let(:type_de_champ_1) { procedure.published_revision.types_de_champ_public.first }
+          let(:type_de_champ_1) { procedure.published_revision.root_types_de_champ_public.first }
           let(:value_1) { "any value" }
           let(:champ_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id) }
 
-          let(:type_de_champ_2) { procedure.published_revision.types_de_champ_public.second }
+          let(:type_de_champ_2) { procedure.published_revision.root_types_de_champ_public.second }
           let(:value_2) { "33612345678" }
           let(:champ_2) { find_champ_by_stable_id(dossier, type_de_champ_2.stable_id) }
 
-          let(:type_de_champ_3) { procedure.published_revision.types_de_champ_private.first }
+          let(:type_de_champ_3) { procedure.published_revision.root_types_de_champ_private.first }
           let(:value_3) { "some value" }
           let(:champ_3) { find_champ_by_stable_id(dossier, type_de_champ_3.stable_id) }
 
@@ -71,18 +71,18 @@ RSpec.describe DossierPrefillableConcern do
           it "updates the champs with the new values and mark them as prefilled" do
             fill
 
-            expect(dossier.project_champs_public.first.value).to eq(value_1)
-            expect(dossier.project_champs_public.first.prefilled).to eq(true)
-            expect(dossier.project_champs_public.last.value).to eq(value_2)
-            expect(dossier.project_champs_public.last.prefilled).to eq(true)
-            expect(dossier.project_champs_private.first.value).to eq(value_3)
-            expect(dossier.project_champs_private.first.prefilled).to eq(true)
+            expect(dossier.root_champs_public.first.value).to eq(value_1)
+            expect(dossier.root_champs_public.first.prefilled).to eq(true)
+            expect(dossier.root_champs_public.last.value).to eq(value_2)
+            expect(dossier.root_champs_public.last.prefilled).to eq(true)
+            expect(dossier.root_champs_private.first.value).to eq(value_3)
+            expect(dossier.root_champs_private.first.prefilled).to eq(true)
           end
         end
 
         context 'when a champ is invalid' do
           let(:types_de_champ_public) { [{ type: :phone }] }
-          let(:type_de_champ_1) { procedure.published_revision.types_de_champ_public.first }
+          let(:type_de_champ_1) { procedure.published_revision.root_types_de_champ_public.first }
           let(:value) { "a non phone value" }
           let(:champ_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id) }
 
@@ -91,11 +91,11 @@ RSpec.describe DossierPrefillableConcern do
           it_behaves_like 'a dossier marked as prefilled'
 
           it "still updates the champ" do
-            expect { fill }.to change { dossier.project_champs_public.first.value }.from(nil).to(value)
+            expect { fill }.to change { dossier.root_champs_public.first.value }.from(nil).to(value)
           end
 
           it "still marks it as prefilled" do
-            expect { fill }.to change { dossier.project_champs_public.first.prefilled }.from(nil).to(true)
+            expect { fill }.to change { dossier.root_champs_public.first.prefilled }.from(nil).to(true)
           end
         end
       end
@@ -108,14 +108,14 @@ RSpec.describe DossierPrefillableConcern do
       context 'when champs_attributes has values' do
         context 'when the champs are valid' do
           let(:types_de_champ_public) { [{ type: :text }] }
-          let(:type_de_champ_1) { procedure.published_revision.types_de_champ_public.first }
+          let(:type_de_champ_1) { procedure.published_revision.root_types_de_champ_public.first }
           let(:value_1) { "any value" }
           let(:champ_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id) }
           let(:values) { [[champ_1, { value: value_1 }]] }
 
           it "updates the champs with the new values and mark them as prefilled" do
             fill
-            expect(dossier.project_champs_public.first.value).to eq(value_1)
+            expect(dossier.root_champs_public.first.value).to eq(value_1)
             expect(dossier.individual).to be_nil # Fix #9486
           end
 
@@ -126,7 +126,7 @@ RSpec.describe DossierPrefillableConcern do
 
     context 'when dossier contains a pre_rempli champ' do
       let(:types_de_champ_public) { [{ type: :pre_rempli }] }
-      let(:type_de_champ_1) { procedure.published_revision.types_de_champ_public.first }
+      let(:type_de_champ_1) { procedure.published_revision.root_types_de_champ_public.first }
       let(:value_1) { "valeur pré-remplie" }
       let(:champ_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id) }
       let(:values) { [[champ_1, { value: value_1 }]] }
@@ -135,8 +135,8 @@ RSpec.describe DossierPrefillableConcern do
 
       it "assigns the value correctly via prefill" do
         fill
-        expect(dossier.project_champs_public.first.value).to eq(value_1)
-        expect(dossier.project_champs_public.first.prefilled).to eq(true)
+        expect(dossier.root_champs_public.first.value).to eq(value_1)
+        expect(dossier.root_champs_public.first.prefilled).to eq(true)
       end
     end
 
@@ -145,8 +145,8 @@ RSpec.describe DossierPrefillableConcern do
       # screening with champ.valid?(:prefill), and could leak to the database
       # through the dossier champ_data autosave when a valid champ triggered a save.
       let(:types_de_champ_public) { [{ type: :text }, { type: :date }] }
-      let(:text_type_de_champ) { procedure.published_revision.types_de_champ_public.first }
-      let(:date_type_de_champ) { procedure.published_revision.types_de_champ_public.second }
+      let(:text_type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
+      let(:date_type_de_champ) { procedure.published_revision.root_types_de_champ_public.second }
       let(:params) do
         {
           "champ_#{text_type_de_champ.to_typed_id_for_query}" => "any value",
@@ -165,7 +165,7 @@ RSpec.describe DossierPrefillableConcern do
     context 'when dossier contains champs with external_id' do
       let(:types_de_champ_public) { [{ type: :siret }] }
       let(:values) { [[champ_1, { external_id: value_1 }]] }
-      let(:type_de_champ_1) { procedure.published_revision.types_de_champ_public.first }
+      let(:type_de_champ_1) { procedure.published_revision.root_types_de_champ_public.first }
       let(:value_1) { "130 025 265 00013" }
       let(:champ_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id) }
 

--- a/spec/models/concerns/dossier_rebase_concern_spec.rb
+++ b/spec/models/concerns/dossier_rebase_concern_spec.rb
@@ -4,9 +4,9 @@ describe DossierRebaseConcern do
   describe '#can_rebase?' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ mandatory: true }, { type: :yes_no, mandatory: false }], types_de_champ_private: [{}]) }
     let(:attestation_template) { procedure.draft_revision.attestation_acceptation_template.find_or_revise! }
-    let(:type_de_champ) { procedure.active_revision.types_de_champ_public.find { |tdc| !tdc.mandatory? } }
-    let(:private_type_de_champ) { procedure.active_revision.types_de_champ_private.first }
-    let(:mandatory_type_de_champ) { procedure.active_revision.types_de_champ_public.find(&:mandatory?) }
+    let(:type_de_champ) { procedure.active_revision.root_types_de_champ_public.find { |tdc| !tdc.mandatory? } }
+    let(:private_type_de_champ) { procedure.active_revision.root_types_de_champ_private.first }
+    let(:mandatory_type_de_champ) { procedure.active_revision.root_types_de_champ_public.find(&:mandatory?) }
 
     context 'on unpublished procedure' do
       context 'en_construction' do
@@ -123,19 +123,19 @@ describe DossierRebaseConcern do
     let(:datetime_type_de_champ) { types_de_champ.find { _1.stable_id == 103 } }
     let(:yes_no_type_de_champ) { types_de_champ.find { _1.stable_id == 104 } }
 
-    let(:text_champ) { dossier.project_champs_public.find { _1.stable_id == 1 } }
-    let(:repetition_champ) { dossier.project_champs_public.find { _1.stable_id == 101 } }
-    let(:datetime_champ) { dossier.project_champs_public.find { _1.stable_id == 103 } }
+    let(:text_champ) { dossier.root_champs_public.find { _1.stable_id == 1 } }
+    let(:repetition_champ) { dossier.root_champs_public.find { _1.stable_id == 101 } }
+    let(:datetime_champ) { dossier.root_champs_public.find { _1.stable_id == 103 } }
 
-    let(:rebased_text_champ) { dossier.project_champs_public.find { _1.stable_id == 1 } }
-    let(:rebased_repetition_champ) { dossier.project_champs_public.find { _1.stable_id == 101 } }
-    let(:rebased_datetime_champ) { dossier.project_champs_public.find { _1.stable_id == 103 } }
-    let(:rebased_number_champ) { dossier.project_champs_public.find { _1.stable_id == 105 } }
+    let(:rebased_text_champ) { dossier.root_champs_public.find { _1.stable_id == 1 } }
+    let(:rebased_repetition_champ) { dossier.root_champs_public.find { _1.stable_id == 101 } }
+    let(:rebased_datetime_champ) { dossier.root_champs_public.find { _1.stable_id == 103 } }
+    let(:rebased_number_champ) { dossier.root_champs_public.find { _1.stable_id == 105 } }
 
-    let(:rebased_new_repetition_champ) { dossier.project_champs_public.find { _1.libelle == "une autre repetition" } }
+    let(:rebased_new_repetition_champ) { dossier.root_champs_public.find { _1.libelle == "une autre repetition" } }
 
     let(:private_text_type_de_champ) { types_de_champ.find { _1.stable_id == 11 } }
-    let(:rebased_private_text_champ) { dossier.project_champs_private.find { _1.stable_id == 11 } }
+    let(:rebased_private_text_champ) { dossier.root_champs_private.find { _1.stable_id == 11 } }
 
     context "when revision is published" do
       before do
@@ -186,7 +186,7 @@ describe DossierRebaseConcern do
 
       it "updates the brouillon champs with the latest revision changes", :slow do
         expect(dossier.revision).to eq(procedure.published_revision)
-        expect(dossier.project_champs_public.size).to eq(5)
+        expect(dossier.root_champs_public.size).to eq(5)
         expect(dossier.champ_data.count(&:public?)).to eq(6)
         expect(repetition_champ.rows.size).to eq(2)
         expect(repetition_champ.rows[0].size).to eq(1)
@@ -199,7 +199,7 @@ describe DossierRebaseConcern do
 
         expect(procedure.revisions.size).to eq(3)
         expect(dossier.revision).to eq(procedure.published_revision)
-        expect(dossier.project_champs_public.size).to eq(7)
+        expect(dossier.root_champs_public.size).to eq(7)
         expect(dossier.champ_data.count(&:public?)).to eq(7)
         expect(rebased_text_champ.value).to eq(text_champ.value)
         expect(rebased_text_champ.type_de_champ).not_to eq(text_champ.type_de_champ)
@@ -235,7 +235,7 @@ describe DossierRebaseConcern do
         let(:dossier) { create(:dossier, :en_construction, procedure:) }
 
         it 'is noop' do
-          expect { subject }.not_to change { dossier.reload.project_champs_public[0].rebased_at }
+          expect { subject }.not_to change { dossier.reload.root_champs_public[0].rebased_at }
           expect { subject }.not_to change { dossier.updated_at }
         end
       end
@@ -261,38 +261,38 @@ describe DossierRebaseConcern do
 
       context 'when a dropdown option is added' do
         before do
-          dossier.project_champs_public.first.update(value: 'v1')
+          dossier.root_champs_public.first.update(value: 'v1')
 
           stable_id = procedure.draft_revision.types_de_champ.find { _1.libelle == 'l1' }
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
           tdc_to_update.update(drop_down_options: ["option", "updated", "v1"])
         end
 
-        it { expect { subject }.not_to change { dossier.project_champs_public.first.to_s } }
+        it { expect { subject }.not_to change { dossier.root_champs_public.first.to_s } }
       end
 
       context 'when a dropdown option is removed' do
         before do
-          dossier.project_champs_public.first.update(value: 'v1')
+          dossier.root_champs_public.first.update(value: 'v1')
 
           stable_id = procedure.draft_revision.types_de_champ.find { _1.libelle == 'l1' }
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
           tdc_to_update.update(drop_down_options: ["option", "updated"])
         end
 
-        it { expect { subject }.not_to change { dossier.project_champs_public.first.to_s } }
+        it { expect { subject }.not_to change { dossier.root_champs_public.first.to_s } }
       end
 
       context 'when a dropdown unused option is removed' do
         before do
-          dossier.project_champs_public.first.update(value: 'v1')
+          dossier.root_champs_public.first.update(value: 'v1')
 
           stable_id = procedure.draft_revision.types_de_champ.find { _1.libelle == 'l1' }
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
           tdc_to_update.update(drop_down_options: ["v1", "updated"])
         end
 
-        it { expect { subject }.not_to change { dossier.project_champs_public.first.to_s } }
+        it { expect { subject }.not_to change { dossier.root_champs_public.first.to_s } }
       end
     end
 
@@ -307,38 +307,38 @@ describe DossierRebaseConcern do
 
       context 'when a dropdown option is added' do
         before do
-          dossier.project_champs_public.first.update(value: '["v1"]')
+          dossier.root_champs_public.first.update(value: '["v1"]')
 
           stable_id = procedure.draft_revision.types_de_champ.find { _1.libelle == 'l1' }
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
           tdc_to_update.update(drop_down_options: ["option", "updated", "v1"])
         end
 
-        it { expect { subject }.not_to change { dossier.project_champs_public.first.to_s } }
+        it { expect { subject }.not_to change { dossier.root_champs_public.first.to_s } }
       end
 
       context 'when a dropdown option is removed' do
         before do
-          dossier.project_champs_public.first.update(value: '["v1", "option"]')
+          dossier.root_champs_public.first.update(value: '["v1", "option"]')
 
           stable_id = procedure.draft_revision.types_de_champ.find { _1.libelle == 'l1' }
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
           tdc_to_update.update(drop_down_options: ["option", "updated"])
         end
 
-        it { expect { subject }.not_to change { dossier.project_champs_public.first.to_s } }
+        it { expect { subject }.not_to change { dossier.root_champs_public.first.to_s } }
       end
 
       context 'when a dropdown unused option is removed' do
         before do
-          dossier.project_champs_public.first.update(value: '["v1"]')
+          dossier.root_champs_public.first.update(value: '["v1"]')
 
           stable_id = procedure.draft_revision.types_de_champ.find { _1.libelle == 'l1' }
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
           tdc_to_update.update(drop_down_options: ["v1", "updated"])
         end
 
-        it { expect { subject }.not_to change { dossier.project_champs_public.first.to_s } }
+        it { expect { subject }.not_to change { dossier.root_champs_public.first.to_s } }
       end
     end
 
@@ -353,38 +353,38 @@ describe DossierRebaseConcern do
 
       context 'when a dropdown option is added' do
         before do
-          dossier.project_champs_public.first.update(value: '["titre1",""]')
+          dossier.root_champs_public.first.update(value: '["titre1",""]')
 
           stable_id = procedure.draft_revision.types_de_champ.find { _1.libelle == 'l1' }
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
           tdc_to_update.update(drop_down_options: ["--titre1--", "option", "v1", "updated", "--titre2--", "option2", "v2"])
         end
 
-        it { expect { subject }.not_to change { dossier.project_champs_public.first.to_s } }
+        it { expect { subject }.not_to change { dossier.root_champs_public.first.to_s } }
       end
 
       context 'when a dropdown option is removed' do
         before do
-          dossier.project_champs_public.first.update(value: '["titre2","option2"]')
+          dossier.root_champs_public.first.update(value: '["titre2","option2"]')
 
           stable_id = procedure.draft_revision.types_de_champ.find { _1.libelle == 'l1' }
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
           tdc_to_update.update(drop_down_options: ["--titre1--", "option", "updated", "--titre2--", "v2"])
         end
 
-        it { expect { subject }.to change { dossier.project_champs_public.first.to_s }.from('titre2 / option2').to('titre2') }
+        it { expect { subject }.to change { dossier.root_champs_public.first.to_s }.from('titre2 / option2').to('titre2') }
       end
 
       context 'when a dropdown unused option is removed' do
         before do
-          dossier.project_champs_public.first.update(value: '["titre2",""]')
+          dossier.root_champs_public.first.update(value: '["titre2",""]')
 
           stable_id = procedure.draft_revision.types_de_champ.find { _1.libelle == 'l1' }
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
           tdc_to_update.update(drop_down_options: ["--titre1--", "v1", "updated", "--titre2--", "option2", "v2"])
         end
 
-        it { expect { subject }.not_to change { dossier.project_champs_public.first.to_s } }
+        it { expect { subject }.not_to change { dossier.root_champs_public.first.to_s } }
       end
     end
 
@@ -399,14 +399,14 @@ describe DossierRebaseConcern do
 
       context 'and the cadastre are removed' do
         before do
-          dossier.project_champs_public.first.update(value: 'v1', geo_areas: [build(:geo_area, :cadastre)])
+          dossier.root_champs_public.first.update(value: 'v1', geo_areas: [build(:geo_area, :cadastre)])
 
           stable_id = procedure.draft_revision.types_de_champ.find { _1.libelle == 'l1' }
           tdc_to_update = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)
           tdc_to_update.update(cadastres: false)
         end
 
-        it { expect { subject }.to change { dossier.project_champs_public.first.cadastres.count }.from(1).to(0) }
+        it { expect { subject }.to change { dossier.root_champs_public.first.cadastres.count }.from(1).to(0) }
       end
     end
 
@@ -416,7 +416,7 @@ describe DossierRebaseConcern do
       end
       let!(:dossier) { create(:dossier, procedure: procedure) }
 
-      def champ_libelles = dossier.revision.types_de_champ_public.map(&:libelle)
+      def champ_libelles = dossier.revision.root_types_de_champ_public.map(&:libelle)
 
       context 'when a tdc is added in the middle' do
         before do
@@ -457,7 +457,7 @@ describe DossierRebaseConcern do
       end
 
       context 'when the first tdc type is updated' do
-        def first_champ = dossier.project_champs_public.first
+        def first_champ = dossier.root_champs_public.first
 
         before do
           first_champ.update(value: 'v1', external_id: '123', geo_areas: [build(:geo_area)])
@@ -478,7 +478,7 @@ describe DossierRebaseConcern do
           tdc_to_update.update(type_champ: :integer_number)
         end
 
-        it { expect { subject }.to change { dossier.revision.types_de_champ_public.map(&:type_champ) }.from(['text', 'text']).to(['integer_number', 'text']) }
+        it { expect { subject }.to change { dossier.revision.root_types_de_champ_public.map(&:type_champ) }.from(['text', 'text']).to(['integer_number', 'text']) }
         it { expect { subject }.to change { first_champ.class }.from(Champs::TextChamp).to(Champs::IntegerNumberChamp) }
         it { expect { subject }.not_to change { first_champ.to_s } }
         it { expect { subject }.to change { first_champ.external_id }.from('123').to(nil) }
@@ -558,7 +558,7 @@ describe DossierRebaseConcern do
           parent.update(type_champ: :integer_number)
         end
 
-        it { expect { subject }.to change { dossier.project_champs_public.find(&:repetition?)&.libelle }.from('p1').to(nil) }
+        it { expect { subject }.to change { dossier.root_champs_public.find(&:repetition?)&.libelle }.from('p1').to(nil) }
         it { expect { subject }.not_to change { Champ.count } }
       end
     end

--- a/spec/models/concerns/dossier_searchable_concern_spec.rb
+++ b/spec/models/concerns/dossier_searchable_concern_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 describe DossierSearchableConcern do
-  let(:champ_public) { dossier.project_champs_public.first }
-  let(:champ_private) { dossier.project_champs_private.first }
+  let(:champ_public) { dossier.root_champs_public.first }
+  let(:champ_private) { dossier.root_champs_private.first }
 
   describe '#index_search_terms' do
     let(:etablissement) { dossier.etablissement }

--- a/spec/models/concerns/dossier_sections_concern_spec.rb
+++ b/spec/models/concerns/dossier_sections_concern_spec.rb
@@ -10,8 +10,8 @@ describe DossierSectionsConcern do
     let(:procedure) { create(:procedure, :for_individual, types_de_champ_public:, types_de_champ_private:) }
     let(:dossier) { create(:dossier, procedure: procedure) }
 
-    let(:public_type_de_champ) { dossier.types_de_champ_public[1] }
-    let(:private_type_de_champ) { dossier.types_de_champ_private[1] }
+    let(:public_type_de_champ) { dossier.root_types_de_champ_public[1] }
+    let(:private_type_de_champ) { dossier.root_types_de_champ_private[1] }
 
     context "with no section having number" do
       it do
@@ -39,7 +39,7 @@ describe DossierSectionsConcern do
     context "header_section in a repetition are not auto-numbered" do
       let(:types_de_champ_public) { [{ type: :header_section, libelle: public_libelle }, { type: :repetition, mandatory: true, children: [{ type: :header_section, libelle: "Enfant" }, { type: :text }] }] }
 
-      let(:public_type_de_champ) { dossier.revision.children_of(dossier.types_de_champ_public[1]).first }
+      let(:public_type_de_champ) { dossier.revision.children_of(dossier.root_types_de_champ_public[1]).first }
 
       context "with parent section having headers with number" do
         let(:public_libelle) { "1. Infos" }
@@ -68,7 +68,7 @@ describe DossierSectionsConcern do
     let(:procedure) { create(:procedure, :for_individual, types_de_champ_public: types_de_champ) }
     let(:dossier) { create(:dossier, procedure: procedure) }
 
-    let(:headers) { dossier.revision.types_de_champ_public.filter(&:header_section?) }
+    let(:headers) { dossier.revision.root_types_de_champ_public.filter(&:header_section?) }
 
     let(:number_value) { nil }
 

--- a/spec/models/concerns/dossier_state_concern_spec.rb
+++ b/spec/models/concerns/dossier_state_concern_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe DossierStateConcern do
       procedure.publish_revision!(procedure.administrateurs.first)
       perform_enqueued_jobs
       dossier.reload
-      champ_repetition = dossier.project_champs_public.find { _1.stable_id == 94 }
+      champ_repetition = dossier.root_champs_public.find { _1.stable_id == 94 }
       row_id = champ_repetition.row_ids.first
       dossier.champ_data.filter(&:row?).find { _1.row_id == row_id }.touch(:discarded_at)
     end
@@ -42,7 +42,7 @@ RSpec.describe DossierStateConcern do
       expect(dossier.champ_data.filter { _1.row? && _1.stable_id.in?([95, 96]) }.size).to eq(4)
       expect(dossier.champ_data.filter { _1.stable_id.in?([90, 92, 93, 97, 961, 951]) }.size).to eq(8)
 
-      champ_text = dossier.project_champs_public.find { _1.stable_id == 90 }
+      champ_text = dossier.root_champs_public.find { _1.stable_id == 90 }
       champ_text.update(value: '')
 
       dossier.passer_en_construction!
@@ -374,7 +374,7 @@ RSpec.describe DossierStateConcern do
       let(:dossier) { create(:dossier, :brouillon, :with_individual, procedure:) }
 
       before do
-        champ = dossier.project_champs_public.find { _1.stable_id == 100 }
+        champ = dossier.root_champs_public.find { _1.stable_id == 100 }
         champ.update(value: "valeur cachée")
       end
 
@@ -382,7 +382,7 @@ RSpec.describe DossierStateConcern do
         dossier.passer_en_construction!
         dossier.reload
 
-        champ = dossier.project_champs_public.find { _1.stable_id == 100 }
+        champ = dossier.root_champs_public.find { _1.stable_id == 100 }
         expect(champ.value).to eq("valeur cachée")
       end
     end
@@ -392,7 +392,7 @@ RSpec.describe DossierStateConcern do
       let(:dossier) { create(:dossier, :brouillon, :with_individual, procedure:) }
 
       before do
-        champ = dossier.project_champs_public.find { _1.stable_id == 101 }
+        champ = dossier.root_champs_public.find { _1.stable_id == 101 }
         champ.update(value: "valeur conditionnelle")
       end
 
@@ -400,7 +400,7 @@ RSpec.describe DossierStateConcern do
         dossier.passer_en_construction!
         dossier.reload
 
-        champ = dossier.project_champs_public.find { _1.stable_id == 101 }
+        champ = dossier.root_champs_public.find { _1.stable_id == 101 }
         expect(champ.value).to be_nil
       end
     end

--- a/spec/models/concerns/initiation_procedure_concern_spec.rb
+++ b/spec/models/concerns/initiation_procedure_concern_spec.rb
@@ -10,7 +10,7 @@ describe InitiationProcedureConcern do
       subject.reload
       expect(subject).to be_valid
       expect(subject.defaut_groupe_instructeur.instructeurs.count).to eq(1)
-      expect(subject.draft_revision.types_de_champ_public).not_to be_empty
+      expect(subject.draft_revision.root_types_de_champ_public).not_to be_empty
       expect(subject.service).not_to be_nil
     end
   end

--- a/spec/models/concerns/procedure_clone_concern_spec.rb
+++ b/spec/models/concerns/procedure_clone_concern_spec.rb
@@ -21,8 +21,8 @@ describe ProcedureCloneConcern, type: :model do
     end
     let(:types_de_champ_public) { [{}, {}, { type: :drop_down_list }, { type: :piece_justificative }, { type: :repetition, children: [{}] }] }
     let(:types_de_champ_private) { [{}, {}, { type: :drop_down_list }, { type: :repetition, children: [{}] }] }
-    let(:type_de_champ_repetition) { procedure.draft_revision.types_de_champ_public.last }
-    let(:type_de_champ_private_repetition) { procedure.draft_revision.types_de_champ_private.last }
+    let(:type_de_champ_repetition) { procedure.draft_revision.root_types_de_champ_public.last }
+    let(:type_de_champ_private_repetition) { procedure.draft_revision.root_types_de_champ_private.last }
     let(:received_mail) { build(:received_mail) }
     let(:from_library) { false }
     let(:opendata) { true }
@@ -93,28 +93,28 @@ describe ProcedureCloneConcern, type: :model do
     it 'should duplicate specific objects with different id' do
       expect(subject.id).not_to eq(procedure.id)
 
-      expect(subject.draft_revision.types_de_champ_public.size).to eq(procedure.draft_revision.types_de_champ_public.size)
-      expect(subject.draft_revision.types_de_champ_private.size).to eq(procedure.draft_revision.types_de_champ_private.size)
+      expect(subject.draft_revision.root_types_de_champ_public.size).to eq(procedure.draft_revision.root_types_de_champ_public.size)
+      expect(subject.draft_revision.root_types_de_champ_private.size).to eq(procedure.draft_revision.root_types_de_champ_private.size)
 
-      procedure.draft_revision.types_de_champ_public.zip(subject.draft_revision.types_de_champ_public).each do |ptc, stc|
+      procedure.draft_revision.root_types_de_champ_public.zip(subject.draft_revision.root_types_de_champ_public).each do |ptc, stc|
         expect(stc).to have_same_attributes_as(ptc)
         expect(stc.revisions).to include(subject.draft_revision)
       end
 
       public_repetition = type_de_champ_repetition
-      cloned_public_repetition = subject.draft_revision.types_de_champ_public.find(&:repetition?)
+      cloned_public_repetition = subject.draft_revision.root_types_de_champ_public.find(&:repetition?)
       procedure.draft_revision.children_of(public_repetition).zip(subject.draft_revision.children_of(cloned_public_repetition)).each do |ptc, stc|
         expect(stc).to have_same_attributes_as(ptc)
         expect(stc.revisions).to include(subject.draft_revision)
       end
 
-      procedure.draft_revision.types_de_champ_private.zip(subject.draft_revision.types_de_champ_private).each do |ptc, stc|
+      procedure.draft_revision.root_types_de_champ_private.zip(subject.draft_revision.root_types_de_champ_private).each do |ptc, stc|
         expect(stc).to have_same_attributes_as(ptc)
         expect(stc.revisions).to include(subject.draft_revision)
       end
 
       private_repetition = type_de_champ_private_repetition
-      cloned_private_repetition = subject.draft_revision.types_de_champ_private.find(&:repetition?)
+      cloned_private_repetition = subject.draft_revision.root_types_de_champ_private.find(&:repetition?)
       procedure.draft_revision.children_of(private_repetition).zip(subject.draft_revision.children_of(cloned_private_repetition)).each do |ptc, stc|
         expect(stc).to have_same_attributes_as(ptc)
         expect(stc.revisions).to include(subject.draft_revision)
@@ -147,8 +147,8 @@ describe ProcedureCloneConcern, type: :model do
         end
 
         it 'keeps API keys' do
-          expect(subject.draft_revision.types_de_champ_public.first.referentiel.authentication_method).to eq(referentiel.authentication_method)
-          expect(subject.draft_revision.types_de_champ_public.first.referentiel.authentication_data).to eq(referentiel.authentication_data)
+          expect(subject.draft_revision.root_types_de_champ_public.first.referentiel.authentication_method).to eq(referentiel.authentication_method)
+          expect(subject.draft_revision.root_types_de_champ_public.first.referentiel.authentication_data).to eq(referentiel.authentication_data)
         end
       end
 
@@ -160,7 +160,7 @@ describe ProcedureCloneConcern, type: :model do
         end
 
         it 'discards API keys' do
-          expect(subject.draft_revision.types_de_champ_public.first.referentiel.authentication_data).to eq(nil)
+          expect(subject.draft_revision.root_types_de_champ_public.first.referentiel.authentication_data).to eq(nil)
         end
       end
     end
@@ -184,7 +184,7 @@ describe ProcedureCloneConcern, type: :model do
       end
 
       it 'should discard old pj information' do
-        subject.draft_revision.types_de_champ_public.each do |stc|
+        subject.draft_revision.root_types_de_champ_public.each do |stc|
           expect(stc.old_pj).to be_nil
         end
       end
@@ -236,7 +236,7 @@ describe ProcedureCloneConcern, type: :model do
       end
 
       it 'should discard old pj information' do
-        subject.draft_revision.types_de_champ_public.each do |stc|
+        subject.draft_revision.root_types_de_champ_public.each do |stc|
           expect(stc.old_pj).to be_nil
         end
       end
@@ -327,12 +327,12 @@ describe ProcedureCloneConcern, type: :model do
     end
 
     it 'should keep types_de_champ ids stable' do
-      expect(subject.draft_revision.types_de_champ_public.first.id).not_to eq(procedure.draft_revision.types_de_champ_public.first.id)
-      expect(subject.draft_revision.types_de_champ_public.first.stable_id).to eq(procedure.draft_revision.types_de_champ_public.first.id)
+      expect(subject.draft_revision.root_types_de_champ_public.first.id).not_to eq(procedure.draft_revision.root_types_de_champ_public.first.id)
+      expect(subject.draft_revision.root_types_de_champ_public.first.stable_id).to eq(procedure.draft_revision.root_types_de_champ_public.first.id)
     end
 
     it 'should duplicate piece_justificative_template on a type_de_champ' do
-      expect(subject.draft_revision.types_de_champ_public.find(&:piece_justificative?).piece_justificative_template.attached?).to be_truthy
+      expect(subject.draft_revision.root_types_de_champ_public.find(&:piece_justificative?).piece_justificative_template.attached?).to be_truthy
     end
 
     context 'with a notice attached' do
@@ -398,8 +398,8 @@ describe ProcedureCloneConcern, type: :model do
       let(:procedure) { create(:procedure, types_de_champ_public:, service:) }
       let(:types_de_champ_public) { [{ type: :drop_down_list, referentiel:, drop_down_mode: 'advanced' }] }
       let(:referentiel) { create(:csv_referentiel, :with_items) }
-      let(:drop_down_list) { procedure.draft_revision.types_de_champ_public.first }
-      let(:cloned_drop_down_list) { subject.draft_revision.types_de_champ_public.first }
+      let(:drop_down_list) { procedure.draft_revision.root_types_de_champ_public.first }
+      let(:cloned_drop_down_list) { subject.draft_revision.root_types_de_champ_public.first }
 
       it {
         expect(cloned_drop_down_list.drop_down_mode).to eq('advanced')

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -168,11 +168,11 @@ describe TagsSubstitutionConcern, type: :model do
 
         context 'and their value in the dossier are not nil' do
           before do
-            dossier.project_champs_public
+            dossier.root_champs_public
               .find { |champ| champ.libelle == 'libelleA' }
               .update(value: 'libelle1')
 
-            dossier.project_champs_public
+            dossier.root_champs_public
               .find { |champ| champ.libelle == "libelle\xc2\xA0B".encode('utf-8') }
               .update(value: 'libelle2')
           end
@@ -194,7 +194,7 @@ describe TagsSubstitutionConcern, type: :model do
 
         context 'and their value in the dossier are not nil' do
           before do
-            dossier.project_champs_public
+            dossier.root_champs_public
               .find { |champ| champ.libelle == "Intitulé de l'’«\"évènement\"»’" }
               .update(value: 'ceci est mon évènement')
           end
@@ -216,7 +216,7 @@ describe TagsSubstitutionConcern, type: :model do
 
         context 'and their value in the dossier are not nil' do
           before do
-            dossier.project_champs_public
+            dossier.root_champs_public
               .find { |champ| champ.libelle == "bon pote -- c’est top" }
               .update(value: 'ceci est mon évènement')
           end
@@ -232,7 +232,7 @@ describe TagsSubstitutionConcern, type: :model do
       let(:dossier) { create(:dossier, procedure:) }
 
       before do
-        repetition = dossier.project_champs_public.find(&:repetition?)
+        repetition = dossier.root_champs_public.find(&:repetition?)
         repetition.add_row(updated_by: 'test')
         paul_champs, pierre_champs = repetition.rows
 
@@ -250,7 +250,7 @@ describe TagsSubstitutionConcern, type: :model do
       let(:template) { '--Carte--' }
       let(:types_de_champ_public) { [{ type: :carte, libelle: 'Carte' }] }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ) { dossier.project_champs_public.find { _1.type_de_champ.type_champ == 'carte' } }
+      let(:champ) { dossier.root_champs_public.find { _1.type_de_champ.type_champ == 'carte' } }
 
       before { dossier.reload }
 
@@ -352,7 +352,7 @@ describe TagsSubstitutionConcern, type: :model do
 
       before do
         dropdown_list_tdc.update(referentiel:, drop_down_mode: 'advanced')
-        champ = dossier.project_champs_public.first
+        champ = dossier.root_champs_public.first
         item = referentiel.items.first
         champ.update(value: item.id)
       end
@@ -390,7 +390,7 @@ describe TagsSubstitutionConcern, type: :model do
         let(:template) { '--libelleA--' }
 
         context 'and its value in the dossier is not nil' do
-          before { dossier.project_champs_private.first.update(value: 'libelle1') }
+          before { dossier.root_champs_private.first.update(value: 'libelle1') }
 
           it { is_expected.to eq('libelle1') }
         end
@@ -413,7 +413,7 @@ describe TagsSubstitutionConcern, type: :model do
       context 'champs publics are valid tags' do
         let(:types_de_champ_public) { [{ libelle: 'libelleA' }] }
 
-        before { dossier.project_champs_public.first.update(value: 'libelle1') }
+        before { dossier.root_champs_public.first.update(value: 'libelle1') }
 
         it { is_expected.to eq('libelle1') }
       end
@@ -432,11 +432,11 @@ describe TagsSubstitutionConcern, type: :model do
 
         context 'and its value in the dossier are not nil' do
           before do
-            dossier.project_champs_public
+            dossier.root_champs_public
               .find { |champ| champ.type_champ == TypeDeChamp.type_champs.fetch(:date) }
               .update(value: '2017-04-15')
 
-            dossier.project_champs_public
+            dossier.root_champs_public
               .find { |champ| champ.type_champ == TypeDeChamp.type_champs.fetch(:datetime) }
               .update(value: '2017-09-13 09:00')
           end
@@ -509,7 +509,7 @@ describe TagsSubstitutionConcern, type: :model do
       let(:template) { '--mon tag--' }
       let(:types_de_champ_public) { [{ libelle: "mon\u00A0tag" }] }
 
-      before { dossier.project_champs_public.first.update(value: 'valeur') }
+      before { dossier.root_champs_public.first.update(value: 'valeur') }
 
       it 'treats all kinds of space as equivalent', :aggregate_failures do
         # tag with NBSP in template, champ with NBSP in libelle
@@ -537,7 +537,7 @@ describe TagsSubstitutionConcern, type: :model do
 
       before do
         draft_type_de_champ.update(libelle: 'mon nouveau libellé')
-        dossier.project_champs_public.first.update(value: 'valeur')
+        dossier.root_champs_public.first.update(value: 'valeur')
         procedure.publish_revision!(procedure.administrateurs.first)
       end
 
@@ -559,7 +559,7 @@ describe TagsSubstitutionConcern, type: :model do
       context 'in a champ' do
         let(:types_de_champ_public) { [{ libelle: 'libelleA' }] }
 
-        before { dossier.project_champs_public.first.update(value: 'hey <a href="https://oops.com">anchor</a>') }
+        before { dossier.root_champs_public.first.update(value: 'hey <a href="https://oops.com">anchor</a>') }
 
         it { is_expected.to eq('hey &lt;a href=&quot;https://oops.com&quot;&gt;anchor&lt;/a&gt; --nom--') }
       end

--- a/spec/models/concerns/treeable_concern_spec.rb
+++ b/spec/models/concerns/treeable_concern_spec.rb
@@ -14,7 +14,7 @@ describe TreeableConcern do
   describe "to_tree" do
     let(:procedure) { create(:procedure, types_de_champ_public:) }
     let(:types_de_champ_public) { [] }
-    let(:types_de_champ) { procedure.active_revision.types_de_champ_public }
+    let(:types_de_champ) { procedure.active_revision.root_types_de_champ_public }
 
     let(:header_1) { { type: :header_section, level: 1, stable_id: 99 } }
     let(:header_1_2) { { type: :header_section, level: 2, stable_id: 199 } }
@@ -24,13 +24,13 @@ describe TreeableConcern do
     let(:champ_explication) { { type: :explication, stable_id: 599 } }
     let(:champ_communes) { { type: :communes, stable_id: 699 } }
 
-    let(:header_1_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 99 } }
-    let(:header_1_2_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 199 } }
-    let(:header_2_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 299 } }
-    let(:champ_text_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 399 } }
-    let(:champ_textarea_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 499 } }
-    let(:champ_explication_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 599 } }
-    let(:champ_communes_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 699 } }
+    let(:header_1_tdc) { procedure.active_revision.root_types_de_champ_public.find { _1.stable_id == 99 } }
+    let(:header_1_2_tdc) { procedure.active_revision.root_types_de_champ_public.find { _1.stable_id == 199 } }
+    let(:header_2_tdc) { procedure.active_revision.root_types_de_champ_public.find { _1.stable_id == 299 } }
+    let(:champ_text_tdc) { procedure.active_revision.root_types_de_champ_public.find { _1.stable_id == 399 } }
+    let(:champ_textarea_tdc) { procedure.active_revision.root_types_de_champ_public.find { _1.stable_id == 499 } }
+    let(:champ_explication_tdc) { procedure.active_revision.root_types_de_champ_public.find { _1.stable_id == 599 } }
+    let(:champ_communes_tdc) { procedure.active_revision.root_types_de_champ_public.find { _1.stable_id == 699 } }
 
     context 'without section' do
       let(:types_de_champ_public) do
@@ -66,7 +66,7 @@ describe TreeableConcern do
 
     context 'leading champs, and in between sections only' do
       let(:champ_textarea_bis) { { type: :textarea, stable_id: 799 } }
-      let(:champ_textarea_bis_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 799 } }
+      let(:champ_textarea_bis_tdc) { procedure.active_revision.root_types_de_champ_public.find { _1.stable_id == 799 } }
       let(:types_de_champ_public) do
         [
           champ_text,
@@ -114,9 +114,9 @@ describe TreeableConcern do
       let(:header_1_2_2) { { type: :header_section, level: 2, stable_id: 899 } }
       let(:header_1_2_3) { { type: :header_section, level: 2, stable_id: 999 } }
 
-      let(:header_1_2_1_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 799 } }
-      let(:header_1_2_2_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 899 } }
-      let(:header_1_2_3_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 999 } }
+      let(:header_1_2_1_tdc) { procedure.active_revision.root_types_de_champ_public.find { _1.stable_id == 799 } }
+      let(:header_1_2_2_tdc) { procedure.active_revision.root_types_de_champ_public.find { _1.stable_id == 899 } }
+      let(:header_1_2_3_tdc) { procedure.active_revision.root_types_de_champ_public.find { _1.stable_id == 999 } }
 
       let(:types_de_champ_public) do
        [
@@ -144,7 +144,7 @@ describe TreeableConcern do
 
     context 'with skipped header level (h1 then h3, no h2)' do
       let(:header_1_3) { { type: :header_section, level: 3, stable_id: 799 } }
-      let(:header_1_3_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 799 } }
+      let(:header_1_3_tdc) { procedure.active_revision.root_types_de_champ_public.find { _1.stable_id == 799 } }
 
       let(:types_de_champ_public) do
         [
@@ -165,7 +165,7 @@ describe TreeableConcern do
 
     context 'with one sub sections and one subsub section' do
       let(:header_1_2_3) { { type: :header_section, level: 3, stable_id: 799 } }
-      let(:header_1_2_3_tdc) { procedure.active_revision.types_de_champ_public.find { _1.stable_id == 799 } }
+      let(:header_1_2_3_tdc) { procedure.active_revision.root_types_de_champ_public.find { _1.stable_id == 799 } }
 
       let(:types_de_champ_public) do
         [

--- a/spec/models/dossier_preloader_spec.rb
+++ b/spec/models/dossier_preloader_spec.rb
@@ -10,8 +10,8 @@ describe DossierPreloader do
   end
   let(:procedure) { create(:procedure, types_de_champ_public: types_de_champ) }
   let(:dossier) { create(:dossier, procedure: procedure) }
-  let(:repetition) { subject.project_champs_public.second }
-  let(:repetition_optional) { subject.project_champs_public.third }
+  let(:repetition) { subject.root_champs_public.second }
+  let(:repetition_optional) { subject.root_champs_public.third }
   let(:first_child) { repetition.rows.first.first }
 
   describe 'all' do
@@ -25,20 +25,20 @@ describe DossierPreloader do
       callback = lambda { |*_args| count += 1 }
       ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
         expect(subject.id).to eq(dossier.id)
-        expect(subject.project_champs_public.size).to eq(types_de_champ.size)
+        expect(subject.root_champs_public.size).to eq(types_de_champ.size)
         expect(subject.changed?).to be false
 
         expect(first_child.type).to eq('Champs::TextChamp')
         expect(repetition).not_to eq(first_child)
         expect(subject.champ_data.first.dossier).to eq(subject)
         expect(subject.champ_data.find(&:public?).dossier).to eq(subject)
-        expect(subject.project_champs_public.first.dossier).to eq(subject)
+        expect(subject.root_champs_public.first.dossier).to eq(subject)
 
-        expect(subject.project_champs_public.first.type_de_champ.piece_justificative_template.attached?).to eq(false)
+        expect(subject.root_champs_public.first.type_de_champ.piece_justificative_template.attached?).to eq(false)
 
         expect(subject.champ_data.first.conditional?).to eq(false)
         expect(subject.champ_data.find(&:public?).conditional?).to eq(false)
-        expect(subject.project_champs_public.first.conditional?).to eq(false)
+        expect(subject.root_champs_public.first.conditional?).to eq(false)
 
         expect(repetition.rows.first.first.public_id).to eq(first_child.public_id)
         expect(repetition_optional.row_ids).to be_empty

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -429,7 +429,7 @@ describe Dossier, type: :model do
       let(:procedure) { create(:procedure, :for_individual, types_de_champ_public: [{ type: :date }]) }
       let(:user) { create(:user, france_connect_informations: [build(:france_connect_information)]) }
       let(:dossier) { create(:dossier, procedure:, user:) }
-      let(:tdc) { procedure.active_revision.types_de_champ_public.first }
+      let(:tdc) { procedure.active_revision.root_types_de_champ_public.first }
 
       before do
         tdc.update!(options: { 'birthdate' => '1', 'prefill_with_france_connect_information' => '1' })
@@ -1110,7 +1110,7 @@ describe Dossier, type: :model do
     let(:tdc_8) { { libelle: "unspecified annotation privée-in-body" } }
 
     before do
-      (dossier.project_champs_public + dossier.project_champs_private)
+      (dossier.root_champs_public + dossier.root_champs_private)
         .filter { |c| c.libelle.match?(/^specified/) }
         .each { |c| c.update_attribute(:value, "specified") }
     end
@@ -1204,7 +1204,7 @@ describe Dossier, type: :model do
     it { is_expected.not_to eq(modif_date) }
 
     context 'when a champ is modified' do
-      before { dossier.project_champs_public.first.update_attribute('value', 'yop') }
+      before { dossier.root_champs_public.first.update_attribute('value', 'yop') }
 
       it { is_expected.to eq(modif_date) }
     end
@@ -2160,7 +2160,7 @@ describe Dossier, type: :model do
     let(:max_character_length) { "" }
 
     before do
-      champ = dossier.project_champs_public.first
+      champ = dossier.root_champs_public.first
       champ.value = value
       dossier.save(context: :champs_public_value)
     end
@@ -2288,14 +2288,14 @@ describe Dossier, type: :model do
       let(:expression_reguliere_error_message) { "Le champ doit être composé de lettres majuscules" }
 
       before do
-        champ = dossier.project_champs_public.first
+        champ = dossier.root_champs_public.first
         champ.value = expression_reguliere_exemple_text
         dossier.save(context: :champs_public_value)
       end
 
       it 'should have errors' do
         expect(dossier.errors).not_to be_empty
-        expect(dossier.errors.full_messages.join(',')).to include(dossier.project_champs_public.first.expression_reguliere_error_message)
+        expect(dossier.errors.full_messages.join(',')).to include(dossier.root_champs_public.first.expression_reguliere_error_message)
       end
     end
 
@@ -2305,7 +2305,7 @@ describe Dossier, type: :model do
       let(:expression_reguliere_error_message) { "Le champ doit être composé de lettres majuscules" }
 
       before do
-        champ = dossier.project_champs_public.first
+        champ = dossier.root_champs_public.first
         champ.value = expression_reguliere_exemple_text
         dossier.save
       end
@@ -2568,7 +2568,7 @@ describe Dossier, type: :model do
     context 'with integer_number' do
       let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :integer_number, libelle: 'c1' }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:integer_number_type_de_champ) { procedure.active_revision.types_de_champ_public.find(&:integer_number?) }
+      let(:integer_number_type_de_champ) { procedure.active_revision.root_types_de_champ_public.find(&:integer_number?) }
 
       it 'give me back my decimal number' do
         dossier
@@ -2591,14 +2591,14 @@ describe Dossier, type: :model do
         ]
       end
 
-      let(:text_type_de_champ) { procedure.active_revision.types_de_champ_public.find { |type_de_champ| type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:text) } }
-      let(:yes_no_type_de_champ) { procedure.active_revision.types_de_champ_public.find { |type_de_champ| type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:yes_no) } }
-      let(:datetime_type_de_champ) { procedure.active_revision.types_de_champ_public.find { |type_de_champ| type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:datetime) } }
-      let(:explication_type_de_champ) { procedure.active_revision.types_de_champ_public.find { |type_de_champ| type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:explication) } }
-      let(:commune_type_de_champ) { procedure.active_revision.types_de_champ_public.find { |type_de_champ| type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:communes) } }
-      let(:repetition_type_de_champ) { procedure.active_revision.types_de_champ_public.find { |type_de_champ| type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:repetition) } }
-      let(:repetition_champ) { dossier.project_champs_public.find(&:repetition?) }
-      let(:repetition_second_revision_champ) { dossier_second_revision.project_champs_public.find(&:repetition?) }
+      let(:text_type_de_champ) { procedure.active_revision.root_types_de_champ_public.find { |type_de_champ| type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:text) } }
+      let(:yes_no_type_de_champ) { procedure.active_revision.root_types_de_champ_public.find { |type_de_champ| type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:yes_no) } }
+      let(:datetime_type_de_champ) { procedure.active_revision.root_types_de_champ_public.find { |type_de_champ| type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:datetime) } }
+      let(:explication_type_de_champ) { procedure.active_revision.root_types_de_champ_public.find { |type_de_champ| type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:explication) } }
+      let(:commune_type_de_champ) { procedure.active_revision.root_types_de_champ_public.find { |type_de_champ| type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:communes) } }
+      let(:repetition_type_de_champ) { procedure.active_revision.root_types_de_champ_public.find { |type_de_champ| type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:repetition) } }
+      let(:repetition_champ) { dossier.root_champs_public.find(&:repetition?) }
+      let(:repetition_second_revision_champ) { dossier_second_revision.root_champs_public.find(&:repetition?) }
       let(:dossier) { create(:dossier, procedure: procedure) }
       let(:dossier_second_revision) { create(:dossier, procedure: procedure) }
       let(:dossier_champ_values_for_export) { dossier.champ_values_for_export(procedure.types_de_champ_for_procedure_export, format: :xlsx) }
@@ -2619,8 +2619,8 @@ describe Dossier, type: :model do
         end
 
         it "should have champs from all revisions" do
-          expect(dossier.types_de_champ_public.map(&:libelle)).to eq([text_type_de_champ.libelle, datetime_type_de_champ.libelle, "Yes/no", explication_type_de_champ.libelle, commune_type_de_champ.libelle, repetition_type_de_champ.libelle])
-          expect(dossier_second_revision.types_de_champ_public.map(&:libelle)).to eq([datetime_type_de_champ.libelle, "Updated yes/no", explication_type_de_champ.libelle, 'Commune de naissance', "Repetition", "New text field"])
+          expect(dossier.root_types_de_champ_public.map(&:libelle)).to eq([text_type_de_champ.libelle, datetime_type_de_champ.libelle, "Yes/no", explication_type_de_champ.libelle, commune_type_de_champ.libelle, repetition_type_de_champ.libelle])
+          expect(dossier_second_revision.root_types_de_champ_public.map(&:libelle)).to eq([datetime_type_de_champ.libelle, "Updated yes/no", explication_type_de_champ.libelle, 'Commune de naissance', "Repetition", "New text field"])
           expect(dossier_champ_values_for_export.map { |(libelle)| libelle }).to eq([datetime_type_de_champ.libelle, text_type_de_champ.libelle, "Updated yes/no", "Commune de naissance", "Commune de naissance (Code INSEE)", "Commune de naissance (Département)", "New text field"])
           expect(dossier_champ_values_for_export).to eq(dossier_second_revision_champ_values_for_export)
         end
@@ -2668,16 +2668,16 @@ describe Dossier, type: :model do
       let(:types_de_champ) { [{ type: :yes_no }, { type: :text }] }
       let(:procedure) { create(:procedure, types_de_champ_public: types_de_champ) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:yes_no_tdc) { procedure.active_revision.types_de_champ_public.first }
-      let(:text_tdc) { procedure.active_revision.types_de_champ_public.second }
-      let(:tdcs) { dossier.project_champs_public.map(&:type_de_champ) }
+      let(:yes_no_tdc) { procedure.active_revision.root_types_de_champ_public.first }
+      let(:text_tdc) { procedure.active_revision.root_types_de_champ_public.second }
+      let(:tdcs) { dossier.root_champs_public.map(&:type_de_champ) }
 
       subject { dossier.champ_values_for_export(tdcs, format: :xlsx) }
 
       before do
         text_tdc.update(condition: ds_eq(champ_value(yes_no_tdc.stable_id), constant(true)))
 
-        yes_no, text = dossier.project_champs_public
+        yes_no, text = dossier.root_champs_public
         yes_no.update(value: yes_no_value)
         text.update(value: 'text')
       end
@@ -2696,7 +2696,7 @@ describe Dossier, type: :model do
 
       context 'with another revision' do
         let(:tdc_from_another_revision) { create(:type_de_champ_communes, libelle: 'commune', condition: ds_eq(constant(true), constant(true))) }
-        let(:tdcs) { dossier.project_champs_public.map(&:type_de_champ) << tdc_from_another_revision }
+        let(:tdcs) { dossier.root_champs_public.map(&:type_de_champ) << tdc_from_another_revision }
         let(:yes_no_value) { 'true' }
 
         let(:expected) do

--- a/spec/models/etablissement_spec.rb
+++ b/spec/models/etablissement_spec.rb
@@ -171,7 +171,7 @@ describe Etablissement do
     it "touches dossier updated_at when etablissement is linked via champ only" do
       procedure = create(:procedure, types_de_champ_public: [{ type: :siret }])
       dossier = create(:dossier, procedure:)
-      champ = dossier.project_champs_public.find { |c| c.is_a?(Champs::SiretChamp) }
+      champ = dossier.root_champs_public.find { |c| c.is_a?(Champs::SiretChamp) }
       etablissement = create(:etablissement, siret: "44011762001530")
       champ.update!(etablissement:)
       previous_updated_at = dossier.updated_at

--- a/spec/models/export_template_spec.rb
+++ b/spec/models/export_template_spec.rb
@@ -60,7 +60,7 @@ describe ExportTemplate do
     end
 
     context 'for pj' do
-      let(:champ_pj) { dossier.project_champs_public.first }
+      let(:champ_pj) { dossier.root_champs_public.first }
       let(:export_template) { create(:export_template, groupe_instructeur:, pjs: [ExportItem.default(stable_id: 3, prefix: "justif", enabled: true)]) }
 
       let(:attachment) { ActiveStorage::Attachment.new(name: 'pj', record: champ_pj, blob: ActiveStorage::Blob.new(filename: "superpj.png")) }

--- a/spec/models/export_template_tabular_spec.rb
+++ b/spec/models/export_template_tabular_spec.rb
@@ -35,7 +35,7 @@ describe ExportTemplate do
 
     context 'when there is a previous revision with a renamed tdc' do
       context 'with already column in export template' do
-        let(:previous_tdc) { procedure.published_revision.types_de_champ_public.find { _1.stable_id == 1 } }
+        let(:previous_tdc) { procedure.published_revision.root_types_de_champ_public.find { _1.stable_id == 1 } }
         let(:changed_tdc) { { libelle: "Ca roule ?" } }
 
         context 'with already column in export template' do
@@ -59,7 +59,7 @@ describe ExportTemplate do
         end
       end
       context 'without columns in export template' do
-        let(:previous_tdc) { procedure.published_revision.types_de_champ_public.find { _1.stable_id == 1 } }
+        let(:previous_tdc) { procedure.published_revision.root_types_de_champ_public.find { _1.stable_id == 1 } }
         let(:changed_tdc) { { libelle: "Ca roule ?" } }
 
         before do

--- a/spec/models/groupe_instructeur_spec.rb
+++ b/spec/models/groupe_instructeur_spec.rb
@@ -238,7 +238,7 @@ describe GroupeInstructeur, type: :model do
     include Logic
 
     let(:routed_procedure) { create(:procedure, :published, routing_enabled: true, administrateur: admin) }
-    let(:stable_id) { routed_procedure.published_revision.types_de_champ_public.last.stable_id }
+    let(:stable_id) { routed_procedure.published_revision.root_types_de_champ_public.last.stable_id }
 
     before do
       routed_procedure.draft_revision.add_type_de_champ(

--- a/spec/models/logic/champ_value_spec.rb
+++ b/spec/models/logic/champ_value_spec.rb
@@ -203,13 +203,13 @@ describe Logic::ChampValue do
       let(:procedure) do
         create(:procedure, :published, :for_individual, types_de_champ_public: [{ type: :drop_down_list, libelle: 'dropdown', options: options }])
       end
-      let(:drop_down_r1) { procedure.published_revision.types_de_champ_public.first }
+      let(:drop_down_r1) { procedure.published_revision.root_types_de_champ_public.first }
       let(:stable_id) { drop_down_r1.stable_id }
 
       it { expect(champ_value(stable_id).options([drop_down_r1])).to match_array([["revision_1", "revision_1"]]) }
 
       context 'with a new revision' do
-        let(:drop_down_r2) { procedure.draft_revision.types_de_champ_public.first }
+        let(:drop_down_r2) { procedure.draft_revision.root_types_de_champ_public.first }
 
         before do
           tdc = procedure.draft_revision.find_and_ensure_exclusive_use(stable_id)

--- a/spec/models/mail_template_spec.rb
+++ b/spec/models/mail_template_spec.rb
@@ -2,7 +2,7 @@
 
 describe Mails::InitiatedMail, type: :model do
   let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :text, libelle: 'nom' }]) }
-  let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+  let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public.first }
   let(:mail) { described_class.default_for_procedure(procedure) }
 
   let(:email_subject) { '' }

--- a/spec/models/prefill_champs_spec.rb
+++ b/spec/models/prefill_champs_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe PrefillChamps do
 
     context "when the stable ids match the TypeDeChamp of the corresponding procedure" do
       let(:types_de_champ_public) { [{ type: :text }, { type: :textarea }] }
-      let(:type_de_champ_1) { procedure.published_revision.types_de_champ_public.first }
+      let(:type_de_champ_1) { procedure.published_revision.root_types_de_champ_public.first }
       let(:value_1) { "any value" }
       let(:champ_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id) }
 
-      let(:type_de_champ_2) { procedure.published_revision.types_de_champ_public.second }
+      let(:type_de_champ_2) { procedure.published_revision.root_types_de_champ_public.second }
       let(:value_2) { "another value" }
       let(:champ_2) { find_champ_by_stable_id(dossier, type_de_champ_2.stable_id) }
 
@@ -36,7 +36,7 @@ RSpec.describe PrefillChamps do
     end
 
     context "when the typed id is not prefixed by 'champ_'" do
-      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+      let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
       let(:types_de_champ_public) { [{ type: :text }] }
 
       let(:params) { { type_de_champ.to_typed_id_for_query => "value" } }
@@ -79,7 +79,7 @@ RSpec.describe PrefillChamps do
           end
         end
 
-        let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+        let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
         let(:champ) { find_champ_by_stable_id(dossier, type_de_champ.stable_id) }
         let(:champ_value) { value == 'linked_dossier_id' ? linked_dossier.id : value }
 
@@ -104,7 +104,7 @@ RSpec.describe PrefillChamps do
           end
         end
 
-        let(:type_de_champ) { procedure.published_revision.types_de_champ_private.first }
+        let(:type_de_champ) { procedure.published_revision.root_types_de_champ_private.first }
         let(:champ) { find_champ_by_stable_id(dossier, type_de_champ.stable_id) }
         let(:champ_value) { value == 'linked_dossier_id' ? linked_dossier.id : value }
 
@@ -118,7 +118,7 @@ RSpec.describe PrefillChamps do
 
     shared_examples "a champ public value that is unauthorized" do |type_de_champ_type, value|
       let(:types_de_champ_public) { [{ type: type_de_champ_type }] }
-      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+      let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => value } }
 
@@ -158,7 +158,7 @@ RSpec.describe PrefillChamps do
 
     context "when the public type de champ is authorized (repetition)" do
       let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :text }] }] }
-      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+      let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
       let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
       let(:type_de_champ_child_value) { "value" }
       let(:type_de_champ_child_value2) { "value2" }
@@ -200,7 +200,7 @@ RSpec.describe PrefillChamps do
 
     context "when the private type de champ is authorized (repetition)" do
       let(:types_de_champ_private) { [{ type: :repetition, children: [{ type: :text }] }] }
-      let(:type_de_champ) { procedure.published_revision.types_de_champ_private.first }
+      let(:type_de_champ) { procedure.published_revision.root_types_de_champ_private.first }
       let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
       let(:type_de_champ_child_value) { "value" }
       let(:type_de_champ_child_value2) { "value2" }
@@ -234,7 +234,7 @@ RSpec.describe PrefillChamps do
 
     context "when the public type de champ is unauthorized because of wrong value format (repetition)" do
       let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :text }] }] }
-      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+      let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
       let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => "value" } }
@@ -246,7 +246,7 @@ RSpec.describe PrefillChamps do
 
     context "when the public type de champ is unauthorized because of wrong value typed_id (repetition)" do
       let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :text }] }] }
-      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+      let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
       let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => ["{\"wrong\":\"value\"}", "{\"wrong\":\"value2\"}"] } }
@@ -258,7 +258,7 @@ RSpec.describe PrefillChamps do
 
     context "when the value is a Hash (malicious input)" do
       let(:types_de_champ_public) { [{ type: :text }] }
-      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+      let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => { "injected" => "x" } } }
 
@@ -269,7 +269,7 @@ RSpec.describe PrefillChamps do
 
     context "when the value is an Array containing a Hash on a simple type" do
       let(:types_de_champ_public) { [{ type: :text }] }
-      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+      let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => [{ "injected" => "x" }] } }
 
@@ -280,7 +280,7 @@ RSpec.describe PrefillChamps do
 
     context "when the address value is a Hash (malicious input)" do
       let(:types_de_champ_public) { [{ type: :address }] }
-      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+      let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => { "injected" => "x" } } }
 
@@ -291,7 +291,7 @@ RSpec.describe PrefillChamps do
 
     context "when the siret value is a Hash (malicious input)" do
       let(:types_de_champ_public) { [{ type: :siret }] }
-      let(:type_de_champ) { procedure.published_revision.types_de_champ_public.first }
+      let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => { "injected" => "x" } } }
 

--- a/spec/models/prefill_description_spec.rb
+++ b/spec/models/prefill_description_spec.rb
@@ -120,9 +120,9 @@ RSpec.describe PrefillDescription, type: :model do
         },
       ])
     end
-    let(:type_de_champ_text) { procedure.active_revision.types_de_champ_public.find(&:text?) }
-    let(:type_de_champ_epci) { procedure.active_revision.types_de_champ_public.find(&:epci?) }
-    let(:type_de_champ_repetition) { procedure.active_revision.types_de_champ_public.find(&:repetition?) }
+    let(:type_de_champ_text) { procedure.active_revision.root_types_de_champ_public.find(&:text?) }
+    let(:type_de_champ_epci) { procedure.active_revision.root_types_de_champ_public.find(&:epci?) }
+    let(:type_de_champ_repetition) { procedure.active_revision.root_types_de_champ_public.find(&:repetition?) }
 
     let(:prefillable_subchamps) { TypesDeChamp::PrefillRepetitionTypeDeChamp.new(type_de_champ_repetition, procedure.active_revision).send(:prefillable_subchamps) }
     let(:region_repetition) { prefillable_subchamps.third }
@@ -161,9 +161,9 @@ RSpec.describe PrefillDescription, type: :model do
         },
       ])
     end
-    let(:type_de_champ_text) { procedure.active_revision.types_de_champ_public.find(&:text?) }
-    let(:type_de_champ_epci) { procedure.active_revision.types_de_champ_public.find(&:epci?) }
-    let(:type_de_champ_repetition) { procedure.active_revision.types_de_champ_public.find(&:repetition?) }
+    let(:type_de_champ_text) { procedure.active_revision.root_types_de_champ_public.find(&:text?) }
+    let(:type_de_champ_epci) { procedure.active_revision.root_types_de_champ_public.find(&:epci?) }
+    let(:type_de_champ_repetition) { procedure.active_revision.root_types_de_champ_public.find(&:repetition?) }
 
     let(:prefill_type_de_champ_epci) { TypesDeChamp::PrefillTypeDeChamp.build(type_de_champ_epci, procedure.active_revision) }
     let(:prefillable_subchamps) { TypesDeChamp::PrefillRepetitionTypeDeChamp.new(type_de_champ_repetition, procedure.active_revision).send(:prefillable_subchamps) }

--- a/spec/models/procedure_presentation_and_revisions_spec.rb
+++ b/spec/models/procedure_presentation_and_revisions_spec.rb
@@ -45,7 +45,7 @@ describe ProcedurePresentation do
         it { is_expected.to match(['libelle 0', 'libelle 1']) }
 
         context 'and finally, when this tdc is removed' do
-          let!(:previous_tdc0) { procedure.published_revision.types_de_champ_public.find { _1.libelle == 'libelle 0' } }
+          let!(:previous_tdc0) { procedure.published_revision.root_types_de_champ_public.find { _1.libelle == 'libelle 0' } }
 
           before do
             procedure.draft_revision.remove_type_de_champ(previous_tdc0.stable_id)
@@ -58,7 +58,7 @@ describe ProcedurePresentation do
       end
 
       context 'when there is another published revision with a renamed tdc' do
-        let!(:previous_tdc) { procedure.published_revision.types_de_champ_public.first }
+        let!(:previous_tdc) { procedure.published_revision.root_types_de_champ_public.first }
         let!(:changed_tdc) { { type_champ: :number, libelle: 'changed libelle 1' } }
 
         before do

--- a/spec/models/procedure_revision_preloader_spec.rb
+++ b/spec/models/procedure_revision_preloader_spec.rb
@@ -42,8 +42,8 @@ describe ProcedureRevisionPreloader do
       expect_relation_is_preloaded_sorted(original, procedure, :revision_types_de_champ_public)
       expect_relation_is_preloaded_sorted(original, procedure, :revision_types_de_champ_private)
       expect_relation_is_preloaded_sorted(original, procedure, :types_de_champ)
-      expect_relation_is_preloaded_sorted(original, procedure, :types_de_champ_public)
-      expect_relation_is_preloaded_sorted(original, procedure, :types_de_champ_private)
+      expect_relation_is_preloaded_sorted(original, procedure, :root_types_de_champ_public)
+      expect_relation_is_preloaded_sorted(original, procedure, :root_types_de_champ_private)
     end
 
     def expect_relation_is_preloaded_sorted(original, preloaded, association)

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -2,10 +2,10 @@
 
 describe ProcedureRevision do
   let(:draft) { procedure.draft_revision }
-  let(:type_de_champ_public) { draft.types_de_champ_public.first }
-  let(:type_de_champ_private) { draft.types_de_champ_private.first }
+  let(:type_de_champ_public) { draft.root_types_de_champ_public.first }
+  let(:type_de_champ_private) { draft.root_types_de_champ_private.first }
   let(:type_de_champ_repetition) do
-    repetition = draft.types_de_champ_public.find(&:repetition?)
+    repetition = draft.root_types_de_champ_public.find(&:repetition?)
     repetition.update(stable_id: 3333)
     repetition
   end
@@ -32,11 +32,11 @@ describe ProcedureRevision do
     subject { draft.add_type_de_champ(tdc_params) }
 
     context 'with a text tdc' do
-      let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: procedure.draft_revision.types_de_champ_public.last.stable_id } }
+      let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: procedure.draft_revision.root_types_de_champ_public.last.stable_id } }
 
       it 'public' do
-        expect { subject }.to change { draft.types_de_champ_public.size }.from(2).to(3)
-        expect(draft.types_de_champ_public.last).to eq(subject)
+        expect { subject }.to change { draft.root_types_de_champ_public.size }.from(2).to(3)
+        expect(draft.root_types_de_champ_public.last).to eq(subject)
         expect(draft.revision_types_de_champ_public.map(&:position)).to eq([0, 1, 2])
 
         expect(last_coordinate.position).to eq(2)
@@ -45,15 +45,15 @@ describe ProcedureRevision do
     end
 
     context 'with a private tdc' do
-      let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: procedure.draft_revision.types_de_champ_private.last.id } }
+      let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: procedure.draft_revision.root_types_de_champ_private.last.id } }
       let(:tdc_params) { text_params.merge(private: true) }
 
       it 'private' do
-        expect { subject }.to change { draft.types_de_champ_private.count }.from(1).to(2)
-        expect(draft.types_de_champ_private.last).to eq(subject)
+        expect { subject }.to change { draft.root_types_de_champ_private.count }.from(1).to(2)
+        expect(draft.root_types_de_champ_private.last).to eq(subject)
         expect(draft.revision_types_de_champ_private.map(&:position)).to eq([0, 1])
         expect(last_coordinate.position).to eq(1)
-        expect(draft.types_de_champ_private.last.mandatory).to be_falsey
+        expect(draft.root_types_de_champ_private.last.mandatory).to be_falsey
       end
     end
 
@@ -74,7 +74,7 @@ describe ProcedureRevision do
     end
 
     context 'when a parent is incorrect' do
-      let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: procedure.draft_revision.types_de_champ_private.last.id } }
+      let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: procedure.draft_revision.root_types_de_champ_private.last.id } }
       let(:tdc_params) { text_params.merge(parent_id: 123456789) }
 
       it { expect(subject.errors.full_messages).not_to be_empty }
@@ -82,7 +82,7 @@ describe ProcedureRevision do
 
     context 'after_stable_id' do
       context 'with a valid after_stable_id' do
-        let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: procedure.draft_revision.types_de_champ_private.last.id } }
+        let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: procedure.draft_revision.root_types_de_champ_private.last.id } }
         let(:tdc_params) { text_params.merge(after_stable_id: draft.revision_types_de_champ_public.first.stable_id, libelle: 'in the middle') }
 
         it do
@@ -94,7 +94,7 @@ describe ProcedureRevision do
       end
 
       context 'with blank valid after_stable_id' do
-        let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: procedure.draft_revision.types_de_champ_private.last.id } }
+        let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: procedure.draft_revision.root_types_de_champ_private.last.id } }
         let(:tdc_params) { text_params.merge(after_stable_id: '', libelle: 'in the middle') }
 
         it do
@@ -107,25 +107,25 @@ describe ProcedureRevision do
 
   describe '#move_type_de_champ' do
     let(:procedure) { create(:procedure, types_de_champ_public: Array.new(4) { { type: :text } }) }
-    let(:last_type_de_champ) { draft.types_de_champ_public.last }
+    let(:last_type_de_champ) { draft.root_types_de_champ_public.last }
 
     context 'with 4 types de champ publiques' do
       it 'move down' do
-        expect(draft.types_de_champ_public.index(type_de_champ_public)).to eq(0)
+        expect(draft.root_types_de_champ_public.index(type_de_champ_public)).to eq(0)
         stable_id_before = draft.revision_types_de_champ_public.map(&:stable_id)
         draft.move_type_de_champ(type_de_champ_public.stable_id, 2)
         draft.reload
         expect(draft.revision_types_de_champ_public.map(&:position)).to eq([0, 1, 2, 3])
-        expect(draft.types_de_champ_public.index(type_de_champ_public)).to eq(2)
+        expect(draft.root_types_de_champ_public.index(type_de_champ_public)).to eq(2)
         expect(draft.procedure.types_de_champ_for_procedure_export.index(type_de_champ_public)).to eq(2)
       end
 
       it 'move up' do
-        expect(draft.types_de_champ_public.index(last_type_de_champ)).to eq(3)
+        expect(draft.root_types_de_champ_public.index(last_type_de_champ)).to eq(3)
         draft.move_type_de_champ(last_type_de_champ.stable_id, 0)
         draft.reload
         expect(draft.revision_types_de_champ_public.map(&:position)).to eq([0, 1, 2, 3])
-        expect(draft.types_de_champ_public.index(last_type_de_champ)).to eq(0)
+        expect(draft.root_types_de_champ_public.index(last_type_de_champ)).to eq(0)
         expect(draft.procedure.types_de_champ_for_procedure_export.index(last_type_de_champ)).to eq(0)
       end
     end
@@ -176,13 +176,13 @@ describe ProcedureRevision do
       it 'type_de_champ' do
         draft.remove_type_de_champ(type_de_champ_public.stable_id)
 
-        expect(draft.types_de_champ_public).to be_empty
+        expect(draft.root_types_de_champ_public).to be_empty
       end
 
       it 'type_de_champ_private' do
         draft.remove_type_de_champ(type_de_champ_private.stable_id)
 
-        expect(draft.types_de_champ_private).to be_empty
+        expect(draft.root_types_de_champ_private).to be_empty
       end
     end
 
@@ -193,7 +193,7 @@ describe ProcedureRevision do
         it 'reorders' do
           expect(draft.revision_types_de_champ_public.pluck(:position)).to eq([0, 1, 2])
 
-          first_stable_id = draft.types_de_champ_public[1].stable_id
+          first_stable_id = draft.root_types_de_champ_public[1].stable_id
 
           draft.remove_type_de_champ(first_stable_id)
 
@@ -241,7 +241,7 @@ describe ProcedureRevision do
         draft.remove_type_de_champ(child.stable_id)
 
         expect { child.reload }.to raise_error ActiveRecord::RecordNotFound
-        expect(draft.types_de_champ_public.size).to eq(1)
+        expect(draft.root_types_de_champ_public.size).to eq(1)
       end
 
       it 'can remove the parent' do
@@ -249,7 +249,7 @@ describe ProcedureRevision do
 
         expect { child.reload }.to raise_error ActiveRecord::RecordNotFound
         expect { type_de_champ_repetition.reload }.to raise_error ActiveRecord::RecordNotFound
-        expect(draft.types_de_champ_public).to be_empty
+        expect(draft.root_types_de_champ_public).to be_empty
       end
 
       context 'when there already is a revision with this child' do
@@ -268,8 +268,8 @@ describe ProcedureRevision do
 
           expect { child.reload }.not_to raise_error
           expect { type_de_champ_repetition.reload }.not_to raise_error
-          expect(draft.types_de_champ_public.size).to eq(1)
-          expect(new_draft.types_de_champ_public).to be_empty
+          expect(draft.root_types_de_champ_public.size).to eq(1)
+          expect(new_draft.root_types_de_champ_public).to be_empty
         end
       end
     end
@@ -292,10 +292,10 @@ describe ProcedureRevision do
       let(:procedure) { create(:procedure, :with_type_de_champ, :with_type_de_champ_private) }
 
       it 'should have the same tdcs with different links' do
-        expect(new_draft.types_de_champ_public.count).to eq(1)
-        expect(new_draft.types_de_champ_private.count).to eq(1)
-        expect(new_draft.types_de_champ_public).to eq(draft.types_de_champ_public)
-        expect(new_draft.types_de_champ_private).to eq(draft.types_de_champ_private)
+        expect(new_draft.root_types_de_champ_public.count).to eq(1)
+        expect(new_draft.root_types_de_champ_private.count).to eq(1)
+        expect(new_draft.root_types_de_champ_public).to eq(draft.root_types_de_champ_public)
+        expect(new_draft.root_types_de_champ_private).to eq(draft.root_types_de_champ_private)
 
         expect(new_draft.revision_types_de_champ_public.count).to eq(1)
         expect(new_draft.revision_types_de_champ_private.count).to eq(1)
@@ -348,8 +348,8 @@ describe ProcedureRevision do
     subject { procedure.active_revision.compare_types_de_champ(new_draft.reload).map(&:to_h) }
 
     describe 'when tdcs changes' do
-      let(:first_tdc) { draft.types_de_champ_public.first }
-      let(:second_tdc) { draft.types_de_champ_public.second }
+      let(:first_tdc) { draft.root_types_de_champ_public.first }
+      let(:second_tdc) { draft.root_types_de_champ_public.second }
 
       context 'with a procedure with 2 tdcs' do
         let(:procedure) do
@@ -555,8 +555,8 @@ describe ProcedureRevision do
 
       context 'when a type de champ is moved' do
         let(:procedure) { create(:procedure, types_de_champ_public: Array.new(3) { { type: :text } }) }
-        let(:new_draft_second_tdc) { new_draft.types_de_champ_public.second }
-        let(:new_draft_third_tdc) { new_draft.types_de_champ_public.third }
+        let(:new_draft_second_tdc) { new_draft.root_types_de_champ_public.second }
+        let(:new_draft_third_tdc) { new_draft.root_types_de_champ_public.third }
 
         before do
           new_draft_second_tdc
@@ -609,7 +609,7 @@ describe ProcedureRevision do
         let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{ type: :text, libelle: 'sub type de champ' }, { type: :integer_number }] }]) }
 
         before do
-          child = new_draft.children_of(new_draft.types_de_champ_public.last).first
+          child = new_draft.children_of(new_draft.root_types_de_champ_public.last).first
           new_draft.find_and_ensure_exclusive_use(child.stable_id).update(type_champ: :drop_down_list, drop_down_options: ['one', 'two'])
         end
 
@@ -622,7 +622,7 @@ describe ProcedureRevision do
               private: false,
               from: "text",
               to: "drop_down_list",
-              stable_id: new_draft.children_of(new_draft.types_de_champ_public.last).first.stable_id,
+              stable_id: new_draft.children_of(new_draft.root_types_de_champ_public.last).first.stable_id,
             },
             {
               op: :update,
@@ -631,7 +631,7 @@ describe ProcedureRevision do
               private: false,
               from: [],
               to: ["one", "two"],
-              stable_id: new_draft.children_of(new_draft.types_de_champ_public.last).first.stable_id,
+              stable_id: new_draft.children_of(new_draft.root_types_de_champ_public.last).first.stable_id,
             },
           ])
         end
@@ -641,7 +641,7 @@ describe ProcedureRevision do
         let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{ type: :text, libelle: 'sub type de champ' }, { type: :integer_number }] }]) }
 
         before do
-          child = new_draft.children_of(new_draft.types_de_champ_public.last).first
+          child = new_draft.children_of(new_draft.root_types_de_champ_public.last).first
           new_draft.find_and_ensure_exclusive_use(child.stable_id).update(type_champ: :carte, options: { cadastres: true, znieff: true })
         end
 
@@ -654,7 +654,7 @@ describe ProcedureRevision do
               private: false,
               from: "text",
               to: "carte",
-              stable_id: new_draft.children_of(new_draft.types_de_champ_public.last).first.stable_id,
+              stable_id: new_draft.children_of(new_draft.root_types_de_champ_public.last).first.stable_id,
             },
             {
               op: :update,
@@ -663,7 +663,7 @@ describe ProcedureRevision do
               private: false,
               from: [],
               to: [:cadastres, :znieff],
-              stable_id: new_draft.children_of(new_draft.types_de_champ_public.last).first.stable_id,
+              stable_id: new_draft.children_of(new_draft.root_types_de_champ_public.last).first.stable_id,
             },
           ])
         end
@@ -805,7 +805,7 @@ describe ProcedureRevision do
 
     context 'when repetition limits are changed' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, libelle: 'bloc' }]) }
-      let(:repetition_tdc) { draft.types_de_champ_public.first }
+      let(:repetition_tdc) { draft.root_types_de_champ_public.first }
 
       before do
         updated_tdc = new_draft.find_and_ensure_exclusive_use(repetition_tdc.stable_id)
@@ -854,7 +854,7 @@ describe ProcedureRevision do
     context 'when ineligibilite_rules changes' do
       let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
       let(:types_de_champ_public) { [{ type: :yes_no }] }
-      let(:yes_no_tdc) { new_draft.types_de_champ_public.first }
+      let(:yes_no_tdc) { new_draft.root_types_de_champ_public.first }
 
       context 'when nothing changed' do
         it { is_expected.to be_empty }
@@ -974,8 +974,8 @@ describe ProcedureRevision do
         { type: :integer_number, libelle: 'value' },
       ])
     end
-    let(:gate_tdc) { draft.types_de_champ_public.first }
-    let(:value_tdc) { draft.types_de_champ_public.second }
+    let(:gate_tdc) { draft.root_types_de_champ_public.first }
+    let(:value_tdc) { draft.root_types_de_champ_public.second }
     let(:gate_column) { procedure.find_column(label: 'gate') }
 
     subject { procedure.reload.draft_revision.champ_value_in_condition? }
@@ -1205,8 +1205,8 @@ describe ProcedureRevision do
         { type: :integer_number, libelle: 'l2' },
       ]
     end
-    def first_champ = procedure.draft_revision.types_de_champ_public.first
-    def second_champ = procedure.draft_revision.types_de_champ_public.second
+    def first_champ = procedure.draft_revision.root_types_de_champ_public.first
+    def second_champ = procedure.draft_revision.root_types_de_champ_public.second
 
     let(:draft_revision) { procedure.draft_revision }
     let(:condition) { nil }
@@ -1255,7 +1255,7 @@ describe ProcedureRevision do
       end
 
       let(:children_of_repetition) do
-        repetition = procedure.draft_revision.types_de_champ_public.find(&:repetition?)
+        repetition = procedure.draft_revision.root_types_de_champ_public.find(&:repetition?)
         procedure.draft_revision.children_of(repetition)
       end
 
@@ -1368,8 +1368,8 @@ describe ProcedureRevision do
   describe "#dependent_conditions" do
     include Logic
 
-    def first_champ = procedure.draft_revision.types_de_champ_public.first
-    def second_champ = procedure.draft_revision.types_de_champ_public.second
+    def first_champ = procedure.draft_revision.root_types_de_champ_public.first
+    def second_champ = procedure.draft_revision.root_types_de_champ_public.second
 
     let(:procedure) do
       create(:procedure, types_de_champ_public: [{ type: :integer_number, libelle: 'l1' }]).tap do |p|
@@ -1389,7 +1389,7 @@ describe ProcedureRevision do
 
   describe 'only_present_on_draft?' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ libelle: 'Un champ texte' }]) }
-    let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+    let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public.first }
 
     it {
       expect(type_de_champ.only_present_on_draft?).to be_truthy
@@ -1425,7 +1425,7 @@ describe ProcedureRevision do
       let(:revision) { procedure.draft_revision }
 
       before do
-        revision.types_de_champ_public.first.update_column(:options, nil)
+        revision.root_types_de_champ_public.first.update_column(:options, nil)
       end
 
       it 'does not raise' do
@@ -1447,7 +1447,7 @@ describe ProcedureRevision do
         create(:llm_rule_suggestion_item, llm_rule_suggestion:, verify_status: 'accepted', stable_id: 2, op_kind: 'update', payload: { 'stable_id' => 2, 'libelle' => 'B modifié' })
 
         expect { revision.apply_llm_rule_suggestion_items(llm_rule_suggestion.changes_to_apply) }.not_to raise_error
-        libelles = revision.reload.types_de_champ_public.map(&:libelle)
+        libelles = revision.reload.root_types_de_champ_public.map(&:libelle)
         expect(libelles).to include("B modifié")
       end
     end
@@ -1460,7 +1460,7 @@ describe ProcedureRevision do
         create(:llm_rule_suggestion_item, llm_rule_suggestion:, verify_status: 'accepted', stable_id: 2, op_kind: 'add', payload: { 'libelle' => 'Ajouté', type_champ: 'header_section' })
 
         expect { revision.apply_llm_rule_suggestion_items(llm_rule_suggestion.changes_to_apply) }.not_to raise_error
-        libelles = revision.reload.types_de_champ_public.map(&:libelle)
+        libelles = revision.reload.root_types_de_champ_public.map(&:libelle)
         expect(libelles).to include("Ajouté")
       end
     end
@@ -1476,7 +1476,7 @@ describe ProcedureRevision do
           revision.apply_llm_rule_suggestion_items(llm_rule_suggestion.changes_to_apply)
           revision.reload
 
-          tdc = revision.types_de_champ_public.find { |t| t.stable_id == 10 }
+          tdc = revision.root_types_de_champ_public.find { |t| t.stable_id == 10 }
           expect(tdc.type_champ).to eq('email')
           expect(tdc.libelle).to eq("Email du contact")
         end
@@ -1507,7 +1507,7 @@ describe ProcedureRevision do
           revision.apply_llm_rule_suggestion_items(llm_rule_suggestion.changes_to_apply)
           revision.reload
 
-          tdc = revision.types_de_champ_public.find { |t| t.stable_id == 10 }
+          tdc = revision.root_types_de_champ_public.find { |t| t.stable_id == 10 }
           expect(tdc.type_champ).to eq('formatted')
           expect(tdc.options['letters_accepted']).to eq(false)
           expect(tdc.options['numbers_accepted']).to eq(true)
@@ -1531,13 +1531,13 @@ describe ProcedureRevision do
           llm_rule_suggestion = create(:llm_rule_suggestion, procedure_revision: revision, rule: 'cleaner', schema_hash:)
           create(:llm_rule_suggestion_item, llm_rule_suggestion:, verify_status: 'accepted', stable_id: 21, op_kind: 'destroy', payload: { 'stable_id' => 21 })
 
-          expect(revision.types_de_champ_public.map(&:stable_id)).to include(21)
+          expect(revision.root_types_de_champ_public.map(&:stable_id)).to include(21)
 
           revision.apply_llm_rule_suggestion_items(llm_rule_suggestion.changes_to_apply)
           revision.reload
 
-          expect(revision.types_de_champ_public.map(&:stable_id)).not_to include(21)
-          expect(revision.types_de_champ_public.map(&:stable_id)).to include(20)
+          expect(revision.root_types_de_champ_public.map(&:stable_id)).not_to include(21)
+          expect(revision.root_types_de_champ_public.map(&:stable_id)).to include(20)
         end
       end
     end
@@ -1558,9 +1558,9 @@ describe ProcedureRevision do
         let!(:item) { create(:llm_rule_suggestion_item, llm_rule_suggestion:, verify_status: :accepted, op_kind: 'add', payload: { 'generated_stable_id' => -1, 'libelle' => 'Nouveau titre de section', 'header_section_level' => 1, 'after_stable_id' => nil }) }
 
         it 'adds a header section at the start' do
-          expect { revision.apply_llm_rule_suggestion_items(llm_rule_suggestion.changes_to_apply) }.to change { revision.types_de_champ_public.size }.by(1)
-          expect(revision.types_de_champ_public.first.libelle).to eq('Nouveau titre de section')
-          expect(revision.types_de_champ_public.first.type_champ).to eq('header_section')
+          expect { revision.apply_llm_rule_suggestion_items(llm_rule_suggestion.changes_to_apply) }.to change { revision.root_types_de_champ_public.size }.by(1)
+          expect(revision.root_types_de_champ_public.first.libelle).to eq('Nouveau titre de section')
+          expect(revision.root_types_de_champ_public.first.type_champ).to eq('header_section')
         end
       end
 
@@ -1569,11 +1569,11 @@ describe ProcedureRevision do
         let!(:update_item) { create(:llm_rule_suggestion_item, llm_rule_suggestion:, verify_status: :accepted, op_kind: 'update', payload: { 'stable_id' => 2, 'after_stable_id' => -1 }) }
 
         it 'adds section and moves field after it' do
-          expect { revision.apply_llm_rule_suggestion_items(llm_rule_suggestion.changes_to_apply) }.to change { revision.types_de_champ_public.size }.by(1)
+          expect { revision.apply_llm_rule_suggestion_items(llm_rule_suggestion.changes_to_apply) }.to change { revision.root_types_de_champ_public.size }.by(1)
           revision.reload
-          nom_coord = revision.coordinate_for(revision.types_de_champ_public.find { |tdc| tdc.libelle == 'nom' })
-          prenom_coord = revision.coordinate_for(revision.types_de_champ_public.find { |tdc| tdc.libelle == 'prenom' })
-          nouveau_coord = revision.coordinate_for(revision.types_de_champ_public.find { |tdc| tdc.libelle == 'Nouveau titre' })
+          nom_coord = revision.coordinate_for(revision.root_types_de_champ_public.find { |tdc| tdc.libelle == 'nom' })
+          prenom_coord = revision.coordinate_for(revision.root_types_de_champ_public.find { |tdc| tdc.libelle == 'prenom' })
+          nouveau_coord = revision.coordinate_for(revision.root_types_de_champ_public.find { |tdc| tdc.libelle == 'Nouveau titre' })
           expect(prenom_coord.position).to be > nouveau_coord.position
           expect(nouveau_coord.position).to be > nom_coord.position
         end
@@ -1583,8 +1583,8 @@ describe ProcedureRevision do
         let!(:item) { create(:llm_rule_suggestion_item, llm_rule_suggestion:, verify_status: :accepted, op_kind: 'add', payload: { 'generated_stable_id' => -2, 'libelle' => 'Nouveau titre après nom', 'header_section_level' => 1, 'after_stable_id' => 1 }) }
 
         it 'adds a header section after the specified field' do
-          expect { revision.apply_llm_rule_suggestion_items(llm_rule_suggestion.changes_to_apply) }.to change { revision.types_de_champ_public.size }.by(1)
-          noms = revision.reload.types_de_champ_public.map(&:libelle)
+          expect { revision.apply_llm_rule_suggestion_items(llm_rule_suggestion.changes_to_apply) }.to change { revision.root_types_de_champ_public.size }.by(1)
+          noms = revision.reload.root_types_de_champ_public.map(&:libelle)
           nom_index = noms.index('nom')
           nouveau_index = noms.index('Nouveau titre après nom')
           expect(nouveau_index).to eq(nom_index + 1)
@@ -1597,8 +1597,8 @@ describe ProcedureRevision do
         it 'moves the field after the specified existing field' do
           revision.apply_llm_rule_suggestion_items(llm_rule_suggestion.changes_to_apply)
           revision.reload
-          prenom_coord = revision.coordinate_for(revision.types_de_champ_public.find { |tdc| tdc.libelle == 'prenom' })
-          explication_coord = revision.coordinate_for(revision.types_de_champ_public.find { |tdc| tdc.libelle == 'explication a la fin' })
+          prenom_coord = revision.coordinate_for(revision.root_types_de_champ_public.find { |tdc| tdc.libelle == 'prenom' })
+          explication_coord = revision.coordinate_for(revision.root_types_de_champ_public.find { |tdc| tdc.libelle == 'explication a la fin' })
           expect(explication_coord.position).to be > prenom_coord.position
         end
       end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -582,7 +582,7 @@ describe Procedure do
           expect(procedure.errors.messages_for(:draft_types_de_champ_public)).to include(invalid_repetition_error_message)
 
           new_draft = procedure.draft_revision
-          repetition = new_draft.types_de_champ_public.find(&:repetition?)
+          repetition = new_draft.root_types_de_champ_public.find(&:repetition?)
           new_draft.add_type_de_champ(type_champ: :text, libelle: 'Nom', parent_stable_id: repetition.stable_id)
 
           procedure.validate(:publication)
@@ -590,7 +590,7 @@ describe Procedure do
         end
 
         it 'validates that no drop-down type de champ is empty' do
-          drop_down = procedure.draft_revision.types_de_champ_public.find(&:any_drop_down_list?)
+          drop_down = procedure.draft_revision.root_types_de_champ_public.find(&:any_drop_down_list?)
 
           drop_down.update!(drop_down_options: [])
           procedure.reload.validate(:publication)
@@ -749,12 +749,12 @@ describe Procedure do
           procedure.validate(:publication)
           expect(procedure.errors.messages_for(:draft_types_de_champ_private)).to include(invalid_repetition_error_message)
 
-          repetition = procedure.draft_revision.types_de_champ_private.find(&:repetition?)
+          repetition = procedure.draft_revision.root_types_de_champ_private.find(&:repetition?)
           expect(procedure.errors.to_enum.to_a.map { _1.options[:type_de_champ] }).to include(repetition)
         end
 
         it 'validates that no drop-down type de champ is empty' do
-          drop_down = procedure.draft_revision.types_de_champ_private.find(&:any_drop_down_list?)
+          drop_down = procedure.draft_revision.root_types_de_champ_private.find(&:any_drop_down_list?)
           drop_down.update!(drop_down_options: [])
           procedure.reload.validate(:publication)
 
@@ -1121,15 +1121,15 @@ describe Procedure do
       subject
       expect(procedure.published_revision).to be_present
       expect(procedure.published_revision.published_at).to eq(publication_date)
-      expect(procedure.published_revision.types_de_champ_public.first.libelle).to eq('libelle 1')
+      expect(procedure.published_revision.root_types_de_champ_public.first.libelle).to eq('libelle 1')
     end
 
     it 'creates a new draft revision' do
       expect { subject }.to change(ProcedureRevision, :count).by(1)
       expect(procedure.draft_revision).to be_present
       expect(procedure.draft_revision.revision_types_de_champ_public).to be_present
-      expect(procedure.draft_revision.types_de_champ_public).to be_present
-      expect(procedure.draft_revision.types_de_champ_public.first.libelle).to eq('libelle 1')
+      expect(procedure.draft_revision.root_types_de_champ_public).to be_present
+      expect(procedure.draft_revision.root_types_de_champ_public.first.libelle).to eq('libelle 1')
     end
 
     it 'records the publishing administrateur' do
@@ -1158,14 +1158,14 @@ describe Procedure do
       let(:procedure) { create(:procedure, types_de_champ_public:) }
       let(:types_de_champ_public) { [{ type: :drop_down_list, referentiel:, drop_down_mode: 'advanced' }] }
       let(:referentiel) { create(:csv_referentiel, :with_items) }
-      let(:tdc) { procedure.draft_revision.types_de_champ_public.last }
+      let(:tdc) { procedure.draft_revision.root_types_de_champ_public.last }
 
       before do
-        procedure.draft_revision.types_de_champ_public.last.update(type_champ: :textarea, options: { "character_limit" => "" })
+        procedure.draft_revision.root_types_de_champ_public.last.update(type_champ: :textarea, options: { "character_limit" => "" })
       end
 
       it 'nullifies the referentiel' do
-        expect(procedure.draft_revision.types_de_champ_public.first.referentiel).to be_nil
+        expect(procedure.draft_revision.root_types_de_champ_public.first.referentiel).to be_nil
       end
     end
   end
@@ -1629,7 +1629,7 @@ describe Procedure do
 
       context 'with brouillon procedure' do
         it do
-          expect(procedure.draft_revision.types_de_champ_public.count).to eq(2)
+          expect(procedure.draft_revision.root_types_de_champ_public.count).to eq(2)
           expect(procedure.draft_revision.types_de_champ.count).to eq(3)
         end
       end
@@ -1638,9 +1638,9 @@ describe Procedure do
         let(:procedure) { create(:procedure, :published, types_de_champ_public: types_de_champ) }
 
         it do
-          expect(procedure.draft_revision.types_de_champ_public.count).to eq(2)
+          expect(procedure.draft_revision.root_types_de_champ_public.count).to eq(2)
           expect(procedure.draft_revision.types_de_champ.count).to eq(3)
-          expect(procedure.published_revision.types_de_champ_public.count).to eq(2)
+          expect(procedure.published_revision.root_types_de_champ_public.count).to eq(2)
           expect(procedure.published_revision.types_de_champ.count).to eq(3)
         end
       end
@@ -1652,7 +1652,7 @@ describe Procedure do
       it do
         expect(procedure.revisions.size).to eq(1)
         expect(procedure.draft_revision.types_de_champ.size).to eq(4)
-        expect(procedure.draft_revision.types_de_champ_public.size).to eq(2)
+        expect(procedure.draft_revision.root_types_de_champ_public.size).to eq(2)
         expect(procedure.published_revision).to be_nil
       end
     end
@@ -1663,9 +1663,9 @@ describe Procedure do
       it do
         expect(procedure.revisions.size).to eq(2)
         expect(procedure.draft_revision.types_de_champ.size).to eq(4)
-        expect(procedure.draft_revision.types_de_champ_public.size).to eq(2)
+        expect(procedure.draft_revision.root_types_de_champ_public.size).to eq(2)
         expect(procedure.published_revision.types_de_champ.size).to eq(4)
-        expect(procedure.published_revision.types_de_champ_public.size).to eq(2)
+        expect(procedure.published_revision.root_types_de_champ_public.size).to eq(2)
       end
     end
 
@@ -1691,8 +1691,8 @@ describe Procedure do
 
         it do
           expect(revision.types_de_champ.size).to eq(5)
-          expect(revision.types_de_champ_public.size).to eq(2)
-          expect(revision.types_de_champ_public.map(&:type_champ)).to eq(['yes_no', 'repetition'])
+          expect(revision.root_types_de_champ_public.size).to eq(2)
+          expect(revision.root_types_de_champ_public.map(&:type_champ)).to eq(['yes_no', 'repetition'])
           expect(repetition.revision_types_de_champ.size).to eq(3)
           expect(repetition.revision_types_de_champ.map(&:type_champ)).to eq(['text', 'text', 'integer_number'])
           expect(repetition.revision_types_de_champ.map(&:mandatory?)).to eq([true, true, false])
@@ -1705,8 +1705,8 @@ describe Procedure do
         context 'draft revision' do
           it do
             expect(revision.types_de_champ.size).to eq(5)
-            expect(revision.types_de_champ_public.size).to eq(2)
-            expect(revision.types_de_champ_public.map(&:type_champ)).to eq(['yes_no', 'repetition'])
+            expect(revision.root_types_de_champ_public.size).to eq(2)
+            expect(revision.root_types_de_champ_public.map(&:type_champ)).to eq(['yes_no', 'repetition'])
             expect(repetition.revision_types_de_champ.size).to eq(3)
             expect(repetition.revision_types_de_champ.map(&:type_champ)).to eq(['text', 'text', 'integer_number'])
             expect(repetition.revision_types_de_champ.map(&:mandatory?)).to eq([true, true, false])
@@ -1718,8 +1718,8 @@ describe Procedure do
 
           it do
             expect(revision.types_de_champ.size).to eq(5)
-            expect(revision.types_de_champ_public.size).to eq(2)
-            expect(revision.types_de_champ_public.map(&:type_champ)).to eq(['yes_no', 'repetition'])
+            expect(revision.root_types_de_champ_public.size).to eq(2)
+            expect(revision.root_types_de_champ_public.map(&:type_champ)).to eq(['yes_no', 'repetition'])
             expect(repetition.revision_types_de_champ.size).to eq(3)
             expect(repetition.revision_types_de_champ.map(&:type_champ)).to eq(['text', 'text', 'integer_number'])
             expect(repetition.revision_types_de_champ.map(&:mandatory?)).to eq([true, true, false])
@@ -2031,7 +2031,7 @@ describe Procedure do
 
     let(:admin) { create :administrateur }
     let(:procedure) { create(:procedure, :published, routing_enabled: true, administrateur: admin) }
-    let(:stable_id) { procedure.published_revision.types_de_champ_public.last.stable_id }
+    let(:stable_id) { procedure.published_revision.root_types_de_champ_public.last.stable_id }
 
     before do
       procedure.draft_revision.add_type_de_champ(
@@ -2128,8 +2128,8 @@ describe Procedure do
       ])
     end
     let(:revision) { procedure.draft_revision }
-    let(:gate_tdc) { revision.types_de_champ_public.first }
-    let(:value_tdc) { revision.types_de_champ_public.second }
+    let(:gate_tdc) { revision.root_types_de_champ_public.first }
+    let(:value_tdc) { revision.root_types_de_champ_public.second }
     let(:gate_column) { procedure.find_column(label: 'gate') }
 
     subject { procedure.reload.champ_value_in_condition? }

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -12,7 +12,7 @@ describe TypeDeChamp do
       let(:dossier) { create(:dossier, procedure:) }
 
       it do
-        dossier.revision.types_de_champ_public.each do |type_de_champ|
+        dossier.revision.root_types_de_champ_public.each do |type_de_champ|
           champ = dossier.project_champ(type_de_champ)
           expect(type_de_champ.dynamic_type.class.name).to match(/^TypesDeChamp::/)
           expect(champ.class.name).to match(/^Champs::/)
@@ -347,8 +347,8 @@ describe TypeDeChamp do
     let(:procedure) { create(:procedure, :with_type_de_champ, :with_type_de_champ_private) }
 
     it 'partition public and private' do
-      expect(procedure.active_revision.types_de_champ_public.count).to eq(1)
-      expect(procedure.active_revision.types_de_champ_private.count).to eq(1)
+      expect(procedure.active_revision.root_types_de_champ_public.count).to eq(1)
+      expect(procedure.active_revision.root_types_de_champ_private.count).to eq(1)
     end
   end
 

--- a/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/drop_down_list_type_de_champ_spec.rb
@@ -72,7 +72,7 @@ describe TypesDeChamp::DropDownListTypeDeChamp do
 
       describe 'when a champ has a other value' do
         let(:dossier) { create(:dossier, procedure:) }
-        let(:champ) { dossier.project_champs.first }
+        let(:champ) { dossier.champs.first }
 
         it 'matches other' do
           champ.value = '__other__'

--- a/spec/models/types_de_champ/prefill_dossier_link_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_dossier_link_type_de_champ_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe TypesDeChamp::PrefillDossierLinkTypeDeChamp do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :dossier_link }]) }
   let(:dossier) { create(:dossier, :brouillon, procedure:) }
-  let(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }
+  let(:type_de_champ) { procedure.active_revision.root_types_de_champ_public.first }
   let(:champ) { dossier.champ_data.first }
 
   describe 'ancestors' do

--- a/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe TypesDeChamp::PrefillRepetitionTypeDeChamp, type: :model do
   let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{}, { type: :integer_number }, { type: :regions }] }]) }
   let(:dossier) { create(:dossier, procedure: procedure) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
   let(:type_de_champ) { champ.type_de_champ }
   let(:prefillable_subchamps) { TypesDeChamp::PrefillRepetitionTypeDeChamp.new(type_de_champ, procedure.active_revision).send(:prefillable_subchamps) }
   let(:text_repetition) { prefillable_subchamps.first }

--- a/spec/perf/heavy_dossier_spec.rb
+++ b/spec/perf/heavy_dossier_spec.rb
@@ -12,7 +12,7 @@ describe Users::DossiersController, type: :controller do
     let(:types_de_champ_public) { (0...nb_champ).map { |i| { type: :yes_no, libelle: "c_#{i}" } } }
     let(:dossier) { create(:dossier, user:, procedure:) }
 
-    let(:last_champ) { dossier.project_champs_public.last }
+    let(:last_champ) { dossier.root_champs_public.last }
 
     before do
       tdcs = procedure.active_revision.types_de_champ.to_a
@@ -24,7 +24,7 @@ describe Users::DossiersController, type: :controller do
       end
 
       # all champs are visible
-      dossier.project_champs_public.take((nb_champ - 1)).each { |champ| champ.update_columns(value: 'true') }
+      dossier.root_champs_public.take((nb_champ - 1)).each { |champ| champ.update_columns(value: 'true') }
       last_champ.update_columns(value: 'false')
     end
 
@@ -33,7 +33,7 @@ describe Users::DossiersController, type: :controller do
         preloaded_dossier = DossierPreloader.load_one(dossier)
         expect(preloaded_dossier.valid?).to eq(true)
 
-        expect(preloaded_dossier.project_champs_public.last.visible?).to eq(true)
+        expect(preloaded_dossier.root_champs_public.last.visible?).to eq(true)
         expect(last_champ.reload.true?).to eq(false)
       end
     end

--- a/spec/perf/instructeur_dossier_controller_spec.rb
+++ b/spec/perf/instructeur_dossier_controller_spec.rb
@@ -16,7 +16,7 @@ describe Instructeurs::DossiersController, type: :controller do
     end
     let(:dossier) { create(:dossier, :en_construction, user:, procedure:) }
 
-    let(:last_yes_no_champ) { dossier.project_champs_public[99] }
+    let(:last_yes_no_champ) { dossier.root_champs_public[99] }
 
     before do
       tdcs = procedure.active_revision.types_de_champ.to_a
@@ -28,11 +28,11 @@ describe Instructeurs::DossiersController, type: :controller do
       end
 
       # all champs are visible
-      dossier.project_champs_public.take((nb_champ - 1)).each { |champ| champ.update_columns(value: 'true') }
+      dossier.root_champs_public.take((nb_champ - 1)).each { |champ| champ.update_columns(value: 'true') }
       last_yes_no_champ.update_columns(value: 'false')
 
       # attachements to the piece justificative champs
-      dossier.project_champs_public.filter(&:piece_justificative?).each do |champ|
+      dossier.root_champs_public.filter(&:piece_justificative?).each do |champ|
         champ.piece_justificative_file.attach(
           io: Rails.root.join('spec/fixtures/files/logo_test_procedure.png').open,
           filename: 'logo_test_procedure.png',

--- a/spec/services/attachment/piece_justificative_service_spec.rb
+++ b/spec/services/attachment/piece_justificative_service_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Attachment::PieceJustificativeService do
   let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }]) }
   let(:dossier) { create(:dossier, procedure:) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
 
   let(:blob_1) { ActiveStorage::Blob.create_and_upload!(io: StringIO.new("file1"), filename: "file1.pdf", content_type: "application/pdf") }
   let(:blob_2) { ActiveStorage::Blob.create_and_upload!(io: StringIO.new("file2"), filename: "file2.pdf", content_type: "application/pdf") }
@@ -20,8 +20,8 @@ RSpec.describe Attachment::PieceJustificativeService do
 
     context 'with concurrent uploads (simulated stale state)' do
       it 'preserves all attachments' do
-        champ_a = Dossier.find(dossier.id).project_champs_public.first
-        champ_b = Dossier.find(dossier.id).project_champs_public.first
+        champ_a = Dossier.find(dossier.id).root_champs_public.first
+        champ_b = Dossier.find(dossier.id).root_champs_public.first
 
         # Force-load the blobs association on both instances before either attaches.
         # This simulates two concurrent requests that both read blobs = [] at the same time.

--- a/spec/services/demarches_publiques_export_service_spec.rb
+++ b/spec/services/demarches_publiques_export_service_spec.rb
@@ -35,8 +35,8 @@ describe DemarchesPubliquesExportService do
         revision: {
           champDescriptors: [
             {
-              description: procedure.active_revision.types_de_champ_public.first.description,
-              label: procedure.active_revision.types_de_champ_public.first.libelle,
+              description: procedure.active_revision.root_types_de_champ_public.first.description,
+              label: procedure.active_revision.root_types_de_champ_public.first.libelle,
               required: true,
               __typename: "TextChampDescriptor",
             },

--- a/spec/services/dossier_filter_service_spec.rb
+++ b/spec/services/dossier_filter_service_spec.rb
@@ -65,7 +65,7 @@ describe DossierFilterService do
   describe '#sorted_ids' do
     let(:procedure) { create(:procedure, :published, types_de_champ_public:, types_de_champ_private: [{}]) }
     let(:types_de_champ_public) { [{}] }
-    let(:first_type_de_champ) { assign_to.procedure.active_revision.types_de_champ_public.first }
+    let(:first_type_de_champ) { assign_to.procedure.active_revision.root_types_de_champ_public.first }
     let(:dossiers) { procedure.dossiers }
     let(:instructeur) { create(:instructeur) }
     let(:assign_to) { create(:assign_to, procedure:, instructeur:) }
@@ -145,8 +145,8 @@ describe DossierFilterService do
         let(:tartine_dossier) { create(:dossier, procedure:) }
 
         before do
-          beurre_dossier.project_champs_public.first.update(value: 'beurre')
-          tartine_dossier.project_champs_public.first.update(value: 'tartine')
+          beurre_dossier.root_champs_public.first.update(value: 'beurre')
+          tartine_dossier.root_champs_public.first.update(value: 'tartine')
         end
 
         context 'asc' do
@@ -174,8 +174,8 @@ describe DossierFilterService do
           nothing_dossier
           procedure.draft_revision.add_type_de_champ(tdc)
           procedure.publish_revision!(procedure.administrateurs.first)
-          beurre_dossier.project_champs_public.last.update(value: 'beurre')
-          tartine_dossier.project_champs_public.last.update(value: 'tartine')
+          beurre_dossier.root_champs_public.last.update(value: 'beurre')
+          tartine_dossier.root_champs_public.last.update(value: 'tartine')
         end
 
         context 'asc' do
@@ -192,14 +192,14 @@ describe DossierFilterService do
 
     context 'for type_de_champ_private table' do
       context 'with no revisions' do
-        let(:column) { procedure.find_column(label: procedure.active_revision.types_de_champ_private.first.libelle) }
+        let(:column) { procedure.find_column(label: procedure.active_revision.root_types_de_champ_private.first.libelle) }
 
         let(:biere_dossier) { create(:dossier, procedure:) }
         let(:vin_dossier) { create(:dossier, procedure:) }
 
         before do
-          biere_dossier.project_champs_private.first.update(value: 'biere')
-          vin_dossier.project_champs_private.first.update(value: 'vin')
+          biere_dossier.root_champs_private.first.update(value: 'biere')
+          vin_dossier.root_champs_private.first.update(value: 'vin')
         end
 
         context 'asc' do
@@ -485,7 +485,7 @@ describe DossierFilterService do
 
       let(:kept_dossier) { create(:dossier, procedure:) }
       let(:discarded_dossier) { create(:dossier, procedure:) }
-      let(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }
+      let(:type_de_champ) { procedure.active_revision.root_types_de_champ_public.first }
 
       context 'with single value' do
         before do
@@ -558,7 +558,7 @@ describe DossierFilterService do
             { type: :yes_no },
           ]
         end
-        let(:types_de_champ) { procedure.active_revision.types_de_champ_public }
+        let(:types_de_champ) { procedure.active_revision.root_types_de_champ_public }
         let(:type_de_champ_resto) { types_de_champ[0] }
         let(:type_de_champ_a_emporter) { types_de_champ[1] }
 
@@ -659,7 +659,7 @@ describe DossierFilterService do
 
       let(:kept_dossier) { create(:dossier, procedure:) }
       let(:discarded_dossier) { create(:dossier, procedure:) }
-      let(:type_de_champ_private) { procedure.active_revision.types_de_champ_private.first }
+      let(:type_de_champ_private) { procedure.active_revision.root_types_de_champ_private.first }
 
       before do
         kept_dossier.champ_data.find_by(stable_id: type_de_champ_private.stable_id).update(value: 'keep me')
@@ -680,8 +680,8 @@ describe DossierFilterService do
         let(:filter) { ["rna – Code postal (5 chiffres)", value] }
 
         before do
-          kept_dossier.project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "postal_code" => value })
-          create(:dossier, procedure:).project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "postal_code" => "unknown" })
+          kept_dossier.root_champs_public.find { _1.stable_id == 1 }.update(value_json: { "postal_code" => value })
+          create(:dossier, procedure:).root_champs_public.find { _1.stable_id == 1 }.update(value_json: { "postal_code" => "unknown" })
         end
 
         it { is_expected.to contain_exactly(kept_dossier.id) }
@@ -697,8 +697,8 @@ describe DossierFilterService do
         let(:filter) { ["rna – Département", value] }
 
         before do
-          kept_dossier.project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "department_code" => value })
-          create(:dossier, procedure:).project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "department_code" => "unknown" })
+          kept_dossier.root_champs_public.find { _1.stable_id == 1 }.update(value_json: { "department_code" => value })
+          create(:dossier, procedure:).root_champs_public.find { _1.stable_id == 1 }.update(value_json: { "department_code" => "unknown" })
         end
 
         it { is_expected.to contain_exactly(kept_dossier.id) }
@@ -714,8 +714,8 @@ describe DossierFilterService do
         let(:filter) { ["rna – Région", value] }
 
         before do
-          kept_dossier.project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "region_code" => value })
-          create(:dossier, procedure:).project_champs_public.find { _1.stable_id == 1 }.update(value_json: { "region_code" => "unknown" })
+          kept_dossier.root_champs_public.find { _1.stable_id == 1 }.update(value_json: { "region_code" => value })
+          create(:dossier, procedure:).root_champs_public.find { _1.stable_id == 1 }.update(value_json: { "region_code" => "unknown" })
         end
 
         it { is_expected.to contain_exactly(kept_dossier.id) }

--- a/spec/services/dossier_search_service_spec.rb
+++ b/spec/services/dossier_search_service_spec.rb
@@ -22,8 +22,8 @@ describe DossierSearchService do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text }], types_de_champ_private: [{ type: :text }]) }
       let(:dossier) do
         create(:dossier, procedure:, state: :en_construction, user:, etablissement:).tap do |dossier|
-          dossier.project_champs_public.first.update!(value: 'Hélène mange des pommes')
-          dossier.project_champs_private.first.update!(value: 'annotations')
+          dossier.root_champs_public.first.update!(value: 'Hélène mange des pommes')
+          dossier.root_champs_private.first.update!(value: 'annotations')
         end
       end
 
@@ -99,7 +99,7 @@ describe DossierSearchService do
       let(:procedure) { create(:procedure, types_de_champ_private: [{ type: :text }]) }
       let(:dossier) do
         create(:dossier, procedure:, state: :brouillon, user:).tap do |dossier|
-          dossier.project_champs_private.first.update!(value: 'annotations')
+          dossier.root_champs_private.first.update!(value: 'annotations')
         end
       end
 
@@ -127,7 +127,7 @@ describe DossierSearchService do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text }]) }
       let!(:dossier) do
         create(:dossier, procedure:, state: :en_construction, user:).tap do |dossier|
-          dossier.project_champs_public.first.update!(value: 'pommes')
+          dossier.root_champs_public.first.update!(value: 'pommes')
         end
       end
 

--- a/spec/services/llm/cleaner_improver_spec.rb
+++ b/spec/services/llm/cleaner_improver_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe LLM::CleanerImprover do
     end
 
     it 'normalises destroy tool calls' do
-      tdcs = revision.types_de_champ_public
+      tdcs = revision.root_types_de_champ_public
       commune_stable_id = tdcs.find { it.libelle == 'Commune' }.stable_id
 
       calls = [

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -10,8 +10,8 @@ describe PiecesJustificativesService do
     let(:pj_service) { PiecesJustificativesService.new(user_profile:, export_template:) }
     let(:user_profile) { build(:administrateur) }
 
-    def pj_champ(d) = d.project_champs_public.find(&:piece_justificative?)
-    def repetition(d) = d.project_champs_public.find(&:repetition?)
+    def pj_champ(d) = d.root_champs_public.find(&:piece_justificative?)
+    def repetition(d) = d.root_champs_public.find(&:repetition?)
     def attachments(champ) = champ.piece_justificative_file.attachments
 
     before { attach_file_to_champ(pj_champ(witness)) }
@@ -115,7 +115,7 @@ describe PiecesJustificativesService do
       let(:user_profile) { build(:administrateur) }
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
       let(:witness) { create(:dossier, procedure: procedure) }
-      def pj_champ(d) = d.project_champs_public.find(&:piece_justificative?)
+      def pj_champ(d) = d.root_champs_public.find(&:piece_justificative?)
 
       context 'with a single attachment' do
         before do
@@ -158,7 +158,7 @@ describe PiecesJustificativesService do
         let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: 'titre_identite' }]) }
         let(:dossier) { create(:dossier, procedure: procedure) }
 
-        let(:champ_identite) { dossier.project_champs_public.find(&:titre_identite?) }
+        let(:champ_identite) { dossier.root_champs_public.find(&:titre_identite?) }
 
         before { attach_file_to_champ(champ_identite) }
 
@@ -275,7 +275,7 @@ describe PiecesJustificativesService do
       let(:witness) { create(:dossier, procedure: procedure) }
 
       let!(:private_pj) { create(:type_de_champ_piece_justificative, procedure: procedure, private: true) }
-      def private_pj_champ(d) = d.project_champs_private.find(&:piece_justificative?)
+      def private_pj_champ(d) = d.root_champs_private.find(&:piece_justificative?)
 
       before do
         attach_file_to_champ(private_pj_champ(dossier))
@@ -526,7 +526,7 @@ describe PiecesJustificativesService do
     let(:dossier_1) { create(:dossier, :with_populated_champs, procedure:) }
     let(:champs) { dossier_1.filled_champs }
 
-    def repetition(d, index:) = d.project_champs_public.filter(&:repetition?)[index]
+    def repetition(d, index:) = d.root_champs_public.filter(&:repetition?)[index]
 
     subject { PiecesJustificativesService.new(user_profile:, export_template: nil).send(:compute_champ_id_row_index, champs) }
 
@@ -555,7 +555,7 @@ describe PiecesJustificativesService do
     end
 
     it do
-      champs = dossier_1.project_champs_public
+      champs = dossier_1.root_champs_public
       repet_0 = champs[0]
       pj_0 = repet_0.rows.first.first
       pj_1 = repet_0.rows.second.first

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -189,7 +189,7 @@ describe ProcedureExportService do
         let!(:dossier) { create(:dossier, :en_instruction, :with_populated_champs, :with_individual, procedure:) }
         let!(:dossier_2) { create(:dossier, :en_instruction, :with_populated_champs, :with_individual, procedure:) }
         before do
-          dossier_2.project_champs_public
+          dossier_2.root_champs_public
             .find { _1.is_a? Champs::PieceJustificativeChamp }
             .piece_justificative_file
             .attach(io: StringIO.new("toto"), filename: "toto.txt", content_type: "text/plain")
@@ -420,7 +420,7 @@ describe ProcedureExportService do
           create(:dossier, :en_instruction, :with_populated_champs, :with_individual, procedure: procedure),
         ]
       end
-      let(:champ_repetition) { dossiers.first.project_champs_public.find { |champ| champ.type_champ == 'repetition' } }
+      let(:champ_repetition) { dossiers.first.root_champs_public.find { |champ| champ.type_champ == 'repetition' } }
 
       it 'should have sheets' do
         expect(subject.sheets.map(&:name)).to eq(['Dossiers', 'Etablissements', 'Avis', champ_repetition.type_de_champ.libelle_for_export])
@@ -459,7 +459,7 @@ describe ProcedureExportService do
 
       context 'with long libelle composed of utf8 characteres' do
         before do
-          procedure.active_revision.types_de_champ_public.each do |type_de_champ|
+          procedure.active_revision.root_types_de_champ_public.each do |type_de_champ|
             type_de_champ.update!(libelle: "#{type_de_champ.id} - ?/[] ééé ééé ééééééé ééééééé éééééééé. ééé éé éééééééé éé ééé. ééééé éééééééé ééé ééé.")
           end
           procedure.active_revision.children_of(champ_repetition.type_de_champ).each do |type_de_champ|
@@ -475,8 +475,8 @@ describe ProcedureExportService do
       context 'with non unique labels' do
         let(:types_de_champ_public) { [{ type: :repetition, libelle: 'Une repetition', children: [{}] }, { type: :repetition, libelle: 'Une repetition', children: [{}] }] }
         let(:dossier) { create(:dossier, :en_instruction, :with_populated_champs, :with_individual, procedure:) }
-        let(:type_de_champ_repetition) { dossier.revision.types_de_champ_public.first }
-        let(:another_type_de_champ_repetition) { dossier.revision.types_de_champ_public.second }
+        let(:type_de_champ_repetition) { dossier.revision.root_types_de_champ_public.first }
+        let(:another_type_de_champ_repetition) { dossier.revision.root_types_de_champ_public.second }
 
         it 'should have sheets' do
           expect(subject.sheets.map(&:name)).to eq(['Dossiers', 'Etablissements', 'Avis', type_de_champ_repetition.libelle_for_export, another_type_de_champ_repetition.libelle_for_export])
@@ -485,7 +485,7 @@ describe ProcedureExportService do
 
       context 'with empty repetition' do
         before do
-          dossiers.flat_map { |dossier| dossier.project_champs_public.filter(&:repetition?) }.each do |champ|
+          dossiers.flat_map { |dossier| dossier.root_champs_public.filter(&:repetition?) }.each do |champ|
             Champ.where(row_id: champ.row_ids).destroy_all
           end
         end
@@ -509,7 +509,7 @@ describe ProcedureExportService do
         # doivent suivre l'ordre canonique, comme l'export caxlsx historique.
         before do
           canonical = procedure.all_revisions_types_de_champ.repetition.to_a
-          rep = -> (dossier, stable_id) { dossier.project_champs_public.find { _1.repetition? && _1.stable_id == stable_id } }
+          rep = -> (dossier, stable_id) { dossier.root_champs_public.find { _1.repetition? && _1.stable_id == stable_id } }
 
           dossiers.first.update!(depose_at: 2.days.ago)
           Champ.where(row_id: rep.call(dossiers.first, canonical.first.stable_id).row_ids).destroy_all
@@ -623,7 +623,7 @@ describe ProcedureExportService do
     end
 
     let(:dossier) { create(:dossier, :en_instruction, :with_populated_champs, :with_individual, procedure: procedure) }
-    let(:champ_carte) { dossier.project_champs_public.find(&:carte?) }
+    let(:champ_carte) { dossier.root_champs_public.find(&:carte?) }
     let(:properties) { subject['features'].first['properties'] }
 
     before do

--- a/spec/services/procedure_export_service_zip_spec.rb
+++ b/spec/services/procedure_export_service_zip_spec.rb
@@ -9,8 +9,8 @@ describe ProcedureExportService do
   let(:export_template) { create(:export_template, :enabled_pjs, groupe_instructeur: procedure.defaut_groupe_instructeur) }
   let(:service) { ProcedureExportService.new(procedure, procedure.dossiers, instructeur, export_template) }
 
-  def pj_champ(d) = d.project_champs_public.find(&:piece_justificative?)
-  def repetition(d) = d.project_champs_public.find(&:repetition?)
+  def pj_champ(d) = d.root_champs_public.find(&:piece_justificative?)
+  def repetition(d) = d.root_champs_public.find(&:repetition?)
   def attachments(champ) = champ.piece_justificative_file.attachments
 
   before do

--- a/spec/services/referentiel_service_spec.rb
+++ b/spec/services/referentiel_service_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe ReferentielService, type: :service do
     context 'with Dossier as values_source' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+      let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public.first }
       let(:url_tiptap) do
         {
           "type" => "doc", "content" => [
@@ -199,7 +199,7 @@ RSpec.describe ReferentielService, type: :service do
     context 'with yes_no champ as values_source' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :yes_no }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+      let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public.first }
       let(:url_tiptap) do
         {
           "type" => "doc", "content" => [
@@ -237,7 +237,7 @@ RSpec.describe ReferentielService, type: :service do
     context 'with address champ as values_source' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :address }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:type_de_champ) { procedure.draft_revision.types_de_champ_public.first }
+      let(:type_de_champ) { procedure.draft_revision.root_types_de_champ_public.first }
       let(:url_tiptap) do
         {
           "type" => "doc", "content" => [

--- a/spec/system/administrateurs/annotations_spec.rb
+++ b/spec/system/administrateurs/annotations_spec.rb
@@ -14,18 +14,18 @@ describe 'As an administrateur I can edit annotation', js: true do
     click_on 'Ajouter une annotation'
 
     select('Titre de section', from: 'Type de champ')
-    wait_until { procedure.reload.active_revision.types_de_champ_private.first&.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
-    first_header = procedure.active_revision.types_de_champ_private.first
+    wait_until { procedure.reload.active_revision.root_types_de_champ_private.first&.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
+    first_header = procedure.active_revision.root_types_de_champ_private.first
     select('Titre de niveau 1', from: dom_id(first_header, :header_section_level))
 
     within(find('.type-de-champ-add-button', match: :first)) {
       click_on 'Ajouter une annotation'
     }
 
-    wait_until { procedure.reload.active_revision.types_de_champ_private.count == 2 }
-    second_header = procedure.active_revision.types_de_champ_private.last
+    wait_until { procedure.reload.active_revision.root_types_de_champ_private.count == 2 }
+    second_header = procedure.active_revision.root_types_de_champ_private.last
     select('Titre de section', from: dom_id(second_header, :type_champ))
-    wait_until { procedure.reload.active_revision.types_de_champ_private.last&.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
+    wait_until { procedure.reload.active_revision.root_types_de_champ_private.last&.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
     select('Titre de niveau 2', from: dom_id(second_header, :header_section_level))
 
     within(".types-de-champ-block li:first-child") do
@@ -37,7 +37,7 @@ describe 'As an administrateur I can edit annotation', js: true do
     expect(page).to have_content("devrait être précédé d’un titre de niveau 1")
 
     # check summary
-    procedure.reload.active_revision.types_de_champ_private.each do |header_section|
+    procedure.reload.active_revision.root_types_de_champ_private.each do |header_section|
       expect(page).to have_link(header_section.libelle)
     end
   end

--- a/spec/system/administrateurs/api_referentiel_spec.rb
+++ b/spec/system/administrateurs/api_referentiel_spec.rb
@@ -176,10 +176,10 @@ describe 'Referentiel API:' do
             dossier = Dossier.last
 
             # check prefill values in db
-            expect(dossier.project_champs_public_all.find { it.stable_id.to_s == referentiel_stable_id.to_s }.value).to eq("PG46YY6YWCX8")
-            expect(dossier.project_champs_public_all.find { it.stable_id.to_s == prefill_text_stable_id.to_s }.value).to eq("constructed")
-            expect(dossier.project_champs_public_all.find { it.stable_id.to_s == prefill_boolean_stable_id.to_s }.value).to eq("true")
-            repetition_values = dossier.project_champs_public_all.filter { it.stable_id.to_s == prefill_repetition_children_stable_id.to_s }.map(&:value)
+            expect(dossier.flat_champs_public.find { it.stable_id.to_s == referentiel_stable_id.to_s }.value).to eq("PG46YY6YWCX8")
+            expect(dossier.flat_champs_public.find { it.stable_id.to_s == prefill_text_stable_id.to_s }.value).to eq("constructed")
+            expect(dossier.flat_champs_public.find { it.stable_id.to_s == prefill_boolean_stable_id.to_s }.value).to eq("true")
+            repetition_values = dossier.flat_champs_public.filter { it.stable_id.to_s == prefill_repetition_children_stable_id.to_s }.map(&:value)
             expect(repetition_values).to include("rue du puits")
             expect(repetition_values).to include("place de la bourse")
 
@@ -296,15 +296,15 @@ describe 'Referentiel API:' do
           dossier = Dossier.last
 
           # wait until selected key had been submitted to backend
-          wait_until { dossier.reload.project_champs.find(&:referentiel).value&.match?(/010002699 CENTRE MEDICAL REGINA/) }
+          wait_until { dossier.reload.champs.find(&:referentiel).value&.match?(/010002699 CENTRE MEDICAL REGINA/) }
 
           # wait until refreshed with prefilled values
           expect(page).to have_content("Donnée remplie automatiquement.", count: 2)
 
           dossier.reload
 
-          expect(dossier.project_champs.find { _1.stable_id.to_s == prefill_text_stable_id.to_s }.value).to eq("010002699")
-          expect(dossier.project_champs.find { _1.stable_id.to_s == prefill_date_stable_id.to_s }.value).to eq("2004-12-31")
+          expect(dossier.champs.find { _1.stable_id.to_s == prefill_text_stable_id.to_s }.value).to eq("010002699")
+          expect(dossier.champs.find { _1.stable_id.to_s == prefill_date_stable_id.to_s }.value).to eq("2004-12-31")
 
           expect(page).to have_content("$.data[0].adresse_nom_voie")
           expect(page).to have_content("GEORGES GIRERD")
@@ -384,7 +384,7 @@ describe 'Referentiel API:' do
             expect(page).to have_content("Référence trouvée : PG46YY6YWCX8")
             dossier.reload
             # check prefill values in db
-            expect(dossier.project_champs_private_all.find { it.stable_id.to_s == prefill_by_public_referentiel_stable_id.to_s }.value).to eq("constructed")
+            expect(dossier.flat_champs_private.find { it.stable_id.to_s == prefill_by_public_referentiel_stable_id.to_s }.value).to eq("constructed")
           end
           click_on("Déposer le dossier")
         end
@@ -494,11 +494,11 @@ describe 'Referentiel API:' do
           dossier.reload
 
           # check civilite was prefilled with normalized value
-          civilite_champ = dossier.project_champs_public_all.find { it.stable_id.to_s == prefill_civilite_stable_id.to_s }
+          civilite_champ = dossier.flat_champs_public.find { it.stable_id.to_s == prefill_civilite_stable_id.to_s }
           expect(civilite_champ.value).to eq("M.")
 
           # check address was prefilled and resolved via BAN API
-          address_champ = dossier.project_champs_public_all.find { it.stable_id.to_s == prefill_address_stable_id.to_s }
+          address_champ = dossier.flat_champs_public.find { it.stable_id.to_s == prefill_address_stable_id.to_s }
           expect(address_champ.external_id).to eq("20 avenue de Ségur, 75007 Paris")
           expect(address_champ.value).to be_present
           expect(address_champ.value_json).to be_present
@@ -580,7 +580,7 @@ describe 'Referentiel API:' do
             expect(page).to have_content("Référence trouvée : PG46YY6YWCX8")
             dossier.reload
             # check prefill values in db
-            expect(dossier.project_champs_private_all.find { it.stable_id.to_s == prefill_by_private_referentiel_stable_id.to_s }.value).to eq("constructed")
+            expect(dossier.flat_champs_private.find { it.stable_id.to_s == prefill_by_private_referentiel_stable_id.to_s }.value).to eq("constructed")
           end
         end
       end
@@ -663,11 +663,11 @@ describe 'Referentiel API:' do
           dossier = Dossier.last
 
           # wait until selected key had been submitted to backend
-          wait_until { dossier.reload.project_champs_private_all.find(&:repetition?).rows.first.find(&:referentiel?).value&.match?(/010002699 CENTRE MEDICAL REGINA/) }
+          wait_until { dossier.reload.flat_champs_private.find(&:repetition?).rows.first.find(&:referentiel?).value&.match?(/010002699 CENTRE MEDICAL REGINA/) }
 
           # wait until refreshed with prefilled values
           expect(page).to have_content("Donnée remplie automatiquement.", count: 2)
-          expect(dossier.reload.project_champs_private_all.find(&:repetition?).rows.first.map(&:value)).to include("010002699")
+          expect(dossier.reload.flat_champs_private.find(&:repetition?).rows.first.map(&:value)).to include("010002699")
         end
       end
     end

--- a/spec/system/administrateurs/procedure_publish_spec.rb
+++ b/spec/system/administrateurs/procedure_publish_spec.rb
@@ -71,9 +71,9 @@ describe 'Publishing a procedure', js: true do
       end
 
       before do
-        drop_down = procedure.draft_revision.types_de_champ_public.find(&:any_drop_down_list?)
+        drop_down = procedure.draft_revision.root_types_de_champ_public.find(&:any_drop_down_list?)
         drop_down.update!(drop_down_options: [])
-        drop_down = procedure.draft_revision.types_de_champ_private.find(&:any_drop_down_list?)
+        drop_down = procedure.draft_revision.root_types_de_champ_private.find(&:any_drop_down_list?)
         drop_down.update!(drop_down_options: [])
       end
 

--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -54,7 +54,7 @@ describe 'As an administrateur I can edit types de champ', js: true do
     expect(page).to have_text('file.pdf')
 
     # Verify attachment is persisted in database
-    tdc = procedure.active_revision.types_de_champ_public.first
+    tdc = procedure.active_revision.root_types_de_champ_public.first
     wait_until { tdc.reload.piece_justificative_template.attached? }
     expect(tdc.piece_justificative_template).to be_attached
     expect(tdc.piece_justificative_template.filename.to_s).to eq('file.pdf')
@@ -76,7 +76,7 @@ describe 'As an administrateur I can edit types de champ', js: true do
 
       expect(page).to have_text('file.pdf')
 
-      tdc = procedure.active_revision.types_de_champ_public.first
+      tdc = procedure.active_revision.root_types_de_champ_public.first
       wait_until { tdc.reload.notice_explicative.attached? }
       expect(tdc.notice_explicative).to be_attached
 
@@ -99,7 +99,7 @@ describe 'As an administrateur I can edit types de champ', js: true do
       expect(page).to have_text('Fichier de référentiel à importer (CSV)')
 
       # Upload CSV file
-      tdc = procedure.active_revision.types_de_champ_public.first
+      tdc = procedure.active_revision.root_types_de_champ_public.first
       file_input = find("##{dom_id(tdc, :import_referentiel)}", visible: :all)
       file_input.attach_file(Rails.root.join('spec/fixtures/files/modele-import-referentiel.csv'))
 
@@ -233,10 +233,10 @@ describe 'As an administrateur I can edit types de champ', js: true do
     fill_in 'Libellé du champ', with: 'Libellé de champ carte', fill_options: { clear: :backspace }
     # Serialize before the next change event: checking a layer aborts an in-flight
     # keystroke save, so the libellé must be persisted first.
-    wait_until { procedure.active_revision.reload.types_de_champ_public.first&.libelle == 'Libellé de champ carte' }
+    wait_until { procedure.active_revision.reload.root_types_de_champ_public.first&.libelle == 'Libellé de champ carte' }
 
     check 'Cadastres'
-    wait_until { procedure.active_revision.reload.types_de_champ_public.first&.layer_enabled?(:cadastres) }
+    wait_until { procedure.active_revision.reload.root_types_de_champ_public.first&.layer_enabled?(:cadastres) }
     expect(page).to have_content('Formulaire enregistré')
 
     page.refresh
@@ -258,13 +258,13 @@ describe 'As an administrateur I can edit types de champ', js: true do
     # the next one, so the form re-render that follows a change event has fully
     # settled and the dropdown-specific fields are stable before we type into
     # them (avoids flakiness when autosaves overlap under load).
-    wait_until { procedure.active_revision.reload.types_de_champ_public.first&.drop_down_list? }
+    wait_until { procedure.active_revision.reload.root_types_de_champ_public.first&.drop_down_list? }
 
     fill_in 'Options de la liste', with: 'Un menu', fill_options: { clear: :backspace }
-    wait_until { procedure.active_revision.reload.types_de_champ_public.first.drop_down_options == ['Un menu'] }
+    wait_until { procedure.active_revision.reload.root_types_de_champ_public.first.drop_down_options == ['Un menu'] }
 
     check "Proposer une option « autre » avec un texte libre"
-    wait_until { procedure.active_revision.reload.types_de_champ_public.first.drop_down_other == "1" }
+    wait_until { procedure.active_revision.reload.root_types_de_champ_public.first.drop_down_other == "1" }
     expect(page).to have_content('Formulaire enregistré')
 
     page.refresh
@@ -312,18 +312,18 @@ describe 'As an administrateur I can edit types de champ', js: true do
     scenario 'with public tdc, having invalid order, it pops up errors summary' do
       add_champ
       select('Titre de section', from: 'Type de champ')
-      wait_until { procedure.reload.active_revision.types_de_champ_public.first&.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
-      first_header = procedure.active_revision.types_de_champ_public.first
+      wait_until { procedure.reload.active_revision.root_types_de_champ_public.first&.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
+      first_header = procedure.active_revision.root_types_de_champ_public.first
       select('Titre de niveau 1', from: dom_id(first_header, :header_section_level))
 
       within(find('.type-de-champ-add-button', match: :first)) {
         add_champ
       }
 
-      wait_until { procedure.reload.active_revision.types_de_champ_public.count == 2 }
-      second_header = procedure.active_revision.types_de_champ_public.last
+      wait_until { procedure.reload.active_revision.root_types_de_champ_public.count == 2 }
+      second_header = procedure.active_revision.root_types_de_champ_public.last
       select('Titre de section', from: dom_id(second_header, :type_champ))
-      wait_until { procedure.reload.active_revision.types_de_champ_public.last&.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
+      wait_until { procedure.reload.active_revision.root_types_de_champ_public.last&.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
       select('Titre de niveau 2', from: dom_id(second_header, :header_section_level))
 
       within(".types-de-champ-block li:first-child") do
@@ -334,7 +334,7 @@ describe 'As an administrateur I can edit types de champ', js: true do
       expect(page).to have_content("devrait être précédé d’un titre de niveau 1")
 
       # check summary refresh
-      procedure.reload.active_revision.types_de_champ_private.each do |header_section|
+      procedure.reload.active_revision.root_types_de_champ_private.each do |header_section|
         expect(page).to have_link(header_section.libelle)
       end
     end

--- a/spec/system/instructeurs/edit_dossier_spec.rb
+++ b/spec/system/instructeurs/edit_dossier_spec.rb
@@ -142,7 +142,7 @@ describe 'Editing a dossier as an instructeur:', js: true do
       expect(page).to have_button('Enregistrer les modifications', disabled: false)
 
       # adding a new attachment is buffered too
-      input_selector = "##{dossier.project_champs_public.find { _1.stable_id == 88 }.focusable_input_id}"
+      input_selector = "##{dossier.root_champs_public.find { _1.stable_id == 88 }.focusable_input_id}"
       expect(page).to have_selector(input_selector)
       find(input_selector).attach_file(Rails.root.join('spec/fixtures/files/file.pdf'))
 

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -207,7 +207,7 @@ describe 'Instructing a dossier:', js: true do
   context 'with dossiers having attached files' do
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }], instructeurs: [instructeur]) }
     let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
-    let(:champ) { dossier.project_champs_public.first }
+    let(:champ) { dossier.root_champs_public.first }
     let(:path) { 'spec/fixtures/files/piece_justificative_0.pdf' }
     let(:commentaire) { create(:commentaire, instructeur: instructeur, dossier: dossier) }
 

--- a/spec/system/instructeurs/procedure_filters_spec.rb
+++ b/spec/system/instructeurs/procedure_filters_spec.rb
@@ -4,7 +4,7 @@ describe "procedure filters" do
   let(:instructeur) { create(:instructeur) }
   let(:procedure) { create(:procedure, :published, :with_labels, types_de_champ_public:, instructeurs: [instructeur]) }
   let(:types_de_champ_public) { [{ type: :text }] }
-  let!(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }
+  let!(:type_de_champ) { procedure.active_revision.root_types_de_champ_public.first }
   let!(:new_unfollow_dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_instruction)) }
   let!(:champ) { Champ.find_by(stable_id: type_de_champ.stable_id, dossier_id: new_unfollow_dossier.id) }
   let!(:new_unfollow_dossier_2) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_instruction)) }

--- a/spec/system/instructeurs/procedure_sort_spec.rb
+++ b/spec/system/instructeurs/procedure_sort_spec.rb
@@ -10,7 +10,7 @@ describe "procedure sort", js: true do
   before do
     instructeur.follow(followed_dossier)
     instructeur.follow(followed_dossier_2)
-    followed_dossier.project_champs_public.first.update(value: '123') # touch the dossier
+    followed_dossier.root_champs_public.first.update(value: '123') # touch the dossier
 
     login_as(instructeur.user, scope: :user)
     visit instructeur_procedure_path(procedure, statut: "suivis")

--- a/spec/system/instructeurs/referentiel_prefilled_badge_spec.rb
+++ b/spec/system/instructeurs/referentiel_prefilled_badge_spec.rb
@@ -5,7 +5,7 @@ describe 'Referentiel prefilled badge', js: true do
   let(:instructeur) { create(:instructeur) }
   let(:procedure) { create(:procedure, :published, :for_individual, :with_service, types_de_champ_public: [{ type: :text, libelle: 'Nom entreprise' }]) }
   let(:dossier) { create(:dossier, :en_construction, user:, procedure:) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
 
   before do
     procedure.defaut_groupe_instructeur.add(instructeur)

--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -204,7 +204,7 @@ describe 'The routing with rules', js: true do
     click_on litteraire_user.dossiers.first.procedure.libelle, match: :first
     click_on 'Modifier le dossier'
 
-    fill_in litteraire_user.dossiers.first.project_champs_public.first.libelle, with: 'some value'
+    fill_in litteraire_user.dossiers.first.root_champs_public.first.libelle, with: 'some value'
     wait_for_autosave
 
     click_on 'Déposer les modifications'

--- a/spec/system/users/address_spec.rb
+++ b/spec/system/users/address_spec.rb
@@ -39,7 +39,7 @@ describe 'address champ', js: true do
     find('label', text: 'Je ne trouve pas mon adresse dans les suggestions').click
     select "Suisse", from: "Pays"
 
-    wait_until { user_dossier.reload.project_champs_public.first.value_json["country_code"] == "CH" }
+    wait_until { user_dossier.reload.root_champs_public.first.value_json["country_code"] == "CH" }
 
     select "France", from: "Pays"
     expect(page).to have_select("Pays", selected: 'France')
@@ -51,7 +51,7 @@ describe 'address champ', js: true do
     find('label', text: 'Je ne trouve pas mon adresse dans les suggestions').click
     select "Suisse", from: "Pays"
 
-    wait_until { user_dossier.reload.project_champs_public.first.value_json["country_code"] == "CH" }
+    wait_until { user_dossier.reload.root_champs_public.first.value_json["country_code"] == "CH" }
 
     find('label', text: 'Je ne trouve pas mon adresse dans les suggestions').click
     expect(page).to have_selector('.fr-input-group.address-ban input:enabled')

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -166,7 +166,7 @@ describe 'The user', js: true do
 
   let(:procedure_with_repetition_limited) do
     procedure = create(:procedure, :published, :for_individual, types_de_champ_public: [{ type: :repetition, libelle: 'bloc', children: [{ libelle: 'sous champ' }] }])
-    tdc = procedure.draft_revision.types_de_champ_public.first
+    tdc = procedure.draft_revision.root_types_de_champ_public.first
     tdc.update!(limit_repetitions: '1', max_repetitions: '2')
     procedure
   end
@@ -677,7 +677,7 @@ describe 'The user', js: true do
   end
 
   def champ_for(libelle)
-    champs = user_dossier.reload.project_champs_public
+    champs = user_dossier.reload.root_champs_public
     champ = champs.find { |c| c.libelle == libelle }
     champ.reload
   end

--- a/spec/system/users/date_prefill_france_connect_spec.rb
+++ b/spec/system/users/date_prefill_france_connect_spec.rb
@@ -3,7 +3,7 @@
 describe 'Prefill date champ from FranceConnect:', js: true do
   let(:user) { create(:user, france_connect_informations: [build(:france_connect_information)]) }
   let(:procedure) { create(:procedure, :published, :for_individual, :with_service, types_de_champ_public: [{ type: :date, libelle: 'Votre date de naissance' }]) }
-  let(:tdc) { procedure.active_revision.types_de_champ_public.first }
+  let(:tdc) { procedure.active_revision.root_types_de_champ_public.first }
 
   before do
     tdc.update!(options: { 'birthdate' => '1', 'prefill_with_france_connect_information' => '1' })

--- a/spec/system/users/dossier_prefill_get_spec.rb
+++ b/spec/system/users/dossier_prefill_get_spec.rb
@@ -20,7 +20,7 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
   let(:procedure) { create(:procedure, :for_individual, :published, opendata: true, types_de_champ_public:) }
   let(:dossier) { procedure.dossiers.last }
   let(:linked_dossier) { create(:dossier, :en_construction, procedure:) }
-  let(:types_de_champ) { procedure.active_revision.types_de_champ_public }
+  let(:types_de_champ) { procedure.active_revision.root_types_de_champ_public }
 
   let(:type_de_champ_text) { types_de_champ[0] }
   let(:type_de_champ_phone) { types_de_champ[1] }

--- a/spec/system/users/dossier_prefill_post_spec.rb
+++ b/spec/system/users/dossier_prefill_post_spec.rb
@@ -20,7 +20,7 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
   let(:procedure) { create(:procedure, :for_individual, :published, types_de_champ_public:) }
   let(:dossier) { procedure.dossiers.last }
   let(:linked_dossier) { create(:dossier, :en_construction, procedure:) }
-  let(:types_de_champ) { procedure.active_revision.types_de_champ_public }
+  let(:types_de_champ) { procedure.active_revision.root_types_de_champ_public }
 
   let(:type_de_champ_text) { types_de_champ[0] }
   let(:type_de_champ_phone) { types_de_champ[1] }

--- a/spec/system/users/dropdown_rebase_spec.rb
+++ b/spec/system/users/dropdown_rebase_spec.rb
@@ -12,7 +12,7 @@ describe 'Multiple dropdown after rebase removes an option', js: true do
     ])
   end
   let(:dossier) { create(:dossier, :en_construction, :with_individual, user:, procedure:) }
-  let(:stable_id) { procedure.active_revision.types_de_champ_public.first.stable_id }
+  let(:stable_id) { procedure.active_revision.root_types_de_champ_public.first.stable_id }
 
   before do
     # User had selected "Bravo" and "Charlie" before submitting
@@ -45,7 +45,7 @@ describe 'Multiple dropdown after rebase removes an option', js: true do
     expect(page).not_to have_content('« Zonage(s) » doit être dans les options proposées')
 
     # After submit, champ value contains only valid options: "Bravo" was dropped, "Alpha" was added
-    champ = dossier.reload.project_champs_public.find { _1.stable_id == stable_id }
+    champ = dossier.reload.root_champs_public.find { _1.stable_id == stable_id }
     expect(champ.selected_options).to match_array(["Alpha", "Charlie"])
   end
 end

--- a/spec/system/users/dropdown_spec.rb
+++ b/spec/system/users/dropdown_spec.rb
@@ -30,13 +30,13 @@ describe 'dropdown list with other option activated', js: true do
 
       fill_in(I18n.t('shared.champs.drop_down_list.other_label'), with: "My choice")
 
-      wait_until { user_dossier.reload.project_champs_public.first.value == "My choice" }
-      expect(user_dossier.project_champs_public.first.value).to eq("My choice")
+      wait_until { user_dossier.reload.root_champs_public.first.value == "My choice" }
+      expect(user_dossier.root_champs_public.first.value).to eq("My choice")
 
       choose "Secondary 1.1", allow_label_click: true
 
-      wait_until { user_dossier.reload.project_champs_public.first.value == "Secondary 1.1" }
-      expect(user_dossier.project_champs_public.first.value).to eq("Secondary 1.1")
+      wait_until { user_dossier.reload.root_champs_public.first.value == "Secondary 1.1" }
+      expect(user_dossier.root_champs_public.first.value).to eq("Secondary 1.1")
     end
   end
 
@@ -63,8 +63,8 @@ describe 'dropdown list with other option activated', js: true do
       select("Secondary 1.2")
       expect(page).to have_selector(".autosave-status.succeeded", visible: true)
 
-      wait_until { user_dossier.reload.project_champs_public.first.value == "Secondary 1.2" }
-      expect(user_dossier.project_champs_public.first.value).to eq("Secondary 1.2")
+      wait_until { user_dossier.reload.root_champs_public.first.value == "Secondary 1.2" }
+      expect(user_dossier.root_champs_public.first.value).to eq("Secondary 1.2")
     end
   end
 

--- a/spec/system/users/en_construction_spec.rb
+++ b/spec/system/users/en_construction_spec.rb
@@ -6,10 +6,10 @@ describe "Dossier en_construction", js: true do
   let(:dossier) { create(:dossier, :en_construction, :with_individual, :with_populated_champs, user:, procedure:) }
   let(:mandatory) { false }
   let(:types_de_champ_public) { [{ type: :piece_justificative, stable_id: 99, mandatory: }] }
-  let(:champ) { dossier.project_champs_public.find { _1.stable_id == 99 } }
+  let(:champ) { dossier.root_champs_public.find { _1.stable_id == 99 } }
 
   def user_buffer_champ
-    dossier.reload.with_update_stream(user).project_champs_public.find { _1.stable_id == 99 }
+    dossier.reload.with_update_stream(user).root_champs_public.find { _1.stable_id == 99 }
   end
 
   scenario 'delete a non mandatory piece justificative' do

--- a/spec/system/users/invite_spec.rb
+++ b/spec/system/users/invite_spec.rb
@@ -239,7 +239,7 @@ describe 'Invitations' do
 
       it "can search something inside the dossier and it displays the dossier" do
         within('.user-search-bar__form') do
-          page.find_by_id('search').set(dossier_2.project_champs_public.first.value)
+          page.find_by_id('search').set(dossier_2.root_champs_public.first.value)
           find('.fr-search-bar .fr-btn').click
         end
         expect(current_path).to eq(dossiers_path)

--- a/spec/system/users/pre_rempli_spec.rb
+++ b/spec/system/users/pre_rempli_spec.rb
@@ -8,7 +8,7 @@ describe 'Pre-rempli champ:', js: true do
   describe 'usager views a pre_rempli champ' do
     let(:procedure) { create(:procedure, :published, :for_individual, types_de_champ_public: [{ type: :pre_rempli, libelle: 'Référence interne' }]) }
     let(:dossier) { create(:dossier, :brouillon, :with_individual, user:, procedure:) }
-    let(:tdc) { procedure.active_revision.types_de_champ_public.first }
+    let(:tdc) { procedure.active_revision.root_types_de_champ_public.first }
 
     before do
       Flipper.enable(:pre_rempli_type_de_champ, procedure)
@@ -45,7 +45,7 @@ describe 'Pre-rempli champ:', js: true do
 
   describe 'pre_rempli champ via prefill URL' do
     let(:procedure) { create(:procedure, :published, :for_individual, types_de_champ_public: [{ type: :pre_rempli, libelle: 'Code projet' }]) }
-    let(:tdc) { procedure.active_revision.types_de_champ_public.first }
+    let(:tdc) { procedure.active_revision.root_types_de_champ_public.first }
 
     before do
       Flipper.enable(:pre_rempli_type_de_champ, procedure)
@@ -82,7 +82,7 @@ describe 'Pre-rempli champ:', js: true do
   describe 'instructeur views a pre_rempli champ' do
     let(:procedure) { create(:procedure, :published, :for_individual, instructeurs: [instructeur], types_de_champ_public: [{ type: :pre_rempli, libelle: 'Référence interne' }]) }
     let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure:) }
-    let(:tdc) { procedure.active_revision.types_de_champ_public.first }
+    let(:tdc) { procedure.active_revision.root_types_de_champ_public.first }
 
     before do
       Flipper.enable(:pre_rempli_type_de_champ, procedure)
@@ -101,7 +101,7 @@ describe 'Pre-rempli champ:', js: true do
   describe 'expert views a pre_rempli champ' do
     let(:procedure) { create(:procedure, :published, :for_individual, instructeurs: [instructeur], types_de_champ_public: [{ type: :pre_rempli, libelle: 'Code expert' }]) }
     let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure:) }
-    let(:tdc) { procedure.active_revision.types_de_champ_public.first }
+    let(:tdc) { procedure.active_revision.root_types_de_champ_public.first }
     let(:expert) { create(:expert) }
     let(:experts_procedure) { create(:experts_procedure, expert:, procedure:) }
     let!(:avis) { create(:avis, dossier:, claimant: instructeur, experts_procedure:) }

--- a/spec/system/users/referentiel_prefill_revert_spec.rb
+++ b/spec/system/users/referentiel_prefill_revert_spec.rb
@@ -4,7 +4,7 @@ describe 'Referentiel prefill revert', js: true do
   let(:user) { create(:user) }
   let(:procedure) { create(:procedure, :published, :for_individual, :with_service, types_de_champ_public: [{ type: :text, libelle: 'Nom entreprise' }]) }
   let(:dossier) { create(:dossier, :brouillon, user:, procedure:) }
-  let(:champ) { dossier.project_champs_public.first }
+  let(:champ) { dossier.root_champs_public.first }
 
   before { login_as user, scope: :user }
 

--- a/spec/tasks/maintenance/backfill_cloned_champs_private_piece_justificatives_task_spec.rb
+++ b/spec/tasks/maintenance/backfill_cloned_champs_private_piece_justificatives_task_spec.rb
@@ -11,8 +11,8 @@ module Maintenance
       let(:parent_dossier) { create(:dossier, procedure:) }
       let(:cloned_dossier) { create(:dossier, procedure:) }
 
-      let(:parent_champ_pj) { parent_dossier.project_champs_private.find(&:piece_justificative?) }
-      let(:cloned_champ_pj) { cloned_dossier.project_champs_private.find(&:piece_justificative?) }
+      let(:parent_champ_pj) { parent_dossier.root_champs_private.find(&:piece_justificative?) }
+      let(:cloned_champ_pj) { cloned_dossier.root_champs_private.find(&:piece_justificative?) }
 
       before do
         cloned_dossier.update(parent_dossier:) # used on factorie, does not seed private_champs..

--- a/spec/tasks/maintenance/t20250116_backfill_address_value_json_task_spec.rb
+++ b/spec/tasks/maintenance/t20250116_backfill_address_value_json_task_spec.rb
@@ -7,7 +7,7 @@ module Maintenance
     describe "#process" do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :address, libelle: 'address' }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:address_champ) { dossier.project_champs_public.first }
+      let(:address_champ) { dossier.root_champs_public.first }
       let(:address_data) { { 'address' => 'address', 'country_code' => 'FR' } }
 
       before { address_champ.update(data: address_data) }

--- a/spec/tasks/maintenance/t20250605fix_conflictual_row_id_during_mep_task_spec.rb
+++ b/spec/tasks/maintenance/t20250605fix_conflictual_row_id_during_mep_task_spec.rb
@@ -8,7 +8,7 @@ module Maintenance
       subject(:process) { described_class.process(dossier) }
       let(:procedure) { create(:procedure, types_de_champ_public: [{}]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-      let(:type_de_champ) { dossier.revision.types_de_champ_public.first }
+      let(:type_de_champ) { dossier.revision.root_types_de_champ_public.first }
 
       before {
         dossier.champ_data.create(**type_de_champ.params_for_champ.merge(row_id: 'N'))

--- a/spec/tasks/maintenance/t20250825backfill_champ_external_state_task_spec.rb
+++ b/spec/tasks/maintenance/t20250825backfill_champ_external_state_task_spec.rb
@@ -8,7 +8,7 @@ module Maintenance
         subject(:process) { described_class.process(champ) }
         let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :referentiel }]) }
         let(:dossier) { create(:dossier, procedure:) }
-        let(:champ) { dossier.project_champs_public.first }
+        let(:champ) { dossier.root_champs_public.first }
 
         context "when external_data_fetched? is true" do
           before { allow(champ).to receive(:external_data_fetched?).and_return(true) }

--- a/spec/tasks/maintenance/t20250825backfill_pj_external_state_task_spec.rb
+++ b/spec/tasks/maintenance/t20250825backfill_pj_external_state_task_spec.rb
@@ -9,7 +9,7 @@ module Maintenance
         create(:procedure, types_de_champ_public: [{ type: :piece_justificative, nature: 'rib' }])
       end
       let(:dossier) { create(:dossier, procedure:) }
-      let(:pj) { dossier.project_champs_public.first }
+      let(:pj) { dossier.root_champs_public.first }
 
       subject(:process) { described_class.process(dossier) }
 

--- a/spec/tasks/maintenance/t20251029backfill_champ_siret_external_state_task_spec.rb
+++ b/spec/tasks/maintenance/t20251029backfill_champ_siret_external_state_task_spec.rb
@@ -7,7 +7,7 @@ module Maintenance
     describe "#process" do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ) { dossier.project_champs_public.first }
+      let(:champ) { dossier.root_champs_public.first }
 
       subject(:process) { described_class.process(Champs::SiretChamp.all) }
 

--- a/spec/tasks/maintenance/t20251031backfill_missing_etablissement_task_spec.rb
+++ b/spec/tasks/maintenance/t20251031backfill_missing_etablissement_task_spec.rb
@@ -9,7 +9,7 @@ module Maintenance
 
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ) { dossier.project_champs_public.first }
+      let(:champ) { dossier.root_champs_public.first }
       let(:element) { { "champ_id" => champ.id.to_s } }
       let(:task) { described_class.new }
       let(:csv_content) do

--- a/spec/tasks/maintenance/t20251112backfill_champ_siret_external_state_with_etablissement_but_no_value_or_external_id_task_spec.rb
+++ b/spec/tasks/maintenance/t20251112backfill_champ_siret_external_state_with_etablissement_but_no_value_or_external_id_task_spec.rb
@@ -7,7 +7,7 @@ module Maintenance
     describe "#process" do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
       let(:dossier1) { create(:dossier, procedure:) }
-      let(:champ1) { dossier1.project_champs_public.first }
+      let(:champ1) { dossier1.root_champs_public.first }
       let(:etablissement1) { create(:etablissement, siret: "12345678901234") }
 
       subject(:process) { described_class.process(Champs::SiretChamp.first) }

--- a/spec/tasks/maintenance/t20251208backfill_unique_and_valid_routing_rule_in_groupe_instructeurs_task_spec.rb
+++ b/spec/tasks/maintenance/t20251208backfill_unique_and_valid_routing_rule_in_groupe_instructeurs_task_spec.rb
@@ -8,7 +8,7 @@ module Maintenance
 
     let(:procedure) { create(:procedure, routing_enabled: true, administrateur: admin) }
     let(:admin) { administrateurs(:default_admin) }
-    let(:stable_id) { procedure.published_revision.types_de_champ_public.last.stable_id }
+    let(:stable_id) { procedure.published_revision.root_types_de_champ_public.last.stable_id }
 
     before do
       procedure.draft_revision.add_type_de_champ(

--- a/spec/tasks/maintenance/t20260223normalize_drop_down_options_and_related_champs_task_spec.rb
+++ b/spec/tasks/maintenance/t20260223normalize_drop_down_options_and_related_champs_task_spec.rb
@@ -23,7 +23,7 @@ module Maintenance
             ]
           )
         end
-        let(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }
+        let(:type_de_champ) { procedure.active_revision.root_types_de_champ_public.first }
         let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
         let(:champ) { dossier.champ_data.first }
 
@@ -55,7 +55,7 @@ module Maintenance
             ]
           )
         end
-        let(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }
+        let(:type_de_champ) { procedure.active_revision.root_types_de_champ_public.first }
         let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
         let!(:champ) { dossier.champ_data.first }
 

--- a/spec/tasks/maintenance/t20260403backfill_no_ban_address_value_task_spec.rb
+++ b/spec/tasks/maintenance/t20260403backfill_no_ban_address_value_task_spec.rb
@@ -7,7 +7,7 @@ module Maintenance
     describe "#process" do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :address, libelle: 'address' }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:address_champ) { dossier.project_champs_public.first }
+      let(:address_champ) { dossier.root_champs_public.first }
 
       subject(:process) { described_class.process(address_champ) }
 

--- a/spec/tasks/maintenance/t20260623backfill_rna_external_state_task_spec.rb
+++ b/spec/tasks/maintenance/t20260623backfill_rna_external_state_task_spec.rb
@@ -9,7 +9,7 @@ module Maintenance
 
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rna }]) }
       let(:dossier) { create(:dossier, procedure:) }
-      let(:champ) { dossier.project_champs_public.first }
+      let(:champ) { dossier.root_champs_public.first }
 
       context "quand le champ est idle avec une data déjà présente" do
         before do

--- a/spec/tasks/maintenance/update_conditions_based_on_commune_or_epci_champ_task_spec.rb
+++ b/spec/tasks/maintenance/update_conditions_based_on_commune_or_epci_champ_task_spec.rb
@@ -11,10 +11,10 @@ module Maintenance
       let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :communes }, { type: :epci }, { type: :drop_down_list, libelle: 'Votre choix', options: ['Choix 1', 'Choix 2', 'Choix 3'] }, { type: :text }]) }
       let(:revision) { procedure.active_revision }
 
-      let(:text_tdc) { revision.types_de_champ_public.find(&:text?) }
-      let(:commune_tdc) { revision.types_de_champ_public.find(&:communes?) }
-      let(:epci_tdc) { revision.types_de_champ_public.find(&:epci?) }
-      let(:drop_down_list_tdc) { revision.types_de_champ_public.find(&:drop_down_list?) }
+      let(:text_tdc) { revision.root_types_de_champ_public.find(&:text?) }
+      let(:commune_tdc) { revision.root_types_de_champ_public.find(&:communes?) }
+      let(:epci_tdc) { revision.root_types_de_champ_public.find(&:epci?) }
+      let(:drop_down_list_tdc) { revision.root_types_de_champ_public.find(&:drop_down_list?) }
 
       context "with a condition based on commune and epci" do
         before { text_tdc.update(condition: ds_and([ds_eq(champ_value(commune_tdc.stable_id), constant('11')), ds_not_eq(champ_value(epci_tdc.stable_id), constant('84'))])) }

--- a/spec/tasks/maintenance/update_routing_rules_based_on_commune_or_epci_champ_task_spec.rb
+++ b/spec/tasks/maintenance/update_routing_rules_based_on_commune_or_epci_champ_task_spec.rb
@@ -10,9 +10,9 @@ module Maintenance
 
       let(:procedure) { create(:procedure, :published, :routee, types_de_champ_public: [{ type: :communes }, { type: :epci }, { type: :drop_down_list, libelle: 'Votre choix', options: ['Choix 1', 'Choix 2', 'Choix 3'] }, { type: :text }]) }
 
-      let(:commune_tdc) { procedure.active_revision.types_de_champ_public.find(&:communes?) }
-      let(:epci_tdc) { procedure.active_revision.types_de_champ_public.find(&:epci?) }
-      let(:drop_down_list_tdc) { procedure.active_revision.types_de_champ_public.find(&:drop_down_list?) }
+      let(:commune_tdc) { procedure.active_revision.root_types_de_champ_public.find(&:communes?) }
+      let(:epci_tdc) { procedure.active_revision.root_types_de_champ_public.find(&:epci?) }
+      let(:drop_down_list_tdc) { procedure.active_revision.root_types_de_champ_public.find(&:drop_down_list?) }
 
       let(:groupe_defaut) { procedure.defaut_groupe_instructeur }
 

--- a/spec/validators/types_de_champ/date_validator_spec.rb
+++ b/spec/validators/types_de_champ/date_validator_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe TypesDeChamp::DateValidator do
 
   describe "prefill_with_france_connect_information uniqueness" do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :date }, { type: :date }, { type: :text }]) }
-    let(:tdcs) { procedure.active_revision.types_de_champ_public }
+    let(:tdcs) { procedure.active_revision.root_types_de_champ_public }
 
     subject { procedure.validate(:types_de_champ_public_editor) }
 

--- a/spec/validators/types_de_champ/libelle_validator_spec.rb
+++ b/spec/validators/types_de_champ/libelle_validator_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe TypesDeChamp::LibelleValidator do
   let(:procedure) { create(:procedure, types_de_champ_public: types) }
-  let(:type_de_champ) { procedure.active_revision.types_de_champ_public.first }
+  let(:type_de_champ) { procedure.active_revision.root_types_de_champ_public.first }
 
   subject { procedure.validate(:types_de_champ_public_editor) }
 
@@ -36,7 +36,7 @@ RSpec.describe TypesDeChamp::LibelleValidator do
 
   context 'with a champ inside a repetition' do
     let(:types) { [{ type: :repetition, children: [{ type: :text }] }] }
-    let(:repetition) { procedure.active_revision.types_de_champ_public.find(&:repetition?) }
+    let(:repetition) { procedure.active_revision.root_types_de_champ_public.find(&:repetition?) }
     let(:child) { procedure.draft_revision.children_of(repetition).first }
 
     context 'when the child libelle is empty' do

--- a/spec/views/dossiers/show.pdf.prawn_spec.rb
+++ b/spec/views/dossiers/show.pdf.prawn_spec.rb
@@ -31,10 +31,10 @@ describe 'dossiers/show.pdf', type: :view do
 
     let(:dossier) do
       d = create(:dossier, :en_construction, procedure: procedure)
-      d.project_champs_public.find { _1.libelle == 'Nom' }&.update(value: 'Dupont')
-      d.project_champs_public.find { _1.libelle == 'Prénom' }&.update(value: 'Jean')
-      d.project_champs_public.find { _1.libelle == 'Email' }&.update(value: 'jean.dupont@example.fr')
-      d.project_champs_public.find { _1.libelle == 'Numéro' }&.update(value: 'AB123456')
+      d.root_champs_public.find { _1.libelle == 'Nom' }&.update(value: 'Dupont')
+      d.root_champs_public.find { _1.libelle == 'Prénom' }&.update(value: 'Jean')
+      d.root_champs_public.find { _1.libelle == 'Email' }&.update(value: 'jean.dupont@example.fr')
+      d.root_champs_public.find { _1.libelle == 'Numéro' }&.update(value: 'AB123456')
       d
     end
 
@@ -131,7 +131,7 @@ describe 'dossiers/show.pdf', type: :view do
     end
     let(:dossier) do
       d = create(:dossier, :en_construction, procedure: procedure)
-      d.project_champs_public.find { _1.stable_id == stable_id_number }&.update(value: 1)
+      d.root_champs_public.find { _1.stable_id == stable_id_number }&.update(value: 1)
       d.reload
       d
     end

--- a/spec/views/shared/dossiers/_champs.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_champs.html.haml_spec.rb
@@ -6,7 +6,7 @@ describe 'shared/dossiers/champs', type: :view do
   let(:profile) { "instructeur" }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:types_de_champ) { dossier.revision.types_de_champ_public }
+  let(:types_de_champ) { dossier.revision.root_types_de_champ_public }
 
   before do
     view.extend DossierHelper
@@ -21,12 +21,12 @@ describe 'shared/dossiers/champs', type: :view do
 
   context "there are some champs" do
     let(:types_de_champ_public) { [{ type: :checkbox }, { type: :header_section }, { type: :explication }, { type: :dossier_link }, { type: :textarea }, { type: :integer_number }] }
-    let(:champ1) { dossier.project_champs_public[0] }
-    let(:champ2) { dossier.project_champs_public[1] }
-    let(:champ3) { dossier.project_champs_public[2] }
-    let(:champ4) { dossier.project_champs_public[3] }
-    let(:champ5) { dossier.project_champs_public[4] }
-    let(:champ6) { dossier.project_champs_public[5] }
+    let(:champ1) { dossier.root_champs_public[0] }
+    let(:champ2) { dossier.root_champs_public[1] }
+    let(:champ3) { dossier.root_champs_public[2] }
+    let(:champ4) { dossier.root_champs_public[3] }
+    let(:champ5) { dossier.root_champs_public[4] }
+    let(:champ6) { dossier.root_champs_public[5] }
 
     before do
       champ1.update(value: 'true')
@@ -57,8 +57,8 @@ describe 'shared/dossiers/champs', type: :view do
 
   context "with auto-link" do
     let(:types_de_champ_public) { [{ type: :text }, { type: :textarea }] }
-    let(:champ1) { dossier.project_champs_public.first }
-    let(:champ2) { dossier.project_champs_public.second }
+    let(:champ1) { dossier.root_champs_public.first }
+    let(:champ2) { dossier.root_champs_public.second }
 
     before do
       champ1.update(value: 'https://github.com/tchak')

--- a/spec/views/shared/dossiers/_demande.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_demande.html.haml_spec.rb
@@ -48,7 +48,7 @@ describe 'shared/dossiers/demande', type: :view do
     let(:procedure) { create(:procedure, :published, :with_type_de_champ) }
 
     it 'renders the champs' do
-      dossier.project_champs_public.each do |champ|
+      dossier.root_champs_public.each do |champ|
         expect(subject).to include(champ.libelle)
       end
     end
@@ -57,7 +57,7 @@ describe 'shared/dossiers/demande', type: :view do
   context 'when a champ is freshly build' do
     let(:procedure) { create(:procedure, :published, :with_type_de_champ) }
     before do
-      dossier.project_champs_public.first.destroy
+      dossier.root_champs_public.first.destroy
     end
 
     it 'renders without error' do

--- a/spec/views/shared/dossiers/_edit.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_edit.html.haml_spec.rb
@@ -46,7 +46,7 @@ describe 'shared/dossiers/edit', type: :view do
     let(:types_de_champ_public) { [{ type: :textarea }] }
     let(:procedure) { create(:procedure, types_de_champ_public:) }
     let(:dossier) { create(:dossier, procedure:) }
-    let(:champ) { dossier.project_champs_public.first }
+    let(:champ) { dossier.root_champs_public.first }
 
     before do
       champ.update(value: 'This <strong>should be escaped</strong>')
@@ -60,7 +60,7 @@ describe 'shared/dossiers/edit', type: :view do
 
   context 'with a single-value list' do
     let(:types_de_champ_public) { [{ type: :drop_down_list, options:, mandatory: }] }
-    let(:champ) { dossier.project_champs_public.first }
+    let(:champ) { dossier.root_champs_public.first }
     let(:type_de_champ) { champ.type_de_champ }
     let(:enabled_options) { type_de_champ.drop_down_options }
     let(:mandatory) { true }

--- a/spec/views/users/dossiers/demande.html.haml_spec.rb
+++ b/spec/views/users/dossiers/demande.html.haml_spec.rb
@@ -146,7 +146,7 @@ describe 'users/dossiers/demande', type: :view do
     let(:types_de_champ_public) { [{ type: :textarea }] }
     let(:procedure) { create(:procedure, :published, types_de_champ_public:) }
     let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
-    let(:champ) { dossier.project_champs_public.first }
+    let(:champ) { dossier.root_champs_public.first }
 
     before do
       champ.update(value: '<strong>important</strong>')


### PR DESCRIPTION
Renommage mécanique, sans changement de comportement.

| Avant | Après |
|---|---|
| `ProcedureRevision#types_de_champ_public` | `root_types_de_champ_public` |
| `ProcedureRevision#types_de_champ_private` | `root_types_de_champ_private` |
| `Dossier#project_champs` | `champs` |
| `Dossier#project_champs_public` | `root_champs_public` |
| `Dossier#project_champs_private` | `root_champs_private` |
| `Dossier#project_champs_public_all` | `flat_champs_public` |
| `Dossier#project_champs_private_all` | `flat_champs_private` |

## Points d'attention pour la revue

- `Dossier` déléguait `types_de_champ_public` / `types_de_champ_private` à sa `revision` : la délégation suit le renommage de `ProcedureRevision`. C'est le seul endroit qui va un peu au-delà du renommage demandé.
- `Dossier#champs` était libre : aucune méthode ni association de ce nom (l'association est `champ_data` ; le `where(champs: {...})` est un nom de table).
- Volontairement **non** renommés, car ils ne partagent que l'orthographe : les transients de la factory `procedure`, les clés JSON de `ProcedureSerializer` (`has_many :types_de_champ_private`), les symboles de scope de validation et les clés i18n.

## Tests

`rubocop` et `haml-lint` OK. Suites models / services / graphql / components / views / validators / controllers / jobs / lib / policies / helpers / tasks / perf passantes.

Les échecs restants en local sont préexistants et sans lien avec ce renommage (vérifié en rejouant les mêmes specs sur `main` dans un workspace propre) : ils viennent tous d'un souci d'environnement sur la création des zip (`ArchiveUploader` / `File.size`) et d'appels sortants vers l'API Adresse. On s'appuie sur la CI pour confirmer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)