### PR TITLE
ETQ usager, refuser l'envoi d'un fichier vide

### DIFF
--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -60,7 +60,7 @@ module Administrateurs
 
         render :create
       else
-        render json: { errors: @champ.errors.full_messages }, status: 422
+        render json: { errors: type_de_champ.errors.full_messages }, status: 422
       end
     end
 
@@ -74,7 +74,7 @@ module Administrateurs
 
         render :create
       else
-        render json: { errors: @champ.errors.full_messages }, status: 422
+        render json: { errors: type_de_champ.errors.full_messages }, status: 422
       end
     end
 

--- a/app/javascript/controllers/autosave_controller.ts
+++ b/app/javascript/controllers/autosave_controller.ts
@@ -298,6 +298,11 @@ export class AutosaveController extends ApplicationController {
         errors.push(sizeError);
       }
 
+      const emptyError = this.checkFileEmpty(file);
+      if (emptyError) {
+        errors.push(emptyError);
+      }
+
       if (errors.length > 0) {
         invalidFiles.push({ file, errors });
       } else {
@@ -363,6 +368,14 @@ export class AutosaveController extends ApplicationController {
     }
 
     return null;
+  }
+
+  // Le nom du fichier n'est pas interpolé dans le message : il est inséré via
+  // innerHTML par showAttachmentError.
+  private checkFileEmpty(file: File): string | null {
+    if (file.size > 0) return null;
+
+    return `Le fichier envoyé est&nbsp;<strong>vide</strong>.`;
   }
 
   private countCurrentFiles(container: Element): number {

--- a/app/javascript/shared/activestorage/uploader.ts
+++ b/app/javascript/shared/activestorage/uploader.ts
@@ -44,6 +44,10 @@ export default class Uploader {
     */
   async start() {
     this.progressBar.start();
+    if (this.file.size == 0) {
+      throw `Le fichier « ${this.file.name} » est vide
+             (in english: the file is empty).`;
+    }
     if (this.maxFileSize > 0 && this.file.size > this.maxFileSize) {
       throw `La taille du fichier ne peut dépasser
              ${this.maxFileSize / BYTES_TO_MB_RATIO} Mo

--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -26,8 +26,8 @@ class AttestationTemplate < ApplicationRecord
   validates :kind, presence: true
 
   FILE_MAX_SIZE = 1.megabyte
-  validates :logo, content_type: ['image/png', 'image/jpeg'], size: { less_than: FILE_MAX_SIZE }
-  validates :signature, content_type: ['image/png', 'image/jpeg'], size: { less_than: FILE_MAX_SIZE }
+  validates :logo, content_type: ['image/png', 'image/jpeg'], size: { less_than: FILE_MAX_SIZE }, empty_file: true
+  validates :signature, content_type: ['image/png', 'image/jpeg'], size: { less_than: FILE_MAX_SIZE }, empty_file: true
 
   DOSSIER_STATE = Dossier.states.fetch(:accepte)
 

--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -17,11 +17,13 @@ class Avis < ApplicationRecord
   FILE_MAX_SIZE = 20.megabytes
   validates :piece_justificative_file,
     content_type: -> (_record) { AUTHORIZED_CONTENT_TYPES },
-    size: { less_than: FILE_MAX_SIZE }
+    size: { less_than: FILE_MAX_SIZE },
+    empty_file: true
 
   validates :introduction_file,
     content_type: -> (_record) { AUTHORIZED_CONTENT_TYPES },
-    size: { less_than: FILE_MAX_SIZE }
+    size: { less_than: FILE_MAX_SIZE },
+    empty_file: true
 
   validates :question_answer, inclusion: { in: [true, false] }, on: :update, if: -> { question_label.present? }
   validates :piece_justificative_file, size: { less_than: FILE_MAX_SIZE }

--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -13,6 +13,8 @@ class Champs::PieceJustificativeChamp < ChampData
     content_type: -> (_record) { AUTHORIZED_CONTENT_TYPES },
     if: -> { should_validate_in_current_context? && !type_de_champ.skip_content_type_pj_validation }
 
+  validates :piece_justificative_file, empty_file: true, if: -> { should_validate_in_current_context? }
+
   validate :validate_dynamic_piece_justificative_rules,
     if: -> { should_validate_in_current_context? && piece_justificative_file.attached? }
 

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -21,7 +21,8 @@ class Commentaire < ApplicationRecord
 
   validates :piece_jointe,
     content_type: -> (_record) { AUTHORIZED_CONTENT_TYPES },
-    size: { less_than: FILE_MAX_SIZE }
+    size: { less_than: FILE_MAX_SIZE },
+    empty_file: true
 
   scope :chronological, -> { order(created_at: :asc) }
   scope :updated_since?, -> (date) { where('commentaires.updated_at > ?', date) }

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -20,7 +20,7 @@ class GroupeInstructeur < ApplicationRecord
   has_one_attached :signature
 
   SIGNATURE_MAX_SIZE = 1.megabyte
-  validates :signature, content_type: ['image/png', 'image/jpeg'], size: { less_than: SIGNATURE_MAX_SIZE }
+  validates :signature, content_type: ['image/png', 'image/jpeg'], size: { less_than: SIGNATURE_MAX_SIZE }, empty_file: true
 
   validates :label, presence: true, allow_nil: false
   validates :label, uniqueness: { scope: :procedure }

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -310,7 +310,7 @@ class Procedure < ApplicationRecord
     "image/jpeg",
     "image/png",
     "text/plain",
-  ], size: { less_than: FILE_MAX_SIZE }, if: -> { new_record? || created_at > Date.new(2020, 2, 28) }
+  ], size: { less_than: FILE_MAX_SIZE }, empty_file: true, if: -> { new_record? || created_at > Date.new(2020, 2, 28) }
 
   validates :deliberation, content_type: [
     "application/msword",
@@ -320,11 +320,12 @@ class Procedure < ApplicationRecord
     "image/jpeg",
     "image/png",
     "text/plain",
-  ], size: { less_than: FILE_MAX_SIZE }, if: -> { new_record? || created_at > Date.new(2020, 4, 29) }
+  ], size: { less_than: FILE_MAX_SIZE }, empty_file: true, if: -> { new_record? || created_at > Date.new(2020, 4, 29) }
 
   LOGO_MAX_SIZE = 5.megabytes
   validates :logo, content_type: ['image/png', 'image/jpeg'],
     size: { less_than: LOGO_MAX_SIZE },
+    empty_file: true,
     if: -> { new_record? || created_at > Date.new(2020, 11, 13) }
 
   validates :api_particulier_token, format: { with: /\A[A-Za-z0-9\-_=.]{15,}\z/ }, allow_blank: true

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -229,9 +229,11 @@ class TypeDeChamp < ApplicationRecord
   has_one_attached :piece_justificative_template
   validates :piece_justificative_template, size: { less_than: FILE_MAX_SIZE }, on: :update
   validates :piece_justificative_template, content_type: -> (_record) { AUTHORIZED_CONTENT_TYPES }, on: :update
+  validates :piece_justificative_template, empty_file: true, on: :update
 
   has_one_attached :notice_explicative
   validates :notice_explicative, content_type: -> (_record) { AUTHORIZED_CONTENT_TYPES }, size: { less_than: 20.megabytes }, on: :update
+  validates :notice_explicative, empty_file: true, on: :update
 
   validates :type_champ, presence: true, allow_blank: false, allow_nil: false
   validates :character_limit, numericality: {

--- a/app/services/attachment/piece_justificative_service.rb
+++ b/app/services/attachment/piece_justificative_service.rb
@@ -17,8 +17,11 @@ class Attachment::PieceJustificativeService
       # the main stream, and conditional visibility (the validation gate) must
       # be computed on the stream being edited
       champ.association(:dossier).target = dossier
-      champ.updated_by = updated_by # keep record dirty so attach defers save to us
-      champ.piece_justificative_file.attach(blob_signed_id)
+      champ.updated_by = updated_by
+      # Assign rather than #attach: attach saves immediately unless the record
+      # happens to be dirty, which would commit the attachment without running
+      # the :champ_value validations (size, content type, empty file).
+      champ.piece_justificative_file = champ.piece_justificative_file.blobs + [blob_signed_id]
 
       # fetch_later should be called inside the transaction to avoid
       # race condition with processor_job

--- a/app/tasks/maintenance/t20260728_purge_empty_attachments_task.rb
+++ b/app/tasks/maintenance/t20260728_purge_empty_attachments_task.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260728PurgeEmptyAttachmentsTask < MaintenanceTasks::Task
+    # Nettoie les pièces jointes de 0 octet déjà présentes en base. Elles sont
+    # inexploitables : AttachmentProcessorConcern ignore les blobs vides, donc
+    # elles restent affichées « Analyse antivirus en cours… », ni visualisables
+    # ni téléchargeables.
+    #
+    # EmptyFileValidator empêche d'en créer de nouvelles, et exempte celles déjà
+    # enregistrées pour ne pas bloquer leur porteur : cette tâche n'est donc pas
+    # un prérequis du déploiement, elle peut être lancée à la main quand on veut.
+    #
+    # Les variantes et les aperçus PDF sont exclus : ils sont dérivés d'un blob
+    # déjà scanné et seront regénérés à la demande.
+
+    include RunnableOnDeployConcern
+
+    throttle_on(backoff: 1.minute) do
+      Sidekiq::Queue.new("default").size > 100 || Sidekiq::Queue.new("low").size > 1_000
+    end
+
+    def collection
+      ActiveStorage::Attachment
+        .joins(:blob)
+        .where(active_storage_blobs: { byte_size: 0 })
+        .where.not(record_type: 'ActiveStorage::VariantRecord')
+        .where.not(name: 'preview_image')
+    end
+
+    def process(attachment)
+      attachment.purge_later
+    end
+  end
+end

--- a/app/validators/empty_file_validator.rb
+++ b/app/validators/empty_file_validator.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Rejects zero-byte attachments.
+#
+# An empty file carries no information, and it is also never processed:
+# AttachmentProcessorConcern#process_later skips empty blobs, so the blob keeps
+# the `pending` virus scan result it gets on create and the attachment stays
+# "Analyse antivirus en cours…" forever, neither viewable nor downloadable.
+#
+# Only blobs being attached by the current save are rejected. An empty
+# attachment already committed predates this validation, and flagging it would
+# make its record impossible to save at all — an usager could no longer submit
+# their dossier. Those are cleaned up by
+# Maintenance::T20260728PurgeEmptyAttachmentsTask instead.
+class EmptyFileValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, _value)
+    attached = record.public_send(attribute)
+    return if !attached.attached?
+
+    blobs(attached).each do
+      next unless it.byte_size == 0
+      next if already_attached?(record, attribute, it)
+
+      record.errors.add(attribute, :file_empty, filename: it.filename.to_s)
+    end
+  end
+
+  private
+
+  # Attached::Many exposes #blobs, Attached::One only #blob.
+  def blobs(attached)
+    attached.respond_to?(:blobs) ? attached.blobs : [attached.blob]
+  end
+
+  # Attachments are inserted after validation, so a blob already joined to this
+  # record in database was attached by an earlier save, not by this one.
+  def already_attached?(record, attribute, blob)
+    return false if record.new_record? || blob.id.nil?
+
+    ActiveStorage::Attachment.exists?(record:, name: attribute.to_s, blob_id: blob.id)
+  end
+end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -109,6 +109,7 @@ ignore_unused:
   - 'errors.messages.blank'
   - 'errors.messages.content_type_invalid.*'
   - 'errors.messages.file_size_out_of_range'
+  - 'errors.messages.file_empty'
   - 'pluralize.*'
   - 'views.pagination.*'
   - 'time.formats.*'

--- a/config/locales/active_storage_validations.en.yml
+++ b/config/locales/active_storage_validations.en.yml
@@ -5,3 +5,4 @@ en:
         one: is not of an accepted type (%{content_type}).
         other: is not of an accepted type (%{content_type}).
       file_size_out_of_range: is too big. The file must be at most %{max_size}.
+      file_empty: is empty (%{filename}). The uploaded file contains no data.

--- a/config/locales/active_storage_validations.fr.yml
+++ b/config/locales/active_storage_validations.fr.yml
@@ -5,3 +5,4 @@ fr:
         one: n’est pas d’un type accepté (%{content_type}).
         other: n’est pas d’un type accepté (%{content_type}).
       file_size_out_of_range: est trop lourd(e). Le fichier doit faire au plus %{max_size}.
+      file_empty: est vide (%{filename}). Le fichier envoyé ne contient aucune donnée.

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -450,8 +450,8 @@ describe Administrateurs::TypesDeChampController, type: :controller do
   describe '#notice_explicative' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :explication }]) }
     let(:coordinate) { procedure.draft_revision.types_de_champ.first }
-    let(:file) { Tempfile.new }
-    let(:blob) { ActiveStorage::Blob.create_before_direct_upload!(filename: File.basename(file.path), byte_size: file.size, checksum: Digest::SHA256.file(file.path), content_type: 'text/plain') }
+    let(:content) { 'notice' }
+    let(:blob) { ActiveStorage::Blob.create_and_upload!(io: StringIO.new(content), filename: 'notice.txt', content_type: 'text/plain') }
 
     context 'when sending a valid blob' do
       it 'attaches the blob and responds with 200' do
@@ -459,6 +459,17 @@ describe Administrateurs::TypesDeChampController, type: :controller do
           .to change { coordinate.reload.notice_explicative.attached? }
           .from(false).to(true)
         expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'when sending an empty blob' do
+      let(:content) { '' }
+
+      it 'rejects it and responds with 422' do
+        expect { put :notice_explicative, format: :turbo_stream, params: { stable_id: coordinate.stable_id, procedure_id: procedure.id, blob_signed_id: blob.signed_id } }
+          .not_to change { coordinate.reload.notice_explicative.attached? }
+        expect(response).to have_http_status(422)
+        expect(response.parsed_body['errors'].join).to include('vide')
       end
     end
   end

--- a/spec/fixtures/files/file.pdf
+++ b/spec/fixtures/files/file.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << >> >>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+203
+%%EOF

--- a/spec/system/users/piece_justificative_drag_drop_spec.rb
+++ b/spec/system/users/piece_justificative_drag_drop_spec.rb
@@ -171,6 +171,26 @@ describe 'Piece justificative drag and drop', js: true do
       end
     end
 
+    scenario 'rejects an empty file' do
+      empty_file_path = Rails.root.join('tmp', 'empty_document.pdf')
+      File.write(empty_file_path, '')
+
+      begin
+        within find('.editable-champ', text: 'Documents') do
+          attach_file('Documents', empty_file_path)
+
+          within('[data-attachment-error]') do
+            expect(page).to have_selector('.fr-message--error', text: /est\s+vide/i)
+          end
+
+          # Le fichier ne doit pas être envoyé
+          expect(page).not_to have_selector('.direct-upload')
+        end
+      ensure
+        File.delete(empty_file_path) if File.exist?(empty_file_path)
+      end
+    end
+
     scenario 'validates file size using titre_identite nature (20 Mo limit)' do
       # Créer un fichier légèrement au-dessus de 20 Mo
       large_content = 'x' * (21 * 1024 * 1024) # 21 Mo

--- a/spec/tasks/maintenance/t20260728_purge_empty_attachments_task_spec.rb
+++ b/spec/tasks/maintenance/t20260728_purge_empty_attachments_task_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260728PurgeEmptyAttachmentsTask do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
+    let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+    let(:champ) { dossier.root_champs_public.first }
+
+    def attach_without_validation(blob)
+      champ.piece_justificative_file = [blob]
+      champ.save!(validate: false)
+      champ.piece_justificative_file.attachments.last
+    end
+
+    describe "#collection" do
+      subject(:collection) { described_class.new.collection }
+
+      let(:empty_attachment) do
+        attach_without_validation(
+          ActiveStorage::Blob.create_and_upload!(io: StringIO.new(''), filename: 'empty.pdf', content_type: 'application/pdf')
+        )
+      end
+
+      let(:filled_attachment) do
+        attach_without_validation(
+          ActiveStorage::Blob.create_and_upload!(io: StringIO.new('x'), filename: 'doc.pdf', content_type: 'application/pdf')
+        )
+      end
+
+      it "sélectionne les pièces vides" do
+        expect(collection).to include(empty_attachment)
+      end
+
+      it "ignore les pièces non vides" do
+        expect(collection).not_to include(filled_attachment)
+      end
+
+      it "ignore les variantes" do
+        empty_attachment.update_column(:record_type, 'ActiveStorage::VariantRecord')
+
+        expect(collection).not_to include(empty_attachment)
+      end
+
+      it "ignore les aperçus PDF" do
+        empty_attachment.update_column(:name, 'preview_image')
+
+        expect(collection).not_to include(empty_attachment)
+      end
+    end
+
+    describe "#process" do
+      let(:attachment) do
+        attach_without_validation(
+          ActiveStorage::Blob.create_and_upload!(io: StringIO.new(''), filename: 'empty.pdf', content_type: 'application/pdf')
+        )
+      end
+
+      it "purge la pièce vide" do
+        perform_enqueued_jobs do
+          described_class.process(attachment)
+        end
+
+        expect(champ.reload.piece_justificative_file).not_to be_attached
+      end
+    end
+  end
+end

--- a/spec/validators/empty_file_validator_spec.rb
+++ b/spec/validators/empty_file_validator_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+describe EmptyFileValidator do
+  def empty_blob(filename: 'empty.pdf')
+    ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(''),
+      filename:,
+      content_type: 'application/pdf'
+    )
+  end
+
+  describe "on a has_many_attached association" do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
+    let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+    let(:champ) { dossier.root_champs_public.first }
+
+    it "rejects an empty file" do
+      champ.piece_justificative_file = [empty_blob]
+
+      expect(champ.valid?(:champ_value)).to be false
+      expect(champ.errors[:piece_justificative_file].join).to include('vide')
+    end
+
+    it "rejects an empty file among valid ones" do
+      champ.piece_justificative_file = [
+        { io: StringIO.new('x'), filename: 'doc.pdf', content_type: 'application/pdf' },
+        empty_blob,
+      ]
+
+      expect(champ.valid?(:champ_value)).to be false
+    end
+
+    it "accepts a file with content" do
+      champ.piece_justificative_file = [
+        { io: StringIO.new('x'), filename: 'doc.pdf', content_type: 'application/pdf' },
+      ]
+
+      expect(champ.valid?(:champ_value)).to be true
+    end
+
+    it "rejects an empty file even when PJ size validation is disabled" do
+      champ.type_de_champ.update(skip_pj_validation: true)
+      champ.piece_justificative_file = [empty_blob]
+
+      expect(champ.valid?(:champ_value)).to be false
+    end
+
+    it "does not run outside the :champ_value context" do
+      champ.piece_justificative_file = [empty_blob]
+
+      expect(champ.valid?).to be true
+    end
+
+    it "prevents the attachment from being persisted through the PJ service" do
+      champ.piece_justificative_file.purge
+
+      expect(Attachment::PieceJustificativeService.attach_champ_pj(champ, empty_blob.signed_id)).to be false
+      expect(champ.reload.piece_justificative_file).not_to be_attached
+    end
+  end
+
+  # An empty attachment committed before this validation existed must not make
+  # its record unsaveable, otherwise the dossier holding it can no longer be
+  # submitted. The purge task cleans those up, and is not a deploy prerequisite.
+  describe "with an empty attachment already in database" do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
+    let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+    let(:champ) { dossier.root_champs_public.first }
+
+    before do
+      champ.piece_justificative_file = [empty_blob]
+      champ.save!(validate: false)
+      champ.reload
+    end
+
+    it "keeps the record valid" do
+      expect(champ.valid?(:champ_value)).to be true
+    end
+
+    it "still rejects a newly added empty file" do
+      champ.piece_justificative_file = champ.piece_justificative_file.blobs + [empty_blob(filename: 'other.pdf')]
+
+      expect(champ.valid?(:champ_value)).to be false
+    end
+
+    it "accepts a newly added file with content" do
+      champ.piece_justificative_file = champ.piece_justificative_file.blobs + [
+        { io: StringIO.new('x'), filename: 'doc.pdf', content_type: 'application/pdf' },
+      ]
+
+      expect(champ.valid?(:champ_value)).to be true
+    end
+  end
+
+  describe "on a has_one_attached association" do
+    let(:avis) { create(:avis) }
+
+    it "rejects an empty file" do
+      avis.introduction_file = empty_blob
+
+      expect(avis).not_to be_valid
+      expect(avis.errors[:introduction_file].join).to include('vide')
+    end
+
+    it "accepts a file with content" do
+      avis.introduction_file = { io: StringIO.new('x'), filename: 'intro.pdf', content_type: 'application/pdf' }
+
+      expect(avis).to be_valid
+    end
+
+    it "accepts a record without any attachment" do
+      expect(avis).to be_valid
+    end
+
+    # #attach on a persisted record saves it right away: the validation still
+    # runs then, because the attachment is only inserted once it passes.
+    it "prevents #attach from replacing a template with an empty file" do
+      tdc = create(:type_de_champ_piece_justificative)
+
+      tdc.piece_justificative_template.attach(empty_blob)
+
+      expect(tdc.reload.piece_justificative_template.blob.filename.to_s).to eq('toto.txt')
+    end
+  end
+end


### PR DESCRIPTION
## Problème

Rien ne validait de taille minimale : toutes les validations de pièces jointes ne posaient qu'une borne supérieure (`size: { less_than: ... }`), côté serveur comme côté client. Un fichier de 0 octet était donc accepté partout. La validation de `content_type` ne le rattrapait pas non plus, puisque le navigateur déduit le type MIME du nom du fichier (un `foo.pdf` vide passe pour un `application/pdf`).

Le résultat est silencieusement cassé : `AttachmentProcessorConcern#process_later` ignore les blobs vides, donc le blob garde le `virus_scan_result` « pending » posé à la création. La pièce reste affichée **« Analyse antivirus en cours… »** indéfiniment, ni visualisable ni téléchargeable, sans aucun message expliquant pourquoi.

## Correction

- `EmptyFileValidator`, appliqué à toutes les pièces jointes déjà validées (PJ de champ, messagerie, avis, logo/signature d'attestation, signature de groupe, logo/notice/délibération de démarche, modèles de PJ).
- Vérification côté client sur les deux chemins d'envoi (`autosave_controller` pour le message d'erreur DSFR en amont, `uploader` pour le garde-fou), afin que l'usager ait un retour immédiat.
- Tâche de maintenance qui nettoie les pièces vides déjà en base.

Seuls les blobs attachés par la sauvegarde en cours sont refusés. Une pièce vide déjà enregistrée est antérieure à la validation : la signaler rendrait son enregistrement insauvegardable — un usager ne pourrait plus déposer son dossier. La tâche de maintenance n'est donc **pas** un prérequis de déploiement, elle peut être lancée à la main quand c'est commode.

## Au passage

Trois bugs latents que cette validation a rendus visibles :

- `Attachment::PieceJustificativeService` s'appuyait sur `updated_by` pour garder l'enregistrement *dirty* et différer la sauvegarde. Or réassigner la valeur déjà en base ne salit pas l'enregistrement : lors d'un second envoi par le même usager, `#attach` sauvegardait immédiatement et **contournait les validations `:champ_value`** (taille, type de contenu). On assigne désormais les blobs, ce qui ne sauvegarde jamais, et on laisse le `save(context: :champ_value)` explicite valider.
- `Administrateurs::TypesDeChampController` affichait `@champ.errors` dans la branche d'échec de ses deux actions d'attachement, alors que cet ivar n'existe pas dans ce contrôleur : tout envoi refusé levait un `NoMethodError` sur `nil` au lieu de renvoyer un 422 explicite. La branche était inatteignable jusqu'ici.
- La fixture `spec/fixtures/files/file.pdf` faisait 0 octet alors qu'une dizaine de specs l'utilisent comme un PDF ordinaire. Remplacée par un PDF d'une page minimal mais valide (346 octets).

## Tests

- `spec/validators/empty_file_validator_spec.rb` — `has_many_attached` et `has_one_attached`, contexte de validation, exemption des pièces déjà en base, et non-persistance via le service comme via `#attach`.
- `spec/tasks/maintenance/t20260728_purge_empty_attachments_task_spec.rb`
- Nouveau scénario dans `spec/system/users/piece_justificative_drag_drop_spec.rb` pour le refus côté client, et dans `types_de_champ_controller_spec.rb` pour le 422 côté administrateur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)