### PR TITLE
Tech : migration des specs vers les seeds Oaken et ajout des démarches close et dépubliée

### DIFF
--- a/db/seeds/procedures.rb
+++ b/db/seeds/procedures.rb
@@ -33,6 +33,33 @@ instructeurs.default.assign_to_procedure(procedure)
 
 procedures.label individual: procedure
 
+# Procedures that went through their whole lifecycle: published, then closed
+# (procedures.close) or unpublished (procedures.depubliee).
+{ close: :close!, depubliee: :unpublish! }.each do |label, event|
+  procedure = Procedure.new(
+    libelle: "Démarche de démonstration (#{label})",
+    description: "Une démarche de démonstration qui n’accepte plus de nouveaux dossiers.",
+    cadre_juridique: "https://www.legifrance.gouv.fr/",
+    lien_site_web: "https://www.exemple.fr",
+    duree_conservation_dossiers_dans_ds: 3,
+    max_duree_conservation_dossiers_dans_ds: Procedure::OLD_MAX_DUREE_CONSERVATION,
+    for_individual: true,
+    administrateurs: [administrateurs.default],
+    zones: [zones.default],
+    service: services.default
+  )
+  procedure.draft_revision = procedure.revisions.build
+  procedure.save!
+
+  type_de_champ = procedure.draft_revision.add_type_de_champ(type_champ: "text", libelle: "Nom du projet", mandatory: true)
+  raise type_de_champ.errors.full_messages.to_sentence if type_de_champ.errors.any?
+
+  procedure.publish_or_reopen!(administrateurs.default, "demarche-demo-#{label}")
+  procedure.public_send(event)
+
+  procedures.label(label => procedure)
+end
+
 brouillon_procedure = Procedure.new(
   libelle: "Démarche de démonstration (brouillon)",
   description: "Une démarche de démonstration encore en brouillon.",

--- a/spec/components/dossiers/no_access_to_dossier_component_spec.rb
+++ b/spec/components/dossiers/no_access_to_dossier_component_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Dossiers::NoAccessToDossierComponent, type: :component do
 
   context "when no administrateur shares the instructeur email domain" do
     let(:instructeur_email) { "agent@other-domain.gouv.fr" }
-    let(:procedure) { create(:procedure, :with_service) }
+    let(:procedure) { procedures.brouillon }
     let(:dossier) { create(:dossier, procedure:) }
 
     it "exposes no administrateur email" do

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -725,7 +725,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       end
 
       context 'when procedure is closed' do
-        let(:procedure) { create(:procedure, :closed, administrateurs: [admin]) }
+        let(:procedure) { procedures.close }
         let(:csv_file) { fixture_file_upload('spec/fixtures/files/groupe-instructeur.csv', 'text/csv') }
 
         before { subject }
@@ -737,7 +737,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       end
 
       context 'when emails are invalid' do
-        let(:procedure) { create(:procedure, :closed, administrateurs: [admin]) }
+        let(:procedure) { procedures.close }
         let(:csv_file) { fixture_file_upload('spec/fixtures/files/groupe-instructeur-emails-invalides.csv', 'text/csv') }
 
         before do

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -106,9 +106,9 @@ describe Administrateurs::ProceduresController, type: :controller do
   end
 
   describe 'GET #all' do
-    let!(:draft_procedure)     { create(:procedure) }
-    let!(:published_procedure) { create(:procedure_with_dossiers, :published, dossiers_count: 2) }
-    let!(:closed_procedure)    { create(:procedure, :closed) }
+    let!(:draft_procedure)     { procedures.brouillon }
+    let!(:published_procedure) { procedures.individual }
+    let!(:closed_procedure)    { procedures.close }
 
     subject { get :all }
 
@@ -174,8 +174,8 @@ describe Administrateurs::ProceduresController, type: :controller do
     end
 
     context 'for specific status' do
-      let!(:procedure1) { create(:procedure, :published) }
-      let!(:procedure2) { create(:procedure, :closed) }
+      let!(:procedure1) { procedures.individual }
+      let!(:procedure2) { procedures.close }
 
       it 'display only published procedures' do
         get :all, params: { statuses: ['publiee'] }
@@ -1141,9 +1141,11 @@ describe Administrateurs::ProceduresController, type: :controller do
   end
 
   describe 'DELETE #destroy' do
-    let(:procedure_draft)     { create(:procedure, administrateurs: [admin]) }
+    let(:procedure_draft)     { procedures.brouillon }
+    # must own only the dossiers created by the test: destroy is refused as
+    # long as any dossier is en_instruction
     let(:procedure_published) { create(:procedure, :published, administrateurs: [admin]) }
-    let(:procedure_closed)    { create(:procedure, :closed, administrateurs: [admin]) }
+    let(:procedure_closed)    { procedures.close }
     let(:procedure) { dossier.procedure }
 
     subject { delete :destroy, params: { id: procedure } }
@@ -1411,7 +1413,7 @@ describe Administrateurs::ProceduresController, type: :controller do
     subject(:perform_request) { get :publication, params: { procedure_id: procedure.id } }
 
     context 'when procedure is closed' do
-      let(:procedure) { create(:procedure, :closed, administrateur: admin) }
+      let(:procedure) { procedures.close }
 
       it 'assigns procedure' do
         perform_request

--- a/spec/controllers/api/public/v1/stats_controller_spec.rb
+++ b/spec/controllers/api/public/v1/stats_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe API::Public::V1::StatsController, type: :controller do
 
       context 'when the procedure is not publiee and not brouillon' do
         it_behaves_like 'the procedure is found' do
-          let(:procedure) { create(:procedure, :closed) }
+          let(:procedure) { procedures.close }
         end
       end
     end

--- a/spec/controllers/instructeurs/batch_operations_controller_spec.rb
+++ b/spec/controllers/instructeurs/batch_operations_controller_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 describe Instructeurs::BatchOperationsController, type: :controller do
-  let(:instructeur) { create(:instructeur) }
-  let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+  let(:instructeur) { instructeurs.default }
+  let(:procedure) { procedures.individual }
   let(:dossier) { create(:dossier, :accepte, :with_individual, procedure: procedure) }
 
   describe '#POST create' do
@@ -43,7 +43,7 @@ describe Instructeurs::BatchOperationsController, type: :controller do
         batch_operation = BatchOperation.first
         expect(batch_operation.dossiers).to include(dossier)
         expect(batch_operation.instructeur).to eq(instructeur)
-        expect(batch_operation.groupe_instructeurs.to_a).to eq(instructeur.groupe_instructeurs.to_a)
+        expect(batch_operation.groupe_instructeurs.to_a).to eq(instructeur.groupe_instructeurs.where(procedure:).to_a)
       end
       it 'enqueues a BatchOperationJob' do
         expect { subject }.to have_enqueued_job(BatchOperationEnqueueAllJob).with(BatchOperation.last)
@@ -89,7 +89,7 @@ describe Instructeurs::BatchOperationsController, type: :controller do
         batch_operation = BatchOperation.first
         expect(batch_operation.dossiers).to include(dossier)
         expect(batch_operation.instructeur).to eq(instructeur)
-        expect(batch_operation.groupe_instructeurs.to_a).to eq(instructeur.groupe_instructeurs.to_a)
+        expect(batch_operation.groupe_instructeurs.to_a).to eq(instructeur.groupe_instructeurs.where(procedure:).to_a)
       end
 
       it 'enqueues a BatchOperationJob' do

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -73,9 +73,9 @@ describe Instructeurs::ProceduresController, type: :controller do
       it { expect(response).to have_http_status(:ok) }
 
       context "with procedures assigned" do
-        let(:procedure_draft) { create(:procedure) }
-        let(:procedure_published) { create(:procedure, :published) }
-        let(:procedure_closed) { create(:procedure, :closed) }
+        let(:procedure_draft) { procedures.brouillon }
+        let(:procedure_published) { procedures.individual }
+        let(:procedure_closed) { procedures.close }
         let(:procedure_draft_discarded) { create(:procedure, :discarded) }
         let(:procedure_closed_discarded) { create(:procedure, :discarded) }
         let(:procedure_not_assigned) { create(:procedure) }

--- a/spec/controllers/prefill_descriptions_controller_spec.rb
+++ b/spec/controllers/prefill_descriptions_controller_spec.rb
@@ -36,7 +36,7 @@ describe PrefillDescriptionsController, type: :controller do
       end
 
       context 'when the procedure is not publiee and not brouillon' do
-        let(:procedure) { create(:procedure, :closed) }
+        let(:procedure) { procedures.close }
 
         it { expect { edit_request }.to raise_error(ActiveRecord::RecordNotFound) }
       end

--- a/spec/controllers/prefill_type_de_champs_controller_spec.rb
+++ b/spec/controllers/prefill_type_de_champs_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe PrefillTypeDeChampsController, type: :controller do
       end
 
       context 'when the procedure is not publiee and not brouillon' do
-        let(:procedure) { create(:procedure, :closed) }
+        let(:procedure) { procedures.close }
 
         it { expect { show_request }.to raise_error(ActiveRecord::RecordNotFound) }
       end

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -469,7 +469,7 @@ describe Users::CommencerController, type: :controller do
   end
 
   describe '#dossier_vide_pdf' do
-    let(:procedure) { create(:procedure, :published, :with_service, :with_path) }
+    let(:procedure) { procedures.individual }
     before { get :dossier_vide_pdf, params: { path: procedure.path } }
 
     context 'published procedure' do

--- a/spec/graphql/demarche_spec.rb
+++ b/spec/graphql/demarche_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Types::DemarcheType, type: :graphql do
   end
 
   describe 'republier une demarche depubliee' do
-    let(:procedure) { create(:procedure, :unpublished, administrateurs: [admin]) }
+    let(:procedure) { procedures.depubliee }
     let(:query) { PUBLIER_DEMARCHE_QUERY }
     let(:variables) { { demarcheNumber: procedure.id, path: procedure.path, lienSiteWeb: 'https://test.gouv.fr' } }
 

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe DossierHelper, type: :helper do
     let(:dossier) { create(:dossier, procedure: procedure, individual: individual, etablissement: etablissement) }
 
     context "when the dossier is for an individual" do
-      let(:procedure) { create(:simple_procedure, :for_individual) }
+      let(:procedure) { procedures.individual }
 
       context "when the individual is not provided" do
         let(:individual) { build(:individual, :empty) }

--- a/spec/jobs/batch_operation_process_one_job_spec.rb
+++ b/spec/jobs/batch_operation_process_one_job_spec.rb
@@ -323,8 +323,8 @@ describe BatchOperationProcessOneJob, type: :job do
     end
 
     context 'when the dossier is out of sync (ie: someone applied a transition somewhere we do not know)' do
-      let(:instructeur) { create(:instructeur) }
-      let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+      let(:instructeur) { instructeurs.default }
+      let(:procedure) { procedures.individual }
       let(:dossier) { create(:dossier, :accepte, :with_individual, archived: true, procedure: procedure) }
       let(:batch_operation) { create(:batch_operation, operation: :archiver, instructeur: instructeur, dossiers: [dossier]) }
 

--- a/spec/lib/tasks/clean_services_spec.rb
+++ b/spec/lib/tasks/clean_services_spec.rb
@@ -10,7 +10,7 @@ describe 'service tasks' do
   describe 'service:remove_orphans' do
     let(:task) { 'service:remove_orphans' }
     let(:service) { create(:service) }
-    let(:procedure) { create(:procedure, :with_service) }
+    let(:procedure) { procedures.brouillon }
     let(:service_with_procedure) { procedure.service }
     it 'remove orphans' do
       service

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe ApplicationMailer, type: :mailer do
   describe 'dealing with invalid emails' do
-    let(:dossier) { create(:dossier, procedure: create(:simple_procedure)) }
+    let(:dossier) { create(:dossier, procedure: procedures.individual) }
     subject { DossierMailer.with(dossier:).notify_new_draft }
 
     describe 'invalid emails are not sent' do

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe DossierMailer, type: :mailer do
   end
 
   describe '.notify_new_answer with dossier en construction' do
-    let(:dossier) { create(:dossier, :en_construction, procedure: create(:simple_procedure)) }
+    let(:dossier) { create(:dossier, :en_construction, procedure: procedures.individual) }
     let(:commentaire) { create(:commentaire, dossier: dossier) }
 
     subject { described_class.with(commentaire: commentaire).notify_new_answer }
@@ -82,7 +82,7 @@ RSpec.describe DossierMailer, type: :mailer do
   end
 
   describe '.notify_new_answer with commentaire discarded' do
-    let(:dossier) { create(:dossier, procedure: create(:simple_procedure)) }
+    let(:dossier) { create(:dossier, procedure: procedures.individual) }
     let(:commentaire) { create(:commentaire, dossier: dossier, discarded_at: 2.minutes.ago) }
 
     subject { described_class.with(commentaire: commentaire).notify_new_answer }

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -3,10 +3,10 @@
 RSpec.describe NotificationMailer, type: :mailer do
   let(:administrateur) { administrateurs.default }
   let(:user) { create(:user) }
-  let(:procedure) { create(:simple_procedure, :with_service) }
+  let(:procedure) { procedures.individual }
 
   describe 'send_notification_for_tiers' do
-    let(:dossier_for_tiers) { create(:dossier, :en_construction, :for_tiers_with_notification, procedure: create(:simple_procedure)) }
+    let(:dossier_for_tiers) { create(:dossier, :en_construction, :for_tiers_with_notification, procedure: procedures.individual) }
 
     subject { described_class.send_notification_for_tiers(dossier_for_tiers) }
 
@@ -19,7 +19,7 @@ RSpec.describe NotificationMailer, type: :mailer do
   end
 
   describe 'send_notification_for_tiers for repasser_en_instruction' do
-    let(:dossier_for_tiers) { create(:dossier, :accepte, :for_tiers_with_notification, procedure: create(:simple_procedure)) }
+    let(:dossier_for_tiers) { create(:dossier, :accepte, :for_tiers_with_notification, procedure: procedures.individual) }
 
     subject { described_class.send_notification_for_tiers(dossier_for_tiers, repasser_en_instruction: true) }
 
@@ -74,7 +74,7 @@ RSpec.describe NotificationMailer, type: :mailer do
         expect(body).to include(procedure.service.contact_link)
         expect(body).to include(messagerie_dossier_url(dossier))
         expect(body).to include(procedure.service.telephone)
-        expect(body).to include(procedure.service.horaires)
+        expect(body).to include(procedure.service.horaires.sub(/\S/, &:downcase))
         expect(body).to include(procedure.service.other_contact_info)
         expect(mail.attachments.first.filename).to eq("attestation-depot_dossier-#{dossier.id}.pdf")
       end

--- a/spec/models/batch_operation_spec.rb
+++ b/spec/models/batch_operation_spec.rb
@@ -52,8 +52,8 @@ describe BatchOperation, type: :model do
   end
 
   describe '#finalize_if_complete!' do
-    let(:instructeur) { create(:instructeur) }
-    let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+    let(:instructeur) { instructeurs.default }
+    let(:procedure) { procedures.individual }
     let(:dossier) { create(:dossier, :accepte, :with_individual, archived: true, procedure: procedure) }
     let(:batch_operation) { create(:batch_operation, operation: :archiver, instructeur: instructeur, dossiers: [dossier]) }
 
@@ -86,8 +86,8 @@ describe BatchOperation, type: :model do
   end
 
   describe '#track_processed_dossier' do
-    let(:instructeur) { create(:instructeur) }
-    let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+    let(:instructeur) { instructeurs.default }
+    let(:procedure) { procedures.individual }
     let(:dossier) { create(:dossier, :accepte, :with_individual, archived: true, procedure: procedure) }
     let(:batch_operation) { create(:batch_operation, operation: :archiver, instructeur: instructeur, dossiers: [dossier]) }
 
@@ -131,8 +131,8 @@ describe BatchOperation, type: :model do
   end
 
   describe '#dossiers_safe_scope (with archiver)' do
-    let(:instructeur) { create(:instructeur) }
-    let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+    let(:instructeur) { instructeurs.default }
+    let(:procedure) { procedures.individual }
     let(:batch_operation) { create(:batch_operation, operation: :archiver, instructeur: instructeur, dossiers: [dossier]) }
 
     context 'when dossier is valid' do
@@ -168,8 +168,8 @@ describe BatchOperation, type: :model do
   end
 
   describe '#dossiers_safe_scope (with passer_en_instruction)' do
-    let(:instructeur) { create(:instructeur) }
-    let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+    let(:instructeur) { instructeurs.default }
+    let(:procedure) { procedures.individual }
     let(:batch_operation) { create(:batch_operation, operation: :passer_en_instruction, instructeur: instructeur, dossiers: [dossier]) }
 
     context 'when dossier is valid' do
@@ -198,8 +198,8 @@ describe BatchOperation, type: :model do
   end
 
   describe '#dossiers_safe_scope (with accepter)' do
-    let(:instructeur) { create(:instructeur) }
-    let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+    let(:instructeur) { instructeurs.default }
+    let(:procedure) { procedures.individual }
     let(:batch_operation) { create(:batch_operation, operation: :accepter, instructeur: instructeur, dossiers: [dossier]) }
 
     context 'when dossier is valid' do
@@ -228,8 +228,8 @@ describe BatchOperation, type: :model do
   end
 
   describe '#safe_create!' do
-    let(:instructeur) { create(:instructeur) }
-    let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+    let(:instructeur) { instructeurs.default }
+    let(:procedure) { procedures.individual }
     let(:dossier_2) { create(:dossier, :accepte, procedure: procedure) }
     subject { BatchOperation.safe_create!(instructeur: instructeur, operation: :archiver, dossier_ids: [dossier.id, dossier_2.id]) }
 

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -161,8 +161,8 @@ describe Dossier, type: :model do
       empty_seeds Dossier
 
       let(:published_procedure) { procedures.individual }
-      let_it_be(:closed_procedure) { create(:procedure, :closed) }
-      let(:draft_procedure) { procedures.brouillon }
+      let(:closed_procedure) { procedures.close }
+      let(:draft_procedure)  { procedures.brouillon }
 
       # targets: expired + structurally never notified
       let!(:expired_on_closed) { create(:dossier, procedure: closed_procedure).tap { |d| d.update_column(:expired_at, 1.day.ago) } }
@@ -2568,8 +2568,8 @@ describe Dossier, type: :model do
   describe "with_notifiable_procedure" do
     empty_seeds Dossier
 
-    let_it_be(:closed_procedure) { create(:procedure, :closed) }
-    let_it_be(:unpublished_procedure) { create(:procedure, :unpublished) }
+    let_it_be(:closed_procedure) { procedures.close }
+    let_it_be(:unpublished_procedure) { procedures.depubliee }
 
     let_it_be(:dossier_on_test_procedure) { create(:dossier, procedure: procedures.brouillon) }
     let_it_be(:dossier_on_published_procedure) { create(:dossier, procedure: procedures.individual) }

--- a/spec/models/dubious_procedure_spec.rb
+++ b/spec/models/dubious_procedure_spec.rb
@@ -30,7 +30,7 @@ describe DubiousProcedure, type: :model do
       end
 
       context 'and a closed procedure' do
-        let(:procedure) { create(:procedure, :closed) }
+        let(:procedure) { procedures.close }
 
         it { expect(subject).to eq([]) }
       end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -3,7 +3,7 @@
 describe Procedure do
   [:lien_notice, :lien_dpo, :web_hook_url].each do |field|
     describe "#{field} validation" do
-        let(:procedure) { build(:procedure) }
+        let(:procedure) { procedures.brouillon }
 
         it 'accepts a valid https URL' do
           procedure.send("#{field}=".to_sym, 'https://example.com/')
@@ -59,7 +59,7 @@ describe Procedure do
   end
 
   describe 'mail templates' do
-    subject { create(:procedure) }
+    subject { procedures.brouillon }
 
     it "returns expected classes" do
       expect(subject.passer_en_construction_email_template).to be_a(Mails::InitiatedMail)
@@ -86,7 +86,7 @@ describe Procedure do
   end
 
   describe 'initiated_mail' do
-    let(:procedure) { create(:procedure) }
+    let(:procedure) { procedures.brouillon }
 
     subject { procedure }
 
@@ -111,13 +111,13 @@ describe Procedure do
       end
       it do
         expect(subject.passer_en_construction_email_template.body).to eq('toto')
-        expect(Mails::InitiatedMail.count).to eq(1)
+        expect(Mails::InitiatedMail.where(procedure:).count).to eq(1)
       end
     end
   end
 
   describe 'closed mail template body' do
-    let(:procedure) { create(:procedure, attestation_acceptation_template: attestation_template) }
+    let(:procedure) { procedures.brouillon.tap { it.update!(attestation_acceptation_template: attestation_template) } }
     let(:attestation_template) { nil }
 
     subject { procedure.accepter_email_template.body }
@@ -144,7 +144,7 @@ describe Procedure do
   end
 
   describe 'refused mail template body' do
-    let(:procedure) { create(:procedure, attestation_refus_template: attestation_template) }
+    let(:procedure) { procedures.brouillon.tap { it.update!(attestation_refus_template: attestation_template) } }
     let(:attestation_template) { nil }
 
     subject { procedure.refuser_email_template.body }
@@ -171,12 +171,12 @@ describe Procedure do
   end
 
   describe '#mail_template_attestation_inconsistency_state with closed_mail' do
-    let(:procedure_without_attestation) { create(:procedure, closed_mail: closed_mail, attestation_acceptation_template: nil) }
+    let(:procedure_without_attestation) { procedures.brouillon.tap { it.update!(closed_mail: closed_mail, attestation_acceptation_template: nil) } }
     let(:procedure_with_active_attestation) do
-      create(:procedure, closed_mail: closed_mail, attestation_acceptation_template: build(:attestation_template, activated: true))
+      procedures.brouillon.tap { it.update!(closed_mail: closed_mail, attestation_acceptation_template: build(:attestation_template, activated: true)) }
     end
     let(:procedure_with_inactive_attestation) do
-      create(:procedure, closed_mail: closed_mail, attestation_acceptation_template: build(:attestation_template, activated: false))
+      procedures.brouillon.tap { it.update!(closed_mail: closed_mail, attestation_acceptation_template: build(:attestation_template, activated: false)) }
     end
 
     subject { procedure.mail_template_attestation_inconsistency_state(:acceptation) }
@@ -232,12 +232,12 @@ describe Procedure do
   end
 
   describe '#mail_template_attestation_inconsistency_state with refused_mail' do
-    let(:procedure_without_attestation) { create(:procedure, refused_mail: refused_mail, attestation_refus_template: nil) }
+    let(:procedure_without_attestation) { procedures.brouillon.tap { it.update!(refused_mail: refused_mail, attestation_refus_template: nil) } }
     let(:procedure_with_active_attestation) do
-      create(:procedure, refused_mail: refused_mail, attestation_refus_template: build(:attestation_template, activated: true, kind: 'refus'))
+      procedures.brouillon.tap { it.update!(refused_mail: refused_mail, attestation_refus_template: build(:attestation_template, activated: true, kind: 'refus')) }
     end
     let(:procedure_with_inactive_attestation) do
-      create(:procedure, refused_mail: refused_mail, attestation_refus_template: build(:attestation_template, activated: false, kind: 'refus'))
+      procedures.brouillon.tap { it.update!(refused_mail: refused_mail, attestation_refus_template: build(:attestation_template, activated: false, kind: 'refus')) }
     end
 
     subject { procedure.mail_template_attestation_inconsistency_state(:refus) }
@@ -293,7 +293,7 @@ describe Procedure do
   end
 
   describe 'scopes' do
-    let!(:procedure) { create(:procedure) }
+    let!(:procedure) { procedures.individual }
     let!(:discarded_procedure) { create(:procedure, :discarded) }
 
     describe 'default_scope' do
@@ -316,7 +316,7 @@ describe Procedure do
 
     context 'closing procedure' do
       context 'without replacing procedure in DS' do
-        let(:procedure) { create(:procedure) }
+        let(:procedure) { procedures.brouillon }
 
         context 'valid' do
           before do
@@ -345,7 +345,7 @@ describe Procedure do
     end
 
     context 'before_remove callback for minimal administrator presence' do
-      let(:procedure) { create(:procedure) }
+      let(:procedure) { procedures.brouillon }
 
       it 'raises an error when trying to remove the last administrateur' do
         expect(procedure.administrateurs.count).to eq(1)
@@ -365,7 +365,7 @@ describe Procedure do
       end
 
       context 'with deliberation' do
-        let(:procedure) { build(:procedure, cadre_juridique: nil, revisions: [build(:procedure_revision)]) }
+        let(:procedure) { procedures.brouillon.tap { it.cadre_juridique = nil } }
 
         it { expect(procedure.valid?(:publication)).to eq(false) }
 
@@ -387,7 +387,7 @@ describe Procedure do
       end
 
       context 'when juridique_required is false' do
-        let(:procedure) { build(:procedure, juridique_required: false, cadre_juridique: nil) }
+        let(:procedure) { procedures.brouillon.tap { it.assign_attributes(juridique_required: false, cadre_juridique: nil) } }
 
         it { expect(procedure.valid?(:publication)).to eq(true) }
       end
@@ -406,12 +406,12 @@ describe Procedure do
       subject { procedure.tap { it.validate(:publication) }.errors.full_messages }
 
       context 'random string is not allowed' do
-        let(:procedure) { build(:procedure, monavis_embed: "plop") }
+        let(:procedure) { procedures.brouillon.tap { it.monavis_embed = "plop" } }
         it { is_expected.to eq(["Le code MonAvis doit comporter un lien", "Le code MonAvis doit comporter une image"]) }
       end
 
       context 'random html is not allowed' do
-        let(:procedure) { build(:procedure, monavis_embed: '<img src="http://some.analytics/hello.gif">') }
+        let(:procedure) { procedures.brouillon.tap { it.monavis_embed = '<img src="http://some.analytics/hello.gif">' } }
         it { is_expected.to include("Le code MonAvis contient une image pointont vers un domaine invalide") }
       end
 
@@ -421,7 +421,7 @@ describe Procedure do
           <img src="https://jedonnemonavis.numerique.gouv.fr/monavis-static/bouton-blanc.png" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche" />
         </a>
         MSG
-        let(:procedure) { build(:procedure, monavis_embed: monavis_blanc) }
+        let(:procedure) { procedures.brouillon.tap { it.monavis_embed = monavis_blanc } }
         it { is_expected.to eq([]) }
       end
 
@@ -431,7 +431,7 @@ describe Procedure do
           <img src="https://jedonnemonavis.numerique.gouv.fr/monavis-static/bouton-bleu.png" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche" />
         </a>
         MSG
-        let(:procedure) { build(:procedure, monavis_embed: monavis_bleu) }
+        let(:procedure) { procedures.brouillon.tap { it.monavis_embed = monavis_bleu } }
         it { is_expected.to eq([]) }
       end
 
@@ -441,7 +441,7 @@ describe Procedure do
           <img src="https://monavis.numerique.gouv.fr/monavis-static/bouton-bleu.png" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche" />
         </a>
         MSG
-        let(:procedure) { build(:procedure, monavis_embed: monavis_old) }
+        let(:procedure) { procedures.brouillon.tap { it.monavis_embed = monavis_old } }
         it { is_expected.to eq([]) }
       end
 
@@ -451,7 +451,7 @@ describe Procedure do
           <img src="https://monavis.numerique.gouv.fr/monavis-static/bouton-bleu.png" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche" />
         </a>
         MSG
-        let(:procedure) { build(:procedure, monavis_embed: monavis_issue_phillipe) }
+        let(:procedure) { procedures.brouillon.tap { it.monavis_embed = monavis_issue_phillipe } }
         it { is_expected.to eq([]) }
       end
 
@@ -461,7 +461,7 @@ describe Procedure do
             <img src="https://voxusagers.numerique.gouv.fr/static/bouton-bleu.svg" alt="Je donne mon avis" />
           </a>
         MSG
-        let(:procedure) { build(:procedure, monavis_embed: monavis_issue_bouchra) }
+        let(:procedure) { procedures.brouillon.tap { it.monavis_embed = monavis_issue_bouchra } }
         it { is_expected.to eq([]) }
       end
 
@@ -471,7 +471,7 @@ describe Procedure do
             <img src="https://jedonnemonavis.numerique.gouv.fr/static/bouton-bleu.svg" alt="Je donne mon avis" />
           </a>
         MSG
-        let(:procedure) { build(:procedure, monavis_embed: monavis_jedonnemonavis) }
+        let(:procedure) { procedures.brouillon.tap { it.monavis_embed = monavis_jedonnemonavis } }
         it { is_expected.to eq([]) }
       end
 
@@ -481,7 +481,7 @@ describe Procedure do
             <img src="https://kthxbye.fr/static/bouton-bleu.svg" alt="Je donne mon avis" />
           </a>
         MSG
-        let(:procedure) { build(:procedure, monavis_embed: monavis_jedonnemonavis) }
+        let(:procedure) { procedures.brouillon.tap { it.monavis_embed = monavis_jedonnemonavis } }
         it { is_expected.to include("Le code MonAvis contient un lien pointant vers un domaine invalide") }
       end
 
@@ -491,7 +491,7 @@ describe Procedure do
             <img src="https://monavis.numerique.gouv.fr/monavis-static/bouton-bleu.png" alt="avis" />
           </a>
         MSG
-        let(:procedure) { build(:procedure, monavis_embed: malicious_embed) }
+        let(:procedure) { procedures.brouillon.tap { it.monavis_embed = malicious_embed } }
         it { is_expected.to be_present }
       end
 
@@ -500,7 +500,7 @@ describe Procedure do
          <a href="https://monavis.numerique.gouv.fr/Demarches/123456?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=cd4a872d4"></a>
          <img src="https://monavis.numerique.gouv.fr/monavis-static/bouton-bleu.pngx" alt="x" onerror=import('https://hks.ec/ATOXSS-ze4fzfze54.js') />
         MSG
-        let(:procedure) { build(:procedure, monavis_embed: monavis_ywh_pgm5381_46) }
+        let(:procedure) { procedures.brouillon.tap { it.monavis_embed = monavis_ywh_pgm5381_46 } }
         it { is_expected.to eq(["Le code MonAvis contient un attribut interdit : onerror"]) }
       end
 
@@ -513,7 +513,7 @@ describe Procedure do
           </a>
         MSG
 
-       let(:procedure) { build(:procedure, monavis_embed: monavis_blanc) }
+       let(:procedure) { procedures.brouillon.tap { it.monavis_embed = monavis_blanc } }
        it { is_expected.to eq([]) }
      end
 
@@ -526,7 +526,7 @@ describe Procedure do
         </a>
         MSG
 
-        let(:procedure) { build(:procedure, monavis_embed: monavis_blanc) }
+        let(:procedure) { procedures.brouillon.tap { it.monavis_embed = monavis_blanc } }
         it { is_expected.to eq([]) }
       end
     end
@@ -857,7 +857,7 @@ describe Procedure do
       end
 
       context 'when procedure is published without sva' do
-        let(:procedure) { create(:procedure, :published) }
+        let(:procedure) { procedures.individual }
 
         it 'allow activation' do
           expect(procedure).to be_valid
@@ -893,7 +893,7 @@ describe Procedure do
   end
 
   describe 'opendata' do
-    let(:procedure) { create(:procedure) }
+    let(:procedure) { procedures.brouillon }
 
     it 'is true by default' do
       expect(procedure.opendata).to be_truthy
@@ -934,7 +934,7 @@ describe Procedure do
   end
 
   describe 'active' do
-    let(:procedure) { create(:procedure) }
+    let(:procedure) { procedures.brouillon }
     subject { Procedure.active(procedure.id) }
 
     context 'when procedure is in draft status and not closed' do
@@ -942,7 +942,7 @@ describe Procedure do
     end
 
     context 'when procedure is published and not closed' do
-      let(:procedure) { create(:procedure, :published) }
+      let(:procedure) { procedures.individual }
       it { is_expected.to be_truthy }
     end
 
@@ -953,7 +953,7 @@ describe Procedure do
   end
 
   describe '#publish!' do
-    let(:procedure) { create(:procedure, path: 'example-path', zones: [create(:zone)]) }
+    let(:procedure) { create(:procedure, path: 'example-path', zones: [zones.default]) }
     let(:now) { Time.zone.now.beginning_of_minute }
 
     context 'when publishing a new procedure' do
@@ -983,7 +983,7 @@ describe Procedure do
     end
 
     context 'when publishing over a previous canonical procedure' do
-      let(:canonical_procedure) { create(:procedure, :published) }
+      let(:canonical_procedure) { procedures.individual }
 
       before do
         travel_to(now) do
@@ -1003,10 +1003,10 @@ describe Procedure do
   end
 
   describe "#publish_or_reopen!" do
-    let(:canonical_procedure) { create(:procedure, :published) }
+    let(:canonical_procedure) { procedures.individual }
     let(:administrateur) { canonical_procedure.administrateurs.first }
 
-    let(:procedure) { create(:procedure, administrateurs: [administrateur], zones: [create(:zone)]) }
+    let(:procedure) { create(:procedure, administrateurs: [administrateur], zones: [zones.default]) }
     let(:now) { Time.zone.now.beginning_of_minute }
 
     context 'when publishing over a previous canonical procedure' do
@@ -1071,7 +1071,7 @@ describe Procedure do
     end
 
     context 'when republishing a previously closed procedure' do
-      let(:procedure) { create(:procedure, :published, administrateurs: [administrateur]) }
+      let(:procedure) { procedures.individual }
 
       before do
         procedure.close!
@@ -1174,7 +1174,7 @@ describe Procedure do
   end
 
   describe "#reset_draft_revision!" do
-    let(:procedure) { create(:procedure) }
+    let(:procedure) { procedures.brouillon }
     let(:tdc_attributes) { { type_champ: :number, libelle: 'libelle 1' } }
     let(:publication_date) { Time.zone.local(2021, 1, 1, 12, 00, 00) }
 
@@ -1227,7 +1227,7 @@ describe Procedure do
   end
 
   describe "#unpublish!" do
-    let(:procedure) { create(:procedure, :published) }
+    let(:procedure) { procedures.individual }
     let(:now) { Time.zone.now.beginning_of_minute }
 
     before do
@@ -1251,8 +1251,8 @@ describe Procedure do
   end
 
   describe "#brouillon?" do
-    let(:procedure_brouillon) { build(:procedure) }
-    let(:procedure_publiee) { build(:procedure, :published) }
+    let(:procedure_brouillon) { procedures.brouillon }
+    let(:procedure_publiee) { procedures.individual }
     let(:procedure_close) { build(:procedure, :closed) }
     let(:procedure_depubliee) { build(:procedure, :unpublished) }
 
@@ -1265,8 +1265,8 @@ describe Procedure do
   end
 
   describe "#publiee?" do
-    let(:procedure_brouillon) { build(:procedure) }
-    let(:procedure_publiee) { build(:procedure, :published) }
+    let(:procedure_brouillon) { procedures.brouillon }
+    let(:procedure_publiee) { procedures.individual }
     let(:procedure_close) { build(:procedure, :closed) }
     let(:procedure_depubliee) { build(:procedure, :unpublished) }
 
@@ -1279,8 +1279,8 @@ describe Procedure do
   end
 
   describe "#close?" do
-    let(:procedure_brouillon) { build(:procedure) }
-    let(:procedure_publiee) { build(:procedure, :published) }
+    let(:procedure_brouillon) { procedures.brouillon }
+    let(:procedure_publiee) { procedures.individual }
     let(:procedure_close) { build(:procedure, :closed) }
     let(:procedure_depubliee) { build(:procedure, :unpublished) }
 
@@ -1293,8 +1293,8 @@ describe Procedure do
   end
 
   describe "#depubliee?" do
-    let(:procedure_brouillon) { build(:procedure) }
-    let(:procedure_publiee) { build(:procedure, :published) }
+    let(:procedure_brouillon) { procedures.brouillon }
+    let(:procedure_publiee) { procedures.individual }
     let(:procedure_close) { build(:procedure, :closed) }
     let(:procedure_depubliee) { build(:procedure, :unpublished) }
 
@@ -1307,8 +1307,8 @@ describe Procedure do
   end
 
   describe "#locked?" do
-    let(:procedure_brouillon) { build(:procedure) }
-    let(:procedure_publiee) { build(:procedure, :published) }
+    let(:procedure_brouillon) { procedures.brouillon }
+    let(:procedure_publiee) { procedures.individual }
     let(:procedure_close) { build(:procedure, :closed) }
     let(:procedure_depubliee) { build(:procedure, :unpublished) }
 
@@ -1321,7 +1321,7 @@ describe Procedure do
   end
 
   describe 'close' do
-    let(:procedure) { create(:procedure, :published) }
+    let(:procedure) { procedures.individual }
     let(:now) { Time.zone.now.beginning_of_minute }
     before do
       travel_to(now) do
@@ -1344,21 +1344,16 @@ describe Procedure do
   end
 
   describe 'total_dossier' do
-    let(:procedure) { create :procedure }
-
-    before do
-      create :dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction)
-      create :dossier, procedure: procedure, state: Dossier.states.fetch(:brouillon)
-      create :dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction)
-    end
+    let(:procedure) { procedures.individual }
 
     subject { procedure.total_dossier }
 
