### PR TITLE
Tech: champs référentiel — retry des erreurs réseau transitoires et erreurs Sentry lisibles

### DIFF
--- a/app/services/referentiel_service.rb
+++ b/app/services/referentiel_service.rb
@@ -67,8 +67,8 @@ class ReferentielService
       Failure(retryable: true, error: StandardError.new("Retryable: #{code}"), code:)
     in Failure(code:) if code.in?(NON_RETRYABLE_STATUS_CODES) # search may not have been found
       Failure(retryable: false, error: StandardError.new("Not retryable: #{code}"), code:)
-    in Failure
-      Failure(retryable: false, error: StandardError.new('Unknown error'), code:)
+    in Failure(type:, code:)
+      Failure(retryable: false, error: StandardError.new("Unknown error: #{type} (code: #{code})"), code:)
     end
   end
 

--- a/app/services/referentiel_service.rb
+++ b/app/services/referentiel_service.rb
@@ -3,8 +3,10 @@
 class ReferentielService
   include Dry::Monads[:result]
 
-  RETRYABLE_STATUS_CODES = [429, 500, 503, 408, 502].freeze
+  RETRYABLE_STATUS_CODES = [429, 500, 503, 504, 408, 502].freeze
   NON_RETRYABLE_STATUS_CODES = [404, 400, 403, 401].freeze
+  # types returned by API::Client when no HTTP response was received: transient, worth retrying
+  RETRYABLE_ERROR_TYPES = [:timeout, :network].freeze
 
   API_TIMEOUT = 4 # in seconds
   MAX_FILE_SIZE = 1.megabyte
@@ -63,6 +65,8 @@ class ReferentielService
     case result
     in Success(body:)
       Success(body)
+    in Failure(type:, code:) if type.in?(RETRYABLE_ERROR_TYPES) # network issue or timeout, api may recover
+      Failure(retryable: true, error: StandardError.new("Retryable: #{type}"), code:)
     in Failure(code:) if code.in?(RETRYABLE_STATUS_CODES) # api may be rate limited, or down etc..
       Failure(retryable: true, error: StandardError.new("Retryable: #{code}"), code:)
     in Failure(code:) if code.in?(NON_RETRYABLE_STATUS_CODES) # search may not have been found

--- a/spec/services/referentiel_service_spec.rb
+++ b/spec/services/referentiel_service_spec.rb
@@ -87,6 +87,29 @@ RSpec.describe ReferentielService, type: :service do
       end
     end
 
+    context "when referentiel 504 (gateway timeout)" do
+      let(:status) { 504 }
+      let(:body) { nil }
+      it "returns a retryable Failure" do
+        expect(subject).to be_failure
+        expect(subject.failure).to include(retryable: true, error: StandardError.new('Retryable: 504'), code: 504)
+      end
+    end
+
+    context "when the request times out or the network fails (no HTTP response)" do
+      let(:status) { 200 }
+      let(:body) { nil }
+      before do
+        allow_any_instance_of(API::Client).to receive(:call)
+          .and_return(Dry::Monads::Failure(API::Client::Error[:timeout, 0, true, StandardError.new("Timeout")]))
+      end
+
+      it "returns a retryable Failure" do
+        expect(subject).to be_failure
+        expect(subject.failure).to include(retryable: true, error: StandardError.new('Retryable: timeout'), code: 0)
+      end
+    end
+
     context "when referentiel teapots" do
       let(:status) { 418 }
       let(:body) { nil }

--- a/spec/services/referentiel_service_spec.rb
+++ b/spec/services/referentiel_service_spec.rb
@@ -90,9 +90,20 @@ RSpec.describe ReferentielService, type: :service do
     context "when referentiel teapots" do
       let(:status) { 418 }
       let(:body) { nil }
-      it "returns a retryable Failure" do
+      it "returns a non retryable Failure detailing the type and code" do
         expect(subject).to be_failure
-        expect(subject.failure).to include(retryable: false, error: StandardError.new('Unknown error'), code: 418)
+        expect(subject.failure).to include(retryable: false, error: StandardError.new('Unknown error: http (code: 418)'), code: 418)
+      end
+    end
+
+    context "when referentiel returns 200 with a non-JSON body" do
+      let(:status) { 200 }
+      let(:body) { nil }
+      before { stub_request(:get, resolved_url).to_return(status: 200, body: "<html>oops</html>") }
+
+      it "returns a non retryable Failure detailing the type and code" do
+        expect(subject).to be_failure
+        expect(subject.failure).to include(retryable: false, error: StandardError.new('Unknown error: json (code: 200)'), code: 200)
       end
     end
 


### PR DESCRIPTION
## Contexte

L'issue Sentry « Unknown error » ([RAILS-CBH](https://demarches-simplifiees.sentry.io/issues/6635198267/), ~1800 occurrences) sur `ChampFetchExternalDataJob` ne donnait aucun détail : le catch-all de `ReferentielService#handle_api_result` remplaçait l'erreur riche renvoyée par `API::Client` (type + code HTTP) par un `StandardError.new('Unknown error')` nu, fusionnant tous les cas dans une seule issue opaque.

## Changements

1. **Erreurs lisibles** : le message capturé remonte désormais le `type` et le `code` (ex. `Unknown error: http (code: 504)`), pour que Sentry regroupe par cause réelle. Le corps de réponse est volontairement exclu (pas de fuite de données).

2. **Retry des cas transitoires** : les erreurs réseau / timeout (aucune réponse HTTP, type `:timeout` / `:network`) et le `504` sont maintenant ré-essayées au lieu d'être remontées comme erreurs. Les échecs réellement permanents (4xx, 3xx, corps malformé) restent des erreurs.

Fixes RAILS-CBH
