### PR TITLE
Tech: réactive la limite de complexité des requêtes GraphQL (budget 60k)

### DIFF
--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -3,9 +3,18 @@
 class API::V2::Schema < GraphQL::Schema
   default_max_page_size 100
   default_page_size 100
-  # Disable max_complexity for now because of what looks like a bug in graphql gem.
-  # After some internal changes complexity for our avarage query went from < 300 to 25 000.
-  max_complexity nil
+  # Connection fields multiply their child complexity by the requested page size, so a
+  # full page (first: 100) of our richest query is expensive by design:
+  #   - getDossier (single dossier, all includes): ~430
+  #   - getDemarche dossiers(first: 100), all includes on: ~37 600  <- legitimate ceiling
+  # The budget is set to ~1.6x that ceiling: enough headroom for schema growth and the
+  # heaviest legitimate query, while rejecting the real abuse vector (aliasing several
+  # full-page connections into one request, e.g. 2x the canonical query ~= 75 000).
+  # GRAPHQL_MAX_COMPLEXITY overrides it without a release if a legitimate integration
+  # ever trips it: raise it, or set it to 0 to lift the limit entirely.
+  DEFAULT_MAX_COMPLEXITY = 60_000
+  MAX_COMPLEXITY = ENV['GRAPHQL_MAX_COMPLEXITY'].presence&.to_i || DEFAULT_MAX_COMPLEXITY
+  max_complexity MAX_COMPLEXITY.nonzero?
   max_depth 15
 
   query Types::QueryType

--- a/config/env.example
+++ b/config/env.example
@@ -105,3 +105,9 @@ STRICT_EMAIL_VALIDATION_STARTS_ON="2024-02-19"
 # Weasyprint endpoint generating attestations v2
 # See https://github.com/demarche-numerique/weasyprint_server
 WEASYPRINT_URL="http://127.0.0.1:5000/pdf"
+
+# Budget of the GraphQL API query complexity analyzer (defaults to 60000).
+# Raise it if a legitimate integration starts getting "complexity" errors, or set it
+# to 0 to lift the limit entirely. See app/graphql/api/v2/schema.rb for how the
+# default was measured.
+# GRAPHQL_MAX_COMPLEXITY="60000"

--- a/spec/graphql/api/v2/schema_spec.rb
+++ b/spec/graphql/api/v2/schema_spec.rb
@@ -1,5 +1,59 @@
 # frozen_string_literal: true
 
+RSpec.describe API::V2::Schema do
+  describe 'query complexity budget' do
+    def complexity_of(operation_name, variables)
+      query = GraphQL::Query.new(
+        described_class,
+        API::V2::StoredQuery::QUERY_V2,
+        variables: variables.transform_keys(&:to_s),
+        operation_name:,
+        context: { internal_use: false }
+      )
+      expect(query.static_errors).to be_empty
+      GraphQL::Analysis::AST.analyze_query(query, [GraphQL::Analysis::AST::QueryComplexity]).first
+    end
+
+    it 'keeps the complexity limit enabled' do
+      expect(described_class.max_complexity).to be_a(Integer).and(be > 0)
+    end
+
+    # Canary: the heaviest query our own client sends (getDemarche, a full page of
+    # dossiers with every include on) must stay under budget. If this fails, the schema
+    # grew past the budget — re-measure and raise max_complexity deliberately rather than
+    # letting legitimate integrations start getting complexity errors in production.
+    it 'admits the heaviest legitimate query with headroom' do
+      complexity = complexity_of('getDemarche', {
+        demarcheNumber: 1, includeDossiers: true, first: 100,
+        includeChamps: true, includeAnotations: true, includeTraitements: true,
+        includeInstructeurs: true, includeAvis: true, includeMessages: true,
+        includeCorrections: true, includeGeometry: true, includeGroupeInstructeurs: true,
+        includeService: true, includeRevision: true, includeRevisions: true,
+        includePendingDeletedDossiers: true, includeDeletedDossiers: true,
+        pendingDeletedFirst: 100, deletedFirst: 100,
+      })
+
+      # Sanity check that the query is genuinely heavy (guards a broken measurement).
+      expect(complexity).to be > 20_000
+      expect(complexity).to be < described_class.max_complexity
+    end
+
+    # The abuse vector: over-requesting the page size multiplies the per-node cost. The
+    # query is rejected during analysis, before any resolver or DB access runs.
+    it 'rejects an over-budget query before executing it' do
+      result = described_class.execute(
+        API::V2::StoredQuery::QUERY_V2,
+        operation_name: 'getDemarche',
+        variables: { 'demarcheNumber' => 1, 'includeDossiers' => true, 'first' => 250 },
+        context: { internal_use: false }
+      )
+
+      expect(result['data']).to be_nil
+      expect(result['errors'].map { _1['message'] }.join).to match(/complexity/i)
+    end
+  end
+end
+
 RSpec.describe API::V2::Schema::Timeout do
   describe '#filter_sensitive_query_string' do
     let(:timeout_instance) { described_class.new(max_seconds: 30) }


### PR DESCRIPTION
## Contexte

La limite de complexité de l'API GraphQL v2 était **désactivée** (`max_complexity nil`), avec une note indiquant que la complexité de nos requêtes moyennes était passée de <300 à ~25000 après une mise à jour de `graphql-ruby`.

Ce saut n'est pas un bug : les champs de type *connection* multiplient désormais la complexité de leurs enfants par la taille de page demandée. Une page complète (`first: 100`) de notre requête la plus riche est donc légitimement coûteuse. L'ancien budget était calibré sur le modèle précédent (sans multiplication).

Sans cette limite, seuls `max_depth 15`, le timeout de 30s et le rate-limiting protègent l'endpoint contre une requête volontairement lourde (la revue de perf classait ce point en **critique / DoS**).

## Mesures (modèle actuel)

| Requête | Complexité |
|---|---|
| `getDossier` (1 dossier, tous les includes) | ~430 |
| `getDemarche` `dossiers(first: 100)`, includes par défaut | ~32 800 |
| `getDemarche` `dossiers(first: 100)`, **tous** les includes | **~37 600** ← plafond légitime |
| 2× requête canonique aliasée (abus) | ~75 000 |

## Choix du budget : `max_complexity = 60000`

~1,6× le plafond légitime : de la marge pour la requête la plus lourde et l'évolution du schéma, tout en rejetant le vrai vecteur d'abus (plusieurs connections pleine page aliasées dans une même requête) et les tailles de page démesurées. Le rejet a lieu pendant l'analyse, **avant** tout resolver ou accès base.

## Tests

- Canari : la requête la plus lourde de notre propre client (`getDemarche`, `first: 100`, tous les includes) reste sous le budget avec de la marge. Si le schéma grossit au point de dépasser le budget, ce test échoue — on relève alors la limite délibérément plutôt que de laisser des intégrations légitimes tomber en erreur en production.
- Une requête au-dessus du budget est rejetée avec une erreur de complexité, sans exécution.
- Les 118 specs de `graphql_controller_stored_queries_spec` (requêtes réelles sur données complètes) passent : aucune requête légitime n'est rejetée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)