### PR TITLE
Tech : la purge des brouillons expirés ne bute plus sur un type de champ supprimé

### DIFF
--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -30,6 +30,24 @@ class ChampData < ApplicationRecord
     end
   end
 
+  # Champ types removed from the codebase (legacy France Connect data sources). Rows
+  # written before their removal are still in the table, and Rails raises
+  # ActiveRecord::SubclassNotFound as soon as one is loaded — which aborts the expired
+  # brouillon purge, rolling the dossier back and failing again on every cron run.
+  # Nothing renders these any more, so read them as plain ChampData: enough to inspect
+  # and destroy them. Any other unresolvable type still raises.
+  REMOVED_TYPES = [
+    'Champs::CnafChamp',
+    'Champs::CNAFChamp',
+    'Champs::DGFIPChamp',
+    'Champs::MESRIChamp',
+    'Champs::PoleEmploiChamp',
+  ].freeze
+
+  def self.find_sti_class(type_name)
+    REMOVED_TYPES.include?(type_name) ? ChampData : super
+  end
+
   attr_readonly :stable_id
 
   belongs_to :dossier, inverse_of: false, touch: true, optional: false

--- a/spec/models/dossier_purge_spec.rb
+++ b/spec/models/dossier_purge_spec.rb
@@ -102,6 +102,24 @@ describe Dossier, type: :model do
       end
     end
 
+    # Rows written before a champ type was deleted from the codebase are still in the
+    # table; loading one used to raise ActiveRecord::SubclassNotFound and roll the whole
+    # purge back, so the cron retried the same dossier and failed again every run.
+    context 'with a champ whose type was removed from the codebase' do
+      let(:procedure) { create(:procedure_with_dossiers, :published) }
+      let(:dossier) { procedure.dossiers.first }
+      let(:type_de_champ) { create(:type_de_champ_text, procedure:, libelle: 'Test') }
+      let!(:champ) { dossier.champ_data.create!(type_de_champ:, value: 'legacy') }
+
+      before { ChampData.where(id: champ.id).update_all(type: 'Champs::CnafChamp') }
+
+      it 'destroys the dossier instead of aborting the purge' do
+        expect { dossier.purge_without_notice }.not_to raise_error
+        expect(ChampData.where(id: champ.id)).not_to exist
+        expect { dossier.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
     context 'when destroy raises after champs batching' do
       let(:procedure) { create(:procedure_with_dossiers, :published) }
       let(:dossier) { procedure.dossiers.first }


### PR DESCRIPTION
## Contexte

Sentry [RAILS-MCF](https://demarches-simplifiees.sentry.io/issues/RAILS-MCF) : `ActiveRecord::SubclassNotFound: … 'Champs::CnafChamp'` dans `Cron::ExpiredDossiersBrouillonDeletionJob`.

Les anciens types de champ France Connect (CNAF, DGFIP, MESRI, Pôle Emploi) ont été supprimés du code, mais les lignes écrites avant leur suppression sont toujours en base. Dès qu'une de ces lignes est chargée, Rails lève `SubclassNotFound` : `purge_freeing_champs_cascade` part en `rescue`, `raise ActiveRecord::Rollback`, et le dossier est réessayé — puis échoue à nouveau — à chaque passage du cron.

C'est un chemin de rétention : ces brouillons expirés ne sont jamais réellement supprimés.

## Correction

`ChampData.find_sti_class` renvoie la classe de base pour la liste explicite des types supprimés. Plus rien ne les affiche : les lire en `ChampData` suffit à les inspecter et à les détruire.

La liste est volontairement explicite plutôt qu'un `rescue` générique — un type réellement inconnu (faute de frappe, classe pas encore chargée) continue de lever.

## Tests

Un exemple dans `dossier_purge_spec` : un champ dont le `type` a été réécrit en `Champs::CnafChamp` n'empêche plus la purge. Vérifié comme échouant avant correctif avec le `SubclassNotFound` exact.

## Suite possible

Une tâche de maintenance pourrait supprimer ces lignes orphelines pour de bon ; ce correctif débloque déjà le cron sans toucher aux données.