### PR TITLE
Tech : stocker les tsvector des dossiers pour rendre la recherche plein texte performante

### DIFF
--- a/app/models/concerns/dossier_searchable_concern.rb
+++ b/app/models/concerns/dossier_searchable_concern.rb
@@ -28,8 +28,20 @@ module DossierSearchableConcern
 
     private_search_terms = root_champs_private.flat_map(&:search_terms).compact_blank.join(' ')
 
-    sql = "UPDATE dossiers SET search_terms = :search_terms, private_search_terms = :private_search_terms WHERE id = :id"
-    sanitized_sql = self.class.sanitize_sql_array([sql, search_terms:, private_search_terms:, id:])
+    # Mirrors the `search_terms || ' ' || private_search_terms` expression the
+    # annotations index is built on: `to_tsquery` ANDs its terms, so a query
+    # spanning the public and private parts must see them as one document.
+    all_search_terms = "#{search_terms} #{private_search_terms}"
+
+    sql = <<~SQL.squish
+      UPDATE dossiers SET
+        search_terms = :search_terms,
+        private_search_terms = :private_search_terms,
+        search_terms_tsvector = to_tsvector('french_unaccent', :search_terms),
+        all_search_terms_tsvector = to_tsvector('french_unaccent', :all_search_terms)
+      WHERE id = :id
+    SQL
+    sanitized_sql = self.class.sanitize_sql_array([sql, search_terms:, private_search_terms:, all_search_terms:, id:])
     self.class.connection.execute(sanitized_sql)
   end
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class Dossier < ApplicationRecord
-  self.ignored_columns += [:search_terms, :private_search_terms, :editing_fork_origin_id, :last_champ_piece_jointe_updated_at]
+  # The search columns are only ever read and written as raw SQL: loading them as
+  # attributes would carry a full-text blob on every dossier instance.
+  self.ignored_columns += [:search_terms, :private_search_terms, :search_terms_tsvector, :all_search_terms_tsvector, :editing_fork_origin_id, :last_champ_piece_jointe_updated_at]
 
   include DossierCloneConcern
   include DossierCorrectableConcern

--- a/app/services/dossier_search_service.rb
+++ b/app/services/dossier_search_service.rb
@@ -42,10 +42,44 @@ class DossierSearchService
   end
 
   def self.dossier_by_full_text(dossiers, search_terms, with_annotations: false)
-    columns = with_annotations ? 'dossiers.search_terms || \' \' || dossiers.private_search_terms' : 'dossiers.search_terms'
+    if Flipper.enabled?(:search_terms_tsvector)
+      dossier_by_stored_tsvector(dossiers, search_terms, with_annotations)
+    else
+      dossier_by_tsvector_expression(dossiers, search_terms, with_annotations)
+    end
+  end
 
-    ts_vector = "to_tsvector('french_unaccent', #{columns})"
+  # The tsquery is rebuilt in each branch rather than passed in: Brakeman only
+  # tracks the quoting within a method, and flags the interpolation otherwise.
+  #
+  # Ranking reads a precomputed column, so it is cheap enough to order the whole
+  # match set: the cap now keeps the *best* MAX_RESULTS rather than an arbitrary
+  # slice. Sorting also removes the early-exit plan a bare LIMIT invited, where
+  # the planner walked the instructeur scope hoping to fill the limit instead of
+  # using the GIN index — which is what made the capped query time out (RAILS-MC2).
+  def self.dossier_by_stored_tsvector(dossiers, search_terms, with_annotations)
     ts_query = "to_tsquery('french_unaccent', #{Dossier.connection.quote(to_tsquery(search_terms))})"
