### PR TITLE
ETQ admin, supprimer deux fois un champ ne provoque plus d'erreur

### DIFF
--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -131,8 +131,9 @@ module Administrateurs
         flash.alert = errors
       else
         @coordinate = draft.remove_type_de_champ(params[:stable_id])
-        ProcedureRevisionPreloader.load_one(@coordinate.revision)
+        # nil in case of replay (double click, champ already removed)
         if @coordinate.present?
+          ProcedureRevisionPreloader.load_one(@coordinate.revision)
           @destroyed = @coordinate
           @morphed = champ_components_starting_at(@coordinate)
         end

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -402,6 +402,20 @@ describe Administrateurs::TypesDeChampController, type: :controller do
       expect(morpheds).to eq([['l3', ['l1']]])
     end
 
+    context 'when the champ was already removed (replayed double click)' do
+      let(:params) { { procedure_id: procedure.id, stable_id: @removed_stable_id } }
+
+      before do
+        @removed_stable_id = second_coordinate.stable_id
+        procedure.draft_revision.remove_type_de_champ(@removed_stable_id)
+      end
+
+      it 'is a no-op instead of failing (RAILS-JYT)' do
+        is_expected.to have_http_status(:ok)
+        expect(assigns(:destroyed)).to be_nil
+      end
+    end
+
     context 'rejected if type changed and routing involved' do
       let(:params) do
         { procedure_id: procedure.id, stable_id: third_coordinate.stable_id }


### PR DESCRIPTION
## Contexte

Sentry [RAILS-JYT](https://demarches-simplifiees.sentry.io/issues/RAILS-JYT) : 130 événements, 51 admins depuis mars. Un double-clic sur la suppression d'un champ (ou une suppression déjà effectuée dans un autre onglet) provoquait une 500.

`remove_type_de_champ` retourne `nil` en cas de replay — cas prévu — et le contrôleur garde bien sur `@coordinate.present?`… mais le préchargement de la révision ajouté en janvier 2024 (01752bc2e8) s'exécutait une ligne **au-dessus** de la garde : `nil.revision`.

## Correction

Le préchargement est déplacé dans la branche gardée ; le replay devient un no-op. La spec rejoue la suppression et échouait avec le `NoMethodError` exact de production sans le correctif.

Fixes RAILS-JYT

🤖 Generated with [Claude Code](https://claude.com/claude-code)