### PR TITLE
Tech: les fichiers de l'éditeur de champs sont enregistrés avec le formulaire

### DIFF
--- a/app/components/attachment/attachment_row_component.rb
+++ b/app/components/attachment/attachment_row_component.rb
@@ -6,7 +6,7 @@
 class Attachment::AttachmentRowComponent < ApplicationComponent
   attr_reader :attachment, :context
 
-  delegate :champ, :auto_attach_url, :direct_upload, :view_as, :user_can_destroy?,
+  delegate :champ, :direct_upload, :view_as, :user_can_destroy?,
            to: :context
 
   def initialize(attachment:, context:, field_name: nil)
@@ -23,7 +23,7 @@ class Attachment::AttachmentRowComponent < ApplicationComponent
     if champ.present?
       attachment_path
     else
-      attachment_path(auto_attach_url:, view_as:, direct_upload:)
+      attachment_path(view_as:, direct_upload:)
     end
   end
 

--- a/app/components/attachment/context.rb
+++ b/app/components/attachment/context.rb
@@ -3,7 +3,7 @@
 # Value object for attachment component configuration.
 # Eliminates parameter duplication across attachment components.
 class Attachment::Context
-  attr_reader :champ, :attached_file, :auto_attach_url, :direct_upload, :view_as,
+  attr_reader :champ, :attached_file, :direct_upload, :view_as,
               :user_can_destroy, :form_object_name, :aria_labelledby,
               :parent_hint_id
 
@@ -12,7 +12,6 @@ class Attachment::Context
   def initialize(
     champ: nil,
     attached_file: nil,
-    auto_attach_url: nil,
     direct_upload: true,
     view_as: :link,
     user_can_destroy: true,
@@ -22,7 +21,6 @@ class Attachment::Context
   )
     @champ = champ
     @attached_file = attached_file || champ&.piece_justificative_file
-    @auto_attach_url = auto_attach_url
     @direct_upload = direct_upload
     @view_as = view_as
     @user_can_destroy = user_can_destroy

--- a/app/components/attachment/file_input_component.rb
+++ b/app/components/attachment/file_input_component.rb
@@ -76,10 +76,7 @@ class Attachment::FileInputComponent < ApplicationComponent
   end
 
   def auto_attach_url
-    return context.auto_attach_url if context.auto_attach_url.present?
-    return helpers.auto_attach_url(champ) if champ.present?
-
-    nil
+    helpers.auto_attach_url(champ) if champ.present?
   end
 
   def direct_upload_url

--- a/app/components/types_de_champ_editor/champ_component.rb
+++ b/app/components/types_de_champ_editor/champ_component.rb
@@ -108,7 +108,6 @@ class TypesDeChampEditor::ChampComponent < ApplicationComponent
   def notice_explicative_options
     {
       attached_file: type_de_champ.notice_explicative,
-      auto_attach_url: helpers.auto_attach_url(type_de_champ, procedure_id: procedure.id),
       view_as: :download,
     }
   end

--- a/app/components/types_de_champ_editor/champ_piece_justificative_component.rb
+++ b/app/components/types_de_champ_editor/champ_piece_justificative_component.rb
@@ -20,7 +20,6 @@ class TypesDeChampEditor::ChampPieceJustificativeComponent < TypesDeChampEditor:
   def piece_justificative_template_options
     {
       attached_file: type_de_champ.piece_justificative_template,
-      auto_attach_url: helpers.auto_attach_url(type_de_champ, procedure_id: procedure.id),
       view_as: :download,
     }
   end

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -50,34 +50,6 @@ module Administrateurs
       end
     end
 
-    def piece_justificative_template
-      type_de_champ = draft.find_and_ensure_exclusive_use(params[:stable_id])
-
-      if type_de_champ.piece_justificative_template.attach(params[:blob_signed_id])
-        reload_procedure_with_includes
-        @coordinate = draft.coordinate_for(type_de_champ)
-        @morphed = [champ_component_from(@coordinate)]
-
-        render :create
-      else
-        render json: { errors: type_de_champ.errors.full_messages }, status: 422
-      end
-    end
-
-    def notice_explicative
-      type_de_champ = draft.find_and_ensure_exclusive_use(params[:stable_id])
-
-      if type_de_champ.notice_explicative.attach(params[:blob_signed_id])
-        reload_procedure_with_includes
-        @coordinate = draft.coordinate_for(type_de_champ)
-        @morphed = [champ_component_from(@coordinate)]
-
-        render :create
-      else
-        render json: { errors: type_de_champ.errors.full_messages }, status: 422
-      end
-    end
-
     def move_and_morph
       source_type_de_champ = draft.find_and_ensure_exclusive_use(params[:stable_id])
       target_type_de_champ = draft.find_and_ensure_exclusive_use(params[:target_stable_id])