+    ts_vector = with_annotations ? 'dossiers.all_search_terms_tsvector' : 'dossiers.search_terms_tsvector'
+    rank = Arel.sql("COALESCE(ts_rank(#{ts_vector}, #{ts_query}), 0) DESC")
+
+    matching_ids = dossiers
+      .where("#{ts_vector} @@ #{ts_query}")
+      .order(rank)
+      .limit(MAX_RESULTS)
+      .ids
+
+    dossiers
+      .where(id: matching_ids)
+      .order(rank)
+  end
+
+  # Legacy path: ts_rank recomputes the tsvector for every row, so the match set
+  # has to be capped *before* ranking (RAILS-K81). Dropped, along with the two
+  # expression indexes, once :search_terms_tsvector is permanently on.
+  def self.dossier_by_tsvector_expression(dossiers, search_terms, with_annotations)
+    ts_query = "to_tsquery('french_unaccent', #{Dossier.connection.quote(to_tsquery(search_terms))})"
+    columns = with_annotations ? "dossiers.search_terms || ' ' || dossiers.private_search_terms" : 'dossiers.search_terms'
+    ts_vector = "to_tsvector('french_unaccent', #{columns})"
 
     matching_ids = dossiers
       .where("#{ts_vector} @@ #{ts_query}")

--- a/app/tasks/maintenance/t20260728_backfill_search_terms_tsvector_task.rb
+++ b/app/tasks/maintenance/t20260728_backfill_search_terms_tsvector_task.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260728BackfillSearchTermsTsvectorTask < MaintenanceTasks::Task
+    # Backfill the stored tsvector columns added by
+    # AddSearchTermsTsvectorToDossiers.
+    #
+    # Computed entirely in SQL from the existing text columns, so no champ,
+    # etablissement or individual is reloaded: each batch is a single UPDATE.
+    # Rows whose text columns were never populated end up with an empty tsvector
+    # rather than NULL, which matches nothing — same as before — and keeps them
+    # out of the collection on a rerun.
+    #
+    # Run this to completion before enabling the :search_terms_tsvector flag:
+    # until then the search still reads the expression indexes.
+
+    BATCH_SIZE = 1_000
+
+    def collection
+      Dossier
+        .where(search_terms_tsvector: nil)
+        .in_batches(of: BATCH_SIZE)
+    end
+
+    def process(batch)
+      batch.update_all(<<~SQL.squish)
+        search_terms_tsvector =
+          to_tsvector('french_unaccent', COALESCE(search_terms, '')),
+        all_search_terms_tsvector =
+          to_tsvector('french_unaccent', COALESCE(search_terms, '') || ' ' || COALESCE(private_search_terms, ''))
+      SQL
+    end
+  end
+end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -40,6 +40,8 @@ features = [
   :api_entreprise_tva_job,
   :usager_dossiers_alert_filters,
   :s3_storage,
+  # Enable only once T20260728BackfillSearchTermsTsvectorTask has completed.
+  :search_terms_tsvector,
 ]
 
 def database_exists?

--- a/db/migrate/20260728120000_add_search_terms_tsvector_to_dossiers.rb
+++ b/db/migrate/20260728120000_add_search_terms_tsvector_to_dossiers.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Stored tsvector columns for the instructeur/expert full-text search.
+#
+# The search filters and ranks on expression indexes over
+# `to_tsvector('french_unaccent', search_terms [|| private_search_terms])`. The
+# GIN indexes serve the `@@` filter, but `ts_rank` cannot use them: it recomputes
+# the tsvector for every candidate row, so ranking a large match set times out
+# (RAILS-K81). Capping the match set before ranking only moved the timeout into
+# the capped query itself (RAILS-MC2). Storing the tsvector lets ranking read a
+# precomputed value instead.
+#
+# Two columns, mirroring the two existing expression indexes rather than
+# splitting public/private: `to_tsquery` builds an AND of prefixes, so a query
+# whose terms span the public and private parts matches the concatenation but
+# neither part alone. `all_search_terms_tsvector` keeps that behaviour.
+#
+# Nullable, and deliberately not GENERATED ... STORED: a generated column would
+# rewrite this very large table under an ACCESS EXCLUSIVE lock. Maintained going
+# forward by DossierSearchableConcern#index_search_terms and backfilled by
+# Maintenance::T20260728BackfillSearchTermsTsvectorTask.
+class AddSearchTermsTsvectorToDossiers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :dossiers, :search_terms_tsvector, :tsvector
+    add_column :dossiers, :all_search_terms_tsvector, :tsvector
+  end
+end

