### PR TITLE
ETQ admin, réorganisation de la page de gestion d'une démarche

### DIFF
--- a/app/components/procedure/card/emails_component.rb
+++ b/app/components/procedure/card/emails_component.rb
@@ -11,8 +11,8 @@ class Procedure::Card::EmailsComponent < ApplicationComponent
     "#{customized_count} / #{CUSTOMIZABLE_COUNT}"
   end
 
-  def fully_customized?
-    customized_count == CUSTOMIZABLE_COUNT
+  def customized?
+    customized_count.positive?
   end
 
   private

--- a/app/components/procedure/card/emails_component/emails_component.html.haml
+++ b/app/components/procedure/card/emails_component/emails_component.html.haml
@@ -4,10 +4,10 @@
       %div
         - if error_messages.present?
           %p.fr-badge.fr-badge--warning À modifier
-        - elsif fully_customized?
-          %p.fr-badge.fr-badge--success Validé
+        - elsif customized?
+          %p.fr-badge.fr-badge--info.fr-badge--no-icon Configurés
         - else
-          %p.fr-badge.fr-badge--info À configurer
+          %p.fr-badge Configurés par défaut
       %div
         .line-count.fr-my-1w
           %p.fr-tag= customized_progress

--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -87,23 +87,23 @@
 
 .fr-container
   %h2= "Gestion de la démarche № #{number_with_html_delimiter(@procedure.id)}"
-  %h3.fr-h6 Indispensable avant publication
+  %h3.fr-h6 Paramètres prioritaires
   .fr-grid-row.fr-grid-row--gutters.fr-mb-5w
     = render Procedure::Card::PresentationComponent.new(procedure: @procedure)
     = render Procedure::Card::ZonesComponent.new(procedure: @procedure) if Rails.application.config.ds_zonage_enabled
     = render Procedure::Card::ChampsComponent.new(procedure: @procedure)
     = render Procedure::Card::AiComponent.new(procedure: @procedure)
-    = render Procedure::Card::IneligibiliteDossierComponent.new(procedure: @procedure)
     = render Procedure::Card::ServiceComponent.new(procedure: @procedure, administrateur: current_administrateur)
     = render Procedure::Card::AdministrateursComponent.new(procedure: @procedure)
     = render Procedure::Card::InstructeursComponent.new(procedure: @procedure)
+    = render Procedure::Card::EmailsComponent.new(procedure: @procedure)
 
   %h3.fr-h6 Autres paramètres
   .fr-grid-row.fr-grid-row--gutters.fr-mb-5w
+    = render Procedure::Card::IneligibiliteDossierComponent.new(procedure: @procedure)
     = render Procedure::Card::AttestationComponent.new(procedure: @procedure, kind: AttestationTemplate.kinds.fetch(:acceptation))
     = render Procedure::Card::AttestationComponent.new(procedure: @procedure, kind: AttestationTemplate.kinds.fetch(:refus))
     = render Procedure::Card::ExpertsComponent.new(procedure: @procedure)
-    = render Procedure::Card::EmailsComponent.new(procedure: @procedure)
     = render Procedure::Card::AnnotationsComponent.new(procedure: @procedure)
     = render Procedure::Card::APITokenComponent.new(procedure: @procedure)
     = render Procedure::Card::SVASVRComponent.new(procedure: @procedure)

--- a/spec/components/procedure/card/emails_component_spec.rb
+++ b/spec/components/procedure/card/emails_component_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Procedure::Card::EmailsComponent, type: :component do
+  let(:procedure) { create(:procedure) }
+
+  before { render_inline(described_class.new(procedure:)) }
+
+  context 'when no email template is customized' do
+    it 'shows the default configuration badge' do
+      expect(page).to have_css('p.fr-badge', text: 'Configurés par défaut')
+      expect(page).to have_no_css('.fr-badge--info')
+      expect(page).to have_css('.fr-tag', text: '0 / 6')
+    end
+  end
+
+  context 'when at least one email template is customized' do
+    let(:procedure) { create(:procedure).tap { create(:initiated_mail, procedure: it) } }
+
+    it 'shows the configured badge' do
+      expect(page).to have_css('p.fr-badge.fr-badge--info', text: 'Configurés')
+      expect(page).to have_css('.fr-tag', text: '1 / 6')
+    end
+  end
+end


### PR DESCRIPTION
Étape 1 de #13332.

Réorganisation de l'écran de gestion d'une démarche :

- la section « Indispensable avant publication » devient « Paramètres prioritaires » ;
- la tuile « Modèles d'email » y remonte, en dernière position ;
- la tuile « Inéligibilité des dossiers » descend en tête d'« Autres paramètres ».

Les badges de la tuile « Modèles d'email » reflètent désormais « au moins un modèle personnalisé » plutôt que « tous personnalisés » : « Configurés par défaut » (gris) tant qu'aucun modèle n'est modifié, « Configurés » (bleu) dès le premier. L'état d'erreur « À modifier » est inchangé.

![gestion-demarche.png](https://gist.githubusercontent.com/colinux/7df9a4faad10e92f963dd8b78e1cebb1/raw/2134ca31db5acf211a6356e97d01b11c3461881b/gestion-demarche.png)

| 0 / 6 | 3 / 6 |
| --- | --- |
| ![badge-configures-par-defaut.png](https://gist.githubusercontent.com/colinux/7df9a4faad10e92f963dd8b78e1cebb1/raw/badge-configures-par-defaut.png) | ![badge-configures.png](https://gist.githubusercontent.com/colinux/7df9a4faad10e92f963dd8b78e1cebb1/raw/badge-configures.png) |
