### PR TITLE
Tech: paralléliser les linters sur la CI

### DIFF
--- a/.github/actions/ci-setup-rails/action.yml
+++ b/.github/actions/ci-setup-rails/action.yml
@@ -1,6 +1,12 @@
 name: 'Setup Rails app'
 description: 'Setup the environment for running the Rails app'
 
+inputs:
+  database:
+    description: 'Setup the test database. Disable it for jobs that only read the source code (linters, static analysis).'
+    required: false
+    default: 'true'
+
 runs:
   using: composite
   steps:
@@ -14,12 +20,14 @@ runs:
       shell: bash
 
     - name: Restore cached test database schema
+      if: inputs.database == 'true'
       uses: actions/cache@v4
       with:
         path: tmp/schema_cache.sql
         key: db-schema-v1-${{ hashFiles('db/schema.rb', 'db/migrate/**') }}
 
     - name: Setup test database
+      if: inputs.database == 'true'
       env:
         RAILS_ENV: test
         DATABASE_URL: 'postgres://tps_test:tps_test@localhost:5432/tps_test'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ env:
   DISABLE_SPRING: '1'
 
 jobs:
+  # The linters are split in three jobs so they run in parallel: Brakeman alone
+  # is slower than every other linter combined, and the JS side needs neither
+  # Ruby nor a database.
   linters:
     name: Linters
     runs-on: ubuntu-22.04
@@ -27,13 +30,38 @@ jobs:
       - name: Setup the app code and dependancies
         uses: ./.github/actions/ci-setup-rails
 
+      - name: Run linters
+        run: |
+          bundle exec rake lint:ruby
+          RAILS_ENV=test bundle exec rake zeitwerk:check
+
+  js_linters:
+    name: JavaScript linters
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Setup bun and node modules
         uses: ./.github/actions/ci-setup-bun-node
 
       - name: Run linters
-        run: |
-          bundle exec rake lint
-          RAILS_ENV=test bundle exec rake zeitwerk:check
+        run: bun lint
+
+  brakeman:
+    name: Brakeman
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup the app code and dependancies
+        uses: ./.github/actions/ci-setup-rails
+        with:
+          database: 'false'
+
+      - name: Run Brakeman
+        run: bundle exec rake lint:security
 
   js_tests:
     name: JavaScript tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ demarche.numerique.gouv.fr (formerly demarches-simplifiees.fr) is a French gover
 
 ### Linting & Code Quality
 - `bin/rake lint` - Run all linters (Rubocop, haml-lint, herb linter/formatter, i18n-tasks, Brakeman, ESLint, TypeScript, CSS)
+- `bin/rake lint:ruby` / `lint:js` / `lint:security` - Run one group only (CI runs the three in parallel jobs; `lint:security` is Brakeman, by far the slowest)
 - `bundle exec rubocop --parallel` - Ruby linting
 - `bun lint:js` - JavaScript linting
 - `bun lint:types` - TypeScript type checking

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,18 +1,30 @@
 # frozen_string_literal: true
 
