### PR TITLE
Tech : une démarche sans révision publiée ne fait plus échouer l'export datagouv

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -181,6 +181,11 @@ class Procedure < ApplicationRecord
   scope :publiques,              -> do
     publiees_ou_closes
       .opendata
+      # None of these states is brouillon, so active_revision is published_revision.
+      # A few procedures have none; DemarcheDescriptor.revision is non-nullable, so
+      # exporting one raises InvalidNullError and aborts the whole datagouv run. A
+      # procedure with no revision has no form to describe anyway.
+      .where.not(published_revision_id: nil)
       .where(estimated_dossiers_count: 1..)
       .where.not('lien_site_web LIKE ?', '%mail%')
       .where.not('lien_site_web LIKE ?', '%intra%')

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -931,6 +931,18 @@ describe Procedure do
     it "does not return procedures without any dossier" do
       expect(Procedure.publiques).not_to include(published_procedure_without_dossier)
     end
+
+    # DemarcheDescriptor.revision resolves to active_revision — published_revision for
+    # any of these states — and is non-nullable, so exporting such a procedure aborts
+    # the whole datagouv run.
+    it "does not return procedures without a published revision" do
+      expect(Procedure.publiques).to include(published_procedure)
+
+      published_procedure.update_column(:published_revision_id, nil)
+
+      expect(Procedure.publiques).not_to include(published_procedure.reload)
+      expect(published_procedure.active_revision).to be_nil
+    end
   end
 
   describe 'active' do

--- a/spec/services/demarches_publiques_export_service_spec.rb
+++ b/spec/services/demarches_publiques_export_service_spec.rb
@@ -56,6 +56,20 @@ describe DemarchesPubliquesExportService do
 
       expect { DemarchesPubliquesExportService.new(gzip_filename).call }.to raise_error(DemarchesPubliquesExportService::Error)
     end
+
+    # DemarcheDescriptor.revision is non-nullable, so one procedure without a published
+    # revision used to raise InvalidNullError and take the whole export down with it.
+    it 'skips a procedure without a published revision instead of aborting the export' do
+      exported = procedure # the `let` is lazy: create it before the export runs
+      orphan = create(:procedure, :published, :with_zone, :with_service, :with_type_de_champ, estimated_dossiers_count: 4)
+      orphan.update_column(:published_revision_id, nil)
+
+      DemarchesPubliquesExportService.new(gzip_filename).call
+
+      numbers = JSON.parse(deflat_gzip(gzip_filename)).map { it['number'] }
+      expect(numbers).to include(exported.id)
+      expect(numbers).not_to include(orphan.id)
+    end
   end
 
   def deflat_gzip(gzip_filename)


### PR DESCRIPTION
## Contexte

Sentry [RAILS-M8F](https://demarches-simplifiees.sentry.io/issues/RAILS-M8F) : 30 événements, `InvalidNullError: Cannot return null for non-nullable field DemarcheDescriptor.revision`.

`DemarcheDescriptor.revision` est `null: false` et résout `Procedure#active_revision`. Aucun des états retenus par `publiees_ou_closes` n'est `brouillon`, donc `active_revision` vaut toujours `published_revision` — et quelques démarches du périmètre `publiques` n'en ont pas.

**Ce n'est pas cosmétique** : le `type_error` du schéma empile l'erreur dans `ctx.errors`, `SerializerService#execute_query` voit `result['errors']` et relève, `DemarchesPubliquesExportService` s'interrompt. **Une seule démarche dans cet état fait tomber l'export datagouv entier.** Reproduit en spec, avec le message exact de production.

C'est le même symptôme que le timeout de #13602 — export interrompu, `.gz` tronqué, publication open data ratée — mais une cause distincte. #13602 avait explicitement laissé cette issue de côté ; la voici.

## Correction

`Procedure.publiques` exclut les démarches sans `published_revision`. Une démarche sans révision n'a aucun formulaire à décrire : elle n'a rien à apporter à l'export. Le périmètre est contenu — `publiques` n'est utilisé que par cette requête (`query_type.rb:24`).

## Ce que je n'ai pas trouvé

**Je n'ai pas identifié comment une démarche publiée se retrouve sans `published_revision`.** Les pistes explorées et écartées : le clonage (`initialize_clone_defaults` remet `aasm_state` à `brouillon` et `estimated_dossiers_count` à 0, donc hors périmètre), `reset_draft_revision!` (gardé par `published_revision.present?` et ne détruit que le brouillon), `publish_new_revision` (les deux révisions sont bien distinctes), et le `dependent: :nullify` de `ProcedureRevision#published_procedure` (aucun job ne détruit de révision). `belongs_to :published_revision, optional: true` autorise le `nil` dans tous les états, et rien nulle part ne garde `active_revision` contre `nil`.

C'est donc une anomalie de données dont l'origine reste ouverte. Ce correctif traite la conséquence — l'export ne doit pas tomber pour autant — et pas la cause. L'issue est dormante depuis 12 jours, ce qui va aussi dans le sens d'un état transitoire.

## Tests

- `Procedure.publiques` exclut une démarche dont `published_revision_id` est nul ;
- l'export saute cette démarche et exporte les autres, là où il levait `DemarchesPubliquesExportService::Error: Cannot return null for non-nullable field DemarcheDescriptor.revision` (vérifié avant correctif).