### PR TITLE
Tech : corrige deux défauts du camembert des dossiers traités

### DIFF
--- a/app/models/concerns/procedure_stats_concern.rb
+++ b/app/models/concerns/procedure_stats_concern.rb
@@ -46,9 +46,9 @@ module ProcedureStatsConcern
   def stats_termines_states
     Rails.cache.fetch("#{cache_key_with_version}/stats_termines_states", expires_in: 12.hours) do
       [
-        ['Acceptés', percentage(dossiers.visible_by_administration.state_accepte.count, nb_dossiers_termines)],
-        ['Refusés', percentage(dossiers.visible_by_administration.state_refuse.count, nb_dossiers_termines)],
-        ['Classés sans suite', percentage(dossiers.visible_by_administration.state_sans_suite.count, nb_dossiers_termines)],
+        ['Acceptés', percentage(nb_dossiers_termines_in_state(:accepte), nb_dossiers_termines)],
+        ['Refusés', percentage(nb_dossiers_termines_in_state(:refuse), nb_dossiers_termines)],
+        ['Classés sans suite', percentage(nb_dossiers_termines_in_state(:sans_suite), nb_dossiers_termines)],
       ]
     end
   end
@@ -128,6 +128,12 @@ module ProcedureStatsConcern
 
   def nb_dossiers_termines_supprimes
     @nb_dossiers_termines_supprimes ||= deleted_dossiers.state_termine.count
+  end
+
+  # `nb_dossiers_termines` counts deleted dossiers as well, so the per-state
+  # numerators have to count them too, otherwise the shares don't add up to 100%.
+  def nb_dossiers_termines_in_state(state)
+    dossiers.visible_by_administration.where(state:).count + deleted_dossiers.where(state:).count
   end
 
   def first_processed_at

--- a/app/models/concerns/procedure_stats_concern.rb
+++ b/app/models/concerns/procedure_stats_concern.rb
@@ -148,7 +148,12 @@ module ProcedureStatsConcern
     (seconds / 60.0 / 60.0 / 24.0).ceil
   end
 
+  # A procedure with no dossier terminé would divide 0 by 0 and yield NaN, which
+  # the JSON encoder turns into null: the public stats API then serves null shares
+  # and the pie chart renders empty.
   def percentage(value, total)
+    return 0.0 if total.zero?
+
     (100 * value / total.to_f).round(1)
   end
 

--- a/spec/controllers/api/public/v1/stats_controller_spec.rb
+++ b/spec/controllers/api/public/v1/stats_controller_spec.rb
@@ -75,5 +75,22 @@ RSpec.describe API::Public::V1::StatsController, type: :controller do
         let(:procedure) { double(Procedure, id: -1) }
       end
     end
+
+    context 'when the procedure has no dossier terminé' do
+      # The state shares divide by the number of terminés; with none, every share
+      # used to be NaN, which JSON refuses to serialize and 500s this public
+      # endpoint.
+      let(:procedure) { create(:procedure, :published, opendata: true) }
+
+      before do
+        create(:dossier, :en_instruction, procedure: procedure)
+        index_request
+      end
+
+      it 'serves zeroed shares instead of failing to serialize' do
+        expect(response).to be_successful
+        expect(response.parsed_body[:processed]).to eq([['Acceptés', 0.0], ['Refusés', 0.0], ['Classés sans suite', 0.0]])
+      end
+    end
   end
 end

--- a/spec/models/concerns/procedure_stats_concern_spec.rb
+++ b/spec/models/concerns/procedure_stats_concern_spec.rb
@@ -50,26 +50,35 @@ describe ProcedureStatsConcern do
 
     subject(:stats_termines_states) { procedure.stats_termines_states }
 
-    before do
-      create(:dossier, :accepte, procedure: procedure)
-      create(:dossier, :refuse, procedure: procedure)
-    end
-
-    context 'when no dossier has been deleted' do
-      it 'splits the terminés between the three states' do
-        expect(stats_termines_states).to match([['Acceptés', 50.0], ['Refusés', 50.0], ['Classés sans suite', 0.0]])
+    context 'when the procedure has no dossier terminé' do
+      # Dividing 0 by 0 yielded NaN, which the JSON encoder turns into null.
+      it 'returns zeroed shares rather than NaN' do
+        expect(stats_termines_states).to eq([['Acceptés', 0.0], ['Refusés', 0.0], ['Classés sans suite', 0.0]])
       end
     end
 
-    context 'when a terminé dossier has been deleted' do
-      # `nb_dossiers_termines` counts deleted dossiers, so the numerators must too:
-      # otherwise the deleted dossier inflates the denominator only and the shares
-      # add up to less than 100%.
-      before { create(:deleted_dossier, procedure: procedure, state: :accepte) }
+    context 'with dossiers terminés' do
+      before do
+        create(:dossier, :accepte, procedure: procedure)
+        create(:dossier, :refuse, procedure: procedure)
+      end
 
