### PR TITLE
ETQ admin, l'objet trop long d'un modèle d'email ne déborde plus la mise en page

### DIFF
--- a/app/assets/stylesheets/mail_template_edit.scss
+++ b/app/assets/stylesheets/mail_template_edit.scss
@@ -1,4 +1,12 @@
 #mail-template-edit {
+  // A <fieldset> defaults to `min-inline-size: min-content` (UA stylesheet). The
+  // single-line subject editor sets `white-space: nowrap`, so a long subject inflates
+  // that min-content and stretches the fieldset past its column, overflowing the page.
+  // Let the fieldset shrink to its column; the editor then clips the subject as intended.
+  .fr-fieldset {
+    min-width: 0;
+  }
+
   // Blue "backdrop" that hugs the preview (title + email card + hint) and follows
   // the scroll. Generous padding gives the white card room to breathe.
   .mail-preview-panel {


### PR DESCRIPTION
## Problème

Dans l'éditeur de modèles d'email, un objet très long débordait en largeur : le champ « Objet » s'étirait au-delà de sa colonne et passait sous le panneau d'aperçu, provoquant un défilement horizontal de la page.

## Cause

Le champ objet est un éditeur *single-line* (`white-space: nowrap`). Or un `<fieldset>` a par défaut `min-inline-size: min-content` dans la feuille de style du navigateur : il refuse donc de rétrécir sous la largeur de son contenu et déborde sa colonne dès que l'objet est long. Le `overflow: hidden` déjà posé sur l'éditeur ne suffit pas — il n'empêche pas cette largeur minimale de remonter jusqu'au `<fieldset>`.

## Correctif

`min-width: 0` sur le `.fr-fieldset` de la page : le fieldset rétrécit à sa colonne et l'éditeur tronque l'objet comme prévu. Aucun changement pour un objet court.


## Après (sur page théorique)

![après](https://gist.githubusercontent.com/colinux/a6abe900b9f09dec87cd9050580d0567/raw/mail-editor-after.png)


## Avant

![avant](https://gist.githubusercontent.com/colinux/a6abe900b9f09dec87cd9050580d0567/raw/mail-editor-before.png)