-    it { is_expected.to eq 2 }
+    # the seeded procedure has one dossier per state; only the brouillon is excluded
+    it { is_expected.to eq(procedure.dossiers.count - 1) }
   end
 
   describe 'suggested_path' do
-    let!(:procedure) { create(:procedure, aasm_state: :publiee, libelle: 'Inscription au Collège', zones: [create(:zone)]) }
+    let!(:procedure) { create(:procedure, aasm_state: :publiee, libelle: 'Inscription au Collège', zones: [zones.default]) }
     let(:path) { nil }
 
     before do
@@ -1380,7 +1375,7 @@ describe Procedure do
 
     context 'when the suggestion conflicts with one procedure' do
       before do
-        create(:procedure, aasm_state: :publiee, path: 'inscription-au-college', zones: [create(:zone)])
+        create(:procedure, aasm_state: :publiee, path: 'inscription-au-college', zones: [zones.default])
       end
 
       it { is_expected.to eq 'inscription-au-college-2' }
@@ -1388,8 +1383,8 @@ describe Procedure do
 
     context 'when the suggestion conflicts with several procedures' do
       before do
-        create(:procedure, aasm_state: :publiee, path: 'inscription-au-college', zones: [create(:zone)])
-        create(:procedure, aasm_state: :publiee, path: 'inscription-au-college-2', zones: [create(:zone)])
+        create(:procedure, aasm_state: :publiee, path: 'inscription-au-college', zones: [zones.default])
+        create(:procedure, aasm_state: :publiee, path: 'inscription-au-college-2', zones: [zones.default])
       end
 
       it { is_expected.to eq 'inscription-au-college-3' }
