### PR TITLE
Tech : ne plus remonter dans Sentry les dates invalides envoyées à l'API GraphQL

### DIFF
--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -164,6 +164,12 @@ class API::V2::Schema < GraphQL::Schema
       raise GraphQL::ExecutionError.new(error.message, extensions: { code: :bad_request })
     end
 
+    # An unparsable Date argument (e.g. free text sent to an annotation date) is a client
+    # input error too, and the default handler already turns it into a proper validation
+    # error for the client. Only the Sentry report is wrong: the message embeds the
+    # offending value, so one defect was split into a new issue per distinct bad date.
+    return super if error.is_a?(GraphQL::DateEncodingError)
+
     # Capture type errors in Sentry. Thouse errors are our responsability and usually linked to
     # instances of "bad data".
     if error.is_a?(GraphQL::InvalidNullError)

--- a/spec/graphql/api/v2/schema_spec.rb
+++ b/spec/graphql/api/v2/schema_spec.rb
@@ -52,6 +52,35 @@ RSpec.describe API::V2::Schema do
       expect(result['errors'].map { _1['message'] }.join).to match(/complexity/i)
     end
   end
+
+  # A client sending free text to a Date argument gets a proper validation error from
+  # graphql-ruby on its own. Reporting it to Sentry on top of that was pure noise, and
+  # since GraphQL::DateEncodingError embeds the offending value in its message, Sentry
+  # split one defect into a new issue per distinct bad date.
+  describe 'unparsable Date argument' do
+    # Argument coercion runs before `authorized?` and `resolve`, so nothing referenced
+    # here has to exist.
+    let(:mutation) do
+      <<~GRAPHQL
+        mutation($value: ISO8601Date!) {
+          dossierModifierAnnotationDate(input: {
+            dossierId: "RG9zc2llci0x", instructeurId: "SW5zdHJ1Y3RldXItMQ==",
+            annotationId: "Q2hhbXAtMQ==", value: $value
+          }) { clientMutationId }
+        }
+      GRAPHQL
+    end
+
+    subject do
+      described_class.execute(query: mutation, variables: { 'value' => '31 août 2000' }, context: { internal_use: false })
+    end
+
+    it 'reports nothing to Sentry and still returns a validation error to the client' do
+      expect(Sentry).not_to receive(:capture_exception)
+      expect(subject['data']).to be_nil
+      expect(subject['errors'].map { _1['message'] }.join).to match(/provided invalid value/)
+    end
+  end
 end
 
 RSpec.describe API::V2::Schema::Timeout do


### PR DESCRIPTION
## Contexte

Sentry [RAILS-MCN](https://demarches-simplifiees.sentry.io/issues/RAILS-MCN), [RAILS-MCM](https://demarches-simplifiees.sentry.io/issues/RAILS-MCM), [RAILS-MCK](https://demarches-simplifiees.sentry.io/issues/RAILS-MCK), [RAILS-MCH](https://demarches-simplifiees.sentry.io/issues/RAILS-MCH), [RAILS-MC8](https://demarches-simplifiees.sentry.io/issues/RAILS-MC8), [RAILS-MC7](https://demarches-simplifiees.sentry.io/issues/RAILS-MC7) — et les suivantes : **dix issues distinctes en trois jours**, toutes des `GraphQL::DateEncodingError`.

Un client envoie du texte libre là où une `ISO8601Date` est attendue (`dossierModifierAnnotationDate`, `dossierModifierAnnotations(date:)`, `demarcheModifierParametres(dateLimite:)`). Vu les valeurs (« 31 août 2000 », « 03‑07‑2026 (requête) – 16‑07‑2026 (mémoire complémentaire) ; … »), l'intégration semble alimentée par un LLM.

**Ce n'est pas une 500.** Vérifié en reproduction : le `type_error` par défaut de graphql-ruby renvoie `nil` pour cette erreur, et la couche de validation produit déjà un message correct côté client — `argumentLiteralsIncompatible` pour un littéral inline, « provided invalid value » pour une variable. Le seul comportement fautif est notre `Sentry.capture_exception` sur la branche générique de `type_error`.

Comme le message de `DateEncodingError` embarque la valeur fautive, Sentry découpe un même défaut en une nouvelle issue par date invalide — d'où le bruit.

## Correction

`type_error` délègue à `super` pour `GraphQL::DateEncodingError` sans le remonter, exactement comme l'`IntegerDecodingError` juste au-dessus est traité comme une erreur d'entrée client. Les deux messages rendus au client sont inchangés (vérifié sur les deux chemins).

## Tests

Un exemple dans le spec du schéma : aucune remontée Sentry, et le client reçoit toujours son erreur de validation. Vérifié comme échouant avant correctif (`capture_exception` reçu 1 fois avec la `DateEncodingError`).