### PR TITLE
Tech: valider la complétude des champs via une validation ActiveRecord

### DIFF
--- a/app/models/concerns/champ_validate_concern.rb
+++ b/app/models/concerns/champ_validate_concern.rb
@@ -5,12 +5,20 @@ module ChampValidateConcern
 
   included do
     validates_with ExternalDataChampValidator, if: :validate_external_data_response?
+    validate :validate_completed, on: :champ_completeness, if: :visible?
+  end
+
+  # Overridden by champs with multi-input completeness rules (address, linked drop down)
+  def validate_completed
+    errors.add(:value, :missing) if mandatory_blank?
   end
 
   private
 
   def should_validate_in_current_context?
-    validation_context == :champ_value && visible?
+    # validation_context is an array when champs are validated for completeness
+    # ([:champ_value, :champ_completeness])
+    Array(validation_context).include?(:champ_value) && visible?
   end
 
   def validate_external_data_response?

--- a/app/models/concerns/dossier_correctable_concern.rb
+++ b/app/models/concerns/dossier_correctable_concern.rb
@@ -12,7 +12,7 @@ module DossierCorrectableConcern
 
     scope :with_pending_corrections, -> { joins(:corrections).where(corrections: { resolved_at: nil }) }
 
-    validate :validate_pending_correction, on: :champs_public_value
+    validate :validate_pending_correction, on: :champs_public_completeness
   end
 
   def flag_as_pending_correction!(commentaire, reason = nil)

--- a/app/models/concerns/dossier_validate_concern.rb
+++ b/app/models/concerns/dossier_validate_concern.rb
@@ -3,64 +3,54 @@
 module DossierValidateConcern
   extend ActiveSupport::Concern
 
+  # Autosave's _ensure_no_duplicate_errors calls errors.uniq! after validations,
+  # which would collapse same-attribute, same-type errors imported from
+  # different champs. Include the champ in the error identity to prevent that.
+  class ChampNestedError < ActiveModel::NestedError
+    protected def attributes_for_hash
+      [*super, inner_error.base]
+    end
+  end
+
   included do
     validate :validate_champs_public_value, on: :champs_public_value
     validate :validate_champs_private_value, on: :champs_private_value
+    validate :validate_champs_public_completeness, on: :champs_public_completeness
+    validate :validate_champs_private_completeness, on: :champs_private_completeness
   end
 
   def champs_public_valid?
-    validate(:champs_public_value)
-    check_mandatory_and_visible_champs_for(root_champs_public)
-    errors.blank?
+    validate(:champs_public_completeness)
   end
 
   def champs_private_valid?
-    validate(:champs_private_value)
-    check_mandatory_and_visible_champs_for(root_champs_private)
-    errors.blank?
+    validate(:champs_private_completeness)
   end
 
   private
 
   def validate_champs_public_value
-    validate_projected_champs(flat_champs_public)
+    validate_projected_champs(flat_champs_public, :champ_value)
   end
 
   def validate_champs_private_value
-    validate_projected_champs(flat_champs_private)
+    validate_projected_champs(flat_champs_private, :champ_value)
   end
 
-  def validate_projected_champs(champs)
+  def validate_champs_public_completeness
+    validate_projected_champs(flat_champs_public, [:champ_value, :champ_completeness])
+  end
+
+  def validate_champs_private_completeness
+    validate_projected_champs(flat_champs_private, [:champ_value, :champ_completeness])
+  end
+
+  # Both contexts must be validated in a single call: champ.validate clears
+  # previous errors, so a second pass would erase the first one's errors.
+  def validate_projected_champs(champs, contexts)
     champs.each do |champ|
-      next if champ.validate(:champ_value)
-      champ.errors.each { errors.import(it) }
+      next if champ.validate(contexts)
+      champ.errors.each { errors.objects.append(ChampNestedError.new(self, it)) }
     end
-  end
-
-  def check_mandatory_and_visible_champs_for(collection)
-    collection.filter(&:visible?).each do |champ|
-      if champ.mandatory_blank? && !champ.respond_to?(:validate_completed)
-        error = champ.errors.add(:value, :missing)
-        errors.import(error)
-      end
-
-      if champ.repetition?
-        champ.rows.each do |champs|
-          champs.filter(&:visible?).each do |champ|
-            if champ.respond_to?(:validate_completed)
-              champ.validate_completed
-              champ.errors.each { errors.import(it) }
-            elsif champ.mandatory_blank?
-              error = champ.errors.add(:value, :missing)
-              errors.import(error)
-            end
-          end
-        end
-      elsif champ.respond_to?(:validate_completed)
-        champ.validate_completed
-        champ.errors.each { errors.import(it) }
-      end
-    end
-    errors
   end
 end

--- a/app/validators/external_data_champ_validator.rb
+++ b/app/validators/external_data_champ_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ExternalDataChampValidator < ActiveModel::Validator
-  # Required checks are delegated to check_mandatory_and_visible_champs_public.
+  # Required checks are delegated to Champ#validate_completed (:champ_completeness context).
   def validate(record)
     if record.pending?
       # User filled the field, but background job is still running.


### PR DESCRIPTION
## Résumé

- Remplace la méthode impérative `check_mandatory_and_visible_champs_for` par une vraie validation AR sur les champs : `validate :validate_completed, on: :champ_completeness` (implémentation par défaut basée sur `mandatory_blank?`, surchargée par `AddressChamp` et `LinkedDropDownListChamp`).
- La complétude des champs publics n'est vérifiée qu'au dépôt, celle des annotations privées qu'au moment du traitement (`can_terminer?`) — comme avant, via les nouveaux contextes `:champs_public_completeness` / `:champs_private_completeness`. La page brouillon et le clonage continuent de ne valider que le format (`:champs_public_value`).
- La récursion manuelle dans les répétitions disparaît : `flat_champs_public/private` couvre déjà le même ensemble de champs, et la visibilité est gérée par champ (`visible?` / `parent_hidden?`).
- Corrige au passage un bug latent : `errors.uniq!` (autosave) fusionnait les erreurs de même attribut/type importées depuis des champs différents — une seule erreur « doit être rempli » sur deux s'affichait dans le sommaire. Corrigé via `ChampNestedError` qui inclut le champ dans l'identité de l'erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)