### PR TITLE
Tech: seeds — zones depuis config/zones.yml, service par défaut, API du store Oaken

### DIFF
--- a/app/tasks/maintenance/create_previews_for_pjs_from_messagerie_task.rb
+++ b/app/tasks/maintenance/create_previews_for_pjs_from_messagerie_task.rb
@@ -25,7 +25,7 @@ module Maintenance
         .pluck(:id)
 
       attachments = ActiveStorage::Attachment
-        .where(record_id: commentaire_ids)
+        .where(record_type: 'Commentaire', record_id: commentaire_ids)
 
       attachments.each do |attachment|
         next if !(attachment.previewable? && attachment.representation_required?)

--- a/app/tasks/maintenance/create_variants_for_pjs_from_messagerie__task.rb
+++ b/app/tasks/maintenance/create_variants_for_pjs_from_messagerie__task.rb
@@ -25,7 +25,7 @@ module Maintenance
         .pluck(:id)
 
       attachments = ActiveStorage::Attachment
-        .where(record_id: commentaire_ids)
+        .where(record_type: 'Commentaire', record_id: commentaire_ids)
 
       attachments.each do |attachment|
         next if !(attachment.variable? && attachment.representation_required?)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,7 @@
 # between development and test:
 #
 # - db/seeds/setup.rb        — helpers and defaults (loaded automatically)
+# - db/seeds/zones.rb        — zones (ministères) from config/zones.yml
 # - db/seeds/users.rb        — usager / administrateur / instructeur personas
 # - db/seeds/procedures.rb   — a published demo procedure with common types de champ
 # - db/seeds/dossiers.rb     — dossiers in various states on the individual procedure
@@ -21,5 +22,5 @@
 # Seeds assume an empty database and are not re-runnable: specs replant once
 # per suite, and a development database is refreshed with
 # `bin/rails db:seed:replant` (truncate + reseed).
-Oaken.seed :users, :procedures, :dossiers, :avis, :entreprise, :messagerie
+Oaken.seed :zones, :users, :procedures, :dossiers, :avis, :entreprise, :messagerie
 Oaken.seed :cases if Rails.env.development?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,7 @@
 # - db/seeds/setup.rb        — helpers and defaults (loaded automatically)
 # - db/seeds/zones.rb        — zones (ministères) from config/zones.yml
 # - db/seeds/users.rb        — usager / administrateur / instructeur personas
+# - db/seeds/services.rb     — the default service attached to every seeded procedure
 # - db/seeds/procedures.rb   — a published demo procedure with common types de champ
 # - db/seeds/dossiers.rb     — dossiers in various states on the individual procedure
 # - db/seeds/avis.rb         — two experts with pending, answered, confidentiel and file-attached avis
@@ -22,5 +23,5 @@
 # Seeds assume an empty database and are not re-runnable: specs replant once
 # per suite, and a development database is refreshed with
 # `bin/rails db:seed:replant` (truncate + reseed).
-Oaken.seed :zones, :users, :procedures, :dossiers, :avis, :entreprise, :messagerie
+Oaken.seed :zones, :users, :services, :procedures, :dossiers, :avis, :entreprise, :messagerie
 Oaken.seed :cases if Rails.env.development?

--- a/db/seeds/avis.rb
+++ b/db/seeds/avis.rb
@@ -15,48 +15,38 @@ second_expert_user = users.create :second_expert, email: "expert2@exemple.fr"
 second_expert_user.create_expert!
 experts.label second: second_expert_user.expert
 
-experts_procedure = experts_procedures.create(expert: experts.default, procedure: procedures.individual)
-experts_procedures.label default: experts_procedure
+experts_procedure = experts_procedures.create :default, expert: experts.default, procedure: procedures.individual
+second_experts_procedure = experts_procedures.create :second, expert: experts.second, procedure: procedures.individual
 
-second_experts_procedure = experts_procedures.create(expert: experts.second, procedure: procedures.individual)
-experts_procedures.label second: second_experts_procedure
-
-pending_avis = avis.create(
+avis.create :pending,
   dossier: dossiers.en_instruction,
   claimant: instructeurs.default,
   experts_procedure:,
   confidentiel: false,
   introduction: "Bonjour, merci de me donner votre avis sur ce dossier."
-)
-avis.label pending: pending_avis
 
