### PR TITLE
ETQ usager, la sauvegarde d'un brouillon ne plante plus avec un champ référentiel en autocomplétion

### DIFF
--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -311,7 +311,9 @@ class ChampData < ApplicationRecord
     self.value = champ.value
     self.external_id = champ.external_id
     self.value_json = champ.value_json
-    self.data = champ.data
+    # Copy the stored attribute verbatim: Champs::ReferentielChamp#data= expects
+    # an encrypted payload from the browser and would try to decrypt this hash.
+    write_attribute(:data, champ.read_attribute(:data))
     self.external_state = champ.external_state
     self.prefilled = champ.prefilled
     self.prefilled_original_value = champ.prefilled_original_value

--- a/spec/models/champ_data_spec.rb
+++ b/spec/models/champ_data_spec.rb
@@ -641,5 +641,19 @@ describe ChampData do
       target_champ.clone_value_from(source_champ)
       expect(target_champ.external_state).to eq('fetched')
     end
+
+    context 'with an autocomplete referentiel champ' do
+      let(:referentiel) { create(:api_referentiel, :autocomplete) }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :referentiel, referentiel:, mandatory: true }]) }
+      let(:data) { { 'id' => '123', 'label' => 'foo' } }
+
+      before { source_champ.update_columns(data:) }
+
+      it 'copies stored data verbatim instead of decrypting it (RAILS-KQB)' do
+        expect { target_champ.clone_value_from(source_champ) }.not_to raise_error
+        expect(target_champ.read_attribute(:data)).to eq(data)
+        expect(target_champ.value_json).to eq(source_champ.value_json)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Contexte

Sentry [RAILS-KQB](https://demarches-simplifiees.sentry.io/issues/RAILS-KQB) : 74 usagers touchés depuis le 12 mai, `ArgumentError: wrong number of arguments (given 2, expected 1)` sur `Users::DossiersController#update` (autosave du brouillon).

Lors de la création d'un champ sur le stream usager, `champ_upsert_by!` copie la valeur du stream principal via `ChampData#clone_value_from`, qui faisait `self.data = champ.data`. Or `Champs::ReferentielChamp#data=` (référentiel en autocomplétion) attend le payload **chiffré** envoyé par le navigateur et le déchiffre — le clone lui passait le hash jsonb déjà en clair, et `MessageEncryptor` plantait sur `Hash#[]` à deux arguments. Toute édition d'un dossier contenant un champ référentiel autocomplete rempli renvoyait une 500.

## Correction

`clone_value_from` copie désormais l'attribut stocké tel quel (`write_attribute`) en contournant le setter — c'est aussi la bonne sémantique pour un clone : l'ancien chemin aurait re-déchiffré, recalculé `value_json` et ré-enqueué les jobs de préremplissage.

La spec reproduit l'`ArgumentError` exact de production sans le correctif.

Fixes RAILS-KQB

🤖 Generated with [Claude Code](https://claude.com/claude-code)