### PR TITLE
ETQ usager, modifier l'identité d'un dossier déposé ne plante plus

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -163,10 +163,12 @@ module Users
         if @dossier.for_tiers?
           email = sanitized_params.dig(:individual_attributes, :email)
           User.create_or_promote_to_tiers(email, SecureRandom.hex, @dossier) if email.present?
-          @dossier.reset_champs_from_france_connect(updated_by: current_user.email)
-        else
-          @dossier.prefill_champs_from_france_connect(updated_by: current_user.email)
         end
+
+        # For a brouillon the France Connect champs are synced right away; on a
+        # deposited dossier writing champs on the main stream is forbidden, the
+        # reconciliation happens when the user buffer merges.
+        @dossier.sync_champs_from_france_connect(updated_by: current_user.email) if @dossier.brouillon?
 
         @dossier.update!(autorisation_donnees: true, identity_updated_at: Time.zone.now)
 

--- a/app/models/champs/date_champ.rb
+++ b/app/models/champs/date_champ.rb
@@ -16,6 +16,9 @@ class Champs::DateChamp < ChampData
 
   def clear_prefilled_from_france_connect_information_flag_if_modified
     return if prefilling_from_france_connect_information
+    # a just-created record (e.g. a buffer champ cloned from the main stream)
+    # is a replication, not a user modification of the prefilled value
+    return if previously_new_record?
     return if !value_changed?
     return if data.blank?
 

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -183,6 +183,11 @@ module DossierChampsConcern
   end
 
   def merge_user_buffer_stream!
+    # The identity can change while the dossier is en construction: like the
+    # referentiel prefill, the France Connect champs are only reconciled when
+    # the buffer merges, so canceling the buffer does not lose or leak them.
+    with_stream(Dossier::USER_BUFFER_STREAM) { sync_champs_from_france_connect(updated_by: user&.email) }
+
     buffer_ids, changed_ids = changed_champ_data_ids_for_merge(Dossier::USER_BUFFER_STREAM)
 
     return if buffer_ids.blank?

--- a/app/models/concerns/dossier_france_connect_prefill_concern.rb
+++ b/app/models/concerns/dossier_france_connect_prefill_concern.rb
@@ -25,6 +25,13 @@ module DossierFranceConnectPrefillConcern
     )
   end
 
+  # Reconcile the France Connect prefilled champs with the current identity:
+  # prefill and reset each guard on for_tiers?, so exactly one applies.
+  def sync_champs_from_france_connect(updated_by:)
+    prefill_champs_from_france_connect(updated_by:)
+    reset_champs_from_france_connect(updated_by:)
+  end
+
   def prefill_champs_from_france_connect(updated_by:)
     return if for_tiers?
     return if !france_connected_with_one_identity?

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -250,6 +250,29 @@ describe Users::DossiersController, type: :controller do
       end
     end
 
+    context 'when the dossier is en construction with a france connect prefillable champ' do
+      let(:procedure) { create(:procedure, :for_individual, for_tiers_enabled: true, types_de_champ_public: [{ type: :date }]) }
+      let(:dossier) { create(:dossier, :en_construction, :with_individual, user:, procedure:) }
+      let(:dossier_params) do
+        {
+          for_tiers: 'true',
+          mandataire_first_name: 'Jeanne',
+          mandataire_last_name: 'Dupont',
+          individual_attributes: { gender: 'Mme', nom: 'Benef', prenom: 'Iciaire', notification_method: 'no_notification' },
+        }
+      end
+
+      before do
+        dossier.revision.root_types_de_champ_public.first
+          .update!(options: { 'birthdate' => '1', 'prefill_with_france_connect_information' => '1' })
+      end
+
+      it 'defers the champ reconciliation to the buffer merge instead of crashing (RAILS-KVR)' do
+        expect { subject }.not_to change { dossier.reload.champ_data.pluck(:stream, :value) }
+        expect(response).to redirect_to(demande_dossier_path(dossier))
+      end
+    end
+
     context "when at least one instructeur wants dossier_modifie notification" do
       let(:dossier_params) { { individual_attributes: { gender: 'M', nom: 'Mouse', prenom: 'Mickey' } } }
       let(:instructeur) { create(:instructeur) }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -438,6 +438,34 @@ describe Dossier, type: :model do
       end
     end
 
