### PR TITLE
Tech: deleguer le casting referentiel aux PrefillTypeDeChamp

### DIFF
--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -166,13 +166,13 @@ class Champs::ReferentielChamp < Champ
     end
   end
 
-  def cast_value_for_type_de_champ(value, type_de_champ)
-    case type_de_champ.type_champ.to_sym
-    when :siret, :referentiel, :address
-      { external_id: call_caster(type_de_champ.type_champ, value, type_de_champ) }
+  def normalize_api_value(value, type_de_champ)
+    case [type_de_champ.type_champ.to_sym, value]
+    in [:drop_down_list, Array => arr] if ReferentielMappingUtils.array_of_supported_simple_types?(arr)
+      arr.first.to_s
     else
-      { value: call_caster(type_de_champ.type_champ, value, type_de_champ) }
-    end.merge(prefilled: true)
+      value
+    end
   end
 
   def cast_displayable_values(json)
@@ -233,7 +233,13 @@ class Champs::ReferentielChamp < Champ
 
   def update_prefillable_champ(type_de_champ:, raw_value:, row_id: nil)
     prefill_champ = dossier.champ_for_update(type_de_champ, row_id:, updated_by:)
-    attributes = cast_value_for_type_de_champ(raw_value, type_de_champ)
+    normalized = normalize_api_value(raw_value, type_de_champ)
+    attributes = TypesDeChamp::PrefillTypeDeChamp
+      .build(type_de_champ, dossier.revision)
+      .to_assignable_attributes(prefill_champ, normalized)
+    return prefill_champ if attributes.nil?
+
+    attributes[:prefilled] = true
     prefill_champ.update(attributes.merge(prefilled_original_value: attributes.except(:prefilled)))
     prefill_champ
   end

--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -114,8 +114,8 @@ class Champs::ReferentielChamp < Champ
     self.fetch_external_data_exceptions = []
   end
 
-  def call_caster(mapping_or_type_champ, value, type_de_champ = nil)
-    case [mapping_or_type_champ&.to_sym, value]
+  def cast_display_value(type, value)
+    case [type&.to_sym, value]
     in [:integer_number, v] if v.present?
       v.to_i
     in [:decimal_number, v] if v.present?
@@ -123,7 +123,7 @@ class Champs::ReferentielChamp < Champ
     in [:datetime, v] if DateDetectionUtils.likely_string_timestamp?(v)
       timestamp = DateDetectionUtils.convert_unix_timestamp(v)
       return nil if timestamp.nil?
-      Time.zone.at(timestamp).iso8601 # (0) # 2 digits of precision, meaning we keep the seconds and 2 digits of milliseconds
+      Time.zone.at(timestamp).iso8601
     in [:datetime, v]
       DateDetectionUtils.convert_to_iso8601_datetime(v)
     in [:date, v] if DateDetectionUtils.likely_string_timestamp?(v)
@@ -132,33 +132,10 @@ class Champs::ReferentielChamp < Champ
       Time.zone.at(timestamp).to_date.iso8601
     in [:date, v]
       DateDetectionUtils.convert_to_iso8601_date(v)
-    # cases of type from tdc, used to store in a champ
-    in [:drop_down_list, Array => arr] if ReferentielMappingUtils.array_of_supported_simple_types?(arr)
-      arr.first.to_s
-    in [:drop_down_list, v] if type_de_champ&.value_is_in_options?(v) || type_de_champ&.drop_down_other?
-      v.to_s
-    in [:multiple_drop_down_list, Array => arr] if ReferentielMappingUtils.array_of_supported_simple_types?(arr)
-      arr.compact.to_json
-    in [:checkbox | :yes_no, v]
-      bool = ActiveModel::Type::Boolean.new.cast(v)
-      bool.nil? ? nil : (bool ? Champs::BooleanChamp::TRUE_VALUE : Champs::BooleanChamp::FALSE_VALUE)
-    in [:text | :textarea | :engagement_juridique | :dossier_link | :email | :phone | :iban | :siret | :formatted | :referentiel | :pre_rempli, v]
-      v.to_s
-    # case of type from mapping, used to store for display
     in [:boolean, v]
       ActiveModel::Type::Boolean.new.cast(v)
     in [:array, Array => arr] if ReferentielMappingUtils.array_of_supported_simple_types?(arr)
       Array(arr)