-      it 'counts it in its own state and still adds up to 100%' do
-        expect(stats_termines_states).to match([['Acceptés', 66.7], ['Refusés', 33.3], ['Classés sans suite', 0.0]])
-        expect(stats_termines_states.sum { |_state, share| share }).to be_within(0.1).of(100)
+      context 'when none has been deleted' do
+        it 'splits the terminés between the three states' do
+          expect(stats_termines_states).to match([['Acceptés', 50.0], ['Refusés', 50.0], ['Classés sans suite', 0.0]])
+        end
+      end
+
+      context 'when one has been deleted' do
+        # `nb_dossiers_termines` counts deleted dossiers, so the numerators must too:
+        # otherwise the deleted dossier inflates the denominator only and the shares
+        # add up to less than 100%.
+        before { create(:deleted_dossier, procedure: procedure, state: :accepte) }
+
+        it 'counts it in its own state and still adds up to 100%' do
+          expect(stats_termines_states).to match([['Acceptés', 66.7], ['Refusés', 33.3], ['Classés sans suite', 0.0]])
+          expect(stats_termines_states.sum { |_state, share| share }).to be_within(0.1).of(100)
+        end
       end
     end
   end

--- a/spec/models/concerns/procedure_stats_concern_spec.rb
+++ b/spec/models/concerns/procedure_stats_concern_spec.rb
@@ -45,6 +45,35 @@ describe ProcedureStatsConcern do
     end
   end
 
+  describe '#stats_termines_states' do
+    let(:procedure) { create(:procedure) }
+
+    subject(:stats_termines_states) { procedure.stats_termines_states }
+
+    before do
+      create(:dossier, :accepte, procedure: procedure)
+      create(:dossier, :refuse, procedure: procedure)
+    end
+
+    context 'when no dossier has been deleted' do
+      it 'splits the terminés between the three states' do
+        expect(stats_termines_states).to match([['Acceptés', 50.0], ['Refusés', 50.0], ['Classés sans suite', 0.0]])
+      end
+    end
+
+    context 'when a terminé dossier has been deleted' do
+      # `nb_dossiers_termines` counts deleted dossiers, so the numerators must too:
+      # otherwise the deleted dossier inflates the denominator only and the shares
+      # add up to less than 100%.
+      before { create(:deleted_dossier, procedure: procedure, state: :accepte) }
+
+      it 'counts it in its own state and still adds up to 100%' do
+        expect(stats_termines_states).to match([['Acceptés', 66.7], ['Refusés', 33.3], ['Classés sans suite', 0.0]])
+        expect(stats_termines_states.sum { |_state, share| share }).to be_within(0.1).of(100)
+      end
+    end
+  end
+
   describe '#usual_traitement_time_for_recent_dossiers' do
     let(:procedure) { create(:procedure) }
 


### PR DESCRIPTION
Deux défauts du camembert « répartition des dossiers traités », visible sur la page statistiques d'une démarche (côté instructeur et côté usager) et servi par `api/public/v1/stats`.

## 1. Les parts ne totalisaient pas 100 %

`nb_dossiers_termines` additionne les dossiers visibles et les dossiers supprimés (ajout fait quand les stats de démarche ont commencé à compter les supprimés, #6720), mais les numérateurs par état ne comptaient que les visibles :

```ruby
percentage(dossiers.visible_by_administration.state_accepte.count, nb_dossiers_termines)
```

Un dossier accepté puis supprimé gonflait donc le seul dénominateur. On compte désormais les dossiers supprimés dans leur propre état également : `DeletedDossier` conserve l'état final (`accepte` / `refuse` / `sans_suite`), aucune donnée ne manque, elle n'était simplement pas lue ici.

Sans le correctif, une démarche avec un accepté visible, un refusé visible et un accepté supprimé affiche `Acceptés 33,3 % / Refusés 33,3 %`, soit 66,6 % au total, au lieu de `66,7 % / 33,3 %`.

## 2. Une démarche sans dossier traité renvoyait `null`

`percentage` divisait par le nombre de terminés sans garde sur zéro : une démarche qui n'a encore rien traité produisait `NaN` pour les trois parts. L'encodeur JSON de Rails transforme `NaN` en `null`, donc l'API publique servait `[["Acceptés", null], ["Refusés", null], ["Classés sans suite", null]]` et le camembert s'affichait vide. On renvoie désormais `0.0`.

À noter : pas de 500 — `NaN.round(1)` ne lève pas et `ActiveSupport::JSON` encode `null` sans broncher. Le défaut était silencieux, ce qui explique qu'il ait survécu.

## Vérification

Chaque correctif a une spec qui échoue sans lui, vérifié en les retirant l'un après l'autre. Le premier est neutre pour une démarche sans dossier supprimé.

Les deux défauts ont été repérés lors du triage du backlog (#13586) ; le premier avait été introduit par le correctif de #6720 et n'avait pas d'issue dédiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