-answered_avis = avis.create(
+avis.create :answered,
   dossier: dossiers.accepte,
   claimant: instructeurs.default,
   experts_procedure:,
   confidentiel: false,
   introduction: "Bonjour, merci de me donner votre avis sur ce dossier.",
   answer: "La demande semble pertinente et le demandeur remplit les conditions."
-)
-avis.label answered: answered_avis
 
-confidentiel_avis = avis.create(
+avis.create :confidentiel,
   dossier: dossiers.en_instruction,
   claimant: instructeurs.default,
   experts_procedure: second_experts_procedure,
   confidentiel: true,
   introduction: "Bonjour, merci de me donner votre avis confidentiel sur ce dossier."
-)
-avis.label confidentiel: confidentiel_avis
 
-with_file_avis = avis.create(
+with_file_avis = avis.create :with_file,
   dossier: dossiers.accepte,
   claimant: instructeurs.default,
   experts_procedure:,
   confidentiel: false,
   introduction: "Bonjour, vous trouverez le contexte dans le fichier joint.",
   answer: "Avis favorable, au vu du document joint."
-)
 white_pixel_png = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==")
 with_file_avis.introduction_file.attach(
   io: StringIO.new(white_pixel_png),
@@ -64,4 +54,3 @@ with_file_avis.introduction_file.attach(
   content_type: "image/png",
   metadata: { virus_scan_result: ActiveStorage::VirusScanner::SAFE }
 )
-avis.label with_file: with_file_avis

--- a/db/seeds/cases/champs.rb
+++ b/db/seeds/cases/champs.rb
@@ -92,7 +92,8 @@ ActiveRecord::Base.transaction do
 
   procedures.label tous_champs: procedure
 
-  dossier = Dossier.create!(
+  dossier = dossiers.create(
+    :tous_champs,
     user: users.usager,
     revision: procedure.active_revision,
     groupe_instructeur: procedure.defaut_groupe_instructeur,
@@ -100,5 +101,4 @@ ActiveRecord::Base.transaction do
     autorisation_donnees: true
   )
   dossier.build_default_values
-  dossiers.label tous_champs: dossier
 end

--- a/db/seeds/cases/champs.rb
+++ b/db/seeds/cases/champs.rb
@@ -15,7 +15,8 @@ ActiveRecord::Base.transaction do
     duree_conservation_dossiers_dans_ds: 3,
     max_duree_conservation_dossiers_dans_ds: Procedure::OLD_MAX_DUREE_CONSERVATION,
     for_individual: true,
-    administrateurs: [administrateurs.default]
+    administrateurs: [administrateurs.default],
+    service: services.default
   )
   procedure.draft_revision = procedure.revisions.build
   procedure.save!

--- a/db/seeds/cases/sva.rb
+++ b/db/seeds/cases/sva.rb
@@ -13,6 +13,8 @@
     max_duree_conservation_dossiers_dans_ds: Procedure::OLD_MAX_DUREE_CONSERVATION,
     for_individual: true,
     administrateurs: [administrateurs.default],
+    zones: [zones.default],
+    service: services.default,
     sva_svr: SVASVRConfiguration.new(decision:).attributes
   )
   procedure.draft_revision = procedure.revisions.build

--- a/db/seeds/development/users.rb
+++ b/db/seeds/development/users.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Super-admin account for the manager interface, sharing the admin user's credentials.
-SuperAdmin.create!(email: users.admin.email, password: users.default_password)
+super_admins.create email: users.admin.email, password: users.default_password
 
 # Default instructeur automatically assigned by the platform (see DEFAULT_INSTRUCTEUR_EMAIL).
 fixer = users.create email: ENV.fetch('DEFAULT_INSTRUCTEUR_EMAIL') { CONTACT_EMAIL },

--- a/db/seeds/dossiers.rb
+++ b/db/seeds/dossiers.rb
@@ -2,8 +2,9 @@
 
 procedure = procedures.individual
 
