### PR TITLE
ETQ instructeur, je peux modifier plus de types d’annotations privées via l’API GraphQL

### DIFF
--- a/app/graphql/mutations/dossier_modifier_annotations.rb
+++ b/app/graphql/mutations/dossier_modifier_annotations.rb
@@ -18,6 +18,13 @@ module Mutations
       argument :drop_down_list, String, "Modifier la sélection d’un champ choix simple", required: false
       argument :multiple_drop_down_list, [String], "Modifier la sélection d’un champ choix multiple", required: false
       argument :dossier_link, String, "Modifier la valeur d'un champ lien vers un dossier", required: false
+      argument :phone, String, "Modifier la valeur d’un champ téléphone", required: false
+      argument :iban, String, "Modifier la valeur d’un champ IBAN", required: false
+      argument :formatted, String, "Modifier la valeur d’un champ à format prédéfini", required: false
+      argument :civilite, Types::Civilite, "Modifier la valeur d’un champ civilité", required: false
+      argument :pays, String, "Modifier la valeur d’un champ pays (code ISO 3166-1 alpha-2 ou nom)", required: false
+      argument :regions, String, "Modifier la valeur d’un champ région (code INSEE ou nom)", required: false
+      argument :departements, String, "Modifier la valeur d’un champ département (code INSEE ou nom)", required: false
       argument :repetition, Int, "Ajouter des repetitions à un champ répétable", required: false
     end
 
@@ -107,6 +114,13 @@ module Mutations
         TypeDeChamp.type_champs.fetch(:drop_down_list),
         TypeDeChamp.type_champs.fetch(:multiple_drop_down_list),
         TypeDeChamp.type_champs.fetch(:dossier_link),
+        TypeDeChamp.type_champs.fetch(:phone),
+        TypeDeChamp.type_champs.fetch(:iban),
+        TypeDeChamp.type_champs.fetch(:formatted),
+        TypeDeChamp.type_champs.fetch(:civilite),
+        TypeDeChamp.type_champs.fetch(:pays),
+        TypeDeChamp.type_champs.fetch(:regions),
+        TypeDeChamp.type_champs.fetch(:departements),
         TypeDeChamp.type_champs.fetch(:repetition),
       ]
     end

--- a/app/graphql/mutations/dossier_modifier_annotations.rb
+++ b/app/graphql/mutations/dossier_modifier_annotations.rb
@@ -25,6 +25,7 @@ module Mutations
       argument :pays, String, "Modifier la valeur d’un champ pays (code ISO 3166-1 alpha-2 ou nom)", required: false
       argument :regions, String, "Modifier la valeur d’un champ région (code INSEE ou nom)", required: false
       argument :departements, String, "Modifier la valeur d’un champ département (code INSEE ou nom)", required: false
+      argument :piece_justificative, [ID], "Ajouter des pièces justificatives à un champ pièce justificative (identifiants signés de blobs, créés via la mutation createDirectUpload)", required: false
       argument :repetition, Int, "Ajouter des repetitions à un champ répétable", required: false
     end
 
@@ -42,6 +43,14 @@ module Mutations
 
     def resolve(dossier:, instructeur:, annotations:)
       update_annotations(dossier, annotations)
+    end
+
+    def authorized_before_load?(annotations:, **args)
+      annotations.flat_map { _1.value.piece_justificative || [] }.each do |blob_id|
+        result = validate_blob(blob_id)
+        return result unless result == true
+      end
+      true
     end
 
     def authorized?(dossier:, instructeur:, **args)
@@ -90,6 +99,9 @@ module Mutations
 
       champ = dossier.champ_for_update(type_de_champ, row_id:, updated_by: current_administrateur.email)
       case champ.type_champ
+      when 'piece_justificative'
+        champ.piece_justificative_file.attach(*value)
+        champ.fetch_later if champ.has_async_external_data? && champ.may_fetch_later?
       when 'datetime'
         champ.value = value.iso8601(0)
       when 'multiple_drop_down_list'
@@ -121,6 +133,7 @@ module Mutations
         TypeDeChamp.type_champs.fetch(:pays),
         TypeDeChamp.type_champs.fetch(:regions),
         TypeDeChamp.type_champs.fetch(:departements),
