### PR TITLE
Tech: indexe les colonnes de tri des connections dossiers (API v2)

### DIFF
--- a/db/migrate/20260722000000_add_dossiers_connection_ordering_indexes.rb
+++ b/db/migrate/20260722000000_add_dossiers_connection_ordering_indexes.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# The GraphQL API v2 dossiers connections keyset-paginate over
+# (depose_at, id) — or (updated_at, id) when `updatedSince` is given — always
+# scoped to `visible_by_administration` (hidden_by_administration_at IS NULL AND
+# hidden_by_expired_at IS NULL). The connection is reached two ways, each
+# filtering on a different tenant column:
+#   - demarche.dossiers      -> joins procedure_revisions, filters revision_id
+#   - groupeInstructeur.dossiers -> filters groupe_instructeur_id
+#
+# Without these indexes every page does a filtered sort over the heap. EXPLAIN
+# confirms the plain (depose_at/updated_at, id) index lets the demarche join walk
+# in order and stop at the LIMIT, and the (groupe_instructeur_id, ...) composite
+# gives the groupe path a sort-free Index Scan.
+#
+# Partial on the visible_by_administration predicate, matching
+# index_dossiers_on_groupe_instructeur_id_and_state_and_archived.
+class AddDossiersConnectionOrderingIndexes < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  VISIBLE_BY_ADMINISTRATION = "hidden_by_administration_at IS NULL AND hidden_by_expired_at IS NULL"
+
+  def change
+    add_index :dossiers, [:depose_at, :id],
+              where: VISIBLE_BY_ADMINISTRATION,
+              algorithm: :concurrently,
+              if_not_exists: true
+
+    add_index :dossiers, [:updated_at, :id],
+              where: VISIBLE_BY_ADMINISTRATION,
+              algorithm: :concurrently,
+              if_not_exists: true
+
+    add_index :dossiers, [:groupe_instructeur_id, :depose_at, :id],
+              where: VISIBLE_BY_ADMINISTRATION,
+              algorithm: :concurrently,
+              if_not_exists: true
+
+    add_index :dossiers, [:groupe_instructeur_id, :updated_at, :id],
+              where: VISIBLE_BY_ADMINISTRATION,
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_13_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_22_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -573,15 +573,19 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_13_000000) do
     t.index "to_tsvector('french_unaccent'::regconfig, (search_terms)::text)", name: "index_dossiers_on_search_terms", using: :gin
     t.index ["archived"], name: "index_dossiers_on_archived"
     t.index ["batch_operation_id"], name: "index_dossiers_on_batch_operation_id"
+    t.index ["depose_at", "id"], name: "index_dossiers_on_depose_at_and_id", where: "((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL))"
     t.index ["dossier_transfer_id"], name: "index_dossiers_on_dossier_transfer_id"
     t.index ["editing_fork_origin_id"], name: "index_dossiers_on_editing_fork_origin_id"
+    t.index ["groupe_instructeur_id", "depose_at", "id"], name: "index_dossiers_on_groupe_instructeur_id_and_depose_at_and_id", where: "((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL))"
     t.index ["groupe_instructeur_id", "state", "archived"], name: "index_dossiers_on_groupe_instructeur_id_and_state_and_archived", where: "((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL))"
+    t.index ["groupe_instructeur_id", "updated_at", "id"], name: "index_dossiers_on_groupe_instructeur_id_and_updated_at_and_id", where: "((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL))"
     t.index ["groupe_instructeur_id"], name: "index_dossiers_on_groupe_instructeur_id"
     t.index ["parent_dossier_id"], name: "index_dossiers_on_parent_dossier_id"
     t.index ["prefill_token"], name: "index_dossiers_on_prefill_token", unique: true
     t.index ["revision_id"], name: "index_dossiers_on_revision_id"
     t.index ["revision_id"], name: "index_dossiers_stalled_declarative", where: "(((state)::text = 'en_construction'::text) AND (declarative_triggered_at IS NULL))"
     t.index ["state"], name: "index_dossiers_on_state"
+    t.index ["updated_at", "id"], name: "index_dossiers_on_updated_at_and_id", where: "((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL))"
     t.index ["user_id"], name: "index_dossiers_on_user_id"
   end
 


### PR DESCRIPTION
## Problème

Les connections `dossiers` de l'API GraphQL v2 paginent en keyset sur `(depose_at, id)` — ou `(updated_at, id)` avec `updatedSince` — toujours sous `visible_by_administration`. Aucune de ces colonnes n'était indexée : sur une démarche volumineuse, chaque page effectue un tri filtré sur le tas.

La connection est atteinte par deux chemins, filtrant sur des colonnes de *tenant* différentes :
- `demarche.dossiers` → jointure `procedure_revisions`, filtre `revision_id`
- `groupeInstructeur.dossiers` → filtre `groupe_instructeur_id`

Un simple index `(depose_at, id)` ne servirait donc qu'un seul chemin.

## Analyse (EXPLAIN)

Vérifié par `EXPLAIN` sur chaque requête réelle :
- `(groupe_instructeur_id, depose_at, id)` → `Limit → Index Scan` **sans nœud Sort** pour le chemin groupe.
- `(depose_at, id)` simple → permet à la jointure `demarche` de parcourir dans l'ordre et de s'arrêter au `LIMIT`. Le composite `(revision_id, depose_at, id)` **forçait toujours un Sort complet** sur la jointure — il n'est donc pas ajouté.

## Correctif

Quatre index composites partiels (deux points d'entrée × `depose_at`/`updated_at`), partiels sur le prédicat `visible_by_administration` (`hidden_by_administration_at IS NULL AND hidden_by_expired_at IS NULL`) pour rester légers et cohérents avec `index_dossiers_on_groupe_instructeur_id_and_state_and_archived`. Créés en `CONCURRENTLY`.

## Hors périmètre (volontairement)

Le tri par expression `CASE` de `pendingDeletedDossiers` : son scope `hidden_for_administration` ne conserve que les (rares) dossiers masqués par démarche, le tri porte donc sur un très petit ensemble — un index d'expression fragile n'est pas justifié ici.

## Tests

Une migration d'index n'a pas de comportement à tester. Les specs de connection/pagination (`cursor_connection_spec`, `demarche_spec`) passent (34 exemples) avec les nouveaux index en place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)