@@ -1397,7 +1392,7 @@ describe Procedure do
 
     context 'when the suggestion conflicts with another procedure of the same admin' do
       before do
-        create(:procedure, aasm_state: :publiee, path: 'inscription-au-college', administrateurs: procedure.administrateurs, zones: [create(:zone)])
+        create(:procedure, aasm_state: :publiee, path: 'inscription-au-college', administrateurs: procedure.administrateurs, zones: [zones.default])
       end
 
       it { is_expected.to eq 'inscription-au-college-2' }
@@ -1431,7 +1426,7 @@ describe Procedure do
     subject { procedure.discard_and_keep_track!(super_admin) }
 
     context "when discarding a procedure in brouillon" do
-      let(:procedure) { create(:procedure) }
+      let(:procedure) { procedures.brouillon }
       let!(:dossier) { create(:dossier, procedure:) }
 
       it 'destroys dossiers' do
@@ -1476,12 +1471,12 @@ describe Procedure do
   describe "#organisation_name" do
     subject { procedure.organisation_name }
     context 'when the procedure has a service (and no organization)' do
-      let(:procedure) { create(:procedure, :with_service, organisation: nil) }
+      let(:procedure) { procedures.brouillon }
       it { is_expected.to eq procedure.service.nom }
     end
 
     context 'when the procedure has an organization (and no service)' do
