### PR TITLE
Tech : migrer les specs les plus coûteuses vers les seeds Oaken (point 1 de #13558)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /log/*
 !/log/.keep
 /tmp
-failing_specs.txt
+failing_specs*.txt
 
 public/uploads
 public/downloads

--- a/db/seeds/cases/routage.rb
+++ b/db/seeds/cases/routage.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# A published procedure for individuals routed to two groupes instructeurs
+# ("défaut" and "deuxième groupe"), owned by the default administrateur.
+# Load in a spec with `seed "cases/routage"`.
+
+procedure = Procedure.new(
+  libelle: "Démarche de démonstration (routage)",
+  description: "Une démarche de démonstration routée vers plusieurs groupes d’instructeurs.",
+  cadre_juridique: "https://www.legifrance.gouv.fr/",
+  lien_site_web: "https://www.exemple.fr",
+  duree_conservation_dossiers_dans_ds: 3,
+  max_duree_conservation_dossiers_dans_ds: Procedure::OLD_MAX_DUREE_CONSERVATION,
+  for_individual: true,
+  administrateurs: [administrateurs.default],
+  zones: [zones.default],
+  service: services.default
+)
+procedure.draft_revision = procedure.revisions.build
+procedure.save!
+
+type_de_champ = procedure.draft_revision.add_type_de_champ(type_champ: "text", libelle: "Nom du projet", mandatory: true)
+raise type_de_champ.errors.full_messages.to_sentence if type_de_champ.errors.any?
+
+procedure.publish_or_reopen!(administrateurs.default, "demarche-demo-routage")
+# No instructeur is assigned: specs about groupe management expect empty
+# groupes, like the factory's :routee trait.
+GroupeInstructeur.create!(label: "deuxième groupe", procedure:)
+procedure.toggle_routing
+
+procedures.label routee: procedure

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -4,8 +4,10 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
   render_views
   include Logic
 
+  before_all { seed "cases/routage" }
+
   let(:admin) { administrateurs.default }
-  let(:procedure) { create(:procedure, :routee, :published, :for_individual, administrateurs: [admin]) }
+  let(:procedure) { procedures.routee }
 
   let!(:gi_1_1) { procedure.defaut_groupe_instructeur }
   let!(:gi_1_2) { procedure.defaut_groupe_instructeur.other_groupe_instructeurs.first }

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -3,14 +3,14 @@
 describe Instructeurs::DossiersController, type: :controller do
   render_views
 
-  let(:instructeur) { create(:instructeur) }
+  # the local `let(:instructeurs)` shadows the seed accessor, so go through Oaken::Seeds
+  let(:instructeur) { Oaken::Seeds.instructeurs.default }
   let(:administration) { create(:administration) }
   let(:instructeurs) { [instructeur] }
-  let(:types_de_champ_public) { [] }
-  let(:procedure) { create(:procedure, :published, :for_individual, instructeurs: instructeurs, types_de_champ_public:) }
+  let(:procedure) { procedures.individual }
   let(:procedure_accuse_lecture) { create(:procedure, :published, :for_individual, :accuse_lecture, :new_administrateur, instructeurs: instructeurs) }
-  let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure: procedure) }
-  let(:dossier_accepte) { create(:dossier, :accepte, :with_individual, procedure: procedure) }
+  let(:dossier) { dossiers.en_construction }
+  let(:dossier_accepte) { dossiers.accepte }
   let(:dossier_accuse_lecture) { create(:dossier, :en_construction, :with_individual, procedure: procedure_accuse_lecture) }
   let(:dossier_for_tiers) { create(:dossier, :en_construction, :for_tiers_with_notification, procedure: procedure) }
   let(:dossier_for_tiers_without_notif) { create(:dossier, :en_construction, :for_tiers_without_notification, procedure: procedure) }
@@ -435,6 +435,7 @@ describe Instructeurs::DossiersController, type: :controller do
         let(:emailable) { false }
         let(:template) { create(:attestation_template, kind: :refus) }
         let(:procedure) { create(:procedure, :published, :for_individual, attestation_refus_template: template, instructeurs: [instructeur]) }
