### PR TITLE
Tech: API arborescente pour les types de champ

### DIFF
--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
@@ -1,6 +1,6 @@
 <% each_champ do |champ| %>
   <% if champ.repetition? %>
-    <% types_de_champ = champ.dossier.revision.children_of(champ.type_de_champ) %>
+    <% types_de_champ = champ.type_de_champ.flat_children(champ.dossier.revision) %>
     <% champ.row_ids.each.with_index(1) do |row_id, row_number| %>
       <div class="fr-background-alt--grey fr-p-2w fr-my-3w fr-ml-2w champ-repetition">
         <%= tag.send(repetition_heading_tag, t(".repetition_heading", libelle: champ.libelle, row_number: row_number), class: "fr-h6 fr-text--bold") %>

--- a/app/components/dossiers/errors_full_messages_component.rb
+++ b/app/components/dossiers/errors_full_messages_component.rb
@@ -54,7 +54,7 @@ class Dossiers::ErrorsFullMessagesComponent < ApplicationComponent
   def is_in_fieldset?(model)
     return 0 if !model.child?
 
-    model.dossier.revision.children_of(model.parent).size > 1
+    model.parent.flat_children(model.dossier.revision).size > 1
   end
 
   def render?

--- a/app/components/editable_champ/editable_champ_component.rb
+++ b/app/components/editable_champ/editable_champ_component.rb
@@ -33,7 +33,7 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
   def number_of_siblings_if_in_repetition
     return if !@champ.child?
 
-    @number_of_siblings_if_in_repetition ||= @champ.dossier.revision.children_of(@champ.parent).count
+    @number_of_siblings_if_in_repetition ||= @champ.parent.flat_children(@champ.dossier.revision).count
   end
 
   def row_number_if_in_repetition

--- a/app/components/editable_champ/repetition_component.rb
+++ b/app/components/editable_champ/repetition_component.rb
@@ -14,7 +14,7 @@ class EditableChamp::RepetitionComponent < EditableChamp::EditableChampBaseCompo
   end
 
   def show_toggle_all_button?
-    @champ.dossier.revision.children_of(@champ.type_de_champ).size > 1
+    @champ.type_de_champ.flat_children(@champ.dossier.revision).size > 1
   end
 
   def aria_controls
@@ -29,7 +29,7 @@ class EditableChamp::RepetitionComponent < EditableChamp::EditableChampBaseCompo
     dossier = @champ.dossier
     return false if dossier.errors.empty?
 
-    children_types = dossier.revision.children_of(@champ.type_de_champ)
+    children_types = @champ.type_de_champ.flat_children(dossier.revision)
     public_ids = children_types.map { |tdc| tdc.public_id(row_id) }.to_set
 
     public_ids.intersect?(errors_public_ids)

--- a/app/components/editable_champ/repetition_row_component.rb
+++ b/app/components/editable_champ/repetition_row_component.rb
@@ -6,7 +6,7 @@ class EditableChamp::RepetitionRowComponent < ApplicationComponent
   def initialize(form:, dossier:, champ:, row_id:, row_number:, expanded: false, seen_at: nil)
     @form, @dossier, @champ, @row_id, @row_number, @expanded, @seen_at = form, dossier, champ, row_id, row_number, expanded, seen_at
     @type_de_champ = champ.type_de_champ
-    @types_de_champ = dossier.revision.children_of(@type_de_champ)
+    @types_de_champ = @type_de_champ.flat_children(dossier.revision)
   end
 
   attr_reader :row_id, :row_number

--- a/app/components/editable_champ/section_component.rb
+++ b/app/components/editable_champ/section_component.rb
@@ -4,54 +4,32 @@ class EditableChamp::SectionComponent < ApplicationComponent
   include ApplicationHelper
   include TreeableConcern
 
-  def initialize(dossier:, nodes: nil, types_de_champ: nil, row_id: nil, row_number: nil)
-    nodes ||= to_tree(types_de_champ:)
-    @dossier = dossier
-    @row_id = row_id
-    @row_number = row_number
-    @nodes = to_fieldset(nodes:)
+  def initialize(dossier:, types_de_champ: nil, header_section: nil, row_id: nil, row_number: nil)
+    @dossier, @header_section, @row_id, @row_number = dossier, header_section, row_id, row_number
+    @nodes = types_de_champ ? to_tree_roots(types_de_champ:) : header_section.children(dossier.revision)
   end
 
   def render_within_fieldset?
-    first_champ_is_an_header_section?
+    @header_section.present?
   end
 
   def header_section
-    node = @nodes.first
-    @dossier.project_champ(node, row_id: @row_id) if node.is_a?(TypeDeChamp) && node.header_section?
+    @dossier.project_champ(@header_section, row_id: @row_id) if @header_section
   end
 
   def splitted_tail
-    tail.map { split_section_champ(_1) }
-  end
-
-  def tail
-    return @nodes if !first_champ_is_an_header_section?
-    _, *rest_of_champ = @nodes
-
-    rest_of_champ
+    @nodes.map { split_section_champ(it) }
   end
 
   def tag_for_depth
     "h#{header_section.level + 1}"
   end
 
-  def split_section_champ(node)
-    case node
-    when EditableChamp::SectionComponent
-      [node, nil]
+  def split_section_champ(type_de_champ)
+    if type_de_champ.header_section?
+      [EditableChamp::SectionComponent.new(dossier: @dossier, header_section: type_de_champ, row_id: @row_id), nil]
     else
-      [nil, @dossier.project_champ(node, row_id: @row_id)]
+      [nil, @dossier.project_champ(type_de_champ, row_id: @row_id)]
     end
-  end
-
-  private
-
-  def to_fieldset(nodes:)
-    nodes.map { _1.is_a?(Array) ? EditableChamp::SectionComponent.new(dossier: @dossier, nodes: _1, row_id: @row_id) : _1 }
-  end
-
-  def first_champ_is_an_header_section?
-    header_section.present?
   end
 end

--- a/app/components/types_de_champ_editor/header_sections_summary_component.rb
+++ b/app/components/types_de_champ_editor/header_sections_summary_component.rb
@@ -6,17 +6,28 @@ class TypesDeChampEditor::HeaderSectionsSummaryComponent < ApplicationComponent
     @is_private = is_private
   end
 
-  def header_sections
-    coordinates = if @is_private
-      @procedure.draft_revision.revision_types_de_champ_private
-    else
-      @procedure.draft_revision.revision_types_de_champ_public
-    end
-
-    coordinates.filter { _1.type_de_champ.header_section? }
+  # Header sections and repetitions in document order, as [type_de_champ, depth]
+  # pairs. Depth is the position in the tree; like TypeDeChampBase#level, it
+  # can differ from the stored header_section_level when levels are skipped.
+  def sections
+    @sections ||= flatten_sections(root_types_de_champ, 1)
   end
 
-  def href(header_section) # used by type de champ editor to anchor elements
-    "##{dom_id(header_section, :type_de_champ_editor)}"
+  def href(type_de_champ) # used by type de champ editor to anchor elements
+    "##{dom_id(revision.coordinate_for(type_de_champ), :type_de_champ_editor)}"
+  end
+
+  private
+
+  def revision = @procedure.draft_revision
+
+  def root_types_de_champ
+    @is_private ? revision.types_de_champ_private : revision.types_de_champ_public
+  end
+
+  def flatten_sections(types_de_champ, depth)
+    types_de_champ.filter { it.header_section? || it.repetition? }.flat_map do |type_de_champ|
+      [[type_de_champ, depth], *flatten_sections(type_de_champ.children(revision), depth + 1)]
+    end
   end
 end

--- a/app/components/types_de_champ_editor/header_sections_summary_component/header_sections_summary_component.html.haml
+++ b/app/components/types_de_champ_editor/header_sections_summary_component/header_sections_summary_component.html.haml
@@ -1,11 +1,10 @@
-#summary{ class: header_sections.present? ? 'fr-col-12 fr-col-md-3' : '' }
-  - if header_sections.present?
+#summary{ class: sections.present? ? 'fr-col-12 fr-col-md-3' : '' }
+  - if sections.present?
     %nav.fr-sidemenu.sticky.fr-hidden.fr-unhidden-md{ "aria-labelledby" => "fr-summary-title", role: "navigation" }
       %ul.fr-sidemenu__list
-        - header_sections.each do |header|
+        - sections.each do |type_de_champ, level|
           %li.fr-sidemenu__item
-            - level = header.type_de_champ.header_section_level_value.to_i
             - if level == 1
-              %a.fr-sidemenu__link{ href: href(header) }= header.libelle
+              %a.fr-sidemenu__link{ href: href(type_de_champ) }= type_de_champ.libelle
             - else
-              %a.fr-sidemenu__link{ class: level >= 3 ? 'custom-link-grey': '', href: href(header) }= "-- #{header.libelle}"
+              %a.fr-sidemenu__link{ class: level >= 3 ? 'custom-link-grey': '', href: href(type_de_champ) }= "-- #{type_de_champ.libelle}"

--- a/app/graphql/types/champs/descriptor/header_section_champ_descriptor_type.rb
+++ b/app/graphql/types/champs/descriptor/header_section_champ_descriptor_type.rb
@@ -7,7 +7,7 @@ module Types::Champs::Descriptor
     field :level, Int, null: false
 
     def level
