### PR TITLE
ETQ usager, l'envoi de plusieurs pièces justificatives en parallèle ne plante plus

### DIFF
--- a/app/services/clone_pieces_justificatives_service.rb
+++ b/app/services/clone_pieces_justificatives_service.rb
@@ -23,8 +23,20 @@ class ClonePiecesJustificativesService
   end
 
   def self.clone_many_attachments(original, kopy, attachments_name)
+    kopy_attachments = kopy.public_send(attachments_name)
+    # Concurrent requests can both clone onto the same champ (e.g. parallel
+    # multi-file uploads upserting the same buffer stream champ): skip blobs
+    # already attached instead of violating the attachments unique index.
+    already_attached_blob_ids = kopy_attachments.attachments.map(&:blob_id)
+
     original.public_send(attachments_name).attachments.each do |attachment|
-      kopy.public_send(attachments_name).attach(attachment.blob)
+      next if attachment.blob_id.in?(already_attached_blob_ids)
+
+      begin
+        kopy_attachments.attach(attachment.blob)
+      rescue ActiveRecord::RecordNotUnique
+        kopy.reload
+      end
     end
   end
 

--- a/spec/services/clone_pieces_justificatives_service_spec.rb
+++ b/spec/services/clone_pieces_justificatives_service_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+describe ClonePiecesJustificativesService do
+  describe '.clone_attachments with a piece justificative champ' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
+    let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+    let(:original) { dossier.champ_data.first }
+    let(:kopy) do
+      original.dup.tap do
+        it.stream = Dossier::USER_BUFFER_STREAM
+        it.save!
+      end
+    end
+
+    it 'clones attachments to the copy' do
+      expect { described_class.clone_attachments(original, kopy) }
+        .to change { kopy.piece_justificative_file.attachments.count }.from(0).to(1)
+    end
+
+    context 'when a blob is already attached to the copy' do
+      before { kopy.piece_justificative_file.attach(original.piece_justificative_file.attachments.first.blob) }
+
+      it 'skips it instead of raising RecordNotUnique' do
+        expect { described_class.clone_attachments(original, kopy) }.not_to raise_error
+        expect(kopy.reload.piece_justificative_file.attachments.count).to eq(1)
+      end
+    end
+
+    context 'when a concurrent request attaches the same blob after the association is loaded' do
+      it 'recovers instead of raising RecordNotUnique (RAILS-KJH)' do
+        blob = original.piece_justificative_file.attachments.first.blob
+        kopy.piece_justificative_file.attachments.load
+
+        # a concurrent request cloning the same champ attaches the blob behind our back
+        ChampData.find(kopy.id).piece_justificative_file.attach(blob)
+
+        expect { described_class.clone_attachments(original, kopy) }.not_to raise_error
+        expect(kopy.reload.piece_justificative_file.attachments.count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Sentry [RAILS-KJH](https://demarches-simplifiees.sentry.io/issues/RAILS-KJH) : 266 usagers depuis le 27 avril, `ActiveRecord::RecordNotUnique` sur `index_active_storage_attachments_uniqueness` dans `Champs::PieceJustificativeController#update`.

Le widget PJ envoie chaque fichier dans une requête PUT séparée. Deux requêtes parallèles upsertent le même champ du buffer stream, et chacune peut cloner les pièces jointes du stream principal (`ClonePiecesJustificativesService`) : la perdante insère un attachement déjà créé par la gagnante entre sa lecture de l'association et son `attach` → violation d'unicité → 500 en plein téléversement. Le crash ne survient qu'avec un cache d'association périmé face à une insertion concurrente, d'où sa rareté (~290 événements sur des millions de mises à jour PJ).

## Correction

`clone_many_attachments` est désormais idempotent à deux niveaux : les blobs déjà attachés sont ignorés (cas déterministe), et la fenêtre de course résiduelle est absorbée par un rescue de `RecordNotUnique` avec rechargement de la copie. Dans tous les cas le résultat voulu par les deux requêtes est atteint : le blob attaché exactement une fois.

La spec reproduit la `PG::UniqueViolation` exacte de production sans le correctif (association chargée puis insertion concurrente du même blob).

Fixes RAILS-KJH

🤖 Generated with [Claude Code](https://claude.com/claude-code)