-    in [:civilite, v] if v.present?
-      normalized = v.to_s.strip.downcase
-      case normalized
-      when 'm.', 'm', 'mr', 'monsieur', 'male', 'homme'
-        Individual::GENDER_MALE
-      when 'mme', 'madame', 'mlle', 'mademoiselle', 'female', 'femme'
-        Individual::GENDER_FEMALE
-      end
-    in [:address, v] if v.present?
-      v.to_s
     in [:string, v]
       v.to_s
     else
@@ -178,7 +155,7 @@ class Champs::ReferentielChamp < Champ
   def cast_displayable_values(json)
     referentiel_mapping_displayable.reduce({}) do |accu, (jsonpath, mapping)|
       json = json.first if json.is_a?(Array) # when json is an array, we take the first element
-      casted_value = call_caster(mapping[:type], JSONPathUtil.on_safe(json, jsonpath).first)
+      casted_value = cast_display_value(mapping[:type], JSONPathUtil.on_safe(json, jsonpath).first)
       accu[jsonpath] = casted_value if !casted_value.nil?
       accu
     end

--- a/app/models/types_de_champ/prefill_civilite_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_civilite_type_de_champ.rb
@@ -1,11 +1,26 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::PrefillCiviliteTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
-  CIVILITES = [Individual::GENDER_MALE, Individual::GENDER_FEMALE].freeze
+  NORMALIZE_MAP = {
+    'm.' => Individual::GENDER_MALE,
+    'm' => Individual::GENDER_MALE,
+    'mr' => Individual::GENDER_MALE,
+    'monsieur' => Individual::GENDER_MALE,
+    'male' => Individual::GENDER_MALE,
+    'homme' => Individual::GENDER_MALE,
+    'mme' => Individual::GENDER_FEMALE,
+    'madame' => Individual::GENDER_FEMALE,
+    'mlle' => Individual::GENDER_FEMALE,
+    'mademoiselle' => Individual::GENDER_FEMALE,
+    'female' => Individual::GENDER_FEMALE,
+    'femme' => Individual::GENDER_FEMALE,
+  }.freeze
 
   private
 
   def screened_value(champ, value)
-    value if value.in?(CIVILITES)
+    return nil if !value.is_a?(String)
+
+    NORMALIZE_MAP[value.strip.downcase]
   end
 end

--- a/app/models/types_de_champ/prefill_date_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_date_type_de_champ.rb
@@ -4,16 +4,36 @@ class TypesDeChamp::PrefillDateTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
   private
 
   def screened_value(champ, value)
-    return nil if !value.is_a?(String)
-
-    iso_value = if datetime?
-      DateDetectionUtils.convert_to_iso8601_datetime(value)
-    else
-      DateDetectionUtils.convert_to_iso8601_date(value)
-    end
+    iso_value = convert_value(value)
     return nil if iso_value.nil?
     return nil if DateLimitValidator.violations(iso_value, self).any?
 
     iso_value
+  end
+
+  def convert_value(value)
+    case value
+    when Numeric
+      timestamp_to_iso(value)
+    when String
+      if DateDetectionUtils.likely_string_timestamp?(value)
+        timestamp = DateDetectionUtils.convert_unix_timestamp(value)
+        timestamp_to_iso(timestamp)
+      elsif datetime?
+        DateDetectionUtils.convert_to_iso8601_datetime(value)
+      else
+        DateDetectionUtils.convert_to_iso8601_date(value)
+      end
+    end
+  end
+
+  def timestamp_to_iso(timestamp)
+    return nil if timestamp.nil?
+
+    if datetime?
+      Time.zone.at(timestamp).iso8601
+    else
+      Time.zone.at(timestamp).to_date.iso8601
+    end
   end
 end

--- a/app/models/types_de_champ/prefill_number_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_number_type_de_champ.rb
@@ -6,7 +6,13 @@ class TypesDeChamp::PrefillNumberTypeDeChamp < TypesDeChamp::PrefillTypeDeChamp
   def screened_value(champ, value)
     return nil if !scalar_prefill_value?(value)
 
