### PR TITLE
ETQ usager, l'autocomplétion référentiel supporte un modèle avec paragraphe vide

### DIFF
--- a/app/services/referentiel_autocomplete_render_service.rb
+++ b/app/services/referentiel_autocomplete_render_service.rb
@@ -36,7 +36,8 @@ class ReferentielAutocompleteRenderService
     when "text"
       interpolations << template["text"]
     when "doc", 'paragraph'
-      template['content'].each { |t| interpolations.concat(render_template(t, obj)) }
+      # an empty paragraph in the template editor has no content key
+      template['content']&.each { |t| interpolations.concat(render_template(t, obj)) }
     else
       raise "Unknown template type: #{template['type']}. Expected one of: mention, text, doc, paragraph."
     end

--- a/spec/services/referentiel_autocomplete_render_service_spec.rb
+++ b/spec/services/referentiel_autocomplete_render_service_spec.rb
@@ -65,6 +65,25 @@ RSpec.describe ReferentielAutocompleteRenderService do
       ).to include('Tango (Charlie)')
     end
 
+    context 'with an empty paragraph in the template' do
+      it 'skips it instead of failing (RAILS-KDV)' do
+        obj = { 'finess' => 'Tango' }
+        referentiel.json_template = {
+          "type" => "doc",
+          "content" => [
+            { "type" => "paragraph" },
+            {
+              "type" => "paragraph",
+              "content" => [{ "type" => "mention", "attrs" => { "id" => "$.finess", "label" => "$.finess" } }],
+            },
+          ],
+        }
+        expect(
+          subject.send(:render_template, referentiel.json_template, obj).join('')
+        ).to include('Tango')
+      end
+    end
+
     context 'with incompatible keys with passwed to JsonPath' do
       it 'works' do
         obj = {


### PR DESCRIPTION
## Contexte

Sentry [RAILS-KDV](https://demarches-simplifiees.sentry.io/issues/RAILS-KDV) : un paragraphe vide dans l'éditeur de modèle d'affichage d'un référentiel (nœud TipTap `paragraph` sans clé `content`) faisait planter le rendu des libellés d'autocomplétion : `NoMethodError: undefined method 'each' for nil` à chaque recherche de l'usager.

## Correction

Navigation sûre sur `content` : un paragraphe vide est ignoré. La spec reproduit le `NoMethodError` exact sans le correctif.

Fixes RAILS-KDV

🤖 Generated with [Claude Code](https://claude.com/claude-code)