### PR TITLE
ETQ usager, j'affiche plus vite ma liste de dossiers filtrée par « nouveau message »

### DIFF
--- a/app/models/concerns/dossier_messagerie_concern.rb
+++ b/app/models/concerns/dossier_messagerie_concern.rb
@@ -14,11 +14,27 @@ module DossierMessagerieConcern
     # réponse » (pending_response). Équivalent SQL de la règle d'affichage
     # DossierHelper#show_new_message_notification?, utilisé par le filtre
     # « nouveau message » de la liste des dossiers.
+    #
+    # Les exclusions sont exprimées en NOT EXISTS corrélés (et non en
+    # `NOT IN (sous-requête)`) pour rester bornées à la ligne candidate : un
+    # `NOT IN` balaierait toutes les corrections / attentes de réponse de la
+    # plateforme, ce qui rend le filtre très lent sur une base volumineuse.
     scope :with_unread_messages_for_user, -> {
       joins(:commentaires)
         .merge(Commentaire.sent_by_agent.unread_by_recipient)
-        .where.not(id: with_pending_responses.select(:id))
-        .where.not(id: state_en_construction.with_pending_corrections.select(:id))
+        .where.not(
+          DossierPendingResponse
+            .where("dossier_pending_responses.dossier_id = dossiers.id")
+            .where(responded_at: nil)
+            .arel.exists
+        )
+        .where.not(
+          DossierCorrection
+            .where("dossier_corrections.dossier_id = dossiers.id")
+            .where(resolved_at: nil)
+            .where(dossiers: { state: Dossier.states.fetch(:en_construction) })
+            .arel.exists
+        )
         .distinct
     }
   end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -925,6 +925,14 @@ describe Dossier, type: :model do
     it 'excludes dossiers pending a response (the « en attente de réponse » badge takes precedence)' do
       expect(subject).not_to include(dossier_with_pending_response)
     end
+
+    it 'includes a dossier with an unresolved correction that is no longer en_construction (the « à corriger » badge only applies en_construction)' do
+      dossier = create(:dossier, :en_instruction, procedure: procedures.individual)
+      create(:commentaire, dossier:, instructeur: instructeurs.default, seen_by_recipient_at: nil)
+      create(:dossier_correction, dossier:)
+
+      expect(subject).to include(dossier)
+    end
   end
 
   describe '.ordered_for_export' do


### PR DESCRIPTION
Corrige le bug de performance remonté par Marlène, sur le filtre "Nouveau message".



Le filtre « Nouveau message » de la liste des dossiers usager mettait plusieurs
secondes à répondre (compteur du panneau puis chargement de la page), surtout
combiné à un autre filtre comme « À corriger ».

En cause : le scope `with_unread_messages_for_user` excluait les dossiers « à
corriger » / « en attente de réponse » via deux `NOT IN (sous-requête)` non
bornées, qui matérialisaient toutes les corrections et attentes de réponse de la
plateforme entière. Ce scope est ré-évalué plusieurs fois par affichage du
panneau (compteurs par alerte, compteurs par statut, total, requête de liste).

On réécrit ces exclusions en `NOT EXISTS` corrélés (même idiome que
`Dossier.without_dossier_expirant_notification`), bornés au dossier candidat et
servis en anti-join par les index `dossier_id`. Le comportement est inchangé —
l'exclusion « à corriger » reste limitée à l'état `en_construction`, conforme au
prédicat `pending_correction?`.