+        TypeDeChamp.type_champs.fetch(:piece_justificative),
         TypeDeChamp.type_champs.fetch(:repetition),
       ]
     end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -241,6 +241,11 @@ input AnnotationValueInput @oneOf {
   checkbox: Boolean
 
   """
+  Modifier la valeur d’un champ civilité
+  """
+  civilite: Civilite
+
+  """
   Modifier la valeur d’un champ date
   """
   date: ISO8601Date
@@ -254,6 +259,11 @@ input AnnotationValueInput @oneOf {
   Modifier la valeur d’un champ nombre décimal
   """
   decimalNumber: Float
+
+  """
+  Modifier la valeur d’un champ département (code INSEE ou nom)
+  """
+  departements: String
 
   """
   Modifier la valeur d'un champ lien vers un dossier
@@ -271,6 +281,16 @@ input AnnotationValueInput @oneOf {
   email: String
 
   """
+  Modifier la valeur d’un champ à format prédéfini
+  """
+  formatted: String
+
+  """
+  Modifier la valeur d’un champ IBAN
+  """
+  iban: String
+
+  """
   Modifier la valeur d’un champ nombre entier
   """
   integerNumber: Int
@@ -279,6 +299,21 @@ input AnnotationValueInput @oneOf {
   Modifier la sélection d’un champ choix multiple
   """
   multipleDropDownList: [String!]
+
+  """
+  Modifier la valeur d’un champ pays (code ISO 3166-1 alpha-2 ou nom)
+  """
+  pays: String
+
+  """
+  Modifier la valeur d’un champ téléphone
+  """
+  phone: String
+
+  """
+  Modifier la valeur d’un champ région (code INSEE ou nom)
+  """
+  regions: String
 
   """
   Ajouter des repetitions à un champ répétable

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -311,6 +311,12 @@ input AnnotationValueInput @oneOf {
   phone: String
 
   """
+  Ajouter des pièces justificatives à un champ pièce justificative (identifiants
+  signés de blobs, créés via la mutation createDirectUpload)
+  """
+  pieceJustificative: [ID!]
+
+  """
   Modifier la valeur d’un champ région (code INSEE ou nom)
   """
   regions: String

--- a/spec/graphql/annotation_spec.rb
+++ b/spec/graphql/annotation_spec.rb
@@ -408,6 +408,43 @@ RSpec.describe Mutations::DossierModifierAnnotations, type: :graphql do
         end
       end
     end
+
+    context 'with piece justificative annotation' do
+      let(:types_de_champ_private) { [{ type: :piece_justificative }] }
+      let(:piece_justificative_annotation) { champs_private.find(&:piece_justificative?) }
+
+      let(:blobs) do
+        Array.new(2) do
+          ActiveStorage::Blob.create_and_upload!(
+            io: Rails.root.join('spec/fixtures/files/logo_test_procedure.png').open,
+            filename: 'logo_test_procedure.png',
+            content_type: 'image/png',
+            metadata: { virus_scan_result: ActiveStorage::VirusScanner::SAFE }
+          )
+        end
+      end
+      let(:annotations) { [{ id: piece_justificative_annotation.to_typed_id, value: { pieceJustificative: blobs.map(&:signed_id) } }] }
+
+      it 'attach files' do
+        expect { subject }.to change { piece_justificative_annotation.reload.piece_justificative_file.count }.by(2)
+        expect(data).to eq(dossierModifierAnnotations: {
+          annotations: [{ id: piece_justificative_annotation.to_typed_id }],
+          errors: nil,
+        })
+        expect(piece_justificative_annotation.piece_justificative_file.blobs).to include(*blobs)
+      end
+
+      context 'with invalid signed blob id' do
+        let(:annotations) { [{ id: piece_justificative_annotation.to_typed_id, value: { pieceJustificative: ['fake'] } }] }
+
+        it 'returns error' do
+          expect(data).to eq(dossierModifierAnnotations: {
+            annotations: nil,
+            errors: [{ message: 'L’identifiant du fichier téléversé est invalide' }],
+          })
+        end
+      end
+    end
   end
 
   DOSSIER_MODIFIER_ANNOTATION_AJOUTER_LIGNE_MUTATION = <<-GRAPHQL

--- a/spec/graphql/annotation_spec.rb
+++ b/spec/graphql/annotation_spec.rb
@@ -348,6 +348,66 @@ RSpec.describe Mutations::DossierModifierAnnotations, type: :graphql do
         expect(annotations.map { _1.reload.value }).to eq(values.map { _1.class == Array ? _1.to_json : _1.to_s })
       end
     end
+
+    context 'with etat civil and localisation annotations' do
+      let(:types_de_champ_private) do
+        [
+          { type: :phone },
+          { type: :iban },
+          { type: :formatted },
+          { type: :civilite },
+          { type: :pays },
+          { type: :regions },
+          { type: :departements },
+        ]
+      end
+
+      let(:phone_annotation) { champs_private.find(&:phone?) }
+      let(:iban_annotation) { champs_private.find(&:iban?) }
+      let(:formatted_annotation) { champs_private.find(&:formatted?) }
+      let(:civilite_annotation) { champs_private.find(&:civilite?) }
+      let(:pays_annotation) { champs_private.find(&:pays?) }
+      let(:regions_annotation) { champs_private.find(&:regions?) }
+      let(:departements_annotation) { champs_private.find(&:departements?) }
+
+      let(:annotations) do
+        [
+          { id: phone_annotation.to_typed_id, value: { phone: '0612345678' } },
+          { id: iban_annotation.to_typed_id, value: { iban: 'FR7630006000011234567890189' } },
+          { id: formatted_annotation.to_typed_id, value: { formatted: 'ABC-123' } },
+          { id: civilite_annotation.to_typed_id, value: { civilite: 'M' } },
+          { id: pays_annotation.to_typed_id, value: { pays: 'FR' } },
+          { id: regions_annotation.to_typed_id, value: { regions: '11' } },
+          { id: departements_annotation.to_typed_id, value: { departements: '75' } },
+        ]
+      end
+
+      it 'update annotations' do
+        expect(data).to eq(dossierModifierAnnotations: {
+          annotations: annotations.map { { id: _1[:id] } },
+          errors: nil,
+        })
+        expect(phone_annotation.reload.value).to eq('0612345678')
+        expect(iban_annotation.reload.value).to eq('FR76 3000 6000 0112 3456 7890 189')
+        expect(formatted_annotation.reload.value).to eq('ABC-123')
+        expect(civilite_annotation.reload.value).to eq('M.')
+        expect(pays_annotation.reload.value).to eq('France')
+        expect(pays_annotation.external_id).to eq('FR')
+        expect(regions_annotation.reload.value).to eq('Île-de-France')
+        expect(regions_annotation.external_id).to eq('11')
+        expect(departements_annotation.reload.value).to eq('Paris')
+        expect(departements_annotation.external_id).to eq('75')
+      end
+
+      context 'with an invalid pays code' do
+        let(:annotations) { [{ id: pays_annotation.to_typed_id, value: { pays: 'ZZ' } }] }
+
+        it 'returns error' do
+          expect(data[:dossierModifierAnnotations][:annotations]).to eq([])
+          expect(data[:dossierModifierAnnotations][:errors]).to be_present
+        end
+      end
+    end
   end
 
   DOSSIER_MODIFIER_ANNOTATION_AJOUTER_LIGNE_MUTATION = <<-GRAPHQL


### PR DESCRIPTION
## Description

La mutation `dossierModifierAnnotations` accepte de nouveaux types de champs :

- **phone, iban, formatted, civilite** : valeur scalaire, validations existantes des champs
- **pays, regions, departements** : code (ISO / INSEE) ou nom, résolu par `APIGeoService` via les setters `value=` existants
- **piece_justificative** : liste d’identifiants signés de blobs créés via `createDirectUpload` (même flux que `dossierEnvoyerMessage`) ; les fichiers sont ajoutés au champ, avec validation des blobs en amont et déclenchement de `fetch_later` pour les champs compatibles OCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)