+        let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure:) }
 
         subject do
           post :terminer, params: {
@@ -648,6 +649,7 @@ describe Instructeurs::DossiersController, type: :controller do
         let(:emailable) { false }
         let(:template) { create(:attestation_template) }
         let(:procedure) { create(:procedure, :published, :for_individual, attestation_acceptation_template: template, instructeurs: [instructeur]) }
+        let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure:) }
 
         subject do
           post :terminer, params: {
@@ -1133,7 +1135,7 @@ describe Instructeurs::DossiersController, type: :controller do
       context 'with linked dossiers' do
         let(:asked_confidentiel) { false }
         let(:previous_avis_confidentiel) { false }
-        let(:types_de_champ_public) { [{ type: :dossier_link }] }
+        let(:procedure) { create(:procedure, :published, :for_individual, instructeurs:, types_de_champ_public: [{ type: :dossier_link }]) }
         let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
         before { subject }
         context 'when the expert doesn’t share linked dossiers' do
@@ -1192,20 +1194,19 @@ describe Instructeurs::DossiersController, type: :controller do
       end
 
       it "create attente_avis notification only for instructeur follower" do
-        expect { subject }.to change(DossierNotification, :count).by(1)
+        # scoped to the type: following the seeded dossier also (re)creates its
+        # message notification for the new follower
+        expect { subject }.to change { DossierNotification.attente_avis.count }.by(1)
 
-        notification = DossierNotification.last
+        notification = DossierNotification.attente_avis.last
         expect(notification.dossier_id).to eq(dossier.id)
         expect(notification.instructeur_id).to eq(instructeur.id)
-        expect(notification.notification_type).to eq("attente_avis")
       end
     end
   end
 
   describe "#show" do
     context "when the dossier is exported as PDF" do
-      # the local `let(:instructeurs)` shadows the seed accessor, so go through Oaken::Seeds
-      let(:instructeur) { Oaken::Seeds.instructeurs.default }
       let(:expert) { create(:expert) }
       let(:procedure) { procedures.entreprise }
       let(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: procedure) }

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -3,12 +3,11 @@
 describe Instructeurs::DossiersController, type: :controller do
   render_views
 
-  # the local `let(:instructeurs)` shadows the seed accessor, so go through Oaken::Seeds
-  let(:instructeur) { Oaken::Seeds.instructeurs.default }
+  let(:instructeur) { instructeurs.default }
   let(:administration) { create(:administration) }
-  let(:instructeurs) { [instructeur] }
+  let(:procedure_instructeurs) { [instructeur] }
   let(:procedure) { procedures.individual }
-  let(:procedure_accuse_lecture) { create(:procedure, :published, :for_individual, :accuse_lecture, :new_administrateur, instructeurs: instructeurs) }
+  let(:procedure_accuse_lecture) { create(:procedure, :published, :for_individual, :accuse_lecture, :new_administrateur, instructeurs: procedure_instructeurs) }
   let(:dossier) { dossiers.en_construction }
   let(:dossier_accepte) { dossiers.accepte }
   let(:dossier_accuse_lecture) { create(:dossier, :en_construction, :with_individual, procedure: procedure_accuse_lecture) }
@@ -685,7 +684,7 @@ describe Instructeurs::DossiersController, type: :controller do
     end
 
     context 'when related etablissement is still in degraded_mode' do
-      let(:procedure) { create(:procedure, :published, for_individual: false, instructeurs: instructeurs) }
+      let(:procedure) { create(:procedure, :published, for_individual: false, instructeurs: procedure_instructeurs) }
       let(:dossier) { create(:dossier, :en_instruction, :with_entreprise, procedure: procedure, as_degraded_mode: true) }
 
       subject { post :terminer, params: { process_action: "accepter", procedure_id: procedure.id, dossier_id: dossier.id, statut: 'a-suivre' }, format: :turbo_stream }
@@ -1135,7 +1134,7 @@ describe Instructeurs::DossiersController, type: :controller do
       context 'with linked dossiers' do
         let(:asked_confidentiel) { false }
         let(:previous_avis_confidentiel) { false }
-        let(:procedure) { create(:procedure, :published, :for_individual, instructeurs:, types_de_champ_public: [{ type: :dossier_link }]) }
+        let(:procedure) { create(:procedure, :published, :for_individual, instructeurs: procedure_instructeurs, types_de_champ_public: [{ type: :dossier_link }]) }
         let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
         before { subject }
         context 'when the expert doesn’t share linked dossiers' do
@@ -1235,7 +1234,7 @@ describe Instructeurs::DossiersController, type: :controller do
       end
 
       context 'empty champs commune' do
-        let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :communes }], instructeurs:) }
+        let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :communes }], instructeurs: procedure_instructeurs) }
         let(:dossier) { create(:dossier, :accepte, procedure:) }
 
         it { expect(response).to render_template 'dossiers/show' }
@@ -1344,7 +1343,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
   describe "#update_annotations" do
     let(:procedure) do
