### PR TITLE
ETQ usager, un champ supprimé de la démarche ne fait plus planter la saisie

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,7 @@ class ApplicationController < ActionController::Base
   before_action :display_csrf_retry_message
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+  rescue_from DossierChampsConcern::ChampNotInRevisionError, with: :champ_not_in_revision
 
   around_action :switch_locale
 
@@ -215,6 +216,19 @@ class ApplicationController < ActionController::Base
 
   def user_not_authorized
     head :not_found
+  end
+
+  # The champ is not in the dossier revision — almost always a tab still showing a form
+  # that a newly published revision has replaced. An error page would throw away
+  # everything else the user has typed, so drop just the orphaned input and let the rest
+  # of the page live. The tab stays stale in every other respect; only a reload fixes
+  # that, and taking one away from the user unprompted is worse than the stale form.
+  def champ_not_in_revision(error)
+    respond_to do |format|
+      format.turbo_stream { render turbo_stream: turbo_stream.remove_all("##{TypeDeChamp.html_id(error.public_id)}") }
+      format.json { render json: { errors: [error.message] }, status: :not_found }
+      format.any { head :not_found }
+    end
   end
 
   def set_active_storage_host

--- a/app/controllers/champs/champ_controller.rb
+++ b/app/controllers/champs/champ_controller.rb
@@ -11,7 +11,7 @@ class Champs::ChampController < ApplicationController
     dossier = Dossier.with_revision.includes(:champ_data).find(params[:dossier_id])
     authorize dossier, :read?
 
-    type_de_champ = dossier.find_type_de_champ_by_stable_id(params[:stable_id])
+    type_de_champ = dossier.find_type_de_champ_by_stable_id!(params[:stable_id], row_id: params_row_id)
     dossier.with_update_stream(current_user) if type_de_champ.public?
     @dossier = dossier
 

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -397,7 +397,7 @@ module Instructeurs
 
     def annotation
       @dossier = dossier_with_champs
-      type_de_champ = @dossier.find_type_de_champ_by_stable_id(params[:stable_id], :private)
+      type_de_champ = @dossier.find_type_de_champ_by_stable_id!(params[:stable_id], :private, row_id: params[:row_id])
       annotation = @dossier.project_champ(type_de_champ, row_id: params[:row_id])
       annotation.validate(:champ_value) if annotation.done?
 

--- a/app/controllers/instructeurs/edit_controller.rb
+++ b/app/controllers/instructeurs/edit_controller.rb
@@ -53,7 +53,7 @@ module Instructeurs
     end
 
     def champ
-      type_de_champ = dossier.find_type_de_champ_by_stable_id(params[:stable_id], :public)
+      type_de_champ = dossier.find_type_de_champ_by_stable_id!(params[:stable_id], :public, row_id: params[:row_id])
       champ = dossier.project_champ(type_de_champ, row_id: params[:row_id])
       champ.validate(:champ_value) if champ.done?
 

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -358,7 +358,7 @@ module Users
     def champ
       @polling = true
       @dossier = dossier_with_champs(pj_template: false)
-      type_de_champ = dossier.find_type_de_champ_by_stable_id(params[:stable_id], :public)
+      type_de_champ = dossier.find_type_de_champ_by_stable_id!(params[:stable_id], :public, row_id: params[:row_id])
       champ = dossier.project_champ(type_de_champ, row_id: params[:row_id])
 
       champ.validate(:champ_value) if champ.done?

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -3,6 +3,21 @@
 module DossierChampsConcern
   extend ActiveSupport::Concern
 
+  # A stable_id that is not (or no longer) in the dossier's revision. Publishing a
+  # revision that removes a champ rebases every non-terminated dossier, so a browser
+  # still showing the previous form keeps posting a champ that has since disappeared.
+  # It is also raised for a stable_id taken straight from a URL that never matched
+  # anything. Callers that can render turbo_stream drop the orphaned input; see
+  # ApplicationController#champ_not_in_revision.
+  class ChampNotInRevisionError < StandardError
+    attr_reader :public_id
+
+    def initialize(stable_id, row_id = nil)
+      @public_id = TypeDeChamp.public_id(stable_id, row_id)
+      super("Champ #{@public_id} is not in the dossier revision")
+    end
+  end
+
   def project_champ(type_de_champ, row_id: nil)
     check_valid_row_id_on_read?(type_de_champ, row_id)
     data = champ_data_by_public_id[type_de_champ.public_id(row_id)]