-      object.type_de_champ.level_for_revision(object.revision)
+      object.type_de_champ.level(object.revision)
     end
   end
 end

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -81,7 +81,6 @@ class ChampData < ApplicationRecord
     :collapsible_explanation_enabled?,
     :collapsible_explanation_text,
     :header_section_level_value,
-    :current_section_level,
     :non_fillable?,
     :fillable?,
     :mandatory?,
@@ -155,7 +154,7 @@ class ChampData < ApplicationRecord
   def parent
     return nil if row_id.blank?
 
-    dossier.revision.parent_of(type_de_champ)
+    dossier.revision.repetition_of(type_de_champ)
   end
 
   def row?

--- a/app/models/champs/header_section_champ.rb
+++ b/app/models/champs/header_section_champ.rb
@@ -6,6 +6,6 @@ class Champs::HeaderSectionChamp < ChampData
   end
 
   def level
-    type_de_champ.level_for_revision(dossier.revision)
+    type_de_champ.level(dossier.revision)
   end
 end

--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -62,7 +62,7 @@ class Champs::ReferentielChamp < ChampData
       dossier.root_champs_private
     end.filter do |champ|
       if champ.repetition?
-        dossier.revision.children_of(champ.type_de_champ).any? { _1.stable_id.in?(elligible_stable_ids) }
+        champ.type_de_champ.flat_children(dossier.revision).any? { it.stable_id.in?(elligible_stable_ids) }
       else
         champ.stable_id.in?(elligible_stable_ids)
       end
@@ -87,7 +87,7 @@ class Champs::ReferentielChamp < ChampData
       .transform_values do |mapping|
         types_de_champ_by_stable_id[mapping[:prefill_stable_id].to_i]
       end.compact.group_by do |_, type_de_champ|
-        dossier.revision.parent_of(type_de_champ)
+        type_de_champ.repetition(dossier.revision)
       end.flat_map do |repetition_type_de_champ, mappings|
         if repetition_type_de_champ.present?
           update_repetition_prefillable_champs(data, repetition_type_de_champ, mappings)
@@ -190,7 +190,7 @@ class Champs::ReferentielChamp < ChampData
     # When referentiel champ is inside a repetition, use current row_id to keep related data together.
     # When outside, create new rows for each array element from external data.
     # Note: Limited to updating current row only when inside repetition.
-    if type_de_champ.child?(dossier.revision)
+    if type_de_champ.in_repetition?(dossier.revision)
       self.row_id
     else
       dossier.repetition_add_row(repetition_type_de_champ, updated_by:)

--- a/app/models/champs/repetition_champ.rb
+++ b/app/models/champs/repetition_champ.rb
@@ -4,7 +4,7 @@ class Champs::RepetitionChamp < ChampData
   delegate :libelle_for_export, to: :type_de_champ
 
   def row_libelle
-    children_types = dossier.revision.children_of(type_de_champ)
+    children_types = type_de_champ.flat_children(dossier.revision)
     if children_types.size == 1
       children_types.first.libelle
     else

--- a/app/models/changed_column.rb
+++ b/app/models/changed_column.rb
@@ -19,7 +19,7 @@ class ChangedColumn
       revision.root_types_de_champ_public.flat_map do |type_de_champ|
         if type_de_champ.repetition?
           prefix = type_de_champ.libelle
-          types_de_champ = revision.children_of(type_de_champ)
+          types_de_champ = type_de_champ.flat_children(revision)
           row_ids.flat_map do |row_id|
             types_de_champ.filter_map do |type_de_champ|
               public_id = type_de_champ.public_id(row_id)

--- a/app/models/concerns/champ_conditional_concern.rb
+++ b/app/models/concerns/champ_conditional_concern.rb
@@ -55,7 +55,7 @@ module ChampConditionalConcern
     return false if !child?
 
     # otherwise maybe the champ has been moved outside a repetition
-    parent_tdc = dossier.revision.parent_of(type_de_champ)
+    parent_tdc = dossier.revision.repetition_of(type_de_champ)
 
     return false if parent_tdc.nil?
 

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -82,7 +82,7 @@ module DossierChampsConcern
   def project_rows_for(type_de_champ)
     return [] if !type_de_champ.repetition?
 
-    children = revision.children_of(type_de_champ)
+    children = type_de_champ.flat_children(revision)
     row_ids = repetition_row_ids(type_de_champ)
 
     row_ids.map do |row_id|
@@ -113,7 +113,7 @@ module DossierChampsConcern
     revision
       .types_de_champ
       .filter { _1.stable_id.in?(stable_ids) }
-      .filter { !_1.child?(revision) }
+      .filter { !it.in_repetition?(revision) }
       .map { _1.repetition? ? project_champ(_1) : champ_for_update(_1, updated_by: nil) }
   end
 
@@ -463,7 +463,7 @@ module DossierChampsConcern
   end
 
   def check_valid_row_id_on_read?(type_de_champ, row_id)
-    if type_de_champ.child?(revision)
+    if type_de_champ.in_repetition?(revision)
       if row_id.blank?
         raise "type_de_champ #{type_de_champ.stable_id} in revision #{revision_id} must have a row_id because it is part of a repetition"
       end

--- a/app/models/concerns/dossier_sections_concern.rb
+++ b/app/models/concerns/dossier_sections_concern.rb
@@ -11,14 +11,14 @@ module DossierSectionsConcern
       when :private
         hash[parent] = revision.root_types_de_champ_private.filter(&:header_section?)
       else
-        hash[parent] = revision.children_of(parent).filter(&:header_section?)
+        hash[parent] = parent.flat_children(revision).filter(&:header_section?)
       end
     end
-    @sections[revision.parent_of(type_de_champ) || (type_de_champ.public? ? :public : :private)]
+    @sections[type_de_champ.repetition(revision) || (type_de_champ.public? ? :public : :private)]
   end
 
   def auto_numbering_section_headers_for?(type_de_champ)
-    return false if type_de_champ.child?(revision)
+    return false if type_de_champ.in_repetition?(revision)
 
     sections_for(type_de_champ)&.none? { _1.libelle =~ /^\d/ }
   end
@@ -31,7 +31,7 @@ module DossierSectionsConcern
       .filter(&:header_section?)
       .filter { project_champ(it).visible? }
       .each do |tdc|
-      level = tdc.level_for_revision(revision)
+      level = tdc.level(revision)
 
       # drop counter with a higher level
       # ex: counters = [1,2,2], new header of level 2, drop last

--- a/app/models/concerns/treeable_concern.rb
+++ b/app/models/concerns/treeable_concern.rb
@@ -17,6 +17,18 @@ module TreeableConcern
   #   are added to the current_tree
   # given a root_depth at 0, we build a full tree
   # given a root_depth > 0, we build a partial tree (aka, a repetition)
+  # Top level of the tree: types de champ outside any section and the sections
+  # heading them (the content of a section collapses into its header).
+  def to_tree_roots(types_de_champ:)
+    tree_roots(to_tree(types_de_champ:))
+  end
+
+  # Top level of the given tree nodes: leaves stay as-is, each section subtree
+  # ([header, *children]) collapses into its header.
+  def tree_roots(nodes)
+    nodes.map { it.is_a?(Array) ? it.first : it }
+  end
+
   def to_tree(types_de_champ:)
     rooted_tree = []
     walk = Array.new(MAX_DEPTH)
@@ -26,10 +38,14 @@ module TreeableConcern
     types_de_champ.each do |type_de_champ|
       if type_de_champ.header_section?
         new_tree = [type_de_champ]
-        parent_level = type_de_champ.header_section_level_value - 1
+        level = type_de_champ.header_section_level_value
+        parent_level = level - 1
         parent_level -= 1 while parent_level > 0 && walk[parent_level].nil?
         walk[parent_level].push(new_tree)
-        current_tree = walk[type_de_champ.header_section_level_value] = new_tree
+        current_tree = walk[level] = new_tree
+        # deeper slots belong to a previous sibling's subtree; a later section
+        # with a level gap must not attach to them
+        walk.fill(nil, level + 1)
       else
         current_tree.push(type_de_champ)
       end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -97,7 +97,7 @@ class Procedure < ApplicationRecord
           .where(revision_types_de_champ: { revision_id: draft_revision_id, parent_id: nil })
           .order(:private, :position)
       else
-        draft_revision.children_of(parent)
+        parent.flat_children(draft_revision)
       end
     else
       cache_key = ['all_revisions_types_de_champ', published_revision, parent, with_header_section, ActiveRecord::VERSION::STRING].compact

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -2,6 +2,7 @@
 
 class ProcedureRevision < ApplicationRecord
   include Logic
+  include TreeableConcern
   include RevisionDescribableToLLMConcern
   self.implicit_order_column = :created_at
   belongs_to :administrateur, optional: true
@@ -16,6 +17,57 @@ class ProcedureRevision < ApplicationRecord
   def types_de_champ = revision_types_de_champ.map(&:type_de_champ)
   def root_types_de_champ_public = revision_types_de_champ_public.map(&:type_de_champ)
   def root_types_de_champ_private = revision_types_de_champ_private.map(&:type_de_champ)
