### PR TITLE
Tech : corrige trois erreurs de rendu à faible volume (données dégénérées)

### DIFF
--- a/app/components/attachment/attachment_row_component.rb
+++ b/app/components/attachment/attachment_row_component.rb
@@ -43,8 +43,16 @@ class Attachment::AttachmentRowComponent < ApplicationComponent
   def viewable?
     return false if attachment.virus_scanner_error?
     return false if attachment.watermark_pending?
+    # a blob with an empty filename can not be routed to (UrlGenerationError)
+    return false if attachment.filename.to_s.blank?
 
     true
+  end
+
+  # a blob can have an empty filename; without a placeholder the row (and the
+  # labels of its delete button) would be empty
+  def filename
+    attachment.filename.to_s.presence || t(".unnamed_file")
   end
 
   def error_message

--- a/app/components/attachment/attachment_row_component/attachment_row_component.en.yml
+++ b/app/components/attachment/attachment_row_component/attachment_row_component.en.yml
@@ -3,6 +3,7 @@ en:
   delete_file: Delete file %{filename}
   file_name: "the file %{filename}"
   open_file: Open file %{filename}
+  unnamed_file: "Attachment"
   delete_file_title: "Delete the file %{filename}"
   errors:
     virus_infected: "Virus detected, please send another file."

--- a/app/components/attachment/attachment_row_component/attachment_row_component.fr.yml
+++ b/app/components/attachment/attachment_row_component/attachment_row_component.fr.yml
@@ -3,6 +3,7 @@ fr:
   delete_file: Supprimer
   file_name: "le fichier %{filename}"
   open_file: Ouvrir le fichier %{filename}
+  unnamed_file: "Pièce jointe"
   delete_file_title: "Supprimer le fichier %{filename}"
   errors:
     virus_infected: "Virus détecté, merci d’envoyer un autre fichier."

--- a/app/components/attachment/attachment_row_component/attachment_row_component.html.erb
+++ b/app/components/attachment/attachment_row_component/attachment_row_component.html.erb
@@ -13,20 +13,22 @@
         <%= render Dsfr::DownloadComponent.new(attachment:) %>
       <% else %>
         <p class="fr-mb-2v attachment-filename">
-          <%= link_to_if(viewable?, attachment.filename.to_s, helpers.url_for(attachment.blob), title: t(".open_file", filename: attachment.filename), **helpers.external_link_attributes) %>
+          <% if viewable? %>
+            <%= link_to filename, helpers.url_for(attachment.blob), title: t(".open_file", filename:), **helpers.external_link_attributes %>
+          <% else %>
+            <%= filename %>
+          <% end %>
         </p>
         <%= render Attachment::ProgressComponent.new(attachment:, ignore_antivirus: true, ignore_watermark: true) %>
       <% end %>
 
       <% if user_can_destroy? %>
         <p class="fr-mb-0">
-          <%= render NestedForms::OwnedButtonComponent.new(formaction: destroy_attachment_path, http_method: :delete, opt: {class: "fr-btn fr-btn--tertiary fr-btn--sm", title: t(".delete_file_title", filename: attachment.filename), data: {attachment_delete_button: true}}) do %>
+          <%= render NestedForms::OwnedButtonComponent.new(formaction: destroy_attachment_path, http_method: :delete, opt: {class: "fr-btn fr-btn--tertiary fr-btn--sm", title: t(".delete_file_title", filename:), data: {attachment_delete_button: true}}) do %>
             <span class="fr-icon--sm fr-icon-delete-line fr-mr-1w"></span>
             <%= t('.delete_file') %>
 
-            <span class="fr-sr-only">
-              <%= t('.file_name', filename: attachment.filename) %>
-            </span>
+            <span class="fr-sr-only"><%= t('.file_name', filename:) %></span>
           <% end %>
         </p>
       <% end %>
@@ -42,13 +44,13 @@
       <button
         type="button"
         class="fr-btn fr-btn--tertiary fr-btn--sm fr-icon-delete-line"
-        title="<%= t(".delete_file_title", filename: attachment.filename) %>"
+        title="<%= t(".delete_file_title", filename:) %>"
         data-action="element-remove#remove"
       >
         <%= t('.delete_file') %>
       </button>
     <% end %>
 
-    <span><%= attachment.filename %></span>
+    <span><%= filename %></span>
   </li>
 <% end %>

--- a/app/components/dossiers/rna_component.rb
+++ b/app/components/dossiers/rna_component.rb
@@ -24,13 +24,15 @@ class Dossiers::RNAComponent < ApplicationComponent
   private
 
   def data
-    [
-      [champ.class.human_attribute_name(:value), champ.to_s],
-      *['titre', 'objet'].map { label_value(it) },
-    ]
+    rows = [[champ.class.human_attribute_name(:value), champ.to_s]]
+    return rows if champ.data.blank?
+
+    rows + ['titre', 'objet'].map { label_value(it) }
   end
 
   def details
