### PR TITLE
Tech : ne plus remonter dans Sentry les erreurs de connexion au Redis de cache

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,9 +82,11 @@ Rails.application.configure do
     redis_options = {
       url: ENV['REDIS_CACHE_URL'],
       connect_timeout: 0.2,
+      # The cache Redis is allowed to blip: the store's failsafe degrades to a
+      # cache miss, so don't report to Sentry — this Redis is watched by infra
+      # monitoring. Errors from the Kredis key/value store still reach Sentry.
       error_handler: -> (method:, returning:, exception:) {
-        Sentry.capture_exception exception, level: 'warning',
-          tags: { method: method, returning: returning }
+        Rails.logger.warn("Redis cache #{method} failed (returning #{returning.inspect}): #{exception.class}: #{exception.message}")
       },
     }
 


### PR DESCRIPTION
## Contexte

Le `error_handler` du cache store (`config/environments/production.rb`) capturait chaque `Redis::CannotConnectError` dans Sentry en warning. Or le failsafe du `RedisCacheStore` dégrade déjà chaque blip en cache miss : **aucun impact utilisateur** (vérifié : 100 % des ~900 événements sur 30 jours sont `handled: yes, level: warning`). Résultat : ~66 issues Sentry accumulées (une par action de contrôleur × variante d'erreur), archivées aujourd'hui, et chaque nouveau blip en recrée.

Architecture des deux usages Redis :
- **cache** (`REDIS_CACHE_URL`, instance moins fiable) : les blips doivent rester invisibles — c'est l'objet de cette PR ;
- **clé/valeur** (Kredis : rate limiter API Entreprise, verrous…) : rien ne rescue ces erreurs, elles continueront de remonter dans Sentry — comportement voulu. À noter : `kredis.rb` pointe aujourd'hui vers `REDIS_CACHE_URL`, à réorienter vers l'instance fiable (suivi séparément).

## Correction

Le `error_handler` logge en warning (`Rails.logger.warn`) au lieu de capturer dans Sentry. La supervision de ce Redis relève du monitoring infra.

Fixes RAILS-M4Z
Fixes RAILS-M55
Fixes RAILS-M43
Fixes RAILS-M41

🤖 Generated with [Claude Code](https://claude.com/claude-code)