### PR TITLE
Tech: corrige deux N+1 de l'API GraphQL v2 (champs via edges, attestation de refus)

### DIFF
--- a/app/graphql/connections/dossiers_connection.rb
+++ b/app/graphql/connections/dossiers_connection.rb
@@ -26,8 +26,13 @@ module Connections
     end
 
     # We check if the query selects champs form dossier. If it's the case we preload the dossier.
+    # The connection exposes both Relay shapes, so we look at `nodes { … }` and `edges { node { … } }`.
     def preload?
-      @lookahead.selection(:nodes).selects?(:champs) || @lookahead.selection(:nodes).selects?(:annotations)
+      node_lookaheads.any? { it.selects?(:champs) || it.selects?(:annotations) }
+    end
+
+    def node_lookaheads
+      [@lookahead.selection(:nodes), @lookahead.selection(:edges).selection(:node)]
     end
   end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -410,7 +410,7 @@ class Dossier < ApplicationRecord
   scope :with_revision, -> { includes(revision: :revision_types_de_champ) }
   scope :for_api_v2, -> {
     with_revision
-      .includes(:attestation_acceptation_template, :etablissement, :individual, :traitement, procedure: [:administrateurs], user: [:france_connect_informations])
+      .includes(:attestation_acceptation_template, :attestation_refus_template, :etablissement, :individual, :traitement, procedure: [:administrateurs], user: [:france_connect_informations])
   }
 
   scope :with_notifications, -> (instructeur) {

--- a/spec/graphql/connections/dossiers_connection_spec.rb
+++ b/spec/graphql/connections/dossiers_connection_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe Connections::DossiersConnection, type: :graphql do
+  let_it_be(:admin) { administrateurs.default }
+  let_it_be(:procedure) { create(:procedure, :published, :for_individual, administrateurs: [admin], types_de_champ_public: [{}, {}]) }
+
+  before_all { create(:dossier, :en_construction, :with_individual, :with_populated_champs, procedure:) }
+
+  def execute(query)
+    API::V2::Schema.execute(query, variables: { number: procedure.id }, context: { administrateur_id: admin.id, procedure_ids: admin.procedure_ids })
+  end
+
+  def count_queries(query)
+    # Execute the query a first time so that shared queries (schema, token, …) are never counted
+    execute(query)
+
+    count = 0
+    result = ActiveSupport::Notifications.subscribed(-> (*_args) { count += 1 }, 'sql.active_record') { execute(query) }
+
+    expect(result['errors']).to be_nil
+    count
+  end
+
+  # The connection exposes both Relay shapes; champs must be preloaded for each of them.
+  shared_examples 'a shape preloading champs' do
+    it 'does not run one query per dossier' do
+      count_for_one_dossier = count_queries(query)
+
+      create_list(:dossier, 3, :en_construction, :with_individual, :with_populated_champs, procedure:)
+
+      expect(count_queries(query)).to eq(count_for_one_dossier)
+    end
+  end
+
+  context 'when champs are selected through `nodes`' do
+    let(:query) { NODES_CHAMPS_QUERY }
+
+    it_behaves_like 'a shape preloading champs'
+  end
+
+  context 'when champs are selected through `edges { node }`' do
+    let(:query) { EDGES_NODE_CHAMPS_QUERY }
+
+    it_behaves_like 'a shape preloading champs'
+  end
+
+  NODES_CHAMPS_QUERY = <<-GRAPHQL
+  query getDemarche($number: Int!) {
+    demarche(number: $number) {
+      dossiers {
+        nodes {
+          id
+          champs {
+            id
+            label
+          }
+        }
+      }
+    }
+  }
+  GRAPHQL
+
+  EDGES_NODE_CHAMPS_QUERY = <<-GRAPHQL
+  query getDemarche($number: Int!) {
+    demarche(number: $number) {
+      dossiers {
+        edges {
+          node {
+            id
+            champs {
+              id
+              label
+            }
+          }
+        }
+      }
+    }
+  }
+  GRAPHQL
+end

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -196,12 +196,12 @@ RSpec.describe DossierChampsConcern do
   describe '#filled_champs_public' do
     let(:types_de_champ_public) do
       [
-        { type: :header_section },
-        { type: :text, libelle: "Un champ text" },
-        { type: :text, libelle: "Un autre champ text" },
-        { type: :yes_no, libelle: "Un champ yes no" },
-        { type: :repetition, libelle: "Un champ répétable", mandatory: true, children: [{ type: :text, libelle: 'Nom' }] },
-        { type: :explication },
+        { type: :header_section, stable_id: 9001 },
+        { type: :text, libelle: "Un champ text", stable_id: 9002 },
+        { type: :text, libelle: "Un autre champ text", stable_id: 9003 },
+        { type: :yes_no, libelle: "Un champ yes no", stable_id: 9004 },
+        { type: :repetition, libelle: "Un champ répétable", stable_id: 9005, mandatory: true, children: [{ type: :text, libelle: 'Nom', stable_id: 9006 }] },
+        { type: :explication, stable_id: 9007 },
       ]
     end
     let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
@@ -216,9 +216,9 @@ RSpec.describe DossierChampsConcern do
   describe '#filled_champs_private' do
     let(:types_de_champ_private) do
       [
-        { type: :header_section },
-        { type: :text, libelle: "Une annotation" },
-        { type: :explication },
+        { type: :header_section, stable_id: 9011 },
+        { type: :text, libelle: "Une annotation", stable_id: 9012 },
+        { type: :explication, stable_id: 9013 },
       ]
     end
     subject { dossier.filled_champs_private }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -946,6 +946,18 @@ describe Dossier, type: :model do
     it { is_expected.to match([dossier3, dossier4, dossier2]) }
   end
 
+  describe '.for_api_v2' do
+    let(:dossier) { dossiers.en_construction }
+
+    subject { Dossier.for_api_v2.find(dossier.id) }
+
+    # Types::DossierType#attestation reads both templates, so neither must be lazy loaded
+    it 'preloads both attestation templates' do
+      expect(subject.association(:attestation_acceptation_template)).to be_loaded
+      expect(subject.association(:attestation_refus_template)).to be_loaded
+    end
+  end
+
   describe "#assign_to_groupe_instructeur" do
     let(:procedure) { procedures.brouillon }
     let(:new_groupe_instructeur_new_procedure) { create(:groupe_instructeur) }


### PR DESCRIPTION
Deux N+1 de l'audit API v2 (#13554), en deux commits séparés.

**1. `edges { node { champs } }` ne préchargeait pas les champs**

`Connections::DossiersConnection#preload?` ne regardait que la sélection `nodes`. Avec la forme Relay `edges { node { champs } }` — exposée par le schéma au même titre que `nodes` — le `DossierPreloader` ne se déclenchait pas, et chaque dossier de la page chargeait ses `champ_data` séparément (jusqu'à 100 requêtes pour une page pleine). Le correctif inspecte les deux formes.

**2. `attestation_refus_template` absent de `Dossier.for_api_v2`**

`Types::DossierType#attestation` teste `attestation_refus_template&.activated?`, mais le scope ne préchargeait que `attestation_acceptation_template` → une requête par dossier `termine` dès que `attestation` est sélectionné sur une liste.

## Tests

- `spec/graphql/connections/dossiers_connection_spec.rb` (nouveau) : compte les requêtes SQL pour les deux formes, avec 1 puis 4 dossiers, et vérifie que le total ne bouge pas. Sans le correctif, la forme `edges` passe de 19 à 22 requêtes ; la forme `nodes` reste stable.
- `spec/models/dossier_spec.rb` : `.for_api_v2` précharge bien les deux templates d'attestation.

Ref #13554