@@ -217,8 +189,15 @@ module Administrateurs
         .permit(:type_champ, :parent_stable_id, :private, :libelle, :after_stable_id)
     end
 
+    # Uploaded through direct upload, then submitted with the form as a blob
+    # signed id. An untouched file input submits a blank value, which would
+    # otherwise purge the attachment on every autosave.
+    ATTACHMENT_ATTRIBUTES = ['piece_justificative_template', 'notice_explicative']
+
     def type_de_champ_update_params
       params.required(:type_de_champ).permit(:type_champ,
+        :piece_justificative_template,
+        :notice_explicative,
         :libelle,
         :description,
         :mandatory,
@@ -274,6 +253,7 @@ module Administrateurs
           :zones_humides,
           :znieff,
         ])
+        .reject { |key, value| key.in?(ATTACHMENT_ATTRIBUTES) && value.blank? }
     end
 
     def draft

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -11,7 +11,6 @@ class AttachmentsController < ApplicationController
     @user_can_edit = cast_bool(params[:user_can_edit])
     @direct_upload = cast_bool(params[:direct_upload])
     @view_as = params[:view_as]&.to_sym
-    @auto_attach_url = params[:auto_attach_url]
 
     respond_to do |format|
       format.turbo_stream
@@ -121,7 +120,6 @@ class AttachmentsController < ApplicationController
       attached_file: record.public_send(@attachment.name),
       view_as: params[:view_as]&.to_sym,
       direct_upload: params[:direct_upload] == "true",
-      auto_attach_url: params[:direct_upload] == "true" ? params[:auto_attach_url] : nil,
     }
   end
 end

--- a/app/helpers/champ_helper.rb
+++ b/app/helpers/champ_helper.rb
@@ -9,13 +9,12 @@ module ChampHelper
     simple_format(auto_linked_text, {}, sanitize: false)
   end
 
-  def auto_attach_url(object, procedure_id: nil)
-    if object.is_a?(ChampData)
-      champs_piece_justificative_url(object.dossier, object.stable_id, row_id: object.row_id)
-    elsif object.is_a?(TypeDeChamp) && object.piece_justificative?
-      piece_justificative_template_admin_procedure_type_de_champ_url(stable_id: object.stable_id, procedure_id:)
-    elsif object.is_a?(TypeDeChamp) && object.explication?
-      notice_explicative_admin_procedure_type_de_champ_url(stable_id: object.stable_id, procedure_id:)
-    end
+  # Attachments are normally submitted with their form. Champs are the
+  # exception: the usager form auto-saves each champ on its own, so a piece
+  # justificative is attached as soon as it is uploaded.
+  def auto_attach_url(object)
+    return if !object.is_a?(ChampData)
+
+    champs_piece_justificative_url(object.dossier, object.stable_id, row_id: object.row_id)
   end
 end

