### PR TITLE
ETQ admin, l'éditeur des modèles d'email s'affiche de nouveau sous Safari

### DIFF
--- a/app/assets/stylesheets/tiptap.scss
+++ b/app/assets/stylesheets/tiptap.scss
@@ -91,4 +91,18 @@
   &__toggle[aria-expanded='true']::after {
     transform: rotate(-180deg);
   }
+
+  // WebKit only: before the DSFR collapse JS replaces the --collapse fallback
+  // (-99999px) with the measured height, the ::before negative margin leaks into
+  // the flex line intrinsic height of the surrounding .fr-fieldset, which gets
+  // laid out ~100000px tall and never recovers. Sizing the closed state to zero
+  // without the huge margin avoids that first-layout state; once expanded, the
+  // DSFR mechanics take over untouched.
+  .fr-collapse:not(.fr-collapse--expanded) {
+    max-height: 0;
+
+    &::before {
+      margin-top: 0;
+    }
+  }
 }


### PR DESCRIPTION
Je dis ça je dis rien : 

Sous Safari, la page d'édition des modèles d'email (éditeur TipTap) apparaissait vide et semblait figée : WebKit calcule mal la hauteur de ligne flex du `fr-fieldset` quand le panneau de balises replié (`fr-collapse` DSFR, fallback `--collapse: -99999px` sur le `::before`) s'y trouve. Le fieldset est layouté à ~100 000 px au premier rendu et ne se recalcule jamais : les deux éditeurs sont rendus 100 000 px plus bas, hors de vue.

Le fix dimensionne l'état replié à zéro (`max-height: 0` + marge du `::before` neutralisée) pour éviter ce premier layout ; à l'ouverture (`--expanded`), la mécanique DSFR reprend inchangée.

Vérifié sous Safari 26.5 (chargement, ouverture/fermeture du panneau de balises), sans changement de comportement sous Chrome et Firefox.