### PR TITLE
Tech: met en cache le schéma de la base de données de test pour accélérer la CI

### DIFF
--- a/.github/actions/ci-setup-rails/action.yml
+++ b/.github/actions/ci-setup-rails/action.yml
@@ -13,9 +13,25 @@ runs:
       run: cp config/env.example .env
       shell: bash
 
+    - name: Restore cached test database schema
+      uses: actions/cache@v4
+      with:
+        path: tmp/schema_cache.sql
+        key: db-schema-v1-${{ hashFiles('db/schema.rb', 'db/migrate/**') }}
+
     - name: Setup test database
       env:
         RAILS_ENV: test
         DATABASE_URL: 'postgres://tps_test@localhost:5432/tps_test'
-      run: bin/rails db:schema:load db:migrate
+      # Restoring the cached schema dump with psql is ~10x faster than
+      # bin/rails db:schema:load. pg_dump runs inside the postgres service
+      # container because its client version must match the server.
+      run: |
+        if [ -f tmp/schema_cache.sql ]; then
+          psql "$DATABASE_URL" --quiet -v ON_ERROR_STOP=1 -f tmp/schema_cache.sql > /dev/null
+        else
+          bin/rails db:schema:load db:migrate
+          mkdir -p tmp
+          docker exec "$(docker ps --quiet --filter publish=5432)" pg_dump --username tps_test tps_test > tmp/schema_cache.sql
+        fi
       shell: bash

--- a/.github/workflows/bundle_cache_warming.yml
+++ b/.github/workflows/bundle_cache_warming.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - Gemfile.lock
       - .ruby-version
+      - db/schema.rb
+      - db/migrate/**
       - package.json
       - vite.config.ts
       - app/javascript/**
@@ -27,10 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Ruby and bundle cache
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
+      - name: Setup Ruby, bundle cache and test database schema cache
+        uses: ./.github/actions/ci-setup-rails
 
       - name: Setup assets cache
         uses: ./.github/actions/ci-setup-assets


### PR DESCRIPTION
## Contexte

Chaque job CI (6 shards unit, 4 shards system, slow, linters) recharge le schéma via `bin/rails db:schema:load db:migrate` (~10s par job, mesuré sur les logs CI ; le step composite de setup est à ~18s en médiane sur les shards unit, ~28s sur les shards system).

## Changements

- `ci-setup-rails` : le schéma est restauré depuis un dump SQL mis en cache (`actions/cache`, clé basée sur `db/schema.rb` + `db/migrate/**`) via `psql` — quelques secondes, sans boot Rails. En cas de cache miss, fallback sur `db:schema:load` puis génération du dump (`pg_dump` exécuté dans le conteneur postgres pour que la version du client corresponde au serveur).
- `bundle_cache_warming` : le cache est réchauffé à chaque push sur main touchant le schéma, pour que les PRs suivantes partent d'un cache chaud.

## Résultat attendu

Gain modeste mais gratuit : ~7 à 10s par job (~1,5 à 2 minutes-runner par run), le step `Setup the app runtime and dependencies` devrait passer de ~18s à ~10s. Sur ce premier run le cache est froid (fallback identique au comportement actuel) ; le gain sera visible au run suivant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)