### PR TITLE
ETQ usager, corrige une erreur aléatoire à l'export PDF du dossier

### DIFF
--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -20,7 +20,7 @@ def render_in_2_columns(pdf, label, text)
   pdf.text "\n"
 end
 
-def format_in_2_lines(pdf, champ, nb_lines = 1)
+def empty_format_in_2_lines(pdf, champ, nb_lines = 1)
   add_single_line(pdf, champ.libelle, 9, :bold)
   add_optionnal_description(pdf, champ)
   height = 10 * (nb_lines + 1)
@@ -30,7 +30,7 @@ def format_in_2_lines(pdf, champ, nb_lines = 1)
   pdf.text "\n"
 end
 
-def format_in_2_columns(pdf, label)
+def empty_format_in_2_columns(pdf, label)
   pdf.text_box label, width: 200, height: 100, overflow: :expand, at: [0, pdf.cursor]
   pdf.bounding_box([110, pdf.cursor + 5], :width => 350, :height => 20) do
     pdf.stroke_bounds
@@ -87,22 +87,22 @@ def format_date(date)
   I18n.l(date, format: :message_date_with_year)
 end
 
-def add_identite_individual(pdf)
-  format_in_2_columns(pdf, "Civilité")
-  format_in_2_columns(pdf, "Nom")
-  format_in_2_columns(pdf, "Prénom")
+def empty_add_identite_individual(pdf)
+  empty_format_in_2_columns(pdf, "Civilité")
+  empty_format_in_2_columns(pdf, "Nom")
+  empty_format_in_2_columns(pdf, "Prénom")
 
   if @procedure.ask_birthday?
-    format_in_2_columns(pdf, "Date de naissance")
+    empty_format_in_2_columns(pdf, "Date de naissance")
   end
 end
 
-def add_identite_etablissement(pdf, libelle)
+def empty_add_identite_etablissement(pdf, libelle)
   add_single_line(pdf, libelle, 9, :bold)
 
-  format_in_2_columns(pdf, "SIRET")
-  format_in_2_columns(pdf, "Dénomination")
-  format_in_2_columns(pdf, "Forme juridique")
+  empty_format_in_2_columns(pdf, "SIRET")
+  empty_format_in_2_columns(pdf, "Dénomination")
+  empty_format_in_2_columns(pdf, "Forme juridique")
 end
 
 def add_single_line(pdf, libelle, size, style)
@@ -111,7 +111,7 @@ def add_single_line(pdf, libelle, size, style)
   end
 end
 
-def add_title(pdf, title)
+def empty_add_title(pdf, title)
   add_single_line(pdf, title, 20, :bold)
   pdf.text "\n"
 end
@@ -166,10 +166,10 @@ def render_single_champ(pdf, revision, type_de_champ)
     pdf.text type_de_champ.description
     pdf.text "\n"
   when TypeDeChamp.type_champs.fetch(:address), TypeDeChamp.type_champs.fetch(:carte), TypeDeChamp.type_champs.fetch(:textarea)
-    format_in_2_lines(pdf, type_de_champ, 5)
+    empty_format_in_2_lines(pdf, type_de_champ, 5)
   when TypeDeChamp.type_champs.fetch(:drop_down_list)
     if type_de_champ.drop_down_advanced?
-      format_in_2_lines(pdf, type_de_champ)
+      empty_format_in_2_lines(pdf, type_de_champ)
     else
       add_libelle(pdf, type_de_champ)
       add_optionnal_description(pdf, type_de_champ)
@@ -197,13 +197,13 @@ def render_single_champ(pdf, revision, type_de_champ)
     end
     pdf.text "\n"
   when TypeDeChamp.type_champs.fetch(:siret)
-    add_identite_etablissement(pdf, type_de_champ.libelle)
+    empty_add_identite_etablissement(pdf, type_de_champ.libelle)
   else
-    format_in_2_lines(pdf, type_de_champ)
+    empty_format_in_2_lines(pdf, type_de_champ)
   end
 end
 