-      create(:procedure, :published, types_de_champ_public:, types_de_champ_private:, instructeurs: instructeurs)
+      create(:procedure, :published, types_de_champ_public:, types_de_champ_private:, instructeurs: procedure_instructeurs)
     end
     let(:types_de_champ_private) do
       [
@@ -1593,7 +1592,7 @@ describe Instructeurs::DossiersController, type: :controller do
     end
 
     context "when there are others instructeurs" do
-      let(:instructeurs) { [instructeur, another_instructeur] }
+      let(:procedure_instructeurs) { [instructeur, another_instructeur] }
       let!(:other_instructeur_procedure) { create(:instructeurs_procedure, instructeur: another_instructeur, procedure:, display_annotation_instructeur_notifications: 'all') }
       let(:params) do
         {
@@ -1666,7 +1665,7 @@ describe Instructeurs::DossiersController, type: :controller do
         { type: :explication, stable_id: explication_stable_id, condition: },
       ]
     end
-    let(:procedure) { create(:procedure, :published, types_de_champ_private:, instructeurs:) }
+    let(:procedure) { create(:procedure, :published, types_de_champ_private:, instructeurs: procedure_instructeurs) }
     let(:dossier) { create(:dossier, :en_construction, :with_populated_annotations, procedure:) }
 
     subject do
@@ -2049,7 +2048,7 @@ describe Instructeurs::DossiersController, type: :controller do
   end
 
   describe '#pieces_jointes' do
-    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }], instructeurs:) }
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :piece_justificative }], instructeurs: procedure_instructeurs) }
     let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure: procedure) }
     let(:logo_path) { 'spec/fixtures/files/logo_test_procedure.png' }
     let(:rib_path) { 'spec/fixtures/files/RIB.pdf' }

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -152,7 +152,7 @@ describe Users::DossiersController, type: :controller do
   end
 
   describe 'identite with FranceConnect' do
-    let(:procedure) { create(:procedure, :for_individual, for_tiers_enabled: true) }
+    let(:procedure) { procedures.individual }
     let(:dossier) { create(:dossier, user:, procedure:) }
 
     before { sign_in(user) }
@@ -191,8 +191,8 @@ describe Users::DossiersController, type: :controller do
   end
 
   describe 'identite turbo_stream persists the persona choice' do
-    let(:procedure) { create(:procedure, :for_individual, for_tiers_enabled: true) }
-    let(:dossier) { create(:dossier, user:, procedure:) }
+    let(:procedure) { procedures.individual }
+    let(:dossier) { dossiers.brouillon }
     let(:now) { Time.zone.parse('01/01/2100') }
 
     before { sign_in(user) }
@@ -226,8 +226,8 @@ describe Users::DossiersController, type: :controller do
   end
 
   describe 'update_identite' do
-    let(:procedure) { create(:procedure, :for_individual) }
-    let(:dossier) { create(:dossier, user: user, procedure: procedure) }
+    let(:procedure) { procedures.individual }
+    let(:dossier) { dossiers.brouillon }
 
     subject { post :update_identite, params: { id: dossier.id, dossier: dossier_params } }
 
@@ -279,7 +279,7 @@ describe Users::DossiersController, type: :controller do
     end
 
     context 'when the identite cannot be updated by the user' do
-      let(:dossier) { create(:dossier, :with_individual, :en_instruction, user: user, procedure: procedure) }
+      let(:dossier) { dossiers.en_instruction }
       let(:dossier_params) { { individual_attributes: { gender: 'M', nom: 'Mouse', prenom: 'Mickey' } } }
       before { subject }
 
@@ -455,7 +455,7 @@ describe Users::DossiersController, type: :controller do
 
   describe '#siret' do
     before { sign_in(user) }
-    let!(:dossier) { create(:dossier, user: user) }
+    let!(:dossier) { create(:dossier, user: user, procedure: procedures.entreprise) }
 
     subject { get :siret, params: { id: dossier.id } }
 
@@ -463,7 +463,7 @@ describe Users::DossiersController, type: :controller do
   end
 
   describe '#update_siret' do
-    let(:dossier) { create(:dossier, user: user) }
+    let(:dossier) { create(:dossier, user: user, procedure: procedures.entreprise) }
     let(:siret) { params_siret.delete(' ') }
     let(:siren) { siret[0..8] }
     let(:api_etablissement_status) { 200 }
@@ -473,6 +473,8 @@ describe Users::DossiersController, type: :controller do
 
     before do
       sign_in(user)
+      # the procedure factory sets a dummy token; the seeded procedure has none
+      procedures.entreprise.update!(api_entreprise_token: JWT.encode({ exp: 2.months.from_now.to_i }, nil, 'none'))
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v4\/insee\/sirene\/etablissements\/#{siret}/)
         .to_return(status: api_etablissement_status, body: api_etablissement_body)
       allow_any_instance_of(APIEntrepriseToken).to receive(:roles)