+
+  # Entry points to navigate types de champ as a tree: first-level types de champ
+  # and top-level header sections (their content collapses into the header;
+  # navigate deeper with TypeDeChampBase#children).
+  def types_de_champ_public = to_tree_roots(types_de_champ: root_types_de_champ_public)
+  def types_de_champ_private = to_tree_roots(types_de_champ: root_types_de_champ_private)
+
+  # Sections and repetitions above the given type de champ, outermost first.
+  # Tree navigation answers from a one-pass memoized index; any mutation of the
+  # revision's coordinates or types de champ must call reset_tree_cache.
+  def ancestors_of(type_de_champ)
+    tree_cache[:ancestors][type_de_champ.stable_id] || []
+  end
+
+  # Direct children of a header section or repetition in the tree: its own
+  # types de champ and the immediate subsections (but not their content).
+  def children_of(type_de_champ)
+    tree_cache[:children][type_de_champ.stable_id] || []
+  end
+
+  # The repetition the given type de champ belongs to, nil outside a repetition.
+  def repetition_of(type_de_champ)
+    ancestors_of(type_de_champ).find(&:repetition?)
+  end
+
+  # The innermost section the given type de champ belongs to, nil outside sections.
+  def section_of(type_de_champ)
+    ancestors_of(type_de_champ).reverse.find(&:header_section?)
+  end
+
+  # The direct parent of the given type de champ in the tree, nil at the root.
+  def parent_of(type_de_champ)
+    ancestors_of(type_de_champ).last
+  end
+
+  # Every type de champ below a header section or repetition, in document
+  # order, including nested section headers and their content. A nested
+  # repetition marks a boundary: it is included, its row content is not.
+  # Internal to the tree API: use TypeDeChamp#flat_children.
+  def flat_children_of(type_de_champ)
+    tree_cache[:flat_children][type_de_champ.stable_id] || []
+  end
+
+  def reset_tree_cache
+    @tree_cache = nil
+  end
+
+  def reload(...)
+    reset_tree_cache
+    super
+  end
 
   has_one :draft_procedure, -> { with_discarded }, class_name: 'Procedure', foreign_key: :draft_revision_id, dependent: :nullify, inverse_of: :draft_revision
   has_one :published_procedure, -> { with_discarded }, class_name: 'Procedure', foreign_key: :published_revision_id, dependent: :nullify, inverse_of: :published_revision
@@ -66,6 +118,7 @@ class ProcedureRevision < ApplicationRecord
       end
 
       revision_types_de_champ.reset
+      reset_tree_cache
     end
 
     type_de_champ
@@ -75,12 +128,13 @@ class ProcedureRevision < ApplicationRecord
 
   def find_and_ensure_exclusive_use(stable_id)
     coordinate, tdc = coordinate_and_tdc(stable_id)
+    tdc = replace_type_de_champ_by_clone(coordinate) if !tdc.only_present_on_draft?
 
-    if tdc.only_present_on_draft?
-      tdc
-    else
-      replace_type_de_champ_by_clone(coordinate)
-    end
+    # the caller is about to mutate the type de champ (possibly its position in
+    # the tree, e.g. a header section level); reload lazily so the tree reflects it
+    revision_types_de_champ.reset
+    reset_tree_cache
+    tdc
   end
 
   def move_type_de_champ(stable_id, position)
@@ -97,6 +151,7 @@ class ProcedureRevision < ApplicationRecord
     end
 
     revision_types_de_champ.reset
+    reset_tree_cache
     coordinate.reload
     coordinate
   end
@@ -116,6 +171,7 @@ class ProcedureRevision < ApplicationRecord
     end
 
     revision_types_de_champ.reset
+    reset_tree_cache
     coordinate.reload
     coordinate
   end
@@ -126,7 +182,7 @@ class ProcedureRevision < ApplicationRecord
     # in case of replay
     return nil if coordinate.nil?
 
-    children = children_of(tdc).to_a
+    children = coordinate.types_de_champ.to_a
 
     transaction do
       coordinate.destroy
@@ -138,6 +194,7 @@ class ProcedureRevision < ApplicationRecord
     end
 
     revision_types_de_champ.reset
+    reset_tree_cache
     coordinate
   end
 
@@ -198,17 +255,6 @@ class ProcedureRevision < ApplicationRecord
       types_de_champ.filter(&:private?)
     else
       types_de_champ
-    end
-  end
-
-  def children_of(tdc)
-    coordinate_for(tdc).types_de_champ
-  end
-
-  def parent_of(tdc)
-    coordinate = coordinate_for(tdc)
-    if coordinate&.child?
-      revision_types_de_champ.find { _1.id == coordinate.parent_id }&.type_de_champ
     end
   end
 
@@ -332,6 +378,40 @@ class ProcedureRevision < ApplicationRecord
   end
 
   private
+
+  # One-pass indexes over the whole tree (public and private), keyed by
+  # stable_id: ancestors (outermost first), direct children in the tree and
+  # flat children. index_tree returns the flattened nodes, so each section
+  # accumulates its own content; a repetition contributes only itself to its
+  # parent, its row content being indexed separately.
+  def tree_cache
+    @tree_cache ||= begin
+      cache = { ancestors: {}, children: {}, flat_children: {} }
+      index_tree = lambda do |nodes, ancestors|
+        nodes.flat_map do |node|
+          if node.is_a?(Array)
+            header, *children = node
+            cache[:ancestors][header.stable_id] = ancestors
+            cache[:children][header.stable_id] = tree_roots(children)
+            flat_children = index_tree.call(children, [*ancestors, header])
+            cache[:flat_children][header.stable_id] = flat_children
+            [header, *flat_children]
+          else
+            cache[:ancestors][node.stable_id] = ancestors
+            if node.repetition?
+              subtree = to_tree(types_de_champ: coordinate_for(node)&.types_de_champ || [])
+              cache[:children][node.stable_id] = tree_roots(subtree)
+              cache[:flat_children][node.stable_id] = index_tree.call(subtree, [*ancestors, node])
+            end
+            [node]
+          end
+        end
+      end
+      index_tree.call(to_tree(types_de_champ: root_types_de_champ_public), [])
+      index_tree.call(to_tree(types_de_champ: root_types_de_champ_private), [])
+      cache
+    end
+  end
 
   def compute_estimated_fill_duration
     root_types_de_champ_public.sum do |tdc|

--- a/app/models/procedure_revision_change.rb
+++ b/app/models/procedure_revision_change.rb
@@ -10,7 +10,6 @@ class ProcedureRevisionChange
     def label = @type_de_champ.libelle
     def stable_id = @type_de_champ.stable_id
     def private? = @type_de_champ.private?
-    def child? = @type_de_champ.child?
 
     def to_h = { op:, stable_id:, label:, private: private? }
   end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -194,7 +194,7 @@ class TypeDeChamp < ApplicationRecord
 
   belongs_to :referentiel, optional: true, inverse_of: :types_de_champ
 
-  delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, :column, :canonical_column, :personnalisation_column, :info_columns, to: :dynamic_type
+  delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, :column, :canonical_column, :personnalisation_column, :info_columns, :children, :flat_children, :ancestors, :parent, :section, :repetition, :level, to: :dynamic_type
 
   class WithIndifferentAccess
     def self.load(options)
@@ -266,9 +266,8 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def libelle_with_parent(revision)
-    if child?(revision)
-      parent_type_de_champ = revision.parent_of(self)
-      "#{parent_type_de_champ.libelle} - #{libelle}"
+    if in_repetition?(revision)
+      "#{repetition(revision).libelle} - #{libelle}"
     else
       libelle
     end
@@ -480,8 +479,12 @@ class TypeDeChamp < ApplicationRecord
 
   def api_particulier? = type_champ.in?(API_PART_FC_TDC)
 
-  def child?(revision)
-    revision.coordinate_for(self)&.child?
+  def in_repetition?(revision)
+    repetition(revision).present?
+  end
+
+  def in_section?(revision)
+    section(revision).present?
   end
 
   def filename_for_attachement(attachment_sym)
@@ -592,24 +595,6 @@ class TypeDeChamp < ApplicationRecord
       I18n.t('activerecord.errors.type_de_champ.attributes.header_section_level.gap_error', level: current_level - previous_level - 1)
     else
       nil
-    end
-  end
-
-  def current_section_level(revision)
-    tdcs = private? ? revision.root_types_de_champ_private.to_a : revision.root_types_de_champ_public.to_a
-
-    previous_section_level(tdcs.take(tdcs.find_index(self)))
-  end
-
-  def level_for_revision(revision)
-    parent_type_de_champ = revision.parent_of(self)
-
-    if parent_type_de_champ.present?
-      header_section_level_value.to_i + parent_type_de_champ.current_section_level(revision)
-    elsif header_section_level_value
-      header_section_level_value.to_i
-    else
-      0
     end
   end
 

--- a/app/models/types_de_champ/header_section_type_de_champ.rb
+++ b/app/models/types_de_champ/header_section_type_de_champ.rb
@@ -2,4 +2,11 @@
 
 class TypesDeChamp::HeaderSectionTypeDeChamp < TypesDeChamp::TypeDeChampBase
   def tags_for_template = [].freeze
