### PR TITLE
ETQ usager, un dossier avec une ancienne date mal formatée s'affiche et se dépose à nouveau

### DIFF
--- a/app/models/champs/date_champ.rb
+++ b/app/models/champs/date_champ.rb
@@ -26,6 +26,6 @@ class Champs::DateChamp < ChampData
     return if DateDetectionUtils.parsable_iso8601_date?(value) || value.blank?
 
     # i18n-tasks-use t('errors.messages.not_a_date')
-    errors.add :date, :not_a_date
+    errors.add :value, :not_a_date
   end
 end

--- a/spec/models/champs/date_champ_spec.rb
+++ b/spec/models/champs/date_champ_spec.rb
@@ -22,6 +22,17 @@ describe Champs::DateChamp do
     end
   end
 
+  describe 'iso_8601 validation' do
+    it 'reports an error whose message can be generated (RAILS-MAQ)' do
+      allow(date_champ).to receive(:value).and_return("2023-30-01")
+
+      expect(date_champ.validate(:champ_value)).to be(false)
+      expect(date_champ.errors.first.attribute).to eq(:value)
+      expect { date_champ.errors.map(&:message) }.not_to raise_error
+      expect(date_champ.errors.first.message).to eq('doit être une date correctement formatée')
+    end
+  end
+
   describe "#to_s" do
     it "format the date" do
       champ_with_value("2020-06-20")


### PR DESCRIPTION
## Contexte

Sentry [RAILS-MAQ](https://demarches-simplifiees.sentry.io/issues/RAILS-MAQ) (affichage du brouillon) et [RAILS-MAW](https://demarches-simplifiees.sentry.io/issues/RAILS-MAW) (dépôt) : régression apparue avec la release du 21 juillet, en escalade.

`Champs::DateChamp#iso_8601` enregistrait son erreur sur l'attribut `:date` — qui n'existe pas sur le modèle (`DatetimeChamp` utilise `:value` pour la même validation). Inoffensif tant que personne ne générait le message, car il est construit paresseusement. Depuis la refonte des validations de complétude (ffe32922cc), les erreurs de champs remontent dans le récapitulatif d'erreurs du dossier : `error.message` appelle `read_attribute_for_validation(:date)` → `NoMethodError` → 500. Déclencheur : une valeur de date héritée non-ISO en base (la normalisation actuelle annule les saisies invalides, d'où le faible volume — mais pour les usagers concernés, affichage **et** dépôt du dossier sont bloqués).

## Correction

`errors.add :value, :not_a_date` — aligné sur `DatetimeChamp`. Bonus : l'ancre du récapitulatif d'erreurs pointe désormais vers le vrai champ de saisie. La clé i18n est indépendante de l'attribut, rien ne filtrait sur `:date`.

La spec reproduit le `NoMethodError` exact sans le correctif.

Fixes RAILS-MAQ
Fixes RAILS-MAW

🤖 Generated with [Claude Code](https://claude.com/claude-code)