### PR TITLE
ETQ instructeur, un dossier dont un champ a changé de type ne plante plus à l'affichage

### DIFF
--- a/app/components/dossiers/rnf_component.rb
+++ b/app/components/dossiers/rnf_component.rb
@@ -24,13 +24,15 @@ class Dossiers::RNFComponent < ApplicationComponent
   private
 
   def data
-    [
-      [label(:rnf_id), champ.to_s],
-      *['title', 'email'].map { [label(it), champ.data[it]] },
-    ]
+    rows = [[label(:rnf_id), champ.to_s]]
+    return rows if champ.data.blank?
+
+    rows + ['title', 'email'].map { [label(it), champ.data[it]] }
   end
 
   def details
+    return [] if champ.data.blank?
+
     [
       *['phone', 'status'].map { [label(it), champ.data[it]] },
       *['createdAt', 'updatedAt', 'dissolvedAt'].map { [label(it), champ.data[it]&.to_date] },

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -416,7 +416,9 @@ module DossierChampsConcern
     # Needed when a revision change the champ type in this case, we reset the champ data
     if data.class != type_de_champ.champ_class
       data = data.becomes!(type_de_champ.champ_class)
-      data.assign_attributes(value: nil, value_json: nil, external_id: nil, data: nil)
+      # external_state must be reset too: a champ left "fetched" with nil data
+      # crashes the components rendering the fetched external data
+      data.assign_attributes(value: nil, value_json: nil, external_id: nil, data: nil, external_state: nil, fetch_external_data_exceptions: [])
     elsif !main_stream? && data.previously_new_record?
       main_stream_data = champ_data.find_by(stable_id: type_de_champ.stable_id, row_id:, stream: Dossier::MAIN_STREAM)
       data.clone_value_from(main_stream_data) if main_stream_data.present?

--- a/spec/components/dossiers/rnf_component_spec.rb
+++ b/spec/components/dossiers/rnf_component_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe Dossiers::RNFComponent, type: :component do
     end
   end
 
+  context 'when the champ is fetched but the data is missing' do
+    let(:external_state) { 'fetched' }
+    let(:rnf_data) { nil }
+
+    it 'renders the identifier without crashing (RAILS-MAN)' do
+      expect(subject).to have_text('075-FDD-00003-01')
+    end
+  end
+
   context 'when the champ is waiting for a job' do
     let(:external_state) { 'waiting_for_job' }
     let(:rnf_data) { nil }

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -365,6 +365,18 @@ RSpec.describe DossierChampsConcern do
           expect(subject.value).to be_nil
           expect(project_champ.is_a?(Champs::CheckboxChamp)).to be_truthy
         }
+
+        context "when the previous champ had fetched external data" do
+          before do
+            dossier.champ_data.first.update_columns(external_state: 'fetched', data: { 'title' => 'stale' })
+          end
+
+          it "resets the external state along with the data (RAILS-MAN)" do
+            expect(subject.idle?).to be(true)
+            expect(subject.data).to be_nil
+            expect(subject.fetched?).to be(false)
+          end
+        end
       end
 
       context "champ carte" do


### PR DESCRIPTION
## Contexte

Sentry [RAILS-MAN](https://demarches-simplifiees.sentry.io/issues/RAILS-MAN) : depuis le 21 juillet, les instructeurs de la démarche concernée ne peuvent plus ouvrir un dossier (500 systématique).

Quand une révision change le **type** d'un champ, la réinitialisation dans `champ_upsert_by!` efface `value`, `value_json`, `external_id` et `data` — mais laissait `external_state` à `fetched`. Le champ réinitialisé prétend donc avoir des données externes récupérées avec `data` à nil ; `Dossiers::RNFComponent` prend la branche `fetched?` et plante sur `champ.data['title']`. Une fois le champ fusionné sur le stream principal, la page du dossier est cassée pour tous les instructeurs.

## Correction

- La réinitialisation lors d'un changement de type remet aussi `external_state` à `idle` et vide `fetch_external_data_exceptions` ;
- `RNFComponent` garde désormais `data.blank?` comme son homologue `AnnuaireEducationComponent` (seul composant de champ externe sans cette garde) — ce qui **répare aussi l'affichage des champs déjà corrompus en production** : le dossier s'affiche à nouveau avec l'identifiant RNF seul.

Les specs reproduisent le `NoMethodError` exact sans la garde, et vérifient que le champ réinitialisé revient à l'état `idle`.

Fixes RAILS-MAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)