+
+  # Direct children of the section: its own types de champ and the immediate subsections
+  # (but not their content). Sections have no parent relationship in the database, so
+  # children are reconstructed from the ordered list of siblings and header levels.
+  def children(revision) = revision.children_of(@type_de_champ)
+
+  def flat_children(revision) = revision.flat_children_of(@type_de_champ)
 end

--- a/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
@@ -40,7 +40,7 @@ class TypesDeChamp::PrefillRepetitionTypeDeChamp < TypesDeChamp::PrefillTypeDeCh
 
   def prefillable_subchamps
     @prefillable_subchamps ||=
-      TypesDeChamp::PrefillTypeDeChamp.wrap(@revision.children_of(self).filter(&:prefillable?), @revision)
+      TypesDeChamp::PrefillTypeDeChamp.wrap(flat_children(@revision).filter(&:prefillable?), @revision)
   end
 
   class PrefillRepetitionRow

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
+  # Direct children of the repetition: its own types de champ and top-level sections
+  # (but not the content of those sections).
+  def children(revision) = revision.children_of(@type_de_champ)
+
+  def flat_children(revision) = revision.flat_children_of(@type_de_champ)
+
   def champ_value_for_tag(champ, path = :value)
     return nil if path != :value
     ChampPresentations::RepetitionPresentation.new(libelle, champ.dossier.project_rows_for(@type_de_champ))
@@ -9,7 +15,7 @@ class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
   def estimated_fill_duration(revision)
     estimated_rows_in_repetition = 2.5
 
-    children = revision.children_of(@type_de_champ)
+    children = flat_children(revision)
 
     estimated_row_duration = children.map { _1.estimated_fill_duration(revision) }.sum
     estimated_children_read_duration = children.map(&:estimated_read_duration).sum

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -14,6 +14,26 @@ class TypesDeChamp::TypeDeChampBase
     @type_de_champ = type_de_champ
   end
 
+  # Types de champ are navigable as a tree: header sections and repetitions
+  # have children, other types are leaves.
+  def children(revision) = []
+
+  # Every type de champ below, in document order, including nested section
+  # headers and their content (but not the row content of nested repetitions).
+  def flat_children(revision) = []
+
+  # Sections and repetitions above this type de champ in the tree, outermost
+  # first.
+  def ancestors(revision) = revision.ancestors_of(@type_de_champ)
+
+  def parent(revision) = revision.parent_of(@type_de_champ)
+  def section(revision) = revision.section_of(@type_de_champ)
+  def repetition(revision) = revision.repetition_of(@type_de_champ)
+
+  # Nesting depth of a header section in the tree (1 for a top-level section).
+  # Unlike the stored header_section_level, skipped levels are collapsed.
+  def level(revision) = ancestors(revision).count(&:header_section?) + 1
+
   def tags_for_template
     type_de_champ = @type_de_champ
     conditional = type_de_champ.condition.present?

--- a/app/validators/types_de_champ/condition_validator.rb
+++ b/app/validators/types_de_champ/condition_validator.rb
@@ -32,6 +32,6 @@ class TypesDeChamp::ConditionValidator < ActiveModel::EachValidator
   # condition is validated too
   def tdcs_with_children(procedure, tdcs)
     tdcs.to_a
-      .flat_map { _1.repetition? ? [_1, *procedure.draft_revision.children_of(_1)] : _1 }
+      .flat_map { it.repetition? ? [it, *it.flat_children(procedure.draft_revision)] : it }
   end
 end

--- a/app/validators/types_de_champ/date_validator.rb
+++ b/app/validators/types_de_champ/date_validator.rb
@@ -3,7 +3,7 @@
 class TypesDeChamp::DateValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
     date_tdcs = types_de_champ
-      .flat_map { it.repetition? ? procedure.draft_revision.children_of(it) : [it] }
+      .flat_map { it.repetition? ? it.flat_children(procedure.draft_revision) : [it] }
       .filter { |tdc| tdc.date? || tdc.datetime? }
     date_tdcs.each do |tdc|
       validate_range(procedure, attribute, tdc) if tdc.range_date?

--- a/app/validators/types_de_champ/formatted_validator.rb
+++ b/app/validators/types_de_champ/formatted_validator.rb
@@ -3,7 +3,7 @@
 class TypesDeChamp::FormattedValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
     types_de_champ.to_a
-      .flat_map { _1.repetition? ? procedure.draft_revision.children_of(_1) : _1 }
+      .flat_map { it.repetition? ? it.flat_children(procedure.draft_revision) : it }
       .filter(&:formatted?)
       .each do |tdc|
         validate_characters_rules(procedure, attribute, tdc)

--- a/app/validators/types_de_champ/header_section_consistency_validator.rb
+++ b/app/validators/types_de_champ/header_section_consistency_validator.rb
@@ -6,7 +6,7 @@ class TypesDeChamp::HeaderSectionConsistencyValidator < ActiveModel::EachValidat
 
     root_tdcs_errors = errors_for_header_sections_order(procedure, attribute, public_tdcs)
     repetition_tdcs_errors = public_tdcs
-      .filter_map { _1.repetition? ? procedure.draft_revision.children_of(_1) : nil }
+      .filter_map { it.repetition? ? it.flat_children(procedure.draft_revision) : nil }
       .map { errors_for_header_sections_order(procedure, attribute, _1) }
 
     repetition_tdcs_errors + root_tdcs_errors

--- a/app/validators/types_de_champ/libelle_validator.rb
+++ b/app/validators/types_de_champ/libelle_validator.rb
@@ -7,7 +7,7 @@ class TypesDeChamp::LibelleValidator < ActiveModel::EachValidator
 
       next unless tdc.repetition?
 
-      procedure.draft_revision.children_of(tdc).each do |child|
+      tdc.flat_children(procedure.draft_revision).each do |child|
         validate_libelle(procedure, attribute, child, parent: tdc)
       end
     end

--- a/app/validators/types_de_champ/no_empty_block_validator.rb
+++ b/app/validators/types_de_champ/no_empty_block_validator.rb
@@ -10,7 +10,7 @@ class TypesDeChamp::NoEmptyBlockValidator < ActiveModel::EachValidator
   private
 
   def validate_block_not_empty(procedure, attribute, parent)
