### PR TITLE
Tech : paralléliser la suite de specs en local (bin/parallel-rspec)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ demarche.numerique.gouv.fr (formerly demarches-simplifiees.fr) is a French gover
 
 ### Testing
 - `bundle exec rspec` - Run all tests
+- `bin/parallel-rspec` - Run the suite across 8 processes (~4× faster; run `bin/parallel-rspec --setup` once to create the per-process databases)
 - `bundle exec rspec file_path/file_name_spec.rb:line_number` - Run specific test
 - `bundle exec rspec --only-failures` - Re-run only failed tests
 - `NO_HEADLESS=1 bundle exec rspec spec/system` - Run system tests with visible browser

--- a/Gemfile
+++ b/Gemfile
@@ -131,6 +131,7 @@ group :test do
   gem 'capybara-screenshot' # Save a dump of the page when an integration test fails
   gem 'factory_bot'
   gem 'launchy'
+  gem 'parallel_tests'
   gem 'rack_session_access'
   gem 'rails-controller-testing'
   gem 'rspec_junit_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -567,6 +567,8 @@ GEM
       webfinger (~> 2.0)
     orm_adapter (0.5.0)
     parallel (2.1.0)
+    parallel_tests (5.7.0)
+      parallel
     parsby (1.1.3)
     parser (3.3.12.0)
       ast (~> 2.4.1)
@@ -1069,6 +1071,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   omniauth-rdv-service-public!
   openid_connect
+  parallel_tests
   parsby
   pg
   phonelib