-    formatted_value = NumberFormatValidator.normalize(value, decimal: decimal_number?)
+    stringified = if value.is_a?(Numeric) && integer_number?
+      value.to_i.to_s
+    else
+      value
+    end
+
+    formatted_value = NumberFormatValidator.normalize(stringified, decimal: decimal_number?)
     return nil if formatted_value.blank?
     return nil if NumberFormatValidator.violations(formatted_value, decimal: decimal_number?).any?
     return nil if NumberLimitValidator.violations(formatted_value, self).any?

--- a/spec/models/champs/referentiel_champ_cast_value_spec.rb
+++ b/spec/models/champs/referentiel_champ_cast_value_spec.rb
@@ -113,17 +113,17 @@ describe Champs::ReferentielChamp, type: :model do
 
         context 'when data is an integer' do
           let(:data) { { ok: 2 } }
-          it 'casts and updates the decimal_number with the jsonpath value as float' do
+          it 'casts and updates the decimal_number with the jsonpath value' do
             expect { subject }
-              .to change { dossier.reload.champs.find(&:decimal_number?).value }.from(nil).to("2.0")
+              .to change { dossier.reload.champs.find(&:decimal_number?).value }.from(nil).to("2")
           end
         end
 
         context 'when data is a string integer' do
           let(:data) { { ok: "2" } }
-          it 'casts and updates the decimal_number with the jsonpath value as float' do
+          it 'casts and updates the decimal_number with the jsonpath value' do
             expect { subject }
-              .to change { dossier.reload.champs.find(&:decimal_number?).value }.from(nil).to("2.0")
+              .to change { dossier.reload.champs.find(&:decimal_number?).value }.from(nil).to("2")
           end
         end
 
@@ -450,9 +450,9 @@ describe Champs::ReferentielChamp, type: :model do
 
         context 'when data contains invalid options' do
           let(:data) { { ok: ['valid', 'invalid_option'] } }
-          it 'allows invalid value due to validation afterward' do
+          it 'rejects the value when options are not all valid' do
             expect { subject }
-              .to change { dossier.reload.champs.find(&:multiple_drop_down_list?).value }.from(nil).to(['valid', 'invalid_option'].to_json)
+              .not_to change { dossier.reload.champs.find(&:multiple_drop_down_list?).value }
           end
         end
       end
@@ -544,9 +544,9 @@ describe Champs::ReferentielChamp, type: :model do
               .to change { dossier.reload.champs.find(&:address?).external_id }.from(nil).to("20 avenue de Segur Paris")
           end
 
-          it 'does not set value (stays nil until async BAN resolution)' do
+          it 'sets value (BAN resolution will overwrite later)' do
             expect { subject }
-              .not_to change { dossier.reload.champs.find(&:address?).value }
+              .to change { dossier.reload.champs.find(&:address?).value }.from(nil).to("20 avenue de Segur Paris")
           end
         end
 

--- a/spec/models/types_de_champ/prefill_civilite_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_civilite_type_de_champ_spec.rb
@@ -31,5 +31,30 @@ RSpec.describe TypesDeChamp::PrefillCiviliteTypeDeChamp do
 
       it { is_expected.to be_nil }
     end