@@ -579,7 +581,7 @@ describe Users::DossiersController, type: :controller do
 
   describe '#brouillon' do
     before { sign_in(user) }
-    let!(:dossier) { create(:dossier, user: user, autorisation_donnees: true) }
+    let!(:dossier) { create(:dossier, user: user, autorisation_donnees: true, procedure: procedures.entreprise) }
 
     subject { get :brouillon, params: { id: dossier.id } }
 
@@ -602,14 +604,14 @@ describe Users::DossiersController, type: :controller do
     end
 
     context 'when the dossier is en_construction' do
-      let!(:dossier) { create(:dossier, :en_construction, user: user, autorisation_donnees: true) }
+      let!(:dossier) { dossiers.en_construction }
       it { is_expected.to redirect_to(modifier_dossier_path(dossier)) }
     end
   end
 
   describe '#edit' do
     before { sign_in(user) }
-    let!(:dossier) { create(:dossier, user: user) }
+    let!(:dossier) { create(:dossier, user: user, procedure: procedures.entreprise) }
 
     it 'returns the edit page' do
       get :brouillon, params: { id: dossier.id }
@@ -2009,12 +2011,12 @@ describe Users::DossiersController, type: :controller do
       subject! { get(:show, params: { id: dossier.id }) }
 
       context 'when the dossier is a brouillon' do
-        let(:dossier) { create(:dossier, user: user) }
+        let(:dossier) { dossiers.brouillon }
         it { is_expected.to redirect_to(brouillon_dossier_path(dossier)) }
       end
 
       context 'when the dossier has been submitted' do
-        let(:dossier) { create(:dossier, :en_construction, user: user) }
+        let(:dossier) { dossiers.en_construction }
         it do
           expect(assigns(:dossier)).to eq(dossier)
           is_expected.to render_template(:show)
@@ -2037,7 +2039,7 @@ describe Users::DossiersController, type: :controller do
       subject! { get(:show, params: { id: dossier.id, format: :pdf }) }
 
       context 'when the dossier is a brouillon' do
-        let(:dossier) { create(:dossier, user: user) }
+        let(:dossier) { dossiers.brouillon }
         it { is_expected.to redirect_to(brouillon_dossier_path(dossier)) }
       end
 
@@ -2051,7 +2053,7 @@ describe Users::DossiersController, type: :controller do
   end
 
   describe '#formulaire' do
-    let(:dossier) { create(:dossier, :en_construction, user: user) }
+    let(:dossier) { dossiers.en_construction }
 
     before do
       sign_in(user)
@@ -2068,7 +2070,8 @@ describe Users::DossiersController, type: :controller do
   describe "#create_commentaire" do
     let(:instructeur_with_instant_message) { create(:instructeur) }
     let(:instructeur_without_instant_message) { create(:instructeur) }
-    let(:procedure) { create(:procedure, :published) }
+    let(:procedure) { procedures.individual }
+    # fresh dossier (not the seeded one): saved_commentaire below picks the first commentaire
     let(:dossier) { create(:dossier, :en_construction, procedure: procedure, user: user) }
     let(:saved_commentaire) { dossier.commentaires.first }
     let(:body) { "avant\napres" }
@@ -2241,7 +2244,7 @@ describe Users::DossiersController, type: :controller do
     end
 
     context 'when the dossier has been submitted' do
-      let(:dossier) { create(:dossier, :en_construction, :with_individual, user: user) }
+      let(:dossier) { dossiers.en_construction }
 
       before do
         allow(WeasyprintService).to receive(:generate_pdf).and_return("%PDF-1.4 fake")
@@ -2266,7 +2269,7 @@ describe Users::DossiersController, type: :controller do
     end
 
     context 'when the dossier is still a draft' do
-      let(:dossier) { create(:dossier, :brouillon, user: user) }
+      let(:dossier) { dossiers.brouillon }
 
       it 'raises an error' do
         expect { subject }.to raise_error(ActionController::BadRequest)
@@ -2325,7 +2328,7 @@ describe Users::DossiersController, type: :controller do
       it { is_expected.to redirect_to(dossiers_path) }
 
       context "and the instruction has started" do
-        let(:dossier) { create(:dossier, :en_instruction, user: user, autorisation_donnees: true) }
+        let(:dossier) { dossiers.en_instruction }
 
         it_behaves_like "the dossier can not be deleted"
         it { is_expected.to redirect_to(dossiers_path) }
@@ -2334,7 +2337,7 @@ describe Users::DossiersController, type: :controller do
 
     context 'when dossier is not owned by signed in user' do
       let(:user2) { create(:user) }
-      let(:dossier) { create(:dossier, user: user2, autorisation_donnees: true) }
+      let(:dossier) { create(:dossier, user: user2, autorisation_donnees: true, procedure: procedures.individual) }
 
       it_behaves_like "the dossier can not be deleted"
       it { is_expected.to redirect_to(root_path) }
