### PR TITLE
Tech: corrige le choix d'index catastrophique sur les upserts de champs (index stable_id + dossier_id)

### DIFF
--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -402,7 +402,9 @@ module DossierChampsConcern
     check_valid_stream_on_write?(type_de_champ)
     check_valid_row_id_on_write?(type_de_champ, row_id)
 
-    # FIXME: Try to find the champ data in memory before querying the database
+    # Memory-first lookup: champ_data is (almost) always loaded here, and going
+    # through create_or_find_by for an existing champ costs a savepoint plus an
+    # insert/conflict roundtrip per call.
     data = champ_data.find { _1.stream == stream && _1.public_id == type_de_champ.public_id(row_id) }
 
     if data.nil?

--- a/db/migrate/20260727220000_add_champs_stable_id_and_dossier_id_index.rb
+++ b/db/migrate/20260727220000_add_champs_stable_id_and_dossier_id_index.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddChampsStableIdAndDossierIdIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    # The single-column stable_id index is a planner trap: dossier-scoped champ
+    # lookups (create_or_find_by conflict SELECT, clone-from-main find_by) all
+    # estimate ~1 row, and on that tie the planner picks the smallest index —
+    # scanning every champ of a popular stable_id across all dossiers. Adding
+    # dossier_id keeps the tie-break winner scoped to the dossier.
+    add_index :champs, [:stable_id, :dossier_id], algorithm: :concurrently, name: 'index_champs_on_stable_id_and_dossier_id'
+  end
+end

--- a/db/migrate/20260727220100_remove_champs_stable_id_index.rb
+++ b/db/migrate/20260727220100_remove_champs_stable_id_index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveChampsStableIdIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :champs, name: :index_champs_on_stable_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_22_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_27_220100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -286,7 +286,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_22_000000) do
     t.index ["dossier_id"], name: "index_champs_on_dossier_id"
     t.index ["etablissement_id"], name: "index_champs_on_etablissement_id"
     t.index ["row_id"], name: "index_champs_on_row_id"
-    t.index ["stable_id"], name: "index_champs_on_stable_id"
+    t.index ["stable_id", "dossier_id"], name: "index_champs_on_stable_id_and_dossier_id"
     t.index ["type"], name: "index_champs_on_type"
   end
 


### PR DESCRIPTION
## Contexte

`champ_upsert_by!` porte un `FIXME` depuis juin 2025 : sans le lookup en mémoire, le `SELECT` de résolution de conflit de `create_or_find_by!` (et le `find_by` de clone depuis `main`) passait par le mauvais index en production.

## Cause

Ces requêtes (`dossier_id + stable_id + row_id + stream`) sont toutes estimées à ~1 ligne par le planner. À égalité de coût, Postgres choisit l'index à la descente la moins chère — l'index mono-colonne `stable_id`, plus petit — puis filtre par `dossier_id`. Pour un `stable_id` d'une démarche populaire, cela scanne tous les champs partageant ce `stable_id` sur l'ensemble des dossiers. Les plans génériques des prepared statements (actifs en production) figent ce mauvais plan pour tous les dossiers.

Reproduit sur une table synthétique de 9M de lignes : 30 016 buffers / 87 ms via `index_champs_on_stable_id` contre 7 buffers / 0,03 ms via l'index unique combiné — et les `stable_id` populaires en production comptent des millions de lignes, pas 30k.

## Correction

Remplacement de `index_champs_on_stable_id` par `(stable_id, dossier_id)` : quand le planner le choisit sur une égalité de coût, `dossier_id` fait partie des conditions d'index et le scan reste borné au dossier (vérifié : 3 buffers / 0,025 ms avec des stats hostiles et un plan générique). Les requêtes filtrant uniquement par `stable_id` restent servies par la colonne de tête. Les deux migrations sont `CONCURRENTLY`.

Le lookup en mémoire est conservé (il évite un savepoint + un aller-retour insert/conflit par appel), mais le `FIXME` est remplacé par un commentaire expliquant son rôle réel.

Basé sur #13594 (refactoring des specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)