### PR TITLE
ETQ usager, le préremplissage d'un champ commune ou EPCI dans un bloc répétable fonctionne

### DIFF
--- a/app/models/prefill_description.rb
+++ b/app/models/prefill_description.rb
@@ -32,7 +32,7 @@ class PrefillDescription < SimpleDelegator
   end
 
   def prefill_link
-    @prefill_link ||= CGI.unescape(commencer_url({ path: path, host: Current.host || ENV["APP_HOST"] }.merge(prefilled_champs_as_params).merge(prefilled_identity_as_params)))
+    @prefill_link ||= CGI.unescape(commencer_url({ path: path, host: Current.host || ENV["APP_HOST"] }.merge(prefilled_champs_as_query_params).merge(prefilled_identity_as_params)))
   end
 
   def prefill_query
@@ -40,7 +40,7 @@ class PrefillDescription < SimpleDelegator
       <<~TEXT
         curl --request POST '#{api_public_v1_dossiers_url(self, host: Current.host || ENV["APP_HOST"])}' \\
              --header 'Content-Type: application/json' \\
-             --data '#{prefilled_identity_as_params.merge(prefilled_champs_as_params).to_json}'
+             --data '#{prefilled_identity_as_params.merge(prefilled_champs_as_body_params).to_json}'
       TEXT
   end
 
@@ -54,7 +54,13 @@ class PrefillDescription < SimpleDelegator
     active_revision.public_root_type_de_champs.filter(&:fillable?)
   end
 
-  def prefilled_champs_as_params
+  # The link and the API body do not serialize the same way: see
+  # PrefillRepetitionTypeDeChamp#example_value_for_query.
+  def prefilled_champs_as_query_params
+    prefilled_champs.map { |type_de_champ| ["champ_#{type_de_champ.to_typed_id_for_query}", type_de_champ.example_value_for_query] }.to_h
+  end
+
+  def prefilled_champs_as_body_params
     prefilled_champs.map { |type_de_champ| ["champ_#{type_de_champ.to_typed_id_for_query}", type_de_champ.example_value] }.to_h
   end
 

--- a/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_repetition_type_de_champ.rb
@@ -12,15 +12,38 @@ class TypesDeChamp::PrefillRepetitionTypeDeChamp < TypesDeChamp::PrefillTypeDeCh
     [row_values_format, row_values_format]
   end
 
-  def to_assignable_attributes(champ, value)
-    return [] unless value.is_a?(Array)
+  # A JSON body can carry the rows as an array, a query string cannot: with bare
+  # brackets Rack folds `champ_x[][sub][]=a&champ_x[][sub][]=b` into a *single*
+  # row holding every value, so a repetition of array-valued sub-champs (commune,
+  # EPCI, multiple drop-down list) loses its row boundaries. Indexing the rows
+  # keeps them apart; they then arrive as a hash keyed by position.
+  def example_value_for_query
+    example_value.each_with_index.to_h { |row, index| [index.to_s, row] }
+  end
 
-    value.flat_map.with_index do |repetition, index|
+  def to_assignable_attributes(champ, value)
+    rows = rows_from(value)
+    return [] if rows.blank?
+
+    rows.flat_map.with_index do |repetition, index|
       PrefillRepetitionRow.new(champ, repetition, index, @revision).to_assignable_attributes
     end.compact_blank
   end
 
   private
+
+  # An API body sends an array of rows; a prefill link sends them indexed, which
+  # Rack parses into a hash keyed by position. Accept both.
+  def rows_from(value)
+    case value
+    when Array
+      value
+    when Hash
+      return nil unless value.keys.all? { _1.to_s.match?(/\A\d+\z/) }
+
+      value.sort_by { |index, _| index.to_i }.map { |_, row| row }
+    end
+  end
 
   def subchamps_all_possible_values
     tag.ul(safe_join(prefillable_subchamps.map do |prefill_type_de_champ|
@@ -28,10 +51,13 @@ class TypesDeChamp::PrefillRepetitionTypeDeChamp < TypesDeChamp::PrefillTypeDeCh
     end))
   end
 
+  # Keep each sub-champ's example value in its own type: `to_s` turned the array a
+  # commune or an EPCI returns into the literal `'["01500", "01004"]'`, which their
+  # `to_assignable_attributes` then rejects for not being an Array (#10610).
   def row_values_format
     @row_example_value ||=
       prefillable_subchamps.map do |prefill_type_de_champ|