-labels = %w[brouillon en_construction en_instruction accepte refuse].to_h do |state|
-  dossier = Dossier.create!(
+%w[brouillon en_construction en_instruction accepte refuse].each do |state|
+  dossier = dossiers.create(
+    state.to_sym,
     user: users.usager,
     revision: procedure.active_revision,
     groupe_instructeur: procedure.defaut_groupe_instructeur,
@@ -32,8 +33,4 @@ labels = %w[brouillon en_construction en_instruction accepte refuse].to_h do |st
     dossier.submitted_revision_id = dossier.revision_id
     dossier.save!
   end
-
-  [state.to_sym, dossier]
 end
-
-dossiers.label(**labels)

--- a/db/seeds/entreprise.rb
+++ b/db/seeds/entreprise.rb
@@ -66,7 +66,8 @@ build_etablissement = lambda do
   )
 end
 
-dossier = Dossier.create!(
+dossier = dossiers.create(
+  :avec_siret,
   user: users.usager,
   revision: procedure.active_revision,
   groupe_instructeur: procedure.defaut_groupe_instructeur,
@@ -80,14 +81,13 @@ dossier.traitements.passer_en_construction(processed_at:)
 dossier.submitted_revision_id = dossier.revision_id
 dossier.save!
 
-dossiers.label avec_siret: dossier
-
 champ_values = {
   "Nom du projet" => "Rénovation du réseau de transport",
   "Description du projet" => "Un projet de rénovation du réseau de transport par conduites.",
 }
 
-dossier_en_instruction = Dossier.create!(
+dossier_en_instruction = dossiers.create(
+  :entreprise_en_instruction,
   user: users.usager,
   revision: procedure.active_revision,
   groupe_instructeur: procedure.defaut_groupe_instructeur,
@@ -101,5 +101,3 @@ processed_at = DossierWithReferenceDate.assign(dossier_en_instruction, reference
 dossier_en_instruction.traitements.passer_en_instruction(processed_at:)
 dossier_en_instruction.submitted_revision_id = dossier_en_instruction.revision_id
 dossier_en_instruction.save!
-
-dossiers.label entreprise_en_instruction: dossier_en_instruction

--- a/db/seeds/entreprise.rb
+++ b/db/seeds/entreprise.rb
@@ -13,7 +13,9 @@ procedure = Procedure.new(
   duree_conservation_dossiers_dans_ds: 3,
   max_duree_conservation_dossiers_dans_ds: Procedure::OLD_MAX_DUREE_CONSERVATION,
   for_individual: false,
-  administrateurs: [administrateurs.default]
+  administrateurs: [administrateurs.default],
+  zones: [zones.default],
+  service: services.default
 )
 procedure.draft_revision = procedure.revisions.build
 procedure.save!
@@ -29,9 +31,6 @@ end
 
 procedure.publish_or_reopen!(administrateurs.default, "demarche-demo-entreprise")
 instructeurs.default.assign_to_procedure(procedure)
-
-# A published procedure without a service is nagged about on every admin page.
-procedure.update!(service: procedures.individual.service)
 
 procedures.label entreprise: procedure
 

--- a/db/seeds/messagerie.rb
+++ b/db/seeds/messagerie.rb
@@ -3,17 +3,13 @@
 # A message sent by the default instructeur on the en_construction dossier,
 # and the usager's reply.
 
-message = commentaires.create(
+commentaires.create :from_instructeur,
   dossier: dossiers.en_construction,
   instructeur: instructeurs.default,
   email: users.instructeur.email,
   body: "Bonjour, pouvez-vous préciser la date de début de votre projet ?"
-)
-commentaires.label from_instructeur: message
 
-reply = commentaires.create(
+commentaires.create :from_usager,
   dossier: dossiers.en_construction,
   email: users.usager.email,
   body: "Bonjour, le projet commencera au début du mois de septembre."
-)
-commentaires.label from_usager: reply

--- a/db/seeds/procedures.rb
+++ b/db/seeds/procedures.rb
@@ -8,7 +8,9 @@ procedure = Procedure.new(
   duree_conservation_dossiers_dans_ds: 3,
   max_duree_conservation_dossiers_dans_ds: Procedure::OLD_MAX_DUREE_CONSERVATION,
   for_individual: true,
-  administrateurs: [administrateurs.default]
+  administrateurs: [administrateurs.default],
+  zones: [zones.default],
+  service: services.default
 )
 procedure.draft_revision = procedure.revisions.build
 procedure.save!
@@ -29,19 +31,6 @@ end
 procedure.publish_or_reopen!(administrateurs.default, "demarche-demo")
 instructeurs.default.assign_to_procedure(procedure)
 
-# A published procedure without a service is nagged about on every admin page.
-procedure.update!(service: Service.create!(
-  nom: "Service de démonstration",
-  administrateur: administrateurs.default,
-  organisme: "Organisme de démonstration",
-  type_organisme: Service.type_organismes.fetch(:administration_centrale),
-  email: "contact@exemple.fr",
-  telephone: "0102030405",
-  horaires: "Du lundi au vendredi, de 9 h à 18 h",
-  adresse: "20 avenue de Ségur, 75007 Paris",
-  siret: "13002526500013"
-))
-
 procedures.label individual: procedure
 
 brouillon_procedure = Procedure.new(
@@ -50,7 +39,8 @@ brouillon_procedure = Procedure.new(
   cadre_juridique: "https://www.legifrance.gouv.fr/",
   duree_conservation_dossiers_dans_ds: 3,
   max_duree_conservation_dossiers_dans_ds: Procedure::OLD_MAX_DUREE_CONSERVATION,
-  administrateurs: [administrateurs.default]
+  administrateurs: [administrateurs.default],
+  service: services.default
 )
 brouillon_procedure.draft_revision = brouillon_procedure.revisions.build
 brouillon_procedure.save!

--- a/db/seeds/services.rb
+++ b/db/seeds/services.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# A published procedure without a service is nagged about on every admin page,
+# so every seeded procedure gets this default service.
+services.create :default,
+  nom: "Service de démonstration",
+  administrateur: administrateurs.default,
+  organisme: "Organisme de démonstration",
+  type_organisme: Service.type_organismes.fetch(:administration_centrale),
+  email: "contact@exemple.fr",
+  telephone: "0102030405",
+  horaires: "Du lundi au vendredi, de 9 h à 18 h",
+  adresse: "20 avenue de Ségur, 75007 Paris",
+  siret: "13002526500013"

--- a/db/seeds/zones.rb
+++ b/db/seeds/zones.rb
@@ -6,7 +6,7 @@ ministeres = Psych.safe_load(Rails.root.join("config/zones.yml").read).fetch("mi
 
 ministeres.each do |ministere|
   acronym = ministere.keys.first
-  zone = Zone.create!(acronym:, tchap_hs: ministere["tchap_hs"] || [])
+  zone = zones.create(acronym:, tchap_hs: ministere["tchap_hs"] || [])
   ministere["labels"].each do |label|
     designated_on = label.keys.first
     zone.labels.create!(designated_on:, name: label.fetch(designated_on))

--- a/db/seeds/zones.rb
+++ b/db/seeds/zones.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Zones (ministères) mirror config/zones.yml — the same source of truth
+# Maintenance::UpdateZonesTask syncs in production.
+ministeres = Psych.safe_load(Rails.root.join("config/zones.yml").read).fetch("ministeres")
+
+ministeres.each do |ministere|
+  acronym = ministere.keys.first
+  zone = Zone.create!(acronym:, tchap_hs: ministere["tchap_hs"] || [])
+  ministere["labels"].each do |label|
+    designated_on = label.keys.first
+    zone.labels.create!(designated_on:, name: label.fetch(designated_on))
+  end
+end
+
+# The demo procedures publish under DINUM's ministry.
+zones.label default: Zone.find_by!(acronym: "MTFP")

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -487,6 +487,8 @@ describe Administrateurs::ProceduresController, type: :controller do
   end
 
   describe 'GET #zones' do
+    empty_seeds ZoneLabel, Zone
+
     let(:procedure) { create(:procedure, administrateur: admin) }
     let(:procedure_id) { procedure.id }
 

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -65,8 +65,10 @@ RSpec.describe InviteMailer, type: :mailer do
     end
 
     context 'when an avis exists with same id' do
+      let(:avis) { create(:avis) }
+      let(:invite) { create(:invite, id: avis.id, user: nil, email: 'kikoo@lol.fr') }
+
       it 'associate the TargetedUserLink to the good model [does not search by id only]' do
-        avis = create(:avis, id: invite.id)
         link_on_avis_with_same_id = create(:targeted_user_link, target_model: avis, target_context: TargetedUserLink.target_contexts[:avis])
         deliver
         expect(invite.targeted_user_link).not_to eq(link_on_avis_with_same_id)

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -242,7 +242,7 @@ describe Administrateur, type: :model do
   end
 
   describe 'zones' do
-    let(:admin) { administrateurs.default }
+    let(:admin) { administrateurs.blank }
     let(:zone1) { create(:zone) }
     let(:zone2) { create(:zone) }
     let!(:procedure) { create(:procedure, administrateurs: [admin], zones: [zone1, zone2]) }

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe Zone do
+  empty_seeds ZoneLabel, Zone
+
   let(:now) { Time.zone.parse("2022-08-11") }
   before do
     travel_to(now)

--- a/spec/tasks/maintenance/update_zones_task_spec.rb
+++ b/spec/tasks/maintenance/update_zones_task_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 module Maintenance
   RSpec.describe UpdateZonesTask do
+    empty_seeds ZoneLabel, Zone
+
     describe "#process" do
       subject(:process) { described_class.process(ministere) }
       let(:ministere) {

--- a/spec/views/administrateurs/procedures/zones.html.haml_spec.rb
+++ b/spec/views/administrateurs/procedures/zones.html.haml_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe 'administrateurs/procedures/zones', type: :view do
+  empty_seeds ZoneLabel, Zone
+
   let(:administrateur) { administrateurs.default }
   let(:procedure) { create(:procedure, published_at: Time.zone.parse('2022-07-20')) } # Définir une date de publication de la procédure plus tardive
   let!(:zone1) { create(:zone, acronym: 'MTEI', labels: [{ designated_on: '2022-05-18', name: "Ministère du Travail" }]) }

--- a/spec/views/users/_procedure_footer.html.haml_spec.rb
+++ b/spec/views/users/_procedure_footer.html.haml_spec.rb
@@ -52,8 +52,7 @@ describe 'users/procedure_footer', type: :view do
 
     context "when procedure does not belong to Ministère de l’Intérieur" do
       before do
-        mi_zone = create(:zone, acronym: 'MI', labels: [{ designated_on: Time.zone.today, name: "Ministère de l’Intérieur" }])
-        dossier.procedure.zones << mi_zone
+        dossier.procedure.zones << Zone.find_by!(acronym: 'MI')
       end
 
       it { is_expected.not_to have_link(france_service_link_text) }


### PR DESCRIPTION
## Contexte

Les zones n'étaient synchronisées qu'en production via la tâche de maintenance `UpdateZonesTask` : une base fraîchement seedée n'en contenait aucune. Par ailleurs, les démarches publiées des seeds n'avaient pas toutes de service, et les seeds n'utilisaient pas l'API canonique du store Oaken.

## Changements

- Nouveau seed de base `db/seeds/zones.rb` : charge les zones et leurs labels depuis `config/zones.yml` (même source de vérité que la tâche de maintenance)
- Les démarches publiées des seeds (démo, SVA/SVR, entreprise) sont rattachées à la zone DINUM (MTFP), accessible via `zones.default`
- Les specs qui assertent sur des scopes globaux de `Zone` ou créent des zones avec de vrais acronymes déclarent `empty_seeds ZoneLabel, Zone`
- Nouveau seed de base `db/seeds/services.rb` : un service par défaut, accessible via `services.default`, rattaché à toutes les démarches seedées (démo, brouillon, entreprise, SVA/SVR, tous champs)
- Réécriture des seeds avec l'API canonique du store Oaken (`store.create :label, ...`) partout où la création tient en un seul appel ; les constructions multi-étapes (démarches avec `draft_revision`, rôles via `create_instructeur!`, …) gardent un `label` explicite après coup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
