### PR TITLE
ETQ usager, une condition sur une section masque aussi les champs de la section

### DIFF
--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
@@ -1,6 +1,6 @@
 <% each_champ do |champ| %>
   <% if champ.repetition? %>
-    <% types_de_champ = champ.dossier.revision.children_of(champ.type_de_champ) %>
+    <% types_de_champ = champ.type_de_champ.flat_children(champ.dossier.revision) %>
     <% champ.row_ids.each.with_index(1) do |row_id, row_number| %>
       <div class="fr-background-alt--grey fr-p-2w fr-my-3w fr-ml-2w champ-repetition">
         <%= tag.send(repetition_heading_tag, t(".repetition_heading", libelle: champ.libelle, row_number: row_number), class: "fr-h6 fr-text--bold") %>

--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
@@ -1,12 +1,19 @@
 <% each_champ do |champ| %>
   <% if champ.repetition? %>
-    <% types_de_champ = champ.type_de_champ.flat_children(champ.dossier.revision) %>
-    <% champ.row_ids.each.with_index(1) do |row_id, row_number| %>
-      <div class="fr-background-alt--grey fr-p-2w fr-my-3w fr-ml-2w champ-repetition">
-        <%= tag.send(repetition_heading_tag, t(".repetition_heading", libelle: champ.libelle, row_number: row_number), class: "fr-h6 fr-text--bold") %>
-        <%= render ViewableChamp::SectionComponent.new(dossier: champ.dossier, types_de_champ:, row_id:, demande_seen_at: seen_at, profile:) %>
-      </div>
-    <% end %>
+    <div id="<%= champ.html_id %>">
+      <% champ.rows.each do |row| %>
+        <div
+          id="<%= champ.type_de_champ.html_id(row.id) %>"
+          class="
+            fr-background-alt--grey fr-p-2w fr-my-3w fr-ml-2w
+            champ-repetition
+          "
+        >
+          <%= tag.send(repetition_heading_tag, t(".repetition_heading", libelle: champ.libelle, row_number: row.index), class: "fr-h6 fr-text--bold") %>
+          <%= render ViewableChamp::SectionComponent.new(dossier: champ.dossier, champs: row.champs, demande_seen_at: seen_at, profile:) %>
+        </div>
+      <% end %>
+    </div>
   <% else %>
     <%= render row_show_component(champ) do |c| %>
       <% if champ.blank? %>

--- a/app/components/dossiers/errors_full_messages_component.rb
+++ b/app/components/dossiers/errors_full_messages_component.rb
@@ -54,7 +54,7 @@ class Dossiers::ErrorsFullMessagesComponent < ApplicationComponent
   def is_in_fieldset?(model)
     return 0 if !model.child?
 
-    model.dossier.revision.children_of(model.parent).size > 1
+    model.parent.flat_children(model.dossier.revision).size > 1
   end
 
   def render?

--- a/app/components/dossiers/errors_full_messages_component.rb
+++ b/app/components/dossiers/errors_full_messages_component.rb
@@ -34,27 +34,27 @@ class Dossiers::ErrorsFullMessagesComponent < ApplicationComponent
   end
 
   def parent_prefix(model)
-    return "" if !model.child?
+    return "" if !model.in_repetition?
 