--- a/app/javascript/controllers/type_de_champ_editor_controller.ts
+++ b/app/javascript/controllers/type_de_champ_editor_controller.ts
@@ -57,12 +57,14 @@ export class TypeDeChampEditorController extends ApplicationController {
   private onChange(event: Event) {
     matchInputElement(event.target, {
       file: (target) => {
-        if (target.files?.length && target.name != 'referentiel_file') {
-          const autoupload = new AutoUpload(target, target.files[0]);
-          autoupload.start();
+        const file = target.files?.[0];
+        if (!file) {
+          return;
         }
-        if (target.files?.length && target.name == 'referentiel_file') {
+        if (target.name == 'referentiel_file') {
           this.requestSubmitForm(target.form);
+        } else {
+          this.uploadAndSubmit(target, file);
         }
       },
       changeable: (target) => this.save(target.form),
@@ -80,6 +82,29 @@ export class TypeDeChampEditorController extends ApplicationController {
         }
       }
     });
+  }
+
+  // Attachments are saved with their form: the file is uploaded straight to
+  // the storage service, then the resulting blob signed id is submitted under
+  // the file input's own name.
+  private async uploadAndSubmit(input: HTMLInputElement, file: File) {
+    const form = input.form;
+    const name = input.name;
+    const blobSignedId = await new AutoUpload(input, file)
+      .start()
+      .catch(() => null);
+
+    if (!form || !blobSignedId) {
+      return;
+    }
+
+    // The upload cleared the file input, but it still submits an empty value.
+    // The hidden input is appended after it, so it is the one that wins.
+    const hiddenInput = createHiddenInput(form, name, blobSignedId);
+    this.requestSubmitForm(form);
+    this.#latestPromise = this.#latestPromise.finally(() =>
+      hiddenInput.remove()
+    );
   }
 
   private save(form?: HTMLFormElement | null): void {
@@ -161,4 +186,5 @@ function createHiddenInput(
   input.name = name;
   input.value = String(value);
   form.appendChild(input);
+  return input;
 }

--- a/app/javascript/shared/activestorage/auto-upload.ts
+++ b/app/javascript/shared/activestorage/auto-upload.ts
@@ -12,11 +12,13 @@ type ErrorMessage = {
   retry: boolean;
 };
 
-// Given a file input in a champ with a selected file, upload a file,
-// then attach it to the dossier.
+// Given a file input with a selected file, upload the file, and — when the
+// input carries an auto attach url — attach it right away.
 //
-// On success, the champ is replaced by an HTML fragment describing the attachment.
-// On error, a error message is displayed above the input.
+// On success, the input is replaced by an HTML fragment describing the
+// attachment, and the blob signed id is returned so a caller can submit it
+// with its form instead. On error, an error message is displayed above the
+// input.
 export class AutoUpload {
   #input: HTMLInputElement;
   #uploader: Uploader;
@@ -34,13 +36,14 @@ export class AutoUpload {
     );
   }
 
-  // Create, upload and attach the file.
+  // Create, upload and attach the file. Returns the blob signed id.
   // On failure, display an error message and throw a FileUploadError.
-  async start() {
+  async start(): Promise<string> {
     try {
       this.begin();
-      await this.#uploader.start();
+      const blobSignedId = await this.#uploader.start();
       this.succeeded();
+      return blobSignedId;
     } catch (error) {
       this.failed(error as FileUploadError);
       throw error;

--- a/app/views/attachments/show.turbo_stream.erb
+++ b/app/views/attachments/show.turbo_stream.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream.replace dom_id(@attachment, :edit) do %>
   <% if @user_can_edit %>
-    <%= render Attachment::FileFieldComponent.new(context: Attachment::Context.new(attached_file: @attachment.record.public_send(@attachment.name), drop_zone: :none, auto_attach_url: @auto_attach_url, view_as: @view_as, direct_upload: @direct_upload)) %>
+    <%= render Attachment::FileFieldComponent.new(context: Attachment::Context.new(attached_file: @attachment.record.public_send(@attachment.name), drop_zone: :none, view_as: @view_as, direct_upload: @direct_upload)) %>
   <% else %>
     <%= render Attachment::ShowComponent.new(attachment: @attachment) %>
   <% end %>

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -331,13 +331,13 @@
 
 
       %h3.fr-mt-4w New attachment on TypeDeChamp
-      = render Attachment::FileFieldComponent.new(context: Attachment::Context.new(attached_file: tdc.piece_justificative_template, auto_attach_url: "/some-auto-attach-path"), drop_zone: :none)
+      = render Attachment::FileFieldComponent.new(context: Attachment::Context.new(attached_file: tdc.piece_justificative_template), drop_zone: :none)
 
       %h3.fr-mt-4w Existing attachment on TypeDeChamp, view as link
-      = render Attachment::FileFieldComponent.new(context: Attachment::Context.new(attached_file: tdc.piece_justificative_template, auto_attach_url: "/some-auto-attach-path"), drop_zone: :none)
+      = render Attachment::FileFieldComponent.new(context: Attachment::Context.new(attached_file: tdc.piece_justificative_template), drop_zone: :none)
 
       %h3.fr-mt-4w Existing attachment on TypeDeChamp view as download
-      = render Attachment::FileFieldComponent.new(context: Attachment::Context.new(attached_file: tdc.piece_justificative_template, auto_attach_url: "/some-auto-attach-path", view_as: :download), drop_zone: :none)
+      = render Attachment::FileFieldComponent.new(context: Attachment::Context.new(attached_file: tdc.piece_justificative_template, view_as: :download), drop_zone: :none)
 
       %h3.fr-mt-4w New attachment on generic object
       = render Attachment::FileFieldComponent.new(context: Attachment::Context.new(attached_file: avis.introduction_file), drop_zone: :none)

--- a/config/routes/administrateur.rb
+++ b/config/routes/administrateur.rb
@@ -150,8 +150,6 @@ scope module: 'administrateurs', path: 'admin', as: 'admin', defaults: { nav_bar
         patch :move_and_morph
         patch :move_up
         patch :move_down
-        put :piece_justificative_template
-        put :notice_explicative
         delete :nullify_referentiel
       end
 

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -447,30 +447,66 @@ describe Administrateurs::TypesDeChampController, type: :controller do
     end
   end
 
-  describe '#notice_explicative' do
-    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :explication }]) }
+  describe 'attachments submitted with the form' do
     let(:coordinate) { procedure.draft_revision.types_de_champ.first }
     let(:content) { 'notice' }
     let(:blob) { ActiveStorage::Blob.create_and_upload!(io: StringIO.new(content), filename: 'notice.txt', content_type: 'text/plain') }
 
-    context 'when sending a valid blob' do
-      it 'attaches the blob and responds with 200' do
-        expect { put :notice_explicative, format: :turbo_stream, params: { stable_id: coordinate.stable_id, procedure_id: procedure.id, blob_signed_id: blob.signed_id } }
-          .to change { coordinate.reload.notice_explicative.attached? }
+    subject do
+      patch :update, format: :turbo_stream, params: {
+        procedure_id: procedure.id,
+        stable_id: coordinate.stable_id,
+        type_de_champ: { attribute => value },
+      }
+    end
+
+    shared_examples 'an attachment attribute' do
+      let(:value) { blob.signed_id }
+
+      it 'attaches the blob' do
+        expect { subject }.to change { coordinate.reload.public_send(attribute).attached? }
           .from(false).to(true)
         expect(response).to have_http_status(:success)
+        expect(flash.alert).to be_nil
+      end
+
+      context 'when the blob is empty' do
+        let(:content) { '' }
+
+        it 'rejects it and reports the error' do
+          expect { subject }.not_to change { coordinate.reload.public_send(attribute).attached? }
+          expect(response).to have_http_status(:success)
+          expect(flash.alert.join).to include('vide')
+        end
+      end
+
+      context 'when the file input is submitted empty' do
+        let(:value) { '' }
+
+        before { coordinate.public_send(attribute).attach(blob) }
+
+        it 'leaves the existing attachment alone' do
+          expect { subject }.not_to change { coordinate.reload.public_send(attribute).attachment.id }
+        end
       end
     end
 
-    context 'when sending an empty blob' do
-      let(:content) { '' }
+    context 'piece_justificative_template' do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :piece_justificative }]) }
+      let(:attribute) { :piece_justificative_template }
 