--- a/db/migrate/20260728120001_add_search_terms_tsvector_indexes_to_dossiers.rb
+++ b/db/migrate/20260728120001_add_search_terms_tsvector_indexes_to_dossiers.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# GIN indexes on the stored tsvector columns added by
+# AddSearchTermsTsvectorToDossiers.
+#
+# These replace index_dossiers_on_search_terms and
+# index_dossiers_on_search_terms_private_search_terms, which stay in place until
+# the backfill has completed and the :search_terms_tsvector flag has been on long
+# enough to be trusted — dropping them is a follow-up.
+class AddSearchTermsTsvectorIndexesToDossiers < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :dossiers, :search_terms_tsvector,
+              using: :gin,
+              name: :index_dossiers_on_search_terms_tsvector,
+              algorithm: :concurrently,
+              if_not_exists: true
+
+    add_index :dossiers, :all_search_terms_tsvector,
+              using: :gin,
+              name: :index_dossiers_on_all_search_terms_tsvector,
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_27_220100) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_28_120001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -515,6 +515,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_27_220100) do
 
   create_table "dossiers", id: :serial, force: :cascade do |t|
     t.date "accuse_lecture_agreement_at"
+    t.tsvector "all_search_terms_tsvector"
     t.string "api_entreprise_job_exceptions", array: true
     t.boolean "archived", default: false
     t.datetime "archived_at", precision: nil
@@ -560,6 +561,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_27_220100) do
     t.datetime "processed_at", precision: nil
     t.bigint "revision_id"
     t.string "search_terms"
+    t.tsvector "search_terms_tsvector"
     t.string "state"
     t.bigint "submitted_revision_id"
     t.boolean "submitted_with_france_connect", default: false, null: false
@@ -571,6 +573,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_27_220100) do
     t.integer "user_id"
     t.index "to_tsvector('french_unaccent'::regconfig, (((search_terms)::text || ' '::text) || (private_search_terms)::text))", name: "index_dossiers_on_search_terms_private_search_terms", using: :gin
     t.index "to_tsvector('french_unaccent'::regconfig, (search_terms)::text)", name: "index_dossiers_on_search_terms", using: :gin
+    t.index ["all_search_terms_tsvector"], name: "index_dossiers_on_all_search_terms_tsvector", using: :gin
     t.index ["archived"], name: "index_dossiers_on_archived"
     t.index ["batch_operation_id"], name: "index_dossiers_on_batch_operation_id"
     t.index ["depose_at", "id"], name: "index_dossiers_on_depose_at_and_id", where: "((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL))"
@@ -584,6 +587,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_27_220100) do
     t.index ["prefill_token"], name: "index_dossiers_on_prefill_token", unique: true
     t.index ["revision_id"], name: "index_dossiers_on_revision_id"
     t.index ["revision_id"], name: "index_dossiers_stalled_declarative", where: "(((state)::text = 'en_construction'::text) AND (declarative_triggered_at IS NULL))"
+    t.index ["search_terms_tsvector"], name: "index_dossiers_on_search_terms_tsvector", using: :gin
     t.index ["state"], name: "index_dossiers_on_state"
     t.index ["updated_at", "id"], name: "index_dossiers_on_updated_at_and_id", where: "((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL))"
     t.index ["user_id"], name: "index_dossiers_on_user_id"

--- a/spec/models/concerns/dossier_searchable_concern_spec.rb
+++ b/spec/models/concerns/dossier_searchable_concern_spec.rb
@@ -28,6 +28,28 @@ describe DossierSearchableConcern do
       expect(result["private_search_terms"]).to eq('champ privé')
     end
 
+    it "stores the tsvector columns alongside the text" do
+      champ_public.update_attribute(:value, "champ public")
+      champ_private.update_attribute(:value, "champ privé")
+      perform_enqueued_jobs(only: DossierIndexSearchTermsJob)
+
+      matching = Dossier.connection.select_one(
+        Dossier.sanitize_sql_array([<<~SQL.squish, id: dossier.id])
+          SELECT
+            search_terms_tsvector @@ to_tsquery('french_unaccent', 'public:*') AS public_match,
+            search_terms_tsvector @@ to_tsquery('french_unaccent', 'prive:*') AS private_leaked,
+            all_search_terms_tsvector @@ to_tsquery('french_unaccent', 'public:* & prive:*') AS spanning_match
+          FROM dossiers WHERE id = :id
+        SQL
+      )
+
+      expect(matching["public_match"]).to be(true)
+      # annotations must not leak into the default search vector
+      expect(matching["private_leaked"]).to be(false)
+      # ...but a query spanning both parts matches the combined vector
+      expect(matching["spanning_match"]).to be(true)
+    end
+
     context 'with an update' do
       before do
         stub_const("DossierSearchableConcern::SEARCH_TERMS_DEBOUNCE_LIGHT_USER", 1.second)