--- a/bin/parallel-rspec
+++ b/bin/parallel-rspec
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Run the spec suite across several processes.
+#
+#   bin/parallel-rspec --setup            # create the per-process databases (first run only)
+#   bin/parallel-rspec                    # run the whole suite
+#   bin/parallel-rspec spec/models        # run a subset
+#
+# Each process gets its own PostgreSQL database (tps_test, tps_test2, …) and
+# its own Redis logical database, both derived from TEST_ENV_NUMBER. Oaken
+# seeds are replanted per process by rails_helper's before(:suite); pending
+# migrations are applied per database by maintain_test_schema!.
+#
+# Processes default to 8; override with PARALLEL_TEST_PROCESSORS.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+export RAILS_ENV=test
+processes="${PARALLEL_TEST_PROCESSORS:-8}"
+
+if [ "${1:-}" = "--setup" ]; then
+  shift
+  bin/rake "parallel:create[$processes]" "parallel:load_schema[$processes]"
+  [ $# -eq 0 ] && exit 0
+fi
+
+# Build assets once up front; otherwise every process would race to autobuild.
+bin/vite build
+
+# Processes are balanced with the runtimes recorded in
+# tmp/parallel_runtime_rspec.log by previous runs (parallel_tests' default
+# grouping falls back to file sizes while the log lacks data — don't pass
+# --group-by runtime, which aborts in that case).
+# llm_eval specs need a live LLM endpoint and are also excluded in CI.
+exec bin/bundle exec parallel_rspec -n "$processes" \
+  -o "--tag ~llm_eval" "${@:-spec}"

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,7 +20,7 @@ development:
 
 test:
   <<: *default
-  database: <%= ENV.fetch("DB_DATABASE_TEST", "tps_test") %>
+  database: <%= ENV.fetch("DB_DATABASE_TEST", "tps_test") %><%= ENV["TEST_ENV_NUMBER"] %>
   host: <%= ENV.fetch("DB_HOST_TEST", "localhost") %>
   username: <%= ENV.fetch("DB_USERNAME_TEST", "tps_test") %>
   password: <%= ENV.fetch("DB_PASSWORD_TEST", "tps_test") %>

--- a/config/initializers/kredis.rb
+++ b/config/initializers/kredis.rb
@@ -7,4 +7,11 @@ redis_shared_options = {
 }
 redis_shared_options[:ssl_params] = { verify_mode: OpenSSL::SSL::VERIFY_NONE } if ENV['REDIS_CACHE_SSL_VERIFY_NONE'] == 'enabled'
 
+# Parallel test processes share one Redis server but must not share keys:
+# Kredis keys embed record ids, which overlap across per-process databases.
+# Give each process its own Redis logical database (db 0 stays for dev/serial runs).
+if Rails.env.test? && ENV['TEST_ENV_NUMBER'].present?
+  redis_shared_options[:db] = ENV['TEST_ENV_NUMBER'].to_i
+end
+
 Kredis::Connections.connections[:shared] = Redis.new(redis_shared_options)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ RSpec.configure do |config|
   config.color = true
   config.tty = true
 
-  config.example_status_persistence_file_path = 'failing_specs.txt'
+  config.example_status_persistence_file_path = "failing_specs#{ENV['TEST_ENV_NUMBER']}.txt"
   config.run_all_when_everything_filtered = true
   config.filter_run :focus => true
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,18 @@ require 'simplecov' if ENV["CI"] || ENV["COVERAGE"] # see config in .simplecov f
 
 require 'rspec/retry'
 
+# Under parallel_tests (bin/parallel-rspec), log per-file runtimes so later
+# runs can balance processes with --group-by runtime. TEST_ENV_NUMBER is ""
+# for the first process, nil outside parallel_tests.
+unless ENV['TEST_ENV_NUMBER'].nil?
+  require 'parallel_tests/rspec/runtime_logger'
+
+  RSpec.configure do |config|
+    config.add_formatter :progress
+    config.add_formatter ParallelTests::RSpec::RuntimeLogger, 'tmp/parallel_runtime_rspec.log'
+  end
+end
+
 SECURE_PASSWORD = '{My-$3cure-p4ssWord}'
 
 RSpec.configure do |config|

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -6,6 +6,11 @@ require 'capybara/email/rspec'
 
 Capybara.default_max_wait_time = 6
 
+# Parallel test processes must not share the downloads/screenshots directory:
+# DownloadHelpers reads "the first zip in save_path", which could come from
+# another process. Serial runs keep the default tmp/capybara.
+Capybara.save_path = Rails.root.join("tmp/capybara#{ENV['TEST_ENV_NUMBER']}")
+
 Capybara.ignore_hidden_elements = false
 
 Capybara.enable_aria_label = true

--- a/spec/system/administrateurs/procedure_cloning_spec.rb
+++ b/spec/system/administrateurs/procedure_cloning_spec.rb
@@ -19,7 +19,7 @@ describe 'As an administrateur I wanna clone a procedure', js: true do
     login_as administrateur.user, scope: :user
   end
   context 'Visit all admin procedures and clone from this page' do
-    let(:download_dir) { Rails.root.join('tmp/capybara') }
+    let(:download_dir) { Pathname.new(Capybara.save_path) }
     let(:download_file_pattern) { download_dir.join('*.xlsx') }
 
     scenario do


### PR DESCRIPTION
## Contexte

Point 4 de #13558 : la suite complète tourne en série en 27 min 28 s en local, alors que la CI prouve déjà qu'elle se découpe proprement par fichier.

## Ce que fait cette PR

- `parallel_tests` : une base PostgreSQL par process (suffixe `TEST_ENV_NUMBER`) et une base logique Redis par process (les clés Kredis embarquent des ids d'enregistrements, qui se recoupent entre bases) ; le replant Oaken se fait déjà par process via `before(:suite)`.
- `bin/parallel-rspec` : pré-build Vite (évite 8 autobuilds concurrents), exclusion des specs `llm_eval` (besoin d'un endpoint LLM réel, déjà exclues en CI), `--setup` pour créer les bases la première fois.
- Équilibrage : les temps par fichier sont enregistrés dans `tmp/parallel_runtime_rspec.log` et réutilisés par les runs suivants.
- `Capybara.save_path` par process (les helpers de téléchargement lisent « le premier zip du répertoire », qui pouvait venir d'un autre process) + correction du chemin codé en dur dans `procedure_cloning_spec`.

## Résultat

**Suite complète : 27 min 28 s → 5 min 18 s sur 8 process** (9439 exemples, aucun échec lié à la parallélisation). Les runs en série et la CI sont inchangés (`TEST_ENV_NUMBER` absent → base `tps_test` et Redis db 0 comme avant).

Ref #13558

🤖 Generated with [Claude Code](https://claude.com/claude-code)