@@ -2358,7 +2361,7 @@ describe Users::DossiersController, type: :controller do
   end
 
   describe '#set_accuse_lecture_agreement_at' do
-    let(:dossier) { create(:dossier, :en_instruction, :with_individual, user: user) }
+    let(:dossier) { dossiers.en_instruction }
 
     before { sign_in(user) }
 
@@ -2387,7 +2390,7 @@ describe Users::DossiersController, type: :controller do
     subject { patch :restore, params: { id: dossier.id } }
 
     context 'when the user want to restore his dossier' do
-      let!(:dossier) { create(:dossier, :accepte, :with_individual, en_construction_at: Time.zone.yesterday.beginning_of_day.utc, hidden_by_user_at: Time.zone.yesterday.beginning_of_day.utc, user: user, autorisation_donnees: true) }
+      let!(:dossier) { create(:dossier, :accepte, :with_individual, en_construction_at: Time.zone.yesterday.beginning_of_day.utc, hidden_by_user_at: Time.zone.yesterday.beginning_of_day.utc, user: user, autorisation_donnees: true, procedure: procedures.individual) }
 
       before { subject }
 
@@ -2398,7 +2401,7 @@ describe Users::DossiersController, type: :controller do
   end
 
   describe '#new' do
-    let(:procedure) { create(:procedure, :published) }
+    let(:procedure) { procedures.entreprise }
     let(:procedure_id) { procedure.id }
     let(:params) { { procedure_id: procedure_id } }
 
@@ -2424,7 +2427,7 @@ describe Users::DossiersController, type: :controller do
           end
 
           context 'when procedure is for particulier' do
-            let(:procedure) { create(:procedure, :published, :for_individual) }
+            let(:procedure) { procedures.individual }
             it { is_expected.to redirect_to identite_dossier_path(id: Dossier.last) }
           end
 
@@ -2488,7 +2491,7 @@ describe Users::DossiersController, type: :controller do
     subject { controller.dossier_for_help }
 
     context 'when the id matches a dossier owned by the current user' do
-      let(:dossier) { create(:dossier, user:) }
+      let(:dossier) { dossiers.brouillon }
       let(:dossier_id) { dossier.id }
 
       it { is_expected.to eq dossier }
@@ -2522,7 +2525,7 @@ describe Users::DossiersController, type: :controller do
   end
 
   describe '#extend_conservation' do
-    let(:procedure) { create(:procedure, duree_conservation_dossiers_dans_ds: 3) }
+    let(:procedure) { procedures.individual }
     let(:dossier) { create(:dossier, procedure:, user:) }
     subject { post :extend_conservation, params: { dossier_id: dossier.id } }
     context 'when user logged in' do

--- a/spec/models/concerns/procedure_clone_concern_spec.rb
+++ b/spec/models/concerns/procedure_clone_concern_spec.rb
@@ -2,9 +2,10 @@
 
 describe ProcedureCloneConcern, type: :model do
   describe 'clone' do
-    let(:service) { create(:service) }
+    let(:service) { services.default }
     let(:procedure) do
       create(:procedure,
+        administrateurs: [administrateurs.default],
         received_mail: received_mail,
         service: service,
         opendata: opendata,
@@ -30,7 +31,13 @@ describe ProcedureCloneConcern, type: :model do
     let(:logo) { Rack::Test::UploadedFile.new('spec/fixtures/files/white.png', 'image/png') }
     let(:signature) { Rack::Test::UploadedFile.new('spec/fixtures/files/black.png', 'image/png') }
 
-    let(:groupe_instructeur_1) { create(:groupe_instructeur, procedure: procedure, label: "groupe_1", contact_information: create(:contact_information)) }
+    let(:groupe_instructeur_1) do
+      # the contact_information factory association would build its own groupe
+      # (and procedure): create it against this groupe instead
+      create(:groupe_instructeur, procedure: procedure, label: "groupe_1").tap do |groupe|
+        create(:contact_information, groupe_instructeur: groupe)
+      end
+    end
     let(:instructeur_1) { create(:instructeur) }
     let(:instructeur_2) { create(:instructeur) }
     let!(:assign_to_1) { create(:assign_to, procedure: procedure, groupe_instructeur: groupe_instructeur_1, instructeur: instructeur_1) }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -22,7 +22,7 @@ describe Dossier, type: :model do
     describe '.default_scope' do
       empty_seeds Dossier
 
-      let!(:dossier) { create(:dossier) }
+      let!(:dossier) { create(:dossier, procedure: procedures.individual) }
 
       subject { Dossier.all }
 
@@ -41,8 +41,8 @@ describe Dossier, type: :model do
     describe 'brouillons_recently_updated' do
       empty_seeds Dossier
 
-      let!(:dossier_en_brouillon) { create(:dossier) }
-      let!(:dossier_en_brouillon_2) { create(:dossier) }
+      let!(:dossier_en_brouillon) { create(:dossier, procedure: procedures.individual) }
+      let!(:dossier_en_brouillon_2) { create(:dossier, procedure: procedures.individual) }
 
       it { expect(Dossier.brouillons_recently_updated).to eq([dossier_en_brouillon_2, dossier_en_brouillon]) }
     end

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -4,7 +4,7 @@ describe PiecesJustificativesService do
   describe 'pjs_for_champs' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative, mandatory: false }, { type: :repetition, mandatory: false, children: [{ type: :piece_justificative, mandatory: false }] }]) }
     let(:dossier) { create(:dossier, procedure: procedure) }
