### PR TITLE
Tech : corrige la course DB dans la spec système de routage

### DIFF
--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -300,7 +300,9 @@ describe 'The routing with rules', js: true do
     choose(groupe, allow_label_click: true)
     wait_for_autosave
 
-    expect(dossier.reload.groupe_instructeur_id).not_to be_nil
+    # wait_for_autosave only waits for the save request to be dispatched, not
+    # for its response: poll the DB for the routing computed by the server.
+    wait_until { dossier.reload.groupe_instructeur_id.present? }
     expect(page).to have_text(dossier.service_or_contact_information.nom)
     expect(page).not_to have_text(procedure.service.nom)
 


### PR DESCRIPTION
La spec `spec/system/routing/rules_full_scenario_spec.rb` (« Configuration manuelle du routage ») échouait de façon déterministe en local : `wait_for_autosave` attend que la file de debounce se vide, c'est-à-dire que la requête de sauvegarde soit **envoyée**, pas que sa réponse soit arrivée. L'assertion `expect(dossier.reload.groupe_instructeur_id).not_to be_nil` (sans retry) faisait donc la course avec le PATCH en vol — c'est dans cette requête que `RoutingEngine` assigne le groupe (les logs montrent l'assignation ~120 ms après la lecture de la spec).

Correctif : poll DB (`wait_until`) à la place de l'assertion sèche. Même famille de cause que #13555 (les points de synchronisation d'autosave ne garantissent pas le commit serveur), mais spec indépendante.

Vérification : 3× vert sur le scénario (échouait systématiquement avant), fichier complet vert, Rubocop OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)