-      let(:procedure) { create(:procedure, organisation: 'DDT des Vosges', service: nil) }
+      let(:procedure) { procedures.brouillon.tap { it.update!(organisation: 'DDT des Vosges', service: nil) } }
       it { is_expected.to eq procedure.organisation }
     end
   end
@@ -1524,32 +1519,28 @@ describe Procedure do
   end
 
   describe '.missing_instructeurs?' do
-    let!(:procedure) { create(:procedure) }
+    let!(:procedure) { procedures.brouillon }
 
     subject { procedure.missing_instructeurs? }
 
     it { is_expected.to be true }
 
     context 'when an instructeur is assign to this procedure' do
-      let!(:instructeur) { create(:instructeur) }
-
-      before { instructeur.assign_to_procedure(procedure) }
+      before { instructeurs.default.assign_to_procedure(procedure) }
 
       it { is_expected.to be false }
     end
   end
 
   describe '.missing_zones?' do
-    let(:procedure) { create(:procedure, zones: []) }
+    let(:procedure) { procedures.brouillon }
 
     subject { procedure.missing_zones? }
 
     it { is_expected.to be true }
 
     context 'when a procedure has zones' do
-      let(:zone) { create(:zone) }
-
-      before { procedure.zones << zone }
+      before { procedure.zones << zones.default }
 
       it { is_expected.to be false }
     end