-def add_champs(pdf, revision, types_de_champ)
+def empty_add_champs(pdf, revision, types_de_champ)
   types_de_champ.each do |type_de_champ|
     render_single_champ(pdf, revision, type_de_champ)
   end
@@ -224,20 +224,20 @@ prawn_document(page_size: "A4") do |pdf|
   render_in_2_columns(pdf, 'Organisme', @procedure.organisation_name || "En attente de saisi")
   pdf.text "\n"
 
-  add_title(pdf, "Identité du demandeur")
+  empty_add_title(pdf, "Identité du demandeur")
 
-  format_in_2_columns(pdf, "Email")
+  empty_format_in_2_columns(pdf, "Email")
 
   if @procedure.for_individual?
-    add_identite_individual(pdf)
+    empty_add_identite_individual(pdf)
   else
-    add_identite_etablissement(pdf, 'Etablissement')
+    empty_add_identite_etablissement(pdf, 'Etablissement')
   end
   pdf.text "\n"
 
-  add_title(pdf, 'Formulaire')
+  empty_add_title(pdf, 'Formulaire')
   add_single_line(pdf, @procedure.description + "\n", 9, :italic) if @procedure.description.present?
-  add_champs(pdf, @revision, @revision.root_types_de_champ_public)
+  empty_add_champs(pdf, @revision, @revision.root_types_de_champ_public)
   add_page_numbering(pdf)
   add_procedure(pdf, @procedure)
 end

--- a/spec/views/prawn_templates_spec.rb
+++ b/spec/views/prawn_templates_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe 'prawn templates' do
+  # Top-level `def`s in a template are defined at render time on the shared
+  # view class, common to every template of the process. If two templates
+  # define a method with the same name, each render redefines it globally:
+  # under a multi-threaded server, a template can end up calling the other
+  # template's version mid-render (race condition, see Sentry RAILS-MC3).
+  it 'do not define top-level methods with the same name in two different templates' do
+    method_definitions = Rails.root.glob('app/views/**/*.prawn').flat_map do |path|
+      path.readlines.filter_map do |line|
+        method_name = line[/\Adef (\w+)/, 1]
+        [method_name, path.relative_path_from(Rails.root).to_s] if method_name
+      end
+    end
+
+    collisions = method_definitions
+      .group_by(&:first)
+      .transform_values { |definitions| definitions.map(&:last) }
+      .filter { |_, templates| templates.many? }
+
+    expect(collisions).to be_empty, <<~MSG
+      Some methods are defined in several prawn templates, which causes race conditions in production:
+      #{collisions.map { |name, templates| "  #{name}: #{templates.join(', ')}" }.join("\n")}
+      Rename them so that each template uses unique method names.
+    MSG
+  end
+end


### PR DESCRIPTION
Corrige [RAILS-MC3](https://demarches-simplifiees.sentry.io/issues/RAILS-MC3) : `ArgumentError: wrong number of arguments (given 3, expected 2)` lors du téléchargement du PDF d'un dossier.

Les `def` au top-level d'un template s'exécutent au rendu et se définissent sur la classe de vue **partagée du process**. `show.pdf.prawn` et `dossier_vide.pdf.prawn` définissaient 6 méthodes homonymes avec des signatures différentes (`format_in_2_columns`, `add_champs`, …) : sous Puma multi-threadé, le rendu concurrent d'un formulaire vierge pouvait redéfinir une méthode en pleine génération du PDF d'un dossier — crash, ou PDF silencieusement faux quand les arités coïncident.

- Préfixe `empty_` sur les 6 méthodes en collision dans `dossier_vide.pdf.prawn` (aucun changement fonctionnel, `show.pdf.prawn` intact)
- Ajoute un spec de garde qui échoue si deux templates prawn définissent une méthode du même nom, pour empêcher toute réintroduction du problème

Fixes RAILS-MC3