-    if procedure.draft_revision.children_of(parent).empty?
+    if parent.flat_children(procedure.draft_revision).empty?
       procedure.errors.add(
         attribute,
         procedure.errors.generate_message(attribute, :empty_repetition, { value: parent.libelle }),

--- a/app/validators/types_de_champ/no_empty_drop_down_validator.rb
+++ b/app/validators/types_de_champ/no_empty_drop_down_validator.rb
@@ -13,7 +13,7 @@ class TypesDeChamp::NoEmptyDropDownValidator < ActiveModel::EachValidator
   def with_children(procedure, type_de_champ)
     return [type_de_champ] unless type_de_champ.repetition?
 
-    [type_de_champ, *procedure.draft_revision.children_of(type_de_champ)]
+    [type_de_champ, *type_de_champ.flat_children(procedure.draft_revision)]
   end
 
   def validate_drop_down_not_empty(procedure, attribute, drop_down)

--- a/app/validators/types_de_champ/number_validator.rb
+++ b/app/validators/types_de_champ/number_validator.rb
@@ -3,7 +3,7 @@
 class TypesDeChamp::NumberValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
     types_de_champ
-      .flat_map { it.repetition? ? procedure.draft_revision.children_of(it) : [it] }
+      .flat_map { it.repetition? ? it.flat_children(procedure.draft_revision) : [it] }
       .filter { |tdc| tdc.decimal_number? || tdc.integer_number? }.each do |tdc|
       validate_range(procedure, attribute, tdc) if tdc.range_number?
     end

--- a/app/validators/types_de_champ/referentiel_ready_validator.rb
+++ b/app/validators/types_de_champ/referentiel_ready_validator.rb
@@ -3,7 +3,7 @@
 class TypesDeChamp::ReferentielReadyValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
     types_de_champ
-      .flat_map { it.repetition? ? procedure.draft_revision.children_of(it) : [it] }
+      .flat_map { it.repetition? ? it.flat_children(procedure.draft_revision) : [it] }
       .filter(&:referentiel?).each do |referentiel_champ|
       unless referentiel_champ.referentiel&.ready?
         procedure.errors.add(

--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -132,7 +132,7 @@ def render_single_champ(pdf, revision, type_de_champ)
   case type_de_champ.type_champ
   when TypeDeChamp.type_champs.fetch(:repetition)
     add_libelle(pdf, type_de_champ)
-    types_de_champ = revision.children_of(type_de_champ)
+    types_de_champ = type_de_champ.flat_children(revision)
 
     3.times do
       types_de_champ.each do |type_de_champ|

--- a/app/views/fields/types_de_champ_collection_field/_show.html.erb
+++ b/app/views/fields/types_de_champ_collection_field/_show.html.erb
@@ -15,7 +15,7 @@
         <%= render partial: 'fields/types_de_champ_collection_field/type_champ_line', locals: { type_de_champ: type_de_champ } %>
 
         <% if type_de_champ.type_champ == 'repetition' %>
-          <% revision.children_of(type_de_champ).each do |sub_champ| %>
+          <% type_de_champ.flat_children(revision).each do |sub_champ| %>
             <%= render partial: 'fields/types_de_champ_collection_field/type_champ_line', locals: { type_de_champ: sub_champ } %>
           <% end %>
         <% end %>

--- a/spec/components/types_de_champ_editor/header_sections_summary_component_spec.rb
+++ b/spec/components/types_de_champ_editor/header_sections_summary_component_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+describe TypesDeChampEditor::HeaderSectionsSummaryComponent, type: :component do
+  let(:procedure) { create(:procedure, types_de_champ_public:, types_de_champ_private:) }
+  let(:types_de_champ_private) { [] }
+
+  subject { render_inline(described_class.new(procedure:, is_private:)) }
+
+  context 'public types de champ' do
+    let(:is_private) { false }
+    let(:types_de_champ_public) do
+      [
+        { type: :header_section, level: 1, libelle: 's1' },
+        { type: :text, libelle: 't1' },
+        { type: :header_section, level: 2, libelle: 's1.1' },
+        { type: :header_section, level: 3, libelle: 's1.1.1' },
+        { type: :repetition, libelle: 'rep', children: [{ type: :header_section, level: 1, libelle: 'rs1' }] },
+        { type: :header_section, level: 1, libelle: 's2' },
+      ]
+    end
+
+    it 'renders header sections and repetitions with their depth' do
+      expect(subject).to have_selector("a", text: /\As1\z/)
+      expect(subject).to have_selector("a", text: '-- s1.1')
+      expect(subject).to have_selector("a.custom-link-grey", text: '-- s1.1.1')
+      expect(subject).to have_selector("a.custom-link-grey", text: '-- rep')
+      expect(subject).to have_selector("a.custom-link-grey", text: '-- rs1')
+      expect(subject).to have_selector("a", text: /\As2\z/)
+      expect(subject).not_to have_text('t1')
+    end
+
+    it 'anchors links to the editor coordinates' do
+      ['s1', 'rep', 'rs1'].each do |libelle|
+        coordinate = procedure.draft_revision.revision_types_de_champ.find { it.libelle == libelle }
+        expect(subject).to have_selector("a[href='##{ActionView::RecordIdentifier.dom_id(coordinate, :type_de_champ_editor)}']")
+      end
+    end
+  end
+
+  context 'private types de champ' do
+    let(:is_private) { true }
+    let(:types_de_champ_public) { [{ type: :header_section, level: 1, libelle: 's1' }] }
+    let(:types_de_champ_private) do
+      [
+        { type: :header_section, level: 1, libelle: 'ps1' },
+        { type: :text, libelle: 'pt1' },
+      ]
+    end
+
+    it 'only renders private header sections' do
+      expect(subject).to have_selector("a", text: 'ps1')
+      expect(subject).not_to have_text(/\As1\z/)
+    end
+  end
+
+  context 'without header sections' do
+    let(:is_private) { false }
+    let(:types_de_champ_public) { [{ type: :text, libelle: 't1' }] }
+
+    it 'renders no sidemenu' do
+      expect(subject).not_to have_selector("nav")
+    end
+  end
+end

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -307,7 +307,7 @@ end
 
 def dossier_factory_create_champ_or_repetition(type_de_champ, dossier)
   if type_de_champ.repetition?
-    types_de_champ = dossier.revision.children_of(type_de_champ)
+    types_de_champ = type_de_champ.flat_children(dossier.revision)
     2.times do
       row_id = ULID.generate
       dossier.champ_data << type_de_champ.build_champ(row_id:)

--- a/spec/models/concerns/champ_validate_concern_spec.rb
+++ b/spec/models/concerns/champ_validate_concern_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe ChampValidateConcern do
 
   context 'when in a row' do
     let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :email }], mandatory: true }] }
-    let(:type_de_champ_in_repetition) { dossier.revision.children_of(type_de_champ).first }
+    let(:type_de_champ_in_repetition) { type_de_champ.flat_children(dossier.revision).first }
     let(:row_id) { dossier.repetition_row_ids(type_de_champ).first }
     let(:public_id) { type_de_champ_in_repetition.public_id(row_id) }
 

--- a/spec/models/concerns/dossier_rebase_concern_spec.rb
+++ b/spec/models/concerns/dossier_rebase_concern_spec.rb
@@ -511,7 +511,7 @@ describe DossierRebaseConcern do
 
       context 'when a child tdc is added in the middle' do
         before do
-          last_child = procedure.draft_revision.children_of(repetition).last
+          last_child = repetition.flat_children(procedure.draft_revision).last
           added_tdc = procedure.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'c3', parent_stable_id: repetition.stable_id, after_stable_id: last_child)
           procedure.draft_revision.move_type_de_champ(added_tdc.stable_id, 1)
           # procedure.publish_revision!(procedure.administrateurs.first)

--- a/spec/models/concerns/dossier_sections_concern_spec.rb
+++ b/spec/models/concerns/dossier_sections_concern_spec.rb
@@ -39,7 +39,7 @@ describe DossierSectionsConcern do
     context "header_section in a repetition are not auto-numbered" do
       let(:types_de_champ_public) { [{ type: :header_section, libelle: public_libelle }, { type: :repetition, mandatory: true, children: [{ type: :header_section, libelle: "Enfant" }, { type: :text }] }] }
 
-      let(:public_type_de_champ) { dossier.revision.children_of(dossier.root_types_de_champ_public[1]).first }
+      let(:public_type_de_champ) { dossier.root_types_de_champ_public[1].flat_children(dossier.revision).first }
 
       context "with parent section having headers with number" do
         let(:public_libelle) { "1. Infos" }

--- a/spec/models/concerns/procedure_clone_concern_spec.rb
+++ b/spec/models/concerns/procedure_clone_concern_spec.rb
@@ -103,7 +103,7 @@ describe ProcedureCloneConcern, type: :model do
 
       public_repetition = type_de_champ_repetition
       cloned_public_repetition = subject.draft_revision.root_types_de_champ_public.find(&:repetition?)
-      procedure.draft_revision.children_of(public_repetition).zip(subject.draft_revision.children_of(cloned_public_repetition)).each do |ptc, stc|
+      public_repetition.flat_children(procedure.draft_revision).zip(cloned_public_repetition.flat_children(subject.draft_revision)).each do |ptc, stc|
         expect(stc).to have_same_attributes_as(ptc)
         expect(stc.revisions).to include(subject.draft_revision)
       end
@@ -115,7 +115,7 @@ describe ProcedureCloneConcern, type: :model do
 
       private_repetition = type_de_champ_private_repetition
       cloned_private_repetition = subject.draft_revision.root_types_de_champ_private.find(&:repetition?)
-      procedure.draft_revision.children_of(private_repetition).zip(subject.draft_revision.children_of(cloned_private_repetition)).each do |ptc, stc|
+      private_repetition.flat_children(procedure.draft_revision).zip(cloned_private_repetition.flat_children(subject.draft_revision)).each do |ptc, stc|
         expect(stc).to have_same_attributes_as(ptc)
         expect(stc.revisions).to include(subject.draft_revision)
       end

--- a/spec/models/prefill_champs_spec.rb
+++ b/spec/models/prefill_champs_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe PrefillChamps do
     context "when the public type de champ is authorized (repetition)" do
       let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :text }] }] }
       let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
-      let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
+      let(:type_de_champ_child) { type_de_champ.flat_children(procedure.published_revision).first }
       let(:type_de_champ_child_value) { "value" }
       let(:type_de_champ_child_value2) { "value2" }
       let(:child_champs) { dossier.champ_data.where(stable_id: type_de_champ_child.stable_id) }
@@ -201,7 +201,7 @@ RSpec.describe PrefillChamps do
     context "when the private type de champ is authorized (repetition)" do
       let(:types_de_champ_private) { [{ type: :repetition, children: [{ type: :text }] }] }
       let(:type_de_champ) { procedure.published_revision.root_types_de_champ_private.first }
-      let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
+      let(:type_de_champ_child) { type_de_champ.flat_children(procedure.published_revision).first }
       let(:type_de_champ_child_value) { "value" }
       let(:type_de_champ_child_value2) { "value2" }
       let(:child_champs) { dossier.champ_data.where(stable_id: type_de_champ_child.stable_id) }
@@ -235,7 +235,7 @@ RSpec.describe PrefillChamps do
     context "when the public type de champ is unauthorized because of wrong value format (repetition)" do
       let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :text }] }] }
       let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
-      let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
+      let(:type_de_champ_child) { type_de_champ.flat_children(procedure.published_revision).first }
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => "value" } }
 
@@ -247,7 +247,7 @@ RSpec.describe PrefillChamps do
     context "when the public type de champ is unauthorized because of wrong value typed_id (repetition)" do
       let(:types_de_champ_public) { [{ type: :repetition, children: [{ type: :text }] }] }
       let(:type_de_champ) { procedure.published_revision.root_types_de_champ_public.first }
