### PR TITLE
ETQ instructeur, modifier un filtre avec une valeur invalide affiche l'erreur au lieu d'échouer

### DIFF
--- a/app/controllers/instructeurs/procedure_presentation_controller.rb
+++ b/app/controllers/instructeurs/procedure_presentation_controller.rb
@@ -6,7 +6,9 @@ module Instructeurs
 
     # updates the value of a filter
     def update_filter
-      @procedure_presentation.update_filter_for_statut!(params[:statut], params[:filter_key], filtered_column_from_params)
+      if !@procedure_presentation.update_filter_for_statut(params[:statut], params[:filter_key], filtered_column_from_params)
+        flash.alert = filters_error_messages
+      end
 
       render turbo_stream: turbo_stream.refresh
     end
@@ -36,9 +38,7 @@ module Instructeurs
         toggle_admin_default = params.dig(:procedure_presentation, :admin_default_procedure_presentation_active_virtual)
         set_admin_pp_default if toggle_admin_default.present? && current_instructeur_administrates_procedure?
       else
-        # complicated way to display inner error messages
-        flash.alert = @procedure_presentation.errors
-          .flat_map { _1.detail[:value].flat_map { |c| c.errors.full_messages } }
+        flash.alert = filters_error_messages
       end
 
       redirect_back_or_to([:instructeur, procedure])
@@ -76,6 +76,12 @@ module Instructeurs
 
     def filters_columns_from_params
       Array(params[:filters_columns]).uniq.map { ColumnType.new.cast(it) }
+    end
+
+    # complicated way to display inner error messages
+    def filters_error_messages
+      @procedure_presentation.errors
+        .flat_map { _1.detail[:value].flat_map { |c| c.errors.full_messages } }
     end
 
     def filtered_column_from_params

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -50,10 +50,10 @@ class ProcedurePresentation < ApplicationRecord
     update!(filters_name_for(statut) => [])
   end
 
-  def update_filter_for_statut!(statut, filter_key, filter)
+  def update_filter_for_statut(statut, filter_key, filter)
     filters_attr = filters_name_for(statut)
     current_filters = send(filters_attr) || []
-    update!(filters_attr => current_filters.map { |f| f.id == filter_key ? filter : f })
+    update(filters_attr => current_filters.map { |f| f.id == filter_key ? filter : f })
   end
 
   def replace_filters!(statut, new_filters_columns)

--- a/spec/controllers/instructeurs/procedure_presentation_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedure_presentation_controller_spec.rb
@@ -170,6 +170,20 @@ describe Instructeurs::ProcedurePresentationController, type: :controller do
         expect(procedure_presentation.reload.tous_filters).to eq([FilteredColumn.new(column:, filter: { operator: 'in', value: [] })])
       end
     end
+
+    context 'when the filter value is invalid' do
+      let(:dossier_id_column) { procedure.dossier_id_column }
+      let(:existing_filter) { FilteredColumn.new(column: dossier_id_column, filter: { operator: 'match', value: ['123'] }) }
+      let(:params) { { id: procedure_presentation.id, statut: 'tous', filter_key: existing_filter.id, filter: { id: dossier_id_column.id, filter: { operator: 'match', value: ['13002526500013'] } } } }
+
+      it 'shows the validation message instead of failing (RAILS-K75)' do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(flash.alert.join).to include('n’est pas un numéro de dossier possible')
+        expect(procedure_presentation.reload.tous_filters).to eq([existing_filter])
+      end
+    end
   end
 
   describe '#persist_filters' do

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -41,14 +41,14 @@ describe ProcedurePresentation do
     end
   end
 
-  describe '#update_filter_for_statut!' do
+  describe '#update_filter_for_statut' do
     let(:procedure_presentation) { create(:procedure_presentation, assign_to:) }
     let(:column) { procedure.find_column(label: 'Demandeur') }
     let(:existing_filter) { FilteredColumn.new(column:, filter: { operator: "match", value: ['existing_filter_value'] }) }
     let(:updated_filter) { FilteredColumn.new(column:, filter: { operator: "match", value: ['updated_filter_value'] }) }
     let(:other_filter) { FilteredColumn.new(column:, filter: { operator: "match", value: ['other_filter_value'] }) }
 
-    subject { procedure_presentation.update_filter_for_statut!(statut, filter_key, updated_filter) }
+    subject { procedure_presentation.update_filter_for_statut(statut, filter_key, updated_filter) }
 
     context 'when updating a filter' do
       let(:statut) { 'a-suivre' }


### PR DESCRIPTION
## Contexte

Sentry [RAILS-K75](https://demarches-simplifiees.sentry.io/issues/RAILS-K75) : 522 événements, 176 instructeurs depuis avril. `update_filter` utilisait `update!` : une valeur de filtre invalide (`FilteredColumn` — valeur trop longue, ou un SIRET collé dans le filtre « numéro de dossier », dépassant l'entier PG) levait `RecordInvalid` avec le seul message générique « Le champ « Traites filters » n'est pas valide » — page d'erreur pour l'instructeur, qui réessayait sans comprendre (~3 événements par utilisateur).

L'action sœur `update` gérait déjà ce cas proprement ; `update_filter` n'avait jamais reçu le même traitement.

## Correction

- `update_filter_for_statut!` devient `update_filter_for_statut` (sans bang, retourne le booléen d'`update`) ;
- en cas d'échec, `update_filter` affiche en flash les messages internes de `FilteredColumn` (ex. « Le filtre « Numéro » n'est pas un numéro de dossier possible ») puis rafraîchit — extraction des messages mutualisée avec `update` dans un helper privé.

Bénéfice annexe : un filtre stocké invalide (données antérieures aux validations) affiche désormais un message nommant le filtre en cause au lieu d'une page d'erreur inexpliquée.

Fixes RAILS-K75

🤖 Generated with [Claude Code](https://claude.com/claude-code)