@@ -1559,13 +1550,13 @@ describe Procedure do
     subject { procedure.missing_steps.include?(step) }
 
     context 'without zone' do
-      let(:procedure) { create(:procedure, zones: []) }
+      let(:procedure) { procedures.brouillon }
       let(:step) { :zones }
       it { is_expected.to be_truthy }
     end
 
     context 'with zone' do
-      let(:procedure) { create(:procedure, zones: [create(:zone)]) }
+      let(:procedure) { procedures.individual }
       let(:step) { :zones }
       it { is_expected.to be_falsey }
     end
@@ -1612,11 +1603,16 @@ describe Procedure do
   end
 
   describe 'lien_dpo' do
+    let(:procedure) { procedures.brouillon }
+
     it do
-      expect(build(:procedure).valid?).to be(true)
-      expect(build(:procedure, lien_dpo: 'dpo@ministere.amere').valid?).to be(true)
-      expect(build(:procedure, lien_dpo: 'https://legal.fr/contact_dpo').valid?).to be(true)
-      expect(build(:procedure, lien_dpo: 'askjdlad l akdj asd ').valid?).to be(false)
+      expect(procedure.valid?).to be(true)
+      procedure.lien_dpo = 'dpo@ministere.amere'
+      expect(procedure.valid?).to be(true)
+      procedure.lien_dpo = 'https://legal.fr/contact_dpo'
+      expect(procedure.valid?).to be(true)
+      procedure.lien_dpo = 'askjdlad l akdj asd '
+      expect(procedure.valid?).to be(false)
     end
   end
 
