### PR TITLE
ETQ utilisateur d'un lecteur d'écran, corriger deux annonces manquantes

### DIFF
--- a/app/components/dossiers/pending_correction_checkbox_component/pending_correction_checkbox_component.html.erb
+++ b/app/components/dossiers/pending_correction_checkbox_component/pending_correction_checkbox_component.html.erb
@@ -10,7 +10,7 @@
     <div
       id="dossier_pending_correction_error_messages"
       class="fr-messages-group"
-      aria-live="assertlive"
+      aria-live="assertive"
     >
       <p class="fr-message fr-message--error"><%= error_message %></p>
     </div>

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -264,7 +264,7 @@ module DossierHelper
     case type
     when DossierNotification.notification_types.fetch(:dossier_modifie),
       DossierNotification.notification_types.fetch(:message),
-      DossierNotification.notification_types.fetch(:annotation_instructeur)
+      DossierNotification.notification_types.fetch(:annotation_instructeur),
       DossierNotification.notification_types.fetch(:avis_externe)
       if summary
         t("activerecord.attributes.notification.a11y.news.for_summary")

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -285,6 +285,24 @@ RSpec.describe DossierHelper, type: :helper do
     end
   end
 
+  describe ".badge_notification_text_a11y" do
+    [:dossier_modifie, :message, :annotation_instructeur, :avis_externe].each do |notification_type|
+      context "with a #{notification_type} notification" do
+        it "announces a nouveauté" do
+          expect(badge_notification_text_a11y(notification_type, summary: true)).to eq("dossiers avec au moins une nouveauté")
+          expect(badge_notification_text_a11y(notification_type, summary: false)).to eq("au moins une nouveauté")
+        end
+      end
+    end
+
+    context "with a notification that is not a nouveauté" do
+      it "only announces something in a summary" do
+        expect(badge_notification_text_a11y(:attente_correction, summary: true)).to eq("dossiers")
+        expect(badge_notification_text_a11y(:attente_correction, summary: false)).to be_nil
+      end
+    end
+  end
+
   describe ".partage_badge" do
     subject { partage_badge }
 


### PR DESCRIPTION
Deux correctifs d'accessibilité indépendants, repérés lors d'une revue du backlog `bug`.

### Badge « avis externe » (Ref #12631)

Une virgule manquante dans la liste du `when` faisait de `:avis_externe` la première instruction du corps de la branche au lieu d'une valeur de correspondance. Le type tombait donc dans le `else` : « dossiers » dans les résumés, `nil` ailleurs. La méthode voisine `badge_notification_class` a la forme correcte.

Ajout d'un spec sur `badge_notification_text_a11y`, qui n'en avait aucun — c'est ce qui a laissé passer l'erreur. Vérifié : sans la virgule, seuls les deux exemples `avis_externe` échouent.

### `aria-live` de l'erreur de correction

`assertlive` n'est pas une valeur valide, donc aucun lecteur d'écran n'annonçait le message d'erreur.

---

#12631 reste ouverte : la réorganisation du HTML demandée en commentaire (nature de la notification en premier, suppression du span `aria-hidden` interne) n'est pas traitée ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
