### PR TITLE
ETQ usager ProConnecté, mes nom et prénom sont préremplis à l'étape identité

### DIFF
--- a/app/components/dossiers/individual_form_component.rb
+++ b/app/components/dossiers/individual_form_component.rb
@@ -22,6 +22,13 @@ class Dossiers::IndividualFormComponent < ApplicationComponent
 
   def mandataire_identity_locked? = @identity_source.mandataire_locked?
 
+  def identity_locked_message
+    case @identity_source.resolved
+    when :france_connect then t('.identity_locked_by_france_connect')
+    when :pro_connect then t('.identity_locked_by_pro_connect')
+    end
+  end
+
   private
 
   def back_url

--- a/app/components/dossiers/individual_form_component.rb
+++ b/app/components/dossiers/individual_form_component.rb
@@ -3,8 +3,9 @@
 class Dossiers::IndividualFormComponent < ApplicationComponent
   delegate :for_tiers?, to: :@dossier
 
-  def initialize(dossier:)
+  def initialize(dossier:, identity_source: IdentityPrefillSource.new(dossier:))
     @dossier = dossier
+    @identity_source = identity_source
   end
 
   def email_notifications?(individual)
@@ -15,13 +16,11 @@ class Dossiers::IndividualFormComponent < ApplicationComponent
     @dossier.has_france_connect_type_de_champ? && current_user.france_connected_with_one_identity?
   end
 
-  def identity_locked?
-    !for_tiers? && @dossier.identity_from_fc?
-  end
+  def individual_field_locked?(field) = @identity_source.individual_field_locked?(field)
 
-  def mandataire_identity_locked?
-    @dossier.identity_from_fc?
-  end
+  def individual_identity_locked? = @identity_source.individual_locked_fields.any?
+
+  def mandataire_identity_locked? = @identity_source.mandataire_locked?
 
   private
 

--- a/app/components/dossiers/individual_form_component/individual_form_component.en.yml
+++ b/app/components/dossiers/individual_form_component/individual_form_component.en.yml
@@ -11,3 +11,4 @@ en:
     beneficiaire_title: 'Identity of the beneficiary'
     notify_beneficiary: 'Notify the beneficiary by email about their application processing'
   identity_locked_by_france_connect: Your identity information was provided by FranceConnect and cannot be modified.
+  identity_locked_by_pro_connect: Your first and last name were provided by ProConnect and cannot be modified.

--- a/app/components/dossiers/individual_form_component/individual_form_component.fr.yml
+++ b/app/components/dossiers/individual_form_component/individual_form_component.fr.yml
@@ -11,3 +11,4 @@ fr:
     beneficiaire_title: Identité du bénéficiaire
     notify_beneficiary: Informer le bénéficiaire par email du traitement de son dossier
   identity_locked_by_france_connect: Vos informations d’identité ont été transmises par FranceConnect et ne peuvent pas être modifiées.
+  identity_locked_by_pro_connect: Votre nom et votre prénom ont été transmis par ProConnect et ne peuvent pas être modifiés.

--- a/app/components/dossiers/individual_form_component/individual_form_component.html.erb
+++ b/app/components/dossiers/individual_form_component/individual_form_component.html.erb
@@ -20,7 +20,7 @@
 
         <% if mandataire_identity_locked? %>
           <div class="fr-highlight fr-text--sm">
-            <%= t('.identity_locked_by_france_connect') %>
+            <%= identity_locked_message %>
           </div>
         <% end %>
 
@@ -56,7 +56,7 @@
 
         <% if individual_identity_locked? %>
           <div class="fr-highlight fr-text--sm">
-            <%= t('.identity_locked_by_france_connect') %>
+            <%= identity_locked_message %>
           </div>
         <% end %>
 

--- a/app/components/dossiers/individual_form_component/individual_form_component.html.erb
+++ b/app/components/dossiers/individual_form_component/individual_form_component.html.erb
@@ -54,7 +54,7 @@
           </h2>
         </legend>
 
-        <% if identity_locked? %>
+        <% if individual_identity_locked? %>
           <div class="fr-highlight fr-text--sm">
             <%= t('.identity_locked_by_france_connect') %>
           </div>
@@ -66,8 +66,8 @@
               form: individual,
               target: :gender,
               buttons: [
-                { label: Individual.human_attribute_name('gender.female'), value: Individual::GENDER_FEMALE, required: true, disabled: identity_locked?, translate: "no" },
-                { label: Individual.human_attribute_name('gender.male'), value: Individual::GENDER_MALE, required: true, disabled: identity_locked?, translate: "no" }
+                { label: Individual.human_attribute_name('gender.female'), value: Individual::GENDER_FEMALE, required: true, disabled: individual_field_locked?(:gender), translate: "no" },
+                { label: Individual.human_attribute_name('gender.male'), value: Individual::GENDER_MALE, required: true, disabled: individual_field_locked?(:gender), translate: "no" }
               ],
               error: individual.object.errors.full_messages_for(:gender).first,
               inline: true
