### PR TITLE
ETQ instructeur, une opération de masse ne plante plus quand un dossier a déjà été traité

### DIFF
--- a/app/models/batch_operation.rb
+++ b/app/models/batch_operation.rb
@@ -146,14 +146,17 @@ class BatchOperation < ApplicationRecord
     end
   end
 
+  # Jobs are delivered at least once: a concurrent duplicate may have already
+  # transitioned the operation, so only fire events that are still allowed.
   def track_processed_dossier(success, dossier, error_message)
     dossiers.delete(dossier)
+    operation = dossier_operation(dossier)
 
     if success
-      dossier_operation(dossier).done!
-    else
-      dossier_operation(dossier).update!(error_message:)
-      dossier_operation(dossier).fail!
+      operation.done! if operation.may_done?
+    elsif operation.may_fail?
+      operation.update!(error_message:)
+      operation.fail!
     end
   end
 

--- a/spec/models/batch_operation_spec.rb
+++ b/spec/models/batch_operation_spec.rb
@@ -128,6 +128,25 @@ describe BatchOperation, type: :model do
           .to([dossier.id])
       end
     end
+
+    context 'when a duplicate job already processed the dossier' do
+      subject(:dossier_operation) { batch_operation.dossier_operations.find_by!(dossier:) }
+
+      before { batch_operation.track_processed_dossier(true, dossier, nil) }
+
+      it 'keeps the success state on a duplicate success' do
+        expect { batch_operation.track_processed_dossier(true, dossier, nil) }
+          .not_to change { dossier_operation.reload.state }
+          .from('success')
+      end
+
+      it 'keeps the success state on a duplicate failure' do
+        expect { batch_operation.track_processed_dossier(false, dossier, 'boom') }
+          .not_to change { dossier_operation.reload.state }
+          .from('success')
+        expect(dossier_operation.error_message).to be_nil
+      end
+    end
   end
 
   describe '#dossiers_safe_scope (with archiver)' do


### PR DESCRIPTION
## Contexte

Sentry [RAILS-GGF](https://demarches-simplifiees.sentry.io/issues/RAILS-GGF) (~4200 événements depuis septembre) : `AASM::InvalidTransition: Event 'fail' cannot transition from 'success'` dans `BatchOperationProcessOneJob`.

Les jobs Sidekiq sont livrés *at least once* : quand une exécution dupliquée retrouve la `DossierBatchOperation` déjà en `success`, `done!` lève une exception, puis le rescue tente `fail!` (interdit depuis `success`) et lève à son tour une exception non gérée.

## Correction

`BatchOperation#track_processed_dossier` garde ses transitions avec `may_done?` / `may_fail?` : une exécution dupliquée devient un no-op au lieu de planter. Le comportement « succès après échec » est préservé (`done` reste permis depuis `error`).

Fixes RAILS-GGF

🤖 Generated with [Claude Code](https://claude.com/claude-code)