@@ -1730,7 +1726,7 @@ describe Procedure do
   end
 
   describe 'lien_notice' do
-    let(:procedure) { build(:procedure, lien_notice:) }
+    let(:procedure) { procedures.brouillon.tap { it.lien_notice = lien_notice } }
 
     context 'when empty' do
       let(:lien_notice) { '' }
@@ -1759,7 +1755,7 @@ describe Procedure do
   end
 
   describe 'lien_dpo' do
-    let(:procedure) { build(:procedure, lien_dpo:) }
+    let(:procedure) { procedures.brouillon.tap { it.lien_dpo = lien_dpo } }
 
     context 'when empty' do
       let(:lien_dpo) { '' }
@@ -1828,7 +1824,7 @@ describe Procedure do
   end
 
   describe "#attestation_template" do
-    let(:procedure) { create(:procedure) }
+    let(:procedure) { procedures.brouillon }
     subject { procedure.reload }
 
     context "when there is a v2 draft and a v1" do
@@ -1874,8 +1870,8 @@ describe Procedure do
   end
 
   describe "#parsed_latest_zone_labels" do
-    let!(:draft_procedure) { create(:procedure) }
-    let!(:published_procedure) { create(:procedure_with_dossiers, :published, dossiers_count: 2) }
+    let!(:draft_procedure) { procedures.brouillon }
+    let!(:published_procedure) { procedures.individual }
     let!(:closed_procedure) { create(:procedure, :closed) }
     let!(:procedure_detail_draft) { ProcedureDetail.new(id: draft_procedure.id, latest_zone_labels: '{ "zone1", "zone2" }') }
     let!(:procedure_detail_published) { ProcedureDetail.new(id: published_procedure.id, latest_zone_labels: '{ "zone3", "zone4" }') }
@@ -1948,7 +1944,7 @@ describe Procedure do
   end
 
   describe '#update_labels_position' do
-    let(:procedure) { create(:procedure) }
+    let(:procedure) { procedures.brouillon }
     let!(:labels) { create_list(:label, 5, procedure_id: procedure.id) }
 
     it 'updates the positions of the specified instructeurs_procedures' do
@@ -1966,7 +1962,7 @@ describe Procedure do
 
   describe 'enable_pro_connect_for_moral_procedure callback' do
     context 'when creating a procedure for moral persons' do
-      let(:procedure) { create(:procedure, for_individual: false) }
+      let(:procedure) { procedures.entreprise }
 
       it 'enables pro_connect_for_moral_procedure' do
         expect(procedure.pro_connect_for_moral_procedure).to be true
@@ -1974,7 +1970,7 @@ describe Procedure do
     end
 
     context 'when creating a procedure for individuals' do
-      let(:procedure) { create(:procedure, for_individual: true) }
+      let(:procedure) { procedures.individual }
 
       it 'does not enable pro_connect_for_moral_procedure' do
         expect(procedure.pro_connect_for_moral_procedure).to be false
@@ -1982,7 +1978,7 @@ describe Procedure do
     end
 
     context 'when updating an existing moral procedure with the flag disabled' do
-      let(:procedure) { create(:procedure, for_individual: false) }
+      let(:procedure) { procedures.entreprise }
 
       before do
         procedure.update_column(:pro_connect_for_moral_procedure, false)
@@ -1996,7 +1992,7 @@ describe Procedure do
   end
 
   describe '#enable_pro_connect_restriction!' do
-    let(:procedure) { create(:procedure, opendata: true, robots_indexable: true) }
+    let(:procedure) { procedures.brouillon }
 
     context 'when setting to :none' do
       it 'updates restriction level without changing opendata/robots_indexable' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -947,7 +947,7 @@ describe Procedure do
     end
 
     context 'when procedure is published and closed' do
-      let(:procedure) { create(:procedure, :closed) }
+      let(:procedure) { procedures.close }
       it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
     end
   end
@@ -1253,8 +1253,8 @@ describe Procedure do
   describe "#brouillon?" do
     let(:procedure_brouillon) { procedures.brouillon }
     let(:procedure_publiee) { procedures.individual }
-    let(:procedure_close) { build(:procedure, :closed) }
-    let(:procedure_depubliee) { build(:procedure, :unpublished) }
+    let(:procedure_close) { procedures.close }
+    let(:procedure_depubliee) { procedures.depubliee }
 
     it do
       expect(procedure_brouillon.brouillon?).to be_truthy
@@ -1267,8 +1267,8 @@ describe Procedure do
   describe "#publiee?" do
     let(:procedure_brouillon) { procedures.brouillon }
     let(:procedure_publiee) { procedures.individual }
-    let(:procedure_close) { build(:procedure, :closed) }
-    let(:procedure_depubliee) { build(:procedure, :unpublished) }
+    let(:procedure_close) { procedures.close }
+    let(:procedure_depubliee) { procedures.depubliee }
 
     it do
       expect(procedure_brouillon.publiee?).to be_falsey