--- a/spec/services/dossier_search_service_spec.rb
+++ b/spec/services/dossier_search_service_spec.rb
@@ -37,6 +37,9 @@ describe DossierSearchService do
         expect(searching('annotations')).to eq([])
         # but can be searched with the with_annotations option
         expect(searching('annotations', with_annotations: true)).to eq([dossier.id])
+        # terms are ANDed across the public and private parts, which only works
+        # if both are indexed as a single document
+        expect(searching('pommes annotations', with_annotations: true)).to eq([dossier.id])
 
         # by email
         expect(searching('nicolas@email.com')).to eq([dossier.id])
@@ -95,6 +98,42 @@ describe DossierSearchService do
       before { stub_const('DossierSearchService::MAX_RESULTS', 1) }
 
       it { expect(searching('martin').size).to eq(1) }
+    end
+
+    # The stored columns replace the to_tsvector(...) expression indexes; the two
+    # paths coexist behind the flag until the backfill is done, so they have to
+    # return the same thing.
+    describe 'with the stored tsvector columns' do
+      let(:user) { create(:user, email: 'nicolas@email.com') }
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text }], types_de_champ_private: [{ type: :text }]) }
+      let(:dossier) do
+        create(:dossier, procedure:, state: :en_construction, user:).tap do |dossier|
+          dossier.root_champs_public.first.update!(value: 'Hélène mange des pommes')
+          dossier.root_champs_private.first.update!(value: 'annotations')
+        end
+      end
+
+      before { Flipper.enable(:search_terms_tsvector) }
+      after { Flipper.disable(:search_terms_tsvector) }
+
+      it do
+        expect(searching('')).to eq([])
+
+        expect(searching('nicolas')).to eq([dossier.id])
+        expect(searching('helene')).to eq([dossier.id])
+        expect(searching('la pomme')).to eq([dossier.id])
+
+        expect(searching('annotations')).to eq([])
+        expect(searching('annotations', with_annotations: true)).to eq([dossier.id])
+        expect(searching('pommes annotations', with_annotations: true)).to eq([dossier.id])
+      end
+
+      it 'ignores dossiers whose tsvector has not been backfilled yet' do
+        dossier
+        Dossier.where(id: dossier.id).update_all(search_terms_tsvector: nil, all_search_terms_tsvector: nil)
+
+        expect(searching('nicolas')).to eq([])
+      end
     end
   end
 

--- a/spec/tasks/maintenance/t20260728_backfill_search_terms_tsvector_task_spec.rb
+++ b/spec/tasks/maintenance/t20260728_backfill_search_terms_tsvector_task_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260728BackfillSearchTermsTsvectorTask do
+    let(:dossier) { create(:dossier, state: :en_construction) }
+
+    # Simulate a row indexed before the tsvector columns existed.
+    def clear_tsvectors!(text: 'Hélène pommes', private_text: 'annotations')
+      Dossier.where(id: dossier.id).update_all(
+        Dossier.sanitize_sql_array([
+          "search_terms = :text, private_search_terms = :private_text, search_terms_tsvector = NULL, all_search_terms_tsvector = NULL",
+          text:, private_text:,
+        ])
+      )
+    end
+
+    def collected?
+      described_class.new.collection.any? { _1.ids.include?(dossier.id) }
+    end
+
+    def backfill!
+      described_class.new.process(Dossier.where(id: dossier.id))
+    end
+
+    def match?(column, query)
+      Dossier.connection.select_value(
+        Dossier.sanitize_sql_array([
+          "SELECT #{column} @@ to_tsquery('french_unaccent', :query) FROM dossiers WHERE id = :id",
+          query:, id: dossier.id,
+        ])
+      )
+    end
+
+    describe "#collection" do
+      it "only picks up rows without a stored tsvector" do
+        perform_enqueued_jobs(only: DossierIndexSearchTermsJob)
+        expect(collected?).to be(false)
+
+        clear_tsvectors!
+        expect(collected?).to be(true)
+      end
+    end
+
+    describe "#process" do
+      it "computes both vectors from the text columns" do
+        clear_tsvectors!
+        backfill!
+
+        expect(match?('search_terms_tsvector', 'helene:*')).to be(true)
+        # annotations stay out of the default vector
+        expect(match?('search_terms_tsvector', 'annotations:*')).to be(false)
+        # and the combined vector matches terms spanning both parts
+        expect(match?('all_search_terms_tsvector', 'pommes:* & annotations:*')).to be(true)
+      end
+
+      it "leaves never-indexed rows with an empty vector rather than NULL" do
+        Dossier.where(id: dossier.id).update_all(
+          "search_terms = NULL, private_search_terms = NULL, search_terms_tsvector = NULL, all_search_terms_tsvector = NULL"
+        )
+        backfill!
+
+        expect(collected?).to be(false)
+        expect(match?('search_terms_tsvector', 'helene:*')).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implémente #13524.

