### PR TITLE
ETQ admin, publier deux fois une démarche ne provoque plus d'erreur

### DIFF
--- a/app/models/concerns/procedure_publish_concern.rb
+++ b/app/models/concerns/procedure_publish_concern.rb
@@ -18,8 +18,9 @@ module ProcedurePublishConcern
       if other_procedure.present?
         other_procedure.unpublish! if other_procedure.may_unpublish?
 
-        publish!(administrateur, other_procedure.canonical_procedure || other_procedure)
-      else
+        # may_publish? is false on replay: the procedure is already publiee
+        publish!(administrateur, other_procedure.canonical_procedure || other_procedure) if may_publish?
+      elsif may_publish?
         publish!(administrateur, nil)
       end
     end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1009,6 +1009,15 @@ describe Procedure do
     let(:procedure) { create(:procedure, administrateurs: [administrateur], zones: [zones.default]) }
     let(:now) { Time.zone.now.beginning_of_minute }
 
+    context 'when the procedure is already published (replayed publish)' do
+      let(:procedure) { create(:procedure, :published, administrateurs: [administrateur], zones: [zones.default]) }
+
+      it 'is a no-op instead of failing (RAILS-K6N)' do
+        expect { procedure.publish_or_reopen!(administrateur, procedure.path) }.not_to raise_error
+        expect(procedure.reload).to be_publiee
+      end
+    end
+
     context 'when publishing over a previous canonical procedure' do
       before do
         travel_to(now) do


### PR DESCRIPTION
## Contexte

Sentry [RAILS-K6N](https://demarches-simplifiees.sentry.io/issues/RAILS-K6N) : republier une démarche déjà publiée (double clic, formulaire rejoué) déclenchait `publish!` depuis l'état `publiee` → `AASM::InvalidTransition` non rescuée → 500.

## Correction

`publish_or_reopen!` garde ses `publish!` avec `may_publish?`, sur le modèle du `may_unpublish?` déjà présent deux lignes plus haut : le replay devient un no-op. La spec reproduit l'`InvalidTransition` exacte sans le correctif.

Fixes RAILS-K6N

🤖 Generated with [Claude Code](https://claude.com/claude-code)