-      let(:type_de_champ_child) { procedure.published_revision.children_of(type_de_champ).first }
+      let(:type_de_champ_child) { type_de_champ.flat_children(procedure.published_revision).first }
 
       let(:params) { { "champ_#{type_de_champ.to_typed_id_for_query}" => ["{\"wrong\":\"value\"}", "{\"wrong\":\"value2\"}"] } }
 

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -58,13 +58,13 @@ describe ProcedureRevision do
     end
 
     context 'with a repetition child' do
-      let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: procedure.draft_revision.children_of(type_de_champ_repetition).last.stable_id } }
+      let(:text_params) { { type_champ: :text, libelle: 'text', after_stable_id: type_de_champ_repetition.flat_children(procedure.draft_revision).last.stable_id } }
       let(:tdc_params) { text_params.merge(parent_stable_id: type_de_champ_repetition.stable_id) }
 
       it do
         expect { subject }.to change { draft.reload.types_de_champ.count }.from(4).to(5)
-        expect(draft.children_of(type_de_champ_repetition).last).to eq(subject)
-        expect(draft.children_of(type_de_champ_repetition).map { draft.coordinate_for(_1).position }).to eq([0, 1])
+        expect(type_de_champ_repetition.flat_children(draft).last).to eq(subject)
+        expect(type_de_champ_repetition.flat_children(draft).map { draft.coordinate_for(it).position }).to eq([0, 1])
 
         expect(last_coordinate.position).to eq(1)
 
@@ -138,7 +138,7 @@ describe ProcedureRevision do
           type_champ: TypeDeChamp.type_champs.fetch(:text),
           libelle: "second child",
           parent_stable_id: type_de_champ_repetition.stable_id,
-          after_stable_id: draft.reload.children_of(type_de_champ_repetition).last.stable_id,
+          after_stable_id: type_de_champ_repetition.flat_children(draft.reload).last.stable_id,
         })
       end
 
@@ -147,24 +147,24 @@ describe ProcedureRevision do
           type_champ: TypeDeChamp.type_champs.fetch(:text),
           libelle: "last child",
           parent_stable_id: type_de_champ_repetition.stable_id,
-          after_stable_id: draft.reload.children_of(type_de_champ_repetition).last.stable_id,
+          after_stable_id: type_de_champ_repetition.flat_children(draft.reload).last.stable_id,
         })
       end
 
       it 'move down' do
-        expect(draft.children_of(type_de_champ_repetition).index(second_child)).to eq(2)
+        expect(type_de_champ_repetition.flat_children(draft).index(second_child)).to eq(2)
 
         draft.move_type_de_champ(second_child.stable_id, 3)
 
-        expect(draft.children_of(type_de_champ_repetition).index(second_child)).to eq(3)
+        expect(type_de_champ_repetition.flat_children(draft).index(second_child)).to eq(3)
       end
 
       it 'move up' do
-        expect(draft.children_of(type_de_champ_repetition).index(last_child)).to eq(3)
+        expect(type_de_champ_repetition.flat_children(draft).index(last_child)).to eq(3)
 
         draft.move_type_de_champ(last_child.stable_id, 0)
 
-        expect(draft.children_of(type_de_champ_repetition).index(last_child)).to eq(0)
+        expect(type_de_champ_repetition.flat_children(draft).index(last_child)).to eq(0)
       end
     end
   end
@@ -235,7 +235,7 @@ describe ProcedureRevision do
 
     context 'for a type_de_champ_repetition' do
       let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{ type: :text }, { type: :integer_number }] }]) }
-      let!(:child) { child = draft.children_of(type_de_champ_repetition).first }
+      let!(:child) { child = type_de_champ_repetition.flat_children(draft).first }
 
       it 'can remove its children' do
         draft.remove_type_de_champ(child.stable_id)
@@ -259,8 +259,8 @@ describe ProcedureRevision do
           new_draft.remove_type_de_champ(child.stable_id)
 
           expect { child.reload }.not_to raise_error
-          expect(draft.children_of(type_de_champ_repetition).size).to eq(2)
-          expect(new_draft.children_of(type_de_champ_repetition).size).to eq(1)
+          expect(type_de_champ_repetition.flat_children(draft).size).to eq(2)
+          expect(type_de_champ_repetition.flat_children(new_draft).size).to eq(1)
         end
 
         it 'can remove the parent only in the new revision' do
@@ -609,7 +609,7 @@ describe ProcedureRevision do
         let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{ type: :text, libelle: 'sub type de champ' }, { type: :integer_number }] }]) }
 
         before do
-          child = new_draft.children_of(new_draft.root_types_de_champ_public.last).first
+          child = new_draft.root_types_de_champ_public.last.flat_children(new_draft).first
           new_draft.find_and_ensure_exclusive_use(child.stable_id).update(type_champ: :drop_down_list, drop_down_options: ['one', 'two'])
         end
 
@@ -622,7 +622,7 @@ describe ProcedureRevision do
               private: false,
               from: "text",
               to: "drop_down_list",
-              stable_id: new_draft.children_of(new_draft.root_types_de_champ_public.last).first.stable_id,
+              stable_id: new_draft.root_types_de_champ_public.last.flat_children(new_draft).first.stable_id,
             },
             {
               op: :update,
@@ -631,7 +631,7 @@ describe ProcedureRevision do
               private: false,
               from: [],
               to: ["one", "two"],
-              stable_id: new_draft.children_of(new_draft.root_types_de_champ_public.last).first.stable_id,
+              stable_id: new_draft.root_types_de_champ_public.last.flat_children(new_draft).first.stable_id,
             },
           ])
         end
@@ -641,7 +641,7 @@ describe ProcedureRevision do
         let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{ type: :text, libelle: 'sub type de champ' }, { type: :integer_number }] }]) }
 
         before do
-          child = new_draft.children_of(new_draft.root_types_de_champ_public.last).first
+          child = new_draft.root_types_de_champ_public.last.flat_children(new_draft).first
           new_draft.find_and_ensure_exclusive_use(child.stable_id).update(type_champ: :carte, options: { cadastres: true, znieff: true })
         end
 
@@ -654,7 +654,7 @@ describe ProcedureRevision do
               private: false,
               from: "text",
               to: "carte",
-              stable_id: new_draft.children_of(new_draft.root_types_de_champ_public.last).first.stable_id,
+              stable_id: new_draft.root_types_de_champ_public.last.flat_children(new_draft).first.stable_id,
             },
             {
               op: :update,
@@ -663,7 +663,7 @@ describe ProcedureRevision do
               private: false,
               from: [],
               to: [:cadastres, :znieff],
-              stable_id: new_draft.children_of(new_draft.root_types_de_champ_public.last).first.stable_id,
+              stable_id: new_draft.root_types_de_champ_public.last.flat_children(new_draft).first.stable_id,
             },
           ])
         end
@@ -1020,11 +1020,11 @@ describe ProcedureRevision do
     end
   end
 
-  describe 'children_of' do
+  describe 'flat_children' do
     context 'with a simple tdc' do
       let(:procedure) { create(:procedure, :with_type_de_champ) }
 
-      it { expect(draft.children_of(draft.types_de_champ.first)).to be_empty }
+      it { expect(draft.types_de_champ.first.flat_children(draft)).to be_empty }
     end
 
     context 'with a repetition tdc' do
@@ -1033,7 +1033,7 @@ describe ProcedureRevision do
       let!(:first_child) { draft.types_de_champ.reject(&:repetition?).first }
       let!(:second_child) { draft.types_de_champ.reject(&:repetition?).second }
 
-      it { expect(draft.children_of(parent)).to match([first_child, second_child]) }
+      it { expect(parent.flat_children(draft)).to match([first_child, second_child]) }
 
       context 'with multiple child' do
         let(:child_position_2) { create(:type_de_champ_text) }
@@ -1046,7 +1046,7 @@ describe ProcedureRevision do
         end
 
         it 'returns the children in order' do
-          expect(draft.children_of(parent)).to eq([first_child, second_child, child_position_1, child_position_2])
+          expect(parent.flat_children(draft)).to eq([first_child, second_child, child_position_1, child_position_2])
         end
       end
 
@@ -1062,14 +1062,43 @@ describe ProcedureRevision do
             .revision_types_de_champ
             .where(type_de_champ: first_child)
             .update(type_de_champ: new_child)
-          new_draft.revision_types_de_champ.reload
+          new_draft.reload
         end
 
         it 'returns the children regarding the revision' do
-          expect(draft.children_of(parent)).to match([first_child, second_child])
-          expect(new_draft.children_of(parent)).to match([new_child, second_child])
+          expect(parent.flat_children(draft)).to match([first_child, second_child])
+          expect(parent.flat_children(new_draft)).to match([new_child, second_child])
         end
       end