+
+    {
+      'Monsieur' => 'M.', 'M' => 'M.', 'mr' => 'M.',
+      'male' => 'M.', 'homme' => 'M.',
+      'Madame' => 'Mme', 'mlle' => 'Mme',
+      'Mademoiselle' => 'Mme', 'female' => 'Mme', 'femme' => 'Mme',
+    }.each do |input, expected|
+      context "when the value is #{input.inspect}" do
+        let(:value) { input }
+
+        it { is_expected.to eq({ value: expected }) }
+      end
+    end
+
+    context 'when the value is blank' do
+      let(:value) { '' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the value is not a String' do
+      let(:value) { 42 }
+
+      it { is_expected.to be_nil }
+    end
   end
 end

--- a/spec/models/types_de_champ/prefill_date_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_date_type_de_champ_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe TypesDeChamp::PrefillDateTypeDeChamp do
         it { is_expected.to be_nil }
       end
 
+      context 'when the value is a unix timestamp (Integer)' do
+        let(:date) { Date.new(2025, 7, 10) }
+        let(:value) { date.to_time.to_i }
+
+        it { is_expected.to eq({ value: '2025-07-10' }) }
+      end
+
+      context 'when the value is a unix timestamp (String)' do
+        let(:date) { Date.new(2025, 7, 10) }
+        let(:value) { date.to_time.to_i.to_s }
+
+        it { is_expected.to eq({ value: '2025-07-10' }) }
+      end
+
       context 'when the type de champ expects a date in the past' do
         before { type_de_champ.date_in_past = '1' }
 
@@ -111,6 +125,27 @@ RSpec.describe TypesDeChamp::PrefillDateTypeDeChamp do
         let(:value) { { "injected" => "x" } }
 
         it { is_expected.to be_nil }
+      end
+
+      context 'when the value is a unix timestamp (Float)' do
+        let(:datetime) { Time.zone.parse('2025-07-10T14:30:00') }
+        let(:value) { datetime.to_f }
+
+        it { is_expected.to eq({ value: datetime.iso8601 }) }
+      end
+
+      context 'when the value is a unix timestamp (Integer)' do
+        let(:datetime) { Time.zone.parse('2025-07-10T14:30:00') }
+        let(:value) { datetime.to_i }
+
+        it { is_expected.to eq({ value: datetime.iso8601 }) }
+      end
+
+      context 'when the value is a unix timestamp (String)' do
+        let(:datetime) { Time.zone.parse('2025-07-10T14:30:00') }
+        let(:value) { datetime.to_f.to_s }
+
+        it { is_expected.to eq({ value: datetime.iso8601 }) }
       end
 
       context 'when the type de champ expects a date in the past' do

--- a/spec/models/types_de_champ/prefill_number_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_number_type_de_champ_spec.rb
@@ -42,10 +42,18 @@ RSpec.describe TypesDeChamp::PrefillNumberTypeDeChamp do
         it { is_expected.to eq({ value: '3000' }) }
       end
 
-      context 'when the value is a number' do
+      context 'when the value is an Integer' do
         let(:value) { 42 }
 
         it { is_expected.to eq({ value: '42' }) }
+      end
+
+      context 'when the value is a Float' do
+        let(:value) { 42.2 }
+
+        it 'truncates to integer' do
+          is_expected.to eq({ value: '42' })
+        end
       end
 
       context 'when the value is not an integer' do
@@ -119,10 +127,16 @@ RSpec.describe TypesDeChamp::PrefillNumberTypeDeChamp do
         it { is_expected.to eq({ value: '42' }) }
       end
 
-      context 'when the value is a number' do
+      context 'when the value is a Float' do
         let(:value) { 3.14 }
 
         it { is_expected.to eq({ value: '3.14' }) }
+      end
+
+      context 'when the value is an Integer' do
+        let(:value) { 2 }
+
+        it { is_expected.to eq({ value: '2' }) }
       end
 
       context 'when the value is not a number' do


### PR DESCRIPTION
# Probleme

`ReferentielChamp#call_caster` dupliquait la logique de normalisation et validation que les `PrefillTypeDeChamp` gerent deja pour le prefill URL : conversion de dates, formatting de nombres, validation d'options dropdown, normalisation de civilite, etc. Deux chemins de code distincts pour le meme objectif (caster une valeur brute vers un champ).

# Solution

Enrichir les `PrefillTypeDeChamp` pour accepter les memes inputs que les APIs referentiel, puis deleguer `update_prefillable_champ` a `PrefillTypeDeChamp#to_assignable_attributes` au lieu de `call_caster`.

**Enrichissements prefill :**
- `PrefillCiviliteTypeDeChamp` : fuzzy matching (`"monsieur"`, `"male"`, `"femme"`, etc.)
- `PrefillDateTypeDeChamp` : timestamps unix (Integer, Float, String) pour date et datetime
- `PrefillNumberTypeDeChamp` : tronquer les Float en Integer pour `integer_number`

**Swap :** `update_prefillable_champ` delegue a `PrefillTypeDeChamp.build(tdc, revision).to_assignable_attributes(champ, value)` avec une pre-normalisation `normalize_api_value` pour le cas `drop_down_list` + Array.

**Cleanup :** `call_caster` renomme en `cast_display_value`, reduit de 17 a 7 branches (seuls les types d'affichage JSONB restent).

### Changements de comportement

- `decimal_number` avec input entier : stocke `"2"` au lieu de `"2.0"`
- `multiple_drop_down_list` : rejette les valeurs hors options (screening au lieu de validation ulterieure)
- `address` : set `value` + `external_id` (la resolution BAN ecrase `value` ensuite)

Generated with [Claude Code](https://claude.com/claude-code)