-    "#{[is_in_fieldset?(model) ? "[#{row_number(model)}]" : nil, model.parent.libelle].compact.join(" ")} - "
+    "#{[is_in_fieldset?(model) ? "[#{row_number(model)}]" : nil, model.repetition.libelle].compact.join(" ")} - "
   end
 
   def row_number_prefix(model)
-    return "" if !model.child? || is_in_fieldset?(model)
+    return "" if !model.in_repetition? || is_in_fieldset?(model)
 
     "[#{row_number(model)}] "
   end
 
   def row_number(model)
-    return 1 if !model.child?
+    return 1 if !model.in_repetition?
 
-    model.dossier.repetition_row_ids(model.parent).index(model.row_id) + 1
+    model.repetition.row_ids.index(model.row_id) + 1
   end
 
   def is_in_fieldset?(model)
-    return 0 if !model.child?
+    return 0 if !model.in_repetition?
 
-    model.parent.flat_children(model.dossier.revision).size > 1
+    model.repetition.type_de_champ.flat_children(model.dossier.revision).size > 1
   end
 
   def render?

--- a/app/components/editable_champ/editable_champ_base_component.rb
+++ b/app/components/editable_champ/editable_champ_base_component.rb
@@ -26,7 +26,7 @@ class EditableChamp::EditableChampBaseComponent < ApplicationComponent
   end
 
   def labelledby_id_attr(label_id = nil)
-    return {} if !@champ.child?
+    return {} if !@champ.in_repetition?
 
     { labelledby: labelledby_id(label_id) }
   end
@@ -48,7 +48,7 @@ class EditableChamp::EditableChampBaseComponent < ApplicationComponent
   private
 
   def labelledby_id(label_id = nil)
-    return nil if !@champ.child?
+    return nil if !@champ.in_repetition?
 
     labelledby = []
     # in repetition, aria_labelledby_prefix is the fieldset legend id

--- a/app/components/editable_champ/editable_champ_component.rb
+++ b/app/components/editable_champ/editable_champ_component.rb
@@ -33,7 +33,7 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
   def number_of_siblings_if_in_repetition
     return if !@champ.child?
 
-    @number_of_siblings_if_in_repetition ||= @champ.dossier.revision.children_of(@champ.parent).count
+    @number_of_siblings_if_in_repetition ||= @champ.parent.flat_children(@champ.dossier.revision).count
   end
 
   def row_number_if_in_repetition

--- a/app/components/editable_champ/editable_champ_component.rb
+++ b/app/components/editable_champ/editable_champ_component.rb
@@ -17,11 +17,11 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
   end
 
   def parent_fieldset_legend_id
-    "#{@champ.parent.html_id}-legend"
+    "#{@champ.repetition.html_id}-legend"
   end
 
   def fieldset_legend_id
-    "#{@champ.parent.html_id(@champ.row_id)}-legend"
+    "#{@champ.repetition.type_de_champ.html_id(@champ.row_id)}-legend"
   end
 
   def aria_labelledby_prefix
@@ -31,19 +31,15 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
   end
 
   def number_of_siblings_if_in_repetition
-    return if !@champ.child?
+    return if !@champ.in_repetition?
 
-    @number_of_siblings_if_in_repetition ||= @champ.parent.flat_children(@champ.dossier.revision).count
+    @number_of_siblings_if_in_repetition ||= @champ.repetition.type_de_champ.flat_children(@champ.dossier.revision).count
   end
 
   def row_number_if_in_repetition
-    return if !@champ.child? || number_of_siblings_if_in_repetition > 1
+    return if !@champ.in_repetition? || number_of_siblings_if_in_repetition > 1
 
-    @row_number_if_in_repetition ||= begin
-      parent = @champ.parent
-      row_ids = @champ.dossier.repetition_row_ids(parent)
-      row_ids.find_index(@champ.row_id)&.+ 1
-    end
+    @row_number_if_in_repetition ||= @champ.repetition.row_ids.find_index(@champ.row_id)&.+ 1
   end
 
   private

--- a/app/components/editable_champ/repetition_component.rb
+++ b/app/components/editable_champ/repetition_component.rb
@@ -14,7 +14,7 @@ class EditableChamp::RepetitionComponent < EditableChamp::EditableChampBaseCompo
   end
 
   def show_toggle_all_button?
-    @champ.dossier.revision.children_of(@champ.type_de_champ).size > 1
+    @champ.type_de_champ.flat_children(@champ.dossier.revision).size > 1
   end
 
   def aria_controls
@@ -29,7 +29,7 @@ class EditableChamp::RepetitionComponent < EditableChamp::EditableChampBaseCompo
     dossier = @champ.dossier
     return false if dossier.errors.empty?
 
-    children_types = dossier.revision.children_of(@champ.type_de_champ)
+    children_types = @champ.type_de_champ.flat_children(dossier.revision)
     public_ids = children_types.map { |tdc| tdc.public_id(row_id) }.to_set
 
     public_ids.intersect?(errors_public_ids)

--- a/app/components/editable_champ/repetition_component/repetition_component.html.erb
+++ b/app/components/editable_champ/repetition_component/repetition_component.html.erb
@@ -46,8 +46,8 @@
     id="<%= dom_id(@champ, :rows) %>"
     data-repetition-toggle-all-target="rowsContainer"
   >
-    <% @champ.row_ids.each.with_index(1) do |row_id, row_number| %>
-      <%= render EditableChamp::RepetitionRowComponent.new(form: @form, dossier: @champ.dossier, champ: @champ, row_id: row_id, row_number: row_number, seen_at: @seen_at, expanded: expand_row?(row_id, @champ.row_ids.count)) %>
+    <% @champ.rows.each do |row| %>
+      <%= render EditableChamp::RepetitionRowComponent.new(form: @form, dossier: @champ.dossier, champ: @champ, row:, seen_at: @seen_at, expanded: expand_row?(row.id, @champ.row_ids.count)) %>
     <% end %>
   </div>
 

--- a/app/components/editable_champ/repetition_row_component.rb
+++ b/app/components/editable_champ/repetition_row_component.rb
@@ -3,13 +3,14 @@
 class EditableChamp::RepetitionRowComponent < ApplicationComponent
   include ChampAriaLabelledbyHelper
 
-  def initialize(form:, dossier:, champ:, row_id:, row_number:, expanded: false, seen_at: nil)
-    @form, @dossier, @champ, @row_id, @row_number, @expanded, @seen_at = form, dossier, champ, row_id, row_number, expanded, seen_at
+  def initialize(form:, dossier:, champ:, row:, expanded: false, seen_at: nil)
+    @form, @dossier, @champ, @row, @expanded, @seen_at = form, dossier, champ, row, expanded, seen_at
     @type_de_champ = champ.type_de_champ
     @types_de_champ = @type_de_champ.flat_children(dossier.revision)
   end
 
-  attr_reader :row_id, :row_number
+  def row_id = @row.id
+  def row_number = @row.index
 
   def has_fieldset?
     @types_de_champ.size > 1
@@ -18,7 +19,7 @@ class EditableChamp::RepetitionRowComponent < ApplicationComponent
   private
 
   def section_component
-    EditableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: @types_de_champ, row_id:, row_number: @row_number)
+    EditableChamp::SectionComponent.new(dossier: @dossier, champs: @row.champs, row_number:)
   end
 
   def delete_button

--- a/app/components/editable_champ/repetition_row_component.rb
+++ b/app/components/editable_champ/repetition_row_component.rb
@@ -6,7 +6,7 @@ class EditableChamp::RepetitionRowComponent < ApplicationComponent
   def initialize(form:, dossier:, champ:, row_id:, row_number:, expanded: false, seen_at: nil)
     @form, @dossier, @champ, @row_id, @row_number, @expanded, @seen_at = form, dossier, champ, row_id, row_number, expanded, seen_at
     @type_de_champ = champ.type_de_champ
-    @types_de_champ = dossier.revision.children_of(@type_de_champ)
+    @types_de_champ = @type_de_champ.flat_children(dossier.revision)
   end
 
   attr_reader :row_id, :row_number

--- a/app/components/editable_champ/section_component.rb
+++ b/app/components/editable_champ/section_component.rb
@@ -2,34 +2,30 @@
 
 class EditableChamp::SectionComponent < ApplicationComponent
   include ApplicationHelper
-  include TreeableConcern
 
-  def initialize(dossier:, types_de_champ: nil, header_section: nil, row_id: nil, row_number: nil)
-    @dossier, @header_section, @row_id, @row_number = dossier, header_section, row_id, row_number
-    @nodes = types_de_champ ? to_tree_roots(types_de_champ:) : header_section.children(dossier.revision)
+  def initialize(dossier:, champs:, header_section: nil, row_number: nil)
+    @dossier, @champs, @header_section, @row_number = dossier, champs, header_section, row_number
   end
+
+  attr_reader :header_section
 
   def render_within_fieldset?
-    @header_section.present?
-  end
-
-  def header_section
-    @dossier.project_champ(@header_section, row_id: @row_id) if @header_section
+    header_section.present?
   end
 
   def splitted_tail
-    @nodes.map { split_section_champ(it) }
+    @champs.map { split_section_champ(it) }
   end
 
   def tag_for_depth
     "h#{header_section.level + 1}"
   end
 
-  def split_section_champ(type_de_champ)
-    if type_de_champ.header_section?
-      [EditableChamp::SectionComponent.new(dossier: @dossier, header_section: type_de_champ, row_id: @row_id), nil]
+  def split_section_champ(champ)
+    if champ.header_section?
+      [EditableChamp::SectionComponent.new(dossier: @dossier, champs: champ.children, header_section: champ), nil]
     else
-      [nil, @dossier.project_champ(type_de_champ, row_id: @row_id)]
+      [nil, champ]
     end
   end
 end

--- a/app/components/editable_champ/section_component.rb
+++ b/app/components/editable_champ/section_component.rb
@@ -4,54 +4,32 @@ class EditableChamp::SectionComponent < ApplicationComponent
   include ApplicationHelper
   include TreeableConcern
 
-  def initialize(dossier:, nodes: nil, types_de_champ: nil, row_id: nil, row_number: nil)
-    nodes ||= to_tree(types_de_champ:)
-    @dossier = dossier
-    @row_id = row_id
-    @row_number = row_number
-    @nodes = to_fieldset(nodes:)
+  def initialize(dossier:, types_de_champ: nil, header_section: nil, row_id: nil, row_number: nil)
+    @dossier, @header_section, @row_id, @row_number = dossier, header_section, row_id, row_number
+    @nodes = types_de_champ ? to_tree_roots(types_de_champ:) : header_section.children(dossier.revision)
   end
 
   def render_within_fieldset?
-    first_champ_is_an_header_section?
+    @header_section.present?
   end
 
   def header_section
-    node = @nodes.first
-    @dossier.project_champ(node, row_id: @row_id) if node.is_a?(TypeDeChamp) && node.header_section?
+    @dossier.project_champ(@header_section, row_id: @row_id) if @header_section
   end
 
   def splitted_tail
-    tail.map { split_section_champ(_1) }
-  end
-
-  def tail
-    return @nodes if !first_champ_is_an_header_section?
-    _, *rest_of_champ = @nodes
-
-    rest_of_champ
+    @nodes.map { split_section_champ(it) }
   end
 
   def tag_for_depth
     "h#{header_section.level + 1}"
   end
 
-  def split_section_champ(node)
-    case node
-    when EditableChamp::SectionComponent
-      [node, nil]
+  def split_section_champ(type_de_champ)
+    if type_de_champ.header_section?
+      [EditableChamp::SectionComponent.new(dossier: @dossier, header_section: type_de_champ, row_id: @row_id), nil]
     else
-      [nil, @dossier.project_champ(node, row_id: @row_id)]
+      [nil, @dossier.project_champ(type_de_champ, row_id: @row_id)]
     end
-  end
-
-  private
-
-  def to_fieldset(nodes:)
-    nodes.map { _1.is_a?(Array) ? EditableChamp::SectionComponent.new(dossier: @dossier, nodes: _1, row_id: @row_id) : _1 }
-  end
-
-  def first_champ_is_an_header_section?
-    header_section.present?
   end
 end

--- a/app/components/manager/dossier_champ_row_component.rb
+++ b/app/components/manager/dossier_champ_row_component.rb
@@ -33,13 +33,13 @@ class Manager::DossierChampRowComponent < ApplicationComponent
     class_names(
       'cell-data': true,
       'cell-disabled': !row.visible?,
-      'fr-pl-16v': cell == :label && row.child?
+      'fr-pl-16v': cell == :label && row.in_repetition?
     )
   end
 
   def nested_rows
     if row.respond_to?(:rows)
-      row.rows
+      row.rows.map(&:flat_champs)
     else
       []
     end

--- a/app/components/types_de_champ_editor/header_sections_summary_component.rb
+++ b/app/components/types_de_champ_editor/header_sections_summary_component.rb
@@ -6,17 +6,28 @@ class TypesDeChampEditor::HeaderSectionsSummaryComponent < ApplicationComponent
     @is_private = is_private
   end
 
-  def header_sections
-    coordinates = if @is_private
-      @procedure.draft_revision.revision_types_de_champ_private
-    else
-      @procedure.draft_revision.revision_types_de_champ_public
-    end
-
-    coordinates.filter { _1.type_de_champ.header_section? }
+  # Header sections and repetitions in document order, as [type_de_champ, depth]
+  # pairs. Depth is the position in the tree; like TypeDeChampBase#level, it
+  # can differ from the stored header_section_level when levels are skipped.
+  def sections
+    @sections ||= flatten_sections(root_types_de_champ, 1)
   end
 
-  def href(header_section) # used by type de champ editor to anchor elements
-    "##{dom_id(header_section, :type_de_champ_editor)}"
+  def href(type_de_champ) # used by type de champ editor to anchor elements
+    "##{dom_id(revision.coordinate_for(type_de_champ), :type_de_champ_editor)}"
+  end
+
+  private
+
+  def revision = @procedure.draft_revision
+
+  def root_types_de_champ
+    @is_private ? revision.types_de_champ_private : revision.types_de_champ_public
+  end
+
+  def flatten_sections(types_de_champ, depth)
+    types_de_champ.filter { it.header_section? || it.repetition? }.flat_map do |type_de_champ|
+      [[type_de_champ, depth], *flatten_sections(type_de_champ.children(revision), depth + 1)]
+    end
   end
 end

--- a/app/components/types_de_champ_editor/header_sections_summary_component/header_sections_summary_component.html.haml
+++ b/app/components/types_de_champ_editor/header_sections_summary_component/header_sections_summary_component.html.haml
@@ -1,11 +1,10 @@
-#summary{ class: header_sections.present? ? 'fr-col-12 fr-col-md-3' : '' }
-  - if header_sections.present?
+#summary{ class: sections.present? ? 'fr-col-12 fr-col-md-3' : '' }
+  - if sections.present?
     %nav.fr-sidemenu.sticky.fr-hidden.fr-unhidden-md{ "aria-labelledby" => "fr-summary-title", role: "navigation" }
       %ul.fr-sidemenu__list
-        - header_sections.each do |header|
+        - sections.each do |type_de_champ, level|
           %li.fr-sidemenu__item
-            - level = header.type_de_champ.header_section_level_value.to_i
             - if level == 1
-              %a.fr-sidemenu__link{ href: href(header) }= header.libelle
+              %a.fr-sidemenu__link{ href: href(type_de_champ) }= type_de_champ.libelle
             - else
-              %a.fr-sidemenu__link{ class: level >= 3 ? 'custom-link-grey': '', href: href(header) }= "-- #{header.libelle}"
+              %a.fr-sidemenu__link{ class: level >= 3 ? 'custom-link-grey': '', href: href(type_de_champ) }= "-- #{type_de_champ.libelle}"

--- a/app/components/viewable_champ/header_sections_summary_component.rb
+++ b/app/components/viewable_champ/header_sections_summary_component.rb
@@ -1,22 +1,45 @@
 # frozen_string_literal: true
 
 class ViewableChamp::HeaderSectionsSummaryComponent < ApplicationComponent
-  attr_reader :header_sections
+  Entry = Data.define(:libelle, :anchor_id, :level)
 
   def initialize(dossier:, is_private:)
     @dossier = dossier
     @is_private = is_private
-
-    @header_sections = if is_private
-      dossier.revision.root_types_de_champ_private
-    else
-      dossier.revision.root_types_de_champ_public
-    end.filter(&:header_section?)
   end
 
-  def render? = header_sections.any?
+  # Visible header sections, repetitions and their rows in document order.
+  # Sections hidden by a condition are excluded.
+  def sections
+    @sections ||= flatten_sections(root_champs, 1)
+  end
 
-  def href(header_section) # used by viewable champs to anchor elements
-    "##{header_section.html_id}"
+  def render? = sections.any?
+
+  private
+
+  def root_champs
+    @is_private ? @dossier.champs_private : @dossier.champs_public
+  end
+
+  def flatten_sections(champs, depth)
+    champs.filter { (it.header_section? || it.repetition?) && it.visible? }.flat_map do |champ|
+      children = if champ.header_section?
+        flatten_sections(champ.children, depth + 1)
+      else
+        row_entries(champ, depth + 1)
+      end
+      [Entry.new(libelle: champ.libelle, anchor_id: champ.html_id, level: depth), *children]
+    end
+  end
+
+  # Each row of a repetition is listed with its own sections beneath it.
+  def row_entries(champ, depth)
+    champ.rows.flat_map do |row|
+      [
+        Entry.new(libelle: "#{champ.libelle} #{row.index}", anchor_id: champ.type_de_champ.html_id(row.id), level: depth),
+        *flatten_sections(row.champs, depth + 1),
+      ]
+    end
   end
 end

--- a/app/components/viewable_champ/header_sections_summary_component/header_sections_summary_component.html.haml
+++ b/app/components/viewable_champ/header_sections_summary_component/header_sections_summary_component.html.haml
@@ -1,10 +1,9 @@
 #summary.fr-col-12.fr-col-xl-3
   %nav.fr-sidemenu.sticky.fr-hidden.fr-unhidden-xl{ "aria-labelledby" => "fr-summary-title", role: "navigation" }
     %ul.fr-sidemenu__list
-      - header_sections.each do |header_section|
+      - sections.each do |section|
         %li.fr-sidemenu__item
-          - level = header_section.header_section_level_value.to_i
-          - if level == 1
-            %a.fr-sidemenu__link{ href: href(header_section) }= header_section.libelle
+          - if section.level == 1
+            %a.fr-sidemenu__link{ href: "##{section.anchor_id}" }= section.libelle
           - else
-            %a.fr-sidemenu__link{ class: level >= 3 ? 'custom-link-grey': '', href: href(header_section) }= "-- #{header_section.libelle}"
+            %a.fr-sidemenu__link{ class: section.level >= 3 ? 'custom-link-grey': '', href: "##{section.anchor_id}" }= "-- #{section.libelle}"

--- a/app/components/viewable_champ/section_component.rb
+++ b/app/components/viewable_champ/section_component.rb
@@ -2,38 +2,25 @@
 
 class ViewableChamp::SectionComponent < ApplicationComponent
   include ApplicationHelper
-  include TreeableConcern
 
-  def initialize(dossier:, nodes: nil, types_de_champ: nil, row_id: nil, demande_seen_at:, profile:)
-    @dossier, @demande_seen_at, @profile, @row_id = dossier, demande_seen_at, profile, row_id
-    nodes ||= to_tree(types_de_champ:)
-    @nodes = to_sections(nodes:)
+  def initialize(dossier:, champs:, header_section: nil, demande_seen_at:, profile:)
+    @dossier, @header_section = dossier, header_section
+    @demande_seen_at, @profile = demande_seen_at, profile
+    @section_champs, @champs = champs.partition(&:header_section?)
   end
 
   private
+
+  attr_reader :header_section, :champs
 
   def section_id
     @section_id ||= header_section ? dom_id(header_section, :content) : SecureRandom.uuid
   end
 
-  def header_section
-    node = @nodes.first
-    @dossier.project_champ(node, row_id: @row_id) if node.is_a?(TypeDeChamp) && node.header_section?
-  end
-
-  def champs
-    tail.filter_map { _1.is_a?(TypeDeChamp) ? @dossier.project_champ(_1, row_id: @row_id) : nil }
-  end
-
   def sections
-    tail.filter { _1.is_a?(ViewableChamp::SectionComponent) }
-  end
-
-  def tail
-    return @nodes if header_section.nil?
-    _, *rest_of_champ = @nodes
-
-    rest_of_champ
+    @sections ||= @section_champs.map do |champ|
+      ViewableChamp::SectionComponent.new(dossier: @dossier, champs: champ.children, header_section: champ, demande_seen_at: @demande_seen_at, profile: @profile)
+    end
   end
 
   def reset_tag_for_depth
@@ -52,11 +39,5 @@ class ViewableChamp::SectionComponent < ApplicationComponent
     relative_level = header_section ? header_section.level : 1
     # there are 2 levels of heading before the repetition heading
     [relative_level + 2, 6].min
-  end
-
-  private
-
-  def to_sections(nodes:)
-    nodes.map { _1.is_a?(Array) ? ViewableChamp::SectionComponent.new(dossier: @dossier, nodes: _1, demande_seen_at: @demande_seen_at, profile: @profile, row_id: @row_id) : _1 }
   end
 end

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -103,7 +103,7 @@ module Administrateurs
     end
 
     def create
-      new_procedure_params = { max_duree_conservation_dossiers_dans_ds: Expired::DEFAULT_DOSSIER_RENTENTION_IN_MONTH, no_gender: true }
+      new_procedure_params = { max_duree_conservation_dossiers_dans_ds: Expired::DEFAULT_DOSSIER_RENTENTION_IN_MONTH, no_gender: true, section_conditions_hide_champs: true }
         .merge(procedure_params)
         .merge(administrateurs: [current_administrateur])
 

--- a/app/controllers/champs/repetition_controller.rb
+++ b/app/controllers/champs/repetition_controller.rb
@@ -2,9 +2,9 @@
 
 class Champs::RepetitionController < Champs::ChampController
   def add
-    @row_id = @champ.add_row(updated_by: current_user.email)
+    row_id = @champ.add_row(updated_by: current_user.email)
+    @row = @champ.rows.find { it.id == row_id }
     @first_champ_id = @champ.focusable_input_id
-    @row_number = @row_id.nil? ? 0 : @champ.row_ids.find_index(@row_id) + 1
     @champ.update_timestamps
   end
 

--- a/app/controllers/concerns/turbo_champs_concern.rb
+++ b/app/controllers/concerns/turbo_champs_concern.rb
@@ -22,7 +22,7 @@ module TurboChampsConcern
   end
 
   def champs_to_toggle(champs, to_update)
-    champs.filter { it.conditional? || it.child? }
+    champs.filter { it.conditional? || it.in_repetition? }
       .partition(&:visible?)
       .map { champs_to_one_selector(it - to_update) }
   end

--- a/app/controllers/concerns/turbo_champs_concern.rb
+++ b/app/controllers/concerns/turbo_champs_concern.rb
@@ -22,7 +22,7 @@ module TurboChampsConcern
   end
 
   def champs_to_toggle(champs, to_update)
-    champs.filter { it.conditional? || it.in_repetition? }
+    champs.filter(&:conditional_visibility?)
       .partition(&:visible?)
       .map { champs_to_one_selector(it - to_update) }
   end

--- a/app/graphql/types/champs/descriptor/header_section_champ_descriptor_type.rb
+++ b/app/graphql/types/champs/descriptor/header_section_champ_descriptor_type.rb
@@ -7,7 +7,7 @@ module Types::Champs::Descriptor
     field :level, Int, null: false
 
     def level
-      object.type_de_champ.level_for_revision(object.revision)
+      object.type_de_champ.level(object.revision)
     end
   end
 end

--- a/app/graphql/types/champs/repetition_champ_type.rb
+++ b/app/graphql/types/champs/repetition_champ_type.rb
@@ -13,7 +13,7 @@ module Types::Champs
     field :rows, [Row], null: false
 
     def champs
-      object.rows.flat_map { _1.filter(&:visible?) }
+      object.rows.flat_map { it.flat_champs.filter(&:visible?) }
     end
 
     def rows
@@ -21,8 +21,8 @@ module Types::Champs
         .rows
         .map do
           {
-            id: GraphQL::Schema::UniqueWithinType.encode('Row', _1.first.row_id),
-            champs: _1.filter(&:visible?),
+            id: GraphQL::Schema::UniqueWithinType.encode('Row', it.id),
+            champs: it.flat_champs.filter(&:visible?),
           }
         end
     end

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -32,6 +32,10 @@ class ChampData < ApplicationRecord
 
   attr_readonly :stable_id
 
+  # inverse_of stays disabled: the projection system builds transient champs
+  # with `dossier: self`, and an inverse would register them (and autosave
+  # them) into the loaded champ_data association. Reads share the dossier
+  # instance via DossierChampsConcern#champ_data_on_stream instead.
   belongs_to :dossier, inverse_of: false, touch: true, optional: false
   has_many_attached :piece_justificative_file
 

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -81,7 +81,6 @@ class ChampData < ApplicationRecord
     :collapsible_explanation_enabled?,
     :collapsible_explanation_text,
     :header_section_level_value,
-    :current_section_level,
     :non_fillable?,
     :fillable?,
     :mandatory?,
@@ -155,7 +154,7 @@ class ChampData < ApplicationRecord
   def parent
     return nil if row_id.blank?
 
-    dossier.revision.parent_of(type_de_champ)
+    dossier.revision.repetition_of(type_de_champ)
   end
 
   def row?

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -147,15 +147,18 @@ class ChampData < ApplicationRecord
     data&.dig("prefilled_from_france_connect_information") == true
   end
 
-  def child?
-    row_id.present? && !is_type?(TypeDeChamp.type_champs.fetch(:repetition))
+  # Sections and repetitions above this champ in the tree, outermost first.
+  # Ancestors inside the repetition share the champ's row_id.
+  def ancestors
+    type_de_champ.ancestors(dossier.revision).map { project_ancestor(it) }
   end
 
-  def parent
-    return nil if row_id.blank?
+  def parent = project_ancestor(type_de_champ.parent(dossier.revision))
+  def section = project_ancestor(type_de_champ.section(dossier.revision))
+  def repetition = project_ancestor(type_de_champ.repetition(dossier.revision))
 
-    dossier.revision.repetition_of(type_de_champ)
-  end
+  def in_repetition? = repetition.present?
+  def in_section? = section.present?
 
   def row?
     row_id.present? && is_type?(TypeDeChamp.type_champs.fetch(:repetition))
@@ -357,6 +360,14 @@ class ChampData < ApplicationRecord
   end
 
   private
+
+  # Ancestors inside the champ's repetition are projected on its row.
+  def project_ancestor(ancestor_type_de_champ)
+    return if ancestor_type_de_champ.nil?
+
+    row = ancestor_type_de_champ.in_repetition?(dossier.revision) ? row_id : nil
+    dossier.project_champ(ancestor_type_de_champ, row_id: row)
+  end
 
   def nullify_blank_json_columns
     [:value_json, :data].each do |column|

--- a/app/models/champ_presentations/repetition_presentation.rb
+++ b/app/models/champ_presentations/repetition_presentation.rb
@@ -10,8 +10,8 @@ class ChampPresentations::RepetitionPresentation < ChampPresentations::BasePrese
   end
 
   def to_s
-    ([libelle] + rows.map do |champs|
-      champs.map do |champ|
+    ([libelle] + rows.map do |row|
+      row.flat_champs.map do |champ|
         "#{champ.libelle} : #{champ}"
       end.join("\n")
     end).join("\n\n")
@@ -21,13 +21,13 @@ class ChampPresentations::RepetitionPresentation < ChampPresentations::BasePrese
     {
       type: 'orderedList',
       attrs: { class: 'tdc-repetition' },
-      content: rows.map do |champs|
+      content: rows.map do |row|
         {
           type: 'listItem',
           content: [
             {
               type: 'descriptionList',
-              content: champs.map do |champ|
+              content: row.flat_champs.map do |champ|
                 [
                   {
                     type: 'descriptionTerm',

--- a/app/models/champs/header_section_champ.rb
+++ b/app/models/champs/header_section_champ.rb
@@ -6,6 +6,6 @@ class Champs::HeaderSectionChamp < ChampData
   end
 
   def level
-    type_de_champ.level_for_revision(dossier.revision)
+    type_de_champ.level(dossier.revision)
   end
 end

--- a/app/models/champs/header_section_champ.rb
+++ b/app/models/champs/header_section_champ.rb
@@ -8,4 +8,16 @@ class Champs::HeaderSectionChamp < ChampData
   def level
     type_de_champ.level(dossier.revision)
   end
+
+  # Direct children of the section, as projected champs (sharing the section's
+  # row_id when the section is inside a repetition).
+  def children
+    type_de_champ.children(dossier.revision).map { dossier.project_champ(it, row_id:) }
+  end
+
+  # Every champ below the section in document order, as projected champs; a
+  # nested repetition is a boundary (included, its rows' content excluded).
+  def flat_children
+    type_de_champ.flat_children(dossier.revision).map { dossier.project_champ(it, row_id:) }
+  end
 end

--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -62,7 +62,7 @@ class Champs::ReferentielChamp < ChampData
       dossier.root_champs_private
     end.filter do |champ|
       if champ.repetition?
-        dossier.revision.children_of(champ.type_de_champ).any? { _1.stable_id.in?(elligible_stable_ids) }
+        champ.type_de_champ.flat_children(dossier.revision).any? { it.stable_id.in?(elligible_stable_ids) }
       else
         champ.stable_id.in?(elligible_stable_ids)
       end
@@ -87,7 +87,7 @@ class Champs::ReferentielChamp < ChampData
       .transform_values do |mapping|
         types_de_champ_by_stable_id[mapping[:prefill_stable_id].to_i]
       end.compact.group_by do |_, type_de_champ|
-        dossier.revision.parent_of(type_de_champ)
+        type_de_champ.repetition(dossier.revision)
       end.flat_map do |repetition_type_de_champ, mappings|
         if repetition_type_de_champ.present?
           update_repetition_prefillable_champs(data, repetition_type_de_champ, mappings)
@@ -190,7 +190,7 @@ class Champs::ReferentielChamp < ChampData
     # When referentiel champ is inside a repetition, use current row_id to keep related data together.
     # When outside, create new rows for each array element from external data.
     # Note: Limited to updating current row only when inside repetition.
-    if type_de_champ.child?(dossier.revision)
+    if type_de_champ.in_repetition?(dossier.revision)
       self.row_id
     else
       dossier.repetition_add_row(repetition_type_de_champ, updated_by:)

--- a/app/models/champs/repetition_champ.rb
+++ b/app/models/champs/repetition_champ.rb
@@ -4,7 +4,7 @@ class Champs::RepetitionChamp < ChampData
   delegate :libelle_for_export, to: :type_de_champ
 
   def row_libelle
-    children_types = dossier.revision.children_of(type_de_champ)
+    children_types = type_de_champ.flat_children(dossier.revision)
     if children_types.size == 1
       children_types.first.libelle
     else

--- a/app/models/champs/repetition_champ.rb
+++ b/app/models/champs/repetition_champ.rb
@@ -29,7 +29,7 @@ class Champs::RepetitionChamp < ChampData
   end
 
   def focusable_input_id(attribute = :value)
-    rows.last&.first&.focusable_input_id(attribute)
+    rows.last&.flat_champs&.first&.focusable_input_id(attribute)
   end
 
   def discarded?
@@ -58,7 +58,7 @@ class Champs::RepetitionChamp < ChampData
     return if !type_de_champ.limit_repetitions?
     # Only skip validation when no rows have been filled AND no minimum is required.
     # When a minimum is configured, always validate so that submitting with 0 rows is caught.
-    return if type_de_champ.min_repetitions.blank? && rows.none? { |row| row.any? { _1.value.present? } }
+    return if type_de_champ.min_repetitions.blank? && rows.none? { |row| row.flat_champs.any? { it.value.present? } }
 
     count = row_ids.count
     min = type_de_champ.min_repetitions.to_i
@@ -70,27 +70,6 @@ class Champs::RepetitionChamp < ChampData
 
     if type_de_champ.max_repetitions.present? && count > max
       errors.add(:value, :repetition_too_many, max: max, libelle: type_de_champ.libelle)
-    end
-  end
-
-  class Row < Hashie::Dash
-    property :index
-    property :row_id
-    property :dossier
-
-    def dossier_id
-      dossier.id.to_s
-    end
-
-    def read_attribute_for_serialization(attribute)
-      self[attribute]
-    end
-
-    def spreadsheet_columns(types_de_champ, export_template: nil, format:)
-      [
-        ['Dossier ID', :dossier_id],
-        ['Ligne', :index],
-      ] + dossier.champ_values_for_export(types_de_champ, row_id:, export_template:, format:)
     end
   end
 end

--- a/app/models/changed_column.rb
+++ b/app/models/changed_column.rb
@@ -19,7 +19,7 @@ class ChangedColumn
       revision.root_types_de_champ_public.flat_map do |type_de_champ|
         if type_de_champ.repetition?
           prefix = type_de_champ.libelle
-          types_de_champ = revision.children_of(type_de_champ)
+          types_de_champ = type_de_champ.flat_children(revision)
           row_ids.flat_map do |row_id|
             types_de_champ.filter_map do |type_de_champ|
               public_id = type_de_champ.public_id(row_id)

--- a/app/models/concerns/champ_conditional_concern.rb
+++ b/app/models/concerns/champ_conditional_concern.rb
@@ -11,16 +11,37 @@ module ChampConditionalConcern
     dossier.revision.dependent_conditions(type_de_champ).any?
   end
 
+  def section_conditions_hide_champs?
+    dossier.procedure.section_conditions_hide_champs?
+  end
+
+  # visibility can vary with form data (own condition, repetition membership,
+  # or a conditional ancestor section)
+  def conditional_visibility?
+    conditional? || in_repetition? || (section_conditions_hide_champs? && ancestors.any?(&:conditional?))
+  end
+
   def visible?
     # Huge gain perf for cascade conditions
     return @visible if instance_variable_defined? :@visible
 
-    return false if parent_hidden?
+    # a section condition targeting a champ inside the section itself creates
+    # a cycle (invalid draft config, reachable until publication); treat the
+    # in-progress champ as hidden, so the broken condition computes to nil and
+    # the section stays hidden
+    return false if @visible_computing
 
-    @visible = if conditional?
-      type_de_champ.condition.compute(champs_for_condition)
-    else
-      true
+    @visible_computing = true
+    begin
+      return false if parent_hidden?
+
+      @visible = if conditional?
+        type_de_champ.condition.compute(champs_for_condition)
+      else
+        true
+      end
+    ensure
+      @visible_computing = false
     end
   end
 
@@ -51,11 +72,18 @@ module ChampConditionalConcern
   end
 
   def parent_hidden?
-    # if there is no row_id, it always has been a root champ
-    return false if !in_repetition?
+    if section_conditions_hide_champs?
+      # hidden as soon as the nearest ancestor (section or repetition) is
+      # hidden; the parent's own visible? recurses up the ancestor chain
+      parent.present? && !parent.visible?
+    else
+      # legacy: only the repetition ancestor can hide a champ
+      # if there is no row_id, it always has been a root champ
+      return false if !in_repetition?
 
-    # otherwise maybe the champ has been moved outside a repetition
-    parent = repetition
-    parent.present? && !parent.visible?
+      # otherwise maybe the champ has been moved outside a repetition
+      parent = repetition
+      parent.present? && !parent.visible?
+    end
   end
 end

--- a/app/models/concerns/champ_conditional_concern.rb
+++ b/app/models/concerns/champ_conditional_concern.rb
@@ -52,16 +52,10 @@ module ChampConditionalConcern
 
   def parent_hidden?
     # if there is no row_id, it always has been a root champ
-    return false if !child?
+    return false if !in_repetition?
 
     # otherwise maybe the champ has been moved outside a repetition
-    parent_tdc = dossier.revision.repetition_of(type_de_champ)
-
-    return false if parent_tdc.nil?
-
-    parent = dossier.champs
-      .find { it.type_de_champ == parent_tdc }
-
-    !parent.visible?
+    parent = repetition
+    parent.present? && !parent.visible?
   end
 end

--- a/app/models/concerns/champ_conditional_concern.rb
+++ b/app/models/concerns/champ_conditional_concern.rb
@@ -55,7 +55,7 @@ module ChampConditionalConcern
     return false if !child?
 
     # otherwise maybe the champ has been moved outside a repetition
-    parent_tdc = dossier.revision.parent_of(type_de_champ)
+    parent_tdc = dossier.revision.repetition_of(type_de_champ)
 
     return false if parent_tdc.nil?
 

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -7,10 +7,7 @@ module DossierChampsConcern
     check_valid_row_id_on_read?(type_de_champ, row_id)
     data = champ_data_by_public_id[type_de_champ.public_id(row_id)]
     if data.nil? || !data.is_type?(type_de_champ.type_champ)
-      value = type_de_champ.champ_blank?(data) ? nil : data.value
-      updated_at = data&.updated_at || depose_at || created_at
-      rebased_at = data&.rebased_at
-      type_de_champ.build_champ(dossier: self, row_id:, updated_at:, rebased_at:, value:, stream:)
+      projected_champ(type_de_champ, row_id:, champ_data: data)
     else
       data.type_de_champ = type_de_champ
       data
@@ -26,13 +23,24 @@ module DossierChampsConcern
   end
 
   def champs
-    root_champs_public + root_champs_private
+    flat_champs_public + flat_champs_private
+  end
+
+  # Entry points to navigate champs as a tree: first-level champs and top-level
+  # header sections. Navigate deeper with Champs::HeaderSectionChamp#children
+  # and Champs::RepetitionChamp#rows.
+  def champs_public
+    @champs_public ||= revision.types_de_champ_public.map { project_champ(it) }
+  end
+
+  def champs_private
+    @champs_private ||= revision.types_de_champ_private.map { project_champ(it) }
   end
 
   def filled_champs_public
     @filled_champs_public ||= root_champs_public.flat_map do |champ|
       if champ.repetition?
-        champ.rows.flatten.filter { _1.persisted? && _1.fillable? }
+        champ.rows.flat_map(&:flat_champs).filter { it.persisted? && it.fillable? }
       elsif champ.persisted? && champ.fillable?
         champ
       else
@@ -44,7 +52,7 @@ module DossierChampsConcern
   def filled_champs_private
     @filled_champs_private ||= root_champs_private.flat_map do |champ|
       if champ.repetition?
-        champ.rows.flatten.filter { _1.persisted? && _1.fillable? }
+        champ.rows.flat_map(&:flat_champs).filter { it.persisted? && it.fillable? }
       elsif champ.persisted? && champ.fillable?
         champ
       else
@@ -61,7 +69,7 @@ module DossierChampsConcern
     @flat_champs_public ||= revision.root_types_de_champ_public.flat_map do |type_de_champ|
       champ = project_champ(type_de_champ)
       if type_de_champ.repetition?
-        [champ] + project_rows_for(type_de_champ).flatten
+        [champ] + project_rows_for(type_de_champ).flat_map(&:flat_champs)
       else
         champ
       end
@@ -72,7 +80,7 @@ module DossierChampsConcern
     @flat_champs_private ||= revision.root_types_de_champ_private.flat_map do |type_de_champ|
       champ = project_champ(type_de_champ)
       if type_de_champ.repetition?
-        [champ] + project_rows_for(type_de_champ).flatten
+        [champ] + project_rows_for(type_de_champ).flat_map(&:flat_champs)
       else
         champ
       end
@@ -82,11 +90,8 @@ module DossierChampsConcern
   def project_rows_for(type_de_champ)
     return [] if !type_de_champ.repetition?
 
-    children = type_de_champ.flat_children(revision)
-    row_ids = repetition_row_ids(type_de_champ)
-
-    row_ids.map do |row_id|
-      children.map { project_champ(_1, row_id:) }
+    repetition_row_ids(type_de_champ).map.with_index(1) do |row_id, index|
+      RepetitionRow.new(id: row_id, index:, dossier: self, type_de_champ:)
     end
   end
 
@@ -142,12 +147,6 @@ module DossierChampsConcern
     stable_id, row_id = public_id.split('-')
     type_de_champ = find_type_de_champ_by_stable_id(stable_id, :private)
     champ_for_update(type_de_champ, row_id:, updated_by:)
-  end
-
-  def repetition_rows_for_export(type_de_champ)
-    repetition_row_ids(type_de_champ).map.with_index(1) do |row_id, index|
-      Champs::RepetitionChamp::Row.new(index:, row_id:, dossier: self)
-    end
   end
 
   def repetition_row_ids(type_de_champ)
@@ -331,6 +330,27 @@ module DossierChampsConcern
     @champ_data_by_public_id ||= champ_data_on_stream.index_by(&:public_id)
   end
 
+  # Champs built for types de champ without a persisted champ are memoized so
+  # repeated projections of the same public_id return the same instance.
+  def projected_champ(type_de_champ, row_id:, champ_data:)
+    public_id = type_de_champ.public_id(row_id)
+    projected = champs_by_public_id[public_id]
+    if projected.nil? || !projected.is_type?(type_de_champ.type_champ)
+      value = type_de_champ.champ_blank?(champ_data) ? nil : champ_data.value
+      updated_at = champ_data&.updated_at || depose_at || created_at
+      rebased_at = champ_data&.rebased_at
+      projected = type_de_champ.build_champ(dossier: self, row_id:, updated_at:, rebased_at:, value:, stream:)
+      champs_by_public_id[public_id] = projected
+    else
+      projected.type_de_champ = type_de_champ
+    end
+    projected
+  end
+
+  def champs_by_public_id
+    @champs_by_public_id ||= {}
+  end
+
   def discarded_champ_data_by_public_id
     @discarded_champ_data_by_public_id ||= discarded_champ_data_on_main_stream.index_by(&:public_id)
   end
@@ -474,11 +494,14 @@ module DossierChampsConcern
 
   def reset_champs_cache
     @champ_data_by_public_id = nil
+    @champs_by_public_id = nil
     @discarded_champ_data_by_public_id = nil
     @filled_champs_public = nil
     @filled_champs_private = nil
     @root_champs_public = nil
     @root_champs_private = nil
+    @champs_public = nil
+    @champs_private = nil
     @flat_champs_public = nil
     @flat_champs_private = nil
     @repetition_row_ids = nil

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -356,7 +356,15 @@ module DossierChampsConcern
   end
 
   def champ_data_on_stream
-    @champ_data_on_stream ||= if user_buffer_stream?
+    @champ_data_on_stream ||= champ_data_for_current_stream
+      # champ.dossier is loaded without inverse_of; share this dossier
+      # instance so tree navigation (parent, ancestors) and visibility
+      # memoization stay within one instance graph
+      .each { it.association(:dossier).target = self }
+  end
+
+  def champ_data_for_current_stream
+    if user_buffer_stream?
       (champ_data_on_user_buffer_stream + champ_data_on_main_stream).uniq(&:public_id)
     elsif instructeur_buffer_stream?
       (champ_data_on_instructeur_buffer_stream + champ_data_on_main_stream).uniq(&:public_id)

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -82,7 +82,7 @@ module DossierChampsConcern
   def project_rows_for(type_de_champ)
     return [] if !type_de_champ.repetition?
 
-    children = revision.children_of(type_de_champ)
+    children = type_de_champ.flat_children(revision)
     row_ids = repetition_row_ids(type_de_champ)
 
     row_ids.map do |row_id|
@@ -113,7 +113,7 @@ module DossierChampsConcern
     revision
       .types_de_champ
       .filter { _1.stable_id.in?(stable_ids) }
-      .filter { !_1.child?(revision) }
+      .filter { !it.in_repetition?(revision) }
       .map { _1.repetition? ? project_champ(_1) : champ_for_update(_1, updated_by: nil) }
   end
 
@@ -463,7 +463,7 @@ module DossierChampsConcern
   end
 
   def check_valid_row_id_on_read?(type_de_champ, row_id)
-    if type_de_champ.child?(revision)
+    if type_de_champ.in_repetition?(revision)
       if row_id.blank?
         raise "type_de_champ #{type_de_champ.stable_id} in revision #{revision_id} must have a row_id because it is part of a repetition"
       end

--- a/app/models/concerns/dossier_sections_concern.rb
+++ b/app/models/concerns/dossier_sections_concern.rb
@@ -11,14 +11,14 @@ module DossierSectionsConcern
       when :private
         hash[parent] = revision.root_types_de_champ_private.filter(&:header_section?)
       else
-        hash[parent] = revision.children_of(parent).filter(&:header_section?)
+        hash[parent] = parent.flat_children(revision).filter(&:header_section?)
       end
     end
-    @sections[revision.parent_of(type_de_champ) || (type_de_champ.public? ? :public : :private)]
+    @sections[type_de_champ.repetition(revision) || (type_de_champ.public? ? :public : :private)]
   end
 
   def auto_numbering_section_headers_for?(type_de_champ)
-    return false if type_de_champ.child?(revision)
+    return false if type_de_champ.in_repetition?(revision)
 
     sections_for(type_de_champ)&.none? { _1.libelle =~ /^\d/ }
   end
@@ -31,7 +31,7 @@ module DossierSectionsConcern
       .filter(&:header_section?)
       .filter { project_champ(it).visible? }
       .each do |tdc|
-      level = tdc.level_for_revision(revision)
+      level = tdc.level(revision)
 
       # drop counter with a higher level
       # ex: counters = [1,2,2], new header of level 2, drop last

--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -80,6 +80,7 @@ module ProcedureCloneConcern
     'routing_alert',
     'api_particulier_token',
     'no_gender',
+    'section_conditions_hide_champs',
     'pro_connect_restriction',
     'pro_connect_for_moral_procedure',
     'robots_indexable',

--- a/app/models/concerns/treeable_concern.rb
+++ b/app/models/concerns/treeable_concern.rb
@@ -17,6 +17,18 @@ module TreeableConcern
   #   are added to the current_tree
   # given a root_depth at 0, we build a full tree
   # given a root_depth > 0, we build a partial tree (aka, a repetition)
+  # Top level of the tree: types de champ outside any section and the sections
+  # heading them (the content of a section collapses into its header).
+  def to_tree_roots(types_de_champ:)
+    tree_roots(to_tree(types_de_champ:))
+  end
+
+  # Top level of the given tree nodes: leaves stay as-is, each section subtree
+  # ([header, *children]) collapses into its header.
+  def tree_roots(nodes)
+    nodes.map { it.is_a?(Array) ? it.first : it }
+  end
+
   def to_tree(types_de_champ:)
     rooted_tree = []
     walk = Array.new(MAX_DEPTH)
@@ -26,10 +38,14 @@ module TreeableConcern
     types_de_champ.each do |type_de_champ|
       if type_de_champ.header_section?
         new_tree = [type_de_champ]
-        parent_level = type_de_champ.header_section_level_value - 1
+        level = type_de_champ.header_section_level_value
+        parent_level = level - 1
         parent_level -= 1 while parent_level > 0 && walk[parent_level].nil?
         walk[parent_level].push(new_tree)
-        current_tree = walk[type_de_champ.header_section_level_value] = new_tree
+        current_tree = walk[level] = new_tree
+        # deeper slots belong to a previous sibling's subtree; a later section
+        # with a level gap must not attach to them
+        walk.fill(nil, level + 1)
       else
         current_tree.push(type_de_champ)
       end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -97,7 +97,7 @@ class Procedure < ApplicationRecord
           .where(revision_types_de_champ: { revision_id: draft_revision_id, parent_id: nil })
           .order(:private, :position)
       else
-        draft_revision.children_of(parent)
+        parent.flat_children(draft_revision)
       end
     else
       cache_key = ['all_revisions_types_de_champ', published_revision, parent, with_header_section, ActiveRecord::VERSION::STRING].compact

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -2,6 +2,7 @@
 
 class ProcedureRevision < ApplicationRecord
   include Logic
+  include TreeableConcern
   include RevisionDescribableToLLMConcern
   self.implicit_order_column = :created_at
   belongs_to :administrateur, optional: true
@@ -16,6 +17,57 @@ class ProcedureRevision < ApplicationRecord
   def types_de_champ = revision_types_de_champ.map(&:type_de_champ)
   def root_types_de_champ_public = revision_types_de_champ_public.map(&:type_de_champ)
   def root_types_de_champ_private = revision_types_de_champ_private.map(&:type_de_champ)
+
+  # Entry points to navigate types de champ as a tree: first-level types de champ
+  # and top-level header sections (their content collapses into the header;
+  # navigate deeper with TypeDeChampBase#children).
+  def types_de_champ_public = to_tree_roots(types_de_champ: root_types_de_champ_public)
+  def types_de_champ_private = to_tree_roots(types_de_champ: root_types_de_champ_private)
+
+  # Sections and repetitions above the given type de champ, outermost first.
+  # Tree navigation answers from a one-pass memoized index; any mutation of the
+  # revision's coordinates or types de champ must call reset_tree_cache.
+  def ancestors_of(type_de_champ)
+    tree_cache[:ancestors][type_de_champ.stable_id] || []
+  end
+
+  # Direct children of a header section or repetition in the tree: its own
+  # types de champ and the immediate subsections (but not their content).
+  def children_of(type_de_champ)
+    tree_cache[:children][type_de_champ.stable_id] || []
+  end
+
+  # The repetition the given type de champ belongs to, nil outside a repetition.
+  def repetition_of(type_de_champ)
+    ancestors_of(type_de_champ).find(&:repetition?)
+  end
+
+  # The innermost section the given type de champ belongs to, nil outside sections.
+  def section_of(type_de_champ)
+    ancestors_of(type_de_champ).reverse.find(&:header_section?)
+  end
+
+  # The direct parent of the given type de champ in the tree, nil at the root.
+  def parent_of(type_de_champ)
+    ancestors_of(type_de_champ).last
+  end
+
+  # Every type de champ below a header section or repetition, in document
+  # order, including nested section headers and their content. A nested
+  # repetition marks a boundary: it is included, its row content is not.
+  # Internal to the tree API: use TypeDeChamp#flat_children.
+  def flat_children_of(type_de_champ)
+    tree_cache[:flat_children][type_de_champ.stable_id] || []
+  end
+
+  def reset_tree_cache
+    @tree_cache = nil
+  end
+
+  def reload(...)
+    reset_tree_cache
+    super
+  end
 
   has_one :draft_procedure, -> { with_discarded }, class_name: 'Procedure', foreign_key: :draft_revision_id, dependent: :nullify, inverse_of: :draft_revision
   has_one :published_procedure, -> { with_discarded }, class_name: 'Procedure', foreign_key: :published_revision_id, dependent: :nullify, inverse_of: :published_revision
@@ -66,6 +118,7 @@ class ProcedureRevision < ApplicationRecord
       end
 
       revision_types_de_champ.reset
+      reset_tree_cache
     end
 
     type_de_champ
@@ -75,12 +128,13 @@ class ProcedureRevision < ApplicationRecord
 
   def find_and_ensure_exclusive_use(stable_id)
     coordinate, tdc = coordinate_and_tdc(stable_id)
+    tdc = replace_type_de_champ_by_clone(coordinate) if !tdc.only_present_on_draft?
 
-    if tdc.only_present_on_draft?
-      tdc
-    else
-      replace_type_de_champ_by_clone(coordinate)
-    end
+    # the caller is about to mutate the type de champ (possibly its position in
+    # the tree, e.g. a header section level); reload lazily so the tree reflects it
+    revision_types_de_champ.reset
+    reset_tree_cache
+    tdc
   end
 
   def move_type_de_champ(stable_id, position)
@@ -97,6 +151,7 @@ class ProcedureRevision < ApplicationRecord
     end
 
     revision_types_de_champ.reset
+    reset_tree_cache
     coordinate.reload
     coordinate
   end
@@ -116,6 +171,7 @@ class ProcedureRevision < ApplicationRecord
     end
 
     revision_types_de_champ.reset
+    reset_tree_cache
     coordinate.reload
     coordinate
   end
@@ -126,7 +182,7 @@ class ProcedureRevision < ApplicationRecord
     # in case of replay
     return nil if coordinate.nil?
 
-    children = children_of(tdc).to_a
+    children = coordinate.types_de_champ.to_a
 
     transaction do
       coordinate.destroy
@@ -138,6 +194,7 @@ class ProcedureRevision < ApplicationRecord
     end
 
     revision_types_de_champ.reset
+    reset_tree_cache
     coordinate
   end
 
@@ -198,17 +255,6 @@ class ProcedureRevision < ApplicationRecord
       types_de_champ.filter(&:private?)
     else
       types_de_champ
-    end
-  end
-
-  def children_of(tdc)
-    coordinate_for(tdc).types_de_champ
-  end
-
-  def parent_of(tdc)
-    coordinate = coordinate_for(tdc)
-    if coordinate&.child?
-      revision_types_de_champ.find { _1.id == coordinate.parent_id }&.type_de_champ
     end
   end
 
@@ -332,6 +378,40 @@ class ProcedureRevision < ApplicationRecord
   end
 
   private
+
+  # One-pass indexes over the whole tree (public and private), keyed by
+  # stable_id: ancestors (outermost first), direct children in the tree and
+  # flat children. index_tree returns the flattened nodes, so each section
+  # accumulates its own content; a repetition contributes only itself to its
+  # parent, its row content being indexed separately.
+  def tree_cache
+    @tree_cache ||= begin
+      cache = { ancestors: {}, children: {}, flat_children: {} }
+      index_tree = lambda do |nodes, ancestors|
+        nodes.flat_map do |node|
+          if node.is_a?(Array)
+            header, *children = node
+            cache[:ancestors][header.stable_id] = ancestors
+            cache[:children][header.stable_id] = tree_roots(children)
+            flat_children = index_tree.call(children, [*ancestors, header])
+            cache[:flat_children][header.stable_id] = flat_children
+            [header, *flat_children]
+          else
+            cache[:ancestors][node.stable_id] = ancestors
+            if node.repetition?
+              subtree = to_tree(types_de_champ: coordinate_for(node)&.types_de_champ || [])
+              cache[:children][node.stable_id] = tree_roots(subtree)
+              cache[:flat_children][node.stable_id] = index_tree.call(subtree, [*ancestors, node])
+            end
+            [node]
+          end
+        end
+      end
+      index_tree.call(to_tree(types_de_champ: root_types_de_champ_public), [])
+      index_tree.call(to_tree(types_de_champ: root_types_de_champ_private), [])
+      cache
+    end
+  end
 
   def compute_estimated_fill_duration
     root_types_de_champ_public.sum do |tdc|

--- a/app/models/procedure_revision_change.rb
+++ b/app/models/procedure_revision_change.rb
@@ -10,7 +10,6 @@ class ProcedureRevisionChange
     def label = @type_de_champ.libelle
     def stable_id = @type_de_champ.stable_id
     def private? = @type_de_champ.private?
-    def child? = @type_de_champ.child?
 
     def to_h = { op:, stable_id:, label:, private: private? }
   end

--- a/app/models/repetition_row.rb
+++ b/app/models/repetition_row.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class RepetitionRow < Hashie::Dash
+  property :id
+  property :index
+  property :dossier
+  property :type_de_champ
+
+  # All the champs of the row, including champs nested in header sections.
+  def flat_champs
+    type_de_champ.flat_children(dossier.revision).map { dossier.project_champ(it, row_id: id) }
+  end
+
+  # Entry points to navigate the row's champs as a tree: first-level champs and
+  # top-level header sections. Navigate deeper with
+  # Champs::HeaderSectionChamp#children.
+  def champs
+    type_de_champ.children(dossier.revision).map { dossier.project_champ(it, row_id: id) }
+  end
+
+  def dossier_id
+    dossier.id.to_s
+  end
+
+  def read_attribute_for_serialization(attribute)
+    self[attribute]
+  end
+
+  def spreadsheet_columns(types_de_champ, export_template: nil, format:)
+    [
+      ['Dossier ID', :dossier_id],
+      ['Ligne', :index],
+    ] + dossier.champ_values_for_export(types_de_champ, row_id: id, export_template:, format:)
+  end
+end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -194,7 +194,7 @@ class TypeDeChamp < ApplicationRecord
 
   belongs_to :referentiel, optional: true, inverse_of: :types_de_champ
 
-  delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, :column, :canonical_column, :personnalisation_column, :info_columns, to: :dynamic_type
+  delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, :column, :canonical_column, :personnalisation_column, :info_columns, :children, :flat_children, :ancestors, :parent, :section, :repetition, :level, to: :dynamic_type
 
   class WithIndifferentAccess
     def self.load(options)
@@ -266,9 +266,8 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def libelle_with_parent(revision)
-    if child?(revision)
-      parent_type_de_champ = revision.parent_of(self)
-      "#{parent_type_de_champ.libelle} - #{libelle}"
+    if in_repetition?(revision)
+      "#{repetition(revision).libelle} - #{libelle}"
     else
       libelle
     end
@@ -480,8 +479,12 @@ class TypeDeChamp < ApplicationRecord
 
   def api_particulier? = type_champ.in?(API_PART_FC_TDC)
 
-  def child?(revision)
-    revision.coordinate_for(self)&.child?
+  def in_repetition?(revision)
+    repetition(revision).present?
+  end
+
+  def in_section?(revision)
+    section(revision).present?
   end
 
   def filename_for_attachement(attachment_sym)
@@ -592,24 +595,6 @@ class TypeDeChamp < ApplicationRecord
       I18n.t('activerecord.errors.type_de_champ.attributes.header_section_level.gap_error', level: current_level - previous_level - 1)
     else
       nil
-    end
-  end
-
-  def current_section_level(revision)
-    tdcs = private? ? revision.root_types_de_champ_private.to_a : revision.root_types_de_champ_public.to_a
-
-    previous_section_level(tdcs.take(tdcs.find_index(self)))
-  end
-
-  def level_for_revision(revision)
-    parent_type_de_champ = revision.parent_of(self)
-
-    if parent_type_de_champ.present?
-      header_section_level_value.to_i + parent_type_de_champ.current_section_level(revision)
-    elsif header_section_level_value
-      header_section_level_value.to_i
-    else
-      0
     end
   end
 

--- a/app/models/types_de_champ/header_section_type_de_champ.rb
+++ b/app/models/types_de_champ/header_section_type_de_champ.rb
@@ -2,4 +2,11 @@
 
 class TypesDeChamp::HeaderSectionTypeDeChamp < TypesDeChamp::TypeDeChampBase
   def tags_for_template = [].freeze
+
+  # Direct children of the section: its own types de champ and the immediate subsections
+  # (but not their content). Sections have no parent relationship in the database, so
+  # children are reconstructed from the ordered list of siblings and header levels.
+  def children(revision) = revision.children_of(@type_de_champ)
+
+  def flat_children(revision) = revision.flat_children_of(@type_de_champ)
 end

--- a/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
@@ -40,7 +40,7 @@ class TypesDeChamp::PrefillRepetitionTypeDeChamp < TypesDeChamp::PrefillTypeDeCh
 
   def prefillable_subchamps
     @prefillable_subchamps ||=
-      TypesDeChamp::PrefillTypeDeChamp.wrap(@revision.children_of(self).filter(&:prefillable?), @revision)
+      TypesDeChamp::PrefillTypeDeChamp.wrap(flat_children(@revision).filter(&:prefillable?), @revision)
   end
 
   class PrefillRepetitionRow

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
+  # Direct children of the repetition: its own types de champ and top-level sections
+  # (but not the content of those sections).
+  def children(revision) = revision.children_of(@type_de_champ)
+
+  def flat_children(revision) = revision.flat_children_of(@type_de_champ)
+
   def champ_value_for_tag(champ, path = :value)
     return nil if path != :value
     ChampPresentations::RepetitionPresentation.new(libelle, champ.dossier.project_rows_for(@type_de_champ))
@@ -9,7 +15,7 @@ class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
   def estimated_fill_duration(revision)
     estimated_rows_in_repetition = 2.5
 
-    children = revision.children_of(@type_de_champ)
+    children = flat_children(revision)
 
     estimated_row_duration = children.map { _1.estimated_fill_duration(revision) }.sum
     estimated_children_read_duration = children.map(&:estimated_read_duration).sum

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -14,6 +14,26 @@ class TypesDeChamp::TypeDeChampBase
     @type_de_champ = type_de_champ
   end
 
+  # Types de champ are navigable as a tree: header sections and repetitions
+  # have children, other types are leaves.
+  def children(revision) = []
+
+  # Every type de champ below, in document order, including nested section
+  # headers and their content (but not the row content of nested repetitions).
+  def flat_children(revision) = []
+
+  # Sections and repetitions above this type de champ in the tree, outermost
+  # first.
+  def ancestors(revision) = revision.ancestors_of(@type_de_champ)
+
+  def parent(revision) = revision.parent_of(@type_de_champ)
+  def section(revision) = revision.section_of(@type_de_champ)
+  def repetition(revision) = revision.repetition_of(@type_de_champ)
+
+  # Nesting depth of a header section in the tree (1 for a top-level section).
+  # Unlike the stored header_section_level, skipped levels are collapsed.
+  def level(revision) = ancestors(revision).count(&:header_section?) + 1
+
   def tags_for_template
     type_de_champ = @type_de_champ
     conditional = type_de_champ.condition.present?

--- a/app/serializers/champ_serializer.rb
+++ b/app/serializers/champ_serializer.rb
@@ -48,7 +48,7 @@ class ChampSerializer < ActiveModel::Serializer
   end
 
   def rows
-    object.rows.map.with_index(1) { |champs, index| Row.new(index:, champs:) }
+    object.rows.map { Row.new(index: it.index, champs: it.flat_champs) }
   end
 
   def include_etablissement?

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -342,7 +342,7 @@ class PiecesJustificativesService
   # # # pj_champ_5 (stable_id: 2)
   # it returns { pj_0.id => 0, pj_1.id => 1, pj_2.id => 0, pj_3.id => 0, pj_4.id => 1, pj_5.id => 1 }
   def compute_champ_id_row_index(champs)
-    champs.filter(&:child?).group_by(&:dossier_id).values.each_with_object({}) do |children_for_dossier, hash|
+    champs.filter(&:in_repetition?).group_by(&:dossier_id).values.each_with_object({}) do |children_for_dossier, hash|
       children_for_dossier.group_by(&:stable_id).values.each do |champs_for_stable_id|
         champs_for_stable_id.sort_by(&:row_id).each.with_index { |c, index| hash[c.id] = index }
       end

--- a/app/services/procedure_export_service.rb
+++ b/app/services/procedure_export_service.rb
@@ -117,7 +117,7 @@ class ProcedureExportService
       .repetition
       .filter_map do |type_de_champ_repetition|
         types_de_champ = procedure.all_revisions_types_de_champ(parent: type_de_champ_repetition).to_a
-        rows = dossiers.flat_map { _1.repetition_rows_for_export(type_de_champ_repetition) }
+        rows = dossiers.flat_map { it.project_rows_for(type_de_champ_repetition) }
 
         if types_de_champ.present? && rows.present?
           {

--- a/app/services/procedure_export_service/xlsx_export.rb
+++ b/app/services/procedure_export_service/xlsx_export.rb
@@ -176,7 +176,7 @@ class ProcedureExportService::XlsxExport
 
     def collect_repetitions(dossier, export_template)
       repetition_tdcs.each do |tdc|
-        rows = dossier.repetition_rows_for_export(tdc)
+        rows = dossier.project_rows_for(tdc)
         next if rows.empty?
 
         children_tdcs = repetition_children_tdcs[tdc.stable_id]

--- a/app/validators/types_de_champ/condition_validator.rb
+++ b/app/validators/types_de_champ/condition_validator.rb
@@ -32,6 +32,6 @@ class TypesDeChamp::ConditionValidator < ActiveModel::EachValidator
   # condition is validated too
   def tdcs_with_children(procedure, tdcs)
     tdcs.to_a
-      .flat_map { _1.repetition? ? [_1, *procedure.draft_revision.children_of(_1)] : _1 }
+      .flat_map { it.repetition? ? [it, *it.flat_children(procedure.draft_revision)] : it }
   end
 end

--- a/app/validators/types_de_champ/date_validator.rb
+++ b/app/validators/types_de_champ/date_validator.rb
@@ -3,7 +3,7 @@
 class TypesDeChamp::DateValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
     date_tdcs = types_de_champ
-      .flat_map { it.repetition? ? procedure.draft_revision.children_of(it) : [it] }
+      .flat_map { it.repetition? ? it.flat_children(procedure.draft_revision) : [it] }
       .filter { |tdc| tdc.date? || tdc.datetime? }
     date_tdcs.each do |tdc|
       validate_range(procedure, attribute, tdc) if tdc.range_date?

--- a/app/validators/types_de_champ/formatted_validator.rb
+++ b/app/validators/types_de_champ/formatted_validator.rb
@@ -3,7 +3,7 @@
 class TypesDeChamp::FormattedValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
     types_de_champ.to_a
-      .flat_map { _1.repetition? ? procedure.draft_revision.children_of(_1) : _1 }
+      .flat_map { it.repetition? ? it.flat_children(procedure.draft_revision) : it }
       .filter(&:formatted?)
       .each do |tdc|
         validate_characters_rules(procedure, attribute, tdc)

--- a/app/validators/types_de_champ/header_section_consistency_validator.rb
+++ b/app/validators/types_de_champ/header_section_consistency_validator.rb
@@ -6,7 +6,7 @@ class TypesDeChamp::HeaderSectionConsistencyValidator < ActiveModel::EachValidat
 
     root_tdcs_errors = errors_for_header_sections_order(procedure, attribute, public_tdcs)
     repetition_tdcs_errors = public_tdcs
-      .filter_map { _1.repetition? ? procedure.draft_revision.children_of(_1) : nil }
+      .filter_map { it.repetition? ? it.flat_children(procedure.draft_revision) : nil }
       .map { errors_for_header_sections_order(procedure, attribute, _1) }
 
     repetition_tdcs_errors + root_tdcs_errors

--- a/app/validators/types_de_champ/libelle_validator.rb
+++ b/app/validators/types_de_champ/libelle_validator.rb
@@ -7,7 +7,7 @@ class TypesDeChamp::LibelleValidator < ActiveModel::EachValidator
 
       next unless tdc.repetition?
 
-      procedure.draft_revision.children_of(tdc).each do |child|
+      tdc.flat_children(procedure.draft_revision).each do |child|
         validate_libelle(procedure, attribute, child, parent: tdc)
       end
     end

--- a/app/validators/types_de_champ/no_empty_block_validator.rb
+++ b/app/validators/types_de_champ/no_empty_block_validator.rb
@@ -10,7 +10,7 @@ class TypesDeChamp::NoEmptyBlockValidator < ActiveModel::EachValidator
   private
 
   def validate_block_not_empty(procedure, attribute, parent)
-    if procedure.draft_revision.children_of(parent).empty?
+    if parent.flat_children(procedure.draft_revision).empty?
       procedure.errors.add(
         attribute,
         procedure.errors.generate_message(attribute, :empty_repetition, { value: parent.libelle }),

--- a/app/validators/types_de_champ/no_empty_drop_down_validator.rb
+++ b/app/validators/types_de_champ/no_empty_drop_down_validator.rb
@@ -13,7 +13,7 @@ class TypesDeChamp::NoEmptyDropDownValidator < ActiveModel::EachValidator
   def with_children(procedure, type_de_champ)
     return [type_de_champ] unless type_de_champ.repetition?
 
-    [type_de_champ, *procedure.draft_revision.children_of(type_de_champ)]
+    [type_de_champ, *type_de_champ.flat_children(procedure.draft_revision)]
   end
 
   def validate_drop_down_not_empty(procedure, attribute, drop_down)

--- a/app/validators/types_de_champ/number_validator.rb
+++ b/app/validators/types_de_champ/number_validator.rb
@@ -3,7 +3,7 @@
 class TypesDeChamp::NumberValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
     types_de_champ
-      .flat_map { it.repetition? ? procedure.draft_revision.children_of(it) : [it] }
+      .flat_map { it.repetition? ? it.flat_children(procedure.draft_revision) : [it] }
       .filter { |tdc| tdc.decimal_number? || tdc.integer_number? }.each do |tdc|
       validate_range(procedure, attribute, tdc) if tdc.range_number?
     end

--- a/app/validators/types_de_champ/referentiel_ready_validator.rb
+++ b/app/validators/types_de_champ/referentiel_ready_validator.rb
@@ -3,7 +3,7 @@
 class TypesDeChamp::ReferentielReadyValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
     types_de_champ
-      .flat_map { it.repetition? ? procedure.draft_revision.children_of(it) : [it] }
+      .flat_map { it.repetition? ? it.flat_children(procedure.draft_revision) : [it] }
       .filter(&:referentiel?).each do |referentiel_champ|
       unless referentiel_champ.referentiel&.ready?
         procedure.errors.add(

--- a/app/views/champs/repetition/add.turbo_stream.erb
+++ b/app/views/champs/repetition/add.turbo_stream.erb
@@ -1,6 +1,6 @@
-<% if @row_id.present? %>
+<% if @row.present? %>
   <%= fields_for @champ.input_name, @champ do |form| %>
-    <%= turbo_stream.append dom_id(@champ, :rows), render(EditableChamp::RepetitionRowComponent.new(form: form, dossier: @champ.dossier, champ: @champ, row_id: @row_id, row_number: @row_number, expanded: true)) %>
+    <%= turbo_stream.append dom_id(@champ, :rows), render(EditableChamp::RepetitionRowComponent.new(form:, dossier: @champ.dossier, champ: @champ, row: @row, expanded: true)) %>
 
     <% if @first_champ_id %>
       <%= turbo_stream.focus(@first_champ_id, delay: 50) %>

--- a/app/views/champs/repetition/remove.turbo_stream.erb
+++ b/app/views/champs/repetition/remove.turbo_stream.erb
@@ -3,9 +3,9 @@
 <% end %>
 
 <%= turbo_stream.update dom_id(@champ, :rows) do %>
-  <% @champ.row_ids.each.with_index(1) do |row_id, row_number| %>
+  <% @champ.rows.each do |row| %>
     <%= fields_for @champ.input_name, @champ do |form| %>
-      <%= render EditableChamp::RepetitionRowComponent.new(form: form, dossier: @champ.dossier, champ: @champ, row_id: row_id, row_number: row_number, seen_at: nil, expanded: row_number == 1) %>
+      <%= render EditableChamp::RepetitionRowComponent.new(form:, dossier: @champ.dossier, champ: @champ, row:, seen_at: nil, expanded: row.index == 1) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -132,7 +132,7 @@ def render_single_champ(pdf, revision, type_de_champ)
   case type_de_champ.type_champ
   when TypeDeChamp.type_champs.fetch(:repetition)
     add_libelle(pdf, type_de_champ)
-    types_de_champ = revision.children_of(type_de_champ)
+    types_de_champ = type_de_champ.flat_children(revision)
 
     3.times do
       types_de_champ.each do |type_de_champ|

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -227,7 +227,7 @@ end
 
 def add_single_champ(pdf, champ)
   tdc = champ.type_de_champ
-  return if champ.conditional? && !champ.visible?
+  return if !champ.visible? && (champ.conditional? || champ.section_conditions_hide_champs?)
 
   case champ.type
   when 'Champs::PieceJustificativeChamp'
@@ -307,7 +307,7 @@ def add_champs(pdf, champs)
 
   champs.each do |champ|
     if champ.type == 'Champs::HeaderSectionChamp'
-      next if champ.conditional? && !champ.visible?
+      next if !champ.visible? && (champ.conditional? || champ.section_conditions_hide_champs?)
       current_indent = champ.level * section_indent_step
       add_single_champ(pdf, champ)
     elsif champ.repetition?

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -313,7 +313,7 @@ def add_champs(pdf, champs)
     elsif champ.repetition?
       pdf.indent(current_indent) do
         champ.rows.each do |row|
-          row.each do |inner_champ|
+          row.flat_champs.each do |inner_champ|
             add_single_champ(pdf, inner_champ)
           end
         end

--- a/app/views/fields/types_de_champ_collection_field/_show.html.erb
+++ b/app/views/fields/types_de_champ_collection_field/_show.html.erb
@@ -15,7 +15,7 @@
         <%= render partial: 'fields/types_de_champ_collection_field/type_champ_line', locals: { type_de_champ: type_de_champ } %>
 
         <% if type_de_champ.type_champ == 'repetition' %>
-          <% revision.children_of(type_de_champ).each do |sub_champ| %>
+          <% type_de_champ.flat_children(revision).each do |sub_champ| %>
             <%= render partial: 'fields/types_de_champ_collection_field/type_champ_line', locals: { type_de_champ: sub_champ } %>
           <% end %>
         <% end %>

--- a/app/views/instructeurs/dossiers/print.html.haml
+++ b/app/views/instructeurs/dossiers/print.html.haml
@@ -15,15 +15,13 @@
 
 %h2 Formulaire
 
-- types_de_champ_public = @dossier.revision.root_types_de_champ_public
-- if types_de_champ_public.any? || @dossier.procedure.routing_enabled?
-  = render ViewableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: types_de_champ_public, demande_seen_at: nil, profile: 'instructeur')
+- if @dossier.revision.root_types_de_champ_public.any? || @dossier.procedure.routing_enabled?
+  = render ViewableChamp::SectionComponent.new(dossier: @dossier, champs: @dossier.champs_public, demande_seen_at: nil, profile: 'instructeur')
 
 %h2 Annotations privées
 
-- types_de_champ_private = @dossier.revision.root_types_de_champ_private
-- if types_de_champ_private.any?
-  = render ViewableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: types_de_champ_private, demande_seen_at: nil, profile: 'instructeur')
+- if @dossier.revision.root_types_de_champ_private.any?
+  = render ViewableChamp::SectionComponent.new(dossier: @dossier, champs: @dossier.champs_private, demande_seen_at: nil, profile: 'instructeur')
 - else
   Aucune annotation privée
 

--- a/app/views/instructeurs/dossiers/show_submitted_revision.html.erb
+++ b/app/views/instructeurs/dossiers/show_submitted_revision.html.erb
@@ -34,7 +34,7 @@
         data-clipboard2-copy-text-value="<%= t('clipboard.copy') %>"
         data-clipboard2-copied-text-value="<%= t('clipboard.copied') %>"
       >
-        <%= render ViewableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: @dossier.revision.root_types_de_champ_public, demande_seen_at: @demande_seen_at, profile: 'instructeur') %>
+        <%= render ViewableChamp::SectionComponent.new(dossier: @dossier, champs: @dossier.champs_public, demande_seen_at: @demande_seen_at, profile: 'instructeur') %>
       </div>
     </div>
   </div>

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -33,7 +33,7 @@
 
     %form.form
       = form_for @dossier, url: '', html: { class: 'form' } do |f|
-        = render EditableChamp::SectionComponent.new(dossier: @dossier, types_de_champ: @dossier.revision.root_types_de_champ_public)
+        = render EditableChamp::SectionComponent.new(dossier: @dossier, champs: @dossier.champs_public)
 
         .editable-champ.editable-champ-text
           %label Mot de passe

--- a/app/views/shared/dossiers/_demande.html.erb
+++ b/app/views/shared/dossiers/_demande.html.erb
@@ -121,9 +121,7 @@
     <% end %>
   <% end %>
 
-  <% types_de_champ = dossier.revision.root_types_de_champ_public %>
-
-  <% if types_de_champ.any? || dossier.procedure.routing_enabled? %>
-    <%= render ViewableChamp::SectionComponent.new(dossier:, types_de_champ:, demande_seen_at:, profile:) %>
+  <% if dossier.revision.root_types_de_champ_public.any? || dossier.procedure.routing_enabled? %>
+    <%= render ViewableChamp::SectionComponent.new(dossier:, champs: dossier.champs_public, demande_seen_at:, profile:) %>
   <% end %>
 </div>

--- a/app/views/shared/dossiers/_edit.html.erb
+++ b/app/views/shared/dossiers/_edit.html.erb
@@ -50,7 +50,7 @@
     <h2 class="fr-sr-only">Formulaire</h2>
 
     <fieldset class="fr-fieldset">
-      <%= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.root_types_de_champ_public) %>
+      <%= render EditableChamp::SectionComponent.new(dossier:, champs: dossier.champs_public) %>
     </fieldset>
 
     <%= render Dossiers::PendingCorrectionCheckboxComponent.new(dossier:) %>

--- a/app/views/shared/dossiers/_edit_annotations.html.erb
+++ b/app/views/shared/dossiers/_edit_annotations.html.erb
@@ -5,7 +5,7 @@
 
       <%= form_for dossier, url: annotations_instructeur_dossier_path(dossier.procedure, dossier), html: { class: 'form', multipart: true } do |f| %>
         <fieldset class="fr-fieldset">
-          <%= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.root_types_de_champ_private) %>
+          <%= render EditableChamp::SectionComponent.new(dossier:, champs: dossier.champs_private) %>
         </fieldset>
       <% end %>
 

--- a/app/views/shared/dossiers/_edit_instructeur.html.erb
+++ b/app/views/shared/dossiers/_edit_instructeur.html.erb
@@ -21,7 +21,7 @@
     </header>
 
     <fieldset class="fr-fieldset">
-      <%= render EditableChamp::SectionComponent.new(dossier:, types_de_champ: dossier.revision.root_types_de_champ_public) %>
+      <%= render EditableChamp::SectionComponent.new(dossier:, champs: dossier.champs_public) %>
     </fieldset>
   <% end %>
 

--- a/db/migrate/20260717000000_add_section_conditions_hide_champs_to_procedures.rb
+++ b/db/migrate/20260717000000_add_section_conditions_hide_champs_to_procedures.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSectionConditionsHideChampsToProcedures < ActiveRecord::Migration[8.0]
+  def change
+    add_column :procedures, :section_conditions_hide_champs, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_13_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_17_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -1166,6 +1166,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_13_000000) do
     t.boolean "robots_indexable", default: true, null: false
     t.boolean "routing_alert", default: false, null: false
     t.boolean "routing_enabled"
+    t.boolean "section_conditions_hide_champs", default: false, null: false
     t.bigint "service_id"
     t.jsonb "sva_svr", default: {}, null: false
     t.text "tags", default: [], array: true

--- a/spec/components/champ_header_sections_summary_component_spec.rb
+++ b/spec/components/champ_header_sections_summary_component_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewableChamp::HeaderSectionsSummaryComponent, type: :component do
+  include Logic
+
   subject { render_inline(component).to_html }
 
   let(:is_private) { false }
@@ -14,15 +16,57 @@ RSpec.describe ViewableChamp::HeaderSectionsSummaryComponent, type: :component d
       { type: :text },
     ]
   end
-  let(:procedure) { build(:procedure, types_de_champ_public: types_de_champ, types_de_champ_private: types_de_champ) }
-  let(:dossier) { build(:dossier, procedure:) }
+  let(:procedure) { create(:procedure, types_de_champ_public: types_de_champ, types_de_champ_private: types_de_champ) }
+  let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
   let(:component) { described_class.new(dossier:, is_private:) }
   let(:types_de_champ_public) { dossier.revision.root_types_de_champ_public.filter(&:header_section?) }
   let(:types_de_champ_private) { dossier.revision.root_types_de_champ_private.filter(&:header_section?) }
+  let(:repetition_tdc) { dossier.revision.root_types_de_champ_public.find(&:repetition?) }
+  let(:section_in_repetition) { repetition_tdc.flat_children(dossier.revision).find(&:header_section?) }
 
   context 'public' do
     it do
       types_de_champ_public.each { expect(subject).to have_selector("a[href='##{_1.html_id}']") }
+    end
+
+    it 'anchors the repetition, each of its rows and their sections' do
+      row_ids = dossier.repetition_row_ids(repetition_tdc)
+      expect(row_ids.size).to eq(2)
+      expect(subject).to have_selector("a[href='##{repetition_tdc.html_id}']")
+      row_ids.each.with_index(1) do |row_id, row_number|
+        expect(subject).to have_selector("a[href='##{repetition_tdc.html_id(row_id)}']", text: "#{repetition_tdc.libelle} #{row_number}")
+        expect(subject).to have_selector("a[href='##{section_in_repetition.html_id(row_id)}']")
+      end
+    end
+
+    context 'when the repetition has no rows' do
+      let(:types_de_champ) do
+        [{ type: :repetition, mandatory: false, children: [{ type: :text }, { type: :header_section, level: 1 }] }]
+      end
+      let(:dossier) { create(:dossier, procedure:) }
+
+      it 'lists the repetition but not its content' do
+        expect(subject).to have_selector("a[href='##{repetition_tdc.html_id}']", count: 1)
+      end
+    end
+
+    context 'when sections are hidden by a condition' do
+      let(:procedure) { create(:procedure, types_de_champ_public: types_de_champ) }
+      let(:types_de_champ) do
+        [
+          { type: :yes_no, stable_id: 42 },
+          { type: :header_section, level: 1, libelle: 'visible section' },
+          { type: :header_section, level: 1, libelle: 'hidden section', condition: ds_eq(champ_value(42), constant(true)) },
+          { type: :repetition, mandatory: false, libelle: 'hidden repetition', condition: ds_eq(champ_value(42), constant(true)), children: [{ type: :text }] },
+        ]
+      end
+      let(:dossier) { create(:dossier, procedure:) }
+
+      it 'excludes hidden sections and repetitions from the summary' do
+        expect(subject).to have_text('visible section')
+        expect(subject).not_to have_text('hidden section')
+        expect(subject).not_to have_text('hidden repetition')
+      end
     end
   end
 

--- a/spec/components/dossiers/errors_full_messages_component_spec.rb
+++ b/spec/components/dossiers/errors_full_messages_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Dossiers::ErrorsFullMessagesComponent, type: :component do
       context 'when champ is repetition' do
         let(:champ_repetition) { dossier.champ_data.first }
         let(:rows) { champ_repetition.rows }
-        let(:champ_child) { rows.first.first }
+        let(:champ_child) { rows.first.champs.first }
 
         let(:types_de_champ_public) { [{ libelle: "Champ parent", type: :repetition, children: [{ libelle: "Champ enfant", type: :text }] }] }
 

--- a/spec/components/editable_champ/drop_down_list_component_spec.rb
+++ b/spec/components/editable_champ/drop_down_list_component_spec.rb
@@ -54,7 +54,7 @@ describe EditableChamp::DropDownListComponent, type: :component do
         let(:fieldset) { page.find('fieldset fieldset') }
 
         let(:repetition_champ) { dossier.root_champs_public.first }
-        let(:drop_down_list_champ) { repetition_champ.rows.first.first }
+        let(:drop_down_list_champ) { repetition_champ.rows.first.champs.first }
 
         it do
           render

--- a/spec/components/editable_champ/editable_champ_component_spec.rb
+++ b/spec/components/editable_champ/editable_champ_component_spec.rb
@@ -76,7 +76,7 @@ describe EditableChamp::EditableChampComponent, type: :component do
         [{ type: :repetition, children: [{ type: :text }, { type: :text }] }]
       end
 
-      let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.first.first }
+      let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.first.champs.first }
 
       it "returns nil (because the number of the row is on the fieldset legend)" do
         expect(subject).to be_nil
@@ -89,7 +89,7 @@ describe EditableChamp::EditableChampComponent, type: :component do
       end
 
       context "on the first row" do
-        let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.first.first }
+        let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.first.champs.first }
 
         it do
           expect(component.row_number_if_in_repetition).to eq(1)
