### PR TITLE
Tech : l'autocomplétion référentiel rend un modèle contenant n'importe quel nœud tiptap

### DIFF
--- a/app/controllers/data_sources/referentiel_controller.rb
+++ b/app/controllers/data_sources/referentiel_controller.rb
@@ -7,7 +7,7 @@ class DataSources::ReferentielController < DataSources::BaseController
 
   def search
     if query && params[:referentiel_id].present?
-      return render json: [] if referentiel&.autocomplete_configuration.blank?
+      return render json: [] if !referentiel&.autocomplete_ready?
 
       begin
         result = referentiel_service.call(query, dossier: @dossier)

--- a/app/models/referentiel.rb
+++ b/app/models/referentiel.rb
@@ -6,6 +6,11 @@ class Referentiel < ApplicationRecord
   has_many :items, -> { order(:id) }, class_name: 'ReferentielItem', dependent: :destroy, inverse_of: :referentiel
   has_many :types_de_champ, inverse_of: :referentiel, dependent: :nullify
 
+  # only an API referentiel can serve the autocompletion
+  def autocomplete_ready?
+    false
+  end
+
   def headers_with_path
     headers.map { [_1, self.class.header_to_path(_1)] }
   end

--- a/app/models/referentiels/api_referentiel.rb
+++ b/app/models/referentiels/api_referentiel.rb
@@ -41,8 +41,16 @@ class Referentiels::APIReferentiel < Referentiel
     end
   end
 
+  # the autocompletion needs both halves of the configuration: where to read the
+  # objects in the API response, and how to render each of them as a label
+  def autocomplete_ready?
+    datasource.present? && json_template.present?
+  end
+
   def tiptap_template=(value)
     self.json_template = JSON.parse(value)
+  rescue JSON::ParserError
+    self.json_template = {}
   end
 
   def tiptap_template

--- a/app/services/referentiel_autocomplete_render_service.rb
+++ b/app/services/referentiel_autocomplete_render_service.rb
@@ -12,8 +12,12 @@ class ReferentielAutocompleteRenderService
 
   def format_response
     objects = JsonPath.on(api_response, referentiel.datasource).first
-    objects.take(MAX_RENDERED_OBJECTS).map do |data|
+    objects.take(MAX_RENDERED_OBJECTS).filter_map do |data|
       label = render_template(json_template, data.with_indifferent_access).join("")