-task :lint do
-  sh "bundle exec rubocop --parallel"
-  sh "bundle exec haml-lint app/views/ app/components/"
-  sh "bun lint:herb"
-  sh "bun check-format:herb"
-  sh "bundle exec i18n-tasks missing --locales fr"
-  sh "bundle exec i18n-tasks unused --locale en" # TODO: check for all locales
-  sh "bundle exec i18n-tasks check-consistent-interpolations"
-  sh "bundle exec brakeman --no-pager"
-  sh "bun lint:js"
-  sh "bun lint:types"
-  sh "bun lint:css"
-  sh "bundle exec rake lint:adresse_electronique"
-  sh "bundle exec rake lint:apostrophe"
-  sh "bundle exec rake lint:yaml_newline"
+namespace :lint do
+  desc 'Run the Ruby linters (rubocop, haml-lint, i18n-tasks and the custom text checks)'
+  task :ruby do
+    sh "bundle exec rubocop --parallel"
+    sh "bundle exec haml-lint app/views/ app/components/"
+    sh "bundle exec i18n-tasks missing --locales fr"
+    sh "bundle exec i18n-tasks unused --locale en" # TODO: check for all locales
+    sh "bundle exec i18n-tasks check-consistent-interpolations"
+
+    # Invoked in-process rather than shelled out: these are plain file scans,
+    # and each `bundle exec rake` boot costs ~4s.
+    ['lint:adresse_electronique', 'lint:apostrophe', 'lint:yaml_newline'].each { Rake::Task[it].invoke }
+  end
+
+  desc 'Run the JavaScript, TypeScript, CSS and ERB linters'
+  task :js do
+    # The `lint` script runs them all in parallel, see package.json
+    sh "bun lint"
+  end
+
+  desc 'Run the Brakeman security scanner'
+  task :security do
+    sh "bundle exec brakeman --no-pager"
+  end
 end
+
+desc 'Run all the linters (CI runs lint:ruby, lint:js and lint:security in parallel jobs)'
+task lint: ['lint:ruby', 'lint:js', 'lint:security']

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
   },
   "scripts": {
     "clean": "del tmp public/graphql && bin/vite clobber",
+    "lint": "bun run --parallel --no-exit-on-error lint:herb check-format:herb lint:js lint:types lint:css",
     "lint:js": "eslint ./app/javascript *.ts",
     "lint:types": "tsc",
     "lint:herb": "herb-lint 'app/**/*.html.erb'",


### PR DESCRIPTION
Le job `Linters` prend ~190s, contre ~250s pour les tests unitaires. Avec le travail de perf en cours sur les specs (#13558), il allait devenir le facteur limitant de la CI.

## Ce qui coûte cher

Mesuré en local (total ~123s) :

| étape | temps |
|---|---|
| **brakeman** | **67.2s** |
| rubocop | 14.3s |
| i18n-tasks (×3) | 17.6s |
| 3 tâches rake maison | 12.7s (~4s de boot Rake chacune) |
| zeitwerk:check | 7.2s |
| haml-lint | 3.2s |
| linters JS/CSS/ERB | 8.2s |

Brakeman représente à lui seul plus de la moitié du temps, et c'est du coût d'analyse pur : lancer un seul check (`-t CheckSQL`) prend 66.5s, et `--faster` ne change rien. Il n'y a rien à optimiser dedans, il faut le sortir du chemin critique.

## Changements

- La tâche `lint` est découpée en `lint:ruby`, `lint:js` et `lint:security` ; `rake lint` lance toujours les trois en local.
- La CI les exécute en trois jobs parallèles. Le job JS n'a besoin ni de Ruby ni de base de données, Brakeman n'a pas besoin de base (nouvelle entrée `database` sur l'action `ci-setup-rails`). Le job `Linters` garde Postgres, car `zeitwerk:check` accède à la base au chargement des classes.
- Les trois vérifications textuelles maison sont appelées dans le même process au lieu de trois `bundle exec rake` (12.7s → ~0s).
- Les linters JS sont regroupés dans un seul script `bun lint` qui les lance en parallèle : la liste n'existe plus qu'à un seul endroit (package.json), et le temps passe de 11.2s à 3.6s. `--no-exit-on-error` est volontaire : tous les linters vont au bout et on voit toutes les erreurs d'un coup (sinon Bun interrompt les autres et sort en 130).

## Résultat attendu

Chemin critique du lint : **~190s → ~100s** (Brakeman ~100s, Linters ~85s, JS ~25s).

## ⚠️ À faire après le merge

Les checks requis sur `main` ne contiennent que `Linters`. Le nom est conservé, donc rien ne casse, mais il faut ajouter `Brakeman` et `JavaScript linters` aux checks requis pour qu'un échec bloque à nouveau la fusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)