### PR TITLE
Tech : l'API GraphQL renvoie une erreur de validation plutôt qu'une 500 pour un entier hors bornes

### DIFF
--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -149,6 +149,12 @@ class API::V2::Schema < GraphQL::Schema
   end
 
   def self.type_error(error, ctx)
+    # An out-of-bounds Int in the request (e.g. a SIRET sent as demarche number) is a
+    # client input error: surface it as a validation error instead of a 500.
+    if error.is_a?(GraphQL::IntegerDecodingError)
+      raise GraphQL::ExecutionError.new(error.message, extensions: { code: :bad_request })
+    end
+
     # Capture type errors in Sentry. Thouse errors are our responsability and usually linked to
     # instances of "bad data".
     Sentry.capture_exception(error, extra: ctx.query_info)

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -227,6 +227,28 @@ describe API::V2::GraphqlController do
       end
     end
 
+    describe "demarche with an out of bounds number" do
+      let(:query) { "query GetDemarche($number: Int!) { demarche(number: $number) { id } }" }
+      let(:variables) { { number: 10_000_000_000_000_000 } }
+
+      it "returns a validation error instead of an internal error" do
+        expect(Sentry).not_to receive(:capture_exception)
+        expect(subject).to have_http_status(:ok)
+        expect(gql_errors.first[:message]).to match(/invalid value|out of bounds/)
+      end
+
+      context "when the number is an inline literal" do
+        let(:query) { "{ demarche(number: 10000000000000000) { id } }" }
+        let(:variables) { {} }
+
+        it "returns a validation error instead of an internal error" do
+          expect(Sentry).not_to receive(:capture_exception)
+          expect(subject).to have_http_status(:ok)
+          expect(gql_errors.first[:message]).to match(/invalid value|out of bounds/)
+        end
+      end
+    end
+
     describe "demarche" do
       describe "query a demarche" do
         let(:label) { build(:label) }


### PR DESCRIPTION
## Contexte

Sentry [RAILS-JZN](https://demarches-simplifiees.sentry.io/issues/RAILS-JZN) : ~800 événements depuis mars, un consommateur de l'API envoie `demarche(number: 10000000000000000)` (un SIRET ?) — hors bornes du type `Int` GraphQL (32 bits).

`GraphQL::IntegerDecodingError` traversait le `type_error` du schéma (capture Sentry) puis le rescue générique du contrôleur (seconde capture) et renvoyait une 500 « Internal Server Error » opaque — le client ne voyait jamais que son entrée était invalide, d'où les retries depuis 4 mois.

## Correction

`Schema.type_error` convertit `IntegerDecodingError` en `GraphQL::ExecutionError` (`code: bad_request`) avant la capture Sentry : graphql-ruby la transforme en erreur de validation standard dans la réponse (variable ou littéral inline). Les `IntegerEncodingError` côté résultat (nos données) restent capturées dans Sentry.

Fixes RAILS-JZN

🤖 Generated with [Claude Code](https://claude.com/claude-code)