### PR TITLE
Correctif: ETQ admin, corriger le lien d'info sur le type de champ commune

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -348,6 +348,18 @@ input[type='radio'] {
     var(--underline-hover-width) calc(var(--underline-thickness) * 2),
     var(--underline-idle-width) var(--underline-thickness);
   transition: background-size;
+
+  // pas de fond au survol/actif, comme sur un vrai lien DSFR : seul le
+  // soulignement doit apparaître
+  --hover-tint: var(--idle);
+  --active-tint: var(--idle);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  [data-href]:hover,
+  [data-href]:active {
+    --underline-hover-width: var(--underline-max-width);
+  }
 }
 
 // Hack pour la modale d'instruction qui est déclarée

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
@@ -39,8 +39,8 @@
                     <% c.with_desc { t(".communes_warning_desc_html") } %>
 
                     <% c.with_link do %>
-                      <%= button_tag(t(".communes_info_link"), type: :button, class: "fr-pl-0 fr-notice__link fr-text-default--warning fr-mt-1w",
-                        data: { "fr-opened" => "false", "turbo-frame" => "api-champ-columns", action: "lazy-modal#load", href: 'style' },
+                      <%= button_tag(t(".communes_info_link"), type: :button, class: "fr-pl-0 fr-link fr-notice__link fr-text-default--warning  fr-mt-1w",
+                        data: { "fr-opened" => "false", "turbo-frame" => "api-champ-columns", action: "lazy-modal#load", href: true },
                         src: commune_info_admin_procedure_path(id: procedure.id, stable_id: type_de_champ.stable_id),
                         "aria-controls" => "api-champ-columns-modal",
                         "aria-haspopup" => "dialog") %>


### PR DESCRIPTION
<img width="1461" height="832" alt="image (35)" src="https://github.com/user-attachments/assets/141323a9-cd61-4430-b1b0-cc682ea45b27" />
