### PR TITLE
Tech : audit API GraphQL — trois erreurs client transformées en 500

### DIFF
--- a/app/controllers/api/v2/graphql_controller.rb
+++ b/app/controllers/api/v2/graphql_controller.rb
@@ -14,6 +14,10 @@ class API::V2::GraphqlController < API::V2::BaseController
     handle_parse_error(exception, :graphql_parse_failed)
   rescue ArgumentError => exception
     handle_parse_error(exception, :bad_request)
+  rescue GraphQL::ExecutionError => exception
+    # Raised outside schema execution (e.g. unknown stored queryId): surface the
+    # message instead of letting the generic handler return an opaque 500.
+    render json: { errors: [exception.to_h], data: nil }, status: :bad_request
   rescue => exception
     if Rails.env.production?
       handle_error_in_production(exception)

--- a/app/graphql/types/file.rb
+++ b/app/graphql/types/file.rb
@@ -19,6 +19,13 @@ module Types
       end
     end
 
+    # Deprecated Int field: clamp files over 2^31 - 1 bytes instead of crashing
+    # the whole query with an IntegerEncodingError; byteSizeBigInt has the real value.
+    def byte_size
+      value = object.is_a?(Hash) ? object[:byte_size] : object.byte_size
+      [value.to_i, GraphQL::Types::Int::MAX].min
+    end
+
     def virus_scan_result
       if object.is_a?(Hash)
         object[:virus_scan_result] || ActiveStorage::VirusScanner::PENDING

--- a/app/graphql/types/url.rb
+++ b/app/graphql/types/url.rb
@@ -5,13 +5,13 @@ module Types
     description "A valid URL, transported as a string"
 
     def self.coerce_input(input_value, context)
-      url = Addressable::URI(input_value)
-      if uri.scheme.in?(['http', 'https'])
+      url = Addressable::URI.parse(input_value)
+      if url&.scheme.in?(['http', 'https'])
         url
       else
         raise GraphQL::CoercionError, "#{input_value.inspect} is not a valid URL"
       end
-    rescue Addressable::URI::InvalidURIError
+    rescue Addressable::URI::InvalidURIError, TypeError
       raise GraphQL::CoercionError, "#{input_value.inspect} is not a valid URL"
     end
 

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -987,7 +987,8 @@ describe API::V2::GraphqlController do
           end
 
           it {
-            expect(gql_errors).not_to be_nil
+            expect(gql_errors).to be_nil
+            expect(gql_data).to eq(dossier: { champs: [{ files: [{ byteSize: GraphQL::Types::Int::MAX }] }] })
           }
         end
 

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -69,7 +69,9 @@ describe API::V2::GraphqlController do
       let(:query_id) { 'ds-query-v0' }
 
       it {
+        expect(subject).to have_http_status(:bad_request)
         expect(gql_errors.first[:message]).to eq('No query with id "ds-query-v0"')
+        expect(gql_errors.first[:extensions]).to eq(code: 'bad_request')
       }
     end
 

--- a/spec/graphql/types/file_spec.rb
+++ b/spec/graphql/types/file_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe Types::File, type: :graphql do
+  let(:query) do
+    <<~GRAPHQL
+      query($number: Int!) {
+        dossier(number: $number) {
+          champs {
+            ... on PieceJustificativeChamp {
+              files {
+                byteSize
+                byteSizeBigInt
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+  end
+  let(:context) { { internal_use: true } }
+  let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
+  let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
+  let(:variables) { { number: dossier.id } }
+
+  subject { API::V2::Schema.execute(query, variables: variables, context: context) }
+
+  let(:data) { subject['data'].deep_symbolize_keys }
+  let(:file) { data[:dossier][:champs].first[:files].first }
+
+  describe 'byteSize' do
+    it 'returns the blob byte size' do
+      expect(subject['errors']).to be_nil
+      expect(file[:byteSize]).to eq(file[:byteSizeBigInt].to_i)
+    end
+
+    context 'when the file is larger than a 32-bit integer (RAILS-JZ7)' do
+      before do
+        dossier.champs.first.piece_justificative_file.first.blob.update_column(:byte_size, 3_000_000_000)
+      end
+
+      it 'clamps instead of failing the query' do
+        expect(subject['errors']).to be_nil
+        expect(file[:byteSize]).to eq(GraphQL::Types::Int::MAX)
+        expect(file[:byteSizeBigInt]).to eq('3000000000')
+      end
+    end
+  end
+end

--- a/spec/graphql/types/url_spec.rb
+++ b/spec/graphql/types/url_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Types::URL do
+  describe '.coerce_input' do
+    subject { described_class.coerce_input(input, {}) }
+
+    context 'with a valid http(s) URL' do
+      let(:input) { 'https://www.demarches-simplifiees.fr/commencer/test' }
+
+      it { is_expected.to eq(Addressable::URI.parse(input)) }
+    end
+
+    context 'with a non-http scheme' do
+      let(:input) { 'javascript:alert(1)' }
+
+      it { expect { subject }.to raise_error(GraphQL::CoercionError) }
+    end
+
+    context 'with a relative URL' do
+      let(:input) { '/commencer/test' }
+
+      it { expect { subject }.to raise_error(GraphQL::CoercionError) }
+    end
+
+    context 'with an unparsable value' do
+      let(:input) { 'http://example.com:port' }
+
+      it { expect { subject }.to raise_error(GraphQL::CoercionError) }
+    end
+  end
+
+  describe '.coerce_result' do
+    it { expect(described_class.coerce_result(Addressable::URI.parse('https://example.com/a'), {})).to eq('https://example.com/a') }
+  end
+end


### PR DESCRIPTION
## Contexte

Suite au correctif de [RAILS-JZN](https://demarches-simplifiees.sentry.io/issues/RAILS-JZN) (#13526), audit des chemins d'erreur de l'API GraphQL : entrées malformées sondées empiriquement (entiers hors bornes, enums invalides, dates invalides, IDs corrompus, unicode invalide…) + relecture de tous les `raise` de `app/graphql/`. Les coercitions standard renvoient bien des erreurs de validation ; trois trous restaient, corrigés ici en trois commits atomiques :

## Corrections

1. **`queryId` inconnu → 400 au lieu d'une 500 opaque.** `StoredQuery.get` lève une `GraphQL::ExecutionError` dans le contrôleur, hors exécution du schéma : en production le rescue générique renvoyait « Internal Server Error » (+ capture Sentry) alors qu'en dev/test le message fuitait dans la réponse — les specs passaient en masquant le comportement de prod. Le contrôleur rescue désormais `GraphQL::ExecutionError` en 400 avec le message.

2. **`Types::URL.coerce_input` réparé.** `Addressable::URI(...)` n'est pas une méthode et la variable `uri` n'existait pas : toute entrée, valide ou non, levait `NoMethodError`. Latent (le scalaire n'est utilisé qu'en sortie aujourd'hui), mais le premier `argument` qui l'utiliserait aurait produit une 500 systématique.

3. **`File.byteSize` plafonné à `2^31 - 1`** ([RAILS-JZ7](https://demarches-simplifiees.sentry.io/issues/RAILS-JZ7), toujours actif) : un fichier > 2 Go levait `IntegerEncodingError` et faisait échouer toute la requête en 500 pour les clients encore sur ce champ déprécié. `byteSizeBigInt` porte la vraie valeur.

Fixes RAILS-JZ7

🤖 Generated with [Claude Code](https://claude.com/claude-code)