### PR TITLE
ETQ instructeur, la recherche plein texte ne dépasse plus le timeout sur les recherches larges

### DIFF
--- a/app/services/dossier_search_service.rb
+++ b/app/services/dossier_search_service.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class DossierSearchService
+  # ts_rank cannot use the GIN index: it recomputes the tsvector for every
+  # matching row, so ranking an unbounded match set times out (RAILS-K81).
+  # Matches beyond this cap are dropped before ranking.
+  MAX_RESULTS = 1000
+
   def self.matching_dossiers(dossiers, search_terms, with_annotations = false)
     if dossiers.nil?
       []
@@ -42,8 +47,13 @@ class DossierSearchService
     ts_vector = "to_tsvector('french_unaccent', #{columns})"
     ts_query = "to_tsquery('french_unaccent', #{Dossier.connection.quote(to_tsquery(search_terms))})"
 
-    dossiers
+    matching_ids = dossiers
       .where("#{ts_vector} @@ #{ts_query}")
+      .limit(MAX_RESULTS)
+      .ids
+
+    dossiers
+      .where(id: matching_ids)
       .order(Arel.sql("COALESCE(ts_rank(#{ts_vector}, #{ts_query}), 0) DESC"))
   end
 

--- a/spec/services/dossier_search_service_spec.rb
+++ b/spec/services/dossier_search_service_spec.rb
@@ -85,6 +85,17 @@ describe DossierSearchService do
 
       it { expect(searching(dossier.id.to_s)).to eq([dossier.id]) }
     end
+
+    describe 'caps full-text results to MAX_RESULTS' do
+      let(:user) { create(:user, email: 'martin@email.com') }
+      let(:dossier) { create(:dossier, state: :en_construction, user:) }
+      let(:dossier_2) { create(:dossier, state: :en_construction, user:) }
+      let!(:dossiers) { Dossier.where(id: [dossier.id, dossier_2.id]) }
+
+      before { stub_const('DossierSearchService::MAX_RESULTS', 1) }
+
+      it { expect(searching('martin').size).to eq(1) }
+    end
   end
 
   describe '#matching_dossiers_for_user' do


### PR DESCRIPTION
## Contexte

Sentry [RAILS-K81](https://demarches-simplifiees.sentry.io/issues/RAILS-K81) : ~5300 timeouts (`PG::QueryCanceled`) sur `/recherche` depuis avril, 1150 instructeurs touchés. `ts_rank` ne peut pas utiliser l'index GIN : Postgres recalcule le tsvector pour chaque ligne correspondante, et une recherche large sur un gros périmètre instructeur dépasse le `statement_timeout`.

## Correction

Recherche en deux temps dans `DossierSearchService` : d'abord les ids correspondants via l'index GIN seul, plafonnés à `MAX_RESULTS` (1000), puis le classement `ts_rank` uniquement sur cet ensemble borné. Au-delà de 1000 correspondances, le classement porte sur un sous-ensemble — acceptable pour une recherche où l'on affine plutôt que de paginer des milliers de résultats.

Mitigation en attendant la solution structurelle (tsvector stockés) : plan détaillé dans #13524.

Fixes RAILS-K81

🤖 Generated with [Claude Code](https://claude.com/claude-code)