### PR TITLE
Tech : nettoyer et documenter la liste d'exclusions Brakeman

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ demarche.numerique.gouv.fr (formerly demarches-simplifiees.fr) is a French gover
 ### Linting & Code Quality
 - `bin/rake lint` - Run all linters (Rubocop, haml-lint, herb linter/formatter, i18n-tasks, Brakeman, ESLint, TypeScript, CSS)
 - `bin/rake lint:ruby` / `lint:js` / `lint:security` - Run one group only (CI runs the three in parallel jobs; `lint:security` is Brakeman, by far the slowest)
+- Brakeman options live in `config/brakeman.yml` (auto-loaded, so a bare `brakeman` matches CI). Every entry in `config/brakeman.ignore` must carry a note saying why the warning is not exploitable, and entries that no longer match any code must be deleted — `lint:security` fails on either.
 - `bundle exec rubocop --parallel` - Ruby linting
 - `bun lint:js` - JavaScript linting
 - `bun lint:types` - TypeScript type checking

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -21,26 +21,7 @@
       "cwe_id": [
         502
       ],
-      "note": ""
-    },
-    {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 122,
-      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
-      "check_name": "EOLRails",
-      "message": "Support for Rails 7.2.3.1 ends on 2026-08-09",
-      "file": "Gemfile.lock",
-      "line": 640,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Weak",
-      "cwe_id": [
-        1104
-      ],
-      "note": ""
+      "note": "Disaster-recovery tooling run by hand from a console. The dump is produced by Recovery::RevisionExporter and read from a developer-supplied path, never from user input."
     },
     {
       "warning_type": "SQL Injection",
@@ -63,7 +44,7 @@
       "cwe_id": [
         89
       ],
-      "note": ""
+      "note": "Interpolates only literals: order_column is :updated_at, and order_table is overridden per connection with a hardcoded table name (:dossiers, :deleted_dossiers) or raises. The cursor values decoded from the request are passed as bind parameters."
     },
     {
       "warning_type": "SQL Injection",
@@ -86,7 +67,7 @@
       "cwe_id": [
         89
       ],
-      "note": ""
+      "note": "timeout is a literal written in the maintenance task itself (\"5min\", \"15min\", \"0\"), never user input. SET LOCAL does not accept a bind parameter."
     },
     {
       "warning_type": "Remote Code Execution",
@@ -109,7 +90,7 @@
       "cwe_id": [
         502
       ],
-      "note": ""
+      "note": "Disaster-recovery tooling run by hand from a console. The dump is produced by Recovery::Exporter and read from a developer-supplied path (FILE_PATH by default), never from user input."
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -143,7 +124,7 @@
       "cwe_id": [
         79
       ],
-      "note": "Theses params are not rendered"
+      "note": "The params only pick a key out of the path allowlist FAQsLoaderService builds from the repo; an unknown key raises KeyError, which the controller turns into a 404. The rendered markdown comes from files in the repo, not from the request."
     },
     {
       "warning_type": "SQL Injection",
@@ -166,7 +147,7 @@
       "cwe_id": [
         89
       ],
-      "note": ""
+      "note": "Interpolates only literals: order_column is :updated_at, and order_table is overridden per connection with a hardcoded table name (:dossiers, :deleted_dossiers) or raises. The cursor values decoded from the request are passed as bind parameters."
     },
     {
       "warning_type": "SQL Injection",

--- a/config/brakeman.yml
+++ b/config/brakeman.yml
@@ -1,0 +1,12 @@
+---
+# Brakeman picks this file up automatically, so a bare `brakeman` run behaves
+# the same as CI (`rake lint:security`) and as a local `bin/rake lint`.
+#
+# Every entry in config/brakeman.ignore must carry a note explaining why the
+# warning is not exploitable, and entries that no longer match any code must be
+# removed. Both are enforced rather than advisory: an ignore file nobody prunes
+# ends up silencing checks that have since become relevant, and an ignore
+# without a rationale cannot be reviewed — the reader has to redo the analysis
+# to find out whether it was ever justified.
+:ensure_ignore_notes: true
+:ensure_no_obsolete_ignore_entries: true


### PR DESCRIPTION
Repéré en marge de #13597 : `config/brakeman.ignore` avait dérivé.

## Ce qui n'allait pas

- **Une entrée obsolète** : la fin de support de Rails 7.2.3.1, qui ne correspond plus à rien depuis le passage à Rails 8.0. Brakeman la signalait à chaque exécution sans faire échouer le job, donc personne ne la voyait.
- **Six entrées sur huit sans note.** Une exclusion sans justification n'est pas relisable : il faut refaire l'analyse pour savoir si elle était fondée un jour.

## Ce que fait cette PR

Suppression de l'entrée obsolète, et rédaction d'une note pour chaque exclusion restante **après vérification du code concerné** :

| Fichier | Pourquoi ce n'est pas exploitable |
|---|---|
| `recovery/{importer,revision_importer}.rb` | `Marshal.load` lit un dump produit par l'exporteur correspondant, depuis un chemin fourni par un développeur, lancé à la main depuis une console |
| `connections/cursor_connection.rb` (×2) | n'interpole que des littéraux — `order_column` vaut `:updated_at`, `order_table` est un symbole codé en dur par connection (`:dossiers`, `:deleted_dossiers`) ou lève ; les valeurs du curseur issues de la requête passent en paramètres liés |
| `statements_helpers_concern.rb` | le timeout est un littéral écrit dans la tâche de maintenance (`"5min"`…), et `SET LOCAL` n'accepte pas de paramètre lié |
| `faq/show.html.haml` | les params ne servent qu'à choisir une clé dans la liste blanche construite par `FAQsLoaderService` depuis le dépôt ; une clé inconnue lève `KeyError` → 404 |

La note existante de `faq/show` (« Theses params are not rendered ») était exacte mais ne disait pas la bonne chose : ce qui protège ici, c'est la liste blanche, pas le fait que les params ne soient pas rendus.

`dossier_filtering_concern.rb` avait déjà une note correcte, laissée telle quelle.

## Pour que ça ne redérive pas

Ajout de `config/brakeman.yml` :

```yaml
:ensure_ignore_notes: true
:ensure_no_obsolete_ignore_entries: true
```

Brakeman charge ce fichier automatiquement, donc un `brakeman` nu se comporte désormais comme `rake lint:security` et comme la CI — pas de divergence entre local et CI.

Les deux garde-fous ont été vérifiés en les déclenchant volontairement : note vidée → sortie 8, empreinte bidon → sortie 9, état propre → sortie 0.

## Vérification

`Security Warnings: 0`, `Ignored Warnings: 7`, aucune entrée obsolète.

Aucun changement de code applicatif.