@@ -97,7 +97,7 @@ describe EditableChamp::EditableChampComponent, type: :component do
       end
 
       context "when the champ is in the second row" do
-        let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.last.first }
+        let(:champ) { dossier.root_champs_public.find(&:repetition?).rows.last.champs.first }
 
         it do
           expect(component.row_number_if_in_repetition).to eq(2)

--- a/spec/components/editable_champ/section_component_spec.rb
+++ b/spec/components/editable_champ/section_component_spec.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 describe EditableChamp::SectionComponent, type: :component do
-  include TreeableConcern
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:types_de_champ_public) { [] }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:types_de_champ) { dossier.revision.root_types_de_champ_public }
-  let(:component) { described_class.new(types_de_champ:, dossier:) }
+  let(:component) { described_class.new(champs: dossier.champs_public, dossier:) }
   before { render_inline(component).to_html }
 
   context 'list of champs without an header_section' do

--- a/spec/components/types_de_champ_editor/header_sections_summary_component_spec.rb
+++ b/spec/components/types_de_champ_editor/header_sections_summary_component_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+describe TypesDeChampEditor::HeaderSectionsSummaryComponent, type: :component do
+  let(:procedure) { create(:procedure, types_de_champ_public:, types_de_champ_private:) }
+  let(:types_de_champ_private) { [] }
+
+  subject { render_inline(described_class.new(procedure:, is_private:)) }
+
+  context 'public types de champ' do
+    let(:is_private) { false }
+    let(:types_de_champ_public) do
+      [
+        { type: :header_section, level: 1, libelle: 's1' },
+        { type: :text, libelle: 't1' },
+        { type: :header_section, level: 2, libelle: 's1.1' },
+        { type: :header_section, level: 3, libelle: 's1.1.1' },
+        { type: :repetition, libelle: 'rep', children: [{ type: :header_section, level: 1, libelle: 'rs1' }] },
+        { type: :header_section, level: 1, libelle: 's2' },
+      ]
+    end
+
+    it 'renders header sections and repetitions with their depth' do
+      expect(subject).to have_selector("a", text: /\As1\z/)
+      expect(subject).to have_selector("a", text: '-- s1.1')
+      expect(subject).to have_selector("a.custom-link-grey", text: '-- s1.1.1')
+      expect(subject).to have_selector("a.custom-link-grey", text: '-- rep')
+      expect(subject).to have_selector("a.custom-link-grey", text: '-- rs1')
+      expect(subject).to have_selector("a", text: /\As2\z/)
+      expect(subject).not_to have_text('t1')
+    end
+
+    it 'anchors links to the editor coordinates' do
+      ['s1', 'rep', 'rs1'].each do |libelle|
+        coordinate = procedure.draft_revision.revision_types_de_champ.find { it.libelle == libelle }
+        expect(subject).to have_selector("a[href='##{ActionView::RecordIdentifier.dom_id(coordinate, :type_de_champ_editor)}']")
+      end
+    end
+  end
+
+  context 'private types de champ' do
+    let(:is_private) { true }
+    let(:types_de_champ_public) { [{ type: :header_section, level: 1, libelle: 's1' }] }
+    let(:types_de_champ_private) do
+      [
+        { type: :header_section, level: 1, libelle: 'ps1' },
+        { type: :text, libelle: 'pt1' },
+      ]
+    end
+
+    it 'only renders private header sections' do
+      expect(subject).to have_selector("a", text: 'ps1')
+      expect(subject).not_to have_text(/\As1\z/)
+    end
+  end
+
+  context 'without header sections' do
+    let(:is_private) { false }
+    let(:types_de_champ_public) { [{ type: :text, libelle: 't1' }] }
+
+    it 'renders no sidemenu' do
+      expect(subject).not_to have_selector("nav")
+    end
+  end
+end