@@ -1281,8 +1281,8 @@ describe Procedure do
   describe "#close?" do
     let(:procedure_brouillon) { procedures.brouillon }
     let(:procedure_publiee) { procedures.individual }
-    let(:procedure_close) { build(:procedure, :closed) }
-    let(:procedure_depubliee) { build(:procedure, :unpublished) }
+    let(:procedure_close) { procedures.close }
+    let(:procedure_depubliee) { procedures.depubliee }
 
     it do
       expect(procedure_brouillon.close?).to be_falsey
@@ -1295,8 +1295,8 @@ describe Procedure do
   describe "#depubliee?" do
     let(:procedure_brouillon) { procedures.brouillon }
     let(:procedure_publiee) { procedures.individual }
-    let(:procedure_close) { build(:procedure, :closed) }
-    let(:procedure_depubliee) { build(:procedure, :unpublished) }
+    let(:procedure_close) { procedures.close }
+    let(:procedure_depubliee) { procedures.depubliee }
 
     it do
       expect(procedure_brouillon.depubliee?).to be_falsey
@@ -1309,8 +1309,8 @@ describe Procedure do
   describe "#locked?" do
     let(:procedure_brouillon) { procedures.brouillon }
     let(:procedure_publiee) { procedures.individual }
-    let(:procedure_close) { build(:procedure, :closed) }
-    let(:procedure_depubliee) { build(:procedure, :unpublished) }
+    let(:procedure_close) { procedures.close }
+    let(:procedure_depubliee) { procedures.depubliee }
 
     it do
       expect(procedure_brouillon.locked?).to be_falsey
@@ -1575,9 +1575,10 @@ describe Procedure do
   end
 
   describe "#destroy" do
-    let(:procedure) { create(:procedure, :closed, :with_type_de_champ, :with_bulk_message) }
+    let(:procedure) { procedures.close }
 
     before do
+      create(:bulk_message, procedure:)
       procedure.discard!
     end
 
@@ -1872,7 +1873,7 @@ describe Procedure do
   describe "#parsed_latest_zone_labels" do
     let!(:draft_procedure) { procedures.brouillon }
     let!(:published_procedure) { procedures.individual }
-    let!(:closed_procedure) { create(:procedure, :closed) }
+    let!(:closed_procedure) { procedures.close }
     let!(:procedure_detail_draft) { ProcedureDetail.new(id: draft_procedure.id, latest_zone_labels: '{ "zone1", "zone2" }') }
     let!(:procedure_detail_published) { ProcedureDetail.new(id: published_procedure.id, latest_zone_labels: '{ "zone3", "zone4" }') }
     let!(:procedure_detail_closed) { ProcedureDetail.new(id: closed_procedure.id, latest_zone_labels: '{ "zone5", "zone6" }') }

--- a/spec/services/create_avis_service_spec.rb
+++ b/spec/services/create_avis_service_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 describe CreateAvisService do
-  let(:instructeur) { create(:instructeur) }
-  let(:procedure) { create(:simple_procedure, instructeurs: [instructeur]) }
+  let(:instructeur) { instructeurs.default }
+  let(:procedure) { procedures.individual }
   let(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure:) }
   let(:expert_email) { 'expert@exemple.fr' }
 

--- a/spec/services/instructeur_procedures_counters_service_spec.rb
+++ b/spec/services/instructeur_procedures_counters_service_spec.rb
@@ -15,7 +15,7 @@ describe InstructeursProceduresCountersService do
 
       context "with not draft state on multiple procedures" do
         let(:procedure2) { create(:procedure, :published) }
-        let(:procedure3) { create(:procedure, :closed) }
+        let(:procedure3) { procedures.close }
         let(:procedure4) { create(:procedure, :closed) }
 
         before do

--- a/spec/system/administrateurs/procedure_creation_spec.rb
+++ b/spec/system/administrateurs/procedure_creation_spec.rb
@@ -30,7 +30,7 @@ describe 'Creating a new procedure', js: true do
   end
 
   context 'with an empty procedure' do
-    let(:procedure) { create(:procedure, :with_service, administrateur: administrateur) }
+    let(:procedure) { procedures.brouillon }
 
     scenario 'an admin can add types de champs' do
       visit champs_admin_procedure_path(procedure)

--- a/spec/system/breadcrumbs_spec.rb
+++ b/spec/system/breadcrumbs_spec.rb
@@ -25,7 +25,7 @@ describe 'Breadcrumbs by role', js: false do
   end
 
   describe 'as ADMINISTRATEUR' do
-    let(:administrateur) { create(:administrateur) }
+    let(:administrateur) { administrateurs.default }
 
     before { login_as administrateur.user, scope: :user }
 
@@ -37,24 +37,21 @@ describe 'Breadcrumbs by role', js: false do
     end
 
     scenario 'shows "Démarches publiées" tab label for a published procedure' do
-      procedure = create(:procedure, :published, administrateur: administrateur)
-      visit champs_admin_procedure_path(procedure)
+      visit champs_admin_procedure_path(procedures.individual)
       within('.fr-breadcrumb__list') do
         expect(page).to have_link('Démarches publiées', href: admin_procedures_path(statut: 'publiees'))
       end
     end
 
     scenario 'shows "Démarches en test" tab label for a draft procedure' do
-      procedure = create(:procedure, administrateur: administrateur)
-      visit champs_admin_procedure_path(procedure)
+      visit champs_admin_procedure_path(procedures.brouillon)
       within('.fr-breadcrumb__list') do
         expect(page).to have_link('Démarches en test', href: admin_procedures_path(statut: 'brouillons'))
       end
     end
 
     scenario 'shows "Démarches terminées" tab label for a closed procedure' do
-      procedure = create(:procedure, :closed, administrateur: administrateur)
-      visit champs_admin_procedure_path(procedure)
+      visit champs_admin_procedure_path(procedures.close)
       within('.fr-breadcrumb__list') do
         expect(page).to have_link('Démarches terminées', href: admin_procedures_path(statut: 'archivees'))
       end

--- a/spec/system/help_spec.rb
+++ b/spec/system/help_spec.rb
@@ -9,7 +9,7 @@ describe 'Getting help:' do
   end
 
   context 'on pages related to a procedure' do
-    let(:procedure) { create(:procedure, :published, :with_service) }
+    let(:procedure) { procedures.individual }
 
     scenario 'a Help menu provides administration contacts and a link to the FAQ' do
       visit commencer_path(path: procedure.path)
@@ -28,7 +28,7 @@ describe 'Getting help:' do
 
   context 'as a signed-in user' do
     let(:user) { create(:user) }
-    let(:procedure) { create(:procedure, :with_service) }
+    let(:procedure) { procedures.brouillon }
 
     before do
       login_as user, scope: :user

--- a/spec/system/sessions/sign_in_spec.rb
+++ b/spec/system/sessions/sign_in_spec.rb
@@ -44,7 +44,7 @@ describe 'Signin in:' do
   end
 
   context 'when visiting a procedure', js: true do
-    let(:procedure) { create :simple_procedure, :with_service }
+    let(:procedure) { procedures.individual }
 
     before do
       visit commencer_path(path: procedure.path)

--- a/spec/system/users/sign_up_spec.rb
+++ b/spec/system/users/sign_up_spec.rb
@@ -3,7 +3,7 @@
 describe 'Signing up:', js: true do
   let(:user_email) { generate :user_email }
   let(:user_password) { SECURE_PASSWORD }
-  let(:procedure) { create :simple_procedure, :with_service }
+  let(:procedure) { procedures.individual }
 
   scenario 'a new user can sign-up from scratch' do
     visit new_user_registration_path
@@ -19,7 +19,7 @@ describe 'Signing up:', js: true do
   end
 
   context 'when the user makes a typo in their email address' do
-    let(:procedure) { create :simple_procedure, :with_service }
+    let(:procedure) { procedures.individual }
 
     before do
       visit commencer_path(path: procedure.path)
@@ -67,7 +67,7 @@ describe 'Signing up:', js: true do
   end
 
   context 'when visiting a procedure' do
-    let(:procedure) { create :simple_procedure, :with_service }
+    let(:procedure) { procedures.individual }
 
     scenario 'a new user can sign-up and fill the procedure' do
       visit commencer_path(path: procedure.path)

