### PR TITLE
Tech : l'export datagouv des démarches publiques n'est plus interrompu par le timeout de l'API

### DIFF
--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -186,6 +186,17 @@ class API::V2::Schema < GraphQL::Schema
   end
 
   class Timeout < GraphQL::Schema::Timeout
+    # The ceiling below bounds an interactive HTTP request. SerializerService runs this
+    # same schema from cron jobs — notably the datagouv export, which paginates over every
+    # public procedure — where interrupting a page only yields a truncated export. Give
+    # those a batch-sized budget instead, while keeping the interactive ceiling for the
+    # public API.
+    INTERNAL_MAX_SECONDS = 5.minutes.to_i
+
+    def max_seconds(query)
+      query.context[:internal_use] ? INTERNAL_MAX_SECONDS : super
+    end
+
     def handle_timeout(error, query)
       error.extensions = { code: :timeout }
 

--- a/spec/graphql/api/v2/schema_spec.rb
+++ b/spec/graphql/api/v2/schema_spec.rb
@@ -55,6 +55,22 @@ RSpec.describe API::V2::Schema do
 end
 
 RSpec.describe API::V2::Schema::Timeout do
+  describe '#max_seconds' do
+    let(:timeout_instance) { described_class.new(max_seconds: 30) }
+
+    def query_with(context) = instance_double(GraphQL::Query, context:)
+
+    it 'keeps the interactive ceiling for public API queries' do
+      expect(timeout_instance.max_seconds(query_with(internal_use: false))).to eq(30)
+    end
+
+    # The datagouv export paginates over every public procedure from a cron job; the
+    # interactive ceiling only truncated it.
+    it 'gives internal serializer queries a batch-sized budget' do
+      expect(timeout_instance.max_seconds(query_with(internal_use: true))).to be > 30
+    end
+  end
+
   describe '#filter_sensitive_query_string' do
     let(:timeout_instance) { described_class.new(max_seconds: 30) }
 


### PR DESCRIPTION
## Contexte

Sentry [RAILS-M8Q](https://demarches-simplifiees.sentry.io/issues/RAILS-M8Q) et [RAILS-J7E](https://demarches-simplifiees.sentry.io/issues/RAILS-J7E) : 108 événements, toujours les mêmes deux issues pour un seul et même défaut.

`use Timeout, max_seconds: 30` borne une requête HTTP interactive. Mais `SerializerService` exécute le **même schéma** depuis des jobs cron — notamment `Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob`, qui pagine sur l'ensemble des démarches publiques.

Quand une page dépasse 30 s, la chaîne est :

1. le timeout interrompt la page (`Timeout on DynamicFields.__typename`) ;
2. `SerializerService.execute_query` transforme l'erreur GraphQL en `Sentry.capture_message` (**RAILS-J7E**) puis la relève ;
3. `DemarchesPubliquesExportService#execute_query` la ré-emballe dans sa propre erreur (**RAILS-M8Q**).

Le job échoue, et le fichier `.gz` reste tronqué — la publication open data ne passe pas ce jour-là.

## Correction

`max_seconds(query)` est surchargé pour rendre un budget adapté au batch quand le contexte est `internal_use`. Le plafond interactif de l'API publique est inchangé.

## Hors périmètre

[RAILS-M8F](https://demarches-simplifiees.sentry.io/issues/RAILS-M8F) (`InvalidNullError` sur `DemarcheDescriptor.revision`) tombe dans le même job et j'avais d'abord supposé qu'il s'agissait du même effet en cascade. Vérification faite, **non** : `GraphQL::Schema::Timeout::TimeoutError` hérite de `ExecutionError`, donc un champ interrompu propage un null sans passer par `InvalidNullError`. C'est une autre cause (une démarche `publiques` sans `published_revision`), et l'issue est dormante depuis 12 jours — traitée séparément si elle réapparaît.

## Tests

Deux exemples sur `API::V2::Schema::Timeout#max_seconds` : plafond interactif conservé pour l'API publique, budget élargi pour les requêtes internes.