### PR TITLE
[WIP] ETQ admin, l'aperçu d'attestation suit la révision en cours

### DIFF
--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -7,7 +7,6 @@ module Administrateurs
     before_action :preload_revisions, only: [:edit, :update, :create]
 
     def show
-      preview_dossier = @procedure.dossier_for_preview(current_user)
       attributes = @attestation_template.render_attributes_for(dossier: preview_dossier)
 
       @body = attributes.fetch(:body)
@@ -117,6 +116,15 @@ module Administrateurs
     end
 
     private
+
+    # The editor builds its tag list from `active_revision`, so the preview must use a dossier
+    # of that same revision: a dossier frozen on an older revision does not have the champs the
+    # inserted tags point to, and TagsSubstitutionConcern silently renders their libelle instead.
+    def preview_dossier
+      revision = @procedure.active_revision
+
+      @procedure.dossier_for_preview(current_user, revision:) || revision.dossier_for_preview(current_user)
+    end
 
     def retrieve_attestation_template
       attestation_kind = params[:attestation_kind]

--- a/app/controllers/administrateurs/mail_templates_controller.rb
+++ b/app/controllers/administrateurs/mail_templates_controller.rb
@@ -78,8 +78,8 @@ module Administrateurs
 
     private
 
-    # The preview needs a sample dossier: prefer one on the draft revision, otherwise
-    # fall back to the active (published) revision so a published procedure still previews.
+    # The preview needs a sample dossier: prefer the best existing one, whatever its revision,
+    # and otherwise build a preview dossier on the active revision so there is always one.
     def preview_dossier
       @procedure.dossier_for_preview(current_user) || @procedure.active_revision.dossier_for_preview(current_user)
     end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -773,9 +773,14 @@ class Procedure < ApplicationRecord
     lien_dpo.present? && lien_dpo.match?(/@/)
   end
 
-  def dossier_for_preview(user)
+  # When `revision` is given, candidates are restricted to that revision *before* ranking:
+  # a dossier frozen on an older revision (typically `accepte`, which `can_rebase?` excludes)
+  # would otherwise win and make the preview reference champs the dossier does not have.
+  def dossier_for_preview(user, revision: nil)
+    scope = revision.present? ? dossiers.where(revision_id: revision.id) : dossiers
+
     # Try to use a preview or a dossier filled by current user