-    let(:dossiers) { Dossier.where(id: dossier.id) }
+    let(:dossiers_scope) { Dossier.where(id: dossier.id) }
     let(:witness) { create(:dossier, procedure: procedure) }
     let(:export_template) { double('ExportTemplate') }
     let(:pj_service) { PiecesJustificativesService.new(user_profile:, export_template:) }
@@ -16,7 +16,7 @@ describe PiecesJustificativesService do
 
     before { attach_file_to_champ(pj_champ(witness)) }
 
-    subject { pj_service.send(:pjs_for_champs, dossiers) }
+    subject { pj_service.send(:pjs_for_champs, dossiers_scope) }
 
     context 'without any attachment' do
       it { expect(subject).to be_empty }
@@ -89,7 +89,7 @@ describe PiecesJustificativesService do
         expect(export_template).to receive(:attachment_path)
           .with(dossier, second_child_attachments.first, index: 0, row_index: 1, champ: second_champ)
 
-        DossierPreloader.new(dossiers).all
+        DossierPreloader.new(dossiers_scope).all
         count = 0
 
         callback = lambda { |*_args| count += 1 }
@@ -104,11 +104,11 @@ describe PiecesJustificativesService do
 
   describe '.liste_documents' do
     let(:dossier) { create(:dossier, procedure: procedure) }
-    let(:dossiers) { Dossier.where(id: dossier.id) }
+    let(:dossiers_scope) { Dossier.where(id: dossier.id) }
     let(:default_export_template) { build(:export_template, groupe_instructeur: procedure.defaut_groupe_instructeur) }
     let(:export_template) { nil }
     subject do
-      PiecesJustificativesService.new(user_profile:, export_template:).liste_documents(dossiers).map(&:first)
+      PiecesJustificativesService.new(user_profile:, export_template:).liste_documents(dossiers_scope).map(&:first)
     end
 
     context 'no acl' do
@@ -231,7 +231,7 @@ describe PiecesJustificativesService do
 
         it { expect(subject).to match_array(dossier.attestation.pdf.attachment) }
         it 'uses default name for dossier directory' do
-          expect(PiecesJustificativesService.new(user_profile:, export_template: nil).liste_documents(dossiers).map(&:second)[0].starts_with?("dossier-#{dossier.id}/pieces_justificatives")).to be true
+          expect(PiecesJustificativesService.new(user_profile:, export_template: nil).liste_documents(dossiers_scope).map(&:second)[0].starts_with?("dossier-#{dossier.id}/pieces_justificatives")).to be true
         end
 
         context 'with export_template' do
@@ -242,8 +242,7 @@ describe PiecesJustificativesService do
       end
 
       context 'with an etablissement' do
-        # the local `let(:dossiers)` shadows the seed accessor, so go through Oaken::Seeds
-        let(:dossier) { Oaken::Seeds.dossiers.avec_siret }
+        let(:dossier) { dossiers.avec_siret }
         let(:attestation_sociale) { dossier.etablissement.entreprise_attestation_sociale }
         let(:attestation_fiscale) { dossier.etablissement.entreprise_attestation_fiscale }
 
@@ -259,7 +258,7 @@ describe PiecesJustificativesService do
         it { expect(subject).to match_array([attestation_sociale.attachment, attestation_fiscale.attachment]) }
 
         it 'uses default name for dossier directory' do
-          expect(PiecesJustificativesService.new(user_profile:, export_template: nil).liste_documents(dossiers).map(&:second)[0].starts_with?("dossier-#{dossier.id}/pieces_justificatives")).to be true
+          expect(PiecesJustificativesService.new(user_profile:, export_template: nil).liste_documents(dossiers_scope).map(&:second)[0].starts_with?("dossier-#{dossier.id}/pieces_justificatives")).to be true
         end
 
         context 'with export_template' do