+    return [] if champ.data.blank?
+
     [
       *['date_creation', 'date_declaration', 'date_publication'].map { label_value(it) },
       *helpers.address_array(champ),

--- a/app/helpers/gallery_helper.rb
+++ b/app/helpers/gallery_helper.rb
@@ -4,7 +4,10 @@ module GalleryHelper
   def record_libelle(record)
     case record
     in ChampData
-      record.libelle
+      # a champ and its attachments can outlive its type_de_champ in the dossier
+      # revision; the gallery must render anyway
+      in_revision = record.dossier.revision.types_de_champ.any? { it.stable_id == record.stable_id }
+      in_revision ? record.libelle : 'Pièce jointe'
     in Commentaire
       'Pièce jointe au message'
     in Avis

--- a/spec/components/attachment/attachment_row_component_spec.rb
+++ b/spec/components/attachment/attachment_row_component_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Attachment::AttachmentRowComponent, type: :component do
     expect(subject).to have_selector('[title^="Supprimer le fichier"]')
   end
 
+  context 'when the blob has an empty filename' do
+    before { attachment.blob.update_column(:filename, "") }
+
+    it 'renders a placeholder without a blob link instead of raising (RAILS-M31)' do
+      expect(subject).not_to have_selector('.attachment-filename a')
+      expect(subject).to have_selector('.attachment-filename', text: 'Pièce jointe')
+      expect(subject).to have_selector('[title="Supprimer le fichier Pièce jointe"]')
+    end
+  end
+
   context 'when the user cannot destroy the attachment' do
     let(:context_kwargs) { { user_can_destroy: false } }
 

--- a/spec/components/dossiers/rna_component_spec.rb
+++ b/spec/components/dossiers/rna_component_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe Dossiers::RNAComponent, type: :component do
     end
   end
 
+  context 'when the champ is fetched but the data is missing' do
+    let(:external_state) { 'fetched' }
+    let(:rna_data) { nil }
+
+    it 'renders the identifier without crashing (RAILS-M25)' do
+      expect(subject).to have_text('W173847273')
+    end
+  end
+
   context 'when the champ is waiting for a job' do
     let(:external_state) { 'waiting_for_job' }
     let(:rna_data) { nil }

--- a/spec/helpers/gallery_helper_spec.rb
+++ b/spec/helpers/gallery_helper_spec.rb
@@ -16,6 +16,21 @@ RSpec.describe GalleryHelper, type: :helper do
     champ_pj.piece_justificative_file.attachments.first
   end
 
+  describe ".record_libelle" do
+    it "returns the champ libelle" do
+      expect(helper.record_libelle(champ_pj)).to eq('Justificatif de domicile')
+    end
+
+    context "when the type_de_champ is no longer in the dossier revision" do
+      it "falls back to a generic libelle instead of raising (RAILS-M73)" do
+        fresh_champ = dossier.champ_data.find(champ_pj.id)
+        allow(fresh_champ).to receive(:stable_id).and_return(-1)
+
+        expect(helper.record_libelle(fresh_champ)).to eq('Pièce jointe')
+      end
+    end
+  end
+
   describe ".image_variant_url_for" do
     subject { image_variant_url_for(attachment) }
 


### PR DESCRIPTION
## Contexte

Trois erreurs de rendu à faible volume mais récurrentes dans Sentry, causées par des données dégénérées mais réelles en production. Chaque correctif est un petit garde-fou de rendu, avec une spec qui reproduit l'erreur de production exacte sans le correctif.

- [RAILS-M73](https://demarches-simplifiees.sentry.io/issues/RAILS-M73) : la galerie des pièces jointes plante quand un champ a survécu à son type de champ dans la révision du dossier → libellé générique « Pièce jointe ».
- [RAILS-M31](https://demarches-simplifiees.sentry.io/issues/RAILS-M31) : un blob au nom de fichier vide rend le brouillon inaccessible (`UrlGenerationError`, l'usager ne peut plus ni voir ni corriger son dossier) → la ligne s'affiche sans lien, le bouton supprimer reste disponible.
- [RAILS-M25](https://demarches-simplifiees.sentry.io/issues/RAILS-M25) : le composant RNA plante sur un champ « fetched » sans données → même garde que le composant RNF (#13532, RAILS-MAN).

Par ailleurs, RAILS-M3P/M92/M3Q (variante RNF du même défaut) ont été résolus dans Sentry comme doublons de RAILS-MAN, corrigé par #13532. RAILS-M1K et RAILS-M9Y (révision sans date de publication, démarche sans révision active) sont volontairement laissés en l'état : ils signalent des démarches gravement corrompues qu'on ne veut pas masquer.

Fixes RAILS-M73
Fixes RAILS-M31
Fixes RAILS-M25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
