### PR TITLE
Tech: les listes de types de champ draft/published sont aplaties

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -35,10 +35,10 @@ class Procedure < ApplicationRecord
   has_many :deleted_dossiers, dependent: :destroy
   has_many :llm_rule_suggestions, through: :revisions
 
-  def draft_types_de_champ_public = draft_revision&.root_types_de_champ_public || []
-  def draft_types_de_champ_private = draft_revision&.root_types_de_champ_private || []
-  def published_types_de_champ_public = published_revision&.root_types_de_champ_public || []
-  def published_types_de_champ_private = published_revision&.root_types_de_champ_private || []
+  def draft_types_de_champ_public = draft_revision&.flat_types_de_champ_public || []
+  def draft_types_de_champ_private = draft_revision&.flat_types_de_champ_private || []
+  def published_types_de_champ_public = published_revision&.flat_types_de_champ_public || []
+  def published_types_de_champ_private = published_revision&.flat_types_de_champ_private || []
 
   has_one :published_dossier_submitted_message, dependent: :destroy, through: :published_revision, source: :dossier_submitted_message
   has_one :draft_dossier_submitted_message, dependent: :destroy, through: :draft_revision, source: :dossier_submitted_message

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -17,6 +17,10 @@ class ProcedureRevision < ApplicationRecord
   def root_types_de_champ_public = revision_types_de_champ_public.map(&:type_de_champ)
   def root_types_de_champ_private = revision_types_de_champ_private.map(&:type_de_champ)
 
+  # All types de champ in document order, repetition children inlined after their repetition.
+  def flat_types_de_champ_public = revision_types_de_champ_public.flat_map { [it, *it.revision_types_de_champ] }.map(&:type_de_champ)
+  def flat_types_de_champ_private = revision_types_de_champ_private.flat_map { [it, *it.revision_types_de_champ] }.map(&:type_de_champ)
+
   has_one :draft_procedure, -> { with_discarded }, class_name: 'Procedure', foreign_key: :draft_revision_id, dependent: :nullify, inverse_of: :draft_revision
   has_one :published_procedure, -> { with_discarded }, class_name: 'Procedure', foreign_key: :published_revision_id, dependent: :nullify, inverse_of: :published_revision
 

--- a/app/validators/types_de_champ/condition_validator.rb
+++ b/app/validators/types_de_champ/condition_validator.rb
@@ -7,13 +7,12 @@ class TypesDeChamp::ConditionValidator < ActiveModel::EachValidator
   def validate_each(procedure, collection, tdcs)
     return if tdcs.empty?
 
-    tdcs = tdcs_with_children(procedure, tdcs)
     tdcs.each_with_index do |tdc, tdc_index|
       next unless tdc.condition?
 
       upper_tdcs = []
       if collection == :draft_types_de_champ_private # in case of private tdc validation, we must include public tdcs
-        upper_tdcs += tdcs_with_children(procedure, procedure.draft_types_de_champ_public)
+        upper_tdcs += procedure.draft_types_de_champ_public
       end
       upper_tdcs += tdcs.take(tdc_index) # we take all upper_tdcs of current tdcs
 
@@ -26,12 +25,5 @@ class TypesDeChamp::ConditionValidator < ActiveModel::EachValidator
         type_de_champ: tdc
       )
     end
-  end
-
-  # find children in repetitions, keeping the repetition itself so its own
-  # condition is validated too
-  def tdcs_with_children(procedure, tdcs)
-    tdcs.to_a
-      .flat_map { _1.repetition? ? [_1, *procedure.draft_revision.children_of(_1)] : _1 }
   end
 end

--- a/app/validators/types_de_champ/date_validator.rb
+++ b/app/validators/types_de_champ/date_validator.rb
@@ -2,9 +2,7 @@
 
 class TypesDeChamp::DateValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
-    date_tdcs = types_de_champ
-      .flat_map { it.repetition? ? procedure.draft_revision.children_of(it) : [it] }
-      .filter { |tdc| tdc.date? || tdc.datetime? }
+    date_tdcs = types_de_champ.filter { |tdc| tdc.date? || tdc.datetime? }
     date_tdcs.each do |tdc|
       validate_range(procedure, attribute, tdc) if tdc.range_date?
     end

--- a/app/validators/types_de_champ/formatted_validator.rb
+++ b/app/validators/types_de_champ/formatted_validator.rb
@@ -2,8 +2,7 @@
 
 class TypesDeChamp::FormattedValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
-    types_de_champ.to_a
-      .flat_map { _1.repetition? ? procedure.draft_revision.children_of(_1) : _1 }
+    types_de_champ
       .filter(&:formatted?)
       .each do |tdc|
         validate_characters_rules(procedure, attribute, tdc)

--- a/app/validators/types_de_champ/header_section_consistency_validator.rb
+++ b/app/validators/types_de_champ/header_section_consistency_validator.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::HeaderSectionConsistencyValidator < ActiveModel::EachValidator
+  # header levels are checked per scope: root types de champ together, each
+  # repetition's children together
   def validate_each(procedure, attribute, types_de_champ)