## Contexte

`ts_rank` ne peut pas s'appuyer sur les index GIN d'expression : Postgres recalcule `to_tsvector(...)` pour **chaque ligne** au moment du classement, donc classer un large ensemble de résultats dépasse le `statement_timeout` ([RAILS-K81](https://demarches-simplifiees.sentry.io/issues/RAILS-K81)).

Le plafonnement mis en place en mitigation n'a fait que **déplacer** le timeout dans la requête plafonnée elle-même : [RAILS-MC2](https://demarches-simplifiees.sentry.io/issues/RAILS-MC2) est apparu 9 minutes après le déploiement du correctif, même endpoint, même exception, 34 instructeurs en 4 jours.

## Correction

Deux colonnes `tsvector` stockées, maintenues dans l'UPDATE qui écrit déjà les colonnes texte (coût marginal, calcul en SQL depuis les binds déjà disponibles). Le classement lit une valeur précalculée.

Le classement passe **à l'intérieur** de la requête plafonnée : le plafond garde désormais les *meilleurs* résultats et non une tranche arbitraire, et le tri supprime le plan « early-exit » qu'un simple LIMIT encourageait — c'est ce plan qui faisait scanner tout le périmètre instructeur au lieu d'utiliser l'index GIN.

## Écart assumé par rapport à l'issue

L'issue proposait `search_terms_tsvector @@ q OR private_search_terms_tsvector @@ q`. **Cela régresserait la recherche multi-termes** : `to_tsquery` construit un ET de préfixes, donc « Dupont 75001 » avec *Dupont* dans un champ public et *75001* en annotation privée correspond aujourd'hui à l'index concaténé, mais à aucune des deux colonnes prise isolément.

Les colonnes stockées reprennent donc exactement la topologie des deux index existants (`search_terms_tsvector` et `all_search_terms_tsvector`). Une assertion le couvre :

```ruby
expect(searching('pommes annotations', with_annotations: true)).to eq([dossier.id])
```

## Déploiement

Rien ne change à la livraison : le flag `:search_terms_tsvector` est désactivé, la recherche continue d'utiliser les index d'expression.

1. Livrer.
2. Lancer `T20260728BackfillSearchTermsTsvectorTask` jusqu'au bout.
3. Activer le flag, surveiller RAILS-MC2.
4. PR de suivi : supprimer la branche historique et les deux index d'expression.

Le flag ne sert qu'au rollback immédiat (la sécurité vis-à-vis du backfill vient du séquencement) — il est destiné à être retiré rapidement.

## À vérifier au moment de la bascule

Un `EXPLAIN (ANALYZE, BUFFERS)` en production avant d'activer le flag : le diagnostic du plan « early-exit » est déduit du code et du schéma, pas mesuré sur les données réelles.

## Tests

`104 examples, 0 failures` (recherche, indexation, backfill, contrôleur, filtres usager). Les deux migrations ont été rejouées sur une base vierge depuis le schéma précédent.

Ref #13524