--- a/spec/controllers/api/public/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/dossiers_controller_spec.rb
@@ -102,9 +102,7 @@ RSpec.describe API::Public::V1::DossiersController, type: :controller do
               expect { create_request }.not_to raise_error
               dossier = Dossier.last
 
-              first_row = dossier.root_champs_public.first.rows.first
-              second_row = dossier.root_champs_public.first.rows.last
-              expect(dossier.root_champs_public.first.rows.flatten.map(&:value)).to match_array(['Texte court', 'Texte court'])
+              expect(dossier.root_champs_public.first.rows.flat_map(&:champs).map(&:value)).to match_array(['Texte court', 'Texte court'])
             end
           end
         end

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -1360,7 +1360,7 @@ describe Instructeurs::DossiersController, type: :controller do
     let(:now) { Time.zone.parse('01/01/2100') }
 
     let(:champ_repetition) { dossier.root_champs_private.fourth }
-    let(:champ_text) { champ_repetition.rows.first.first }
+    let(:champ_text) { champ_repetition.rows.first.champs.first }
     let(:champ_multiple_drop_down_list) { dossier.root_champs_private.first }
     let(:champ_linked_drop_down_list) { dossier.root_champs_private.second }
     let(:champ_datetime) { dossier.root_champs_private.third }