-    dossiers.where(for_procedure_preview: true).or(dossiers.visible_by_administration)
+    scope.where(for_procedure_preview: true).or(scope.visible_by_administration)
       .order(Arel.sql("CASE WHEN user_id = #{user.id} THEN 1 ELSE 0 END DESC,
                        CASE WHEN state = 'accepte' THEN 1 ELSE 0 END DESC,
                        CASE WHEN state = 'brouillon' THEN 0 ELSE 1 END DESC,

--- a/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
@@ -41,7 +41,8 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
       render_views
 
       context 'with preview dossier' do
-        let!(:dossier) { create(:dossier, :en_construction, procedure:, for_procedure_preview: true) }
+        # real preview dossiers are always brouillon, cf ProcedureRevision#dossier_for_preview
+        let!(:dossier) { create(:dossier, :brouillon, procedure:, for_procedure_preview: true) }
 
         it do
           is_expected.to include("Mon titre pour Ma démarche")
@@ -50,8 +51,42 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
       end
 
       context 'without preview dossier' do
-        it do
-          is_expected.to include("Mon titre pour --dossier_procedure_libelle--")
+        it 'falls back to a preview dossier built on the active revision' do
+          is_expected.to include("Mon titre pour Ma démarche")
+
+          preview = procedure.dossiers.for_procedure_preview.sole
+          expect(preview.revision).to eq(procedure.active_revision)
+        end
+      end
+
+      context 'when a champ was deleted and recreated, and a dossier stayed on the old revision' do
+        let(:procedure) do
+          create(:procedure, :published, administrateur: admin, attestation_acceptation_template:,
+                                         libelle: "Ma démarche", types_de_champ_public: [{ type: :text, libelle: 'Ville' }])
+        end
+        let!(:old_revision) { procedure.published_revision }
+        let!(:frozen_dossier) { create(:dossier, :accepte, procedure:, revision: old_revision) }
+
+        before do
+          old_tdc = procedure.draft_revision.root_types_de_champ_public.first
+          procedure.draft_revision.remove_type_de_champ(old_tdc.stable_id)
+          new_tdc = procedure.draft_revision.add_type_de_champ({ type_champ: :text, libelle: 'Ville' })
+          procedure.publish_revision!(admin)
+          procedure.reload
+
+          procedure.attestation_acceptation_template.update!(json_body: {
+            "type" => "doc",
+            "content" => [
+              {
+                "type" => "paragraph",
+                "content" => [{ "type" => "mention", "attrs" => { "id" => "tdc#{new_tdc.stable_id}", "label" => "Ville" } }],
+              },
+            ],
+          })
+        end
+
+        it 'never renders the champ libelle in place of its value' do
+          is_expected.not_to include("Ville")
         end
       end
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -2249,6 +2249,52 @@ describe Procedure do
     end
   end
 
+  describe '#dossier_for_preview' do
+    let(:administrateur) { create(:administrateur) }
+    let(:user) { create(:user) }
+    let(:procedure) { create(:procedure, :published, administrateurs: [administrateur], types_de_champ_public: [{ type: :text, libelle: 'Ville' }]) }
+    # `let!` so the revision is captured *before* the `before` hook publishes a new one
+    let!(:old_revision) { procedure.published_revision }
+
+    # publish a new revision so `old_revision` is no longer the active one
+    before do
+      procedure.draft_revision.add_type_de_champ({ type_champ: :text, libelle: 'Autre' })
+      procedure.publish_revision!(administrateur)
+      procedure.reload
+    end
+
+    context 'without a revision argument' do
+      let!(:old_dossier) { create(:dossier, :accepte, procedure:, revision: old_revision, user:) }
+
+      it 'keeps the historical behaviour and may return a dossier of another revision' do
+        expect(procedure.dossier_for_preview(user)).to eq(old_dossier)
+      end
+    end
+
+    context 'with a revision argument' do
+      let(:active_revision) { procedure.published_revision }
+
+      context 'when a dossier of another revision would otherwise win' do
+        let!(:old_accepte) { create(:dossier, :accepte, procedure:, revision: old_revision, user:) }
+        let!(:current_en_instruction) { create(:dossier, :en_instruction, procedure:, revision: active_revision, user:) }
+
+        it 'filters by revision before ranking, so the on-revision dossier wins' do
+          expect(procedure.dossier_for_preview(user, revision: active_revision)).to eq(current_en_instruction)
+        end
+      end
+
+      context 'when only dossiers of another revision exist' do
+        let!(:old_accepte) { create(:dossier, :accepte, procedure:, revision: old_revision, user:) }
+
+        it { expect(procedure.dossier_for_preview(user, revision: active_revision)).to be_nil }
+      end
+
+      context 'when the revision has no dossier at all' do
+        it { expect(procedure.dossier_for_preview(user, revision: active_revision)).to be_nil }
+      end
+    end
+  end
+
   private
 
   def create_dossier_with_pj_of_size(size, procedure)


### PR DESCRIPTION
Un admin a signalé que la valeur d'un champ n'apparaissait pas dans l'attestation : c'est le **libellé** du champ qui s'affichait à la place.

L'éditeur construit sa liste de tags sur `active_revision`, mais l'aperçu choisissait n'importe quel dossier, en privilégiant même les `accepte` — précisément ceux que `can_rebase?` exclut du rebase, et qui restent donc figés sur d'anciennes révisions. Un tag inséré depuis le panneau pointe alors sur un `stable_id` que le dossier prévisualisé ne possède pas, et `TagsSubstitutionConcern` retombe silencieusement sur le libellé.

C'est exactement ce que produit un champ supprimé puis recréé (nouveau `stable_id`), sans que l'admin puisse relier le symptôme à son geste.

## Changements

- `Procedure#dossier_for_preview` accepte un kwarg `revision:` optionnel. Quand il est fourni, les candidats sont filtrés sur la révision **avant** le classement existant — classer d'abord ferait gagner un dossier figé et gâcherait les vrais dossiers de la révision courante.
- L'aperçu d'attestation v2 filtre sur `active_revision`, avec repli sur `ProcedureRevision#dossier_for_preview` pour garantir un dossier cohérent par construction.
- Le kwarg vaut `nil` par défaut : les aperçus mail et export sont inchangés, ce que verrouille un exemple dédié.

## Points d'attention

- `Procedure#dossier_for_preview` n'avait aucun spec jusqu'ici ; son classement est désormais couvert.
- Ce correctif rend l'aperçu honnête, il ne **répare pas** les attestations déjà délivrées avec un libellé à la place d'une valeur. La recopie des valeurs orphelines après recréation d'un champ reste à traiter séparément.