-      ["champ_#{prefill_type_de_champ.to_typed_id_for_query}", prefill_type_de_champ.example_value.to_s]
+      ["champ_#{prefill_type_de_champ.to_typed_id_for_query}", prefill_type_de_champ.example_value]
     end.to_h
   end
 

--- a/app/models/types_de_champ/prefill_type_de_champ.rb
+++ b/app/models/types_de_champ/prefill_type_de_champ.rb
@@ -75,6 +75,13 @@ class TypesDeChamp::PrefillTypeDeChamp < SimpleDelegator
     I18n.t("views.prefill_descriptions.edit.examples.#{type_champ}")
   end
 
+  # Example value as it must appear in a prefill *link*. Identical to the JSON
+  # body representation for every type but repetitions, whose rows have to be
+  # indexed to survive query-string parsing — see PrefillRepetitionTypeDeChamp.
+  def example_value_for_query
+    example_value
+  end
+
   # Screens a raw prefill input and returns the assignable attributes, or nil
   # when the input must be rejected (the champ is then not prefilled at all).
   # Subclasses screening a single value override screened_value to return the

--- a/spec/models/prefill_description_spec.rb
+++ b/spec/models/prefill_description_spec.rb
@@ -139,7 +139,8 @@ RSpec.describe PrefillDescription, type: :model do
             path: procedure.path,
             "champ_#{type_de_champ_text.to_typed_id_for_query}" => TypesDeChamp::PrefillTypeDeChamp.build(type_de_champ_text, procedure.active_revision).example_value,
             "champ_#{type_de_champ_epci.to_typed_id_for_query}" => TypesDeChamp::PrefillTypeDeChamp.build(type_de_champ_epci, procedure.active_revision).example_value,
-            "champ_#{type_de_champ_repetition.to_typed_id_for_query}" => TypesDeChamp::PrefillTypeDeChamp.build(type_de_champ_repetition, procedure.active_revision).example_value,
+            # a repetition indexes its rows in a link, see #example_value_for_query
+            "champ_#{type_de_champ_repetition.to_typed_id_for_query}" => TypesDeChamp::PrefillTypeDeChamp.build(type_de_champ_repetition, procedure.active_revision).example_value_for_query,
             "identite_prenom" => I18n.t("views.prefill_descriptions.edit.examples.prenom")
           )
         )
@@ -177,7 +178,7 @@ RSpec.describe PrefillDescription, type: :model do
       <<~TEXT
         curl --request POST '#{api_public_v1_dossiers_url(procedure)}' \\
              --header 'Content-Type: application/json' \\
-             --data '{"identite_prenom":"#{I18n.t("views.prefill_descriptions.edit.examples.prenom")}","champ_#{type_de_champ_text.to_typed_id_for_query}":"Texte court","champ_#{prefill_type_de_champ_epci.to_typed_id_for_query}":["01","200042935"],"champ_#{type_de_champ_repetition.to_typed_id_for_query}":[{"champ_#{text_repetition.to_typed_id_for_query}":"Texte court","champ_#{integer_repetition.to_typed_id_for_query}":"42","champ_#{region_repetition.to_typed_id_for_query}":"53"},{"champ_#{text_repetition.to_typed_id_for_query}":"Texte court","champ_#{integer_repetition.to_typed_id_for_query}":"42","champ_#{region_repetition.to_typed_id_for_query}":"53"}]}'
+             --data '{"identite_prenom":"#{I18n.t("views.prefill_descriptions.edit.examples.prenom")}","champ_#{type_de_champ_text.to_typed_id_for_query}":"Texte court","champ_#{prefill_type_de_champ_epci.to_typed_id_for_query}":["01","200042935"],"champ_#{type_de_champ_repetition.to_typed_id_for_query}":[{"champ_#{text_repetition.to_typed_id_for_query}":"Texte court","champ_#{integer_repetition.to_typed_id_for_query}":42,"champ_#{region_repetition.to_typed_id_for_query}":"53"},{"champ_#{text_repetition.to_typed_id_for_query}":"Texte court","champ_#{integer_repetition.to_typed_id_for_query}":42,"champ_#{region_repetition.to_typed_id_for_query}":"53"}]}'
       TEXT
     end
 

--- a/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/prefill_repetition_type_de_champ_spec.rb
@@ -48,9 +48,65 @@ RSpec.describe TypesDeChamp::PrefillRepetitionTypeDeChamp, type: :model do
 
   describe '#example_value' do
     subject(:example_value) { described_class.new(type_de_champ, procedure.active_revision).example_value }