+    end
+  end
+
+  describe 'tree cache invalidation' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :header_section, level: 1, libelle: 's1' },
+        { type: :header_section, level: 2, libelle: 's2' },
+        { type: :text, libelle: 't1' },
+      ])
+    end
+    let(:text) { draft.types_de_champ.find { it.libelle == 't1' } }
+
+    it 'resets ancestors after a structural change' do
+      expect(draft.ancestors_of(text).map(&:libelle)).to eq(['s1', 's2'])
+
+      section = draft.types_de_champ.find { it.libelle == 's2' }
+      draft.remove_type_de_champ(section.stable_id)
+
+      expect(draft.ancestors_of(text).map(&:libelle)).to eq(['s1'])
+    end
+
+    it 'resets ancestors when a type de champ is mutated through find_and_ensure_exclusive_use' do
+      expect(draft.ancestors_of(text).map(&:libelle)).to eq(['s1', 's2'])
+
+      section = draft.types_de_champ.find { it.libelle == 's2' }
+      draft.find_and_ensure_exclusive_use(section.stable_id).update!(header_section_level: 1)
+
+      expect(draft.ancestors_of(text).map(&:libelle)).to eq(['s2'])
     end
   end
 
@@ -1256,7 +1285,7 @@ describe ProcedureRevision do
 
       let(:children_of_repetition) do
         repetition = procedure.draft_revision.root_types_de_champ_public.find(&:repetition?)
-        procedure.draft_revision.children_of(repetition)
+        repetition.flat_children(procedure.draft_revision)
       end
 
       let(:integer_champ) { children_of_repetition.first }
@@ -1417,6 +1446,30 @@ describe ProcedureRevision do
     end
 
     it { expect(draft.simple_routable_types_de_champ.pluck(:libelle)).to eq(['l2', 'l3', 'l4', 'l5', 'l6']) }
+  end
+
+  describe '#types_de_champ_public and #types_de_champ_private' do
+    let(:procedure) do
+      create(:procedure,
+        types_de_champ_public: [
+          { type: :text, libelle: 't1' },
+          { type: :repetition, libelle: 'rep', children: [{ type: :text, libelle: 'rt1' }] },
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :text, libelle: 't1.1' },
+          { type: :header_section, level: 2, libelle: 's1.1' },
+          { type: :text, libelle: 't1.1.1' },
+          { type: :header_section, level: 1, libelle: 's2' },
+        ],
+        types_de_champ_private: [
+          { type: :header_section, level: 1, libelle: 'ps1' },
+          { type: :text, libelle: 'pt1' },
+        ])
+    end
+
+    it 'returns first-level types de champ and top-level header sections' do
+      expect(draft.types_de_champ_public.map(&:libelle)).to eq(['t1', 'rep', 's1', 's2'])
+      expect(draft.types_de_champ_private.map(&:libelle)).to eq(['ps1'])
+    end
   end
 
   describe "#schema_to_llm" do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -608,7 +608,7 @@ describe Procedure do
           let(:types_de_champ_public) { [{ type: :repetition, libelle: 'Bloc', children: }] }
           let(:types_de_champ_private) { [] }
           let(:repetition) { procedure.draft_revision.types_de_champ.find(&:repetition?) }
-          let(:nested_tdc) { procedure.draft_revision.children_of(repetition).first }
+          let(:nested_tdc) { repetition.flat_children(procedure.draft_revision).first }
 
           context 'with invalid dropdown' do
             let(:children) { [{ type: :multiple_drop_down_list, libelle: 'Choix imbriqué' }] }

--- a/spec/models/types_de_champ/header_section_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/header_section_type_de_champ_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+describe TypesDeChamp::HeaderSectionTypeDeChamp do
+  describe '#children' do
+    let(:revision) { procedure.draft_revision }
+
+    def children_libelles(libelle)
+      tdc = revision.revision_types_de_champ.map(&:type_de_champ).find { it.libelle == libelle }
+      tdc.children(revision).map(&:libelle)
+    end
+
+    context 'with nested sections' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :text, libelle: 't1' },
+          { type: :header_section, level: 2, libelle: 's1.1' },
+          { type: :text, libelle: 't1.1' },
+          { type: :header_section, level: 1, libelle: 's2' },
+          { type: :text, libelle: 't2' },
+        ])
+      end
+
+      it 'returns only direct children' do
+        expect(children_libelles('s1')).to eq(['t1', 's1.1'])
+        expect(children_libelles('s1.1')).to eq(['t1.1'])
+        expect(children_libelles('s2')).to eq(['t2'])
+      end
+    end
+
+    context 'with a level gap' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :header_section, level: 3, libelle: 's1.1' },
+          { type: :text, libelle: 't1.1' },
+        ])
+      end
+
+      it 'attaches the deeper section to the closest ancestor' do
+        expect(children_libelles('s1')).to eq(['s1.1'])
+        expect(children_libelles('s1.1')).to eq(['t1.1'])
+      end
+    end
+
+    context 'with a level gap after a previous sibling subtree' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :header_section, level: 2, libelle: 's1.1' },
+          { type: :header_section, level: 1, libelle: 's2' },
+          { type: :header_section, level: 3, libelle: 's2.1' },
+        ])
+      end
+
+      it 'attaches the deeper section to the current section, not the previous sibling subtree' do
+        expect(children_libelles('s2')).to eq(['s2.1'])
+        expect(children_libelles('s1.1')).to eq([])
+      end
+    end
+
+    context 'with an empty section' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :header_section, level: 1, libelle: 's2' },
+        ])
+      end
+
+      it { expect(children_libelles('s1')).to eq([]) }
+    end
+
+    context 'inside a repetition' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          {
+            type: :repetition, libelle: 'rep', children: [
+              { type: :header_section, level: 1, libelle: 'rs1' },
+              { type: :text, libelle: 'rt1' },
+              { type: :header_section, level: 1, libelle: 'rs2' },
+              { type: :text, libelle: 'rt2' },
+            ],
+          },
+        ])
+      end
+
+      it 'only includes siblings within the repetition' do
+        expect(children_libelles('rs1')).to eq(['rt1'])
+        expect(children_libelles('rs2')).to eq(['rt2'])
+      end
+    end
+
+    context 'with a private section' do
+      let(:procedure) do
+        create(:procedure,
+          types_de_champ_public: [{ type: :text, libelle: 'public' }],
+          types_de_champ_private: [
+            { type: :header_section, level: 1, libelle: 'ps1' },
+            { type: :text, libelle: 'pt1' },
+          ])
+      end
+
+      it { expect(children_libelles('ps1')).to eq(['pt1']) }
+    end
+  end
+
+  describe '#flat_children' do
+    let(:revision) { procedure.draft_revision }
+
+    def flat_children_libelles(libelle)
+      tdc = revision.revision_types_de_champ.map(&:type_de_champ).find { it.libelle == libelle }
+      tdc.flat_children(revision).map(&:libelle)
+    end
+
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        { type: :header_section, level: 1, libelle: 's1' },
+        { type: :text, libelle: 't1' },
+        { type: :header_section, level: 2, libelle: 's1.1' },
+        { type: :text, libelle: 't1.1' },
+        { type: :repetition, libelle: 'rep', children: [{ type: :text, libelle: 'rt1' }] },
+        { type: :header_section, level: 1, libelle: 's2' },
+        { type: :text, libelle: 't2' },
+      ])
+    end
+
+    it 'returns every type de champ below, in document order, including nested section headers' do
+      expect(flat_children_libelles('s1')).to eq(['t1', 's1.1', 't1.1', 'rep'])
+      expect(flat_children_libelles('s1.1')).to eq(['t1.1', 'rep'])
+      expect(flat_children_libelles('s2')).to eq(['t2'])
+    end
+
+    it 'includes a nested repetition but not its row content' do
+      expect(flat_children_libelles('s1')).not_to include('rt1')
+      expect(flat_children_libelles('rep')).to eq(['rt1'])
+    end
+  end
+end

--- a/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe TypesDeChamp::PrefillRepetitionTypeDeChamp, type: :model do
     let(:repetition_tdc) { procedure_with_dropdown.draft_types_de_champ_public.find(&:repetition?) }
 
     before do
-      sub_tdc = procedure_with_dropdown.active_revision.children_of(repetition_tdc).first
+      sub_tdc = repetition_tdc.flat_children(procedure_with_dropdown.active_revision).first
       sub_tdc.update!(drop_down_options: [xss_payload, "safe"])
     end
 

--- a/spec/models/types_de_champ/repetition_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/repetition_type_de_champ_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe TypesDeChamp::RepetitionTypeDeChamp do
+  describe '#children' do
+    let(:revision) { procedure.draft_revision }
+    let(:repetition) { revision.root_types_de_champ_public.find(&:repetition?) }
+
+    subject(:children_libelles) { repetition.children(revision).map(&:libelle) }
+
+    context 'without sections' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          {
+            type: :repetition, libelle: 'rep', children: [
+              { type: :text, libelle: 't1' },
+              { type: :integer_number, libelle: 'n1' },
+            ],
+          },
+        ])
+      end
+
+      it { is_expected.to eq(['t1', 'n1']) }
+    end
+
+    context 'with nested sections' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          {
+            type: :repetition, libelle: 'rep', children: [
+              { type: :text, libelle: 't1' },
+              { type: :header_section, level: 1, libelle: 's1' },
+              { type: :text, libelle: 't1.1' },
+              { type: :header_section, level: 2, libelle: 's1.1' },
+              { type: :text, libelle: 't1.1.1' },
+            ],
+          },
+        ])
+      end
+
+      it 'returns only direct children' do
+        expect(children_libelles).to eq(['t1', 's1'])
+      end
+    end
+  end
+end