--- a/spec/tasks/maintenance/backfill_closing_reason_in_closed_procedures_task_spec.rb
+++ b/spec/tasks/maintenance/backfill_closing_reason_in_closed_procedures_task_spec.rb
@@ -8,8 +8,7 @@ module Maintenance
       subject(:process) { described_class.process(procedure) }
 
       context 'with a closed and replaced procedure' do
-        let(:published_procedure) { create(:procedure, :published) }
-        let(:procedure) { create(:procedure, :closed, replaced_by_procedure_id: published_procedure.id) }
+        let(:procedure) { procedures.close.tap { it.update_column(:replaced_by_procedure_id, procedures.individual.id) } }
 
         it 'fills closing_reason with internal_procedure' do
           subject
@@ -18,7 +17,7 @@ module Maintenance
       end
 
       context 'with a closed and not replaced procedure' do
-        let(:procedure) { create(:procedure, :closed) }
+        let(:procedure) { procedures.close }
 
         it 'fills closing_reason with other' do
           subject

--- a/spec/tasks/maintenance/t20250106_fix_closed_procedures_replaced_by_self_task_spec.rb
+++ b/spec/tasks/maintenance/t20250106_fix_closed_procedures_replaced_by_self_task_spec.rb
@@ -4,10 +4,10 @@ require "rails_helper"
 
 module Maintenance
   RSpec.describe T20250106FixClosedProceduresReplacedBySelfTask do
-    let!(:replacement_procedure) { create(:procedure, :published) }
+    let!(:replacement_procedure) { procedures.individual }
 
     # Procedures that should be fixed
-    let!(:closed_procedure_to_fix) { create(:procedure, :closed) }
+    let!(:closed_procedure_to_fix) { procedures.close }
     let!(:discarded_closed_procedure_to_fix) { create(:procedure, :closed, :discarded) }
 
     # Procedures that should NOT be fixed

--- a/spec/tasks/maintenance/update_closing_reason_if_no_replaced_by_id_task_spec.rb
+++ b/spec/tasks/maintenance/update_closing_reason_if_no_replaced_by_id_task_spec.rb
@@ -7,7 +7,7 @@ module Maintenance
     describe "#process" do
       subject(:process) { described_class.process(procedure) }
 
-      let(:procedure) { create(:procedure, :closed) }
+      let(:procedure) { procedures.close }
 
       before do
         procedure.update_column(:closing_reason, Procedure.closing_reasons.fetch(:internal_procedure))

--- a/spec/views/commencer/show.html.haml_spec.rb
+++ b/spec/views/commencer/show.html.haml_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'commencer/show', type: :view do
   include Rails.application.routes.url_helpers
 
   let(:stored_query_params) { false }
-  let(:procedure) { create(:procedure, :published, :for_individual, :with_service) }
+  let(:procedure) { procedures.individual }
   let(:dossiers) { drafts + not_drafts }
   let(:drafts) { [] }
   let(:not_drafts) { [] }

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -33,7 +33,7 @@ describe 'layouts/_header', type: :view do
     end
 
     context 'when on a procedure page' do
-      let(:procedure) { create(:procedure, :with_service) }
+      let(:procedure) { procedures.brouillon }
 
       before do
         allow(controller).to receive(:procedure_for_help).and_return(procedure)

--- a/spec/views/layouts/application_html_spec.rb
+++ b/spec/views/layouts/application_html_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'layouts/application', type: :view do
-  let(:procedure) { create(:simple_procedure) }
+  let(:procedure) { procedures.individual }
 
   before do
     allow(view).to receive(:administrateur_signed_in?).and_return(false)

--- a/spec/views/layouts/procedure_context.html.haml_spec.rb
+++ b/spec/views/layouts/procedure_context.html.haml_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'layouts/procedure_context', type: :view do
-  let(:procedure) { create(:simple_procedure, :with_service) }
+  let(:procedure) { procedures.individual }
   let(:dossier) { create(:dossier, procedure: procedure) }
 
   before do

--- a/spec/views/users/dossiers/identite.html.erb_spec.rb
+++ b/spec/views/users/dossiers/identite.html.erb_spec.rb
@@ -11,7 +11,7 @@ describe 'users/dossiers/identite', type: :view do
   subject! { render }
 
   context 'when procedure has for_tiers_enabled' do
-    let_it_be(:procedure) { create(:simple_procedure, :for_individual) }
+    let_it_be(:procedure) { procedures.individual }
 
     it 'has choice for you or a tiers' do
       expect(rendered).to have_content "Pour vous"
@@ -32,7 +32,7 @@ describe 'users/dossiers/identite', type: :view do
   end
 
   context 'when procedure has for_tiers_enabled and identity already set' do
-    let(:procedure) { create(:simple_procedure, :for_individual) }
+    let(:procedure) { procedures.individual }
     let(:dossier) { create(:dossier, :with_service, :with_individual, state: Dossier.states.fetch(:brouillon), procedure: procedure, identity_updated_at: Time.current) }
 
     it 'hides the continue button group' do
@@ -53,7 +53,7 @@ describe 'users/dossiers/identite', type: :view do
   end
 
   context 'when procedure has for_tiers_enabled and identity already set for tiers' do
-    let(:procedure) { create(:simple_procedure, :for_individual) }
+    let(:procedure) { procedures.individual }
     let(:dossier) do
       create(:dossier, :with_service, :with_individual,
              for_tiers: true,

--- a/spec/views/users/dossiers/show/_header.html.haml_spec.rb
+++ b/spec/views/users/dossiers/show/_header.html.haml_spec.rb
@@ -76,7 +76,7 @@ describe 'users/dossiers/show/header', type: :view do
   end
 
   context "when the procedure is discarded with a dossier en construction and a replacement procedure" do
-    let(:new_procedure) { create(:procedure, :with_service, aasm_state: :publiee) }
+    let(:new_procedure) { procedures.individual }
     let!(:procedure) { create(:procedure, :with_service, :discarded, replaced_by_procedure_id: new_procedure.id) }
     let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
 
@@ -104,6 +104,7 @@ describe 'users/dossiers/show/header', type: :view do
   end
 
   context "when the procedure is discarded with a dossier en construction and a replacement procedure is destroyed" do
+    # the replacement gets destroyed: it must be a fresh procedure without dossiers
     let(:new_procedure) { create(:procedure, :with_service, aasm_state: :publiee) }
     let!(:procedure) { create(:procedure, :with_service, :discarded, replaced_by_procedure_id: new_procedure.id) }
     let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }


### PR DESCRIPTION
Migration des specs vers les seeds Oaken, en trois commits :

**1. Migration de `procedure_spec`** — les factories génériques basculent sur les seeds existants (`procedures.brouillon`, `procedures.individual`, `procedures.entreprise`). Les specs de validation mutent le record seedé en mémoire, sans écriture en base.

**2. Seed des démarches close et dépubliée** — ajoute `procedures.close` et `procedures.depubliee` au monde seedé. Elles passent par le cycle de vie réel (publication puis clôture / dépublication), appartiennent à l'administrateur par défaut, sans instructeur ni dossier pour rester neutres vis-à-vis des specs existantes. ~15 fichiers de specs (modèles, contrôleurs, tâches de maintenance, GraphQL, système) basculent dessus.

**3. Migration des specs `simple_procedure` et `:with_service`** (~60 occurrences dans 21 fichiers) — les démarches génériques publiées ou avec service basculent sur les seeds (tous les seeds portent déjà `services.default`), et l'instructeur seedé remplace les instructeurs ad hoc. Deux assertions rendues seed-safe au passage : le footer des emails met en minuscule la première lettre des horaires du service (masqué jusqu'ici par une factory commençant par une minuscule), et les groupes d'un traitement de masse sont désormais comparés aux groupes de l'instructeur *sur la démarche concernée*.

Les factories sont conservées là où leur forme exacte est l'objet du test : le champ unique « Texte obligatoire » rempli par les specs système, les démarches détruites en cours de test, les attributs spécifiques (sva, déclaratif, monavis, discarded…), et les specs wcag (non vérifiables localement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)