-    let(:expected_value) { [{ "champ_#{text_repetition.to_typed_id_for_query}" => "Texte court", "champ_#{integer_repetition.to_typed_id_for_query}" => "42", "champ_#{region_repetition.to_typed_id_for_query}" => "53" }, { "champ_#{text_repetition.to_typed_id_for_query}" => "Texte court", "champ_#{integer_repetition.to_typed_id_for_query}" => "42", "champ_#{region_repetition.to_typed_id_for_query}" => "53" }] }
+    let(:expected_value) { [{ "champ_#{text_repetition.to_typed_id_for_query}" => "Texte court", "champ_#{integer_repetition.to_typed_id_for_query}" => 42, "champ_#{region_repetition.to_typed_id_for_query}" => "53" }, { "champ_#{text_repetition.to_typed_id_for_query}" => "Texte court", "champ_#{integer_repetition.to_typed_id_for_query}" => 42, "champ_#{region_repetition.to_typed_id_for_query}" => "53" }] }
 
     it { expect(example_value).to eq(expected_value) }
+  end
+
+  # Every type de champ that is both prefillable and allowed inside a repetition.
+  # `communes` and `epci` were the ones silently dropped before #10610 was fixed;
+  # `multiple_drop_down_list` also has an array example value but escaped the bug
+  # because its screening parses a JSON string back into an array. The whole set is
+  # covered so that a new type cannot regress unnoticed.
+  PREFILLABLE_IN_REPETITION = [
+    :address, :checkbox, :civilite, :communes, :date, :datetime, :decimal_number,
+    :departements, :drop_down_list, :email, :epci, :formatted, :iban,
+    :integer_number, :multiple_drop_down_list, :pays, :phone, :regions, :text,
+    :textarea, :yes_no,
+  ].freeze
+
+  describe 'prefilling each prefillable type inside a repetition' do
+    PREFILLABLE_IN_REPETITION.each do |type_champ|
+      context "with a #{type_champ} sub-champ" do
+        let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :repetition, children: [{ type: type_champ }] }]) }
+        let(:dossier) { create(:dossier, procedure: procedure) }
+        let(:repetition_type_de_champ) { procedure.public_draft_type_de_champs.find(&:repetition?) }
+        let(:prefill) { described_class.build(repetition_type_de_champ, procedure.active_revision) }
+        let(:key) { "champ_#{repetition_type_de_champ.to_typed_id_for_query}" }
+
+        # Both entry points reach the same code with differently shaped values:
+        # the link goes through a query string, the API through a JSON body.
+        def prefill_with(params)
+          dossier.prefill!(PrefillChamps.new(dossier, params).to_a, {})
+          dossier.reload.root_champs_public.find(&:repetition?)
+        end
+
+        # A champ fetching its data asynchronously (address) is prefilled with an
+        # external_id and stays blank until its job runs, so only assert on the
+        # value for the synchronous ones.
+        def expect_both_rows_prefilled(repetition)
+          expect(repetition.row_ids.size).to eq(2)
+          subchamps = repetition.rows.flatten
+          expect(subchamps.size).to eq(2)
+          expect(subchamps).to all(be_prefilled)
+
+          settled, pending = subchamps.partition { !_1.has_async_external_data? }
+          expect(settled.map(&:blank?)).to all(be(false))
+          expect(pending.map(&:external_id)).to all(be_present)
+        end
+
+        it 'prefills every row from the generated prefill link' do
+          # exactly what the server receives back for the link we hand out
+          params = Rack::Utils.parse_nested_query({ key => prefill.example_value_for_query }.to_query)
+
+          expect_both_rows_prefilled(prefill_with(params))
+        end
+
+        it 'prefills every row from the API body' do
+          expect_both_rows_prefilled(prefill_with({ key => prefill.example_value }))
+        end
+      end
+    end
   end
 
   describe '#to_assignable_attributes' do
@@ -85,6 +141,44 @@ RSpec.describe TypesDeChamp::PrefillRepetitionTypeDeChamp, type: :model do
 
     context 'when a subchamp value fails its type screening' do
       let(:value) { [{ "champ_#{integer_repetition.to_typed_id_for_query}" => "not a number" }] }