--- a/spec/models/types_de_champ/type_de_champ_base_spec.rb
+++ b/spec/models/types_de_champ/type_de_champ_base_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+describe TypesDeChamp::TypeDeChampBase do
+  describe '#ancestors, #parent, #section and #repetition' do
+    let(:procedure) do
+      create(:procedure,
+        types_de_champ_public: [
+          { type: :text, libelle: 't0' },
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :header_section, level: 2, libelle: 's1.1' },
+          {
+            type: :repetition, libelle: 'rep', children: [
+              { type: :header_section, level: 1, libelle: 'rs1' },
+              { type: :text, libelle: 'rt1' },
+            ],
+          },
+        ],
+        types_de_champ_private: [
+          { type: :header_section, level: 1, libelle: 'ps1' },
+          { type: :text, libelle: 'pt1' },
+        ])
+    end
+    let(:revision) { procedure.draft_revision }
+
+    def tdc(libelle) = revision.types_de_champ.find { it.libelle == libelle }
+
+    it 'returns sections and repetitions above, outermost first' do
+      expect(tdc('t0').ancestors(revision)).to eq([])
+      expect(tdc('s1').ancestors(revision)).to eq([])
+      expect(tdc('s1.1').ancestors(revision).map(&:libelle)).to eq(['s1'])
+      expect(tdc('rep').ancestors(revision).map(&:libelle)).to eq(['s1', 's1.1'])
+      expect(tdc('rs1').ancestors(revision).map(&:libelle)).to eq(['s1', 's1.1', 'rep'])
+      expect(tdc('rt1').ancestors(revision).map(&:libelle)).to eq(['s1', 's1.1', 'rep', 'rs1'])
+      expect(tdc('pt1').ancestors(revision).map(&:libelle)).to eq(['ps1'])
+    end
+
+    it 'exposes parent, section and repetition' do
+      expect(tdc('t0').parent(revision)).to be_nil
+      expect(tdc('t0').section(revision)).to be_nil
+      expect(tdc('t0').repetition(revision)).to be_nil
+
+      expect(tdc('rt1').parent(revision).libelle).to eq('rs1')
+      expect(tdc('rt1').section(revision).libelle).to eq('rs1')
+      expect(tdc('rt1').repetition(revision).libelle).to eq('rep')
+      expect(tdc('rs1').section(revision).libelle).to eq('s1.1')
+    end
+
+    it 'exposes in_repetition? and in_section?' do
+      expect(tdc('t0').in_repetition?(revision)).to be(false)
+      expect(tdc('t0').in_section?(revision)).to be(false)
+
+      expect(tdc('s1.1').in_repetition?(revision)).to be(false)
+      expect(tdc('s1.1').in_section?(revision)).to be(true)
+
+      expect(tdc('rep').in_repetition?(revision)).to be(false)
+      expect(tdc('rep').in_section?(revision)).to be(true)
+
+      expect(tdc('rt1').in_repetition?(revision)).to be(true)
+      expect(tdc('rt1').in_section?(revision)).to be(true)
+    end
+
+    it 'exposes level as the nesting depth of a header section' do
+      expect(tdc('s1').level(revision)).to eq(1)
+      expect(tdc('s1.1').level(revision)).to eq(2)
+      expect(tdc('rs1').level(revision)).to eq(3)
+      expect(tdc('ps1').level(revision)).to eq(1)
+    end
+
+    context 'when a header section level is skipped' do
+      let(:procedure) do
+        create(:procedure, types_de_champ_public: [
+          { type: :header_section, level: 1, libelle: 's1' },
+          { type: :header_section, level: 3, libelle: 's3' },
+        ])
+      end
+
+      it 'collapses the gap' do
+        expect(tdc('s3').ancestors(revision).map(&:libelle)).to eq(['s1'])
+        expect(tdc('s3').level(revision)).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -465,7 +465,7 @@ describe ProcedureExportService do
           procedure.active_revision.root_types_de_champ_public.each do |type_de_champ|
             type_de_champ.update!(libelle: "#{type_de_champ.id} - ?/[] ééé ééé ééééééé ééééééé éééééééé. ééé éé éééééééé éé ééé. ééééé éééééééé ééé ééé.")
           end
-          procedure.active_revision.children_of(champ_repetition.type_de_champ).each do |type_de_champ|
+          champ_repetition.type_de_champ.flat_children(procedure.active_revision).each do |type_de_champ|
             type_de_champ.update!(libelle: "#{type_de_champ.id} - Quam rem nam maiores numquam dolorem nesciunt. Cum et possimus et aut. Fugit voluptas qui qui.")
           end
         end

--- a/spec/system/users/dossier_prefill_get_spec.rb
+++ b/spec/system/users/dossier_prefill_get_spec.rb
@@ -48,7 +48,7 @@ describe 'Prefilling a dossier (with a GET request):', js: true do
   let(:commune_value) { ['01540', '01457'] }
   let(:commune_libelle) { 'Vonnas (01540)' }
   let(:address_value) { "20 Avenue de Ségur 75007 Paris" }
-  let(:sub_types_de_champ_repetition) { procedure.active_revision.children_of(type_de_champ_repetition) }
+  let(:sub_types_de_champ_repetition) { type_de_champ_repetition.flat_children(procedure.active_revision) }
   let(:text_repetition_libelle) { sub_types_de_champ_repetition.first.libelle }
   let(:integer_repetition_libelle) { sub_types_de_champ_repetition.second.libelle }
   let(:text_repetition_value) { "First repetition text" }

--- a/spec/system/users/dossier_prefill_post_spec.rb
+++ b/spec/system/users/dossier_prefill_post_spec.rb
@@ -47,7 +47,7 @@ describe 'Prefilling a dossier (with a POST request):', js: true do
   let(:commune_value) { ['01540', '01457'] }
   let(:commune_libelle) { 'Vonnas (01540)' }
   let(:address_value) { "20 Avenue de Ségur 75007 Paris" }
-  let(:sub_type_de_champs_repetition) { procedure.active_revision.children_of(type_de_champ_repetition) }
+  let(:sub_type_de_champs_repetition) { type_de_champ_repetition.flat_children(procedure.active_revision) }
   let(:text_repetition_libelle) { sub_type_de_champs_repetition.first.libelle }
   let(:integer_repetition_libelle) { sub_type_de_champs_repetition.second.libelle }
   let(:text_repetition_value) { "First repetition text" }

--- a/spec/validators/types_de_champ/libelle_validator_spec.rb
+++ b/spec/validators/types_de_champ/libelle_validator_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe TypesDeChamp::LibelleValidator do
   context 'with a champ inside a repetition' do
     let(:types) { [{ type: :repetition, children: [{ type: :text }] }] }
     let(:repetition) { procedure.active_revision.root_types_de_champ_public.find(&:repetition?) }
-    let(:child) { procedure.draft_revision.children_of(repetition).first }
+    let(:child) { repetition.flat_children(procedure.draft_revision).first }
 
     context 'when the child libelle is empty' do
       before { child.update(libelle: '') }

--- a/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
+++ b/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
@@ -14,4 +14,23 @@ describe 'dossiers/dossier_vide', type: :view do
     subject
     expect(rendered).to be_present
   end
+
+  context 'with a repetition containing header sections' do
+    let(:procedure) do
+      create(:procedure, types_de_champ_public: [
+        {
+          type: :repetition, libelle: 'rep', children: [
+            { type: :header_section, level: 1, libelle: 'rs1' },
+            { type: :text, libelle: 'rt1' },
+          ],
+        },
+      ])
+    end
+
+    it 'renders the champs nested in the sections' do
+      allow(view).to receive(:format_in_2_lines).and_call_original
+      subject
+      expect(view).to have_received(:format_in_2_lines).with(anything, having_attributes(libelle: 'rt1'), any_args).thrice
+    end
+  end
 end


### PR DESCRIPTION
## Résumé

- Introduit une API de navigation en arbre des types de champ, portée par `ProcedureRevision` (index mémoïsé en une passe : `ancestors_of`, `children_of`, `flat_children_of`, `repetition_of`, `section_of`, `parent_of`, `types_de_champ_public/private`) et exposée sur `TypesDeChamp::TypeDeChampBase` (`children`, `flat_children`, `ancestors`, `parent`, `section`, `repetition`, `level`).
- Adapte les usages existants sans changer l'API publique de `Dossier`/`Champ` : `revision.children_of(tdc)` → `tdc.flat_children(revision)`, `level_for_revision` → `level`, `tdc.child?` → `tdc.in_repetition?`.
- Refactorise `EditableChamp::SectionComponent` avec cette API (récursion par section via `header_section.children(revision)`), interface inchangée pour les vues.
- ETQ admin : le sommaire de l'éditeur de champs (`TypesDeChampEditor::HeaderSectionsSummaryComponent`) reflète l'imbrication réelle des sections (via `revision.sections_with_depth`) et inclut les répétitions.
- Corrige au passage `TreeableConcern#to_tree` quand un niveau de section est sauté après le sous-arbre d'une section précédente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)