@@ -1442,7 +1442,7 @@ describe Instructeurs::DossiersController, type: :controller do
         context 'repetition' do
           let(:champs_private_attributes) do
             {
-              champ_repetition.rows.first.first.public_id => {
+              champ_repetition.rows.first.champs.first.public_id => {
                 value: 'text',
               },
             }
@@ -1476,7 +1476,7 @@ describe Instructeurs::DossiersController, type: :controller do
             end
             let(:champs_private_attributes) do
               {
-                champ_repetition.rows.first.first.public_id => {
+                champ_repetition.rows.first.champs.first.public_id => {
                   external_id: 'text',
                 },
               }

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1004,6 +1004,39 @@ describe Users::DossiersController, type: :controller do
       end
     end
 
+    context 'when a section is conditioned by the updated champ' do
+      include Logic
+
+      let(:types_de_champ_public) do
+        [
+          { type: :yes_no, stable_id: 1 },
+          { type: :header_section, level: 1, stable_id: 10, condition: ds_eq(champ_value(1), constant(true)) },
+          { type: :text, stable_id: 11 },
+        ]
+      end
+      let(:value) { 'false' }
+
+      def selector_for(stable_id)
+        "##{assigns(:dossier).flat_champs_public.find { it.stable_id == stable_id }.input_group_id}"
+      end
+
+      it 'hides the section and the champs under it' do
+        subject
+        expect(assigns(:to_hide)).to include(selector_for(10))
+        expect(assigns(:to_hide)).to include(selector_for(11))
+      end
+
+      context 'when the procedure uses the legacy behaviour' do
+        before { procedure.update!(section_conditions_hide_champs: false) }
+
+        it 'hides only the section' do
+          subject
+          expect(assigns(:to_hide)).to include(selector_for(10))
+          expect(assigns(:to_hide)).not_to include(selector_for(11))
+        end
+      end
+    end
+
     context 'when the champ is a drop_down_list with referentiel' do
       let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :drop_down_list }]) }
 

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -307,7 +307,7 @@ end
 
 def dossier_factory_create_champ_or_repetition(type_de_champ, dossier)
   if type_de_champ.repetition?
-    types_de_champ = dossier.revision.children_of(type_de_champ)
+    types_de_champ = type_de_champ.flat_children(dossier.revision)
     2.times do
       row_id = ULID.generate
       dossier.champ_data << type_de_champ.build_champ(row_id:)

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
     declarative_with_state { nil }
     sva_svr { {} }
     no_gender { true }
+    section_conditions_hide_champs { true }
     api_entreprise_token { JWT.encode({ exp: 2.months.from_now.to_i }, nil, 'none') }
 
     groupe_instructeurs { [association(:groupe_instructeur, :default, procedure: instance, strategy: :build)] }

--- a/spec/graphql/annotation_spec.rb
+++ b/spec/graphql/annotation_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe Mutations::DossierModifierAnnotations, type: :graphql do
     end
 
     context 'with rows' do
-      let(:annotation) { champs_private.find(&:repetition?).rows.first.first }
-      let(:other_annotation) { champs_private.find(&:repetition?).rows.second.first }
+      let(:annotation) { champs_private.find(&:repetition?).rows.first.champs.first }
+      let(:other_annotation) { champs_private.find(&:repetition?).rows.second.champs.first }
 
       it 'update champ' do
         expect(data).to eq(dossierModifierAnnotationText: {
@@ -169,8 +169,8 @@ RSpec.describe Mutations::DossierModifierAnnotations, type: :graphql do
     end
 
     context 'with rows' do
-      let(:annotation) { champs_private.find(&:repetition?).rows.first.find(&:decimal_number?) }
-      let(:other_annotation) { champs_private.find(&:repetition?).rows.second.find(&:decimal_number?) }
+      let(:annotation) { champs_private.find(&:repetition?).rows.first.champs.find(&:decimal_number?) }
+      let(:other_annotation) { champs_private.find(&:repetition?).rows.second.champs.find(&:decimal_number?) }
 
       it 'update champ' do
         expect(data).to eq(dossierModifierAnnotationDecimalNumber: {
@@ -247,8 +247,8 @@ RSpec.describe Mutations::DossierModifierAnnotations, type: :graphql do
     end
 
     context 'with rows' do
-      let(:annotation) { champs_private.find(&:repetition?).rows.first.find(&:decimal_number?) }
-      let(:other_annotation) { champs_private.find(&:repetition?).rows.second.find(&:decimal_number?) }
+      let(:annotation) { champs_private.find(&:repetition?).rows.first.champs.find(&:decimal_number?) }
+      let(:other_annotation) { champs_private.find(&:repetition?).rows.second.champs.find(&:decimal_number?) }
 
       it 'update annotation' do
         expect(data).to eq(dossierModifierAnnotations: {

--- a/spec/graphql/dossier_spec.rb
+++ b/spec/graphql/dossier_spec.rb
@@ -340,8 +340,8 @@ RSpec.describe Types::DossierType, type: :graphql do
     let(:variables) { { number: dossier.id } }
 
     let(:rows) do
-      dossier.root_champs_public.first.rows.map do |champs|
-        { champs: champs.map { { id: _1.to_typed_id } } }
+      dossier.root_champs_public.first.rows.map do |row|
+        { champs: row.champs.map { { id: it.to_typed_id } } }
       end
     end
 

--- a/spec/lib/recovery/dossier_life_cycle_spec.rb
+++ b/spec/lib/recovery/dossier_life_cycle_spec.rb
@@ -82,7 +82,7 @@ describe 'Dossier::Recovery::LifeCycle' do
 
       expect(reloaded_dossier.champ_data.count).not_to be(0)
 
-      expect(repetition(reloaded_dossier).rows.flatten.map(&:type)).to match_array(["Champs::PieceJustificativeChamp", "Champs::PieceJustificativeChamp", "Champs::PieceJustificativeChamp"])
+      expect(repetition(reloaded_dossier).rows.flat_map(&:champs).map(&:type)).to match_array(["Champs::PieceJustificativeChamp", "Champs::PieceJustificativeChamp", "Champs::PieceJustificativeChamp"])
       expect(pj_champ(reloaded_dossier).piece_justificative_file).to be_attached
       expect(carte(reloaded_dossier).geo_areas).to be_present
 

--- a/spec/models/champ_data_spec.rb
+++ b/spec/models/champ_data_spec.rb
@@ -119,7 +119,7 @@ describe ChampData do
     let(:standalone_champ) { build(:champ, type_de_champ: build(:type_de_champ), dossier: build(:dossier)) }
     let(:public_sections) { dossier.root_champs_public.filter(&:header_section?) }
     let(:private_sections) { dossier.root_champs_private.filter(&:header_section?) }
-    let(:sections_in_repetition) { dossier.root_champs_public.find(&:repetition?).rows.flatten.filter(&:header_section?) }
+    let(:sections_in_repetition) { dossier.root_champs_public.find(&:repetition?).rows.flat_map(&:champs).filter(&:header_section?) }
 
     it 'returns the sibling sections of a champ' do
       expect(public_sections).not_to be_empty
@@ -616,14 +616,55 @@ describe ChampData do
     end
   end
 
-  describe "#parent" do
-    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, mandatory: false, children: [{ type: :text }] }]) }
+  describe "#ancestors, #parent, #section and #repetition" do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :text, libelle: 't0' },
+        { type: :header_section, level: 1, libelle: 's1' },
+        { type: :header_section, level: 2, libelle: 's1.1' },
+        {
+          type: :repetition, mandatory: false, libelle: 'rep', children: [
+            { type: :header_section, level: 1, libelle: 'rs1' },
+            { type: :text, libelle: 'rt1' },
+          ],
+        },
+      ])
+    end
     let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+    let(:champ) { dossier.filled_champs_public.find { it.libelle == 'rt1' } }
 
-    let(:champ) { dossier.champ_data.where(type: "Champs::TextChamp").first }
+    it "returns the projected champs above, outermost first" do
+      expect(champ.ancestors.map(&:libelle)).to eq(['s1', 's1.1', 'rep', 'rs1'])
+      expect(champ.ancestors.map(&:row_id)).to eq([nil, nil, nil, champ.row_id])
+    end
 
-    it "returns the parent" do
-      expect(champ.parent).to eq(TypeDeChamp.find_by(type_champ: "repetition"))
+    it "projects each ancestor once per dossier" do
+      champ.ancestors.zip(champ.ancestors).each do |ancestor, reprojected|
+        expect(ancestor).to equal(reprojected)
+      end
+    end
+
+    it "exposes parent, section and repetition" do
+      expect(champ.parent.libelle).to eq('rs1')
+      expect(champ.parent.row_id).to eq(champ.row_id)
+      expect(champ.section.libelle).to eq('rs1')
+      expect(champ.repetition.libelle).to eq('rep')
+      expect(champ.repetition.row_id).to be_nil
+
+      root_champ = dossier.root_champs_public.find { it.libelle == 't0' }
+      expect(root_champ.ancestors).to eq([])
+      expect(root_champ.parent).to be_nil
+      expect(root_champ.section).to be_nil
+      expect(root_champ.repetition).to be_nil
+    end
+
+    it "exposes in_repetition? and in_section?" do
+      expect(champ.in_repetition?).to be(true)
+      expect(champ.in_section?).to be(true)
+
+      root_champ = dossier.root_champs_public.find { it.libelle == 't0' }
+      expect(root_champ.in_repetition?).to be(false)
+      expect(root_champ.in_section?).to be(false)
     end
   end
 