-      it 'rejects it and responds with 422' do
-        expect { put :notice_explicative, format: :turbo_stream, params: { stable_id: coordinate.stable_id, procedure_id: procedure.id, blob_signed_id: blob.signed_id } }
-          .not_to change { coordinate.reload.notice_explicative.attached? }
-        expect(response).to have_http_status(422)
-        expect(response.parsed_body['errors'].join).to include('vide')
-      end
+      # the factory ships a template, but the editor only offers the input when
+      # there is none
+      before { coordinate.piece_justificative_template.purge }
+
+      it_behaves_like 'an attachment attribute'
+    end
+
+    context 'notice_explicative' do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :explication }]) }
+      let(:attribute) { :notice_explicative }
+
+      it_behaves_like 'an attachment attribute'
     end
   end
 


### PR DESCRIPTION
L'éditeur de démarche attachait le modèle de pièce justificative et la notice explicative via deux endpoints PUT dédiés, appelés juste après le direct upload. Le fichier est maintenant soumis avec le formulaire du champ (le signed id du blob, sous le nom du champ fichier) et attaché par `TypesDeChampController#update`.

Les champs de l'usager gardent leur `auto_attach_url` : le formulaire usager enregistre chaque champ indépendamment. Tout le reste s'attache avec son formulaire, donc la tuyauterie `auto_attach_url` personnalisée disparaît (`Attachment::Context`, `AttachmentsController`, `AttachmentRowComponent`…).

À noter : les erreurs de validation (fichier vide, format, taille) arrivaient en 422 affiché sous le champ, elles passent maintenant par `flash.alert`, comme les autres erreurs de l'éditeur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)