### PR TITLE
Tech: exécuter les specs PDF (pdftotext) sur la CI

### DIFF
--- a/spec/views/dossiers/show.pdf.prawn_spec.rb
+++ b/spec/views/dossiers/show.pdf.prawn_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'dossiers/show.pdf', type: :view do
+describe 'dossiers/show.pdf', :external_deps, type: :view do
   PDFTOTEXT_AVAILABLE = system('which pdftotext > /dev/null 2>&1') unless defined?(PDFTOTEXT_AVAILABLE)
 
   def render_and_extract(dossier, procedure, scenario_label)
@@ -165,7 +165,7 @@ describe 'dossiers/show.pdf', type: :view do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :aah, libelle: 'AAH' }]) }
     let(:dossier) do
       d = create(:dossier, :en_construction, procedure:)
-      d.project_champs_public.first.update(external_state: 'fetched', value: 'true', value_json: { api_part: { est_beneficiaire: true } })
+      d.root_champs_public.first.update(external_state: 'fetched', value: 'true', value_json: { api_part: { est_beneficiaire: true } })
       d
     end
 


### PR DESCRIPTION
Les exemples de `spec/views/dossiers/show.pdf.prawn_spec.rb` conditionnés par `PDFTOTEXT_AVAILABLE` ne tournaient jamais sur la CI : le job `unit_tests` n'installe pas `poppler-utils`, donc `pdftotext` est absent et les exemples sont silencieusement exclus. Un appel obsolète à `Dossier#project_champs_public` (renommé en `root_champs_public` dans b5cd920bde) est ainsi passé inaperçu — la spec échouait en local mais pas sur la CI.

- Tague le fichier `:external_deps` pour qu'il tourne dans le job qui installe `poppler-utils`
- Corrige l'accesseur renommé

🤖 Generated with [Claude Code](https://claude.com/claude-code)