--- a/spec/models/champ_presentations/repetition_presentation_spec.rb
+++ b/spec/models/champ_presentations/repetition_presentation_spec.rb
@@ -20,7 +20,7 @@ describe ChampPresentations::RepetitionPresentation do
   before do
     champ_repetition.add_row(updated_by: 'test')
     champ_repetition.add_row(updated_by: 'test')
-    row1, row2, row3 = champ_repetition.rows
+    row1, row2, row3 = champ_repetition.rows.map(&:champs)
 
     nom, stars = row1
     champ_for_update(nom).update(value: "ruby")

--- a/spec/models/champs/header_section_champ_spec.rb
+++ b/spec/models/champs/header_section_champ_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+describe Champs::HeaderSectionChamp do
+  describe '#children' do
+    let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+
+    context 'at the root of the form' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :text, libelle: 't1' },
+          { type: :header_section, level: 2, libelle: 's1.1' },
+          { type: :text, libelle: 't1.1' },
+        ])
+      end
+      let(:champ) { dossier.root_champs_public.find { it.libelle == 's1' } }
+
+      it 'returns the projected champs of its direct children' do
+        expect(champ.children.map(&:libelle)).to eq(['t1', 's1.1'])
+        expect(champ.children).to all(have_attributes(row_id: nil))
+      end
+    end
+
+    context 'inside a repetition' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          {
+            type: :repetition, libelle: 'rep', children: [
+              { type: :header_section, level: 1, libelle: 'rs1' },
+              { type: :text, libelle: 'rt1' },
+            ],
+          },
+        ])
+      end
+      let(:repetition) { dossier.root_champs_public.find { it.libelle == 'rep' } }
+      let(:champ) { repetition.rows.first.champs.find { it.libelle == 'rs1' } }
+
+      it 'returns the projected champs of the same row' do
+        expect(champ.children.map(&:libelle)).to eq(['rt1'])
+        expect(champ.children).to all(have_attributes(row_id: champ.row_id))
+      end
+    end
+  end
+end

--- a/spec/models/champs/referentiel_champ_cast_value_spec.rb
+++ b/spec/models/champs/referentiel_champ_cast_value_spec.rb
@@ -652,7 +652,7 @@ describe Champs::ReferentielChamp, type: :model do
           ]
         end
         let(:repetition_champ) { dossier.champ_data.find(&:repetition?) }
-        let(:referentiel_champ) { repetition_champ.rows.first.find(&:referentiel?) }
+        let(:referentiel_champ) { repetition_champ.rows.first.champs.find(&:referentiel?) }
 
         context 'when mapping and data are arrays' do
           let(:referentiel_mapping) do
@@ -664,7 +664,7 @@ describe Champs::ReferentielChamp, type: :model do
 
           it 'update current row' do
             expect { subject }.not_to change { repetition_champ.reload.rows.size }
-            champs = repetition_champ.rows.first
+            champs = repetition_champ.rows.first.champs
             expect(champs.find(&:text?).value).to eq('Jeanne')
           end
         end

--- a/spec/models/champs/repetition_champ_spec.rb
+++ b/spec/models/champs/repetition_champ_spec.rb
@@ -101,7 +101,7 @@ describe Champs::RepetitionChamp do
       let(:max_rep) { nil }
 
       before do
-        champ_for_update(champ.rows.first.first).update(value: "rb")
+        champ_for_update(champ.rows.first.champs.first).update(value: "rb")
       end
 
       it "adds a repetition_too_few error" do
@@ -130,7 +130,7 @@ describe Champs::RepetitionChamp do
       let(:max_rep) { 1 }
 
       before do
-        champ_for_update(champ.rows.first.first).update(value: "rb")
+        champ_for_update(champ.rows.first.champs.first).update(value: "rb")
         champ.add_row(updated_by: "test")
         champ.add_row(updated_by: "test")
       end
@@ -146,7 +146,7 @@ describe Champs::RepetitionChamp do
       let(:max_rep) { 3 }
 
       before do
-        champ_for_update(champ.rows.first.first).update(value: "rb")
+        champ_for_update(champ.rows.first.champs.first).update(value: "rb")
       end
 
       it "does not add any errors" do
@@ -158,7 +158,7 @@ describe Champs::RepetitionChamp do
 
   describe "#for_tag" do
     before do
-      champ_for_update(champ.rows.first.first).update(value: "rb")
+      champ_for_update(champ.rows.first.champs.first).update(value: "rb")
     end
 
     it "can render as string" do

--- a/spec/models/concerns/champ_conditional_concern_spec.rb
+++ b/spec/models/concerns/champ_conditional_concern_spec.rb
@@ -44,6 +44,95 @@ describe ChampConditionalConcern do
       }
     end
 
+    context 'inside a conditional section' do
+      let(:section_condition) { ds_eq(champ_value(1), constant(true)) }
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :yes_no, stable_id: 1 },
+          { type: :header_section, level: 1, stable_id: 10, condition: section_condition },
+          { type: :text, stable_id: 11 },
+          { type: :header_section, level: 2, stable_id: 12 },
+          { type: :checkbox, stable_id: 13 },
+          { type: :repetition, stable_id: 14, children: [{ type: :text, stable_id: 15 }] },
+          { type: :header_section, level: 1, stable_id: 20 },
+          { type: :text, stable_id: 21, condition: ds_eq(champ_value(13), constant(true)) },
+        ])
+      end
+      let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+
+      def champ(stable_id)
+        dossier.champ_data.find { it.stable_id == stable_id } || dossier.project_champ(dossier.find_type_de_champ_by_stable_id(stable_id))
+      end
+
+      before { champ(1).update_column(:value, yes_no_value) }
+
+      context 'when the section is visible' do
+        let(:yes_no_value) { 'true' }
+
+        it 'every champ under the section is visible' do
+          expect(champ(10).visible?).to be true
+          expect(champ(11).visible?).to be true
+          expect(champ(12).visible?).to be true
+          expect(champ(13).visible?).to be true
+          expect(champ(14).visible?).to be true
+          expect(champ(15).visible?).to be true
+          expect(champ(21).visible?).to be true
+        end
+      end
+
+      context 'when the section is hidden' do
+        let(:yes_no_value) { 'false' }
+
+        it 'every champ under the section is hidden, including nested sections, repetitions and their rows' do
+          expect(champ(10).visible?).to be false
+          expect(champ(11).visible?).to be false
+          expect(champ(12).visible?).to be false
+          expect(champ(13).visible?).to be false
+          expect(champ(14).visible?).to be false
+          expect(champ(15).visible?).to be false
+        end
+
+        it 'a condition targeting a champ inside the hidden section computes as hidden' do
+          expect(champ(21).visible?).to be false
+        end
+
+        it 'the champ outside the section stays visible' do
+          expect(champ(20).visible?).to be true
+        end
+      end
+
+      context 'when the section condition targets a champ inside the section itself' do
+        let(:procedure) do
+          create(:procedure, types_de_champ_public: [
+            { type: :header_section, level: 1, stable_id: 10, condition: section_condition },
+            { type: :yes_no, stable_id: 1 },
+          ])
+        end
+        let(:yes_no_value) { 'false' }
+
+        it 'does not loop' do
+          expect(champ(10).visible?).to be false
+          expect(champ(1).visible?).to be false
+        end
+      end
+
+      context 'when the procedure uses the legacy behaviour' do
+        let(:procedure) do
+          create(:procedure, section_conditions_hide_champs: false, types_de_champ_public: [
+            { type: :yes_no, stable_id: 1 },
+            { type: :header_section, level: 1, stable_id: 10, condition: section_condition },
+            { type: :text, stable_id: 11 },
+          ])
+        end
+        let(:yes_no_value) { 'false' }
+
+        it 'only the section itself is hidden' do
+          expect(champ(10).visible?).to be false
+          expect(champ(11).visible?).to be true
+        end
+      end
+    end
+
     context 'inside a repetition' do
       let(:procedure) do
         create(:procedure, :published, types_de_champ_public: [
@@ -76,6 +165,30 @@ describe ChampConditionalConcern do
           expect(first_yes_no.visible?).to be false
         end
       end
+    end
+  end
+
+  describe '#conditional_visibility?' do
+    let(:procedure) do
+      create(:procedure, section_conditions_hide_champs:, types_de_champ_public: [
+        { type: :yes_no, stable_id: 1 },
+        { type: :header_section, level: 1, stable_id: 10, condition: ds_eq(champ_value(1), constant(true)) },
+        { type: :text, stable_id: 11 },
+      ])
+    end
+    let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+    let(:text_champ) { dossier.champ_data.find { it.stable_id == 11 } }
+
+    context 'when section conditions hide champs' do
+      let(:section_conditions_hide_champs) { true }
+
+      it { expect(text_champ.conditional_visibility?).to be true }
+    end
+
+    context 'with the legacy behaviour' do
+      let(:section_conditions_hide_champs) { false }
+
+      it { expect(text_champ.conditional_visibility?).to be false }
     end
   end
 

--- a/spec/models/concerns/champ_validate_concern_spec.rb
+++ b/spec/models/concerns/champ_validate_concern_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe ChampValidateConcern do
 
   context 'when in a row' do
     let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :email }], mandatory: true }] }
-    let(:type_de_champ_in_repetition) { dossier.revision.children_of(type_de_champ).first }
+    let(:type_de_champ_in_repetition) { type_de_champ.flat_children(dossier.revision).first }
     let(:row_id) { dossier.repetition_row_ids(type_de_champ).first }
     let(:public_id) { type_de_champ_in_repetition.public_id(row_id) }
 

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -66,6 +66,37 @@ RSpec.describe DossierChampsConcern do
     it { is_expected.to be_truthy }
   end
 
+  describe "#champs_public and #champs_private" do
+    let(:types_de_champ_public) do
+      [
+        { type: :text, libelle: "t1" },
+        { type: :repetition, libelle: "rep", children: [{ type: :text, libelle: "rt1" }] },
+        { type: :header_section, level: 1, libelle: "s1" },
+        { type: :text, libelle: "t2" },
+        { type: :header_section, level: 2, libelle: "s1.1" },
+        { type: :text, libelle: "t3" },
+      ]
+    end
+    let(:types_de_champ_private) do
+      [
+        { type: :header_section, level: 1, libelle: "ps1" },
+        { type: :text, libelle: "pt1" },
+      ]
+    end
+
+    it "returns first-level champs and top-level header sections" do
+      expect(dossier.champs_public.map(&:libelle)).to eq(["t1", "rep", "s1"])
+      expect(dossier.champs_private.map(&:libelle)).to eq(["ps1"])
+    end
+
+    it "composes with children and rows to navigate the tree" do
+      _, repetition, section = dossier.champs_public
+      expect(repetition.rows.flat_map(&:champs).map(&:libelle)).to eq(["rt1"])
+      expect(section.children.map(&:libelle)).to eq(["t2", "s1.1"])
+      expect(section.children.last.children.map(&:libelle)).to eq(["t3"])
+    end
+  end
+
   describe "#project_champ" do
     let(:type_de_champ_repetition) { dossier.find_type_de_champ_by_stable_id(993) }
     let(:type_de_champ_public) { dossier.find_type_de_champ_by_stable_id(99) }
@@ -102,6 +133,12 @@ RSpec.describe DossierChampsConcern do
           expect(subject.is_a?(Champs::TextChamp)).to be_truthy
           expect(subject.updated_at).not_to be_nil
         }
+
+        it "memoizes the built champ" do
+          expect(subject).to equal(dossier.project_champ(type_de_champ_public, row_id:))
+          dossier.reload
+          expect(subject).not_to equal(dossier.project_champ(type_de_champ_public, row_id:))
+        end
 
         context "in repetition" do
           let(:type_de_champ_public) { dossier.find_type_de_champ_by_stable_id(994) }
@@ -248,7 +285,13 @@ RSpec.describe DossierChampsConcern do
 
     it do
       expect(subject.size).to eq(1)
-      expect(subject.first.size).to eq(1)
+      expect(subject.first.index).to eq(1)
+      expect(subject.first.id).to be_present
+      expect(subject.first.champs.size).to eq(1)
+    end
+
+    it "projects the same champ instances across rows built separately" do
+      expect(subject.first.champs.first).to equal(dossier.project_rows_for(type_de_champ_repetition).first.champs.first)
     end
   end
 

--- a/spec/models/concerns/dossier_clone_concern_spec.rb
+++ b/spec/models/concerns/dossier_clone_concern_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe DossierCloneConcern do
           let(:cloned_champ_repetition) { new_dossier.root_champs_public.find(&:repetition?) }
 
           it do
-            expect(cloned_champ_repetition.rows.flatten.count).to eq(4)
-            expect(cloned_champ_repetition.rows.flatten.map(&:id)).not_to eq(champ_repetition.rows.flatten.map(&:id))
+            expect(cloned_champ_repetition.rows.flat_map(&:champs).count).to eq(4)
+            expect(cloned_champ_repetition.rows.flat_map(&:champs).map(&:id)).not_to eq(champ_repetition.rows.flat_map(&:champs).map(&:id))
             expect(cloned_champ_repetition.row_ids).to eq(champ_repetition.row_ids)
           end
         end

--- a/spec/models/concerns/dossier_rebase_concern_spec.rb
+++ b/spec/models/concerns/dossier_rebase_concern_spec.rb
@@ -511,7 +511,7 @@ describe DossierRebaseConcern do
 
       context 'when a child tdc is added in the middle' do
         before do
-          last_child = procedure.draft_revision.children_of(repetition).last
+          last_child = repetition.flat_children(procedure.draft_revision).last
           added_tdc = procedure.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'c3', parent_stable_id: repetition.stable_id, after_stable_id: last_child)
           procedure.draft_revision.move_type_de_champ(added_tdc.stable_id, 1)
           # procedure.publish_revision!(procedure.administrateurs.first)

--- a/spec/models/concerns/dossier_rebase_concern_spec.rb
+++ b/spec/models/concerns/dossier_rebase_concern_spec.rb
@@ -189,8 +189,8 @@ describe DossierRebaseConcern do
         expect(dossier.root_champs_public.size).to eq(5)
         expect(dossier.champ_data.count(&:public?)).to eq(6)
         expect(repetition_champ.rows.size).to eq(2)
-        expect(repetition_champ.rows[0].size).to eq(1)
-        expect(repetition_champ.rows[1].size).to eq(1)
+        expect(repetition_champ.rows[0].champs.size).to eq(1)
+        expect(repetition_champ.rows[1].champs.size).to eq(1)
 
         procedure.publish_revision!(procedure.administrateurs.first)
         perform_enqueued_jobs
@@ -206,14 +206,14 @@ describe DossierRebaseConcern do
         expect(rebased_datetime_champ.type_champ).to eq(TypeDeChamp.type_champs.fetch(:date))
         expect(rebased_datetime_champ.value).to be_nil
         expect(rebased_repetition_champ.rows.size).to eq(2)
-        expect(rebased_repetition_champ.rows[0].size).to eq(2)
-        expect(rebased_repetition_champ.rows[1].size).to eq(2)
+        expect(rebased_repetition_champ.rows[0].champs.size).to eq(2)
+        expect(rebased_repetition_champ.rows[1].champs.size).to eq(2)
         expect(rebased_text_champ.rebased_at).not_to be_nil
         expect(rebased_datetime_champ.rebased_at).not_to be_nil
         expect(rebased_number_champ.rebased_at).to be_nil
         expect(rebased_new_repetition_champ).not_to be_nil
         expect(rebased_new_repetition_champ.rows.size).to eq(1)
-        expect(rebased_new_repetition_champ.rows[0].size).to eq(2)
+        expect(rebased_new_repetition_champ.rows[0].champs.size).to eq(2)
 
         dossier.passer_en_construction!
         procedure.draft_revision.find_and_ensure_exclusive_use(private_text_type_de_champ.stable_id).update(type_champ: TypeDeChamp.type_champs.fetch(:textarea))

--- a/spec/models/concerns/dossier_sections_concern_spec.rb
+++ b/spec/models/concerns/dossier_sections_concern_spec.rb
@@ -39,7 +39,7 @@ describe DossierSectionsConcern do
     context "header_section in a repetition are not auto-numbered" do
       let(:types_de_champ_public) { [{ type: :header_section, libelle: public_libelle }, { type: :repetition, mandatory: true, children: [{ type: :header_section, libelle: "Enfant" }, { type: :text }] }] }
 
-      let(:public_type_de_champ) { dossier.revision.children_of(dossier.root_types_de_champ_public[1]).first }
+      let(:public_type_de_champ) { dossier.root_types_de_champ_public[1].flat_children(dossier.revision).first }
 
       context "with parent section having headers with number" do
         let(:public_libelle) { "1. Infos" }

--- a/spec/models/concerns/procedure_clone_concern_spec.rb
+++ b/spec/models/concerns/procedure_clone_concern_spec.rb
@@ -103,7 +103,7 @@ describe ProcedureCloneConcern, type: :model do
 
       public_repetition = type_de_champ_repetition
       cloned_public_repetition = subject.draft_revision.root_types_de_champ_public.find(&:repetition?)
-      procedure.draft_revision.children_of(public_repetition).zip(subject.draft_revision.children_of(cloned_public_repetition)).each do |ptc, stc|
+      public_repetition.flat_children(procedure.draft_revision).zip(cloned_public_repetition.flat_children(subject.draft_revision)).each do |ptc, stc|
         expect(stc).to have_same_attributes_as(ptc)
         expect(stc.revisions).to include(subject.draft_revision)
       end
@@ -115,7 +115,7 @@ describe ProcedureCloneConcern, type: :model do
 
       private_repetition = type_de_champ_private_repetition
       cloned_private_repetition = subject.draft_revision.root_types_de_champ_private.find(&:repetition?)
-      procedure.draft_revision.children_of(private_repetition).zip(subject.draft_revision.children_of(cloned_private_repetition)).each do |ptc, stc|
+      private_repetition.flat_children(procedure.draft_revision).zip(cloned_private_repetition.flat_children(subject.draft_revision)).each do |ptc, stc|
         expect(stc).to have_same_attributes_as(ptc)
         expect(stc.revisions).to include(subject.draft_revision)
       end

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -234,7 +234,7 @@ describe TagsSubstitutionConcern, type: :model do
       before do
         repetition = dossier.root_champs_public.find(&:repetition?)
         repetition.add_row(updated_by: 'test')
-        paul_champs, pierre_champs = repetition.rows
+        paul_champs, pierre_champs = repetition.rows.map(&:champs)
 
         champ_for_update(paul_champs.first).update(value: 'Paul')
         champ_for_update(paul_champs.last).update(value: 'Chavard')

--- a/spec/models/dossier_preloader_spec.rb
+++ b/spec/models/dossier_preloader_spec.rb
@@ -12,7 +12,7 @@ describe DossierPreloader do
   let(:dossier) { create(:dossier, procedure: procedure) }
   let(:repetition) { subject.root_champs_public.second }
   let(:repetition_optional) { subject.root_champs_public.third }
-  let(:first_child) { repetition.rows.first.first }
+  let(:first_child) { repetition.rows.first.champs.first }
 
   describe 'all' do
     subject { DossierPreloader.load_one(dossier, pj_template: true) }
@@ -40,7 +40,7 @@ describe DossierPreloader do
         expect(subject.champ_data.find(&:public?).conditional?).to eq(false)
         expect(subject.root_champs_public.first.conditional?).to eq(false)
 
-        expect(repetition.rows.first.first.public_id).to eq(first_child.public_id)
+        expect(repetition.rows.first.champs.first.public_id).to eq(first_child.public_id)
         expect(repetition_optional.row_ids).to be_empty
       end
 

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -2095,6 +2095,29 @@ describe Dossier, type: :model do
           expect(errors).to be_empty
         end
       end
+
+      context "inside a hidden section" do
+        let(:types_de_champ) do
+          [
+            { type: :yes_no, stable_id: 99, mandatory: false },
+            { type: :header_section, level: 1, condition: ds_eq(champ_value(99), constant(true)) },
+            type_de_champ,
+          ]
+        end
+        let(:champ_with_error) { dossier.champ_data.find(&:mandatory?) }
+
+        it 'should not have errors' do
+          expect(errors).to be_empty
+        end
+
+        context "with the legacy behaviour" do
+          let(:procedure) { create(:procedure, section_conditions_hide_champs: false, types_de_champ_public: types_de_champ) }
+
+          it 'should have errors' do
+            expect(errors).not_to be_empty
+          end
+        end
+      end
     end
 
     context "with mandatory SIRET champ" do

