### PR TITLE
ETQ instructeur, demander un export sans modèle ni format n'échoue plus

### DIFF
--- a/app/components/dossiers/export_dropdown_component/export_dropdown_component.html.erb
+++ b/app/components/dossiers/export_dropdown_component/export_dropdown_component.html.erb
@@ -186,9 +186,11 @@
                     </button>
                   </li>
 
-                  <li>
-                    <%= f.submit t('.submit_export'), "data-action": "click->menu-button#close", class: 'fr-btn' %>
-                  </li>
+                  <% if export_templates.present? %>
+                    <li>
+                      <%= f.submit t('.submit_export'), "data-action": "click->menu-button#close", class: 'fr-btn' %>
+                    </li>
+                  <% end %>
                 </ul>
               </div>
             <% end %>

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -225,6 +225,12 @@ module Instructeurs
     end
 
     def download_export
+      # stale page or hand built url: without a format the export can not be created
+      if export_format.blank?
+        flash.alert = "Le format de l’export n’est pas renseigné."
+        return redirect_to exports_instructeur_procedure_path(procedure)
+      end
+
       groupe_instructeurs = current_instructeur
         .groupe_instructeurs
         .where(procedure: procedure)

--- a/spec/components/dossiers/export_dropdown_component_spec.rb
+++ b/spec/components/dossiers/export_dropdown_component_spec.rb
@@ -7,6 +7,30 @@ RSpec.describe Dossiers::ExportDropdownComponent, type: :component do
   let(:export_url) { double() }
   before(:each) { allow(export_url).to receive(:call).and_return('http://example.com/export') }
 
+  describe 'export template tab' do
+    subject do
+      component = described_class.new(procedure:, statut: 'tous', export_url:, export_templates:)
+      allow(component).to receive(:params).and_return({ procedure_id: procedure.id })
+      render_inline(component)
+    end
+
+    context 'when the instructeur has no export template' do
+      let(:export_templates) { [] }
+
+      it 'does not render a submit button posting without a format (RAILS-JZW)' do
+        expect(subject.css('#tabpanel-template-panel input[type=submit]')).to be_empty
+      end
+    end
+
+    context 'when the instructeur has export templates' do
+      let(:export_templates) { [create(:export_template)] }
+
+      it 'renders the submit button' do
+        expect(subject.css('#tabpanel-template-panel input[type=submit]')).to be_present
+      end
+    end
+  end
+
   describe '#include_archived_title' do
     context 'when archived_count is greater than 1' do
       it 'returns the pluralized archived title' do

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -1053,6 +1053,15 @@ describe Instructeurs::ProceduresController, type: :controller do
       get :download_export, params: { export_format: :csv, procedure_id: procedure.id }
     end
 
+    context 'when no export format is given' do
+      subject { get :download_export, params: { procedure_id: procedure.id } }
+
+      it 'redirects with an alert instead of failing (RAILS-JZW)' do
+        is_expected.to redirect_to(exports_instructeur_procedure_url(procedure))
+        expect(flash.alert).to be_present
+      end
+    end
+
     context 'when the export does not exist' do
       it 'displays an notice' do
         is_expected.to redirect_to(exports_instructeur_procedure_url(procedure))


### PR DESCRIPTION
## Contexte

Sentry [RAILS-JZW](https://demarches-simplifiees.sentry.io/issues/RAILS-JZW) : 58 instructeurs depuis avril. `download_export` appelé sans `export_format` ni `export_template_id` créait un `Export` sans format → `RecordInvalid: Le champ « Format » doit être rempli` non rescué.

L'analyse des événements (POST avec seulement `statut`, navigateurs réels) montre que la cause principale n'est pas une URL construite à la main : l'onglet « modèles d'export » du menu de téléchargement affiche son bouton « Demander l'export » même quand l'instructeur n'a aucun modèle — le POST part alors sans format.

## Correction

- Le bouton de soumission de l'onglet modèles n'est plus affiché quand il n'y a aucun modèle à sélectionner (le message « aucun modèle » et le lien de configuration restent).
- En garde-fou (pages périmées, URL construites à la main) : sans format, redirection vers la page des exports avec un message au lieu d'un 500.

Fixes RAILS-JZW

🤖 Generated with [Claude Code](https://claude.com/claude-code)