@@ -82,7 +82,7 @@
           <% if for_tiers? %>
             <%= render Dsfr::InputComponent.new(form: individual, attribute: :prenom) %>
           <% else %>
-            <%= render Dsfr::InputComponent.new(form: individual, attribute: :prenom, opts: { autocomplete: 'given-name', disabled: identity_locked? }) %>
+            <%= render Dsfr::InputComponent.new(form: individual, attribute: :prenom, opts: { autocomplete: 'given-name', disabled: individual_field_locked?(:prenom) }) %>
           <% end %>
         </div>
 
@@ -90,7 +90,7 @@
           <% if for_tiers? %>
             <%= render Dsfr::InputComponent.new(form: individual, attribute: :nom) %>
           <% else %>
-            <%= render Dsfr::InputComponent.new(form: individual, attribute: :nom, opts: { autocomplete: 'family-name', disabled: identity_locked? }) %>
+            <%= render Dsfr::InputComponent.new(form: individual, attribute: :nom, opts: { autocomplete: 'family-name', disabled: individual_field_locked?(:nom) }) %>
           <% end %>
         </div>
 

--- a/app/controllers/concerns/identity_prefill_concern.rb
+++ b/app/controllers/concerns/identity_prefill_concern.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Fabrique la source de préremplissage de l'identité pour la requête courante,
+# pour les contrôleurs et les vues qui rendent l'étape identité.
+module IdentityPrefillConcern
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :identity_prefill_source
+  end
+
+  def identity_prefill_source(dossier)
+    IdentityPrefillSource.new(dossier:)
+  end
+end

--- a/app/controllers/concerns/identity_prefill_concern.rb
+++ b/app/controllers/concerns/identity_prefill_concern.rb
@@ -10,6 +10,12 @@ module IdentityPrefillConcern
   end
 
   def identity_prefill_source(dossier)
-    IdentityPrefillSource.new(dossier:)
+    IdentityPrefillSource.new(dossier:, source: current_identity_provider)
+  end
+
+  # Le fournisseur d'identité que cette requête privilégie. Seul ProConnect
+  # dépend de la session : FranceConnect est résolu depuis l'identité persistée.
+  def current_identity_provider
+    logged_in_with_pro_connect? ? :pro_connect : :france_connect
   end
 end

--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -3,6 +3,7 @@
 module Users
   class CommencerController < ApplicationController
     include ProConnectSessionConcern
+    include IdentityPrefillConcern
 
     layout 'procedure_context'
 
@@ -145,8 +146,9 @@ module Users
     # The prefilled dossier is not owned yet, and the user is signed in: they become the new owner
     def set_prefilled_dossier_ownership
       @prefilled_dossier.update!(user: current_user)
-      if @prefilled_dossier.procedure.for_individual? && @prefilled_dossier.france_connected_with_one_identity?
-        @prefilled_dossier.prefill_individual_from_france_connect
+      identity_source = identity_prefill_source(@prefilled_dossier)
+      if @prefilled_dossier.procedure.for_individual? && !identity_source.none?
+        @prefilled_dossier.prefill_individual_from(identity_source)
         @prefilled_dossier.individual.save!
       end
       DossierMailer.with(dossier: @prefilled_dossier).notify_new_draft.deliver_later

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -3,6 +3,7 @@
 module Users
   class DossiersController < UserController
     include DossierHelper
+    include IdentityPrefillConcern
     include TurboChampsConcern
     include LockableConcern
     include ProConnectSessionConcern
@@ -135,10 +136,11 @@ module Users
 
       respond_to do |format|
         format.html do
-          @dossier.prefill_individual_from_france_connect if @dossier.identity_from_fc? && !@dossier.for_tiers?
+          identity_source = identity_prefill_source(@dossier)
+          @dossier.prefill_individual_from(identity_source) if !@dossier.for_tiers?
         end
         format.turbo_stream do
-          @dossier.assign_for_tiers(params.dig(:dossier, :for_tiers) == 'true')
+          @dossier.assign_for_tiers(params.dig(:dossier, :for_tiers) == 'true', identity_source: identity_prefill_source(@dossier))
 
           if @dossier.brouillon?
             # Persist the persona choice so the identity form survives a page reload:
@@ -155,14 +157,16 @@ module Users
       @dossier = dossier
       @no_description = true
 
-      @dossier.assign_for_tiers(dossier_params[:for_tiers] == 'true')
+      identity_source = identity_prefill_source(@dossier)
+      @dossier.assign_for_tiers(dossier_params[:for_tiers] == 'true', identity_source:)
 
       sanitized_params = dossier_params.dup
-      if mandataire_identity_locked?(@dossier)
+      if identity_source.mandataire_locked?
         sanitized_params = sanitized_params.except(:mandataire_first_name, :mandataire_last_name)