@@ -470,9 +469,9 @@ describe PiecesJustificativesService do
     let(:user_profile) { build(:administrateur) }
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :repetition, children: [{ type: :piece_justificative }] }]) }
     let(:dossier) { create(:dossier, :with_populated_champs, procedure: procedure) }
-    let(:dossiers) { Dossier.where(id: dossier.id) }
+    let(:dossiers_scope) { Dossier.where(id: dossier.id) }
     let(:export_template) { nil }
-    subject { PiecesJustificativesService.new(user_profile:, export_template:).generate_dossiers_export(dossiers) }
+    subject { PiecesJustificativesService.new(user_profile:, export_template:).generate_dossiers_export(dossiers_scope) }
 
     it "doesn't update dossier" do
       expect { subject }.not_to change { dossier.updated_at }
@@ -484,7 +483,7 @@ describe PiecesJustificativesService do
       let!(:not_confidentiel_avis) { create(:avis, :not_confidentiel, dossier: dossier) }
       let!(:expert_avis) { create(:avis, :confidentiel, dossier: dossier, expert: user_profile) }
 
-      subject { PiecesJustificativesService.new(user_profile:, export_template:).generate_dossiers_export(dossiers) }
+      subject { PiecesJustificativesService.new(user_profile:, export_template:).generate_dossiers_export(dossiers_scope) }
       it "includes avis not confidentiel as well as expert's avis" do
         expect_any_instance_of(Dossier).to receive(:avis_for_expert).with(user_profile).and_return([])
         subject
@@ -498,7 +497,7 @@ describe PiecesJustificativesService do
     context 'with export template' do
       let(:groupe_instructeur) { procedure.defaut_groupe_instructeur }
       let(:export_template) { create(:export_template, groupe_instructeur:, dossier_folder: ExportItem.default(prefix: 'DOSSIER')) }
-      subject { PiecesJustificativesService.new(user_profile:, export_template:).generate_dossiers_export(dossiers) }
+      subject { PiecesJustificativesService.new(user_profile:, export_template:).generate_dossiers_export(dossiers_scope) }
 
       it 'gives custom name to export pdf file' do
         expect(subject.first.second).to eq "DOSSIER-#{dossier.id}/export-#{dossier.id}.pdf"

--- a/spec/services/users/dossier_filter_service_spec.rb
+++ b/spec/services/users/dossier_filter_service_spec.rb
@@ -3,15 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe Users::DossierFilterService do
-  let(:user) { create(:user) }
-  let!(:own_dossier) { create(:dossier, :en_construction, user: user) }
-  let!(:invited_dossier) do
-    d = create(:dossier, :en_construction)
+  let_it_be(:user) { create(:user) }
+  let_it_be(:own_dossier) { create(:dossier, :en_construction, user: user, procedure: procedures.individual) }
+  let_it_be(:invited_dossier) do
+    d = create(:dossier, :en_construction, procedure: procedures.individual)
     create(:invite, dossier: d, user: user)
     d
   end
-  let!(:other_dossier) { create(:dossier, :en_construction) }
-  let!(:hidden_dossier) { create(:dossier, :en_construction, user: user, hidden_by_user_at: Time.current) }
+  let_it_be(:other_dossier) { create(:dossier, :en_construction, procedure: procedures.individual) }
+  let_it_be(:hidden_dossier) { create(:dossier, :en_construction, user: user, hidden_by_user_at: Time.current, procedure: procedures.individual) }
 
   subject(:service) { described_class.new(user: user, params: ActionController::Parameters.new) }
 
@@ -44,8 +44,8 @@ RSpec.describe Users::DossierFilterService do
   end
 
   describe '#dossiers with procedure_id filter' do
-    let(:procedure_a) { create(:procedure) }
-    let(:procedure_b) { create(:procedure) }
+    let(:procedure_a) { procedures.individual }
+    let(:procedure_b) { procedures.entreprise }
     let!(:dossier_a) { create(:dossier, :en_construction, user: user, procedure: procedure_a) }
     let!(:dossier_b) { create(:dossier, :en_construction, user: user, procedure: procedure_b) }
 
@@ -67,10 +67,10 @@ RSpec.describe Users::DossierFilterService do
   end
 
   describe '#dossiers with state filter' do
