### PR TITLE
Correctif: ETQ usager, le pré-remplissage d'un choix (simple/multiple) adossé à un référentiel fonctionne

### DIFF
--- a/app/models/referentiel.rb
+++ b/app/models/referentiel.rb
@@ -28,7 +28,23 @@ class Referentiel < ApplicationRecord
     items.to_set { _1.value(path) if _1.value(value_path).present? }.compact.sort.map { [_1, _1] }
   end
 
+  # Resolves a prefill input — either an item id or a first-column label — to
+  # the item id a drop_down champ stores, or nil when it matches no item.
+  # Owner of the id-or-label logic so the prefill screening can share it.
+  def resolve_item_id(input)
+    return if input.blank?
+    item = items.find_by(id: input) || item_by_label(input)
+    item&.id&.to_s
+  end
+
   def self.header_to_path(header)
     header.to_s.parameterize.underscore
+  end
+
+  private
+
+  def item_by_label(label)
+    path = self.class.header_to_path(headers.first)
+    items.find { _1.value(path) == label }
   end
 end

--- a/app/models/types_de_champ/prefill_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_drop_down_list_type_de_champ.rb
@@ -15,10 +15,19 @@ class TypesDeChamp::PrefillDropDownListTypeDeChamp < TypesDeChamp::PrefillTypeDe
 
   private
 
-  # Advanced (referentiel-backed) lists and lists accepting "other" take
-  # values the options don't enumerate, so only simple lists are screened.
+  # Advanced (referentiel-backed) lists store an item id, so a prefill input
+  # given as a human label is resolved to its item id (the champ setter only
+  # accepts ids). Simple lists are screened against their options; lists
+  # accepting "other" take any value.
   def screened_value(champ, value)
     return nil if !value.is_a?(String)
+
+    if drop_down_advanced?
+      resolved = referentiel&.resolve_item_id(value)
+      return resolved if resolved.present?
+      return drop_down_other? ? value : nil
+    end
+
     return nil if screenable? && DropDownOptionsValidator.violations([value], self).any?
 
     value

--- a/app/models/types_de_champ/prefill_multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_multiple_drop_down_list_type_de_champ.rb
@@ -14,6 +14,14 @@ class TypesDeChamp::PrefillMultipleDropDownListTypeDeChamp < TypesDeChamp::Prefi
     return nil if !acceptable_prefill_value?(value)
 
     values = Champs::MultipleDropDownListChamp.parse_values(value)
+
+    # Advanced lists store item ids: resolve each input (id or label) and keep
+    # only the ones matching an item, serialized like the champ setter expects.
+    if drop_down_advanced?
+      resolved = values.filter_map { referentiel&.resolve_item_id(_1) }
+      return resolved.empty? ? nil : resolved.to_json
+    end
+
     return nil if DropDownOptionsValidator.violations(values, self).any?
 
     value

--- a/spec/models/concerns/dossier_prefillable_concern_spec.rb
+++ b/spec/models/concerns/dossier_prefillable_concern_spec.rb
@@ -162,6 +162,25 @@ RSpec.describe DossierPrefillableConcern do
       end
     end
 
+    context 'when dossier contains an advanced (referentiel-backed) drop_down_list' do
+      # Regression: prefilling such a champ with a human label used to be wiped
+      # to nil by the store_referentiel before_save (which only matched item ids).
+      let(:referentiel) { create(:csv_referentiel, :with_items) }
+      let(:types_de_champ_public) { [{ type: :drop_down_list, drop_down_mode: 'advanced', referentiel: }] }
+      let(:type_de_champ_1) { procedure.published_revision.root_types_de_champ_public.first }
+      let(:champ_1) { find_champ_by_stable_id(dossier, type_de_champ_1.stable_id) }
+      let(:params) { { "champ_#{type_de_champ_1.to_typed_id_for_query}" => "fromage" } }
+      let(:values) { PrefillChamps.new(dossier, params).to_a }
+
+      it 'resolves the label to its item id and keeps the value after save' do
+        fill
+        champ = find_champ_by_stable_id(dossier, type_de_champ_1.stable_id)
+        expect(champ.value).to eq(referentiel.items.first.id.to_s)
+        expect(champ.prefilled).to eq(true)
+        expect(champ.referentiel_item_column_values).to eq([["option", "fromage"], ["calorie (kcal)", "145"], ["poids (g)", "60"]])
+      end
+    end
+
     context 'when dossier contains champs with external_id' do
       let(:types_de_champ_public) { [{ type: :siret }] }
       let(:values) { [[champ_1, { external_id: value_1 }]] }

--- a/spec/models/referentiel_spec.rb
+++ b/spec/models/referentiel_spec.rb
@@ -114,6 +114,26 @@ describe Referentiel do
       it '#options_for_path' do
         expect(referentiel.options_for_path('calorie_kcal')).to eq([["100", "100"], ["145", "145"], ["170", "170"]])
       end
