### PR TITLE
Tech : createDirectUpload avec un jeton en lecture seule renvoie une erreur claire

### DIFF
--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -157,13 +157,17 @@ class API::V2::Schema < GraphQL::Schema
 
     # Capture type errors in Sentry. Thouse errors are our responsability and usually linked to
     # instances of "bad data".
-    Sentry.capture_exception(error, extra: ctx.query_info)
-
     if error.is_a?(GraphQL::InvalidNullError)
+      # Relay mutation payload classes are anonymous, so the error class name
+      # (#<Class:0x...>::InvalidNullError) varies per process and Sentry splits one
+      # defect into many issues; group by message instead.
+      Sentry.capture_exception(error, extra: ctx.query_info, fingerprint: ['GraphQL::InvalidNullError', error.message])
+
       execution_error = GraphQL::ExecutionError.new(error.message, ast_node: error.ast_node, extensions: { code: :invalid_null })
       execution_error.path = ctx[:current_path]
       ctx.errors << execution_error
     else
+      Sentry.capture_exception(error, extra: ctx.query_info)
       super
     end
   end

--- a/app/graphql/mutations/create_direct_upload.rb
+++ b/app/graphql/mutations/create_direct_upload.rb
@@ -21,6 +21,17 @@ module Mutations
 
     field :direct_upload, DirectUpload, null: false
 
+    # Unlike other mutations, the payload has no errors field and directUpload is
+    # non-null: reporting a read-only token in the payload would violate nullability,
+    # so surface it as a top-level error instead.
+    def ready?(**args)
+      if context.write_access?
+        true
+      else
+        raise GraphQL::ExecutionError.new('Le jeton utilisé est configuré seulement en lecture', extensions: { code: :unauthorized })
+      end
+    end
+
     def resolve(filename:, byte_size:, checksum:, content_type:, dossier:)
       blob = ActiveStorage::Blob.create_before_direct_upload!(
         filename: filename,

--- a/spec/controllers/api/v2/graphql_controller_stored_mutations_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_mutations_spec.rb
@@ -869,6 +869,16 @@ describe API::V2::GraphqlController do
         expect(direct_upload_data[:signedBlobId]).not_to be_nil
       end
 
+      context "with a read-only token" do
+        before { api_token.update(write_access: false) }
+
+        it "returns an unauthorized error instead of a null violation (RAILS-MAY)" do
+          expect(gql_data[:createDirectUpload]).to be_nil
+          expect(gql_errors.first[:message]).to eq('Le jeton utilisé est configuré seulement en lecture')
+          expect(gql_errors.first[:extensions][:code]).to eq('unauthorized')
+        end
+      end
+
       context "when the s3_storage feature is enabled on the procedure" do
         before { Flipper.enable(:s3_storage, procedure) }
 


### PR DESCRIPTION
## Contexte

Sentry [RAILS-MAY](https://demarches-simplifiees.sentry.io/issues/RAILS-MAY) (et RAILS-MAA, RAILS-MAM, RAILS-MAV — même défaut, ~150 événements sur 5 jours) : `createDirectUpload` appelé avec un jeton en lecture seule. Contrairement aux autres mutations, son payload n'a pas de champ `errors` et `directUpload` est non-null : le payload `{ errors: [...] }` renvoyé par `ready?` viole la nullabilité, et le client reçoit un message opaque « Cannot return null for non-nullable field ».

Les quatre issues Sentry sont le même défaut : les classes de payload Relay sont anonymes, donc le nom de la classe d'erreur (`#<Class:0x...>::InvalidNullError`) change à chaque process et casse le regroupement.

## Correction

- `createDirectUpload` avec un jeton en lecture seule renvoie désormais une erreur GraphQL top-level explicite (« Le jeton utilisé est configuré seulement en lecture », code `unauthorized`), sans changement de schéma.
- Les captures Sentry des `InvalidNullError` sont fingerprintées par message pour regrouper correctement les futures occurrences.

Fixes RAILS-MAY
Fixes RAILS-MAA
Fixes RAILS-MAM
Fixes RAILS-MAV

🤖 Generated with [Claude Code](https://claude.com/claude-code)