+
+      it { is_expected.to match([]) }
+    end
+
+    # A prefill link indexes its rows, so they come back as a hash keyed by
+    # position rather than as an array. Links generated before that change used
+    # bare brackets and still arrive as an array, hence both shapes are accepted.
+    context 'when the rows are indexed, as a prefill link sends them' do
+      let(:value) do
+        {
+          "0" => { "champ_#{text_repetition.to_typed_id_for_query}" => "first" },
+          "1" => { "champ_#{text_repetition.to_typed_id_for_query}" => "second" },
+        }
+      end
+
+      it 'keeps the rows in index order' do
+        expect(to_assignable_attributes).to match([
+          [text_repetition_champs.first, { value: "first" }],
+          [text_repetition_champs.second, { value: "second" }],
+        ])
+      end
+    end
+
+    context 'when the indexed rows arrive out of order' do
+      let(:value) do
+        {
+          "1" => { "champ_#{text_repetition.to_typed_id_for_query}" => "second" },
+          "0" => { "champ_#{text_repetition.to_typed_id_for_query}" => "first" },
+        }
+      end
+
+      it 'sorts them by index' do
+        expect(to_assignable_attributes.map(&:last)).to eq([{ value: "first" }, { value: "second" }])
+      end
+    end
+
+    context 'when a hash is not keyed by index' do
+      let(:value) { { "champ_#{text_repetition.to_typed_id_for_query}" => "not a row" } }
 
       it { is_expected.to match([]) }
     end


### PR DESCRIPTION
## Contexte

Sur une démarche contenant un bloc répétable avec un champ commune ou EPCI, le préremplissage de ces sous-champs ne fonctionnait pas — ni par le lien, ni par le code curl proposés sur la page de préremplissage.

`PrefillRepetitionTypeDeChamp#row_values_format` sérialisait chaque valeur d'exemple avec `.to_s` :

```ruby
["champ_#{...}", prefill_type_de_champ.example_value.to_s]
```

`PrefillCommuneTypeDeChamp#example_value` renvoie un **tableau** (`["01500", "01004"]`), que `.to_s` transformait en littéral `'["01500", "01004"]'`. Côté réception, `to_assignable_attributes` abandonne dès la première ligne :

```ruby
return if value.blank? || !value.is_a?(Array)
```

Le sous-champ n'était donc pas prérempli, silencieusement. Idem pour EPCI. Les champs commune de premier niveau fonctionnaient car ils ne passent pas par `row_values_format` — ce que les deux tickets avaient bien relevé.

## Correction

**1. Ne plus stringifier.** Chaque valeur d'exemple garde son type. Le corps JSON correspond désormais à la charge utile que le rapporteur avait identifiée comme fonctionnelle dans #10631.

**2. Indexer les lignes dans le lien.** Nécessaire et non évident : avec des crochets vides, Rack replie `champ_x[][sous][]=a&champ_x[][sous][]=b` en une **seule** ligne contenant toutes les valeurs — les frontières de lignes disparaissent dès qu'un sous-champ vaut un tableau. Les liens indexent donc les lignes (`champ_x[0][sous][]=`), qui reviennent sous forme de dictionnaire indexé par position. `to_assignable_attributes` accepte cette forme **en plus** du tableau envoyé par l'API, donc les liens générés avant ce correctif continuent de fonctionner.

## Tests

Nouveau jeu de tests couvrant **les 21 types de champ à la fois préremplissables et autorisés dans un bloc répétable**, chacun par les deux points d'entrée : le lien (params tels que Rack les reparse) et le corps d'API. Le test va jusqu'au bout du chemin réel (`PrefillChamps` puis `prefill!`) et vérifie que les deux lignes sont préremplies et non vides.

Vérifié en remettant le `.to_s` : exactement 4 exemples échouent, commune et EPCI par chacun des deux points d'entrée.

Deux précisions relevées en écrivant ces tests :

- `multiple_drop_down_list` renvoie aussi un tableau mais **n'était pas affecté** : son écran de validation passe par `Champs::MultipleDropDownListChamp.parse_values`, qui reparse une chaîne JSON en tableau. Seuls commune et EPCI étaient cassés.
- `address` récupère ses données de façon asynchrone : il est bien prérempli avec son `external_id` mais reste vide jusqu'à l'exécution de son job. Les assertions en tiennent compte plutôt que de le traiter comme un cas particulier.

## Changement visible

Les valeurs d'exemple gardent leur type dans le corps d'API : un entier vaut désormais `42` et non `"42"`. Les specs de format ont été mises à jour en conséquence. C'est plus correct pour un corps JSON, et `to_assignable_attributes` accepte les deux.

Fixes #10610
Ref #13586

🤖 Generated with [Claude Code](https://claude.com/claude-code)
