### PR TITLE
ETQ admin je veux mieux voir les démarches et administrateurs de mon organisation

### DIFF
--- a/app/assets/stylesheets/all_demarches.scss
+++ b/app/assets/stylesheets/all_demarches.scss
@@ -2,26 +2,6 @@
   border: none;
   padding-left: 0;
 
-  ul {
-    list-style: none;
-    padding-inline-start: 0;
-    border-top: 1px solid var(--border-plain-grey);
-  }
-
-  li {
-    border-bottom: 1px solid var(--border-plain-grey);
-  }
-
-  button {
-    font-size: 1rem;
-    line-height: 1.5rem;
-  }
-
-  .filter-accordion-btn {
-    display: flex;
-    align-items: center;
-  }
-
   legend {
     width: 100%;
     display: flex;

--- a/app/assets/stylesheets/all_demarches.scss
+++ b/app/assets/stylesheets/all_demarches.scss
@@ -24,3 +24,14 @@
     justify-content: flex-end;
   }
 }
+
+.selected-zones,
+.selected-statuses,
+.selected-kind_usagers,
+.selected-tag,
+.selected-template,
+.selected-from_publication_date,
+.selected-email,
+.selected-query {
+  display: contents;
+}

--- a/app/assets/stylesheets/all_demarches.scss
+++ b/app/assets/stylesheets/all_demarches.scss
@@ -17,10 +17,16 @@
     line-height: 1.5rem;
   }
 