-    public_tdcs = types_de_champ.to_a
-
-    root_tdcs_errors = errors_for_header_sections_order(procedure, attribute, public_tdcs)
-    repetition_tdcs_errors = public_tdcs
-      .filter_map { _1.repetition? ? procedure.draft_revision.children_of(_1) : nil }
-      .map { errors_for_header_sections_order(procedure, attribute, _1) }
-
-    repetition_tdcs_errors + root_tdcs_errors
+    types_de_champ.to_a
+      .group_by { procedure.draft_revision.parent_of(it) }
+      .each_value { errors_for_header_sections_order(procedure, attribute, it) }
   end
 
   private

--- a/app/validators/types_de_champ/libelle_validator.rb
+++ b/app/validators/types_de_champ/libelle_validator.rb
@@ -4,19 +4,15 @@ class TypesDeChamp::LibelleValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
     types_de_champ.each do |tdc|
       validate_libelle(procedure, attribute, tdc)
-
-      next unless tdc.repetition?
-
-      procedure.draft_revision.children_of(tdc).each do |child|
-        validate_libelle(procedure, attribute, child, parent: tdc)
-      end
     end
   end
 
   private
 
-  def validate_libelle(procedure, attribute, tdc, parent: nil)
+  def validate_libelle(procedure, attribute, tdc)
     return if tdc.libelle.present?
+
+    parent = procedure.draft_revision.parent_of(tdc)
 
     message_key, options = if parent
       [:missing_libelle_in_repetition, { position: position_of(tdc), parent_position: position_of(parent) }]

--- a/app/validators/types_de_champ/no_empty_drop_down_validator.rb
+++ b/app/validators/types_de_champ/no_empty_drop_down_validator.rb
@@ -3,18 +3,11 @@
 class TypesDeChamp::NoEmptyDropDownValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
     types_de_champ
-      .flat_map { with_children(procedure, it) }
       .filter(&:any_drop_down_list?)
       .each { validate_drop_down_not_empty(procedure, attribute, it) }
   end
 
   private
-
-  def with_children(procedure, type_de_champ)
-    return [type_de_champ] unless type_de_champ.repetition?
-
-    [type_de_champ, *procedure.draft_revision.children_of(type_de_champ)]
-  end
 
   def validate_drop_down_not_empty(procedure, attribute, drop_down)
     if (drop_down.drop_down_list? || drop_down.multiple_drop_down_list?) && drop_down.drop_down_advanced? && drop_down.referentiel.blank?

--- a/app/validators/types_de_champ/number_validator.rb
+++ b/app/validators/types_de_champ/number_validator.rb
@@ -3,7 +3,6 @@
 class TypesDeChamp::NumberValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
     types_de_champ
-      .flat_map { it.repetition? ? procedure.draft_revision.children_of(it) : [it] }
       .filter { |tdc| tdc.decimal_number? || tdc.integer_number? }.each do |tdc|
       validate_range(procedure, attribute, tdc) if tdc.range_number?
     end

--- a/app/validators/types_de_champ/referentiel_ready_validator.rb
+++ b/app/validators/types_de_champ/referentiel_ready_validator.rb
@@ -3,7 +3,6 @@
 class TypesDeChamp::ReferentielReadyValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
     types_de_champ
-      .flat_map { it.repetition? ? procedure.draft_revision.children_of(it) : [it] }
       .filter(&:referentiel?).each do |referentiel_champ|
       unless referentiel_champ.referentiel&.ready?
         procedure.errors.add(

--- a/app/views/fields/types_de_champ_collection_field/_show.html.erb
+++ b/app/views/fields/types_de_champ_collection_field/_show.html.erb
@@ -1,5 +1,3 @@
-<% revision = page.resource.is_a?(Procedure) ? page.resource.active_revision : page.resource.revision %>
-
 <% if field.data.any? %>
   <table class="collection-data" aria-labelledby="page-title">
     <thead>
@@ -13,12 +11,6 @@
     <tbody>
       <% field.data.each do |type_de_champ| %>
         <%= render partial: 'fields/types_de_champ_collection_field/type_champ_line', locals: { type_de_champ: type_de_champ } %>
-
-        <% if type_de_champ.type_champ == 'repetition' %>
-          <% revision.children_of(type_de_champ).each do |sub_champ| %>
-            <%= render partial: 'fields/types_de_champ_collection_field/type_champ_line', locals: { type_de_champ: sub_champ } %>
-          <% end %>
-        <% end %>
       <% end %>
     </tbody>
   </table>


### PR DESCRIPTION
## Résumé

- `draft_types_de_champ_*` et `published_types_de_champ_*` retournent désormais des listes plates (les champs des répétitions sont inclus à la suite de leur répétition), via les nouvelles méthodes `ProcedureRevision#flat_types_de_champ_public/private`.
- Les validateurs de types de champ n'ont plus besoin de descendre eux-mêmes dans les répétitions ; le validateur de cohérence des sections regroupe la liste plate par parent pour conserver la vérification des niveaux par périmètre.
- Le tableau des types de champ du manager n'affiche plus les enfants de répétition en double.

🤖 Generated with [Claude Code](https://claude.com/claude-code)