### PR TITLE
Tech: synchroniser dossier.updated_at lors de l'ajout/retrait d'un label

### DIFF
--- a/app/models/dossier_label.rb
+++ b/app/models/dossier_label.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DossierLabel < ApplicationRecord
-  belongs_to :dossier
+  belongs_to :dossier, touch: true
   belongs_to :label
 
   validate :label_belongs_to_dossier_procedure

--- a/spec/models/dossier_label_spec.rb
+++ b/spec/models/dossier_label_spec.rb
@@ -21,4 +21,23 @@ describe DossierLabel do
       end
     end
   end
+
+  describe 'touching the dossier' do
+    let(:label) { procedure.labels.first }
+
+    it 'bumps dossier.updated_at when a label is added' do
+      dossier.update_column(:updated_at, 1.day.ago)
+
+      expect { DossierLabel.create!(dossier:, label:) }
+        .to(change { dossier.reload.updated_at })
+    end
+
+    it 'bumps dossier.updated_at when a label is removed' do
+      dossier_label = DossierLabel.create!(dossier:, label:)
+      dossier.update_column(:updated_at, 1.day.ago)
+
+      expect { dossier_label.destroy }
+        .to(change { dossier.reload.updated_at })
+    end
+  end
 end


### PR DESCRIPTION
## Problème

Un usager de l'API GraphQL nous a signalé que les changements de label ne remontent pas via `updatedSince`.

En effet, le filtre `updatedSince` s'appuie sur `dossiers.updated_at` (scope `Dossier.updated_since`). Or l'ajout ou le retrait d'un label par un instructeur crée/détruit une ligne `DossierLabel` sans jamais mettre à jour `dossier.updated_at` — ces changements étaient donc invisibles pour un client qui synchronise sur cette date.

## Solution

Ajout de `touch: true` sur `belongs_to :dossier` dans `DossierLabel`. ActiveRecord bumpe désormais `dossier.updated_at` au `create` **et** au `destroy` d'un label, de façon symétrique et sans modifier le contrôleur.

Un label posé par un instructeur compte donc maintenant comme une mise à jour du dossier, ce qui le fait remonter dans `updatedSince`.

## Tests

Specs model ajoutés : `updated_at` est bumpé à l'ajout et au retrait d'un label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)