+  .filter-accordion-btn {
+    display: flex;
+    align-items: center;
+  }
+
   legend {
     width: 100%;
     display: flex;
     justify-content: space-between;
+    align-items: center;
   }
 
   .reinit a {

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -585,6 +585,11 @@ module Administrateurs
       procedures_result = procedures_result.where(service: services) if services
       procedures_result = procedures_result.where(for_individual: filter.for_individual) if filter.for_individual.present?
       procedures_result = procedures_result.where('unaccent(libelle) ILIKE unaccent(?)', "%#{filter.libelle}%") if filter.libelle.present?
+      if filter.email.present?
+        procedures_result = procedures_result
+          .joins(administrateurs_procedures: { administrateur: :user })
+          .where('unaccent(users.email) ILIKE unaccent(?)', "%#{filter.email}%")
+      end
       procedures_sql = procedures_result.to_sql
 
       sql = "select procedures.id, libelle, published_at, aasm_state, estimated_dossiers_count, template, array_agg(distinct latest_labels.name) filter (where latest_labels.name is not null) as latest_zone_labels from administrateurs_procedures inner join procedures on procedures.id = administrateurs_procedures.procedure_id left join procedures_zones ON procedures.id = procedures_zones.procedure_id left join zones ON zones.id = procedures_zones.zone_id left join (select zone_id, name from zone_labels where (zone_id, designated_on) in (select zone_id, max(designated_on) from zone_labels group by zone_id)) as latest_labels on zones.id = latest_labels.zone_id

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -584,7 +584,16 @@ module Administrateurs
       procedures_result = procedures_result.where(service: service) if filter.service_siret.present?
       procedures_result = procedures_result.where(service: services) if services
       procedures_result = procedures_result.where(for_individual: filter.for_individual) if filter.for_individual.present? && filter_applicable?(filter, :for_individual)
-      procedures_result = procedures_result.where('unaccent(libelle) ILIKE unaccent(?)', "%#{filter.libelle}%") if filter.libelle.present? && filter_applicable?(filter, :libelle)
+      if filter.libelle.present? && filter_applicable?(filter, :libelle)
+        if filter.libelle.match?(/\A\d+\z/)
+          procedures_result = procedures_result.where(
+            'unaccent(libelle) ILIKE unaccent(?) OR procedures.id = ?',
+            "%#{filter.libelle}%", filter.libelle.to_i
+          )
+        else
+          procedures_result = procedures_result.where('unaccent(libelle) ILIKE unaccent(?)', "%#{filter.libelle}%")
+        end
+      end
       if filter.email.present?
         procedures_result = procedures_result
           .joins(administrateurs_procedures: { administrateur: :user })

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -569,7 +569,7 @@ module Administrateurs
       procedures_result = procedures_result.where(procedures_zones: { zone_id: filter.zone_ids }) if filter.zone_ids.present?
       procedures_result = procedures_result.where(hidden_at_as_template: nil)
       procedures_result = procedures_result.where(aasm_state: filter.statuses) if filter.statuses.present?
-      if filter.tags.present?
+      if filter.tags.present? && filter_applicable?(filter, :tags)
         tag_ids = ProcedureTag.where(name: filter.tags).pluck(:id).flatten
 
         if tag_ids.any?
@@ -579,12 +579,12 @@ module Administrateurs
             .distinct
         end
       end
-      procedures_result = procedures_result.where(template: true) if filter.template?
+      procedures_result = procedures_result.where(template: true) if filter.template? && filter_applicable?(filter, :template)
       procedures_result = procedures_result.where(published_at: filter.from_publication_date..) if filter.from_publication_date.present?
       procedures_result = procedures_result.where(service: service) if filter.service_siret.present?
       procedures_result = procedures_result.where(service: services) if services
-      procedures_result = procedures_result.where(for_individual: filter.for_individual) if filter.for_individual.present?
-      procedures_result = procedures_result.where('unaccent(libelle) ILIKE unaccent(?)', "%#{filter.libelle}%") if filter.libelle.present?
+      procedures_result = procedures_result.where(for_individual: filter.for_individual) if filter.for_individual.present? && filter_applicable?(filter, :for_individual)
+      procedures_result = procedures_result.where('unaccent(libelle) ILIKE unaccent(?)', "%#{filter.libelle}%") if filter.libelle.present? && filter_applicable?(filter, :libelle)
       if filter.email.present?
         procedures_result = procedures_result
           .joins(administrateurs_procedures: { administrateur: :user })
@@ -599,6 +599,14 @@ module Administrateurs
 
     def paginate(result, ordered_by)
       result.page(params[:page]).per(ITEMS_PER_PAGE).order(ordered_by)
+    end
+
+    # A procedure-only filter (see ProceduresFilter::PROCEDURE_ONLY_FILTERS) only
+    # applies on the "all" tab, since it describes the content of a procedure
+    # rather than an administrative/relational property — it doesn't make sense
+    # to restrict administrateurs by it.
+    def filter_applicable?(filter, name)
+      !filter.procedure_only_filter?(name) || action_name == 'all'
     end
 
     def draft_valid?

--- a/app/helpers/administrateurs/procedures_helper.rb
+++ b/app/helpers/administrateurs/procedures_helper.rb
@@ -10,4 +10,21 @@ module Administrateurs::ProceduresHelper
   def procedures_filter_path(params = {})
     url_for(params.merge(only_path: true))
   end
+
+  def visible_filter_tags_count(filter)
+    count = 0
+    count += 1 if filter.email.present?
+    count += 1 if filter.service_siret.present?
+    count += 1 if filter.service_departement.present?
+    count += filter.selected_zones.to_a.size
+    count += filter.statuses.to_a.size
+    count += 1 if filter.from_publication_date.present?
+    if action_name == 'all'
+      count += 1 if filter.libelle.present?
+      count += filter.kind_usagers.to_a.size
+      count += filter.tags.to_a.size
+      count += 1 if filter.template?
+    end
+    count
+  end
 end

--- a/app/helpers/administrateurs/procedures_helper.rb
+++ b/app/helpers/administrateurs/procedures_helper.rb
@@ -6,4 +6,8 @@ module Administrateurs::ProceduresHelper
       render partial: "administrateurs/procedures/sticky_title", locals: { procedure: }
     end
   end
+
+  def procedures_filter_path(params = {})
+    url_for(params.merge(only_path: true))
+  end
 end

--- a/app/models/procedures_filter.rb
+++ b/app/models/procedures_filter.rb
@@ -4,6 +4,7 @@ class ProceduresFilter
   attr_reader :admin, :params
 
   ITEMS_PER_PAGE = 25
+  PROCEDURE_ONLY_FILTERS = [:template, :for_individual, :libelle, :tags].freeze
 
   def initialize(admin, params)
     @admin = admin
@@ -86,6 +87,10 @@ class ProceduresFilter
 
   def status_filtered?(status)
     statuses&.include?(status)
+  end
+
+  def procedure_only_filter?(name)
+    PROCEDURE_ONLY_FILTERS.include?(name)
   end
 
   def without(filter, value = nil)

--- a/app/views/administrateurs/_main_navigation.html.haml
+++ b/app/views/administrateurs/_main_navigation.html.haml
@@ -2,7 +2,7 @@
   %ul.fr-nav__list
     %li.fr-nav__item= link_to 'Mes démarches', admin_procedures_path, class:'fr-nav__link', 'aria-current': current_page?(controller: 'administrateurs/procedures', action: :index) ? 'true' : nil
     - if Rails.application.config.ds_zonage_enabled
-      %li.fr-nav__item= link_to 'Toutes les démarches', all_admin_procedures_path(zone_ids: :admin_default), class:'fr-nav__link', 'aria-current': current_page?(all_admin_procedures_path) ? 'page' : nil
+      %li.fr-nav__item= link_to 'Annuaire des démarches', all_admin_procedures_path(zone_ids: :admin_default), class:'fr-nav__link', 'aria-current': current_page?(all_admin_procedures_path) ? 'page' : nil
     - if current_administrateur.groupe_gestionnaire_id
       %li.fr-nav__item= link_to 'Mon groupe gestionnaire', admin_groupe_gestionnaire_path, class:'fr-nav__link', 'aria-current': current_page?(admin_groupe_gestionnaire_path) ? 'page' : nil
 

--- a/app/views/administrateurs/procedures/_common_filter_tags.html.erb
+++ b/app/views/administrateurs/procedures/_common_filter_tags.html.erb
@@ -1,0 +1,39 @@
+<% if @filter.email %>
+  <div class="selected-email">
+    <%= link_to "Administrateur : #{@filter.email}", procedures_filter_path(@filter.without(:email)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
+  </div>
+<% end %>
+
+<% if @filter.service_siret %>
+  <div class="selected-query">
+    <%= link_to "SIRET : #{@filter.service_siret}", procedures_filter_path(@filter.without(:service_siret)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
+  </div>
+<% end %>
+
+<% if @filter.service_departement %>
+  <div class="selected-query">
+    <%= link_to "Département : #{@filter.service_departement} – #{APIGeoService.departement_name(@filter.service_departement)}", procedures_filter_path(@filter.without(:service_departement)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
+  </div>
+<% end %>
+
+<% if @filter.selected_zones.present? %>
+  <div class="selected-zones">
+    <% @filter.selected_zones.each do |zone| %>
+      <%= link_to "Zone : #{zone.current_label}", procedures_filter_path(@filter.without(:zone_ids, zone.id)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
+    <% end %>
+  </div>
+<% end %>
+
+<% if @filter.statuses.present? %>
+  <div class="selected-statuses">
+    <% @filter.statuses.each do |status| %>
+      <%= link_to "Statut : #{t(status, scope: 'activerecord.attributes.procedure.aasm_state')}", procedures_filter_path(@filter.without(:statuses, status)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
+    <% end %>
+  </div>
+<% end %>
+
+<% if @filter.from_publication_date.present? %>
+  <div class="selected-from-publication-date">
+    <%= link_to "Date de publication : depuis #{l(@filter.from_publication_date)}", procedures_filter_path(@filter.without(:from_publication_date)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
+  </div>
+<% end %>

--- a/app/views/administrateurs/procedures/administrateurs.html.erb
+++ b/app/views/administrateurs/procedures/administrateurs.html.erb
@@ -16,7 +16,7 @@
       <%= f.label 'email', t('.search_label'), class: 'fr-label' %>
       <span class="fr-hint-text fr-mb-1w"><%= t('.search_hint') %></span>
       <div class="fr-input-wrap fr-input-wrap--addon">
-        <%= f.search_field 'email', size: 40, class: 'fr-input', data: { turbo_force: :server } %>
+        <%= f.search_field 'email', value: @filter.email, size: 40, class: 'fr-input', data: { turbo_force: :server } %>
         <%= f.button 'Rechercher', class: 'fr-btn fr-icon-search-line' %>
       </div>
     <% end %>

--- a/app/views/administrateurs/procedures/administrateurs.html.erb
+++ b/app/views/administrateurs/procedures/administrateurs.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :results do %>
   <div class="main-filter-header fr-mb-3w">
-    <%= form_with(url: administrateurs_admin_procedures_path, method: :get, data: { turbo_frame: 'procedures' }, html: { role: 'search' }) do |f| %>
+    <%= form_with(url: administrateurs_admin_procedures_path, method: :get, class: 'width-66', data: { turbo_frame: 'procedures' }, html: { role: 'search' }) do |f| %>
       <% @filter.zone_ids&.each do |zone_id| %>
         <%= hidden_field_tag 'zone_ids[]', zone_id, id: "zone_#{zone_id}" %>
       <% end %>
@@ -14,7 +14,11 @@
      <%= hidden_field_tag 'from_publication_date', @filter.from_publication_date if @filter.from_publication_date.present? %>
 
      <%= f.label 'email', t('.search_label'), class: 'fr-label' %>
-      <%= f.search_field 'email', size: 40, class: 'fr-input', data: { turbo_force: :server } %>
+     <span class="fr-hint-text fr-mb-1w"><%= t('.search_hint') %></span>
+     <div class="fr-input-wrap fr-input-wrap--addon">
+       <%= f.search_field 'email', size: 40, class: 'fr-input', data: { turbo_force: :server } %>
+       <%= f.button 'Rechercher', class: 'fr-btn fr-icon-search-line' %>
+     </div>
     <% end %>
   </div>
 

--- a/app/views/administrateurs/procedures/administrateurs.html.erb
+++ b/app/views/administrateurs/procedures/administrateurs.html.erb
@@ -7,48 +7,54 @@
         <%= hidden_field_tag 'zone_ids[]', zone_id, id: "zone_#{zone_id}" %>
       <% end %>
 
-     <% @filter.statuses&.each do |status| %>
+      <% @filter.statuses&.each do |status| %>
         <%= hidden_field_tag 'statuses[]', status, id: "status_#{status}" %>
       <% end %>
 
-     <%= hidden_field_tag 'from_publication_date', @filter.from_publication_date if @filter.from_publication_date.present? %>
+      <%= hidden_field_tag 'from_publication_date', @filter.from_publication_date if @filter.from_publication_date.present? %>
 
-     <%= f.label 'email', t('.search_label'), class: 'fr-label' %>
-     <span class="fr-hint-text fr-mb-1w"><%= t('.search_hint') %></span>
-     <div class="fr-input-wrap fr-input-wrap--addon">
-       <%= f.search_field 'email', size: 40, class: 'fr-input', data: { turbo_force: :server } %>
-       <%= f.button 'Rechercher', class: 'fr-btn fr-icon-search-line' %>
-     </div>
+      <%= f.label 'email', t('.search_label'), class: 'fr-label' %>
+      <span class="fr-hint-text fr-mb-1w"><%= t('.search_hint') %></span>
+      <div class="fr-input-wrap fr-input-wrap--addon">
+        <%= f.search_field 'email', size: 40, class: 'fr-input', data: { turbo_force: :server } %>
+        <%= f.button 'Rechercher', class: 'fr-btn fr-icon-search-line' %>
+      </div>
     <% end %>
   </div>
 
-  <% if @filter.email %>
-    <div class="selected-email fr-mb-2w">
-      <%= link_to @filter.email, administrateurs_admin_procedures_path(@filter.without(:email)), class: 'fr-tag fr-tag--dismiss fr-mb-1w' %>
-    </div>
-  <% end %>
+  <div class="flex flex-gap-1 wrap align-center fr-mb-2w">
+    <% if @filter.email %>
+      <div class="selected-email">
+        <%= link_to "Administrateur : #{@filter.email}", administrateurs_admin_procedures_path(@filter.without(:email)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
+      </div>
+    <% end %>
 
-  <% if @filter.selected_zones.present? %>
-    <div class="selected-zones fr-mb-2w">
-      <% @filter.selected_zones.each do |zone| %>
-        <%= link_to zone.current_label, administrateurs_admin_procedures_path(@filter.without(:zone_ids, zone.id)), class: 'fr-tag fr-tag--dismiss fr-mb-1w' %>
-      <% end %>
-    </div>
-  <% end %>
+    <% if @filter.selected_zones.present? %>
+      <div class="selected-zones">
+        <% @filter.selected_zones.each do |zone| %>
+          <%= link_to "Zone : #{zone.current_label}", administrateurs_admin_procedures_path(@filter.without(:zone_ids, zone.id)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
+        <% end %>
+      </div>
+    <% end %>
 
-  <% if @filter.statuses.present? %>
-    <div class="selected-statuses fr-mb-2w">
-      <% @filter.statuses.each do |status| %>
-        <%= link_to status, administrateurs_admin_procedures_path(@filter.without(:statuses, status)), class: 'fr-tag fr-tag--dismiss fr-mb-1w' %>
-      <% end %>
-    </div>
-  <% end %>
+    <% if @filter.statuses.present? %>
+      <div class="selected-statuses">
+        <% @filter.statuses.each do |status| %>
+          <%= link_to "Statut : #{t(status, scope: 'activerecord.attributes.procedure.aasm_state')}", administrateurs_admin_procedures_path(@filter.without(:statuses, status)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
+        <% end %>
+      </div>
+    <% end %>
 
-  <% if @filter.from_publication_date.present? %>
-    <div class="selected-from-publication-date fr-mb-2w">
-      <%= link_to t('.since_date', date: l(@filter.from_publication_date)), administrateurs_admin_procedures_path(@filter.without(:from_publication_date)), class: 'fr-tag fr-tag--dismiss fr-mb-1w' %>
-    </div>
-  <% end %>
+    <% if @filter.from_publication_date.present? %>
+      <div class="selected-from-publication-date">
+        <%= link_to t('.since_date', date: l(@filter.from_publication_date)), administrateurs_admin_procedures_path(@filter.without(:from_publication_date)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
+      </div>
+    <% end %>
+
+    <% if visible_filter_tags_count(@filter) >= 3 %>
+      <%= link_to 'Tout supprimer', procedures_filter_path, data: { turbo: 'false' }, class: 'fr-btn fr-btn--tertiary-no-outline fr-btn--sm' %>
+    <% end %>
+  </div>
 
   <% if @admins.any? %>
     <div class="fr-table fr-table--bordered">

--- a/app/views/administrateurs/procedures/administrateurs.html.erb
+++ b/app/views/administrateurs/procedures/administrateurs.html.erb
@@ -7,13 +7,13 @@
         <%= hidden_field_tag 'zone_ids[]', zone_id, id: "zone_#{zone_id}" %>
       <% end %>
 
-      <% @filter.statuses&.each do |status| %>
+     <% @filter.statuses&.each do |status| %>
         <%= hidden_field_tag 'statuses[]', status, id: "status_#{status}" %>
       <% end %>
 
-      <%= hidden_field_tag 'from_publication_date', @filter.from_publication_date if @filter.from_publication_date.present? %>
+     <%= hidden_field_tag 'from_publication_date', @filter.from_publication_date if @filter.from_publication_date.present? %>
 
-      <%= f.label 'email', t('.search_label'), class: 'fr-label' %>
+     <%= f.label 'email', t('.search_label'), class: 'fr-label' %>
       <%= f.search_field 'email', size: 40, class: 'fr-input', data: { turbo_force: :server } %>
     <% end %>
   </div>

--- a/app/views/administrateurs/procedures/administrateurs.html.erb
+++ b/app/views/administrateurs/procedures/administrateurs.html.erb
@@ -1,29 +1,19 @@
 <% content_for(:title, t('.title')) %>
 
 <% content_for :results do %>
-  <div class="main-filter-header fr-mb-3w">
-    <%= form_with(url: administrateurs_admin_procedures_path, method: :get, class: 'width-66', data: { turbo_frame: 'procedures' }, html: { role: 'search' }) do |f| %>
-      <% @filter.zone_ids&.each do |zone_id| %>
-        <%= hidden_field_tag 'zone_ids[]', zone_id, id: "zone_#{zone_id}" %>
-      <% end %>
+  <div class="fr-mb-3w width-66">
+    <%= label_tag 'email', t('.search_label'), class: 'fr-label' %>
+    <span class="fr-hint-text fr-mb-1w"><%= t('.search_hint') %></span>
 
-      <% @filter.statuses&.each do |status| %>
-        <%= hidden_field_tag 'statuses[]', status, id: "status_#{status}" %>
-      <% end %>
-
-      <%= hidden_field_tag 'from_publication_date', @filter.from_publication_date if @filter.from_publication_date.present? %>
-
-      <%= f.label 'email', t('.search_label'), class: 'fr-label' %>
-      <span class="fr-hint-text fr-mb-1w"><%= t('.search_hint') %></span>
-      <div class="fr-input-wrap fr-input-wrap--addon">
-        <%= f.search_field 'email', value: @filter.email, size: 40, class: 'fr-input', data: { turbo_force: :server } %>
-        <%= f.button 'Rechercher', class: 'fr-btn fr-icon-search-line' %>
-      </div>
-    <% end %>
+    <div class="fr-input-wrap fr-input-wrap--addon">
+      <%= search_field_tag :email, @filter.email,  class: 'fr-input', form: 'procedures-filter-form', data: { no_autosubmit: 'input', turbo_force: :server } %>
+      <%= button_tag 'Rechercher', form: 'procedures-filter-form', class: 'fr-btn fr-icon-search-line' %>
+    </div>
   </div>
 
   <div class="flex flex-gap-1 wrap align-center fr-mb-2w">
     <%= render 'administrateurs/procedures/common_filter_tags' %>
+
     <% if visible_filter_tags_count(@filter) >= 3 %>
       <%= link_to 'Tout supprimer', procedures_filter_path, data: { turbo: 'false' }, class: 'fr-btn fr-btn--tertiary-no-outline fr-btn--sm' %>
     <% end %>

--- a/app/views/administrateurs/procedures/administrateurs.html.erb
+++ b/app/views/administrateurs/procedures/administrateurs.html.erb
@@ -31,7 +31,7 @@
   <% if @filter.selected_zones.present? %>
     <div class="selected-zones fr-mb-2w">
       <% @filter.selected_zones.each do |zone| %>
-        <%= link_to zone.current_label, all_admin_procedures_path(@filter.without(:zone_ids, zone.id)), class: 'fr-tag fr-tag--dismiss fr-mb-1w' %>
+        <%= link_to zone.current_label, administrateurs_admin_procedures_path(@filter.without(:zone_ids, zone.id)), class: 'fr-tag fr-tag--dismiss fr-mb-1w' %>
       <% end %>
     </div>
   <% end %>
@@ -39,14 +39,14 @@
   <% if @filter.statuses.present? %>
     <div class="selected-statuses fr-mb-2w">
       <% @filter.statuses.each do |status| %>
-        <%= link_to status, all_admin_procedures_path(@filter.without(:statuses, status)), class: 'fr-tag fr-tag--dismiss fr-mb-1w' %>
+        <%= link_to status, administrateurs_admin_procedures_path(@filter.without(:statuses, status)), class: 'fr-tag fr-tag--dismiss fr-mb-1w' %>
       <% end %>
     </div>
   <% end %>
 
   <% if @filter.from_publication_date.present? %>
     <div class="selected-from-publication-date fr-mb-2w">
-      <%= link_to t('.since_date', date: l(@filter.from_publication_date)), all_admin_procedures_path(@filter.without(:from_publication_date)), class: 'fr-tag fr-tag--dismiss fr-mb-1w' %>
+      <%= link_to t('.since_date', date: l(@filter.from_publication_date)), administrateurs_admin_procedures_path(@filter.without(:from_publication_date)), class: 'fr-tag fr-tag--dismiss fr-mb-1w' %>
     </div>
   <% end %>
 

--- a/app/views/administrateurs/procedures/administrateurs.html.erb
+++ b/app/views/administrateurs/procedures/administrateurs.html.erb
@@ -16,10 +16,6 @@
       <%= f.label 'email', t('.search_label'), class: 'fr-label' %>
       <%= f.search_field 'email', size: 40, class: 'fr-input', data: { turbo_force: :server } %>
     <% end %>
-
-    <div class="actions">
-      <%= link_to t('.view_procedures'), all_admin_procedures_path(@filter.params), class: 'fr-btn fr-btn--secondary' %>
-    </div>
   </div>
 
   <% if @filter.email %>

--- a/app/views/administrateurs/procedures/administrateurs.html.erb
+++ b/app/views/administrateurs/procedures/administrateurs.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, t('.title')) %>
 
 <% content_for :results do %>
-  <div class="main-filter-header fr-my-3w">
+  <div class="main-filter-header fr-mb-3w">
     <%= form_with(url: administrateurs_admin_procedures_path, method: :get, data: { turbo_frame: 'procedures' }, html: { role: 'search' }) do |f| %>
       <% @filter.zone_ids&.each do |zone_id| %>
         <%= hidden_field_tag 'zone_ids[]', zone_id, id: "zone_#{zone_id}" %>
@@ -46,90 +46,96 @@
     </div>
   <% end %>
 
-  <div class="fr-table fr-table--bordered">
-    <div class="fr-table__wrapper">
-      <div class="fr-table__container">
-        <div class="fr-table__content">
-          <table id="all-admins">
-            <caption>
-              <%= t('.admin_count', count: @admins.total_count) %>
+  <% if @admins.any? %>
+    <div class="fr-table fr-table--bordered">
+      <div class="fr-table__wrapper">
+        <div class="fr-table__container">
+          <div class="fr-table__content">
+            <table id="all-admins">
+              <caption>
+                <%= t('.admin_count', count: @admins.total_count) %>
 
-              <span
-                class="hidden spinner"
-                aria-hidden="true"
-                data-turbo-target="spinner"
-              ></span>
-            </caption>
+                <span
+                  class="hidden spinner"
+                  aria-hidden="true"
+                  data-turbo-target="spinner"
+                ></span>
+              </caption>
 
-            <thead>
-              <tr>
-                <th scope="col"></th>
-                <th scope="col"><%= t('.col_administrators') %></th>
-                <th scope="col"><%= t('.col_procedures_count') %></th>
-                <th scope="col"><%= t('.col_registered_at') %></th>
-              </tr>
-            </thead>
+              <thead>
+                <tr>
+                  <th scope="col"></th>
+                  <th scope="col"><%= t('.col_administrators') %></th>
+                  <th scope="col"><%= t('.col_procedures_count') %></th>
+                  <th scope="col"><%= t('.col_registered_at') %></th>
+                </tr>
+              </thead>
 
-            <% @admins.each do |admin| %>
-              <tbody data-controller="expand">
-                <tr class="procedure" data-action="click->expand#toggle">
-                  <th class="fr-cell--center" scope="row">
-                    <button
-                      class="fr-btn fr-btn--tertiary-no-outline"
-                      aria-expanded="false"
-                      data-action="click->expand#toggle:stop"
+              <% @admins.each do |admin| %>
+                <tbody data-controller="expand">
+                  <tr class="procedure" data-action="click->expand#toggle">
+                    <th class="fr-cell--center" scope="row">
+                      <button
+                        class="fr-btn fr-btn--tertiary-no-outline"
+                        aria-expanded="false"
+                        data-action="click->expand#toggle:stop"
+                      >
+                        <span
+                          class="
+                            fr-icon-add-line fr-icon--sm
+                            fr-text-action-high--blue-france
+                          "
+                          aria-hidden="true"
+                          data-expand-target="icon"
+                        ></span>
+
+                        <span class="fr-sr-only">
+                          <%= t('.expand_admin') %>
+                        </span>
+                      </button>
+                    </th>
+
+                    <td><%= admin.email %></td>
+
+                    <td class="fr-cell--right fr-cell--numeric">
+                      <%= admin.procedures.size %>
+                    </td>
+
+                    <td class="fr-cell--numeric">
+                      <%= l(admin.created_at.to_date, format: :short) %>
+                    </td>
+                  </tr>
+
+                  <tr class="hidden" data-expand-target="content">
+                    <td
+                      class="fr-cell--multiline fr-background-alt--green-emeraude"
+                      colspan="4"
                     >
-                      <span
-                        class="
-                          fr-icon-add-line fr-icon--sm
-                          fr-text-action-high--blue-france
-                        "
-                        aria-hidden="true"
-                        data-expand-target="icon"
-                      ></span>
-
-                      <span class="fr-sr-only"><%= t('.expand_admin') %></span>
-                    </button>
-                  </th>
-
-                  <td><%= admin.email %></td>
-
-                  <td class="fr-cell--right fr-cell--numeric">
-                    <%= admin.procedures.size %>
-                  </td>
-
-                  <td class="fr-cell--numeric">
-                    <%= l(admin.created_at.to_date, format: :short) %>
-                  </td>
-                </tr>
-
-                <tr class="hidden" data-expand-target="content">
-                  <td
-                    class="fr-cell--multiline fr-background-alt--green-emeraude"
-                    colspan="4"
-                  >
-                    <ul>
-                      <% admin.procedures.each do |procedure| %>
-                        <li><%= procedure.libelle %></li>
-                      <% end %>
-                    </ul>
-                  </td>
-                </tr>
-              </tbody>
-            <% end %>
-          </table>
+                      <ul>
+                        <% admin.procedures.each do |procedure| %>
+                          <li><%= procedure.libelle %></li>
+                        <% end %>
+                      </ul>
+                    </td>
+                  </tr>
+                </tbody>
+              <% end %>
+            </table>
+          </div>
         </div>
       </div>
-    </div>
 
-    <div class="fr-table__footer">
-      <div class="fr-table__footer--start"></div>
+      <div class="fr-table__footer">
+        <div class="fr-table__footer--start"></div>
 
-      <div class="fr-table__footer--middle">
-        <%= paginate @admins, views_prefix: 'shared' %>
+        <div class="fr-table__footer--middle">
+          <%= paginate @admins, views_prefix: 'shared' %>
+        </div>
+
+        <div class="fr-table__footer--end flex-no-grow"></div>
       </div>
-
-      <div class="fr-table__footer--end flex-no-grow"></div>
     </div>
-  </div>
+  <% else %>
+    <p>Aucun administrateur trouvé.</p>
+  <% end %>
 <% end %>

--- a/app/views/administrateurs/procedures/administrateurs.html.erb
+++ b/app/views/administrateurs/procedures/administrateurs.html.erb
@@ -23,34 +23,7 @@
   </div>
 
   <div class="flex flex-gap-1 wrap align-center fr-mb-2w">
-    <% if @filter.email %>
-      <div class="selected-email">
-        <%= link_to "Administrateur : #{@filter.email}", administrateurs_admin_procedures_path(@filter.without(:email)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
-      </div>
-    <% end %>
-
-    <% if @filter.selected_zones.present? %>
-      <div class="selected-zones">
-        <% @filter.selected_zones.each do |zone| %>
-          <%= link_to "Zone : #{zone.current_label}", administrateurs_admin_procedures_path(@filter.without(:zone_ids, zone.id)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
-        <% end %>
-      </div>
-    <% end %>
-
-    <% if @filter.statuses.present? %>
-      <div class="selected-statuses">
-        <% @filter.statuses.each do |status| %>
-          <%= link_to "Statut : #{t(status, scope: 'activerecord.attributes.procedure.aasm_state')}", administrateurs_admin_procedures_path(@filter.without(:statuses, status)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
-        <% end %>
-      </div>
-    <% end %>
-
-    <% if @filter.from_publication_date.present? %>
-      <div class="selected-from-publication-date">
-        <%= link_to t('.since_date', date: l(@filter.from_publication_date)), administrateurs_admin_procedures_path(@filter.without(:from_publication_date)), class: 'fr-tag fr-tag--dismiss fr-tag--sm' %>
-      </div>
-    <% end %>
-
+    <%= render 'administrateurs/procedures/common_filter_tags' %>
     <% if visible_filter_tags_count(@filter) >= 3 %>
       <%= link_to 'Tout supprimer', procedures_filter_path, data: { turbo: 'false' }, class: 'fr-btn fr-btn--tertiary-no-outline fr-btn--sm' %>
     <% end %>

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -13,7 +13,6 @@
       = f.label :libelle, 'Rechercher des démarches par libellé', class: 'fr-label'
       = f.search_field 'libelle', size: 30, class: 'fr-input', data: { turbo_force: :server }
     .actions
-      .link.fr-mx-1w= link_to 'Voir les administrateurs', administrateurs_admin_procedures_path(@filter.params), class: 'fr-btn fr-btn--secondary'
       .link.fr-mx-1w{ "data-turbo": "false" }= link_to 'Exporter les résultats', all_admin_procedures_path(@filter.params.merge(format: :xlsx)), class: 'fr-btn fr-btn--secondary'
 
   - if @filter.libelle

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -15,40 +15,43 @@
         = f.search_field 'libelle', class: 'fr-input', data: { turbo_force: :server }
         = f.button 'Rechercher', class: 'fr-btn fr-icon-search-line'
 
-  - if @filter.libelle
-    .selected-query.fr-mb-2w
-      = link_to @filter.libelle, all_admin_procedures_path(@filter.without(:libelle)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
-  - if @filter.email
-    .selected-email.fr-mb-2w
-      = link_to @filter.email, all_admin_procedures_path(@filter.without(:email)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
-  - if @filter.service_siret
-    .selected-query.fr-mb-2w
-      = link_to @filter.service_siret, all_admin_procedures_path(@filter.without(:service_siret)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
-  - if @filter.service_departement
-    .selected-query.fr-mb-2w
-      = link_to "#{@filter.service_departement} – #{APIGeoService.departement_name(@filter.service_departement)}", all_admin_procedures_path(@filter.without(:service_departement)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
-  - if @filter.selected_zones.present?
-    .selected-zones.fr-mb-2w
-      - @filter.selected_zones.each do |zone|
-        = link_to zone.current_label, all_admin_procedures_path(@filter.without(:zone_ids, zone.id)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
-  - if @filter.statuses.present?
-    .selected-statuses.fr-mb-2w
-      - @filter.statuses.each do |status|
-        = link_to status, all_admin_procedures_path(@filter.without(:statuses, status)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
-  - if @filter.kind_usagers.present?
-    .selected-kind_usagers.fr-mb-2w
-      - @filter.kind_usagers.each do |kind_usager|
-        = link_to t(kind_usager, scope: 'activerecord.attributes.procedure.kind_usager'), all_admin_procedures_path(@filter.without(:kind_usagers, kind_usager)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
-  - if @filter.tags.present?
-    .selected-tag.fr-mb-2w
-      - @filter.tags.each do |tag|
-        = link_to tag, all_admin_procedures_path(@filter.without(:tags, tag)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
-  - if @filter.template?
-    .selected-template.fr-mb-2w
-      = link_to "Modèle DS", all_admin_procedures_path(@filter.without(:template)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
-  - if @filter.from_publication_date.present?
-    .selected-from-publication-date.fr-mb-2w
-      = link_to "Depuis #{l(@filter.from_publication_date)}", all_admin_procedures_path(@filter.without(:from_publication_date)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
+  .flex.flex-gap-1.wrap.align-center
+    - if @filter.libelle
+      .selected-query
+        = link_to "Libellé : #{@filter.libelle}", all_admin_procedures_path(@filter.without(:libelle)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
+    - if @filter.email
+      .selected-email
+        = link_to "Administrateur : #{@filter.email}", all_admin_procedures_path(@filter.without(:email)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
+    - if @filter.service_siret
+      .selected-query
+        = link_to "SIRET : #{@filter.service_siret}", all_admin_procedures_path(@filter.without(:service_siret)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
+    - if @filter.service_departement
+      .selected-query
+        = link_to "Département : #{@filter.service_departement} – #{APIGeoService.departement_name(@filter.service_departement)}", all_admin_procedures_path(@filter.without(:service_departement)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
+    - if @filter.selected_zones.present?
+      .selected-zones
+        - @filter.selected_zones.each do |zone|
+          = link_to "Zone : #{zone.current_label}", all_admin_procedures_path(@filter.without(:zone_ids, zone.id)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
+    - if @filter.statuses.present?
+      .selected-statuses
+        - @filter.statuses.each do |status|
+          = link_to "Statut : #{t(status, scope: 'activerecord.attributes.procedure.aasm_state')}", all_admin_procedures_path(@filter.without(:statuses, status)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
+    - if @filter.kind_usagers.present?
+      .selected-kind_usagers
+        - @filter.kind_usagers.each do |kind_usager|
+          = link_to "Type d’usager : #{t(kind_usager, scope: 'activerecord.attributes.procedure.kind_usager')}", all_admin_procedures_path(@filter.without(:kind_usagers, kind_usager)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
+    - if @filter.tags.present?
+      .selected-tag
+        - @filter.tags.each do |tag|
+          = link_to "Thématique : #{tag}", all_admin_procedures_path(@filter.without(:tags, tag)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
+    - if @filter.template?
+      .selected-template
+        = link_to "Modèle DS", all_admin_procedures_path(@filter.without(:template)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
+    - if @filter.from_publication_date.present?
+      .selected-from-publication-date
+        = link_to "Date de publication : depuis #{l(@filter.from_publication_date)}", all_admin_procedures_path(@filter.without(:from_publication_date)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
+    - if visible_filter_tags_count(@filter) >= 3
+      = link_to 'Tout supprimer', procedures_filter_path, { data: { turbo: 'false' }, class: 'fr-btn fr-btn--tertiary-no-outline fr-btn--sm' }
 
   - if @procedures.any?
     .flex.align-center.fr-mt-2w

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -1,7 +1,8 @@
 - content_for(:title, "Démarches")
 - content_for :results do
   .fr-mb-3w.width-66
-    = label_tag :libelle, 'Rechercher des démarches par libellé', class: 'fr-label'
+    = label_tag :libelle, t('.search_label'), class: 'fr-label'
+    %span.fr-hint-text.fr-mb-1w= t('.search_hint')
     .fr-input-wrap.fr-input-wrap--addon
       = search_field_tag :libelle, @filter.libelle, class: 'fr-input', form: 'procedures-filter-form', data: { no_autosubmit: 'input', turbo_force: :server }
       = button_tag 'Rechercher', type: 'submit', form: 'procedures-filter-form', class: 'fr-btn fr-icon-search-line'
@@ -10,7 +11,7 @@
   .flex.flex-gap-1.wrap.align-center
     - if @filter.libelle
       .selected-query
-        = link_to "Libellé : #{@filter.libelle}", all_admin_procedures_path(@filter.without(:libelle)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
+        = link_to "Libellé ou numéro : #{@filter.libelle}", all_admin_procedures_path(@filter.without(:libelle)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
     = render 'administrateurs/procedures/common_filter_tags'
     - if @filter.kind_usagers.present?
       .selected-kind_usagers

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -1,7 +1,7 @@
 - content_for(:title, "Démarches")
 - content_for :results do
   .main-filter-header.fr-mb-3w
-    = form_with(url: all_admin_procedures_path, method: :get, data: { turbo_frame: 'procedures' }, html: { role: 'search', class: 'search' }) do |f|
+    = form_with(url: all_admin_procedures_path, method: :get, data: { turbo_frame: 'procedures' }, html: { role: 'search', class: 'search width-66' }) do |f|
       - @filter.zone_ids&.each do |zone_id|
         = hidden_field_tag 'zone_ids[]', zone_id, id: "zone_#{zone_id}"
       - @filter.statuses&.each do |status|
@@ -11,7 +11,9 @@
       = hidden_field_tag 'from_publication_date', @filter.from_publication_date if @filter.from_publication_date.present?
 
       = f.label :libelle, 'Rechercher des démarches par libellé', class: 'fr-label'
-      = f.search_field 'libelle', size: 30, class: 'fr-input', data: { turbo_force: :server }
+      .fr-input-wrap.fr-input-wrap--addon
+        = f.search_field 'libelle', class: 'fr-input', data: { turbo_force: :server }
+        = f.button 'Rechercher', class: 'fr-btn fr-icon-search-line'
 
   - if @filter.libelle
     .selected-query.fr-mb-2w

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -1,19 +1,11 @@
 - content_for(:title, "Démarches")
 - content_for :results do
-  .main-filter-header.fr-mb-3w
-    = form_with(url: all_admin_procedures_path, method: :get, data: { turbo_frame: 'procedures' }, html: { role: 'search', class: 'search width-66' }) do |f|
-      - @filter.zone_ids&.each do |zone_id|
-        = hidden_field_tag 'zone_ids[]', zone_id, id: "zone_#{zone_id}"
-      - @filter.statuses&.each do |status|
-        = hidden_field_tag 'statuses[]', status, id: "status_#{status}"
-      - @filter.tags&.each do|tag|
-        = hidden_field_tag 'tags[]', tag, id: "tag_#{tag}"
-      = hidden_field_tag 'from_publication_date', @filter.from_publication_date if @filter.from_publication_date.present?
+  .fr-mb-3w.width-66
+    = label_tag :libelle, 'Rechercher des démarches par libellé', class: 'fr-label'
+    .fr-input-wrap.fr-input-wrap--addon
+      = search_field_tag :libelle, @filter.libelle, class: 'fr-input', form: 'procedures-filter-form', data: { no_autosubmit: 'input', turbo_force: :server }
+      = button_tag 'Rechercher', type: 'submit', form: 'procedures-filter-form', class: 'fr-btn fr-icon-search-line'
 
-      = f.label :libelle, 'Rechercher des démarches par libellé', class: 'fr-label'
-      .fr-input-wrap.fr-input-wrap--addon
-        = f.search_field 'libelle', value: @filter.libelle, class: 'fr-input', data: { turbo_force: :server }
-        = f.button 'Rechercher', class: 'fr-btn fr-icon-search-line'
 
   .flex.flex-gap-1.wrap.align-center
     - if @filter.libelle

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -1,6 +1,6 @@
 - content_for(:title, "Démarches")
 - content_for :results do
-  .main-filter-header.fr-my-3w
+  .main-filter-header.fr-mb-3w
     = form_with(url: all_admin_procedures_path, method: :get, data: { turbo_frame: 'procedures' }, html: { role: 'search', class: 'search' }) do |f|
       - @filter.zone_ids&.each do |zone_id|
         = hidden_field_tag 'zone_ids[]', zone_id, id: "zone_#{zone_id}"
@@ -12,8 +12,6 @@
 
       = f.label :libelle, 'Rechercher des démarches par libellé', class: 'fr-label'
       = f.search_field 'libelle', size: 30, class: 'fr-input', data: { turbo_force: :server }
-    .actions
-      .link.fr-mx-1w{ "data-turbo": "false" }= link_to 'Exporter les résultats', all_admin_procedures_path(@filter.params.merge(format: :xlsx)), class: 'fr-btn fr-btn--secondary'
 
   - if @filter.libelle
     .selected-query.fr-mb-2w
@@ -47,30 +45,35 @@
     .selected-from-publication-date.fr-mb-2w
       = link_to "Depuis #{l(@filter.from_publication_date)}", all_admin_procedures_path(@filter.without(:from_publication_date)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
 
-  .fr-table.fr-table--sm.fr-table--no-scroll.fr-table--bordered{ 'data-turbo': 'true', 'data-turbo-force': 'server' }
-    .fr-table__wrapper
-      .fr-table__container
-        .fr-table__content
-          %table
-            %caption
-              = "#{@procedures.total_count} #{t('pluralize.procedures', count: @procedures.total_count)}"
-              %span.hidden.spinner{ 'aria-hidden': 'true', 'data-turbo-target': 'spinner' }
+  - if @procedures.any?
+    .flex.align-center.fr-mt-2w
+      .fr-h6.fr-mb-0= "#{@procedures.total_count} #{t('pluralize.procedures', count: @procedures.total_count)}"
+      %span.hidden.spinner{ 'aria-hidden': 'true', 'data-turbo-target': 'spinner' }
 
-            %thead
-              %tr
-                %th{ role: 'columnheader' }
-                %th{ scope: 'col' } Démarche
-                %th{ scope: 'col' } №
-                %th{ scope: 'col' } Nombre de dossiers
-                %th{ scope: 'col' } Zones
-                %th{ scope: 'col' } Statut
-                %th{ scope: 'col' } Date
-                %th{ scope: 'col' } Action
-            %tbody
-              - @procedures.each do |procedure|
-                = render partial: 'detail', locals: { procedure: procedure, show_detail: false }
-    .fr-table__footer
-      .fr-table__footer--start
-      .fr-table__footer--middle
-        = paginate @procedures, views_prefix: 'shared'
-      .fr-table__footer--end.flex-no-grow
+      .fr-ml-auto{ "data-turbo": "false" }= link_to 'Exporter les résultats', all_admin_procedures_path(@filter.params.merge(format: :xlsx)), class: 'fr-btn fr-btn--secondary'
+    .fr-table.fr-table--sm.fr-table--no-scroll.fr-table--bordered{ 'data-turbo': 'true', 'data-turbo-force': 'server' }
+      .fr-table__wrapper
+        .fr-table__container
+          .fr-table__content
+            %table
+              %thead
+                %tr
+                  %th{ role: 'columnheader' }
+                  %th{ scope: 'col' } Démarche
+                  %th{ scope: 'col' } №
+                  %th{ scope: 'col' } Nombre de dossiers
+                  %th{ scope: 'col' } Zones
+                  %th{ scope: 'col' } Statut
+                  %th{ scope: 'col' } Date
+                  %th{ scope: 'col' } Action
+              %tbody
+                - @procedures.each do |procedure|
+                  = render partial: 'detail', locals: { procedure: procedure, show_detail: false }
+      .fr-table__footer
+        .fr-table__footer--start
+        .fr-table__footer--middle
+          = paginate @procedures, views_prefix: 'shared'
+        .fr-table__footer--end.flex-no-grow
+
+  - else
+    %p Aucune démarche trouvée.

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -16,6 +16,9 @@
   - if @filter.libelle
     .selected-query.fr-mb-2w
       = link_to @filter.libelle, all_admin_procedures_path(@filter.without(:libelle)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
+  - if @filter.email
+    .selected-email.fr-mb-2w
+      = link_to @filter.email, all_admin_procedures_path(@filter.without(:email)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'
   - if @filter.service_siret
     .selected-query.fr-mb-2w
       = link_to @filter.service_siret, all_admin_procedures_path(@filter.without(:service_siret)), class: 'fr-tag fr-tag--dismiss fr-mb-1w'

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -12,7 +12,7 @@
 
       = f.label :libelle, 'Rechercher des démarches par libellé', class: 'fr-label'
       .fr-input-wrap.fr-input-wrap--addon
-        = f.search_field 'libelle', class: 'fr-input', data: { turbo_force: :server }
+        = f.search_field 'libelle', value: @filter.libelle, class: 'fr-input', data: { turbo_force: :server }
         = f.button 'Rechercher', class: 'fr-btn fr-icon-search-line'
 
   .flex.flex-gap-1.wrap.align-center

--- a/app/views/administrateurs/procedures/all.html.haml
+++ b/app/views/administrateurs/procedures/all.html.haml
@@ -19,23 +19,7 @@
     - if @filter.libelle
       .selected-query
         = link_to "Libellé : #{@filter.libelle}", all_admin_procedures_path(@filter.without(:libelle)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
-    - if @filter.email
-      .selected-email
-        = link_to "Administrateur : #{@filter.email}", all_admin_procedures_path(@filter.without(:email)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
-    - if @filter.service_siret
-      .selected-query
-        = link_to "SIRET : #{@filter.service_siret}", all_admin_procedures_path(@filter.without(:service_siret)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
-    - if @filter.service_departement
-      .selected-query
-        = link_to "Département : #{@filter.service_departement} – #{APIGeoService.departement_name(@filter.service_departement)}", all_admin_procedures_path(@filter.without(:service_departement)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
-    - if @filter.selected_zones.present?
-      .selected-zones
-        - @filter.selected_zones.each do |zone|
-          = link_to "Zone : #{zone.current_label}", all_admin_procedures_path(@filter.without(:zone_ids, zone.id)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
-    - if @filter.statuses.present?
-      .selected-statuses
-        - @filter.statuses.each do |status|
-          = link_to "Statut : #{t(status, scope: 'activerecord.attributes.procedure.aasm_state')}", all_admin_procedures_path(@filter.without(:statuses, status)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
+    = render 'administrateurs/procedures/common_filter_tags'
     - if @filter.kind_usagers.present?
       .selected-kind_usagers
         - @filter.kind_usagers.each do |kind_usager|
@@ -47,9 +31,6 @@
     - if @filter.template?
       .selected-template
         = link_to "Modèle DS", all_admin_procedures_path(@filter.without(:template)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
-    - if @filter.from_publication_date.present?
-      .selected-from-publication-date
-        = link_to "Date de publication : depuis #{l(@filter.from_publication_date)}", all_admin_procedures_path(@filter.without(:from_publication_date)), class: 'fr-tag fr-tag--dismiss fr-tag--sm'
     - if visible_filter_tags_count(@filter) >= 3
       = link_to 'Tout supprimer', procedures_filter_path, { data: { turbo: 'false' }, class: 'fr-btn fr-btn--tertiary-no-outline fr-btn--sm' }
 

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -39,7 +39,9 @@
                   .fr-checkbox-group
                     = f.label :email, 'Adresse électronique ou domaine', class: 'fr-label'
                     %span.fr-hint-text.fr-mb-1w Exemple: adresse@mail.com ou @culture.gouv.fr
-                    = f.search_field :email, class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }
+                    .fr-input-wrap.fr-input-wrap--addon
+                      = f.search_field :email, class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }
+                      = f.button 'Rechercher', class: 'fr-btn fr-icon-search-line'
 
 
               = render Dsfr::AccordionComponent.new(expanded: @filter.tags.present?) do |c|
@@ -97,7 +99,11 @@
                   - if @filter.service_siret.present?
                     %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
                 %div
-                  = f.text_field :service_siret, placeholder: 'Indiquez le SIRET', class: 'fr-input'
+                  = f.label :service_siret, 'Numéro SIRET', class: 'fr-label'
+                  %span.fr-hint-text.fr-mb-1w Exemple : 500 001 234 56789
+                  .fr-input-wrap.fr-input-wrap--addon
+                    = f.text_field :service_siret, class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }
+                    = f.button 'Rechercher', class: 'fr-btn fr-icon-search-line'
 
 
               = render Dsfr::AccordionComponent.new(expanded: @filter.service_departement.present?) do |c|
@@ -131,8 +137,9 @@
                     %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
                 .fr-input-group
                   = f.label 'from_publication_date', 'Depuis', class: 'fr-label'
-                  .fr-input-wrap.fr-fi-calendar-line
-                    = f.date_field 'from_publication_date', value: @filter.from_publication_date, class: 'fr-input'
+                  .fr-input-wrap.fr-input-wrap--addon
+                    = f.date_field 'from_publication_date', value: @filter.from_publication_date, class: 'fr-input', data: { no_autosubmit: 'input change blur', turbo_force: :server }
+                    = f.button 'Rechercher', class: 'fr-btn fr-icon-search-line'
 
 
               = render Dsfr::AccordionComponent.new(expanded: @filter.statuses.present?) do |c|

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -4,165 +4,147 @@
   .sub-header
     .fr-container
       %h1.fr-my-4w= t('administrateurs.procedures.all.title')
-
       .fr-container
         .fr-grid-row.fr-grid-row--gutters
           .fr-col-12
             .fr-highlight.fr-mb-4w
               %p= t('administrateurs.procedures.all.description_html')
 
-
   %turbo-frame#procedures{ data: { turbo_action: 'advance', turbo: 'true' } }
-  .sub-header.fr-mt-n4w
+    .sub-header.fr-mt-n4w
+      .fr-container
+        %nav.fr-tabs{ role: 'navigation', 'aria-label': t('administrateurs.all_procedures_menu') }
+          %ul.fr-tabs__list
+            = tab_item(t('administrateurs.procedure_list'), procedures_filter_path(request.query_parameters.merge(action: 'all')), active: action_name == 'all')
+            = tab_item(t('administrateurs.administrator_list'), procedures_filter_path(request.query_parameters.merge(action: 'administrateurs')), active: action_name == 'administrateurs')
+
     .fr-container
-      %nav.fr-tabs{ role: 'navigation', 'aria-label': t('administrateurs.all_procedures_menu') }
-        %ul.fr-tabs__list
-          = tab_item(t('administrateurs.procedure_list'), procedures_filter_path(request.query_parameters.merge(action: 'all')), active: action_name == 'all')
-          = tab_item(t('administrateurs.administrator_list'), procedures_filter_path(request.query_parameters.merge(action: 'administrateurs')), active: action_name == 'administrateurs')
+      .fr-grid-row.fr-grid-row--gutters
+        .fr-col-12.fr-col-lg-3
+          = form_with(url: procedures_filter_path, method: :get, data: { controller: 'autosubmit', turbo_frame: 'procedures' }) do |f|
 
-  .fr-container
-    .fr-grid-row.fr-grid-row--gutters
-      .fr-col-12.fr-col-lg-3
-        = form_with(url: procedures_filter_path, method: :get, data: { controller: 'autosubmit', turbo_frame: 'procedures' }) do |f|
+            %fieldset.sidebar-filter
+              %legend
+                .title.fr-text--bold
+                  Filtrer
+                .reinit
+                  = link_to 'Réinitialiser', procedures_filter_path(zone_ids: current_administrateur.zones), { data: { turbo: 'false' }, class: 'fr-link fr-link--icon-left fr-icon-arrow-go-back-line' }
 
-          %fieldset.sidebar-filter
-            %legend
-              .title.fr-text--bold
-                Filtrer
-              .reinit
-                = link_to 'Réinitialiser', procedures_filter_path(zone_ids: current_administrateur.zones), { data: { turbo: 'false' }, class: 'fr-link fr-link--icon-left fr-icon-arrow-go-back-line' }
-
-            %ul
               - if action_name == 'all'
-                %li.fr-py-1w{ 'data-controller': "expand" }
-                  .fr-my-1w
-                    %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
-                      %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                      Administrateur
-                      - if @filter.email.present?
-                        %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
-                  .hidden{ 'data-expand-target': 'content' }
-                    %div
-                      = f.label :email, 'Adresse électronique ou domaine', class: 'fr-label'
-                      %span.fr-hint-text.fr-mb-1w Exemple: adresse@mail.com ou @culture.gouv.fr
-                      = f.search_field :email, class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }
-
-
-              %li.fr-py-1w{ 'data-controller': "expand" }
-                .fr-my-1w
-                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
-                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                    Thématique
-                    - if @filter.tags.present?
-                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= @filter.tags.size
-                .hidden{ 'data-expand-target': 'content' }
-                  %div
-                    = f.search_field :tags, placeholder: 'Choisissez un thème', list: 'tags_list', class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }, multiple: true
-                    %datalist#tags_list
-                      - ProcedureTag.order(:name).each do |tag|
-                        %option{ value: tag.name, data: { id: tag.id } }
-                    - if @filter.tags.present?
-                      - @filter.tags.each do |tag|
-                        = f.hidden_field :tags, value: tag, multiple: true, id: "tag-#{tag.tr(' ', '_')}"
-
-              %li.fr-py-1w{ 'data-controller': "expand" }
-                .fr-my-1w
-                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
-                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                    Démarches modèles
-                    - if @filter.template?
+                = render Dsfr::AccordionComponent.new(expanded: @filter.email.present?) do |c|
+                  - c.with_title do
+                    Administrateur
+                    - if @filter.email.present?
                       %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
-                .hidden{ 'data-expand-target': 'content' }
+                  .fr-checkbox-group
+                    = f.label :email, 'Adresse électronique ou domaine', class: 'fr-label'
+                    %span.fr-hint-text.fr-mb-1w Exemple: adresse@mail.com ou @culture.gouv.fr
+                    = f.search_field :email, class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }
+
+
+              = render Dsfr::AccordionComponent.new(expanded: @filter.tags.present?) do |c|
+                - c.with_title do
+                  Thématique
+                  - if @filter.tags.present?
+                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= @filter.tags.size
+                %div
+                  = f.search_field :tags, placeholder: 'Choisissez un thème', list: 'tags_list', class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }, multiple: true
+                  %datalist#tags_list
+                    - ProcedureTag.order(:name).each do |tag|
+                      %option{ value: tag.name, data: { id: tag.id } }
+                  - if @filter.tags.present?
+                    - @filter.tags.each do |tag|
+                      = f.hidden_field :tags, value: tag, multiple: true, id: "tag-#{tag.tr(' ', '_')}"
+
+
+              = render Dsfr::AccordionComponent.new(expanded: @filter.template?) do |c|
+                - c.with_title do
+                  Démarches modèles
+                  - if @filter.template?
+                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
+                .fr-checkbox-group.fr-py-1w
+                  = f.check_box :template, class: 'fr-input'
+                  = f.label :template, 'Modèle DS', class: 'fr-label'
+
+              - other_zones_count = @filter.other_zones.count { |z| @filter.zone_filtered?(z.id) }
+
+              = render Dsfr::AccordionComponent.new(expanded: other_zones_count > 0) do |c|
+                - c.with_title do
+                  Autres zones
+                  - if other_zones_count > 0
+                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= other_zones_count
+                = f.collection_check_boxes :zone_ids, @filter.other_zones, :id, :current_label, include_hidden: false do |b|
                   .fr-checkbox-group.fr-ml-2w.fr-py-1w
-                    = f.check_box :template, class: 'fr-input'
-                    = f.label :template, 'Modèle DS', class: 'fr-label'
-              %li.fr-py-1w{ 'data-controller': "expand" }
-                .fr-my-1w
-                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
-                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                    Autres zones
-                    - other_zones_count = @filter.other_zones.count { |z| @filter.zone_filtered?(z.id) }
-                    - if other_zones_count > 0
-                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= other_zones_count
-                .hidden{ 'data-expand-target': 'content' }
-                  = f.collection_check_boxes :zone_ids, @filter.other_zones, :id, :current_label, include_hidden: false do |b|
-                    .fr-checkbox-group.fr-ml-2w.fr-py-1w
-                      = b.check_box(checked: @filter.zone_filtered?(b.value))
-                      = b.label(class: 'fr-label') { b.text }
-              %li.fr-py-1w{ 'data-controller': "expand" }
-                .fr-my-1w
-                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
-                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                    Mes zones
-                    - admin_zones_count = @filter.admin_zones.count { |z| @filter.zone_filtered?(z.id) }
-                    - if admin_zones_count > 0
-                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= admin_zones_count
-                .hidden{ 'data-expand-target': 'content' }
-                  = f.collection_check_boxes :zone_ids, @filter.admin_zones, :id, :current_label, include_hidden: false do |b|
-                    .fr-checkbox-group.fr-ml-2w.fr-py-1w
-                      = b.check_box(checked: @filter.zone_filtered?(b.value))
-                      = b.label(class: 'fr-label') { b.text }
-              %li.fr-py-1w{ 'data-controller': "expand" }
-                .fr-my-1w
-                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
-                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                    Service
-                    - if @filter.service_siret.present?
-                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
-                .hidden{ 'data-expand-target': 'content' }
-                  %div
-                    = f.text_field :service_siret, placeholder: 'Indiquez le SIRET', class: 'fr-input'
-              %li.fr-py-1w{ 'data-controller': "expand" }
-                .fr-my-1w
-                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
-                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                    Département
-                    - if @filter.service_departement.present?
-                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
-                .hidden{ 'data-expand-target': 'content' }
-                  %div
-                    = f.select :service_departement,
-                      APIGeoService.departement_options,
-                      { selected: @filter.service_departement, include_blank: ''},
-                      id: "service_dep_select",
-                      class: 'fr-select'
-              %li.fr-py-1w{ 'data-controller': "expand" }
-                .fr-my-1w
-                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
-                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                    Type d’usager
-                    - if @filter.kind_usagers.present?
-                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= @filter.kind_usagers.size
-                .hidden{ 'data-expand-target': 'content' }
-                  = f.collection_check_boxes :kind_usagers, ['individual', 'personne_morale'], :to_s, :to_s, include_hidden: false do |b|
-                    .fr-checkbox-group.fr-ml-2w.fr-py-1w
-                      = b.check_box(checked: @filter.kind_usager_filtered?(b.value))
-                      = b.label(class: 'fr-label') { t b.text, scope: 'activerecord.attributes.procedure.kind_usager' }
-              %li.fr-py-1w{ 'data-controller': "expand" }
-                .fr-my-1w
-                  %button.filter-accordion-btn{ 'data-action': 'click->expand#toggle' }
-                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                    Date de publication
-                    - if @filter.from_publication_date.present?
-                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
-                .fr-input-group.hidden{ 'data-expand-target': 'content' }
+                    = b.check_box(checked: @filter.zone_filtered?(b.value))
+                    = b.label(class: 'fr-label') { b.text }
+
+              - admin_zones_count = @filter.admin_zones.count { |z| @filter.zone_filtered?(z.id) }
+
+              = render Dsfr::AccordionComponent.new(expanded: admin_zones_count > 0) do |c|
+                - c.with_title do
+                  Mes zones
+                  - if admin_zones_count > 0
+                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= admin_zones_count
+                = f.collection_check_boxes :zone_ids, @filter.admin_zones, :id, :current_label, include_hidden: false do |b|
+                  .fr-checkbox-group.fr-ml-2w.fr-py-1w
+                    = b.check_box(checked: @filter.zone_filtered?(b.value))
+                    = b.label(class: 'fr-label') { b.text }
+
+
+              = render Dsfr::AccordionComponent.new(expanded: @filter.service_siret.present?) do |c|
+                - c.with_title do
+                  Service
+                  - if @filter.service_siret.present?
+                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
+                %div
+                  = f.text_field :service_siret, placeholder: 'Indiquez le SIRET', class: 'fr-input'
+
+
+              = render Dsfr::AccordionComponent.new(expanded: @filter.service_departement.present?) do |c|
+                - c.with_title do
+                  Département
+                  - if @filter.service_departement.present?
+                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
+                %div
+                  = f.select :service_departement,
+                    APIGeoService.departement_options,
+                    { selected: @filter.service_departement, include_blank: ''},
+                    id: "service_dep_select",
+                    class: 'fr-select'
+
+
+              = render Dsfr::AccordionComponent.new(expanded: @filter.kind_usagers.present?) do |c|
+                - c.with_title do
+                  Type d’usager
+                  - if @filter.kind_usagers.present?
+                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= @filter.kind_usagers.size
+                = f.collection_check_boxes :kind_usagers, ['individual', 'personne_morale'], :to_s, :to_s, include_hidden: false do |b|
+                  .fr-checkbox-group.fr-ml-2w.fr-py-1w
+                    = b.check_box(checked: @filter.kind_usager_filtered?(b.value))
+                    = b.label(class: 'fr-label') { t b.text, scope: 'activerecord.attributes.procedure.kind_usager' }
+
+
+              = render Dsfr::AccordionComponent.new(expanded: @filter.from_publication_date.present?) do |c|
+                - c.with_title do
+                  Date de publication
+                  - if @filter.from_publication_date.present?
+                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
+                .fr-input-group
                   = f.label 'from_publication_date', 'Depuis', class: 'fr-label'
                   .fr-input-wrap.fr-fi-calendar-line
                     = f.date_field 'from_publication_date', value: @filter.from_publication_date, class: 'fr-input'
 
-              %li.fr-py-1w{ 'data-controller': "expand" }
-                .fr-my-1w
-                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
-                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                    Statut
-                    - if @filter.statuses.present?
-                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= @filter.statuses.size
-                .hidden{ 'data-expand-target': 'content' }
-                  = f.collection_check_boxes :statuses, ['publiee', 'close'], :to_s, :to_s, include_hidden: false do |b|
-                    .fr-checkbox-group.fr-ml-2w.fr-py-1w
-                      = b.check_box(checked: @filter.status_filtered?(b.value))
-                      = b.label(class: 'fr-label') { t b.text, scope: 'activerecord.attributes.procedure.aasm_state' }
 
-      .fr-col-12.fr-col-lg-9
-        = yield(:results)
+              = render Dsfr::AccordionComponent.new(expanded: @filter.statuses.present?) do |c|
+                - c.with_title do
+                  Statut
+                  - if @filter.statuses.present?
+                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= @filter.statuses.size
+                = f.collection_check_boxes :statuses, ['publiee', 'close'], :to_s, :to_s, include_hidden: false do |b|
+                  .fr-checkbox-group.fr-ml-2w.fr-py-1w
+                    = b.check_box(checked: @filter.status_filtered?(b.value))
+                    = b.label(class: 'fr-label') { t b.text, scope: 'activerecord.attributes.procedure.aasm_state' }
+
+        .fr-col-12.fr-col-lg-9
+          = yield(:results)
 = render template: 'layouts/application'

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -27,21 +27,20 @@
 
           %fieldset.sidebar-filter
             %legend
-              .title.fr-text--bold.fr-pl-2w
-                %span.fr-icon-filter-fill.fr-icon--sm.fr-mr-1w{ 'aria-hidden': 'true' }
-                  Filtrer
+              .title.fr-text--bold
+                Filtrer
               .reinit
-                = link_to procedures_filter_path(zone_ids: current_administrateur.zones), { data: { turbo: 'false' } } do
-                  %span.fr-icon-arrow-go-back-line Réinitialiser
+                = link_to 'Réinitialiser', procedures_filter_path(zone_ids: current_administrateur.zones), { data: { turbo: 'false' }, class: 'fr-link fr-link--icon-left fr-icon-arrow-go-back-line' }
 
             %ul
-
-              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                .fr-mb-1w
-                  %button{ 'data-action': 'expand#toggle' }
+              %li.fr-py-1w{ 'data-controller': "expand" }
+                .fr-my-1w
+                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Thématique
-                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                    - if @filter.tags.present?
+                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= @filter.tags.size
+                .hidden{ 'data-expand-target': 'content' }
                   %div
                     = f.search_field :tags, placeholder: 'Choisissez un thème', list: 'tags_list', class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }, multiple: true
                     %datalist#tags_list
@@ -51,81 +50,99 @@
                       - @filter.tags.each do |tag|
                         = f.hidden_field :tags, value: tag, multiple: true, id: "tag-#{tag.tr(' ', '_')}"
 
-              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                .fr-mb-1w
-                  %button{ 'data-action': 'expand#toggle' }
+              %li.fr-py-1w{ 'data-controller': "expand" }
+                .fr-my-1w
+                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Démarches modèles
-                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                    - if @filter.template?
+                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
+                .hidden{ 'data-expand-target': 'content' }
                   .fr-checkbox-group.fr-ml-2w.fr-py-1w
                     = f.check_box :template, class: 'fr-input'
                     = f.label :template, 'Modèle DS', class: 'fr-label'
-              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                .fr-mb-1w
-                  %button{ 'data-action': 'expand#toggle' }
+              %li.fr-py-1w{ 'data-controller': "expand" }
+                .fr-my-1w
+                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Autres zones
-                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                    - other_zones_count = @filter.other_zones.count { |z| @filter.zone_filtered?(z.id) }
+                    - if other_zones_count > 0
+                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= other_zones_count
+                .hidden{ 'data-expand-target': 'content' }
                   = f.collection_check_boxes :zone_ids, @filter.other_zones, :id, :current_label, include_hidden: false do |b|
                     .fr-checkbox-group.fr-ml-2w.fr-py-1w
                       = b.check_box(checked: @filter.zone_filtered?(b.value))
                       = b.label(class: 'fr-label') { b.text }
-              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                .fr-mb-1w
-                  %button{ 'data-action': 'expand#toggle' }
+              %li.fr-py-1w{ 'data-controller': "expand" }
+                .fr-my-1w
+                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Mes zones
-                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                    - admin_zones_count = @filter.admin_zones.count { |z| @filter.zone_filtered?(z.id) }
+                    - if admin_zones_count > 0
+                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= admin_zones_count
+                .hidden{ 'data-expand-target': 'content' }
                   = f.collection_check_boxes :zone_ids, @filter.admin_zones, :id, :current_label, include_hidden: false do |b|
                     .fr-checkbox-group.fr-ml-2w.fr-py-1w
                       = b.check_box(checked: @filter.zone_filtered?(b.value))
                       = b.label(class: 'fr-label') { b.text }
-              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                .fr-mb-1w
-                  %button{ 'data-action': 'expand#toggle' }
+              %li.fr-py-1w{ 'data-controller': "expand" }
+                .fr-my-1w
+                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Service
-                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                    - if @filter.service_siret.present?
+                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
+                .hidden{ 'data-expand-target': 'content' }
                   %div
                     = f.text_field :service_siret, placeholder: 'Indiquez le SIRET', class: 'fr-input'
-              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                .fr-mb-1w
-                  %button{ 'data-action': 'expand#toggle' }
+              %li.fr-py-1w{ 'data-controller': "expand" }
+                .fr-my-1w
+                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Département
-                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                    - if @filter.service_departement.present?
+                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
+                .hidden{ 'data-expand-target': 'content' }
                   %div
                     = f.select :service_departement,
                       APIGeoService.departement_options,
                       { selected: @filter.service_departement, include_blank: ''},
                       id: "service_dep_select",
                       class: 'fr-select'
-              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                .fr-mb-1w
-                  %button{ 'data-action': 'expand#toggle' }
+              %li.fr-py-1w{ 'data-controller': "expand" }
+                .fr-my-1w
+                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Type d’usager
-                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                    - if @filter.kind_usagers.present?
+                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= @filter.kind_usagers.size
+                .hidden{ 'data-expand-target': 'content' }
                   = f.collection_check_boxes :kind_usagers, ['individual', 'personne_morale'], :to_s, :to_s, include_hidden: false do |b|
                     .fr-checkbox-group.fr-ml-2w.fr-py-1w
                       = b.check_box(checked: @filter.kind_usager_filtered?(b.value))
                       = b.label(class: 'fr-label') { t b.text, scope: 'activerecord.attributes.procedure.kind_usager' }
-              %li.fr-py-2w{ 'data-controller': "expand" }
-                .fr-mb-1w.fr-pl-2w
-                  %button{ 'data-action': 'click->expand#toggle' }
+              %li.fr-py-1w{ 'data-controller': "expand" }
+                .fr-my-1w
+                  %button.filter-accordion-btn{ 'data-action': 'click->expand#toggle' }
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Date de publication
+                    - if @filter.from_publication_date.present?
+                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
                 .fr-input-group.hidden{ 'data-expand-target': 'content' }
                   = f.label 'from_publication_date', 'Depuis', class: 'fr-label'
                   .fr-input-wrap.fr-fi-calendar-line
                     = f.date_field 'from_publication_date', value: @filter.from_publication_date, class: 'fr-input'
 
-              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                .fr-mb-1w
-                  %button{ 'data-action': 'expand#toggle' }
+              %li.fr-py-1w{ 'data-controller': "expand" }
+                .fr-my-1w
+                  %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
                     %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
                     Statut
-                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                    - if @filter.statuses.present?
+                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= @filter.statuses.size
+                .hidden{ 'data-expand-target': 'content' }
                   = f.collection_check_boxes :statuses, ['publiee', 'close'], :to_s, :to_s, include_hidden: false do |b|
                     .fr-checkbox-group.fr-ml-2w.fr-py-1w
                       = b.check_box(checked: @filter.status_filtered?(b.value))

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -65,26 +65,24 @@
                     = f.check_box :template, class: 'fr-input'
                     = f.label :template, 'Modèle DS', class: 'fr-label'
 
-              - other_zones_count = @filter.other_zones.count { |z| @filter.zone_filtered?(z.id) }
-
-              = render Dsfr::AccordionComponent.new(expanded: other_zones_count > 0) do |c|
-                - c.with_title do
-                  Autres zones
-                  - if other_zones_count > 0
-                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= other_zones_count
-                = f.collection_check_boxes :zone_ids, @filter.other_zones, :id, :current_label, include_hidden: false do |b|
-                  .fr-checkbox-group.fr-ml-2w.fr-py-1w
-                    = b.check_box(checked: @filter.zone_filtered?(b.value))
-                    = b.label(class: 'fr-label') { b.text }
-
               - admin_zones_count = @filter.admin_zones.count { |z| @filter.zone_filtered?(z.id) }
-
               = render Dsfr::AccordionComponent.new(expanded: admin_zones_count > 0) do |c|
                 - c.with_title do
                   Mes zones
                   - if admin_zones_count > 0
                     %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= admin_zones_count
                 = f.collection_check_boxes :zone_ids, @filter.admin_zones, :id, :current_label, include_hidden: false do |b|
+                  .fr-checkbox-group.fr-ml-2w.fr-py-1w
+                    = b.check_box(checked: @filter.zone_filtered?(b.value))
+                    = b.label(class: 'fr-label') { b.text }
+
+              - other_zones_count = @filter.other_zones.count { |z| @filter.zone_filtered?(z.id) }
+              = render Dsfr::AccordionComponent.new(expanded: other_zones_count > 0) do |c|
+                - c.with_title do
+                  Autres zones
+                  - if other_zones_count > 0
+                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= other_zones_count
+                = f.collection_check_boxes :zone_ids, @filter.other_zones, :id, :current_label, include_hidden: false do |b|
                   .fr-checkbox-group.fr-ml-2w.fr-py-1w
                     = b.check_box(checked: @filter.zone_filtered?(b.value))
                     = b.label(class: 'fr-label') { b.text }

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -1,125 +1,136 @@
 - content_for(:main_navigation) do
   = render 'administrateurs/main_navigation'
 - content_for :content do
+  .sub-header
+    .fr-container
+      %h1.fr-my-4w= t('administrateurs.procedures.all.title')
+
+      .fr-container
+        .fr-grid-row.fr-grid-row--gutters
+          .fr-col-12
+            .fr-highlight.fr-mb-4w
+              %p= t('administrateurs.procedures.all.description_html')
+
+
+  %turbo-frame#procedures{ data: { turbo_action: 'advance', turbo: 'true' } }
+  .sub-header.fr-mt-n4w
+    .fr-container
+      %nav.fr-tabs{ role: 'navigation', 'aria-label': t('administrateurs.all_procedures_menu') }
+        %ul.fr-tabs__list
+          = tab_item(t('administrateurs.procedure_list'), procedures_filter_path(request.query_parameters.merge(action: 'all')), active: action_name == 'all')
+          = tab_item(t('administrateurs.administrator_list'), procedures_filter_path(request.query_parameters.merge(action: 'administrateurs')), active: action_name == 'administrateurs')
+
   .fr-container
-    %h1.fr-my-4w Toutes les démarches
+    .fr-grid-row.fr-grid-row--gutters
+      .fr-col-12.fr-col-lg-3
+        = form_with(url: procedures_filter_path, method: :get, data: { controller: 'autosubmit', turbo_frame: 'procedures' }) do |f|
 
-    .fr-container--fluid
-      .fr-grid-row.fr-grid-row--gutters
-        .fr-col-8
-          .fr-highlight.fr-mb-4w
-            %p Ce tableau de bord permet de consulter les informations sur les démarches pour toutes les zones. Filtrez par zone et statut. Consultez la liste des démarches et cliquez sur une démarche pour voir la zone et quels sont les administrateurs.
-
-    .fr-container--fluid{ data: { turbo: 'true' } }
-      %turbo-frame#procedures.fr-grid-row.fr-grid-row--gutters{ 'data-turbo-action': 'advance' }
-        .fr-col-12.fr-col-lg-3
-          = form_with(url: procedures_filter_path, method: :get, data: { controller: 'autosubmit', turbo_frame: 'procedures' }) do |f|
-
-            %fieldset.sidebar-filter
-              %legend
-                .title.fr-text--bold.fr-pl-2w
-                  %span.fr-icon-filter-fill.fr-icon--sm.fr-mr-1w{ 'aria-hidden': 'true' }
+          %fieldset.sidebar-filter
+            %legend
+              .title.fr-text--bold.fr-pl-2w
+                %span.fr-icon-filter-fill.fr-icon--sm.fr-mr-1w{ 'aria-hidden': 'true' }
                   Filtrer
-                .reinit
-                  = link_to procedures_filter_path(zone_ids: current_administrateur.zones), { data: { turbo: 'false' } } do
-                    %span.fr-icon-arrow-go-back-line Réinitialiser
-              %ul
+              .reinit
+                = link_to procedures_filter_path(zone_ids: current_administrateur.zones), { data: { turbo: 'false' } } do
+                  %span.fr-icon-arrow-go-back-line Réinitialiser
 
-                %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                  .fr-mb-1w
-                    %button{ 'data-action': 'expand#toggle' }
-                      %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                      Thématique
-                  .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
-                    %div
-                      = f.search_field :tags, placeholder: 'Choisissez un thème', list: 'tags_list', class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }, multiple: true
-                      %datalist#tags_list
-                        - ProcedureTag.order(:name).each do |tag|
-                          %option{ value: tag.name, data: { id: tag.id } }
-                      - if @filter.tags.present?
-                        - @filter.tags.each do |tag|
-                          = f.hidden_field :tags, value: tag, multiple: true, id: "tag-#{tag.tr(' ', '_')}"
+            %ul
 
-                %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                  .fr-mb-1w
-                    %button{ 'data-action': 'expand#toggle' }
-                      %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                      Démarches modèles
-                  .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
+                .fr-mb-1w
+                  %button{ 'data-action': 'expand#toggle' }
+                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+                    Thématique
+                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                  %div
+                    = f.search_field :tags, placeholder: 'Choisissez un thème', list: 'tags_list', class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }, multiple: true
+                    %datalist#tags_list
+                      - ProcedureTag.order(:name).each do |tag|
+                        %option{ value: tag.name, data: { id: tag.id } }
+                    - if @filter.tags.present?
+                      - @filter.tags.each do |tag|
+                        = f.hidden_field :tags, value: tag, multiple: true, id: "tag-#{tag.tr(' ', '_')}"
+
+              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
+                .fr-mb-1w
+                  %button{ 'data-action': 'expand#toggle' }
+                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+                    Démarches modèles
+                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                  .fr-checkbox-group.fr-ml-2w.fr-py-1w
+                    = f.check_box :template, class: 'fr-input'
+                    = f.label :template, 'Modèle DS', class: 'fr-label'
+              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
+                .fr-mb-1w
+                  %button{ 'data-action': 'expand#toggle' }
+                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+                    Autres zones
+                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                  = f.collection_check_boxes :zone_ids, @filter.other_zones, :id, :current_label, include_hidden: false do |b|
                     .fr-checkbox-group.fr-ml-2w.fr-py-1w
-                      = f.check_box :template, class: 'fr-input'
-                      = f.label :template, 'Modèle DS', class: 'fr-label'
-                %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                  .fr-mb-1w
-                    %button{ 'data-action': 'expand#toggle' }
-                      %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                      Autres zones
-                  .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
-                    = f.collection_check_boxes :zone_ids, @filter.other_zones, :id, :current_label, include_hidden: false do |b|
-                      .fr-checkbox-group.fr-ml-2w.fr-py-1w
-                        = b.check_box(checked: @filter.zone_filtered?(b.value))
-                        = b.label(class: 'fr-label') { b.text }
-                %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                  .fr-mb-1w
-                    %button{ 'data-action': 'expand#toggle' }
-                      %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                      Mes zones
-                  .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
-                    = f.collection_check_boxes :zone_ids, @filter.admin_zones, :id, :current_label, include_hidden: false do |b|
-                      .fr-checkbox-group.fr-ml-2w.fr-py-1w
-                        = b.check_box(checked: @filter.zone_filtered?(b.value))
-                        = b.label(class: 'fr-label') { b.text }
-                %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                  .fr-mb-1w
-                    %button{ 'data-action': 'expand#toggle' }
-                      %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                      Service
-                  .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
-                    %div
-                      = f.text_field :service_siret, placeholder: 'Indiquez le SIRET', class: 'fr-input'
-                %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                  .fr-mb-1w
-                    %button{ 'data-action': 'expand#toggle' }
-                      %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                      Département
-                  .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
-                    %div
-                      = f.select :service_departement,
-                        APIGeoService.departement_options,
-                        { selected: @filter.service_departement, include_blank: ''},
-                        id: "service_dep_select",
-                        class: 'fr-select'
-                %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                  .fr-mb-1w
-                    %button{ 'data-action': 'expand#toggle' }
-                      %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                      Type d’usager
-                  .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
-                    = f.collection_check_boxes :kind_usagers, ['individual', 'personne_morale'], :to_s, :to_s, include_hidden: false do |b|
-                      .fr-checkbox-group.fr-ml-2w.fr-py-1w
-                        = b.check_box(checked: @filter.kind_usager_filtered?(b.value))
-                        = b.label(class: 'fr-label') { t b.text, scope: 'activerecord.attributes.procedure.kind_usager' }
-                %li.fr-py-2w{ 'data-controller': "expand" }
-                  .fr-mb-1w.fr-pl-2w
-                    %button{ 'data-action': 'click->expand#toggle' }
-                      %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                      Date de publication
-                  .fr-input-group.hidden{ 'data-expand-target': 'content' }
-                    = f.label 'from_publication_date', 'Depuis', class: 'fr-label'
-                    .fr-input-wrap.fr-fi-calendar-line
-                      = f.date_field 'from_publication_date', value: @filter.from_publication_date, class: 'fr-input'
+                      = b.check_box(checked: @filter.zone_filtered?(b.value))
+                      = b.label(class: 'fr-label') { b.text }
+              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
+                .fr-mb-1w
+                  %button{ 'data-action': 'expand#toggle' }
+                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+                    Mes zones
+                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                  = f.collection_check_boxes :zone_ids, @filter.admin_zones, :id, :current_label, include_hidden: false do |b|
+                    .fr-checkbox-group.fr-ml-2w.fr-py-1w
+                      = b.check_box(checked: @filter.zone_filtered?(b.value))
+                      = b.label(class: 'fr-label') { b.text }
+              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
+                .fr-mb-1w
+                  %button{ 'data-action': 'expand#toggle' }
+                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+                    Service
+                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                  %div
+                    = f.text_field :service_siret, placeholder: 'Indiquez le SIRET', class: 'fr-input'
+              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
+                .fr-mb-1w
+                  %button{ 'data-action': 'expand#toggle' }
+                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+                    Département
+                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                  %div
+                    = f.select :service_departement,
+                      APIGeoService.departement_options,
+                      { selected: @filter.service_departement, include_blank: ''},
+                      id: "service_dep_select",
+                      class: 'fr-select'
+              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
+                .fr-mb-1w
+                  %button{ 'data-action': 'expand#toggle' }
+                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+                    Type d’usager
+                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                  = f.collection_check_boxes :kind_usagers, ['individual', 'personne_morale'], :to_s, :to_s, include_hidden: false do |b|
+                    .fr-checkbox-group.fr-ml-2w.fr-py-1w
+                      = b.check_box(checked: @filter.kind_usager_filtered?(b.value))
+                      = b.label(class: 'fr-label') { t b.text, scope: 'activerecord.attributes.procedure.kind_usager' }
+              %li.fr-py-2w{ 'data-controller': "expand" }
+                .fr-mb-1w.fr-pl-2w
+                  %button{ 'data-action': 'click->expand#toggle' }
+                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+                    Date de publication
+                .fr-input-group.hidden{ 'data-expand-target': 'content' }
+                  = f.label 'from_publication_date', 'Depuis', class: 'fr-label'
+                  .fr-input-wrap.fr-fi-calendar-line
+                    = f.date_field 'from_publication_date', value: @filter.from_publication_date, class: 'fr-input'
 
-                %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
-                  .fr-mb-1w
-                    %button{ 'data-action': 'expand#toggle' }
-                      %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
-                      Statut
-                  .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
-                    = f.collection_check_boxes :statuses, ['publiee', 'close'], :to_s, :to_s, include_hidden: false do |b|
-                      .fr-checkbox-group.fr-ml-2w.fr-py-1w
-                        = b.check_box(checked: @filter.status_filtered?(b.value))
-                        = b.label(class: 'fr-label') { t b.text, scope: 'activerecord.attributes.procedure.aasm_state' }
+              %li.fr-py-2w.fr-pl-2w{ 'data-controller': "expand" }
+                .fr-mb-1w
+                  %button{ 'data-action': 'expand#toggle' }
+                    %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+                    Statut
+                .fr-ml-1w.hidden{ 'data-expand-target': 'content' }
+                  = f.collection_check_boxes :statuses, ['publiee', 'close'], :to_s, :to_s, include_hidden: false do |b|
+                    .fr-checkbox-group.fr-ml-2w.fr-py-1w
+                      = b.check_box(checked: @filter.status_filtered?(b.value))
+                      = b.label(class: 'fr-label') { t b.text, scope: 'activerecord.attributes.procedure.aasm_state' }
 
-        .fr-col-12.fr-col-lg-9
-          = yield(:results)
+      .fr-col-12.fr-col-lg-9
+        = yield(:results)
 = render template: 'layouts/application'

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -21,8 +21,7 @@
     .fr-container
       .fr-grid-row.fr-grid-row--gutters
         .fr-col-12.fr-col-lg-3
-          = form_with(url: procedures_filter_path, method: :get, data: { controller: 'autosubmit', turbo_frame: 'procedures' }) do |f|
-
+          = form_with(url: procedures_filter_path, method: :get, id: 'procedures-filter-form', data: { controller: 'autosubmit', turbo_frame: 'procedures' }) do |f|
             %fieldset.sidebar-filter
               %legend
                 .title.fr-text--bold

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -27,8 +27,6 @@
               %legend
                 .title.fr-text--bold
                   Filtrer
-                .reinit
-                  = link_to 'Réinitialiser', procedures_filter_path(zone_ids: current_administrateur.zones), { data: { turbo: 'false' }, class: 'fr-link fr-link--icon-left fr-icon-arrow-go-back-line' }
 
               - if action_name == 'all'
                 = render Dsfr::AccordionComponent.new(expanded: @filter.email.present?) do |c|

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -38,7 +38,7 @@
                     = f.label :email, 'Adresse électronique ou domaine', class: 'fr-label'
                     %span.fr-hint-text.fr-mb-1w Exemple: adresse@mail.com ou @culture.gouv.fr
                     .fr-input-wrap.fr-input-wrap--addon
-                      = f.search_field :email, class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }
+                      = f.search_field :email, value: @filter.email, class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }
                       = f.button 'Rechercher', class: 'fr-btn fr-icon-search-line'
 
               - if action_name == 'all'
@@ -100,7 +100,7 @@
                   = f.label :service_siret, 'Numéro SIRET', class: 'fr-label'
                   %span.fr-hint-text.fr-mb-1w Exemple : 500 001 234 56789
                   .fr-input-wrap.fr-input-wrap--addon
-                    = f.text_field :service_siret, class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }
+                    = f.text_field :service_siret, value: @filter.service_siret, class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }
                     = f.button 'Rechercher', class: 'fr-btn fr-icon-search-line'
 
 

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -33,6 +33,21 @@
                 = link_to 'Réinitialiser', procedures_filter_path(zone_ids: current_administrateur.zones), { data: { turbo: 'false' }, class: 'fr-link fr-link--icon-left fr-icon-arrow-go-back-line' }
 
             %ul
+              - if action_name == 'all'
+                %li.fr-py-1w{ 'data-controller': "expand" }
+                  .fr-my-1w
+                    %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }
+                      %span.fr-icon-add-line.fr-icon--sm.fr-mr-1w.fr-text-action-high--blue-france{ 'aria-hidden': 'true', 'data-expand-target': 'icon' }
+                      Administrateur
+                      - if @filter.email.present?
+                        %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
+                  .hidden{ 'data-expand-target': 'content' }
+                    %div
+                      = f.label :email, 'Adresse électronique ou domaine', class: 'fr-label'
+                      %span.fr-hint-text.fr-mb-1w Exemple: adresse@mail.com ou @culture.gouv.fr
+                      = f.search_field :email, class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }
+
+
               %li.fr-py-1w{ 'data-controller': "expand" }
                 .fr-my-1w
                   %button.filter-accordion-btn{ 'data-action': 'expand#toggle' }

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -41,30 +41,30 @@
                       = f.search_field :email, class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }
                       = f.button 'Rechercher', class: 'fr-btn fr-icon-search-line'
 
+              - if action_name == 'all'
+                = render Dsfr::AccordionComponent.new(expanded: @filter.tags.present?) do |c|
+                  - c.with_title do
+                    Thématique
+                    - if @filter.tags.present?
+                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= @filter.tags.size
+                  %div
+                    = f.search_field :tags, placeholder: 'Choisissez un thème', list: 'tags_list', class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }, multiple: true
+                    %datalist#tags_list
+                      - ProcedureTag.order(:name).each do |tag|
+                        %option{ value: tag.name, data: { id: tag.id } }
+                    - if @filter.tags.present?
+                      - @filter.tags.each do |tag|
+                        = f.hidden_field :tags, value: tag, multiple: true, id: "tag-#{tag.tr(' ', '_')}"
 
-              = render Dsfr::AccordionComponent.new(expanded: @filter.tags.present?) do |c|
-                - c.with_title do
-                  Thématique
-                  - if @filter.tags.present?
-                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= @filter.tags.size
-                %div
-                  = f.search_field :tags, placeholder: 'Choisissez un thème', list: 'tags_list', class: 'fr-input', data: { no_autosubmit: 'input', turbo_force: :server }, multiple: true
-                  %datalist#tags_list
-                    - ProcedureTag.order(:name).each do |tag|
-                      %option{ value: tag.name, data: { id: tag.id } }
-                  - if @filter.tags.present?
-                    - @filter.tags.each do |tag|
-                      = f.hidden_field :tags, value: tag, multiple: true, id: "tag-#{tag.tr(' ', '_')}"
-
-
-              = render Dsfr::AccordionComponent.new(expanded: @filter.template?) do |c|
-                - c.with_title do
-                  Démarches modèles
-                  - if @filter.template?
-                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
-                .fr-checkbox-group.fr-py-1w
-                  = f.check_box :template, class: 'fr-input'
-                  = f.label :template, 'Modèle DS', class: 'fr-label'
+              - if action_name == 'all'
+                = render Dsfr::AccordionComponent.new(expanded: @filter.template?) do |c|
+                  - c.with_title do
+                    Démarches modèles
+                    - if @filter.template?
+                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w 1
+                  .fr-checkbox-group.fr-py-1w
+                    = f.check_box :template, class: 'fr-input'
+                    = f.label :template, 'Modèle DS', class: 'fr-label'
 
               - other_zones_count = @filter.other_zones.count { |z| @filter.zone_filtered?(z.id) }
 
@@ -116,16 +116,16 @@
                     id: "service_dep_select",
                     class: 'fr-select'
 
-
-              = render Dsfr::AccordionComponent.new(expanded: @filter.kind_usagers.present?) do |c|
-                - c.with_title do
-                  Type d’usager
-                  - if @filter.kind_usagers.present?
-                    %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= @filter.kind_usagers.size
-                = f.collection_check_boxes :kind_usagers, ['individual', 'personne_morale'], :to_s, :to_s, include_hidden: false do |b|
-                  .fr-checkbox-group.fr-ml-2w.fr-py-1w
-                    = b.check_box(checked: @filter.kind_usager_filtered?(b.value))
-                    = b.label(class: 'fr-label') { t b.text, scope: 'activerecord.attributes.procedure.kind_usager' }
+              - if action_name == 'all'
+                = render Dsfr::AccordionComponent.new(expanded: @filter.kind_usagers.present?) do |c|
+                  - c.with_title do
+                    Type d’usager
+                    - if @filter.kind_usagers.present?
+                      %span.fr-badge.fr-badge--sm.fr-badge--blue-france.fr-ml-1w= @filter.kind_usagers.size
+                  = f.collection_check_boxes :kind_usagers, ['individual', 'personne_morale'], :to_s, :to_s, include_hidden: false do |b|
+                    .fr-checkbox-group.fr-ml-2w.fr-py-1w
+                      = b.check_box(checked: @filter.kind_usager_filtered?(b.value))
+                      = b.label(class: 'fr-label') { t b.text, scope: 'activerecord.attributes.procedure.kind_usager' }
 
 
               = render Dsfr::AccordionComponent.new(expanded: @filter.from_publication_date.present?) do |c|

--- a/app/views/layouts/all.html.haml
+++ b/app/views/layouts/all.html.haml
@@ -13,7 +13,7 @@
     .fr-container--fluid{ data: { turbo: 'true' } }
       %turbo-frame#procedures.fr-grid-row.fr-grid-row--gutters{ 'data-turbo-action': 'advance' }
         .fr-col-12.fr-col-lg-3
-          = form_with(url: all_admin_procedures_path, method: :get, data: { controller: 'autosubmit', turbo_frame: 'procedures' }) do |f|
+          = form_with(url: procedures_filter_path, method: :get, data: { controller: 'autosubmit', turbo_frame: 'procedures' }) do |f|
 
             %fieldset.sidebar-filter
               %legend
@@ -21,7 +21,7 @@
                   %span.fr-icon-filter-fill.fr-icon--sm.fr-mr-1w{ 'aria-hidden': 'true' }
                   Filtrer
                 .reinit
-                  = link_to all_admin_procedures_path(zone_ids: current_administrateur.zones), { data: { turbo: 'false' } } do
+                  = link_to procedures_filter_path(zone_ids: current_administrateur.zones), { data: { turbo: 'false' } } do
                     %span.fr-icon-arrow-go-back-line Réinitialiser
               %ul
 

--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -6,6 +6,8 @@ en:
     procedures:
       all:
         title: Procedures directory
+        search_label: Search procedures
+        search_hint: "By label or procedure number"
         description_html: This directory allows you to view information about processes and administrators for all zones.<br>Search for a process to see its zone and administrators, or search for an administrator to see the processes they manage.
       administrateurs:
         title: Administrators

--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -1,10 +1,15 @@
 en:
   administrateurs:
+    all_procedures_menu: Directory search
+    procedure_list: Procedure list
+    administrator_list: Administrator list
     procedures:
+      all:
+        title: Procedures directory
+        description_html: This directory allows you to view information about processes and administrators for all zones.<br>Search for a process to see its zone and administrators, or search for an administrator to see the processes they manage.
       administrateurs:
         title: Administrators
         search_label: Search administrators by email address
-        view_procedures: View procedures list
         since_date: "Since %{date}"
         admin_count:
           one: "%{count} administrator"

--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -11,7 +11,6 @@ en:
         title: Administrators
         search_label: Search administrators
         search_hint: "By email address (e.g., email@mail.com) or domain (e.g., @culture.gouv.fr)"
-        since_date: "Since %{date}"
         admin_count:
           one: "%{count} administrator"
           other: "%{count} administrators"

--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -9,7 +9,8 @@ en:
         description_html: This directory allows you to view information about processes and administrators for all zones.<br>Search for a process to see its zone and administrators, or search for an administrator to see the processes they manage.
       administrateurs:
         title: Administrators
-        search_label: Search administrators by email address
+        search_label: Search administrators
+        search_hint: "By email address (e.g., email@mail.com) or domain (e.g., @culture.gouv.fr)"
         since_date: "Since %{date}"
         admin_count:
           one: "%{count} administrator"

--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -11,7 +11,6 @@ fr:
         title: Administrateurs
         search_label: Rechercher des administrateurs
         search_hint: "Par adresse électronique (ex. : adresse@mail.com) ou domaine (ex.: @culture.gouv.fr)"
-        since_date: "Depuis le %{date}"
         admin_count:
           one: "%{count} administrateur"
           other: "%{count} administrateurs"

--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -9,7 +9,8 @@ fr:
         description_html: Cet annuaire permet de consulter les informations sur les démarches et les administrateurs pour toutes les zones.<br>Recherchez une démarche pour voir sa zone et ses administrateurs, ou recherchez un administrateur pour voir les démarches qu’il gère.
       administrateurs:
         title: Administrateurs
-        search_label: Rechercher des administrateurs par adresse électronique
+        search_label: Rechercher des administrateurs
+        search_hint: "Par adresse électronique (ex. : adresse@mail.com) ou domaine (ex.: @culture.gouv.fr)"
         since_date: "Depuis le %{date}"
         admin_count:
           one: "%{count} administrateur"

--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -1,10 +1,15 @@
 fr:
   administrateurs:
+    all_procedures_menu: Recherche dans l’annuaire
+    procedure_list: Liste des démarches
+    administrator_list: Liste des administrateurs
     procedures:
+      all:
+        title: Annuaire des démarches
+        description_html: Cet annuaire permet de consulter les informations sur les démarches et les administrateurs pour toutes les zones.<br>Recherchez une démarche pour voir sa zone et ses administrateurs, ou recherchez un administrateur pour voir les démarches qu’il gère.
       administrateurs:
         title: Administrateurs
         search_label: Rechercher des administrateurs par adresse électronique
-        view_procedures: Voir la liste des démarches
         since_date: "Depuis le %{date}"
         admin_count:
           one: "%{count} administrateur"

--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -6,6 +6,8 @@ fr:
     procedures:
       all:
         title: Annuaire des démarches
+        search_label: Rechercher des démarches
+        search_hint: "Par libellé ou numéro de démarche"
         description_html: Cet annuaire permet de consulter les informations sur les démarches et les administrateurs pour toutes les zones.<br>Recherchez une démarche pour voir sa zone et ses administrateurs, ou recherchez un administrateur pour voir les démarches qu’il gère.
       administrateurs:
         title: Administrateurs

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -341,6 +341,29 @@ describe Administrateurs::ProceduresController, type: :controller do
       end
     end
 
+    context 'with libelle search matching a procedure id' do
+      let!(:procedure1) { create(:procedure, :published, libelle: 'Demande de subvention') }
+      let!(:procedure2) { create(:procedure, :published, libelle: 'Autre démarche') }
+
+      it 'returns the procedure whose id matches the numeric search term' do
+        get :all, params: { libelle: procedure1.id.to_s }
+        expect(assigns(:procedures).any? { |p| p.id == procedure1.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == procedure2.id }).to be_falsey
+      end
+
+      it 'still matches by libelle when the search term is not numeric' do
+        get :all, params: { libelle: 'subvention' }
+        expect(assigns(:procedures).any? { |p| p.id == procedure1.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == procedure2.id }).to be_falsey
+      end
+
+      it 'does not match an unrelated procedure id contained in the libelle text' do
+        other_procedure = create(:procedure, :published, libelle: procedure2.id.to_s)
+        get :all, params: { libelle: procedure1.id.to_s }
+        expect(assigns(:procedures).any? { |p| p.id == other_procedure.id }).to be_falsey
+      end
+    end
+
     context 'with administrateur email search' do
       let!(:admin_matching) { create(:administrateur, email: 'jesuis.surmene@education.gouv.fr') }
       let!(:admin_other) { create(:administrateur, email: 'jesuis.alecoute@social.gouv.fr') }

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -353,6 +353,17 @@ describe Administrateurs::ProceduresController, type: :controller do
         expect(assigns(:procedures).any? { |p| p.id == procedure2.id }).to be_falsey
       end
     end
+
+    context 'with procedure-only filters (tags, template, kind_usagers, libelle)' do
+      let!(:template_procedure) { create(:procedure, :published, template: true, libelle: 'Modèle générique') }
+      let!(:other_procedure) { create(:procedure, :published, template: false, libelle: 'Autre démarche') }
+
+      it 'applies the template filter on the all action' do
+        get :all, params: { template: '1' }
+        expect(assigns(:procedures).any? { |p| p.id == template_procedure.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == other_procedure.id }).to be_falsey
+      end
+    end
   end
 
   describe 'GET #administrateurs' do
@@ -400,6 +411,16 @@ describe Administrateurs::ProceduresController, type: :controller do
         assigned_admin1 = assigns(:admins).find { it.id == admin1.id }
         expect(assigned_admin1.procedures).not_to include(published_procedure)
         expect(assigned_admin1.procedures).to include(antoher_published_procedure_for_admin1)
+      end
+    end
+
+    context 'with procedure-only filters in params' do
+      it 'ignores the template filter — admins are not restricted by procedure content' do
+        get :administrateurs, params: { template: '1' }
+        expect(assigns(:admins)).to include(admin1)
+        expect(assigns(:admins)).to include(admin2)
+        expect(assigns(:admins)).to include(admin4)
+        expect(assigns(:admins)).not_to include(admin3)
       end
     end
   end

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -364,6 +364,21 @@ describe Administrateurs::ProceduresController, type: :controller do
         expect(assigns(:procedures).any? { |p| p.id == other_procedure.id }).to be_falsey
       end
     end
+
+    context 'with libelle and email filters combined' do
+      let(:admin1) { create(:administrateur, email: 'admin@education.gouv.fr') }
+      let(:admin2) { create(:administrateur, email: 'autre@test.fr') }
+      let!(:matching_procedure) { create(:procedure, :published, libelle: 'Demande de bourse', administrateur: admin1) }
+      let!(:wrong_libelle) { create(:procedure, :published, libelle: 'Autre chose', administrateur: admin1) }
+      let!(:wrong_admin) { create(:procedure, :published, libelle: 'Demande de bourse', administrateur: admin2) }
+
+      it 'applies both filters simultaneously rather than exclusively' do
+        get :all, params: { libelle: 'bourse', email: 'education.gouv.fr' }
+        expect(assigns(:procedures).any? { |p| p.id == matching_procedure.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == wrong_libelle.id }).to be_falsey
+        expect(assigns(:procedures).any? { |p| p.id == wrong_admin.id }).to be_falsey
+      end
+    end
   end
 
   describe 'GET #administrateurs' do

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -340,6 +340,19 @@ describe Administrateurs::ProceduresController, type: :controller do
         expect(assigns(:procedures).any? { |p| p.id == procedure1.id }).to be_falsey
       end
     end
+
+    context 'with administrateur email search' do
+      let!(:admin_matching) { create(:administrateur, email: 'jesuis.surmene@education.gouv.fr') }
+      let!(:admin_other) { create(:administrateur, email: 'jesuis.alecoute@social.gouv.fr') }
+      let!(:procedure1) { create(:procedure, :published, administrateur: admin_matching) }
+      let!(:procedure2) { create(:procedure, :published, administrateur: admin_other) }
+
+      it 'returns procedures administered by an admin matching the email or domain' do
+        get :all, params: { email: 'education.gouv.fr' }
+        expect(assigns(:procedures).any? { |p| p.id == procedure1.id }).to be_truthy
+        expect(assigns(:procedures).any? { |p| p.id == procedure2.id }).to be_falsey
+      end
+    end
   end
 
   describe 'GET #administrateurs' do

--- a/spec/helpers/administrateurs/procedures_helper_spec.rb
+++ b/spec/helpers/administrateurs/procedures_helper_spec.rb
@@ -15,4 +15,40 @@ describe Administrateurs::ProceduresHelper, type: :helper do
       expect(subject).to include(procedure.id.to_s)
     end
   end
+
+  describe '#visible_filter_tags_count' do
+    let(:admin) { create(:administrateur) }
+    context 'on the all action' do
+      before { allow(helper).to receive(:action_name).and_return('all') }
+
+      it 'counts each active filter as one tag' do
+        filter = ProceduresFilter.new(admin, ActionController::Parameters.new(statuses: ['publiee', 'close']))
+        expect(helper.visible_filter_tags_count(filter)).to eq(2)
+      end
+
+      it 'counts procedure-only filters like template' do
+        filter = ProceduresFilter.new(admin, ActionController::Parameters.new(template: '1'))
+        expect(helper.visible_filter_tags_count(filter)).to eq(1)
+      end
+
+      it 'returns 0 when no filter is active' do
+        filter = ProceduresFilter.new(admin, ActionController::Parameters.new({}))
+        expect(helper.visible_filter_tags_count(filter)).to eq(0)
+      end
+    end
+
+    context 'on the administrateurs action' do
+      before { allow(helper).to receive(:action_name).and_return('administrateurs') }
+
+      it 'excludes procedure-only filters like template' do
+        filter = ProceduresFilter.new(admin, ActionController::Parameters.new(template: '1'))
+        expect(helper.visible_filter_tags_count(filter)).to eq(0)
+      end
+
+      it 'still counts shared filters like email' do
+        filter = ProceduresFilter.new(admin, ActionController::Parameters.new(email: 'test@exemple.fr'))
+        expect(helper.visible_filter_tags_count(filter)).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #12944 

Amélioration globale de la page annuaire pour les admins.

**Nouvelles fonctionnalités :**
- Filtrer une démarche par l'email ou le domaine de son administrateur
- Chercher une démarche par son numéro en plus du libellé
- Supprimer facilement tous les filtres actifs en un clic

**Améliorations UX :**
- Séparation claire en 2 onglets (démarches / administrateurs)
- Les filtres ont des libellés explicites et peuvent fonctionner ensemble
- Les filtres propres au contenu d'une démarche (thématique, modèle, type d'usager) ne s'appliquent plus à la recherche d'administrateurs, où ils n'avaient pas de sens

**Fixes :**
- Les filtres de recherche (email, libellé) s'excluaient mutuellement à cause de deux formulaires HTML distincts non synchronisés — désormais fusionnés en un seul formulaire
- Les liens de filtres redirigeaient parfois vers le mauvais onglet
**APRES**
<img width="1277" height="762" alt="Capture d’écran 2026-07-23 à 18 38 54" src="https://github.com/user-attachments/assets/f3120fdb-2ec2-48cd-97d8-0714240dc256" />
<img width="1243" height="761" alt="Capture d’écran 2026-07-23 à 18 39 58" src="https://github.com/user-attachments/assets/87c4ef2a-d254-4f64-b1c7-ab3afb46cd72" />
**AVANT**
<img width="1297" height="645" alt="Capture d’écran 2026-07-23 à 18 44 26" src="https://github.com/user-attachments/assets/18f70d48-3e27-4fa1-813e-34eea66a07b2" />
