### PR TITLE
ETQ instructeur, correctif: les blocs de données externes reprennent toute la largeur

### DIFF
--- a/app/assets/stylesheets/flex.scss
+++ b/app/assets/stylesheets/flex.scss
@@ -90,6 +90,10 @@
   gap: 1.5rem;
 }
 
+.flex-column-gap-1 {
+  column-gap: 0.5rem;
+}
+
 .flex-1 {
   flex: 1;
 }

--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
@@ -15,7 +15,12 @@
         <% end %>
       <% else %>
         <% c.with_value do %>
-          <div class="flex align-baseline wrap" style="column-gap: 0.5rem">
+          <% prefilled_badge = Dossiers::ChampPrefilledBadgeComponent.new(champ:, profile: @profile) %>
+
+          <div
+            class="<%= class_names("flex align-baseline wrap" => prefilled_badge.render?) %>"
+            style="column-gap: 0.5rem"
+          >
             <% case champ.type_champ %>
             <% when TypeDeChamp.type_champs.fetch(:carte) %>
               <%= render partial: "shared/champs/carte/show", locals: { champ: champ } %>
@@ -81,7 +86,7 @@
               </div>
             <% end %>
 
-            <%= render Dossiers::ChampPrefilledBadgeComponent.new(champ:, profile: @profile) %>
+            <%= render prefilled_badge %>
           </div>
         <% end %>
       <% end %>

--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
@@ -17,10 +17,7 @@
         <% c.with_value do %>
           <% prefilled_badge = Dossiers::ChampPrefilledBadgeComponent.new(champ:, profile: @profile) %>
 
-          <div
-            class="<%= class_names("flex align-baseline wrap" => prefilled_badge.render?) %>"
-            style="column-gap: 0.5rem"
-          >
+          <div class="<%= class_names("flex align-baseline wrap flex-column-gap-1" => prefilled_badge.render?) %>">
             <% case champ.type_champ %>
             <% when TypeDeChamp.type_champs.fetch(:carte) %>
               <%= render partial: "shared/champs/carte/show", locals: { champ: champ } %>

--- a/app/components/dossiers/external_data_card_component.html.erb
+++ b/app/components/dossiers/external_data_card_component.html.erb
@@ -6,7 +6,7 @@
         fr-tag--sm fr-text--regular fr-mb-0
       "
     >
-      Source&nbsp;: <%= source %>
+      Source&nbsp;:&nbsp;<%= source %>
     </span>
   <% end %>
 

--- a/spec/components/dossiers/champs_rows_show_component_spec.rb
+++ b/spec/components/dossiers/champs_rows_show_component_spec.rb
@@ -33,4 +33,31 @@ RSpec.describe Dossiers::ChampsRowsShowComponent, type: :component do
       end
     end
   end
+
+  describe "prefilled badge flex wrapper" do
+    let(:dossier) { dossiers.en_construction }
+    let(:prefill_attrs) { {} }
+    let(:champs) do
+      dossier.root_champs_public.tap do |cs|
+        cs.first.update!(value: "ACME", **prefill_attrs)
+      end
+    end
+    let(:component) { described_class.new(champs:, profile: "instructeur", seen_at: nil) }
+
+    context "when the champ is not prefilled" do
+      it "does not wrap the value in a flex row so block content keeps full width" do
+        expect(page).to have_css(".champ-content")
+        expect(page).not_to have_css(".champ-content > div.flex")
+      end
+    end
+
+    context "when the champ is prefilled from a referentiel" do
+      let(:prefill_attrs) { { prefilled: true, prefilled_original_value: { "value" => "ACME" } } }
+
+      it "wraps the value and the badge in a flex row" do
+        expect(page).to have_css(".champ-content > div.flex.wrap")
+        expect(page).to have_css(".fr-icon-checkbox-circle-line")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Contexte

Un [commit récent](#13231) (badge « donnée du référentiel », visible par l'instructeur/expert sur les champs préremplis) a enveloppé la valeur de **chaque** champ dans un conteneur `flex` pour poser le badge à droite de la valeur. Appliqué sans condition à tous les types, ce wrapper rétrécissait les **blocs de données externes** (référentiel, adresse, communes…) : ils ne prenaient plus toute la largeur et étaient serrés à gauche.

## Correctif

- N'activer le conteneur `flex` **que** lorsque le badge est réellement affiché → les champs sans badge retrouvent leur pleine largeur.
- Nettoyage (commit dédié) : le `style="column-gap"` inline devient l'utilitaire `.flex-column-gap-1`.
- Au passage (commit dédié) : espace manquant après « Source : » dans la carte, supprimé par `.fr-tag` en `inline-flex`.

Le badge lui-même n'est pas modifié : il reste inline à droite de la valeur quand il s'affiche.

## Rendu

### Bloc référentiel

| Avant | Après |
|---|---|
| ![referentiel avant](https://gist.githubusercontent.com/colinux/f62c9872f330503779232fcc6e606985/raw/referentiel_before.png) | ![referentiel apres](https://gist.githubusercontent.com/colinux/f62c9872f330503779232fcc6e606985/raw/referentiel_after.png) |

### Bloc adresse (BAN)

| Avant | Après |
|---|---|
| ![adresse avant](https://gist.githubusercontent.com/colinux/f62c9872f330503779232fcc6e606985/raw/address_before.png) | ![adresse apres](https://gist.githubusercontent.com/colinux/f62c9872f330503779232fcc6e606985/raw/address_after.png) |

### Le badge prérempli (inchangé)

Affichage nominal du badge sur des champs cibles préremplis, et absence de décalage sur un champ non prérempli :

![badge](https://gist.githubusercontent.com/colinux/f62c9872f330503779232fcc6e606985/raw/badge_after.png)
