### PR TITLE
ETQ instructeur, un dossier avec des coordonnées géographiques invalides s'affiche à nouveau

### DIFF
--- a/app/models/geo_area.rb
+++ b/app/models/geo_area.rb
@@ -107,7 +107,13 @@ class GeoArea < ApplicationRecord
 
   def location
     if point?
-      Geo::Coord.new(*geometry['coordinates'][0..1].reverse).to_s
+      coordinates = geometry['coordinates'][0..1]
+      begin
+        Geo::Coord.new(*coordinates.reverse).to_s
+      rescue ArgumentError
+        # out of range coordinates (e.g. projected meters imported from a bad geojson)
+        coordinates.join(', ')
+      end
     end
   end
 

--- a/spec/models/geo_area_spec.rb
+++ b/spec/models/geo_area_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe GeoArea, type: :model do
     let(:geo_area) { build(:geo_area, :point, champ_data: nil) }
 
     it { expect(geo_area.location).to eq("46°32'19\"N 2°25'42\"E") }
+
+    context 'with out of range coordinates (RAILS-M8G)' do
+      let(:geo_area) { build(:geo_area, :point_invalid, champ_data: nil) }
+
+      it 'falls back to the raw coordinates instead of failing' do
+        expect(geo_area.location).to eq('200, 100')
+      end
+    end
   end
 
   describe 'validations' do


### PR DESCRIPTION
## Contexte

Sentry [RAILS-M8G](https://demarches-simplifiees.sentry.io/issues/RAILS-M8G) : un champ carte contenant un point en coordonnées projetées (mètres Lambert/WebMercator importés d'un GeoJSON erroné, ex. latitude 6 949 870) faisait lever `ArgumentError` par `Geo::Coord` au rendu du dossier — l'instructeur ne pouvait plus l'ouvrir.

## Correction

`GeoArea#location` retombe sur les coordonnées brutes quand elles sont hors bornes. La spec (trait `point_invalid` existant) reproduit l'`ArgumentError` exact sans le correctif.

Fixes RAILS-M8G

🤖 Generated with [Claude Code](https://claude.com/claude-code)