### PR TITLE
Tech : corrige la course d'autosave de l'éditeur de champs (specs flaky types_de_champ)

### DIFF
--- a/app/javascript/controllers/type_de_champ_editor_controller.ts
+++ b/app/javascript/controllers/type_de_champ_editor_controller.ts
@@ -24,10 +24,8 @@ export class TypeDeChampEditorController extends ApplicationController {
 
   #latestPromise = Promise.resolve();
   #dirtyForms: Set<HTMLFormElement> = new Set();
-  #inFlightForms: Map<
-    HTMLFormElement,
-    { controller: AbortController; render: boolean }
-  > = new Map();
+  #queuedForms: Map<HTMLFormElement, AbortController> = new Map();
+  #inFlightForms: Map<HTMLFormElement, AbortController> = new Map();
 
   connect() {
     this.#latestPromise = Promise.resolve();
@@ -38,7 +36,11 @@ export class TypeDeChampEditorController extends ApplicationController {
   disconnect() {
     super.disconnect();
     this.#latestPromise = Promise.resolve();
-    for (const { controller } of this.#inFlightForms.values()) {
+    for (const controller of this.#queuedForms.values()) {
+      controller.abort();
+    }
+    this.#queuedForms.clear();
+    for (const controller of this.#inFlightForms.values()) {
       controller.abort();
     }
     this.#inFlightForms.clear();
@@ -92,37 +94,40 @@ export class TypeDeChampEditorController extends ApplicationController {
 
   private requestSubmitForm(form?: HTMLFormElement | null) {
     if (form) {
-      // A form is only passed for change events (type switch, toggle, move…),
-      // which carry a structural change to the champ. Flag them so a following
-      // keystroke save never aborts them while in flight.
-      this.submitForm(form, true);
+      this.submitForm(form);
     } else {
       const forms = [...this.#dirtyForms];
       this.#dirtyForms.clear();
 
       for (const form of forms) {
-        this.submitForm(form, false);
+        this.submitForm(form);
       }
     }
   }
 
-  private submitForm(form: HTMLFormElement, render: boolean) {
-    // Saves are serialized through `#latestPromise`, so they always apply in
-    // order. We supersede a previous in-flight *keystroke* save (only the latest
-    // value matters), but we must never abort an in-flight *re-render* save: it
-    // carries a layout change (new fields after a type switch…) that has to
-    // reach the DOM, otherwise the following interactions target fields that
-    // never appear.
-    const previous = this.#inFlightForms.get(form);
-    if (previous && !previous.render) {
-      previous.controller.abort();
+  private submitForm(form: HTMLFormElement) {
+    // Saves are serialized through `#latestPromise` and each request reads the
+    // form's values (`FormData` below) only when it starts. A save already
+    // queued for this form will therefore pick up this latest change — nothing
+    // to enqueue. And we never abort an in-flight request to supersede it:
+    // aborting only cancels it client-side — the server still processes it —
+    // so dispatching the next save early would let two updates race
+    // server-side, where the stale one can commit last.
+    if (this.#queuedForms.has(form)) {
+      return;
     }
 
     const controller = new AbortController();
-    this.#inFlightForms.set(form, { controller, render });
+    this.#queuedForms.set(form, controller);
 
-    this.#latestPromise = this.#latestPromise.finally(() =>
-      httpRequest(form.action, {
+    this.#latestPromise = this.#latestPromise.finally(() => {
+      this.#queuedForms.delete(form);
+      if (controller.signal.aborted) {
+        return;
+      }
+      this.#inFlightForms.set(form, controller);
+
+      return httpRequest(form.action, {
         method: form.getAttribute('method') ?? '',
         body: new FormData(form),
         signal: controller.signal
@@ -130,11 +135,11 @@ export class TypeDeChampEditorController extends ApplicationController {
         .turbo()
         .catch(() => null)
         .finally(() => {
-          if (this.#inFlightForms.get(form)?.controller == controller) {
+          if (this.#inFlightForms.get(form) == controller) {
             this.#inFlightForms.delete(form);
           }
-        })
-    );
+        });
+    });
   }
 }
 

--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -198,6 +198,12 @@ describe 'As an administrateur I can edit types de champ', js: true do
     fill_in 'Libellé du champ', with: 'libellé de champ'
 
     expect(page).to have_content('Formulaire enregistré')
+    # The notice alone is not a reliable sync point; poll the DB so the
+    # refresh can't race the in-flight saves.
+    wait_until do
+      tdc = procedure.active_revision.reload.root_types_de_champ_public.first
+      tdc&.repetition? && tdc.libelle == 'libellé de champ'
+    end
     page.refresh
 
     within '.type-de-champ .editor-block' do
@@ -231,13 +237,15 @@ describe 'As an administrateur I can edit types de champ', js: true do
     expect(page).to have_field('Cadastres')
 
     fill_in 'Libellé du champ', with: 'Libellé de champ carte', fill_options: { clear: :backspace }
-    # Serialize before the next change event: checking a layer aborts an in-flight
-    # keystroke save, so the libellé must be persisted first.
-    wait_until { procedure.active_revision.reload.root_types_de_champ_public.first&.libelle == 'Libellé de champ carte' }
-
     check 'Cadastres'
-    wait_until { procedure.active_revision.reload.root_types_de_champ_public.first&.layer_enabled?(:cadastres) }
     expect(page).to have_content('Formulaire enregistré')
+
+    # Autosaves are serialized and coalesced client-side, so the last save
+    # carries the whole form; poll for it before refreshing away.
+    wait_until do
+      tdc = procedure.active_revision.reload.root_types_de_champ_public.first
+      tdc&.libelle == 'Libellé de champ carte' && tdc.layer_enabled?(:cadastres)
+    end
 
     page.refresh
     preview_window = window_opened_by { click_on 'Prévisualiser le formulaire' }
@@ -254,18 +262,19 @@ describe 'As an administrateur I can edit types de champ', js: true do
     hide_autonotice_message
 
     select('Choix simple', from: 'Type de champ')
-    # Each interaction triggers an autosave. Wait for it to be persisted before
-    # the next one, so the form re-render that follows a change event has fully
-    # settled and the dropdown-specific fields are stable before we type into
-    # them (avoids flakiness when autosaves overlap under load).
-    wait_until { procedure.active_revision.reload.root_types_de_champ_public.first&.drop_down_list? }
 
+    # 'Options de la liste' only exists once the type-switch re-render has
+    # landed, so fill_in also synchronizes on the morph.
     fill_in 'Options de la liste', with: 'Un menu', fill_options: { clear: :backspace }
-    wait_until { procedure.active_revision.reload.root_types_de_champ_public.first.drop_down_options == ['Un menu'] }
-
     check "Proposer une option « autre » avec un texte libre"
-    wait_until { procedure.active_revision.reload.root_types_de_champ_public.first.drop_down_other == "1" }
     expect(page).to have_content('Formulaire enregistré')
+
+    # Autosaves are serialized and coalesced client-side, so the last save
+    # carries the whole form; poll for it before refreshing away.
+    wait_until do
+      tdc = procedure.active_revision.reload.root_types_de_champ_public.first
+      tdc&.drop_down_options == ['Un menu'] && tdc.drop_down_other == "1"
+    end
 
     page.refresh
 


### PR DESCRIPTION
## Contexte

Les specs système `types_de_champ_spec.rb` (carte :222, choix simple :254) sont flaky sur CI depuis longtemps, malgré trois commits de « deflake » successifs. La cause n'était pas dans les specs mais dans le JS de l'éditeur.

## Cause

`type_de_champ_editor_controller.ts` annulait (`abort()`) la requête de sauvegarde en vol quand une nouvelle frappe déclenchait une sauvegarde. Or l'abort n'annule que côté client : le serveur traite et commit quand même la requête, pendant que la suivante part déjà. Deux UPDATE du même type de champ se retrouvent en course côté serveur, et sous charge le snapshot périmé (libellé tronqué) peut committer en dernier — sans sauvegarde ultérieure pour corriger. En test, `debounce_delay: 0` déclenche une sauvegarde par frappe, ce qui maximise le recouvrement. C'est aussi un bug (rare) de perte de données en production.

## Correctif

- Ne plus jamais annuler une requête en vol. Les sauvegardes restent sérialisées, et comme le `FormData` n'est lu qu'au départ de la requête, une sauvegarde en file couvre déjà les frappes plus récentes : les nouvelles demandes fusionnent avec elle (au plus 1 en file + 1 en vol par formulaire — moins de requêtes qu'avant).
- Specs : un seul poll DB avant `page.refresh` (carte, choix simple), et ajout de la même synchronisation au scénario bloc répétable (:193), qui échouait pour la même famille de raison — la notice « Formulaire enregistré » peut apparaître de façon spurieuse, donc rafraîchir dessus fait la course avec les sauvegardes en vol.

## Vérification

Fichier complet (25 exemples) : 2× vert ; carte + choix simple sous `MAKE_IT_SLOW=1` : 8× vert ; bloc répétable : 4× vert (échouait systématiquement en local avant). `tsc`, ESLint, Rubocop OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)