### PR TITLE
ETQ usager, les pages ne plantent plus quand le calcul du délai usuel de traitement expire

### DIFF
--- a/app/models/concerns/procedure_stats_concern.rb
+++ b/app/models/concerns/procedure_stats_concern.rb
@@ -10,15 +10,26 @@ module ProcedureStatsConcern
   USUAL_TRAITEMENT_TIME_PERCENTILE = 90
 
   def stats_usual_traitement_time
-    Rails.cache.fetch("#{cache_key_with_version}/stats_usual_traitement_time", expires_in: 12.hours) do
+    stats_cache_fetch("#{cache_key_with_version}/stats_usual_traitement_time") do
       usual_traitement_time_for_recent_dossiers(NB_DAYS_RECENT_DOSSIERS)
     end
   end
 
   def stats_usual_traitement_time_by_month_in_days
-    Rails.cache.fetch("#{cache_key_with_version}/stats_usual_traitement_time_by_month_in_days", expires_in: 12.hours) do
+    stats_cache_fetch("#{cache_key_with_version}/stats_usual_traitement_time_by_month_in_days") do
       usual_traitement_time_by_month_in_days
     end
+  end
+
+  # On very large procedures the stats query can hit the statement timeout; these
+  # stats decorate public pages (commencer, dossier status), which must render
+  # anyway. Serve nil and negative-cache it briefly so we don't hammer the
+  # database until the next attempt.
+  def stats_cache_fetch(key, &)
+    Rails.cache.fetch(key, expires_in: 12.hours, &)
+  rescue ActiveRecord::QueryCanceled
+    Rails.cache.write(key, nil, expires_in: 1.hour)
+    nil
   end
 
   def stats_dossiers_funnel

--- a/spec/models/concerns/procedure_stats_concern_spec.rb
+++ b/spec/models/concerns/procedure_stats_concern_spec.rb
@@ -1,6 +1,26 @@
 # frozen_string_literal: true
 
 describe ProcedureStatsConcern do
+  describe '#stats_usual_traitement_time' do
+    let(:procedure) { create(:procedure) }
+
+    context 'when the stats query hits the statement timeout (RAILS-M39)' do
+      before do
+        allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+        allow(procedure).to receive(:usual_traitement_time_for_recent_dossiers)
+          .and_raise(ActiveRecord::QueryCanceled)
+      end
+
+      it 'returns nil and negative-caches instead of raising' do
+        expect(procedure.stats_usual_traitement_time).to be_nil
+
+        # served from the negative cache: the query does not run again
+        expect(procedure.stats_usual_traitement_time).to be_nil
+        expect(procedure).to have_received(:usual_traitement_time_for_recent_dossiers).once
+      end
+    end
+  end
+
   describe '#stats_dossiers_funnel' do
     let(:procedure) { create(:procedure) }
 


### PR DESCRIPTION
## Contexte

Les statistiques de temps de traitement sont calculées de manière synchrone au premier cache miss, pendant le rendu de pages publiques (commencer, suivi de dossier usager, statistiques). Sur les très grosses démarches la requête dépasse le statement timeout et la page renvoie une 500 : environ 100 erreurs utilisateur par mois (Sentry [RAILS-M39](https://demarches-simplifiees.sentry.io/issues/RAILS-M39), K39, [M74](https://demarches-simplifiees.sentry.io/issues/RAILS-M74), M3N, [K6Q](https://demarches-simplifiees.sentry.io/issues/RAILS-K6Q)).

## Correction (court terme)

`ActiveRecord::QueryCanceled` est intercepté dans les deux méthodes de stats : la page se rend sans estimation (les consommateurs affichent déjà un placeholder pour `nil`), et un cache négatif d'une heure évite de marteler la base. La spec reproduit le timeout sans le correctif.

Le vrai correctif (calcul hors requête web, optimisation de la requête, clé de cache) est décrit dans #13552.

Ref #13552
Fixes RAILS-M39
Fixes RAILS-K39
Fixes RAILS-M74
Fixes RAILS-M3N
Fixes RAILS-K6Q

🤖 Generated with [Claude Code](https://claude.com/claude-code)
