### PR TITLE
ETQ usager, vider un champ adresse ne plante plus la sauvegarde

### DIFF
--- a/app/models/champs/address_champ.rb
+++ b/app/models/champs/address_champ.rb
@@ -283,7 +283,8 @@ class Champs::AddressChamp < Champs::TextChamp
   end
 
   def set_full_address
-    address_data = self.value_json
+    # value_json is nil on a blank champ (e.g. cleared by the user)
+    address_data = self.value_json || {}
     if become_france? || become_international?
       address_data.merge!(
         'department_code' => nil,

--- a/spec/models/champs/address_champ_spec.rb
+++ b/spec/models/champs/address_champ_spec.rb
@@ -8,6 +8,15 @@ describe Champs::AddressChamp do
   let(:value) { nil }
   let(:value_json) { nil }
 
+  describe 'clearing the address' do
+    before { champ.update_columns(value_json: { 'city_code' => '75107' }) }
+
+    it 'accepts a nil value_json without failing (RAILS-MA8)' do
+      expect { champ.update!(value_json: nil) }.not_to raise_error
+      expect(champ.reload.value_json).to be_nil
+    end
+  end
+
   context "with value but no data" do
     let(:value) { 'Paris' }
 


### PR DESCRIPTION
## Contexte

Sentry [RAILS-MA8](https://demarches-simplifiees.sentry.io/issues/RAILS-MA8) : `set_full_address` plantait (`NoMethodError: undefined method 'compact' for nil`) quand `value_json` était nil — champ adresse vidé ou vierge — pendant l'autosave du brouillon.

## Correction

`address_data` part d'un hash vide quand `value_json` est nil ; la garde existante `if address_data.present?` évite toujours de fabriquer une adresse « France » sur un champ vierge, et `compact.presence` re-normalise vers nil. La spec reproduit le `NoMethodError` exact sans le correctif.

Fixes RAILS-MA8

🤖 Generated with [Claude Code](https://claude.com/claude-code)