### PR TITLE
Tech : un fichier qui n'est pas l'image annoncée n'est plus réessayé ni remonté

### DIFF
--- a/app/jobs/blob_processor_job.rb
+++ b/app/jobs/blob_processor_job.rb
@@ -2,6 +2,7 @@
 
 class BlobProcessorJob < ApplicationJob
   include Skylight::Helpers
+  include UnreadableVipsSourceConcern
 
   queue_as do
     blob = self.arguments.first
@@ -105,6 +106,11 @@ class BlobProcessorJob < ApplicationJob
 
     blob.watermarked_at = Time.current if watermark_needed
     blob.save!
+  rescue Vips::Error => error
+    # Same policy as autorotate_needed?/interlaced? below: a source vips cannot decode
+    # is not a transient failure, so skip the mutations and let the rest of the job run
+    # (the blob still gets marked processed) instead of burning three retries.
+    raise if !unreadable_vips_source?(error)
   end
 
   def needs_mutations?

--- a/app/jobs/concerns/unreadable_vips_source_concern.rb
+++ b/app/jobs/concerns/unreadable_vips_source_concern.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Browsers derive an upload's content type from its filename, so a file that is not the
+# image it claims to be is accepted at upload and only fails later, in image processing:
+#
+#   Vips::Error: VipsForeignLoad: "/tmp/ActiveStorage-123-abc.jpg" is not a known file format
+#
+# Those bytes will never become an image, so retrying cannot help and reporting it says
+# nothing actionable about the code. Matched narrowly on purpose: every other vips
+# failure (memory pressure, temp file trouble) is transient and keeps its retries.
+module UnreadableVipsSourceConcern
+  extend ActiveSupport::Concern
+
+  UNREADABLE_SOURCE = /is not a known file format/
+
+  private
+
+  def unreadable_vips_source?(error)
+    UNREADABLE_SOURCE.match?(error.message)
+  end
+end

--- a/app/jobs/create_representations_job.rb
+++ b/app/jobs/create_representations_job.rb
@@ -2,6 +2,7 @@
 
 class CreateRepresentationsJob < ApplicationJob
   include Skylight::Helpers
+  include UnreadableVipsSourceConcern
 
   queue_as :ultra_low
 
@@ -35,5 +36,10 @@ class CreateRepresentationsJob < ApplicationJob
         att.variant(resize_to_limit: [1024, 768]).processed
       end
     end
+  rescue Vips::Error => error
+    # The blob is the same file for every attachment, so a source vips cannot decode
+    # yields no representation for any of them — and never will. Give up quietly rather
+    # than retrying three times and reporting.
+    raise if !unreadable_vips_source?(error)
   end
 end

--- a/spec/fixtures/files/not-an-image.jpg
+++ b/spec/fixtures/files/not-an-image.jpg
@@ -1,0 +1,5 @@
+Ce fichier porte l'extension .jpg mais ne contient pas d'image.
+
+Les navigateurs déduisent le type MIME d'un fichier de son nom, donc un
+fichier comme celui-ci est envoyé en image/jpeg et n'échoue qu'au moment du
+traitement d'image, quand vips ne sait pas le décoder.

--- a/spec/jobs/blob_processor_job_spec.rb
+++ b/spec/jobs/blob_processor_job_spec.rb
@@ -360,4 +360,28 @@ describe BlobProcessorJob, :external_deps, type: :job do
       end
     end
   end
+
+  # A file whose bytes are not the image its content type claims. vips can never decode
+  # it, so the mutations are skipped rather than retried, and the job still completes.
+  describe 'when the source is not an image vips can decode' do
+    let(:file) { fixture_file_upload('spec/fixtures/files/not-an-image.jpg', 'image/jpeg') }
+
+    before do
+      allow(ClamavService).to receive(:safe_file?).and_return(true)
+      allow(blob).to receive(:watermark_pending?).and_return(true)
+    end
+
+    it 'skips the mutations without retrying' do
+      expect {
+        expect { described_class.perform_now(blob) }.not_to raise_error
+      }.not_to have_enqueued_job(described_class)
+    end
+
+    it 'still records the virus scan and marks the blob processed' do
+      described_class.perform_now(blob)
+
+      expect(blob.virus_scanner.safe?).to be_truthy
+      expect(blob.reload.metadata["processed"]).to be true
+    end
+  end
 end