+      # an object the template renders as nothing can not be told apart from
+      # another in the autocompletion list: skip it rather than offer a blank row
+      next if label.blank?
+
       {
         id: Digest::MD5.hexdigest(data.to_json), # stable unique key for react-stately (not security-related)
         label:,
@@ -29,17 +33,23 @@ class ReferentielAutocompleteRenderService
     @message_encryptor_service ||= MessageEncryptorService.new
   end
 
+  # The template is authored in a rich text editor, so its node vocabulary is the
+  # editor's, not ours: an empty paragraph carries no `content` key at all (tiptap
+  # omits it), a line break is a `hardBreak` node, and any extension added later
+  # brings its own types. Interpolate the nodes we know, walk through the others,
+  # and ignore what is left: a node we can't render is worth an incomplete label,
+  # not a failed search.
   def render_template(template, obj, interpolations = [])
+    return interpolations if template.blank?
+
     case template["type"]
     when "mention"
-      interpolations << JSONPathUtil.on_safe(obj, template["attrs"]["id"]).first
+      jsonpath = template.dig("attrs", "id")
+      interpolations << JSONPathUtil.on_safe(obj, jsonpath).first if jsonpath.present?
     when "text"
       interpolations << template["text"]
-    when "doc", 'paragraph'
-      # an empty paragraph in the template editor has no content key
-      template['content']&.each { |t| interpolations.concat(render_template(t, obj)) }
     else
-      raise "Unknown template type: #{template['type']}. Expected one of: mention, text, doc, paragraph."
+      template["content"]&.each { interpolations.concat(render_template(it, obj)) }
     end
     interpolations
   end

--- a/spec/controllers/data_sources/referentiel_controller_spec.rb
+++ b/spec/controllers/data_sources/referentiel_controller_spec.rb
@@ -177,6 +177,16 @@ describe DataSources::ReferentielController, type: :controller do
         end
       end
 
+      context 'when the referentiel has no rendering template' do
+        before { referentiel.update_column(:autocomplete_configuration, { 'datasource' => '$.data' }) }
+
+        it 'returns an empty array without calling the API' do
+          expect_any_instance_of(ReferentielService).not_to receive(:call)
+          expect(subject).to have_http_status(:ok)
+          expect(response.parsed_body).to eq([])
+        end
+      end
+
       context 'when failure' do
         let(:referentiel_service) { double(call: service_respone) }
 

--- a/spec/models/api_referentiel_spec.rb
+++ b/spec/models/api_referentiel_spec.rb
@@ -12,6 +12,40 @@ describe Referentiels::APIReferentiel, type: :model do
     expect(Referentiel.where(id: referentiel.id).pluck(:authentication_data)).not_to include("Authorization")
   end
 
+  describe '#tiptap_template=' do
+    let(:referentiel) { build(:api_referentiel, :autocomplete) }
+
+    it 'parses the serialized template' do
+      referentiel.tiptap_template = { "type" => "doc" }.to_json
+      expect(referentiel.json_template).to eq({ "type" => "doc" })
+    end
+
+    it 'empties the template instead of raising on a malformed payload' do
+      expect { referentiel.tiptap_template = "not json" }.not_to raise_error
+      expect(referentiel.json_template).to eq({})
+    end
+  end
+
+  describe '#autocomplete_ready?' do
+    let(:referentiel) { build(:api_referentiel, :autocomplete, datasource: '$.items') }
+
+    it { expect(referentiel).to be_autocomplete_ready }
+
+    it 'is false without a datasource' do
+      referentiel.datasource = nil
+      expect(referentiel).not_to be_autocomplete_ready
+    end
+
+    it 'is false without a rendering template' do
+      referentiel.json_template = {}
+      expect(referentiel).not_to be_autocomplete_ready
+    end
+
+    it 'is false for a csv referentiel' do
+      expect(build(:csv_referentiel)).not_to be_autocomplete_ready
+    end
+  end
+
   describe '#tiptap_mention_stable_ids' do
     let(:referentiel) { build(:api_referentiel, :exact_match, url_tiptap:) }
 

--- a/spec/services/referentiel_autocomplete_render_service_spec.rb
+++ b/spec/services/referentiel_autocomplete_render_service_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe ReferentielAutocompleteRenderService do
       expect(result.map { |item| item[:id] }.uniq.count).to eq(2)
     end
 
+    context 'when the template renders an empty label' do
+      before do
+        referentiel.json_template = { "type" => "doc", "content" => [{ "type" => "paragraph" }] }
+      end
+
+      it 'returns no result rather than blank rows' do
+        expect(subject.format_response).to be_empty
+      end
+    end
+
     context 'with duplicate data' do
       let(:api_response) do
         {
@@ -65,22 +75,44 @@ RSpec.describe ReferentielAutocompleteRenderService do
       ).to include('Tango (Charlie)')
     end
 
-    context 'with an empty paragraph in the template' do
-      it 'skips it instead of failing (RAILS-KDV)' do
-        obj = { 'finess' => 'Tango' }
-        referentiel.json_template = {
+    context 'with nodes the renderer does not interpolate' do
+      let(:obj) { { 'finess' => 'Tango' } }
+      let(:mention) { { "type" => "mention", "attrs" => { "id" => "$.finess", "label" => "$.finess" } } }
+
+      def render(template) = subject.send(:render_template, template, obj).join('')
+
+      it 'skips an empty paragraph, which tiptap serializes without a content key' do
+        template = {
           "type" => "doc",
-          "content" => [
-            { "type" => "paragraph" },
-            {
-              "type" => "paragraph",
-              "content" => [{ "type" => "mention", "attrs" => { "id" => "$.finess", "label" => "$.finess" } }],
-            },
-          ],
+          "content" => [{ "type" => "paragraph" }, { "type" => "paragraph", "content" => [mention] }],
         }
-        expect(
-          subject.send(:render_template, referentiel.json_template, obj).join('')
-        ).to include('Tango')
+        expect(render(template)).to eq('Tango')
+      end
+
+      it 'skips a line break' do
+        template = {
+          "type" => "doc",
+          "content" => [{ "type" => "paragraph", "content" => [mention, { "type" => "hardBreak" }] }],
+        }
+        expect(render(template)).to eq('Tango')
+      end
+
+      it 'renders the children of an unknown node type instead of failing' do
+        template = {
+          "type" => "doc",
+          "content" => [{ "type" => "heading", "attrs" => { "level" => 2 }, "content" => [mention] }],
+        }
+        expect(render(template)).to eq('Tango')
+      end
+
+      it 'skips a mention without a jsonpath' do
+        template = { "type" => "doc", "content" => [{ "type" => "mention" }, mention] }
+        expect(render(template)).to eq('Tango')
+      end
+
+      it 'renders nothing for an empty template' do
+        expect(render({})).to eq('')
+        expect(render(nil)).to eq('')
       end
     end
 


### PR DESCRIPTION
## Contexte

Suite de la discussion sur #13542 : l'état qu'on y corrige n'est pas une donnée dégénérée. Un paragraphe vide **est** la sérialisation normale de tiptap — ProseMirror n'émet la clé `content` que si le nœud a des enfants ([`prosemirror-model` `Node#toJSON`](https://github.com/ProseMirror/prosemirror-model/blob/master/src/node.ts)) :

```js
if (this.content.size)
    obj.content = this.content.toJSON();
```

Un document vide, c'est donc `{"type":"doc","content":[{"type":"paragraph"}]}` — et le contrôleur tiptap écrit la sérialisation dans le champ caché dès la première transaction, avant toute frappe. Un admin qui valide l'étape sans écrire dans l'éditeur enregistre un modèle qui fait échouer toutes les recherches des usagers. RAILS-KDV : 60 occurrences, 5 usagers, depuis avril.

Le vrai défaut est donc côté Ruby : `render_template` lève une exception sur tout ce qu'il n'énumère pas, alors que son vocabulaire de nœuds appartient à l'éditeur. #13542 traite le paragraphe vide ; deux autres entrées du même code restent fatales :

- **`hardBreak`** : l'éditeur du modèle n'est pas en mode ligne unique, donc l'extension est chargée systématiquement. Un Maj+Entrée ou un copier-coller suffit → `Unknown template type: hardBreak`.
- **modèle vide ou absent** : `json_template` est `nil` tant que rien n'a été enregistré, et `resets_tiptap_template` le remet à `{}` à chaque changement de datasource. Le garde de l'endpoint ne teste que `autocomplete_configuration`, non vide dès que le datasource est renseigné.

Dans tous les cas l'usager voit une autocomplétion vide, sans que l'admin ait le moindre signal.

## Correction

- `render_template` devient total : on interpole les nœuds qu'on connaît, on descend dans les enfants des autres (un titre garde donc son texte), on ignore le reste. Même parti pris que `TiptapService.to_html`.
- un objet dont le libellé est vide est retiré de la liste, plutôt que d'offrir une ligne blanche impossible à distinguer d'une autre.
- l'endpoint de recherche est gardé par `autocomplete_ready?` (datasource **et** modèle) : un référentiel non configuré n'appelle plus l'API.
- `tiptap_template=` ne lève plus sur un payload malformé, comme `url_tiptap=` juste en dessous.

Ce qui n'est **pas** dans cette PR : valider le modèle à l'enregistrement pour que l'admin voie son erreur. C'est le correctif de fond, mais une validation s'applique à toutes les sauvegardes du référentiel (y compris les existants déjà cassés) et change le parcours « Étape suivante » — ça mérite sa propre discussion.

À merger après #13542 (conflit trivial sur la ligne modifiée).

Ref RAILS-KDV

🤖 Generated with [Claude Code](https://claude.com/claude-code)