--- a/spec/models/prefill_champs_spec.rb
+++ b/spec/models/prefill_champs_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe PrefillChamps do
     context "when the public type de champ is authorized (repetition)" do
       let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :text }] }] }
       let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
-      let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
+      let(:type_de_champ_child) { type_de_champ.flat_children(procedure.published_revision).first }
       let(:type_de_champ_child_value) { "value" }
       let(:type_de_champ_child_value2) { "value2" }
       let(:child_champs) { dossier.champ_data.where(stable_id: type_de_champ_child.stable_id) }
@@ -201,7 +201,7 @@ RSpec.describe PrefillChamps do
     context "when the private type de champ is authorized (repetition)" do
       let(:types_de_champ_private) { [{ type: :repetition, children: [{ type: :text }] }] }
       let(:type_de_champ) { procedure.published_revision.root_types_de_champ_private.first }
-      let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
+      let(:type_de_champ_child) { type_de_champ.flat_children(procedure.published_revision).first }
       let(:type_de_champ_child_value) { "value" }
       let(:type_de_champ_child_value2) { "value2" }
       let(:child_champs) { dossier.champ_data.where(stable_id: type_de_champ_child.stable_id) }
@@ -235,7 +235,7 @@ RSpec.describe PrefillChamps do
     context "when the public type de champ is unauthorized because of wrong value format (repetition)" do
       let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :text }] }] }
       let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
-      let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
+      let(:type_de_champ_child) { type_de_champ.flat_children(procedure.published_revision).first }
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => "value" } }
 
@@ -247,7 +247,7 @@ RSpec.describe PrefillChamps do
     context "when the public type de champ is unauthorized because of wrong value typed_id (repetition)" do
       let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :text }] }] }
       let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
-      let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
+      let(:type_de_champ_child) { type_de_champ.flat_children(procedure.published_revision).first }
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => ["{\"wrong\":\"value\"}", "{\"wrong\":\"value2\"}"] } }
 

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -58,13 +58,13 @@ describe ProcedureRevision do
     end
 
     context 'with a repetition child' do
-      let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: procedure.draft_revision.children_of(type_de_champ_repetition).last.stable_id } }
+      let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: type_de_champ_repetition.flat_children(procedure.draft_revision).last.stable_id } }
       let(:tdc_params) { text_params.merge(parent_stable_id: type_de_champ_repetition.stable_id) }
 
       it do
         expect { subject }.to change { draft.reload.types_de_champ.count }.from(4).to(5)
-        expect(draft.children_of(type_de_champ_repetition).last).to eq(subject)
-        expect(draft.children_of(type_de_champ_repetition).map { draft.coordinate_for(_1).position }).to eq([0, 1])
+        expect(type_de_champ_repetition.flat_children(draft).last).to eq(subject)
+        expect(type_de_champ_repetition.flat_children(draft).map { draft.coordinate_for(it).position }).to eq([0, 1])
 
         expect(last_coordinate.position).to eq(1)
 
@@ -138,7 +138,7 @@ describe ProcedureRevision do
           type_champ: TypeDeChamp.type_champs.fetch(:text),
           libelle: "second child",
           parent_stable_id: type_de_champ_repetition.stable_id,
-          after_stable_id: draft.reload.children_of(type_de_champ_repetition).last.stable_id,
+          after_stable_id: type_de_champ_repetition.flat_children(draft.reload).last.stable_id,
         })
       end
 
@@ -147,24 +147,24 @@ describe ProcedureRevision do
           type_champ: TypeDeChamp.type_champs.fetch(:text),
           libelle: "last child",
           parent_stable_id: type_de_champ_repetition.stable_id,
-          after_stable_id: draft.reload.children_of(type_de_champ_repetition).last.stable_id,
+          after_stable_id: type_de_champ_repetition.flat_children(draft.reload).last.stable_id,
         })
       end
 
       it 'move down' do
-        expect(draft.children_of(type_de_champ_repetition).index(second_child)).to eq(2)
+        expect(type_de_champ_repetition.flat_children(draft).index(second_child)).to eq(2)
 
         draft.move_type_de_champ(second_child.stable_id, 3)
 
-        expect(draft.children_of(type_de_champ_repetition).index(second_child)).to eq(3)
+        expect(type_de_champ_repetition.flat_children(draft).index(second_child)).to eq(3)
       end
 
       it 'move up' do
-        expect(draft.children_of(type_de_champ_repetition).index(last_child)).to eq(3)
+        expect(type_de_champ_repetition.flat_children(draft).index(last_child)).to eq(3)
 
         draft.move_type_de_champ(last_child.stable_id, 0)
 
-        expect(draft.children_of(type_de_champ_repetition).index(last_child)).to eq(0)
+        expect(type_de_champ_repetition.flat_children(draft).index(last_child)).to eq(0)
       end
     end
   end
@@ -235,7 +235,7 @@ describe ProcedureRevision do
 
     context 'for a type_de_champ_repetition' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{ type: :text }, { type: :integer_number }] }]) }
-      let!(:child) { child = draft.children_of(type_de_champ_repetition).first }
+      let!(:child) { child = type_de_champ_repetition.flat_children(draft).first }
 
       it 'can remove its children' do
         draft.remove_type_de_champ(child.stable_id)
@@ -259,8 +259,8 @@ describe ProcedureRevision do
           new_draft.remove_type_de_champ(child.stable_id)
 
           expect { child.reload }.not_to raise_error
-          expect(draft.children_of(type_de_champ_repetition).size).to eq(2)
-          expect(new_draft.children_of(type_de_champ_repetition).size).to eq(1)
+          expect(type_de_champ_repetition.flat_children(draft).size).to eq(2)
+          expect(type_de_champ_repetition.flat_children(new_draft).size).to eq(1)
         end
 
         it 'can remove the parent only in the new revision' do
@@ -609,7 +609,7 @@ describe ProcedureRevision do
         let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{ type: :text, libelle: 'sub type de champ' }, { type: :integer_number }] }]) }
 
         before do
-          child = new_draft.children_of(new_draft.root_types_de_champ_public.last).first
+          child = new_draft.root_types_de_champ_public.last.flat_children(new_draft).first
           new_draft.find_and_ensure_exclusive_use(child.stable_id).update(type_champ: :drop_down_list, drop_down_options: ['one', 'two'])
         end
 
@@ -622,7 +622,7 @@ describe ProcedureRevision do
               private: false,
               from: "text",
               to: "drop_down_list",
-              stable_id: new_draft.children_of(new_draft.root_types_de_champ_public.last).first.stable_id,
+              stable_id: new_draft.root_types_de_champ_public.last.flat_children(new_draft).first.stable_id,
             },
             {
               op: :update,
@@ -631,7 +631,7 @@ describe ProcedureRevision do
               private: false,
               from: [],
               to: ["one", "two"],
-              stable_id: new_draft.children_of(new_draft.root_types_de_champ_public.last).first.stable_id,
+              stable_id: new_draft.root_types_de_champ_public.last.flat_children(new_draft).first.stable_id,
             },
           ])
         end
@@ -641,7 +641,7 @@ describe ProcedureRevision do
         let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{ type: :text, libelle: 'sub type de champ' }, { type: :integer_number }] }]) }
 
         before do
-          child = new_draft.children_of(new_draft.root_types_de_champ_public.last).first
+          child = new_draft.root_types_de_champ_public.last.flat_children(new_draft).first
           new_draft.find_and_ensure_exclusive_use(child.stable_id).update(type_champ: :carte, options: { cadastres: true, znieff: true })
         end
 
@@ -654,7 +654,7 @@ describe ProcedureRevision do
               private: false,
               from: "text",
               to: "carte",
-              stable_id: new_draft.children_of(new_draft.root_types_de_champ_public.last).first.stable_id,
+              stable_id: new_draft.root_types_de_champ_public.last.flat_children(new_draft).first.stable_id,
             },
             {
               op: :update,
@@ -663,7 +663,7 @@ describe ProcedureRevision do
               private: false,
               from: [],
               to: [:cadastres, :znieff],
-              stable_id: new_draft.children_of(new_draft.root_types_de_champ_public.last).first.stable_id,
+              stable_id: new_draft.root_types_de_champ_public.last.flat_children(new_draft).first.stable_id,
             },
           ])
         end
@@ -1020,11 +1020,11 @@ describe ProcedureRevision do
     end
   end
 
-  describe 'children_of' do
+  describe 'flat_children' do
     context 'with a simple tdc' do
       let(:procedure) { create(:procedure, :with_type_de_champ) }
 
-      it { expect(draft.children_of(draft.types_de_champ.first)).to be_empty }
+      it { expect(draft.types_de_champ.first.flat_children(draft)).to be_empty }
     end
 
     context 'with a repetition tdc' do
@@ -1033,7 +1033,7 @@ describe ProcedureRevision do
       let!(:first_child) { draft.types_de_champ.reject(&:repetition?).first }
       let!(:second_child) { draft.types_de_champ.reject(&:repetition?).second }
 
-      it { expect(draft.children_of(parent)).to match([first_child, second_child]) }
+      it { expect(parent.flat_children(draft)).to match([first_child, second_child]) }
 
       context 'with multiple child' do
         let(:child_position_2) { create(:type_de_champ_text) }
@@ -1046,7 +1046,7 @@ describe ProcedureRevision do
         end
 
         it 'returns the children in order' do
-          expect(draft.children_of(parent)).to eq([first_child, second_child, child_position_1, child_position_2])
+          expect(parent.flat_children(draft)).to eq([first_child, second_child, child_position_1, child_position_2])
         end
       end
 
@@ -1062,14 +1062,43 @@ describe ProcedureRevision do
             .revision_types_de_champ
             .where(type_de_champ: first_child)
             .update(type_de_champ: new_child)
-          new_draft.revision_types_de_champ.reload
+          new_draft.reload
         end
 
         it 'returns the children regarding the revision' do
-          expect(draft.children_of(parent)).to match([first_child, second_child])
-          expect(new_draft.children_of(parent)).to match([new_child, second_child])
+          expect(parent.flat_children(draft)).to match([first_child, second_child])
+          expect(parent.flat_children(new_draft)).to match([new_child, second_child])
         end
       end
+    end
+  end
+
+  describe 'tree cache invalidation' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :header_section, level: 1, libelle: 's1' },
+        { type: :header_section, level: 2, libelle: 's2' },
+        { type: :text, libelle: 't1' },
+      ])
+    end
+    let(:text) { draft.types_de_champ.find { it.libelle == 't1' } }
+
+    it 'resets ancestors after a structural change' do
+      expect(draft.ancestors_of(text).map(&:libelle)).to eq(['s1', 's2'])
+
+      section = draft.types_de_champ.find { it.libelle == 's2' }
+      draft.remove_type_de_champ(section.stable_id)
+
+      expect(draft.ancestors_of(text).map(&:libelle)).to eq(['s1'])
+    end
+
+    it 'resets ancestors when a type de champ is mutated through find_and_ensure_exclusive_use' do
+      expect(draft.ancestors_of(text).map(&:libelle)).to eq(['s1', 's2'])
+
+      section = draft.types_de_champ.find { it.libelle == 's2' }
+      draft.find_and_ensure_exclusive_use(section.stable_id).update!(header_section_level: 1)
+
+      expect(draft.ancestors_of(text).map(&:libelle)).to eq(['s2'])
     end
   end
 
@@ -1256,7 +1285,7 @@ describe ProcedureRevision do
 
       let(:children_of_repetition) do
         repetition = procedure.draft_revision.root_types_de_champ_public.find(&:repetition?)
-        procedure.draft_revision.children_of(repetition)
+        repetition.flat_children(procedure.draft_revision)
       end
 
       let(:integer_champ) { children_of_repetition.first }
@@ -1417,6 +1446,30 @@ describe ProcedureRevision do
     end
 
     it { expect(draft.simple_routable_types_de_champ.pluck(:libelle)).to eq(['l2', 'l3', 'l4', 'l5', 'l6']) }
+  end
+
+  describe '#types_de_champ_public and #types_de_champ_private' do
+    let(:procedure) do
+      create(:procedure,
+        types_de_champ_public: [
+          { type: :text, libelle: 't1' },
+          { type: :repetition, libelle: 'rep', children: [{ type: :text, libelle: 'rt1' }] },
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :text, libelle: 't1.1' },
+          { type: :header_section, level: 2, libelle: 's1.1' },
+          { type: :text, libelle: 't1.1.1' },
+          { type: :header_section, level: 1, libelle: 's2' },
+        ],
+        types_de_champ_private: [
+          { type: :header_section, level: 1, libelle: 'ps1' },
+          { type: :text, libelle: 'pt1' },
+        ])
+    end
+
+    it 'returns first-level types de champ and top-level header sections' do
+      expect(draft.types_de_champ_public.map(&:libelle)).to eq(['t1', 'rep', 's1', 's2'])
+      expect(draft.types_de_champ_private.map(&:libelle)).to eq(['ps1'])
+    end
   end
 
   describe "#schema_to_llm" do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -608,7 +608,7 @@ describe Procedure do
           let(:types_de_champ_public) { [{ type: :repetition, libelle: 'Bloc', children: }] }
           let(:types_de_champ_private) { [] }
           let(:repetition) { procedure.draft_revision.types_de_champ.find(&:repetition?) }
-          let(:nested_tdc) { procedure.draft_revision.children_of(repetition).first }
+          let(:nested_tdc) { repetition.flat_children(procedure.draft_revision).first }
 
           context 'with invalid dropdown' do
             let(:children) { [{ type: :multiple_drop_down_list, libelle: 'Choix imbriqué' }] }

--- a/spec/models/types_de_champ/header_section_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/header_section_type_de_champ_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+describe TypesDeChamp::HeaderSectionTypeDeChamp do
+  describe '#children' do
+    let(:revision) { procedure.draft_revision }
+
+    def children_libelles(libelle)
+      tdc = revision.revision_types_de_champ.map(&:type_de_champ).find { it.libelle == libelle }
+      tdc.children(revision).map(&:libelle)
+    end
+
+    context 'with nested sections' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :text, libelle: 't1' },
+          { type: :header_section, level: 2, libelle: 's1.1' },
+          { type: :text, libelle: 't1.1' },
+          { type: :header_section, level: 1, libelle: 's2' },
+          { type: :text, libelle: 't2' },
+        ])
+      end
+
+      it 'returns only direct children' do
+        expect(children_libelles('s1')).to eq(['t1', 's1.1'])
+        expect(children_libelles('s1.1')).to eq(['t1.1'])
+        expect(children_libelles('s2')).to eq(['t2'])
+      end
+    end
+
+    context 'with a level gap' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :header_section, level: 3, libelle: 's1.1' },
+          { type: :text, libelle: 't1.1' },
+        ])
+      end
+
+      it 'attaches the deeper section to the closest ancestor' do
+        expect(children_libelles('s1')).to eq(['s1.1'])
+        expect(children_libelles('s1.1')).to eq(['t1.1'])
+      end
+    end
+
+    context 'with a level gap after a previous sibling subtree' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :header_section, level: 2, libelle: 's1.1' },
+          { type: :header_section, level: 1, libelle: 's2' },
+          { type: :header_section, level: 3, libelle: 's2.1' },
+        ])
+      end
+
+      it 'attaches the deeper section to the current section, not the previous sibling subtree' do
+        expect(children_libelles('s2')).to eq(['s2.1'])
+        expect(children_libelles('s1.1')).to eq([])
+      end
+    end
+
+    context 'with an empty section' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :header_section, level: 1, libelle: 's2' },
+        ])
+      end
+
+      it { expect(children_libelles('s1')).to eq([]) }
+    end
+
+    context 'inside a repetition' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          {
+            type: :repetition, libelle: 'rep', children: [
+              { type: :header_section, level: 1, libelle: 'rs1' },
+              { type: :text, libelle: 'rt1' },
+              { type: :header_section, level: 1, libelle: 'rs2' },
+              { type: :text, libelle: 'rt2' },
+            ],
+          },
+        ])
+      end
+
+      it 'only includes siblings within the repetition' do
+        expect(children_libelles('rs1')).to eq(['rt1'])
+        expect(children_libelles('rs2')).to eq(['rt2'])
+      end
+    end
+
+    context 'with a private section' do
+      let(:procedure) do
+        create(:procedure,
+          types_de_champ_public: [{ type: :text, libelle: 'public' }],
+          types_de_champ_private: [
+            { type: :header_section, level: 1, libelle: 'ps1' },
+            { type: :text, libelle: 'pt1' },
+          ])
+      end
+
+      it { expect(children_libelles('ps1')).to eq(['pt1']) }
+    end
+  end
+
+  describe '#flat_children' do
+    let(:revision) { procedure.draft_revision }
+
+    def flat_children_libelles(libelle)
+      tdc = revision.revision_types_de_champ.map(&:type_de_champ).find { it.libelle == libelle }
+      tdc.flat_children(revision).map(&:libelle)
+    end
+
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :header_section, level: 1, libelle: 's1' },
+        { type: :text, libelle: 't1' },
+        { type: :header_section, level: 2, libelle: 's1.1' },
+        { type: :text, libelle: 't1.1' },
+        { type: :repetition, libelle: 'rep', children: [{ type: :text, libelle: 'rt1' }] },
+        { type: :header_section, level: 1, libelle: 's2' },
+        { type: :text, libelle: 't2' },
+      ])
+    end
+
+    it 'returns every type de champ below, in document order, including nested section headers' do
+      expect(flat_children_libelles('s1')).to eq(['t1', 's1.1', 't1.1', 'rep'])
+      expect(flat_children_libelles('s1.1')).to eq(['t1.1', 'rep'])
+      expect(flat_children_libelles('s2')).to eq(['t2'])
+    end
+
+    it 'includes a nested repetition but not its row content' do
+      expect(flat_children_libelles('s1')).not_to include('rt1')
+      expect(flat_children_libelles('rep')).to eq(['rt1'])
+    end
+  end
+end

--- a/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe TypesDeChamp::PrefillRepetitionTypeDeChamp, type: :model do
   let(:text_repetition) { prefillable_subchamps.first }
   let(:integer_repetition) { prefillable_subchamps.second }
   let(:region_repetition) { prefillable_subchamps.third }
-  let(:text_repetition_champs) { champ.rows.flat_map(&:first) }
-  let(:integer_repetition_champs) { champ.rows.flat_map(&:second) }
+  let(:text_repetition_champs) { champ.rows.map { it.champs.first } }
+  let(:integer_repetition_champs) { champ.rows.map { it.champs.second } }
 
   describe 'ancestors' do
     subject { described_class.build(type_de_champ, procedure.active_revision) }

--- a/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe TypesDeChamp::PrefillRepetitionTypeDeChamp, type: :model do
     let(:repetition_tdc) { procedure_with_dropdown.draft_types_de_champ_public.find(&:repetition?) }
 
     before do
-      sub_tdc = procedure_with_dropdown.active_revision.children_of(repetition_tdc).first
+      sub_tdc = repetition_tdc.flat_children(procedure_with_dropdown.active_revision).first
       sub_tdc.update!(drop_down_options: [xss_payload, "safe"])
     end
 

--- a/spec/models/types_de_champ/repetition_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/repetition_type_de_champ_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe TypesDeChamp::RepetitionTypeDeChamp do
+  describe '#children' do
+    let(:revision) { procedure.draft_revision }
+    let(:repetition) { revision.root_types_de_champ_public.find(&:repetition?) }
+
+    subject(:children_libelles) { repetition.children(revision).map(&:libelle) }
+
+    context 'without sections' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          {
+            type: :repetition, libelle: 'rep', children: [
+              { type: :text, libelle: 't1' },
+              { type: :integer_number, libelle: 'n1' },
+            ],
+          },
+        ])
+      end
+
+      it { is_expected.to eq(['t1', 'n1']) }
+    end
+
+    context 'with nested sections' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          {
+            type: :repetition, libelle: 'rep', children: [
+              { type: :text, libelle: 't1' },
+              { type: :header_section, level: 1, libelle: 's1' },
+              { type: :text, libelle: 't1.1' },
+              { type: :header_section, level: 2, libelle: 's1.1' },
+              { type: :text, libelle: 't1.1.1' },
+            ],
+          },
+        ])
+      end
+
+      it 'returns only direct children' do
+        expect(children_libelles).to eq(['t1', 's1'])
+      end
+    end
+  end
+end