@@ -101,6 +116,11 @@ module DossierChampsConcern
     end.find { _1.stable_id == stable_id.to_i }
   end
 
+  # Same lookup, for callers that cannot do anything useful without a type de champ.
+  def find_type_de_champ_by_stable_id!(stable_id, scope = nil, row_id: nil)
+    find_type_de_champ_by_stable_id(stable_id, scope) || raise(ChampNotInRevisionError.new(stable_id, row_id))
+  end
+
   def public_type_de_champs_all
     revision.type_de_champs.filter(&:public?)
   end
@@ -134,13 +154,13 @@ module DossierChampsConcern
 
   def public_champ_for_update(public_id, updated_by:)
     stable_id, row_id = public_id.split('-')
-    type_de_champ = find_type_de_champ_by_stable_id(stable_id, :public)
+    type_de_champ = find_type_de_champ_by_stable_id!(stable_id, :public, row_id:)
     champ_for_update(type_de_champ, row_id:, updated_by:)
   end
 
   def private_champ_for_update(public_id, updated_by:)
     stable_id, row_id = public_id.split('-')
-    type_de_champ = find_type_de_champ_by_stable_id(stable_id, :private)
+    type_de_champ = find_type_de_champ_by_stable_id!(stable_id, :private, row_id:)
     champ_for_update(type_de_champ, row_id:, updated_by:)
   end
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -408,7 +408,7 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def html_id(row_id = nil)
-    "champ-#{public_id(row_id)}"
+    self.class.html_id(public_id(row_id))
   end
 
   class << self
@@ -418,6 +418,12 @@ class TypeDeChamp < ApplicationRecord
       else
         "#{stable_id}-#{row_id}"
       end
+    end
+
+    # Usable without a type de champ instance, for a champ that is no longer in the
+    # revision and can only be identified by the public_id the browser posted.
+    def html_id(public_id)
+      "champ-#{public_id}"
     end
 
     def type_champ_to_champ_class_name(type_champ)

--- a/spec/controllers/champs/repetition_controller_spec.rb
+++ b/spec/controllers/champs/repetition_controller_spec.rb
@@ -17,6 +17,16 @@ describe Champs::RepetitionController, type: :controller do
       expect(response).to have_http_status(:not_found)
     end
 
+    # stable_id comes straight from the path here, so an unknown one is reachable both by
+    # a stale tab and by hand. An error page would wipe out the form the user is filling.
+    it 'removes the orphaned input instead of erroring when the stable_id is not in the revision' do
+      post :add, params: { dossier_id: dossier, stable_id: 1234567 }, format: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('action="remove"')
+      expect(response.body).to include('#champ-1234567')
+    end
+
     context 'when instructeur is signed in and try to add a repetition to a dossier en instruction' do
       let(:instructeur) { create(:instructeur) }
       let(:gi) { create(:groupe_instructeur, instructeurs: [instructeur]) }

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1016,6 +1016,27 @@ describe Users::DossiersController, type: :controller do
       end
     end
 
+    # RAILS-JYN: the admin published a revision removing this champ while the usager still
+    # had the form open, and the dossier was rebased onto it. The autosave keeps coming.
+    context 'when a newly published revision removed the champ' do
+      let!(:removed_stable_id) { first_champ.stable_id }
+      let(:champs_public_attributes) { { removed_stable_id.to_s => { value: 'still typing' } } }
+
+      before do
+        procedure.draft_revision.remove_type_de_champ(removed_stable_id)
+        procedure.publish_revision!(procedure.administrateurs.first)
+        dossier.reload.rebase!
+      end
+
+      it 'removes the orphaned input and leaves the rest of the page alone' do
+        subject
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('action="remove"')
+        expect(response.body).to include("#champ-#{removed_stable_id}")
+      end
+    end
+
     context 'when the champ is a drop_down_list with referentiel' do
       let(:procedure) { create(:procedure, :published, public_type_de_champs: [{ type: :drop_down_list }]) }
 

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -85,6 +85,36 @@ RSpec.describe DossierChampsConcern do
     end
   end
 