-      elsif identity_locked?(@dossier)
+      end
+      if (locked_fields = identity_source.individual_locked_fields).any?
         # keep only birthdate for legacy procedures
-        sanitized_params[:individual_attributes] = sanitized_params[:individual_attributes]&.except(:nom, :prenom, :gender)
+        sanitized_params[:individual_attributes] = sanitized_params[:individual_attributes]&.except(*locked_fields)
         sanitized_params.delete(:individual_attributes) if sanitized_params[:individual_attributes].blank? # évite {} qui réinitialise l'individual
       end
 
@@ -568,14 +572,6 @@ module Users
     end
 
     private
-
-    def identity_locked?(dossier)
-      dossier.identity_from_fc?
-    end
-
-    def mandataire_identity_locked?(dossier)
-      dossier.for_tiers? && dossier.identity_from_fc?
-    end
 
     def filter_params_slice
       params.permit(*Users::DossierFilterService::ALLOWED_PARAMS)

--- a/app/models/concerns/dossier_france_connect_prefill_concern.rb
+++ b/app/models/concerns/dossier_france_connect_prefill_concern.rb
@@ -17,14 +17,19 @@ module DossierFranceConnectPrefillConcern
   end
 
   def prefill_individual_from(identity_source)
-    return if !identity_source.france_connect?
-
-    fc_info = identity_source.france_connect_information
-    individual.assign_attributes(
-      nom: fc_info.family_name,
-      prenom: fc_info.given_name,
-      gender: fc_info.gender == 'female' ? Individual::GENDER_FEMALE : Individual::GENDER_MALE
-    )
+    case identity_source.resolved
+    when :france_connect
+      fc_info = identity_source.france_connect_information
+      individual.assign_attributes(
+        nom: fc_info.family_name,
+        prenom: fc_info.given_name,
+        gender: fc_info.gender == 'female' ? Individual::GENDER_FEMALE : Individual::GENDER_MALE
+      )
+    when :pro_connect
+      pc_info = identity_source.pro_connect_information
+      # ProConnect ne fournit pas de civilité : gender laissé éditable.
+      individual.assign_attributes(nom: pc_info.usual_name, prenom: pc_info.given_name)
+    end
   end
 
   def prefill_champs_from_france_connect(updated_by:)
@@ -65,11 +70,16 @@ module DossierFranceConnectPrefillConcern
   private
 
   def prefill_mandataire_from(identity_source)
-    return if !identity_source.france_connect?
-
-    fc_info = identity_source.france_connect_information
-    self.mandataire_first_name = fc_info.given_name
-    self.mandataire_last_name = fc_info.family_name
+    case identity_source.resolved
+    when :france_connect
+      fc_info = identity_source.france_connect_information
+      self.mandataire_first_name = fc_info.given_name
+      self.mandataire_last_name = fc_info.family_name
+    when :pro_connect
+      pc_info = identity_source.pro_connect_information
+      self.mandataire_first_name = pc_info.given_name
+      self.mandataire_last_name = pc_info.usual_name
+    end
   end
 
   def reset_individual_for_tiers

--- a/app/models/concerns/dossier_france_connect_prefill_concern.rb
+++ b/app/models/concerns/dossier_france_connect_prefill_concern.rb
@@ -3,21 +3,23 @@
 module DossierFranceConnectPrefillConcern
   extend ActiveSupport::Concern
 
-  def assign_for_tiers(will_be_for_tiers)
+  def assign_for_tiers(will_be_for_tiers, identity_source: IdentityPrefillSource.new(dossier: self))
     self.for_tiers = will_be_for_tiers
 
-    return unless france_connected_with_one_identity?
+    return if identity_source.none?
 
     if will_be_for_tiers
-      prefill_mandataire_from_france_connect
+      prefill_mandataire_from(identity_source)
       reset_individual_for_tiers
     else
-      prefill_individual_from_france_connect
+      prefill_individual_from(identity_source)
     end
   end
 