--- a/spec/models/types_de_champ/type_de_champ_base_spec.rb
+++ b/spec/models/types_de_champ/type_de_champ_base_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+describe TypesDeChamp::TypeDeChampBase do
+  describe '#ancestors, #parent, #section and #repetition' do
+    let(:procedure) do
+      create(:procedure,
+        types_de_champ_public: [
+          { type: :text, libelle: 't0' },
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :header_section, level: 2, libelle: 's1.1' },
+          {
+            type: :repetition, libelle: 'rep', children: [
+              { type: :header_section, level: 1, libelle: 'rs1' },
+              { type: :text, libelle: 'rt1' },
+            ],
+          },
+        ],
+        types_de_champ_private: [
+          { type: :header_section, level: 1, libelle: 'ps1' },
+          { type: :text, libelle: 'pt1' },
+        ])
+    end
+    let(:revision) { procedure.draft_revision }
+
+    def tdc(libelle) = revision.types_de_champ.find { it.libelle == libelle }
+
+    it 'returns sections and repetitions above, outermost first' do
+      expect(tdc('t0').ancestors(revision)).to eq([])
+      expect(tdc('s1').ancestors(revision)).to eq([])
+      expect(tdc('s1.1').ancestors(revision).map(&:libelle)).to eq(['s1'])
+      expect(tdc('rep').ancestors(revision).map(&:libelle)).to eq(['s1', 's1.1'])
+      expect(tdc('rs1').ancestors(revision).map(&:libelle)).to eq(['s1', 's1.1', 'rep'])
+      expect(tdc('rt1').ancestors(revision).map(&:libelle)).to eq(['s1', 's1.1', 'rep', 'rs1'])
+      expect(tdc('pt1').ancestors(revision).map(&:libelle)).to eq(['ps1'])
+    end
+
+    it 'exposes parent, section and repetition' do
+      expect(tdc('t0').parent(revision)).to be_nil
+      expect(tdc('t0').section(revision)).to be_nil
+      expect(tdc('t0').repetition(revision)).to be_nil
+
+      expect(tdc('rt1').parent(revision).libelle).to eq('rs1')
+      expect(tdc('rt1').section(revision).libelle).to eq('rs1')
+      expect(tdc('rt1').repetition(revision).libelle).to eq('rep')
+      expect(tdc('rs1').section(revision).libelle).to eq('s1.1')
+    end
+
+    it 'exposes in_repetition? and in_section?' do
+      expect(tdc('t0').in_repetition?(revision)).to be(false)
+      expect(tdc('t0').in_section?(revision)).to be(false)
+
+      expect(tdc('s1.1').in_repetition?(revision)).to be(false)
+      expect(tdc('s1.1').in_section?(revision)).to be(true)
+
+      expect(tdc('rep').in_repetition?(revision)).to be(false)
+      expect(tdc('rep').in_section?(revision)).to be(true)
+
+      expect(tdc('rt1').in_repetition?(revision)).to be(true)
+      expect(tdc('rt1').in_section?(revision)).to be(true)
+    end
+
+    it 'exposes level as the nesting depth of a header section' do
+      expect(tdc('s1').level(revision)).to eq(1)
+      expect(tdc('s1.1').level(revision)).to eq(2)
+      expect(tdc('rs1').level(revision)).to eq(3)
+      expect(tdc('ps1').level(revision)).to eq(1)
+    end
+
+    context 'when a header section level is skipped' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :header_section, level: 3, libelle: 's3' },
+        ])
+      end
+
+      it 'collapses the gap' do
+        expect(tdc('s3').ancestors(revision).map(&:libelle)).to eq(['s1'])
+        expect(tdc('s3').level(revision)).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -65,8 +65,8 @@ describe PiecesJustificativesService do
     end
 
     context 'with a repetition' do
-      let(:first_champ) { champ_for_update(repetition(dossier).rows.first.first) }
-      let(:second_champ) { champ_for_update(repetition(dossier).rows.second.first) }
+      let(:first_champ) { champ_for_update(repetition(dossier).rows.first.champs.first) }
+      let(:second_champ) { champ_for_update(repetition(dossier).rows.second.champs.first) }
 
       before do
         repetition(dossier).add_row(updated_by: 'test')
@@ -558,15 +558,15 @@ describe PiecesJustificativesService do
     it do
       champs = dossier_1.root_champs_public
       repet_0 = champs[0]
-      pj_0 = repet_0.rows.first.first
-      pj_1 = repet_0.rows.second.first
+      pj_0 = repet_0.rows.first.champs.first
+      pj_1 = repet_0.rows.second.champs.first
 
       repet_1 = champs[1]
-      pj_2 = repet_1.rows.first.first
-      pj_3 = repet_1.rows.first.second
+      pj_2 = repet_1.rows.first.champs.first
+      pj_3 = repet_1.rows.first.champs.second
 
-      pj_4 = repet_1.rows.second.first
-      pj_5 = repet_1.rows.second.second
+      pj_4 = repet_1.rows.second.champs.first
+      pj_5 = repet_1.rows.second.champs.second
 
       is_expected.to eq({ pj_0.id => 0, pj_1.id => 1, pj_2.id => 0, pj_3.id => 0, pj_4.id => 1, pj_5.id => 1 })
     end

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -465,7 +465,7 @@ describe ProcedureExportService do
           procedure.active_revision.root_types_de_champ_public.each do |type_de_champ|
             type_de_champ.update!(libelle: "#{type_de_champ.id} - ?/[] ééé ééé ééééééé ééééééé éééééééé. ééé éé éééééééé éé ééé. ééééé éééééééé ééé ééé.")
           end
-          procedure.active_revision.children_of(champ_repetition.type_de_champ).each do |type_de_champ|
+          champ_repetition.type_de_champ.flat_children(procedure.active_revision).each do |type_de_champ|
             type_de_champ.update!(libelle: "#{type_de_champ.id} - Quam rem nam maiores numquam dolorem nesciunt. Cum et possimus et aut. Fugit voluptas qui qui.")
           end
         end

--- a/spec/services/procedure_export_service_zip_spec.rb
+++ b/spec/services/procedure_export_service_zip_spec.rb
@@ -18,11 +18,11 @@ describe ProcedureExportService do
       attach_file_to_champ(pj_champ(dossier))
 
       repetition(dossier).add_row(updated_by: 'test')
-      attach_file_to_champ(repetition(dossier).rows.first.first)
-      attach_file_to_champ(repetition(dossier).rows.first.first)
+      attach_file_to_champ(repetition(dossier).rows.first.champs.first)
+      attach_file_to_champ(repetition(dossier).rows.first.champs.first)
 
       repetition(dossier).add_row(updated_by: 'test')
-      attach_file_to_champ(repetition(dossier).rows.second.first)
+      attach_file_to_champ(repetition(dossier).rows.second.champs.first)
     end
 
     allow_any_instance_of(ActiveStorage::Attachment).to receive(:url).and_return("https://opengraph.githubassets.com/d0e7862b24d8026a3c03516d865b28151eb3859029c6c6c2e86605891fbdcd7a/socketry/async-io")

--- a/spec/system/administrateurs/api_referentiel_spec.rb
+++ b/spec/system/administrateurs/api_referentiel_spec.rb
@@ -663,11 +663,11 @@ describe 'Referentiel API:' do
           dossier = Dossier.last
 
           # wait until selected key had been submitted to backend
-          wait_until { dossier.reload.flat_champs_private.find(&:repetition?).rows.first.find(&:referentiel?).value&.match?(/010002699 CENTRE MEDICAL REGINA/) }
+          wait_until { dossier.reload.flat_champs_private.find(&:repetition?).rows.first.champs.find(&:referentiel?).value&.match?(/010002699 CENTRE MEDICAL REGINA/) }
 
           # wait until refreshed with prefilled values
           expect(page).to have_content("Donnée remplie automatiquement.", count: 2)
-          expect(dossier.reload.flat_champs_private.find(&:repetition?).rows.first.map(&:value)).to include("010002699")
+          expect(dossier.reload.flat_champs_private.find(&:repetition?).rows.first.champs.map(&:value)).to include("010002699")
         end
       end
     end

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -552,6 +552,35 @@ describe 'The user', js: true do
       end
     end
 
+    context 'with a conditional section hiding its champs' do
+      let(:age_stable_id) { 999 }
+      let(:section_condition) { greater_than_eq(champ_value(age_stable_id), constant(18)) }
+
+      let(:procedure) do
+        create(:procedure, :published, :for_individual,
+          types_de_champ_public: [
+            { type: :integer_number, libelle: 'age du candidat', stable_id: age_stable_id, mandatory: false },
+            { type: :header_section, libelle: 'info voiture', condition: section_condition },
+            { type: :text, libelle: 'marque', mandatory: false },
+          ])
+      end
+
+      scenario 'the champs under the section toggle with it' do
+        log_in_fast(user, procedure)
+
+        expect(page).to have_no_css('legend', text: 'info voiture', visible: true)
+        expect(page).to have_no_css('label', text: 'marque', visible: true)
+
+        fill_in('age du candidat', with: '18')
+        expect(page).to have_css('legend', text: 'info voiture', visible: true)
+        expect(page).to have_css('label', text: 'marque', visible: true)
+
+        fill_in('age du candidat', with: '2')
+        expect(page).to have_no_css('legend', text: 'info voiture', visible: true)
+        expect(page).to have_no_css('label', text: 'marque', visible: true)
+      end
+    end
+
     context 'with a visibilite in cascade' do
       let(:age_stable_id) { 999 }
       let(:permis_stable_id) { 9999 }

--- a/spec/system/users/dossier_prefill_get_spec.rb
+++ b/spec/system/users/dossier_prefill_get_spec.rb
@@ -48,7 +48,7 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
   let(:commune_value) { ['01540', '01457'] }
   let(:commune_libelle) { 'Vonnas (01540)' }
   let(:address_value) { "20 Avenue de Ségur 75007 Paris" }
-  let(:sub_types_de_champ_repetition) { procedure.active_revision.children_of(type_de_champ_repetition) }
+  let(:sub_types_de_champ_repetition) { type_de_champ_repetition.flat_children(procedure.active_revision) }
   let(:text_repetition_libelle) { sub_types_de_champ_repetition.first.libelle }
   let(:integer_repetition_libelle) { sub_types_de_champ_repetition.second.libelle }
   let(:text_repetition_value) { "First repetition text" }

--- a/spec/system/users/dossier_prefill_post_spec.rb
+++ b/spec/system/users/dossier_prefill_post_spec.rb
@@ -47,7 +47,7 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
   let(:commune_value) { ['01540', '01457'] }
   let(:commune_libelle) { 'Vonnas (01540)' }
   let(:address_value) { "20 Avenue de Ségur 75007 Paris" }
-  let(:sub_type_de_champs_repetition) { procedure.active_revision.children_of(type_de_champ_repetition) }
+  let(:sub_type_de_champs_repetition) { type_de_champ_repetition.flat_children(procedure.active_revision) }
   let(:text_repetition_libelle) { sub_type_de_champs_repetition.first.libelle }
   let(:integer_repetition_libelle) { sub_type_de_champs_repetition.second.libelle }
   let(:text_repetition_value) { "First repetition text" }

--- a/spec/validators/types_de_champ/libelle_validator_spec.rb
+++ b/spec/validators/types_de_champ/libelle_validator_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe TypesDeChamp::LibelleValidator do
   context 'with a champ inside a repetition' do
     let(:types) { [{ type: :repetition, children: [{ type: :text }] }] }
     let(:repetition) { procedure.active_revision.root_types_de_champ_public.find(&:repetition?) }
-    let(:child) { procedure.draft_revision.children_of(repetition).first }
+    let(:child) { repetition.flat_children(procedure.draft_revision).first }
 
     context 'when the child libelle is empty' do
       before { child.update(libelle: '') }

--- a/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
+++ b/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
@@ -14,4 +14,23 @@ describe 'dossiers/dossier_vide', type: :view do
     subject
     expect(rendered).to be_present
   end
+
+  context 'with a repetition containing header sections' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        {
+          type: :repetition, libelle: 'rep', children: [
+            { type: :header_section, level: 1, libelle: 'rs1' },
+            { type: :text, libelle: 'rt1' },
+          ],
+        },
+      ])
+    end
+
+    it 'renders the champs nested in the sections' do
+      allow(view).to receive(:format_in_2_lines).and_call_original
+      subject
+      expect(view).to have_received(:format_in_2_lines).with(anything, having_attributes(libelle: 'rt1'), any_args).thrice
+    end
+  end
 end

--- a/spec/views/dossiers/show.pdf.prawn_spec.rb
+++ b/spec/views/dossiers/show.pdf.prawn_spec.rb
@@ -136,11 +136,31 @@ describe 'dossiers/show.pdf', type: :view do
       d
     end
 
-    it 'skips invisible header and numbers next visible as 1.1', if: PDFTOTEXT_AVAILABLE do
+    it 'skips invisible header and its champs, numbers next visible as 1.1', if: PDFTOTEXT_AVAILABLE do
       text = render_and_extract(dossier, procedure, 'invisible')
       expect(text).to include('1. Parent')
       expect(text).not_to include('Caché')
+      expect(text).not_to include('Optionnel')
       expect(text).to include('1.1. Visible')
+    end
+
+    context 'when the procedure uses the legacy behaviour' do
+      let(:procedure) do
+        create(:procedure, section_conditions_hide_champs: false, types_de_champ_public: [
+          { type: :header_section, libelle: 'Parent', level: 1 },
+          { type: :integer_number, libelle: 'Critère', stable_id: stable_id_number },
+          { type: :header_section, libelle: 'Caché', level: 2, condition: ds_eq(champ_value(stable_id_number), constant(5)) },
+          { type: :text, libelle: 'Optionnel' },
+          { type: :header_section, libelle: 'Visible', level: 2 },
+          { type: :text, libelle: 'Toujours' },
+        ])
+      end
+
+      it 'skips only the invisible header, not its champs', if: PDFTOTEXT_AVAILABLE do
+        text = render_and_extract(dossier, procedure, 'invisible_legacy')
+        expect(text).not_to include('Caché')
+        expect(text).to include('Optionnel')
+      end
     end
   end
 

--- a/spec/views/shared/dossiers/_champs.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_champs.html.haml_spec.rb
@@ -6,7 +6,6 @@ describe 'shared/dossiers/champs', type: :view do
   let(:profile) { "instructeur" }
   let(:procedure) { create(:procedure, types_de_champ_public:) }
   let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
-  let(:types_de_champ) { dossier.revision.root_types_de_champ_public }
 
   before do
     view.extend DossierHelper
@@ -17,7 +16,7 @@ describe 'shared/dossiers/champs', type: :view do
     end
   end
 
-  subject { render ViewableChamp::SectionComponent.new(types_de_champ:, dossier:, demande_seen_at:, profile:) }
+  subject { render ViewableChamp::SectionComponent.new(champs: dossier.champs_public, dossier:, demande_seen_at:, profile:) }
 
   context "there are some champs" do
     let(:types_de_champ_public) { [{ type: :checkbox }, { type: :header_section }, { type: :explication }, { type: :dossier_link }, { type: :textarea }, { type: :integer_number }] }


### PR DESCRIPTION
## Résumé

Aujourd'hui, une condition sur une section (titre de section) ne masque que le titre lui-même : les champs situés sous la section restent visibles. Cette PR fait en sorte qu'une section masquée masque aussi tout ce qu'elle contient (champs, sous-sections, répétitions et leurs lignes), en s'appuyant sur l'API d'arbre des champs (`Champ#ancestors` / `#parent`).

Le changement est conditionné par un nouveau booléen `procedures.section_conditions_hide_champs` :

- `false` par défaut → les démarches existantes conservent le comportement actuel, à l'identique ;
- mis à `true` à la création d'une nouvelle démarche (pas de chemin de migration pour l'existant dans cette première version) ;
- copié tel quel lors d'un clone (une démarche clonée garde le comportement de sa source).

Concrètement, quand le flag est actif :

- `visible?` considère un champ masqué dès que son ancêtre le plus proche (section ou répétition) est masqué — la visibilité de l'ancêtre remonte elle-même la chaîne récursivement ;
- les mises à jour Turbo affichent/masquent en direct les champs *non conditionnés* situés sous une section conditionnée (`conditional_visibility?`) ;
- l'export PDF saute les champs masqués par la cascade ;
- validation de complétude, GraphQL, numérotation des sections, etc. héritent de la cascade sans modification (ils lisent déjà `visible?`).

## Garde anti-cycle : pourquoi et comment

### Le problème

Une section conditionnée par un champ situé *à l'intérieur* d'elle-même crée un cycle : `champ.visible?` → `section.visible?` → évaluation de la condition → `champ.visible?` → ∞.

L'éditeur ne propose que des champs situés *en amont* comme source de condition, mais cet état invalide reste atteignable : il suffit de poser la condition (valide), puis de déplacer le champ source sous le titre de section (ou de déplacer la section, ou de changer le niveau d'un titre). Les endpoints de déplacement ne nettoient pas les conditions ; `TypesDeChamp::ConditionValidator` signale l'erreur dans l'éditeur et bloque la publication, mais la révision brouillon invalide persiste en base — et elle est évaluable à tout moment via les dossiers de test (`?test` → `draft_revision`). Sans garde, l'admin qui teste sa démarche pendant cette fenêtre obtenait un `SystemStackError` (500).

Avant cette PR, cet état était bénin (la visibilité ne remontait jamais les sections), ce qui explique qu'aucun nettoyage n'ait jamais existé : c'est la cascade qui transforme un état invalide toléré en crash potentiel.

### Les solutions essayées

1. **Garde par instance (`@visible_computing`)** — a échoué au premier essai : `champ.dossier` est chargé sans `inverse_of`, donc la traversée saute d'instance en instance (chaque champ persisté recharge sa propre copie du dossier, avec ses propres caches). Le cycle ne repasse jamais par la même instance et la garde ne se déclenche pas.

2. **Garde thread-local keyée sur l'identité en base** (`[dossier_id, stream, public_id]` dans un `Set` sur `Thread.current`) — fonctionnelle, mais un stockage thread-local pour un problème local, c'est lourd et fragile.

3. **`inverse_of: :champ_data` sur `belongs_to :dossier`** — impossible : le système de projection construit des champs *transients* avec `dossier: self` (`projected_champ`), et un `inverse_of` les enregistrerait dans la cible chargée de l'association `champ_data` (les specs le détectent : 22 champs comptés au lieu de 20). Avec `autosave: true`, une sauvegarde du dossier persisterait des champs censés rester virtuels. Le `inverse_of: false` est donc structurel — c'est maintenant documenté par un commentaire sur l'association.

4. **Solution retenue : partage d'instance au point de lecture + garde par instance.** `champs_on_stream` (l'entonnoir unique des lectures) fait `champ.association(:dossier).target = self` sur chaque champ chargé — exactement la technique déjà utilisée par `champ_for_update`. C'est unidirectionnel : les champs persistés pointent vers l'instance de dossier qui les a chargés, sans rien enregistrer dans l'association (les champs projetés restent virtuels). Le graphe d'instances se referme : tout champ atteint depuis un dossier D a `.dossier == D`, un cycle repasse donc forcément par la même instance, et la garde redevient un simple booléen d'instance.

Un champ en cours d'évaluation est traité comme masqué : la condition cassée s'évalue à `nil` et la section reste masquée (comportement sûr pour une config invalide).

Bénéfices annexes du partage d'instance : la mémoïsation de `@visible` est réellement partagée pendant la traversée, et les sauts `champ.dossier` ne déclenchent plus de chargements dupliqués de `Dossier` (N+1 silencieux auparavant).

## Tests

- Specs modèle : cascade (sections imbriquées, répétitions, chaînage de conditions), comportement legacy épinglé, régression anti-cycle, `conditional_visibility?` ;
- complétude : un champ obligatoire sous une section masquée ne bloque plus le dépôt (flag actif) ;
- specs contrôleur : sélecteurs Turbo `@to_show`/`@to_hide` pour les champs sous section conditionnée ;
- spec vue PDF : champs masqués absents (flag actif), présents (legacy) ;
- spec système : un champ non conditionné sous une section conditionnée s'affiche/se masque en direct dans le navigateur.

Suites complètes vertes : `spec/models` (3122), `spec/controllers` (2189), `spec/components` + `spec/graphql` + `spec/views/dossiers` (956).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
