### PR TITLE
Tech : corriger une attente Capybara de 6 s par exemple dans wcag_usager_spec

### DIFF
--- a/spec/system/accessibilite/wcag_usager_spec.rb
+++ b/spec/system/accessibilite/wcag_usager_spec.rb
@@ -6,7 +6,9 @@ describe 'wcag rules for usager', js: true do
   let(:litteraire_user) { create(:user, password: password) }
 
   def test_aria_label_do_not_mix_with_title_attribute
-    elements = page.all("[aria-label][title]")
+    # minimum: 0 — a page with no such element is the expected outcome; without
+    # it Capybara retries for default_max_wait_time before returning empty.
+    elements = page.all("[aria-label][title]", minimum: 0)
     elements.each do |element|
       expect(element[:title]).to be_blank, "path=#{path}, element title=\"#{element[:title]}\" mixes aria-label and title attributes"
     end


### PR DESCRIPTION
## Contexte

Point 5 de #13558 : `wcag_usager_spec` prenait 66–69 s. Le diagnostic initial (scan axe coûteux, ~6,6 s par exemple) était erroné : les scans `be_axe_clean` pleine page ne coûtent que 0,3–0,5 s.

## Cause réelle

`page.all("[aria-label][title]")` : Capybara 3 réessaie pendant `default_max_wait_time` (6 s) avant d'accepter un résultat vide — or un résultat vide est précisément ce qu'on attend sur chaque page. 8 exemples payaient cette pénalité.

## Correction

`minimum: 0` sur l'appel `all` : le fichier passe de **69 s à 21 s** (21 exemples, 0 échec). Aucun autre `all` de spec/system ne présente ce piège (les autres attendent des éléments qui doivent exister).

Ref #13558

🤖 Generated with [Claude Code](https://claude.com/claude-code)