### PR TITLE
Tech: migrer PasswordConfirmation de HAML vers ERB

### DIFF
--- a/app/views/france_connect/_password_confirmation.html.erb
+++ b/app/views/france_connect/_password_confirmation.html.erb
@@ -1,0 +1,10 @@
+<%= form_tag(france_connect_merge_using_password_path, data: { turbo: true }, class: 'fr-mt-4v form fconnect-form', id: 'merge_using_password') do -%>
+  <%= hidden_field_tag(:merge_token, fci.merge_token, id: dom_id(fci, :fusion_merge_token)) %>
+
+  <div class="fr-input-group <%= class_names('fr-input-group--error': wrong_password) %>">
+    <%= label_tag(:password, t('views.registrations.new.password_label', min_length: 8), class: 'fr-label') %>
+    <%= password_field_tag(:password, nil, autocomplete: 'current-password', class: 'fr-mb-2v fr-input') %>
+  </div>
+
+  <%= submit_tag(t('france_connect.merge.button_merge'), class: 'fr-btn') %>
+<% end -%>

--- a/app/views/france_connect/_password_confirmation.html.haml
+++ b/app/views/france_connect/_password_confirmation.html.haml
@@ -1,7 +1,0 @@
-= form_tag france_connect_merge_using_password_path, data: { turbo: true }, class: 'fr-mt-4v form fconnect-form', id: 'merge_using_password' do
-  = hidden_field_tag :merge_token, fci.merge_token, id: dom_id(fci, :fusion_merge_token)
-  .fr-input-group{ class: class_names('fr-input-group--error': wrong_password) }
-    = label_tag :password, t('views.registrations.new.password_label', min_length: 8), class: 'fr-label'
-    = password_field_tag :password, nil, autocomplete: 'current-password', class: 'fr-mb-2v fr-input'
-
-  = submit_tag t('france_connect.merge.button_merge'), class: 'fr-btn'


### PR DESCRIPTION
# Probleme

On migre HAML → ERB. C'est lent, pénible, et c'est une charge mentale.

# Solution

Skill [`/haml-migration`](https://github.com/mfo/night-shift/blob/main/.claude/skills/haml-migration/SKILL.md)

### FranceConnect PasswordConfirmation — ⏭️ screenshots non disponibles

**Validation :** formatter herb ✅, tests ✅ (1 échec préexistant non lié), apostrophes ✅

**Rendu :** partial utilisé dans `app/views/france_connect/merge.html.haml` (via `render :merge` dans le callback OAuth) et `merge_using_password.turbo_stream.haml`. Pas de page accessible directement sans passer par le flow OAuth FranceConnect complet — le serveur de dev n'était pas disponible pour les screenshots.

**Couverture visuelle :** 0/2 utilisations — screenshots non disponibles (serveur éteint)

- ⏭️ `france_connect/callback` — merge page (OAuth flow)
- ⏭️ `france_connect/merge_using_password` — turbo stream

[Voir le gist](https://gist.github.com/mfo/369b6764a3a4202cbb2a7e2f5fb4ccb4)

Generated with [Claude Code](https://claude.com/claude-code)