### PR TITLE
ETQ instructeur, lancer une action de masse sans sélection ne provoque plus d'erreur

### DIFF
--- a/app/controllers/instructeurs/batch_operations_controller.rb
+++ b/app/controllers/instructeurs/batch_operations_controller.rb
@@ -41,9 +41,7 @@ module Instructeurs
       respond_to do |format|
         format.turbo_stream do
           if batch.nil?
-            @ids = Array(params.dig(:batch_operation, :dossier_ids)).flat_map do |value|
-              value.is_a?(String) ? value.split(',') : value
-            end.compact_blank
+            @ids = submitted_dossier_ids
 
             render turbo_stream: turbo_stream.replace("modal-avis-batch-form", partial: "shared/avis/form_wrapper",
               locals: {
@@ -115,8 +113,16 @@ module Instructeurs
     def batch_operation_params
       params.require(:batch_operation)
         .permit(:operation, :motivation, :justificatif_motivation, dossier_ids: [])
-        .merge(dossier_ids: params['batch_operation']['dossier_ids'].join(',').split(',').uniq)
+        .merge(dossier_ids: submitted_dossier_ids)
         .merge(instructeur: current_instructeur)
+    end
+
+    # The form sends either a list of ids, or a list of comma-joined ids — and
+    # nothing at all when no dossier is selected.
+    def submitted_dossier_ids
+      Array(params.dig(:batch_operation, :dossier_ids)).flat_map do |value|
+        value.is_a?(String) ? value.split(',') : value
+      end.compact_blank.uniq
     end
 
     def batch_operation_avis_params
@@ -174,9 +180,7 @@ module Instructeurs
     end
 
     def render_commentaire_form_with_errors(commentaire)
-      @ids = Array(params.dig(:batch_operation, :dossier_ids)).flat_map do |value|
-        value.is_a?(String) ? value.split(',') : value
-      end.compact_blank
+      @ids = submitted_dossier_ids
 
       render turbo_stream: turbo_stream.replace("modal-commentaire-batch-form",
         partial: "instructeurs/batch_operations/commentaire_form",

--- a/spec/controllers/instructeurs/batch_operations_controller_spec.rb
+++ b/spec/controllers/instructeurs/batch_operations_controller_spec.rb
@@ -58,6 +58,40 @@ describe Instructeurs::BatchOperationsController, type: :controller do
         expect(flash.alert).to eq("Le traitement de masse n’a pas été lancé. Vérifiez que l’action demandée est possible pour les dossiers sélectionnés")
       end
     end
+
+    context 'when no dossier is selected' do
+      let(:params) do
+        {
+          procedure_id: procedure.id,
+          batch_operation: { operation: BatchOperation.operations.fetch(:archiver) },
+          statut: 'a-suivre',
+        }
+      end
+
+      it 'does not create a batch operation and warns the instructeur' do
+        expect { subject }.not_to change { instructeur.batch_operations.count }
+        expect(flash.alert).to eq("Le traitement de masse n’a pas été lancé. Vérifiez que l’action demandée est possible pour les dossiers sélectionnés")
+      end
+    end
+
+    context 'when dossier_ids are sent as comma-joined strings' do
+      let(:other_dossier) { create(:dossier, :accepte, :with_individual, procedure: procedure) }
+      let(:params) do
+        {
+          procedure_id: procedure.id,
+          batch_operation: {
+            operation: BatchOperation.operations.fetch(:archiver),
+            dossier_ids: ["#{dossier.id},#{other_dossier.id}", dossier.id.to_s],
+          },
+          statut: 'a-suivre',
+        }
+      end
+
+      it 'splits and deduplicates them' do
+        expect { subject }.to change { instructeur.batch_operations.count }.by(1)
+        expect(BatchOperation.first.dossiers).to contain_exactly(dossier, other_dossier)
+      end
+    end
   end
 
   describe '#POST create_batch_commentaire' do


### PR DESCRIPTION
## Contexte

Sentry [RAILS-M6X](https://demarches-simplifiees.sentry.io/issues/RAILS-M6X) : 66 événements / 33 instructeurs, toujours actif.

`batch_operation_params` lisait `params['batch_operation']['dossier_ids']` sans garde. Quand l'instructeur soumet le formulaire d'action de masse sans avoir coché de dossier, la clé est absente et `.join` lève un `NoMethodError` — donc une 500.

`BatchOperation.safe_create!` retourne déjà `nil` sur une sélection vide, et le contrôleur sait afficher l'alerte « Le traitement de masse n'a pas été lancé… » dans ce cas : il suffisait que le paramètre survive jusque-là.

## Correction

La normalisation des `dossier_ids` (liste d'identifiants **ou** liste de chaînes séparées par des virgules) était déjà écrite deux fois dans ce même contrôleur, sous une forme qui tolère l'absence de clé. Elle est extraite en `submitted_dossier_ids` et utilisée aux trois endroits.

Effet de bord assumé : les deux appels existants gagnent le `.uniq` qu'ils n'avaient pas — dédupliquer la liste réaffichée dans le formulaire est le comportement attendu.

## Tests

Deux exemples ajoutés dans le spec du contrôleur : soumission sans aucun dossier sélectionné (vérifié comme reproduisant le `NoMethodError` avant correctif), et identifiants envoyés en chaînes séparées par des virgules avec doublon.