--- a/spec/jobs/create_representations_job_spec.rb
+++ b/spec/jobs/create_representations_job_spec.rb
@@ -60,4 +60,20 @@ describe CreateRepresentationsJob, :external_deps, type: :job do
       }.to have_enqueued_job(described_class).with(blob)
     end
   end
+
+  # A file whose bytes are not the image its content type claims. It will never become
+  # readable, so it must not be retried or reported.
+  context 'when the source is not an image vips can decode' do
+    let(:file) { fixture_file_upload('spec/fixtures/files/not-an-image.jpg', 'image/jpeg') }
+
+    it 'gives up quietly without retrying' do
+      expect {
+        expect { described_class.perform_now(blob) }.not_to raise_error
+      }.not_to have_enqueued_job(described_class)
+    end
+
+    it 'creates no representation' do
+      expect { described_class.perform_now(blob) }.not_to change { ActiveStorage::VariantRecord.count }
+    end
+  end
 end


### PR DESCRIPTION
## Contexte

Sentry [RAILS-M8S](https://demarches-simplifiees.sentry.io/issues/RAILS-M8S) et [RAILS-KJX](https://demarches-simplifiees.sentry.io/issues/RAILS-KJX) : **280 événements sur 30 jours** (231 sur `CreateRepresentationsJob`, 49 sur `BlobProcessorJob`).

```
Vips::Error: VipsForeignLoad: "/tmp/ActiveStorage-221501609-...jpg" is not a known file format
```

Les navigateurs déduisent le type MIME d'un fichier **de son nom**. Un fichier qui n'est pas l'image qu'il prétend être passe donc l'upload sans encombre et n'échoue qu'au traitement d'image. Ces octets ne deviendront jamais une image : les trois tentatives de `retry_on "Vips::Error"` sont perdues d'avance, et la levée finale ne dit rien d'actionnable sur le code.

Ce n'est **pas** le cas couvert par #13596 (fichier vide) : sa description note que `process_later` ignore les blobs vides, qui n'atteignent donc jamais vips. Ici le fichier a bien un contenu — simplement pas celui d'une image.

## Correction

`BlobProcessorJob` applique **déjà** exactement cette politique dans `autorotate_needed?` et `interlaced?` (« unreadable metadata should not abort processing: skip the mutation instead »). `apply_mutations` n'était juste pas couvert. La correction étend la règle existante plutôt que d'en inventer une :

- `BlobProcessorJob#apply_mutations` : saute les mutations, **la suite du job continue** — l'antivirus reste enregistré et le blob est bien marqué `processed`, au lieu de rester bloqué après trois échecs ;
- `CreateRepresentationsJob` : abandonne sans bruit (le blob est le même fichier pour toutes les pièces jointes).

Le motif est volontairement étroit (`/is not a known file format/`) : toute autre erreur vips (pression mémoire, souci de fichier temporaire) est transitoire et conserve ses tentatives. Le spec existant qui vérifie qu'un `Vips::Error` « unable to load source » est bien réessayé passe toujours.

## Conséquence connue, non traitée ici

Si le fichier est un titre d'identité, `watermarked_at` reste nul, donc `watermark_pending?` reste vrai : `Attachment::ProgressComponent` affiche indéfiniment « filigrane en cours ». Je ne force pas `watermarked_at` — cela ferait afficher par `ShowComponent` un document d'identité présenté comme filigrané alors qu'il ne l'est pas.

Le vrai correctif est de refuser le fichier à l'upload, comme #13596 le fait pour les fichiers vides — c'est une décision produit, séparée de celle-ci, qui se contente de faire taire un bruit inutile et de débloquer le blob.

## Tests

Nouvelle fixture `not-an-image.jpg` (du texte sous une extension `.jpg`), qui reproduit le message exact de production. Pour les deux jobs : aucune levée, aucun réenfilement. Vérifié comme échouant avant correctif — le job se réenfilait bien et le blob n'était jamais marqué `processed`.