-    let!(:brouillon) { create(:dossier, user: user) }
-    let!(:en_construction) { create(:dossier, :en_construction, user: user) }
-    let!(:en_instruction) { create(:dossier, :en_instruction, user: user) }
-    let!(:accepte) { create(:dossier, :accepte, user: user) }
+    let!(:brouillon) { create(:dossier, user: user, procedure: procedures.individual) }
+    let!(:en_construction) { create(:dossier, :en_construction, user: user, procedure: procedures.individual) }
+    let!(:en_instruction) { create(:dossier, :en_instruction, user: user, procedure: procedures.individual) }
+    let!(:accepte) { create(:dossier, :accepte, user: user, procedure: procedures.individual) }
 
     it 'filters by a single UI state' do
       service = described_class.new(user: user, params: ActionController::Parameters.new(state: ['en_construction']))
@@ -86,8 +86,8 @@ RSpec.describe Users::DossierFilterService do
   end
 
   describe '#dossiers with date filters' do
-    let!(:old_dossier) { create(:dossier, :en_construction, user: user, created_at: 30.days.ago, depose_at: 25.days.ago) }
-    let!(:recent_dossier) { create(:dossier, :en_construction, user: user, created_at: 1.day.ago, depose_at: 1.hour.ago) }
+    let!(:old_dossier) { create(:dossier, :en_construction, user: user, created_at: 30.days.ago, depose_at: 25.days.ago, procedure: procedures.individual) }
+    let!(:recent_dossier) { create(:dossier, :en_construction, user: user, created_at: 1.day.ago, depose_at: 1.hour.ago, procedure: procedures.individual) }
 
     it 'filters by from_created_at_date' do
       date = 7.days.ago.to_date.iso8601
@@ -141,9 +141,9 @@ RSpec.describe Users::DossierFilterService do
   end
 
   describe '#counts' do
-    let!(:dossier_depose_corriger) { create(:dossier, :en_construction, user: user) }
-    let!(:dossier_depose_nothing) { create(:dossier, :en_construction, user: user) }
-    let!(:dossier_accepte) { create(:dossier, :accepte, user: user) }
+    let!(:dossier_depose_corriger) { create(:dossier, :en_construction, user: user, procedure: procedures.individual) }
+    let!(:dossier_depose_nothing) { create(:dossier, :en_construction, user: user, procedure: procedures.individual) }
+    let!(:dossier_accepte) { create(:dossier, :accepte, user: user, procedure: procedures.individual) }
 
     before do
       create(:dossier_correction, dossier: dossier_depose_corriger)
@@ -222,7 +222,7 @@ RSpec.describe Users::DossierFilterService do
     it 'runs a constant number of queries regardless of dossier volume (no N+1)' do
       queries_for = lambda do |volume|
         owner = create(:user)
-        create_list(:dossier, volume, :en_construction, user: owner)
+        create_list(:dossier, volume, :en_construction, user: owner, procedure: procedures.individual)
         service = described_class.new(user: owner, params: ActionController::Parameters.new)
         count = 0
         counter = lambda do |_name, _started, _finished, _id, payload|


### PR DESCRIPTION
## Contexte

Point 1 de #13558 : migrer les fichiers de spec les plus coûteux (classement FactoryProf) des factories vers les seeds Oaken. Un commit par fichier.

## Résultats (temps locaux, Mac M-series, en série)

| Fichier | Avant | Après |
|---|---|---|
| `instructeurs/dossiers_controller_spec` | 63 s | 48 s |
| `users/dossiers_controller_spec` | 66 s | 58 s |
| `administrateurs/groupe_instructeurs_controller_spec` | 44 s | 39 s |
| `users/dossier_filter_service_spec` | 39 s | 10 s |
| `procedure_clone_concern_spec` | 31 s | 26 s |
| `dossier_spec` | déjà migré | (3 `create(:dossier)` restants épinglés) |

Soit environ **1 min 40 s** de gagnées sur ces six fichiers (~35 %). Les 838 exemples passent ensemble, vérifiés sur deux seeds aléatoires par fichier.

## Points notables

- Nouveau seed `db/seeds/cases/routage.rb` : démarche publiée routée vers deux groupes (« défaut » + « deuxième groupe »), `routing_enabled` positionné via `toggle_routing`, sans instructeur affecté — même forme que le trait `:routee` de la factory. Réutilisable via `before_all { seed "cases/routage" }`.
- Deux pièges documentés dans les commits : la factory `procedure` embarque un `api_entreprise_token` factice que les seeds n'ont pas (un token absent fait échouer silencieusement tous les appels API Entreprise), et la factory `groupe_instructeur` appelle `toggle_routing` en effet de bord. La factory `contact_information` créait aussi un groupe (et sa démarche) superflus par exemple.
- Les gros describes `#submit_*`/`#update_*` et les validations de champs gardent leurs factories : leurs `types_de_champ` varient par contexte (candidats FactoryDefault, point 3 de l'issue).

Ref #13558

🤖 Generated with [Claude Code](https://claude.com/claude-code)