+
+      describe '#resolve_item_id' do
+        it 'resolves an item id verbatim' do
+          expect(referentiel.resolve_item_id(item_ids.first)).to eq(item_ids.first)
+        end
+
+        it 'resolves a first-column label to its item id' do
+          expect(referentiel.resolve_item_id("fromage")).to eq(item_ids.first)
+          expect(referentiel.resolve_item_id("fruit")).to eq(item_ids.third)
+        end
+
+        it 'returns nil for an unknown value' do
+          expect(referentiel.resolve_item_id("unknown")).to be_nil
+        end
+
+        it 'returns nil for a blank value' do
+          expect(referentiel.resolve_item_id("")).to be_nil
+          expect(referentiel.resolve_item_id(nil)).to be_nil
+        end
+      end
     end
 
     context 'with missing option' do

--- a/spec/models/types_de_champ/prefill_drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_drop_down_list_type_de_champ_spec.rb
@@ -82,10 +82,29 @@ RSpec.describe TypesDeChamp::PrefillDropDownListTypeDeChamp do
     end
 
     context 'when the drop down list is advanced (referentiel-backed)' do
-      let(:type_de_champ) { build(:type_de_champ_drop_down_list, drop_down_mode: 'advanced', procedure:) }
-      let(:value) { "value" }
+      let(:referentiel) { create(:csv_referentiel, :with_items) }
+      let(:type_de_champ) { build(:type_de_champ_drop_down_list, drop_down_mode: 'advanced', referentiel:, procedure:) }
+      let(:item) { referentiel.items.first }
 
-      it { is_expected.to eq({ value: "value" }) }
+      context 'when the value is a first-column label' do
+        let(:value) { "fromage" }
+
+        it 'resolves the label to its item id' do
+          is_expected.to eq({ value: item.id.to_s })
+        end
+      end
+
+      context 'when the value is already an item id' do
+        let(:value) { referentiel.items.second.id.to_s }
+
+        it { is_expected.to eq({ value: referentiel.items.second.id.to_s }) }
+      end
+
+      context 'when the value matches no item' do
+        let(:value) { "unknown" }
+
+        it { is_expected.to be_nil }
+      end
     end
   end
 end

--- a/spec/models/types_de_champ/prefill_multiple_drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_multiple_drop_down_list_type_de_champ_spec.rb
@@ -60,5 +60,32 @@ RSpec.describe TypesDeChamp::PrefillMultipleDropDownListTypeDeChamp do
 
       it { is_expected.to be_nil }
     end
+
+    context 'when the multiple drop down list is advanced (referentiel-backed)' do
+      let(:referentiel) { create(:csv_referentiel, :with_items) }
+      let(:type_de_champ) { build(:type_de_champ_multiple_drop_down_list, drop_down_mode: 'advanced', referentiel:, procedure:) }
+
+      context 'when the values are first-column labels' do
+        let(:value) { ["fromage", "fruit"] }
+
+        it 'resolves each label to its item id, serialized as JSON' do
+          is_expected.to eq({ value: [referentiel.items.first.id.to_s, referentiel.items.third.id.to_s].to_json })
+        end
+      end
+
+      context 'when a value matches no item' do
+        let(:value) { ["fromage", "unknown"] }
+
+        it 'keeps only the resolved item ids' do
+          is_expected.to eq({ value: [referentiel.items.first.id.to_s].to_json })
+        end
+      end
+
+      context 'when no value matches an item' do
+        let(:value) { ["unknown"] }
+
+        it { is_expected.to be_nil }
+      end
+    end
   end
 end


### PR DESCRIPTION
# Problème

Le pré-remplissage (URL `/commencer/...?champ_XXX=...` ou API POST `/dossiers`) d'un champ **choix simple/multiple adossé à un référentiel** (mode `advanced`, CSV) ne fonctionnait pas : le champ restait vide malgré le libellé fourni.

Reproduit sur la démarche 142610 (Fonds Vert), champ « CRTE principal - précision » :

```
/commencer/fonds-vert-2-biodiversite?champ_Q2hhbXAtMzkwOTE2Ng=CRTE CAP Excellence&...
```

Cause racine : pour un référentiel, la valeur **stockée** par le champ est l'`id` de l'item (l'option `<select>` a pour valeur l'id, pour libellé le texte). Le screening de pré-remplissage laissait passer le libellé tel quel, puis le `before_save :store_referentiel` cherchait un item par `id` (`find_by(id: "CRTE CAP Excellence")` → introuvable) et **remettait la valeur à `nil`**. Le libellé exposé par l'UI de pré-remplissage n'était donc jamais assignable. Le choix multiple échouait encore plus tôt (aucune clé autorisée au screening).

# Solution

Sur le modèle du partage de résolution introduit dans #13511 : `Referentiel` devient l'unique propriétaire de la logique « id ou libellé » via `resolve_item_id`, réutilisée par le screening de pré-remplissage.

- Un input de pré-remplissage donné comme **libellé** est résolu vers l'`id` d'item avant assignation ; un `id` déjà fourni passe verbatim ; une valeur inconnue est rejetée (comme les listes simples).
- Choix simple **et** multiple couverts (le multiple sérialise les ids résolus en JSON, comme l'attend son setter).
- La résolution reste dans le screening, **pas** dans le setter du champ : le comportement de migration simple→advanced (qui doit vider une ancienne valeur non-id) est préservé.

Specs : `resolve_item_id`, screening simple/multiple advanced, et régression bout-en-bout (`prefill!` conserve la valeur résolue au lieu de la vider).

Generated with [Claude Code](https://claude.com/claude-code)