-  def prefill_individual_from_france_connect
-    fc_info = user.france_connect_informations.first
+  def prefill_individual_from(identity_source)
+    return if !identity_source.france_connect?
+
+    fc_info = identity_source.france_connect_information
     individual.assign_attributes(
       nom: fc_info.family_name,
       prenom: fc_info.given_name,
@@ -62,8 +64,10 @@ module DossierFranceConnectPrefillConcern
 
   private
 
-  def prefill_mandataire_from_france_connect
-    fc_info = user.france_connect_informations.first
+  def prefill_mandataire_from(identity_source)
+    return if !identity_source.france_connect?
+
+    fc_info = identity_source.france_connect_information
     self.mandataire_first_name = fc_info.given_name
     self.mandataire_last_name = fc_info.family_name
   end

--- a/app/models/identity_prefill_source.rb
+++ b/app/models/identity_prefill_source.rb
@@ -1,30 +1,43 @@
 # frozen_string_literal: true
 
 # Résout la source de préremplissage de l'identité d'un dossier (nom, prénom,
-# civilité) à partir du fournisseur d'identité de l'usager.
+# éventuellement civilité) à partir du fournisseur d'identité de l'usager.
+#
+# `source` est le fournisseur que la requête courante privilégie, `resolved`
+# celui réellement retenu. L'asymétrie entre les deux fournisseurs est assumée :
+# ProConnect se lit dans la session (cf. ProConnectSessionConcern), FranceConnect
+# dans l'identité persistée de l'usager (cf. Dossier#identity_from_fc?) — d'où le
+# repli sur FranceConnect quelle que soit la valeur de `source`.
 #
 # Consommé par le composant du formulaire identité, les contrôleurs et
 # DossierFranceConnectPrefillConcern, qui s'accordent ainsi par construction
 # plutôt que par ordre d'exécution.
 class IdentityPrefillSource
-  attr_reader :dossier
+  attr_reader :dossier, :source
 
-  def initialize(dossier:)
+  def initialize(dossier:, source: :france_connect)
     @dossier = dossier
+    @source = source
   end
 
-  # :france_connect | nil — FranceConnect se résout depuis l'identité persistée
-  # de l'usager, pas depuis la session.
+  # :pro_connect | :france_connect | nil — la session courante prime, avec repli
+  # sur FranceConnect si l'identité ProConnect est incomplète.
   def resolved
     return @resolved if defined?(@resolved)
 
-    @resolved = (:france_connect if dossier.identity_from_fc?)
+    @resolved = if source == :pro_connect && pro_connect_identity_complete?
+      :pro_connect
+    elsif dossier.identity_from_fc?
+      :france_connect
+    end
   end
 
   def none? = resolved.nil?
   def france_connect? = resolved == :france_connect
+  def pro_connect? = resolved == :pro_connect
 
   # Champs de `individual` à verrouiller ET à stripper côté serveur.
+  # ProConnect ne fournit pas de civilité -> le gender reste éditable.
   #
   # Retourne [] quand for_tiers? : c'est ce qui rend `individual_locked_fields`
   # et `mandataire_locked?` mutuellement exclusifs (le contrôleur peut alors
@@ -32,7 +45,7 @@ class IdentityPrefillSource
   def individual_locked_fields
     return [] if dossier.for_tiers? || none?
 
-    [:nom, :prenom, :gender]
+    france_connect? ? [:nom, :prenom, :gender] : [:nom, :prenom]
   end
 
   def individual_field_locked?(field) = individual_locked_fields.include?(field)
@@ -40,4 +53,12 @@ class IdentityPrefillSource
   def mandataire_locked? = dossier.for_tiers? && !none?
 
   def france_connect_information = dossier.user&.france_connect_informations&.first
+  def pro_connect_information = dossier.user&.last_pro_connect_information
+
+  private
+
+  def pro_connect_identity_complete?
+    info = pro_connect_information
+    info.present? && info.given_name.present? && info.usual_name.present?
+  end
 end

--- a/app/models/identity_prefill_source.rb
+++ b/app/models/identity_prefill_source.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Résout la source de préremplissage de l'identité d'un dossier (nom, prénom,
+# civilité) à partir du fournisseur d'identité de l'usager.
+#
+# Consommé par le composant du formulaire identité, les contrôleurs et
+# DossierFranceConnectPrefillConcern, qui s'accordent ainsi par construction
+# plutôt que par ordre d'exécution.
+class IdentityPrefillSource
+  attr_reader :dossier
+
+  def initialize(dossier:)
+    @dossier = dossier
+  end
+
+  # :france_connect | nil — FranceConnect se résout depuis l'identité persistée
+  # de l'usager, pas depuis la session.
+  def resolved
+    return @resolved if defined?(@resolved)
+
+    @resolved = (:france_connect if dossier.identity_from_fc?)
+  end
+
+  def none? = resolved.nil?
+  def france_connect? = resolved == :france_connect
+
+  # Champs de `individual` à verrouiller ET à stripper côté serveur.
+  #
+  # Retourne [] quand for_tiers? : c'est ce qui rend `individual_locked_fields`
+  # et `mandataire_locked?` mutuellement exclusifs (le contrôleur peut alors
+  # traiter les deux dans des `if` indépendants plutôt qu'en if/elsif ordonné).
+  def individual_locked_fields
+    return [] if dossier.for_tiers? || none?
+
+    [:nom, :prenom, :gender]
+  end
+
+  def individual_field_locked?(field) = individual_locked_fields.include?(field)
+
+  def mandataire_locked? = dossier.for_tiers? && !none?
+
+  def france_connect_information = dossier.user&.france_connect_informations&.first
+end

--- a/app/views/users/dossiers/identite.html.erb
+++ b/app/views/users/dossiers/identite.html.erb
@@ -61,7 +61,7 @@
     <% end %>
   <% end %>
   <% if !@dossier.procedure.for_tiers_enabled? || identity_form_active %>
-    <%= render Dossiers::IndividualFormComponent.new(dossier: @dossier) %>
+    <%= render Dossiers::IndividualFormComponent.new(dossier: @dossier, identity_source: identity_prefill_source(@dossier)) %>
   <% else %>
     <div id="identite-form"></div>
   <% end %>

--- a/app/views/users/dossiers/identite.turbo_stream.erb
+++ b/app/views/users/dossiers/identite.turbo_stream.erb
@@ -1,2 +1,2 @@
-<%= turbo_stream.replace 'identite-form', render(Dossiers::IndividualFormComponent.new(dossier: @dossier)) %>
+<%= turbo_stream.replace 'identite-form', render(Dossiers::IndividualFormComponent.new(dossier: @dossier, identity_source: identity_prefill_source(@dossier))) %>
 <%= turbo_stream.hide 'identite-buttons-group' %>

--- a/spec/components/dossiers/individual_form_component_spec.rb
+++ b/spec/components/dossiers/individual_form_component_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe Dossiers::IndividualFormComponent, type: :component do
   let(:procedure) { create(:procedure, :published, :for_individual, no_gender: false) }
   let(:dossier) { create(:dossier, :with_individual, procedure:, user:) }
 
-  subject { render_inline(described_class.new(dossier:)) }
+  let(:source) { :france_connect }
+
+  subject { render_inline(described_class.new(dossier:, identity_source: IdentityPrefillSource.new(dossier:, source:))) }
 
   context "when user is connected via FranceConnect" do
     let(:user) { create(:user, :with_fci) }
@@ -54,6 +56,70 @@ RSpec.describe Dossiers::IndividualFormComponent, type: :component do
         end
 
         expect(page).to have_text("par FranceConnect et ne peuvent pas être modifiées")
+      end
+    end
+  end
+
+  context "when user is connected via ProConnect" do
+    let(:user) { create(:user, :with_pci) }
+    let(:source) { :pro_connect }
+
+    context "for self" do
+      it "locks nom and prénom but leaves civilité editable" do
+        subject
+        expect(page).to have_field("Prénom", disabled: true)
+        expect(page).to have_field("Nom", disabled: true)
+        expect(page).to have_css("input[name='dossier[individual_attributes][gender]']:not([disabled])")
+        expect(page).to have_text("par ProConnect et ne peuvent pas être modifiés")
+      end
+    end
+
+    context "for self, when ProConnect did not provide a usual name" do
+      let(:user) { create(:user, pro_connect_informations: [build(:pro_connect_information, usual_name: nil)]) }
+
+      it "all identity fields are editable" do
+        subject
+        expect(page).to have_field("Prénom", disabled: false)
+        expect(page).to have_field("Nom", disabled: false)
+        expect(page).not_to have_text("par ProConnect")
+      end
+    end
+
+    context "for tiers" do
+      let(:dossier) { create(:dossier, :for_tiers_without_notification, procedure:, user:) }
+
+      it "mandataire fields are disabled and beneficiary fields editable" do
+        subject
+        within(".mandataire-infos") do
+          expect(page).to have_field("Prénom", disabled: true)
+          expect(page).to have_field("Nom", disabled: true)
+        end
+        within(".individual-infos") do
+          expect(page).to have_field("Prénom", disabled: false)
+          expect(page).to have_field("Nom", disabled: false)
+        end
+      end
+    end
+  end
+
+  context "when user has both FranceConnect and ProConnect identities" do
+    let(:user) { create(:user, :with_fci, :with_pci) }
+
+    context "when the session is not ProConnected" do
+      it "falls back to FranceConnect (civilité locked)" do
+        subject
+        expect(page).to have_css("input[name='dossier[individual_attributes][gender]'][disabled]")
+        expect(page).to have_text("par FranceConnect et ne peuvent pas être modifiées")
+      end
+    end
+
+    context "when the session is ProConnected" do
+      let(:source) { :pro_connect }
+
+      it "uses ProConnect (civilité editable)" do
+        subject
+        expect(page).to have_css("input[name='dossier[individual_attributes][gender]']:not([disabled])")
+        expect(page).to have_text("par ProConnect et ne peuvent pas être modifiés")
       end
     end
   end

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -224,6 +224,31 @@ describe Users::DossiersController, type: :controller do
       end
     end
 
+    context 'when the session is connected via ProConnect' do
+      # Attach the ProConnect identity to the seeded usager rather than signing in
+      # another user: `dossiers.brouillon` belongs to them, and ensure_ownership!
+      # would otherwise redirect before the action runs.
+      before do
+        create(:pro_connect_information, user:)
+        allow(controller).to receive(:logged_in_with_pro_connect?).and_return(true)
+      end
+
+      context 'switching to for_tiers then back to for self' do
+        it 'persists the persona choice and prefills the mandataire from ProConnect in the rendered form' do
+          pc_info = user.last_pro_connect_information
+
+          patch :identite, params: { id: dossier.id, dossier: { for_tiers: 'true' } }, format: :turbo_stream
+          expect(dossier.reload.for_tiers).to be true
+          # The mandataire is assigned in memory and re-rendered (persisted only on update_identite).
+          expect(assigns(:dossier).mandataire_first_name).to eq(pc_info.given_name)
+          expect(assigns(:dossier).mandataire_last_name).to eq(pc_info.usual_name)
+
+          patch :identite, params: { id: dossier.id, dossier: { for_tiers: 'false' } }, format: :turbo_stream
+          expect(dossier.reload.for_tiers).to be false
+        end
+      end
+    end
+
     context 'when the dossier is already deposited' do
       let(:dossier) { create(:dossier, :en_construction, :with_individual, user:, procedure:) }
       let(:for_tiers_value) { 'true' }
@@ -418,6 +443,65 @@ describe Users::DossiersController, type: :controller do
           # But identity is still locked to FranceConnect values
           expect(dossier.individual.nom).to eq(fc_info.family_name)
           expect(dossier.individual.prenom).to eq(fc_info.given_name)
+        end
+      end
+    end
+
+    context 'when the session is connected via ProConnect' do
+      let(:user) { create(:user, :with_pci) }
+
+      before { allow(controller).to receive(:logged_in_with_pro_connect?).and_return(true) }
+
+      context 'when dossier is for self' do
+        let(:dossier) { create(:dossier, :with_individual, user:, procedure:) }
+
+        it 'ignores attempts to modify locked nom/prenom but honours the submitted gender' do
+          pc_info = user.last_pro_connect_information
+
+          post :update_identite, params: {
+            id: dossier.id,
+            dossier: {
+              individual_attributes: {
+                nom: 'Hacker',
+                prenom: 'Evil',
+                gender: Individual::GENDER_FEMALE,
+              },
+            },
+          }
+
+          dossier.reload
+          # nom/prenom locked to ProConnect values, ignoring submitted params
+          expect(dossier.individual.nom).to eq(pc_info.usual_name)
+          expect(dossier.individual.prenom).to eq(pc_info.given_name)
+          # gender is not provided by ProConnect: the submitted value is kept
+          expect(dossier.individual.gender).to eq(Individual::GENDER_FEMALE)
+        end
+      end
+
+      context 'when dossier is for tiers' do
+        let(:dossier) { create(:dossier, :for_tiers_without_notification, user:, procedure:) }
+
+        it 'locks the mandataire to ProConnect values and keeps the beneficiary editable' do
+          pc_info = user.last_pro_connect_information
+
+          post :update_identite, params: {
+            id: dossier.id,
+            dossier: {
+              for_tiers: 'true',
+              mandataire_first_name: 'Hacker',
+              mandataire_last_name: 'Evil',
+              individual_attributes: {
+                nom: 'Beneficiaire',
+                prenom: 'Le',
+              },
+            },
+          }
+
+          dossier.reload
+          expect(dossier.mandataire_first_name).to eq(pc_info.given_name)
+          expect(dossier.mandataire_last_name).to eq(pc_info.usual_name)
+          expect(dossier.individual.nom).to eq('Beneficiaire')
+          expect(dossier.individual.prenom).to eq('Le')
         end
       end
     end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -26,6 +26,10 @@ FactoryBot.define do
       france_connect_informations { [association(:france_connect_information)] }
     end
 
+    trait :with_pci do
+      pro_connect_informations { [association(:pro_connect_information)] }
+    end
+
     trait :with_email_verified do
       email_verified_at { Time.zone.now }
     end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -564,6 +564,44 @@ describe Dossier, type: :model do
         end
       end
 
+      context 'when the session is connected via ProConnect' do
+        let(:user) { create(:user, :with_pci) }
+        let(:identity_source) { IdentityPrefillSource.new(dossier:, source: :pro_connect) }
+
+        context 'switching to for_tiers' do
+          it 'prefills mandataire from ProConnect and resets individual' do
+            dossier.assign_for_tiers(true, identity_source:)
+
+            expect(dossier.for_tiers).to be true
+            expect(dossier.mandataire_first_name).to eq('John')
+            expect(dossier.mandataire_last_name).to eq('Doe')
+            expect(dossier.individual.nom).to be_nil
+            expect(dossier.individual.prenom).to be_nil
+          end
+        end
+
+        context 'switching from for_tiers to for self' do
+          before { dossier.update_columns(for_tiers: true) }
+
+          it 'prefills individual nom/prenom from ProConnect, leaves gender untouched' do
+            dossier.individual.update_columns(nom: nil, prenom: nil, gender: nil)
+            dossier.assign_for_tiers(false, identity_source:)
+
+            expect(dossier.for_tiers).to be false
+            expect(dossier.individual.nom).to eq('Doe')
+            expect(dossier.individual.prenom).to eq('John')
+            expect(dossier.individual.gender).to be_nil
+          end
+        end
+
+        it 'without a ProConnected session, keeps individual and clears mandataire' do
+          dossier.assign_for_tiers(true)
+
+          expect(dossier.mandataire_first_name).to be_nil
+          expect(dossier.individual.nom).to eq('Dupont')
+        end
+      end
+
       context 'when user is not connected via FranceConnect' do
         let(:user) { users.usager }
 

--- a/spec/models/identity_prefill_source_spec.rb
+++ b/spec/models/identity_prefill_source_spec.rb
@@ -3,8 +3,9 @@
 RSpec.describe IdentityPrefillSource do
   let(:procedure) { create(:procedure, :for_individual, no_gender: false) }
   let(:dossier) { create(:dossier, :with_individual, procedure:, user:) }
+  let(:source) { :france_connect }
 
-  subject(:identity_source) { described_class.new(dossier:) }
+  subject(:identity_source) { described_class.new(dossier:, source:) }
 
   context "when the user has no identity provider" do
     let(:user) { create(:user) }
@@ -32,11 +33,72 @@ RSpec.describe IdentityPrefillSource do
     end
   end
 
+  context "when the session is ProConnected" do
+    let(:user) { create(:user, :with_pci) }
+    let(:source) { :pro_connect }
+
+    it "resolves to :pro_connect and locks nom/prenom but not gender" do
+      expect(identity_source.resolved).to eq(:pro_connect)
+      expect(identity_source.individual_locked_fields).to contain_exactly(:nom, :prenom)
+    end
+
+    context "when ProConnect did not provide a usual name" do
+      let(:user) { create(:user, pro_connect_informations: [build(:pro_connect_information, usual_name: nil)]) }
+
+      it { expect(identity_source.resolved).to be_nil }
+    end
+
+    context "but the request does not prefer ProConnect" do
+      let(:source) { :france_connect }
+
+      it { expect(identity_source.resolved).to be_nil }
+    end
+  end
+
+  context "when the user has both identities" do
+    let(:user) { create(:user, :with_fci, :with_pci) }
+
+    context "and the session is ProConnected" do
+      let(:source) { :pro_connect }
+
+      it "the current session wins" do
+        expect(identity_source.resolved).to eq(:pro_connect)
+        expect(identity_source.individual_locked_fields).to contain_exactly(:nom, :prenom)
+      end
+    end
+
+    context "and the session is not ProConnected" do
+      it "falls back to FranceConnect" do
+        expect(identity_source.resolved).to eq(:france_connect)
+        expect(identity_source.individual_locked_fields).to contain_exactly(:nom, :prenom, :gender)
+      end
+    end
+
+    context "with the ProConnect session but an incomplete ProConnect identity" do
+      let(:user) { create(:user, :with_fci, pro_connect_informations: [build(:pro_connect_information, usual_name: nil)]) }
+      let(:source) { :pro_connect }
+
+      it "falls back to FranceConnect" do
+        expect(identity_source.resolved).to eq(:france_connect)
+      end
+    end
+  end
+
   context "when the dossier is for_tiers" do
     let(:dossier) { create(:dossier, :for_tiers_without_notification, procedure:, user:) }
 
     context "FranceConnected" do
       let(:user) { create(:user, :with_fci) }
+
+      it "locks the mandataire and nothing on the individual" do
+        expect(identity_source.mandataire_locked?).to be(true)
+        expect(identity_source.individual_locked_fields).to eq([])
+      end
+    end
+
+    context "ProConnected" do
+      let(:user) { create(:user, :with_pci) }
+      let(:source) { :pro_connect }
 
       it "locks the mandataire and nothing on the individual" do
         expect(identity_source.mandataire_locked?).to be(true)

--- a/spec/models/identity_prefill_source_spec.rb
+++ b/spec/models/identity_prefill_source_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe IdentityPrefillSource do
+  let(:procedure) { create(:procedure, :for_individual, no_gender: false) }
+  let(:dossier) { create(:dossier, :with_individual, procedure:, user:) }
+
+  subject(:identity_source) { described_class.new(dossier:) }
+
+  context "when the user has no identity provider" do
+    let(:user) { create(:user) }
+
+    it "resolves to no source and locks nothing" do
+      expect(identity_source.resolved).to be_nil
+      expect(identity_source).to be_none
+      expect(identity_source.individual_locked_fields).to eq([])
+      expect(identity_source.mandataire_locked?).to be(false)
+    end
+  end
+
+  context "when the user is FranceConnected" do
+    let(:user) { create(:user, :with_fci) }
+
+    it "resolves to :france_connect and locks nom/prenom/gender" do
+      expect(identity_source.resolved).to eq(:france_connect)
+      expect(identity_source.individual_locked_fields).to contain_exactly(:nom, :prenom, :gender)
+    end
+
+    context "with an incomplete identity" do
+      let(:user) { create(:user, france_connect_informations: [build(:france_connect_information, family_name: nil)]) }
+
+      it { expect(identity_source.resolved).to be_nil }
+    end
+  end
+
+  context "when the dossier is for_tiers" do
+    let(:dossier) { create(:dossier, :for_tiers_without_notification, procedure:, user:) }
+
+    context "FranceConnected" do
+      let(:user) { create(:user, :with_fci) }
+
+      it "locks the mandataire and nothing on the individual" do
+        expect(identity_source.mandataire_locked?).to be(true)
+        expect(identity_source.individual_locked_fields).to eq([])
+      end
+    end
+
+    context "without an identity provider" do
+      let(:user) { create(:user) }
+
+      it { expect(identity_source.mandataire_locked?).to be(false) }
+    end
+  end
+end

--- a/spec/system/users/dossier_creation_spec.rb
+++ b/spec/system/users/dossier_creation_spec.rb
@@ -103,6 +103,35 @@ describe 'Creating a new dossier:', js: true do
         end
       end
 
+      context 'when the session is connected via ProConnect' do
+        let(:procedure) { create(:procedure, :published, :for_individual, :with_service, no_gender: false, libelle:) }
+        let(:user) { create(:user, :with_pci) }
+
+        before do
+          allow_any_instance_of(ProConnectSessionConcern).to receive(:logged_in_with_pro_connect?).and_return(true)
+        end
+
+        it 'prefills and locks nom/prénom but lets the user pick the civilité' do
+          find('label', text: "Pour vous").click
+
+          expect(page).to have_field('Prénom', with: 'John', disabled: true)
+          expect(page).to have_field('Nom', with: 'Doe', disabled: true)
+          expect(page).to have_text("par ProConnect et ne peuvent pas être modifiés")
+
+          find('label', text: 'Madame').click
+
+          within "#identite-form" do
+            click_button('Continuer')
+          end
+
+          dossier = procedure.dossiers.last
+          expect(page).to have_current_path(brouillon_dossier_path(dossier))
+          expect(dossier.individual.reload.prenom).to eq('John')
+          expect(dossier.individual.nom).to eq('Doe')
+          expect(dossier.individual.gender).to eq(Individual::GENDER_FEMALE)
+        end
+      end
+
       context 'when for tiers is disabled' do
         let(:procedure) { create(:procedure, :published, :for_individual, :with_service, for_tiers_enabled: false, libelle:) }
 

--- a/spec/views/users/dossiers/identite.html.erb_spec.rb
+++ b/spec/views/users/dossiers/identite.html.erb_spec.rb
@@ -6,6 +6,7 @@ describe 'users/dossiers/identite', type: :view do
   before do
     sign_in dossier.user
     assign(:dossier, dossier)
+    allow(view).to receive(:identity_prefill_source) { |dossier| IdentityPrefillSource.new(dossier:) }
   end
 
   subject! { render }


### PR DESCRIPTION
Ref #13327

Un usager ProConnecté qui remplit une démarche `for_individual` ressaisissait
à la main un nom/prénom que le fournisseur d'identité vient pourtant de
transmettre. Cette PR préremplit et verrouille ces champs, à la manière de
FranceConnect.

## Ce que ça change

- L'étape identité préremplit **nom** et **prénom** depuis ProConnect et les
  verrouille (disabled côté vue + strippés des params côté serveur).
- ProConnect ne transmet pas de civilité : le verrou est désormais **par champ**.
  La civilité reste éditable et obligatoire, avec un message dédié « transmis
  par ProConnect ».
- Si l'usager a une identité FranceConnect **et** ProConnect, **la session
  courante prime** ; sinon le comportement FranceConnect est inchangé.

## Comment

Le premier commit est un refactor sans une ligne de ProConnect : il extrait un
PORO `IdentityPrefillSource`, consommé par le composant, les contrôleurs et le
concern de préremplissage — ils s'accordent par construction plutôt que par
ordre d'exécution. Le verrou tout-ou-rien devient un verrou par champ.

Le second commit branche ProConnect dessus (+ i18n + specs).
`IdentityPrefillSource` reçoit le fournisseur que la requête privilégie
(`source:`) et répond avec celui réellement retenu (`resolved`) : seul
ProConnect dépend de la session, FranceConnect continue de se résoudre depuis
l'identité persistée. C'est l'objet source qui circule, pas un drapeau —
`assign_for_tiers(…, identity_source:)`, `prefill_individual_from(identity_source)`.

## Points d'attention

- **Périmètre volontairement réduit au nom/prénom.** Le SIRET (démarches
  morales) fera l'objet d'une seconde itération.
- Effet de bord assumé côté FranceConnect, dans le premier commit : pour une
  identité FC **incomplète**, on ne préremplit plus de valeurs bancales (nom nil,
  civilité défautée) sur un formulaire non verrouillé — c'est une correction en
  faveur de FC.
- `Individual` ne valide pas la présence de la civilité côté serveur (seul le
  `required` HTML5 l'impose) ; préexistant, mais désormais atteignable sur un
  formulaire verrouillé.
