### PR TITLE
Tech: corrige la restauration du cache de schéma de la base de test en CI

### DIFF
--- a/.github/actions/ci-setup-rails/action.yml
+++ b/.github/actions/ci-setup-rails/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Setup test database
       env:
         RAILS_ENV: test
-        DATABASE_URL: 'postgres://tps_test@localhost:5432/tps_test'
+        DATABASE_URL: 'postgres://tps_test:tps_test@localhost:5432/tps_test'
       # Restoring the cached schema dump with psql is ~10x faster than
       # bin/rails db:schema:load. pg_dump runs inside the postgres service
       # container because its client version must match the server.


### PR DESCRIPTION
Le nouveau chemin de restauration via `psql` (introduit par #13518) échoue avec `fe_sendauth: no password supplied` dès qu'un cache existe : la `DATABASE_URL` ne contenait pas le mot de passe, contrairement à `database.yml` utilisé par le chemin `db:schema:load`. Tous les jobs de test échouent donc depuis ce matin (fail-fast annule le reste de la matrice).

Fix : ajout du mot de passe dans la `DATABASE_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)