+  describe "#find_type_de_champ_by_stable_id!" do
+    it "finds a type de champ like the non-bang version" do
+      expect(dossier.find_type_de_champ_by_stable_id!(992, :public).libelle).to eq("Un champ yes no")
+    end
+
+    it "raises for an unknown stable id, carrying the public_id of the orphaned input" do
+      expect { dossier.find_type_de_champ_by_stable_id!(1234567) }
+        .to raise_error(DossierChampsConcern::ChampNotInRevisionError) { expect(it.public_id).to eq("1234567") }
+    end
+
+    it "includes the row_id in the public_id when the champ is inside a repetition" do
+      expect { dossier.find_type_de_champ_by_stable_id!(1234567, :public, row_id: "01J") }
+        .to raise_error(DossierChampsConcern::ChampNotInRevisionError) { expect(it.public_id).to eq("1234567-01J") }
+    end
+
+    it "raises when the champ exists but outside the requested scope" do
+      expect { dossier.find_type_de_champ_by_stable_id!(995, :public) }
+        .to raise_error(DossierChampsConcern::ChampNotInRevisionError)
+    end
+  end
+
+  # A tab still showing a form whose champ a newly published revision removed keeps
+  # autosaving it; the dossier has since been rebased onto the new revision.
+  describe "#public_champ_for_update on a champ removed from the revision" do
+    it "raises instead of dereferencing nil" do
+      expect { dossier.public_champ_for_update("1234567", updated_by: 'user@x.fr') }
+        .to raise_error(DossierChampsConcern::ChampNotInRevisionError)
+    end
+  end
+
   describe "#stable_id_in_revision?" do
     it "accepts an integer or a string, and rejects an unknown stable id" do
       expect(dossier.stable_id_in_revision?(99)).to be(true)


### PR DESCRIPTION
## Contexte

Sentry [RAILS-JYN](https://demarches-simplifiees.sentry.io/issues/RAILS-JYN) : 207 événements / 53 usagers depuis mars, toujours actif.

Publier une révision qui **supprime un champ** rebase tous les dossiers non terminés, brouillons compris (`procedure_publish_concern`, `rebase_later`). Le rebase change `revision_id` mais ne touche pas à l'onglet resté ouvert : le navigateur continue d'autosauvegarder un champ qui n'existe plus dans la nouvelle révision. `find_type_de_champ_by_stable_id` renvoie alors `nil`, et tous les appelants le déréférençaient — d'où `undefined method 'private?' for nil`, une 500 sur une simple autosauvegarde.

Reproduit en spec : c'est bien la suppression + rebase qui produit l'erreur exacte de production.

Le même `nil` était atteint depuis les endpoints pilotés par l'URL (lignes de répétition, pièces justificatives) où `stable_id` vient du chemin, derrière le seul `authorize dossier, :read?` — 18 événements de plus sur `champ_controller.rb:16` (`'public?' for nil`). Là ce n'est même pas une course : n'importe quel usager connecté déclenche la 500 sur son propre dossier avec un `stable_id` fantaisiste.

## Correction

- `ChampNotInRevisionError` + `find_type_de_champ_by_stable_id!`, levée aux endroits qui ne peuvent rien faire sans type de champ. La version non-bang garde son contrat `nil` (des appelants s'en servent, dont les mutations GraphQL qui gèrent déjà le cas).
- Un seul `rescue_from` dans `ApplicationController` : les appelants turbo_stream reçoivent la suppression de l'input orphelin, les appelants JSON une 404.

## Pourquoi pas une 404 côté turbo

Une 404 rend la page d'erreur HTML complète (`ErrorsController#render_error` ne gère que `html`/`json`), et Turbo Drive affiche les réponses 4xx à la place de la page — les champs ne sont dans aucune `turbo-frame`. L'usager perdrait tout ce qu'il est en train de saisir, exactement comme avec la 500 actuelle. Retirer le seul input mort laisse la page vivre.

**Limite assumée** : l'onglet reste périmé pour tout le reste (autres champs supprimés encore affichés, champs ajoutés absents). Seul un rechargement corrigerait cela, et l'imposer sans prévenir coûterait plus à l'usager que le formulaire périmé. Le message est dans le code.

## Tests

Trois niveaux, tous vérifiés comme échouant avant correctif avec les messages exacts de production (`'private?' for nil` et `'public?' for nil`) :

- modèle : `find_type_de_champ_by_stable_id!` et `public_champ_for_update` ;
- `Users::DossiersController#update` : suppression réelle du champ + `publish_revision!` + `rebase!`, puis autosauvegarde ;
- `Champs::RepetitionController#add` : `stable_id` inconnu passé dans l'URL.