### PR TITLE
Tech : format turbo_stream par défaut sur les endpoints qui ne rendent que du turbo_stream

### DIFF
--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -102,7 +102,8 @@ module Administrateurs
           # - draft updated
           # - or, attestation already published, without need for publication (draft procedure)
           @attestation_template.save!
-          render :update
+          # only a turbo_stream template exists; a non-turbo submit would otherwise 500
+          render :update, formats: :turbo_stream
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,7 +219,7 @@ Rails.application.routes.draw do
     # TODO remove in next release
     get ':dossier_id/:stable_id/siret', to: 'siret#show'
 
-    get ':dossier_id/:stable_id/carte/features', to: 'carte#index', as: :carte_features
+    get ':dossier_id/:stable_id/carte/features', to: 'carte#index', as: :carte_features, defaults: { format: :turbo_stream }
     post ':dossier_id/:stable_id/carte/features', to: 'carte#create'
     patch ':dossier_id/:stable_id/carte/features/:id', to: 'carte#update', as: :carte_feature
     delete ':dossier_id/:stable_id/carte/features/:id', to: 'carte#destroy'
@@ -482,7 +482,7 @@ Rails.application.routes.draw do
         patch :update_order_positions
         get :select_procedure
         get :synthese
-        get :counters
+        get :counters, defaults: { format: :turbo_stream }
       end
 
       get 'display_notifications', defaults: { format: :turbo_stream }
@@ -578,7 +578,7 @@ Rails.application.routes.draw do
             get 'telecharger_pjs' => 'dossiers#telecharger_pjs'
             get 'print' => 'dossiers#print'
             patch 'annotations' => 'dossiers#update_annotations'
-            get 'annotations/:stable_id', to: 'dossiers#annotation', as: :annotation
+            get 'annotations/:stable_id', to: 'dossiers#annotation', as: :annotation, defaults: { format: :turbo_stream }
             get 'geo_data'
             get 'apercu_attestation'
             get 'bilans_bdf'
@@ -605,7 +605,7 @@ Rails.application.routes.draw do
         get 'apercu'
         get 'download_export'
         post 'download_export'
-        get 'polling_last_export'
+        get 'polling_last_export', defaults: { format: :turbo_stream }
         get 'polling_batch_operation'
         get 'stats'
         get 'exports'
@@ -742,9 +742,9 @@ Rails.application.routes.draw do
       post 'clone'
       put 'archive'
       get 'publication' => 'procedures#publication', as: :publication
-      post 'check_path' => 'procedures#check_path', as: :check_path
+      post 'check_path' => 'procedures#check_path', as: :check_path, defaults: { format: :turbo_stream }
       # TODO remove in next release
-      get 'check_path' => 'procedures#check_path'
+      get 'check_path' => 'procedures#check_path', defaults: { format: :turbo_stream }
       get 'path'
       patch 'path', to: 'procedures#update_path', as: :update_path
       put 'publish' => 'procedures#publish', as: :publish
@@ -874,7 +874,7 @@ Rails.application.routes.draw do
       end
 
       resource :dossier_submitted_message, only: [:edit, :update, :create] do
-        post :preview, on: :member
+        post :preview, on: :member, defaults: { format: :turbo_stream }
       end
       # ADDED TO ACCESS IT FROM THE IFRAME
       get 'attestation_template/preview' => 'attestation_templates#preview'

--- a/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
+++ b/spec/controllers/administrateurs/attestation_template_v2s_controller_spec.rb
@@ -339,6 +339,15 @@ describe Administrateurs::AttestationTemplateV2sController, type: :controller do
       response.body
     end
 
+    context 'without explicit format (non-turbo submission)' do
+      it 'renders the turbo_stream response instead of raising (RAILS-MAB)' do
+        patch :update, params: { procedure_id: procedure.id, attestation_template: update_params, attestation_kind: :acceptation }
+
+        expect(response).to have_http_status(:success)
+        expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+      end
+    end
+
     context 'when attestation template is valid' do
       it "create a draft template" do
         expect { subject }.to change { procedure.attestation_templates.count }.by(1)

--- a/spec/routing/turbo_stream_defaults_spec.rb
+++ b/spec/routing/turbo_stream_defaults_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# These endpoints only render turbo_stream: without a default format, a plain
+# browser navigation (or a non-JS form submit) raises UnknownFormat (406).
+RSpec.describe 'turbo_stream route defaults', type: :routing do
+  {
+    [:get, '/champs/1/12/carte/features'] => 'champs/carte#index',
+    [:get, '/procedures/counters'] => 'instructeurs/procedures#counters',
+    [:get, '/procedures/1/polling_last_export'] => 'instructeurs/procedures#polling_last_export',
+    [:get, '/procedures/1/dossiers/1/annotations/12'] => 'instructeurs/dossiers#annotation',
+    [:get, '/admin/procedures/1/check_path'] => 'administrateurs/procedures#check_path',
+    [:post, '/admin/procedures/1/check_path'] => 'administrateurs/procedures#check_path',
+    [:post, '/admin/procedures/1/dossier_submitted_message/preview'] => 'administrateurs/dossier_submitted_messages#preview',
+  }.each do |(method, path), controller_action|
+    it "defaults #{method.to_s.upcase} #{path} to turbo_stream" do
+      controller, action = controller_action.split('#')
+      params = Rails.application.routes.recognize_path(path, method:)
+      expect(params).to include(controller:, action:, format: :turbo_stream)
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Les endpoints qui ne rendent que du turbo_stream échouent quand le format de la requête est html : 406 (`UnknownFormat`) sur une navigation directe, ou 500 (`MissingTemplate`, Sentry [RAILS-MAB](https://demarches-simplifiees.sentry.io/issues/RAILS-MAB)) sur une soumission de formulaire sans JS. Les 406 n'apparaissent jamais dans Sentry (Rails les rescue), mais l'utilisateur voit une page d'erreur.

## Correction

- `defaults: { format: :turbo_stream }` au niveau des routes (même approche que `display_notifications`) pour : `champs/carte#index`, `instructeurs/procedures#counters` et `#polling_last_export`, `instructeurs/dossiers#annotation`, `administrateurs/procedures#check_path` (GET et POST), `administrateurs/dossier_submitted_messages#preview`.
- `render :update, formats: :turbo_stream` dans `AttestationTemplateV2sController` (seul un template turbo_stream existe).

Les URLs générées par les helpers restent inchangées (le segment optionnel `.:format` est omis quand il vaut la valeur par défaut).

Fixes RAILS-MAB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