+    describe '#merge_user_buffer_stream! reconciles france connect champs' do
+      let(:procedure) { create(:procedure, :for_individual, for_tiers_enabled: true, types_de_champ_public: [{ type: :date }]) }
+      let(:user) { create(:user, france_connect_informations: [build(:france_connect_information)]) }
+      let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure:, user:) }
+      let(:tdc) { dossier.revision.root_types_de_champ_public.first }
+
+      before { tdc.update!(options: { 'birthdate' => '1', 'prefill_with_france_connect_information' => '1' }) }
+
+      context 'when the dossier became for_tiers after deposit (RAILS-KVR)' do
+        before do
+          dossier.project_champ(tdc).update_columns(value: '1976-02-24', data: { 'prefilled_from_france_connect_information' => true })
+          dossier.update_columns(for_tiers: true, mandataire_first_name: 'Jeanne', mandataire_last_name: 'Dupont')
+        end
+
+        it 'clears the prefilled champ when the buffer merges' do
+          dossier.reload.merge_user_buffer_stream!
+          expect(dossier.reload.project_champ(tdc).value).to be_nil
+        end
+      end
+
+      context 'when the dossier came back to a personal deposit' do
+        it 'prefills the champ when the buffer merges' do
+          dossier.merge_user_buffer_stream!
+          expect(dossier.reload.project_champ(tdc).value).to eq('1976-02-24')
+        end
+      end
+    end
+
     describe '#prefill_champs_from_france_connect' do
       let_it_be(:procedure) { create(:procedure, :for_individual, types_de_champ_public: [{ type: :date }]) }
       let(:user) { create(:user, france_connect_informations: [build(:france_connect_information)]) }


### PR DESCRIPTION
## Contexte

Sentry [RAILS-KVR](https://demarches-simplifiees.sentry.io/issues/RAILS-KVR) : 40 usagers depuis le 1er juin (arrivée des streams). Modifier l'identité d'un dossier **en construction** déclenchait immédiatement la synchronisation des champs préremplis FranceConnect (`reset`/`prefill_champs_from_france_connect`), qui écrivait des champs publics sur le stream principal — interdit par le garde-fou des streams → 500 systématique.

## Correction

Sur le modèle du prefill référentiel des annotations privées, la réconciliation des champs FranceConnect se fait désormais **à la fusion du buffer usager** (`merge_user_buffer_stream!`) :

- `sync_champs_from_france_connect` (prefill + reset, chacun gardé par `for_tiers?`) s'exécute sur le buffer **avant** le calcul des ids de fusion : les champs synchronisés sont emportés par la fusion, les anciennes valeurs sont historisées, et le changement apparaît dans le delta soumis ;
- annuler le buffer ne perd ni ne fuite le changement : la réconciliation converge à chaque fusion avec l'identité courante ;
- les brouillons gardent la synchronisation immédiate (écriture sur main autorisée).

Pourquoi pas dans `merge_buffer_champ_data` à côté du prefill référentiel : ce bloc écrit des champs **privés** (toujours autorisés sur main) ; les champs FC sont publics et y déclencheraient le même garde-fou, en plus de perdre l'historisation (ids de fusion déjà calculés).

Correction annexe débusquée par les specs : le callback `DateChamp` qui efface le flag `prefilled_from_france_connect_information` à la modification traitait le **clone** d'un champ vers le buffer comme une modification usager et effaçait le flag — gardé par `previously_new_record?`.

Fixes RAILS-KVR

🤖 Generated with [Claude Code](https://claude.com/claude-code)