### PR TITLE
Tech: stabiliser les tests flaky de spec/lib/core_ext/typhoeus_spec.rb

### DIFF
--- a/spec/lib/core_ext/typhoeus_spec.rb
+++ b/spec/lib/core_ext/typhoeus_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe Typhoeus::EasyFactory do
     end
 
     it 'sets no proxy headers outside of a request or job context' do
-      expect(easy.proxy_headers).to be_nil
+      Current.set(request_id: nil, job_id: nil) do
+        expect(easy.proxy_headers).to be_nil
+      end
     end
 
     it 'does not alter the request options, keeping the cache key stable' do


### PR DESCRIPTION
# Probleme

Le fichier `spec/lib/core_ext/typhoeus_spec.rb` echoue de maniere intermittente en CI.

### Evidence CI

| Signal | Count | Signification |
|--------|-------|---------------|
| Merge queue | 2 echecs | Pas de changement de code → preuve forte de flakiness |
| Retries | 0 passes au retry | Le test est instable |

Branches concernees : `bettera11ycomboselect`, `auto/haml-migration/batch-beb37214`, `gh-readonly-queue/main/pr-13406-3786acb2d39673a2258e06f1dc996cffa3d3354c`, `gh-readonly-queue/main/pr-13421-10e3d274396be6c8ce80c2592c7a74396ec4b190`

Jobs : [Unit tests (0)](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/29081907643/job/86326470994), [Unit tests (1)](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/29078096196/job/86314240355), [Unit tests (2)](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/actions/runs/28947782676/job/85886075221)

Tests concernes :
- `sets no proxy headers outside of a request or job context`

# Solution

Skill [`/flaky-test-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/flaky-test-fix/SKILL.md)

### Causes identifiees et fixes

| Cause | Scope | Fix | Pourquoi ca resout |
|-------|-------|-----|--------------------|
| `before(:each)` d'un parent group set `Current.request_id` apres notre `before { reset_all }` | test | Wrapper le test dans `Current.set(request_id: nil, job_id: nil)` | Garantit que `Current` est nil pendant l'evaluation de `easy` (le subject), independamment de l'ordre d'execution des `before` hooks entre fichiers |

### Preuve de stabilite

| Test | Runs | Resultat | Type |
|------|------|----------|------|
| `sets no proxy headers outside of a request or job context` | 50/50 | ✅ STABLE | unit |
| Tous les tests du fichier | 50/50 | ✅ STABLE | unit |

Script : [`verify-flaky.sh`](https://github.com/mfo/night-shift/blob/main/.claude/skills/flaky-test-fix/verify-flaky.sh) (50 runs unit, random seed a chaque run)

Generated with [Claude Code](https://claude.com/claude-code)