### PR TITLE
Tech: corrige un contournement de périmètre du jeton d'API sur groupeInstructeurCreer

### DIFF
--- a/app/graphql/mutations/groupe_instructeur_creer.rb
+++ b/app/graphql/mutations/groupe_instructeur_creer.rb
@@ -20,7 +20,12 @@ module Mutations
 
     def resolve(demarche:, groupe_instructeur:)
       demarche_number = demarche.number.presence || ApplicationRecord.id_from_typed_id(demarche.id)
-      procedure = current_administrateur.procedures.find(demarche_number)
+      procedure = Procedure.find_by(id: demarche_number)
+
+      if procedure.blank? || !context.authorized_demarche?(procedure)
+        return { errors: ["La démarche \"#{demarche_number}\" n'existe pas ou vous n'avez pas le droit de la modifier."] }
+      end
+
       ids, emails = partition_instructeurs_by(groupe_instructeur.instructeurs)
 
       groupe_instructeur = procedure

--- a/spec/controllers/api/v2/graphql_controller_stored_mutations_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_mutations_spec.rb
@@ -548,6 +548,22 @@ describe API::V2::GraphqlController do
         }
       end
 
+      context 'when the token is not scoped to the target procedure' do
+        let(:other_procedure) { create(:procedure, :published, administrateurs: [admin]) }
+        let(:variables) { { input: { demarche: { id: other_procedure.to_typed_id }, groupeInstructeur: { label: 'groupe hors périmètre', instructeurs: [{ email: 'attacker@evil.com' }] } }, includeInstructeurs: true } }
+
+        # Token targeted to `procedure` only; `other_procedure` is owned by the same
+        # admin but out of the token's scope.
+        before { api_token.update(allowed_procedure_ids: [procedure.id]) }
+
+        it 'refuses to create the groupe instructeur and does not add the instructeur' do
+          expect(gql_data[:groupeInstructeurCreer][:groupeInstructeur]).to be_nil
+          expect(gql_data[:groupeInstructeurCreer][:errors]).to be_present
+          expect(other_procedure.groupe_instructeurs.count).to eq(1)
+          expect(Instructeur.joins(:user).where(users: { email: 'attacker@evil.com' })).to be_empty
+        end
+      end
+
       context 'with api hack' do
         include Logic
         let(:procedure) { create(:procedure, :published, :for_individual, administrateurs: [admin], types_de_champ_public: [{ type: :drop_down_list }]) }


### PR DESCRIPTION
## Problème

La mutation `groupeInstructeurCreer` résolvait la démarche cible via `current_administrateur.procedures.find`, ce qui **ignore le périmètre du jeton d'API**. Toutes les autres mutations au niveau démarche vérifient `context.authorized_demarche?`, qui respecte les `procedure_ids` du jeton.

Conséquence : un jeton d'écriture *ciblé* (restreint à un sous-ensemble de démarches) pouvait créer un groupe instructeur et y ajouter des instructeurs arbitraires sur **n'importe quelle démarche appartenant à l'administrateur**, hors du périmètre du jeton — donnant à ces instructeurs un accès aux dossiers de démarches hors périmètre.

## Correctif

- Résolution via `Procedure.find_by(id:)` puis contrôle `context.authorized_demarche?`, comme `demarchePublier` / `demarcheModifierParametres`.
- Corrige au passage une erreur 500 latente sur un numéro de démarche inconnu.

## Test

Ajout d'un cas de non-régression : un jeton restreint à `procedure` tente de créer un groupe (et d'ajouter un instructeur) sur une démarche sœur hors périmètre → la mutation renvoie une erreur, aucun groupe ni instructeur n'est créé. Vérifié : le test échoue sans le correctif, passe avec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)