### PR TITLE
ETQ admin, distinguer les balises conditionnées et ajouter une légende des balises

### DIFF
--- a/app/assets/stylesheets/tiptap.scss
+++ b/app/assets/stylesheets/tiptap.scss
@@ -73,6 +73,13 @@
   width: auto;
 }
 
+// Tags legend modal: static tag samples mirror the editor's tag colors
+// (plain DSFR span tags would render grey).
+.tags-legend-modal .fr-tag:not(.fr-tag--purple-glycine) {
+  color: var(--text-action-high-blue-france);
+  background-color: var(--background-action-low-blue-france);
+}
+
 // Subtle panel grouping the tag buttons (shared by the mail body and subject
 // editors) so they read as one block attached to the field above.
 .tags-buttons-panel {

--- a/app/components/tags_button_list_component.rb
+++ b/app/components/tags_button_list_component.rb
@@ -27,6 +27,17 @@ class TagsButtonListComponent < ApplicationComponent
     end
   end
 
+  LEGEND_CATEGORIES = [:champ_public, :champ_private].freeze
+
+  # Unique per instance, for the same reason as optional_toggle_id.
+  def legend_modal_id
+    @legend_modal_id ||= "tags-legend-#{SecureRandom.hex(4)}"
+  end
+
+  def legend?
+    tags.keys.any? { can_toggle_optional?(_1) }
+  end
+
   private
 
   def optional_or_conditional_tag?(tag)
@@ -34,7 +45,7 @@ class TagsButtonListComponent < ApplicationComponent
   end
 
   def can_toggle_optional?(category)
-    return false if category != :champ_public && category != :champ_private
+    return false unless LEGEND_CATEGORIES.include?(category)
 
     tags[category].any? { optional_or_conditional_tag?(_1) }
   end

--- a/app/components/tags_button_list_component.rb
+++ b/app/components/tags_button_list_component.rb
@@ -29,13 +29,13 @@ class TagsButtonListComponent < ApplicationComponent
 
   private
 
-  def optional_tag?(tag)
-    !tag[:mandatory]
+  def optional_or_conditional_tag?(tag)
+    !tag[:mandatory] || tag[:conditional]
   end
 
   def can_toggle_optional?(category)
     return false if category != :champ_public && category != :champ_private
 
-    tags[category].any? { optional_tag?(_1) }
+    tags[category].any? { optional_or_conditional_tag?(_1) }
   end
 end

--- a/app/components/tags_button_list_component/tags_button_list_component.html.erb
+++ b/app/components/tags_button_list_component/tags_button_list_component.html.erb
@@ -29,7 +29,7 @@
 
     <ul class="fr-tags-group" data-category="<%= category %>">
       <% tags.each do |tag| %>
-        <% is_optional = can_toggle_optional && optional_tag?(tag) %>
+        <% is_optional = can_toggle_optional && optional_or_conditional_tag?(tag) %>
         <% label = button_label(tag) %>
 
         <li
@@ -37,7 +37,7 @@
           data-tags-button-list-target="<%= is_optional ? "optionalItem" : nil %>"
         >
           <button
-            class="fr-tag fr-tag--sm <%= class_names("fr-tag--blue-ecume" => tag[:highlight], "fr-tag--purple-glycine" => is_optional) %>"
+            class="fr-tag fr-tag--sm <%= class_names("fr-tag--blue-ecume" => tag[:highlight], "fr-tag--purple-glycine" => tag[:conditional]) %>"
             type="button"
             title="<%= button_title(tag) %>"
             data-action="click->tiptap#insertTag"
@@ -45,12 +45,16 @@
             data-tag-id="<%= tag[:id] %>"
             data-tag-label="<%= label %>"
             data-tag-mandatory="<%= tag[:mandatory].to_s %>"
-            data-tag-category="<%= category %>"
+            data-tag-conditional="<%= tag[:conditional].to_s %>"
           >
             <%= label %>
 
             <% if tag[:mandatory] %>
               *
+            <% end %>
+
+            <% if tag[:conditional] %>
+              [conditionné]
             <% end %>
           </button>
         </li>

--- a/app/components/tags_button_list_component/tags_button_list_component.html.erb
+++ b/app/components/tags_button_list_component/tags_button_list_component.html.erb
@@ -14,10 +14,7 @@
             <%= label_tag "#{optional_toggle_id}_#{category}", for: "#{optional_toggle_id}_#{category}" do %>
               <%= category == :champ_public ? "Voir les champs facultatifs et/ou conditionnés" : "Voir les annotations facultatives et/ou conditionnées" %>
 
-              <span
-                class="hidden fr-hint-text"
-                data-tags-button-list-target="hint"
-              >
+              <span class="fr-hint-text">
                 <%= category == :champ_public ? "Un champ non rempli par l’usager" : "Une annotation non remplie par l’instructeur" %>
                 restera vide.
               </span>

--- a/app/components/tags_button_list_component/tags_button_list_component.html.erb
+++ b/app/components/tags_button_list_component/tags_button_list_component.html.erb
@@ -8,18 +8,37 @@
       </div>
       <% if can_toggle_optional %>
         <div class="fr-fieldset__element fr-px-0">
-          <div class="fr-checkbox-group fr-checkbox-group--sm">
-            <%= check_box_tag("#{optional_toggle_id}_#{category}", 1, false, data: { "no-autosubmit" => true, action: "change->tags-button-list#toggleOptional" }) %>
+          <div class="flex align-center">
+            <div class="fr-checkbox-group fr-checkbox-group--sm">
+              <%= check_box_tag("#{optional_toggle_id}_#{category}", 1, false, data: { "no-autosubmit" => true, action: "change->tags-button-list#toggleOptional" }, aria: { describedby: "#{optional_toggle_id}_#{category}_hint" }) %>
 
-            <%= label_tag "#{optional_toggle_id}_#{category}", for: "#{optional_toggle_id}_#{category}" do %>
-              <%= category == :champ_public ? "Voir les champs facultatifs et/ou conditionnés" : "Voir les annotations facultatives et/ou conditionnées" %>
+              <%= label_tag "#{optional_toggle_id}_#{category}", for: "#{optional_toggle_id}_#{category}" do %>
+                <%= category == :champ_public ? "Voir les champs facultatifs et/ou conditionnés" : "Voir les annotations facultatives et/ou conditionnées" %>
+              <% end %>
+            </div>
 
-              <span class="fr-hint-text">
-                <%= category == :champ_public ? "Un champ non rempli par l’usager" : "Une annotation non remplie par l’instructeur" %>
-                restera vide.
-              </span>
-            <% end %>
+            <button
+              class="
+                fr-btn fr-btn--sm fr-btn--tertiary-no-outline
+                fr-icon-question-line fr-ml-1v
+              "
+              type="button"
+              title="Légende des balises"
+              aria-controls="<%= legend_modal_id %>"
+              aria-haspopup="dialog"
+              data-fr-opened="false"
+            >
+              Légende des balises
+            </button>
           </div>
+
+          <p
+            class="fr-hint-text fr-mt-n1w fr-ml-3w fr-mb-3w"
+            id="<%= optional_toggle_id %>_<%= category %>_hint"
+          >
+            <%= category == :champ_public ? "Un champ non rempli par l’usager" : "Une annotation non remplie par l’instructeur" %>
+            restera vide.
+          </p>
         </div>
       <% end %>
     <% end %>
@@ -58,4 +77,8 @@
       <% end %>
     </ul>
   </div>
+<% end %>
+
+<% if legend? %>
+  <%= render TagsLegendModalComponent.new(modal_id: legend_modal_id) %>
 <% end %>

--- a/app/components/tags_legend_modal_component.rb
+++ b/app/components/tags_legend_modal_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class TagsLegendModalComponent < ApplicationComponent
+  attr_reader :modal_id
+
+  def initialize(modal_id:)
+    @modal_id = modal_id
+  end
+
+  def title_id
+    "#{modal_id}-title"
+  end
+end

--- a/app/components/tags_legend_modal_component/tags_legend_modal_component.html.erb
+++ b/app/components/tags_legend_modal_component/tags_legend_modal_component.html.erb
@@ -1,0 +1,140 @@
+<dialog
+  id="<%= modal_id %>"
+  class="fr-modal tags-legend-modal"
+  role="dialog"
+  aria-labelledby="<%= title_id %>"
+>
+  <div class="fr-container fr-container--fluid fr-container-md">
+    <div class="fr-grid-row fr-grid-row--center">
+      <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
+        <div class="fr-modal__body">
+          <div class="fr-modal__header">
+            <button
+              class="fr-btn--close fr-btn"
+              type="button"
+              aria-controls="<%= modal_id %>"
+              title="<%= t('utils.modal_close_alt') %>"
+            >
+              <%= t('utils.modal_close') %>
+            </button>
+          </div>
+
+          <div class="fr-modal__content">
+            <h1 id="<%= title_id %>" class="fr-modal__title">
+              <span
+                class="fr-icon-arrow-right-line fr-icon--lg"
+                aria-hidden="true"
+              ></span>
+              Légende des balises
+            </h1>
+
+            <p>
+              Si vous utilisez la balise d’un champ
+              <strong>facultatif</strong> ou <strong>conditionné</strong> et
+              que l’usager (ou l’instructeur) n’a pas renseigné ce champ, le
+              texte généré <strong>sera incomplet</strong>.
+            </p>
+
+            <p>
+              Il est donc recommandé de bien prendre en compte les
+              caractéristiques des balises et de privilégier le cas échéant une
+              formulation qui fonctionne aussi bien lorsque la balise est
+              renseignée que lorsqu’elle ne l’est pas.
+            </p>
+
+            <div class="fr-table fr-mb-2w">
+              <div class="fr-table__wrapper">
+                <div class="fr-table__container">
+                  <div class="fr-table__content">
+                    <table>
+                      <caption class="fr-sr-only">Légende des balises</caption>
+
+                      <thead>
+                        <tr>
+                          <th scope="col">Format de balise</th>
+                          <th scope="col">Signification</th>
+                        </tr>
+                      </thead>
+
+                      <tbody>
+                        <tr>
+                          <td>
+                            <span class="fr-tag fr-tag--sm">
+                              Libellé du champ *
+                            </span>
+                          </td>
+
+                          <td>Champ obligatoire</td>
+                        </tr>
+
+                        <tr>
+                          <td>
+                            <span class="fr-tag fr-tag--sm">
+                              Libellé du champ
+                            </span>
+                          </td>
+
+                          <td>
+                            Champ facultatif
+                            <br>
+                            <span class="fr-text--sm fr-text-default--warning">
+                              <span
+                                class="fr-icon-warning-fill fr-icon--sm"
+                                aria-hidden="true"
+                              ></span>
+                              Sera vide si non rempli
+                            </span>
+                          </td>
+                        </tr>
+
+                        <tr>
+                          <td>
+                            <span class="fr-tag fr-tag--sm fr-tag--purple-glycine">
+                              Libellé du champ * [conditionné]
+                            </span>
+                          </td>
+
+                          <td>
+                            Champ obligatoire conditionné
+                            <br>
+                            <span class="fr-text--sm fr-text-default--warning">
+                              <span
+                                class="fr-icon-warning-fill fr-icon--sm"
+                                aria-hidden="true"
+                              ></span>
+                              Sera vide si non rempli
+                            </span>
+                          </td>
+                        </tr>
+
+                        <tr>
+                          <td>
+                            <span class="fr-tag fr-tag--sm fr-tag--purple-glycine">
+                              Libellé du champ [conditionné]
+                            </span>
+                          </td>
+
+                          <td>
+                            Champ facultatif conditionné
+                            <br>
+                            <span class="fr-text--sm fr-text-default--warning">
+                              <span
+                                class="fr-icon-warning-fill fr-icon--sm"
+                                aria-hidden="true"
+                              ></span>
+                              Sera vide si non rempli
+                            </span>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</dialog>

--- a/app/javascript/controllers/tags_button_list_controller.ts
+++ b/app/javascript/controllers/tags_button_list_controller.ts
@@ -3,17 +3,13 @@ import { ApplicationController } from './application_controller';
 // Reveals/hides the optional & conditional tag buttons of one category when its
 // "voir les champs facultatifs" checkbox is toggled.
 export class TagsButtonListController extends ApplicationController {
-  static targets = ['hint', 'optionalItem'];
+  static targets = ['optionalItem'];
 
-  declare readonly hintTargets: HTMLElement[];
   declare readonly optionalItemTargets: HTMLElement[];
 
   toggleOptional(event: Event) {
     const visible = (event.target as HTMLInputElement).checked;
 
-    for (const hint of this.hintTargets) {
-      hint.classList.toggle('hidden', !visible);
-    }
     for (const item of this.optionalItemTargets) {
       item.classList.toggle('hidden', !visible);
     }

--- a/app/javascript/shared/tiptap/editor.ts
+++ b/app/javascript/shared/tiptap/editor.ts
@@ -35,7 +35,7 @@ import {
   HeaderColumn,
   PageBreak
 } from './nodes';
-import { createSuggestionMenu, type TagSchema } from './tags';
+import { createSuggestionMenu, tagDisplay, type TagSchema } from './tags';
 
 const SingleLineDocument = Document.extend({
   content: 'block'
@@ -165,33 +165,21 @@ function getEditorOptions(
 
   if (tags.length > 0) {
     const tagInfo = new Map(
-      tags.map((t) => [t.id, { mandatory: t.mandatory, category: t.category }])
+      tags.map((t) => [
+        t.id,
+        { mandatory: t.mandatory, conditional: t.conditional }
+      ])
     );
 
     const StyledMention = Mention.extend({
       renderHTML({ node, HTMLAttributes }) {
-        const classes = ['fr-tag', 'fr-tag--sm'];
-        const id = node.attrs.id;
-        const info = tagInfo.get(id);
-        if (info?.mandatory) {
-          return [
-            'span',
-            { ...HTMLAttributes, class: classes.join(' ') },
-            `${node.attrs.label} *`
-          ];
-        }
-        if (
-          (info?.category === 'champ_public' ||
-            info?.category === 'champ_private') &&
-          !info?.mandatory
-        ) {
-          classes.push('fr-tag--purple-glycine');
-        }
-        return [
-          'span',
-          { ...HTMLAttributes, class: classes.join(' ') },
-          node.attrs.label
-        ];
+        const info = tagInfo.get(node.attrs.id);
+        const { text, classes } = tagDisplay({
+          label: node.attrs.label,
+          mandatory: info?.mandatory,
+          conditional: info?.conditional
+        });
+        return ['span', { ...HTMLAttributes, class: classes.join(' ') }, text];
       }
     });
 

--- a/app/javascript/shared/tiptap/tags.test.ts
+++ b/app/javascript/shared/tiptap/tags.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { tagDisplay } from './tags';
+
+describe('tagDisplay', () => {
+  it('renders a mandatory tag with a * suffix and default color', () => {
+    expect(
+      tagDisplay({ label: 'Nom', mandatory: true, conditional: false })
+    ).toEqual({
+      text: 'Nom *',
+      classes: ['fr-tag', 'fr-tag--sm']
+    });
+  });
+
+  it('renders an optional tag without suffix and default color', () => {
+    expect(
+      tagDisplay({ label: 'Nom', mandatory: false, conditional: false })
+    ).toEqual({
+      text: 'Nom',
+      classes: ['fr-tag', 'fr-tag--sm']
+    });
+  });
+
+  it('renders a conditional tag with the [conditionné] suffix and glycine color', () => {
+    expect(
+      tagDisplay({ label: 'Nom', mandatory: false, conditional: true })
+    ).toEqual({
+      text: 'Nom [conditionné]',
+      classes: ['fr-tag', 'fr-tag--sm', 'fr-tag--purple-glycine']
+    });
+  });
+
+  it('renders a mandatory conditional tag with both suffixes', () => {
+    expect(
+      tagDisplay({ label: 'Nom', mandatory: true, conditional: true })
+    ).toEqual({
+      text: 'Nom * [conditionné]',
+      classes: ['fr-tag', 'fr-tag--sm', 'fr-tag--purple-glycine']
+    });
+  });
+
+  it('handles tags without flags (dossier, identité…)', () => {
+    expect(tagDisplay({ label: 'numéro du dossier' })).toEqual({
+      text: 'numéro du dossier',
+      classes: ['fr-tag', 'fr-tag--sm']
+    });
+  });
+});

--- a/app/javascript/shared/tiptap/tags.ts
+++ b/app/javascript/shared/tiptap/tags.ts
@@ -8,22 +8,46 @@ export const tagSchema = s.coerce(
     label: s.string(),
     id: s.string(),
     mandatory: s.optional(s.boolean()),
-    category: s.optional(s.string())
+    conditional: s.optional(s.boolean())
   }),
   s.type({
     tagLabel: s.string(),
     tagId: s.string(),
     tagMandatory: s.optional(s.string()),
-    tagCategory: s.optional(s.string())
+    tagConditional: s.optional(s.string())
   }),
-  ({ tagId, tagLabel, tagMandatory, tagCategory }) => ({
+  ({ tagId, tagLabel, tagMandatory, tagConditional }) => ({
     label: tagLabel,
     id: tagId,
     mandatory: tagMandatory === 'true',
-    category: tagCategory
+    conditional: tagConditional === 'true'
   })
 );
 export type TagSchema = s.Infer<typeof tagSchema>;
+
+export function tagDisplay({
+  label,
+  mandatory,
+  conditional
+}: Pick<TagSchema, 'label' | 'mandatory' | 'conditional'>): {
+  text: string;
+  classes: string[];
+} {
+  let text = label;
+  if (mandatory) {
+    text += ' *';
+  }
+  if (conditional) {
+    text += ' [conditionné]';
+  }
+
+  const classes = ['fr-tag', 'fr-tag--sm'];
+  if (conditional) {
+    classes.push('fr-tag--purple-glycine');
+  }
+
+  return { text, classes };
+}
 
 class SuggestionMenu {
   #selectedIndex = 0;
@@ -126,13 +150,14 @@ class SuggestionMenu {
     this.#props.items.forEach((item, i) => {
       const li = document.createElement('li');
       const button = document.createElement('button');
-      button.className = 'fr-tag fr-tag--sm';
+      const { text, classes } = tagDisplay(item);
+      button.className = classes.join(' ');
       button.setAttribute(
         'aria-pressed',
         i == this.#selectedIndex ? 'true' : 'false'
       );
       button.dataset.tagIndex = String(i);
-      button.textContent = item.label;
+      button.textContent = text;
       li.append(button);
       list.append(li);
     });

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -22,7 +22,7 @@ class TypesDeChamp::TypeDeChampBase
         libelle: TagsSubstitutionConcern::TagsParser.normalize(path[:libelle]),
         id: path[:path] == :value ? "tdc#{stable_id}" : "tdc#{stable_id}/#{path[:path]}",
         conditional:,
-        mandatory: mandatory? && !conditional,
+        mandatory: mandatory?,
         lambda: -> (dossier) { dossier.champ_value_for_tag(type_de_champ, path[:path]) }
       )
     end

--- a/spec/components/tags_button_list_component_spec.rb
+++ b/spec/components/tags_button_list_component_spec.rb
@@ -67,6 +67,11 @@ RSpec.describe TagsButtonListComponent, type: :component do
     expect(subject).to have_text("Voir les champs facultatifs et/ou conditionnés")
   end
 
+  it "always displays the empty-value hint" do
+    expect(subject).to have_selector("span.fr-hint-text:not(.hidden)", text: /Un champ non rempli par l’usager\s+restera vide\./)
+    expect(subject).to have_selector("span.fr-hint-text:not(.hidden)", text: /Une annotation non remplie par l’instructeur\s+restera vide\./)
+  end
+
   it "wires the optional toggle to its own controller, with a unique per-instance id" do
     fragment = Nokogiri::HTML.fragment(render_inline(component).to_html)
     checkbox = fragment.at_css("input[type='checkbox']")
@@ -89,17 +94,5 @@ RSpec.describe TagsButtonListComponent, type: :component do
     expect(subject).to have_selector("button.fr-tag.fr-tag--purple-glycine", text: "Un champ obligatoire conditionnel")
     expect(subject).not_to have_selector("button.fr-tag.fr-tag--purple-glycine", text: "Un champ facultatif")
     expect(subject).not_to have_selector("button.fr-tag.fr-tag--purple-glycine", text: "Votre avis")
-  end
-
-  context "no optional or conditional champs" do
-    let(:tags) do
-      {
-        champ_public: [
-          { id: 'tdc12', libelle: 'Votre avis', description: '' },
-        ],
-      }
-    end
-
-    it { expect(subject).not_to have_text("Voir les champs facultatifs et conditionnels") }
   end
 end

--- a/spec/components/tags_button_list_component_spec.rb
+++ b/spec/components/tags_button_list_component_spec.rb
@@ -67,11 +67,6 @@ RSpec.describe TagsButtonListComponent, type: :component do
     expect(subject).to have_text("Voir les champs facultatifs et/ou conditionnés")
   end
 
-  it "always displays the empty-value hint" do
-    expect(subject).to have_selector("span.fr-hint-text:not(.hidden)", text: /Un champ non rempli par l’usager\s+restera vide\./)
-    expect(subject).to have_selector("span.fr-hint-text:not(.hidden)", text: /Une annotation non remplie par l’instructeur\s+restera vide\./)
-  end
-
   it "wires the optional toggle to its own controller, with a unique per-instance id" do
     fragment = Nokogiri::HTML.fragment(render_inline(component).to_html)
     checkbox = fragment.at_css("input[type='checkbox']")

--- a/spec/components/tags_button_list_component_spec.rb
+++ b/spec/components/tags_button_list_component_spec.rb
@@ -12,18 +12,27 @@ RSpec.describe TagsButtonListComponent, type: :component do
           libelle: 'Votre avis',
           description: 'Détaillez votre avis',
           mandatory: true,
+          conditional: false,
         },
         {
           id: 'tdc13',
           libelle: 'Un champ facultatif',
           description: 'Ce champ est facultatif',
           mandatory: false,
+          conditional: false,
         },
         {
           id: 'tdc14',
           libelle: 'Un champ conditionnel',
           description: 'Ce champ est conditionnel',
           mandatory: false,
+          conditional: true,
+        },
+        {
+          id: 'tdc15',
+          libelle: 'Un champ obligatoire conditionnel',
+          description: '',
+          mandatory: true,
           conditional: true,
         },
       ],
@@ -53,6 +62,7 @@ RSpec.describe TagsButtonListComponent, type: :component do
   it "hides optional and conditional tags by default" do
     expect(subject).to have_selector(".hidden button.fr-tag", text: "Un champ facultatif")
     expect(subject).to have_selector(".hidden button.fr-tag", text: "Un champ conditionnel")
+    expect(subject).to have_selector(".hidden button.fr-tag", text: "Un champ obligatoire conditionnel")
     expect(subject).to have_selector(":not(.hidden) button.fr-tag", text: "Votre avis")
     expect(subject).to have_text("Voir les champs facultatifs et/ou conditionnés")
   end
@@ -67,9 +77,17 @@ RSpec.describe TagsButtonListComponent, type: :component do
     expect(other_checkbox[:id]).not_to eq(checkbox[:id])
   end
 
-  it "applies purple-glycine style to optional and conditional tags" do
-    expect(subject).to have_selector("button.fr-tag.fr-tag--purple-glycine", text: "Un champ facultatif")
+  it "suffixes mandatory tags with * and conditional tags with [conditionné]" do
+    expect(subject).to have_selector("button.fr-tag", text: /\A\s*Votre avis\s+\*\s*\z/)
+    expect(subject).to have_selector("button.fr-tag", text: /\A\s*Un champ facultatif\s*\z/)
+    expect(subject).to have_selector("button.fr-tag", text: /\A\s*Un champ conditionnel\s+\[conditionné\]\s*\z/)
+    expect(subject).to have_selector("button.fr-tag", text: /\A\s*Un champ obligatoire conditionnel\s+\*\s+\[conditionné\]\s*\z/)
+  end
+
+  it "applies purple-glycine style to conditional tags only" do
     expect(subject).to have_selector("button.fr-tag.fr-tag--purple-glycine", text: "Un champ conditionnel")
+    expect(subject).to have_selector("button.fr-tag.fr-tag--purple-glycine", text: "Un champ obligatoire conditionnel")
+    expect(subject).not_to have_selector("button.fr-tag.fr-tag--purple-glycine", text: "Un champ facultatif")
     expect(subject).not_to have_selector("button.fr-tag.fr-tag--purple-glycine", text: "Votre avis")
   end
 

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -622,15 +622,15 @@ describe TagsSubstitutionConcern, type: :model do
       let(:types_de_champ_public) do
         [
           { type: :text, libelle: 'public' },
-          { type: :text, libelle: 'conditional', condition: condition },
+          { type: :text, libelle: 'conditional', condition: condition, mandatory: true },
         ]
       end
 
       subject { template_concern.tags }
 
       it do
-        is_expected.to include(include({ libelle: 'public' }))
-        is_expected.to include(include({ libelle: 'conditional' }))
+        is_expected.to include(include({ libelle: 'public', conditional: false }))
+        is_expected.to include(include({ libelle: 'conditional', conditional: true, mandatory: true }))
       end
     end
   end


### PR DESCRIPTION
Implémente les améliorations discutées ici 
https://mattermost.incubateur.net/betagouv/pl/78w37ej4tif55dag6ec4aw4ior

Dans les éditeurs de balises (modèles d'attestation, e-mails, exports…), une balise de champ **facultatif** ou **conditionné** laissé vide produit un texte incomplet. Les différentes situations possibles sont confuses pour les admins.

Cette PR :
- suffixe les balises conditionnées par `[conditionné]` et les colore (glycine), dans les listes de boutons **et** dans le rendu de l'éditeur TipTap ;
- affiche en permanence l'indication « … restera vide » ;
- ajoute un bouton **« Légende des balises »** ouvrant une modale qui explique les 4 formats de balises (obligatoire / facultatif / obligatoire conditionné / facultatif conditionné).

| Liste des balises | Modale de légende |
|---|---|
| ![tags-button-list](https://gist.githubusercontent.com/colinux/5c987664baea68776aa2149ae7f8fa27/raw/tags-button-list.png) | ![tags-legend-modal](https://gist.githubusercontent.com/colinux/5c987664baea68776aa2149ae7f8fa27/raw/tags-legend-modal.png) |
