### PR TITLE
Tech: catégoriser les notifications AMI par démarche via item_type

### DIFF
--- a/app/services/ami/create_notification_service.rb
+++ b/app/services/ami/create_notification_service.rb
@@ -4,8 +4,6 @@ module Ami
   class CreateNotificationService
     SOURCE = ApplicationHelper::APP_HOST
 
-    ITEM_TYPE = "dossier"
-
     ITEM_GENERIC_STATUS_BY_STATE = {
       brouillon: "new",
       en_construction: "wip",
@@ -47,7 +45,7 @@ module Ami
         recipient_fc_hash: RecipientFcHash.call(dossier.user),
         content_title:,
         content_body:,
-        item_type: ITEM_TYPE,
+        item_type: dossier.procedure.id.to_s,
         item_id: dossier.id.to_s,
         item_status_label:,
         item_generic_status:,

--- a/spec/services/ami/create_notification_service_spec.rb
+++ b/spec/services/ami/create_notification_service_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Ami::CreateNotificationService do
         recipient_fc_hash: kind_of(String),
         content_title: kind_of(String),
         content_body: kind_of(String),
-        item_type: "dossier",
+        item_type: dossier.procedure.id.to_s,
         item_id: dossier.id.to_s,
         item_status_label: "En\u00a0instruction",
         item_generic_status: "wip",


### PR DESCRIPTION
Le champ `item_type` du payload de notification AMI valait la constante `"dossier"` pour toutes les notifications. Il contient désormais l'id de la procédure, pour que AMI puisse catégoriser les notifications par démarche.

`item_id` reste inchangé (id du dossier).

Closes #13563