### PR TITLE
Tech: préparation de la table email_templates (unification des modèles d'email) (2/3)

### DIFF
--- a/app/models/concerns/email_template_concern.rb
+++ b/app/models/concerns/email_template_concern.rb
@@ -77,6 +77,11 @@ module EmailTemplateConcern
     validates :json_subject, tags: true, if: -> { json_subject.present? }
     validates :body, tags: true, if: -> { json_body.blank? }
     validates :subject, tags: true, if: -> { json_subject.blank? }
+
+    # In the transaction of the write itself: email_templates can never drift
+    # from the legacy tables, even for a few minutes.
+    after_save { EmailTemplateReplica.replicate(self) }
+    after_destroy { EmailTemplateReplica.delete_replica(self) }
   end
 
   class_methods do

--- a/app/models/email_template_replica.rb
+++ b/app/models/email_template_replica.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Mirrors every write to the 6 legacy mail tables into email_templates, which is
+# already filled but not read yet. Without it, a template edited between the
+# deploy of this table and the STI switch would only resurface after a manual
+# re-run of the copy task. Removed along with the legacy models.
+class EmailTemplateReplica < ApplicationRecord
+  self.table_name = "email_templates"
+
+  # The replicated `type` names a legacy model that is still backed by its own
+  # table: STI must not try to instantiate it from here.
+  self.inheritance_column = nil
+
+  # Same "most recently edited row wins" rule as the copy task, so a replication
+  # racing the copy cannot undo it, whichever lands first. It says nothing about
+  # the switch itself: once the reads move, only email_templates is written.
+  ON_DUPLICATE = <<~SQL.squish
+    subject = excluded.subject,
+    body = excluded.body,
+    json_subject = excluded.json_subject,
+    json_body = excluded.json_body,
+    updated_at = excluded.updated_at
+    WHERE excluded.updated_at > email_templates.updated_at
+  SQL
+
+  def self.replicate(email_template)
+    return if email_template.procedure_id.nil?
+
+    row = {
+      type: email_template.class.name,
+      procedure_id: email_template.procedure_id,
+      subject: email_template.subject,
+      body: email_template.body,
+      json_subject: email_template.json_subject,
+      json_body: email_template.json_body,
+      created_at: email_template.created_at,
+      updated_at: email_template.updated_at,
+    }
+
+    upsert_all([row], unique_by: [:procedure_id, :type], on_duplicate: Arel.sql(ON_DUPLICATE))
+  end
+
+  def self.delete_replica(email_template)
+    where(procedure_id: email_template.procedure_id, type: email_template.class.name).delete_all
+  end
+end

--- a/app/tasks/maintenance/t20260721_copy_legacy_mail_tables_into_email_templates_task.rb
+++ b/app/tasks/maintenance/t20260721_copy_legacy_mail_tables_into_email_templates_task.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Copy the 6 legacy per-type mail tables into the unified email_templates
+# table (STI), ahead of the code switch. Idempotent: re-running upserts
+# rows edited on the legacy tables since the previous run.
+module Maintenance
+  class T20260721CopyLegacyMailTablesIntoEmailTemplatesTask < MaintenanceTasks::Task
+    include RunnableOnDeployConcern
+
+    run_on_first_deploy
+
+    TABLES = {
+      "initiated_mails" => "Emails::Depose",
+      "received_mails" => "Emails::PasseEnInstruction",
+      "closed_mails" => "Emails::Accepte",
+      "refused_mails" => "Emails::Refuse",
+      "without_continuation_mails" => "Emails::ClasseSansSuite",
+      "re_instructed_mails" => "Emails::RepasseEnInstruction",
+    }.freeze
+
+    def collection
+      TABLES.keys
+    end
+
+    def process(table)
+      type = TABLES.fetch(table)
+
+      # One statement per table, over 50-80k rows whose bodies are a few kB each:
+      # the DISTINCT ON sorts on those, which can spill to disk and outlast the
+      # 60s production statement_timeout. Raised for the transaction only.
+      ActiveRecord::Base.transaction do
+        ActiveRecord::Base.connection.execute("SET LOCAL statement_timeout = '5min'")
+
+        # The IN also discards rows email_templates would reject: re_instructed_mails
+        # is the only table without a FK to procedures, so it can hold orphans, and
+        # the 5 others have a nullable procedure_id — a NULL never satisfies an IN.
+        ActiveRecord::Base.connection.execute(<<~SQL.squish)
+          INSERT INTO email_templates (type, procedure_id, subject, body, json_subject, json_body, created_at, updated_at)
+          SELECT DISTINCT ON (procedure_id) '#{type}', procedure_id, subject, body, json_subject, json_body, created_at, updated_at
+          FROM #{table}
+          WHERE procedure_id IN (SELECT id FROM procedures)
+          ORDER BY procedure_id, updated_at DESC
+          ON CONFLICT (procedure_id, type) DO UPDATE
+            SET subject = excluded.subject,
+                body = excluded.body,
+                json_subject = excluded.json_subject,
+                json_body = excluded.json_body,
+                updated_at = excluded.updated_at
+            WHERE excluded.updated_at > email_templates.updated_at
+        SQL
+      end
+    end
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,29 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "053193bbec4da9fb2edd6d2369bbff519b8c5ef8e9ccc0f1c1f6aed3076c772b",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/tasks/maintenance/t20260721_copy_legacy_mail_tables_into_email_templates_task.rb",
+      "line": 34,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ActiveRecord::Base.connection.execute(\"INSERT INTO email_templates (type, procedure_id, subject, body, json_subject, json_body, created_at, updated_at)\\nSELECT DISTINCT ON (procedure_id) '#{:BRAKEMAN_SAFE_LITERAL}', procedure_id, subject, body, json_subject, json_body, created_at, updated_at\\nFROM #{table}\\nWHERE procedure_id IN (SELECT id FROM procedures)\\nORDER BY procedure_id, updated_at DESC\\nON CONFLICT (procedure_id, type) DO UPDATE\\n  SET subject = excluded.subject,\\n      body = excluded.body,\\n      json_subject = excluded.json_subject,\\n      json_body = excluded.json_body,\\n      updated_at = excluded.updated_at\\n  WHERE excluded.updated_at > email_templates.updated_at\\n\".squish)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Maintenance::T20260721CopyLegacyMailTablesIntoEmailTemplatesTask",
+        "method": "process"
+      },
+      "user_input": "table",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "table names and STI types come from a frozen internal constant"
+    },
+    {
       "warning_type": "Remote Code Execution",
       "warning_code": 25,
       "fingerprint": "1d30d61a81ffea8e64121341837db4c47cc97e401d4a9d0e151e01faf0e356a3",

--- a/db/migrate/20260721135955_create_email_templates.rb
+++ b/db/migrate/20260721135955_create_email_templates.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateEmailTemplates < ActiveRecord::Migration[8.0]
+  def change
+    create_table :email_templates do |t|
+      t.string :type, null: false
+      t.references :procedure, null: false, foreign_key: { on_delete: :cascade }, index: false
+      t.string :subject
+      t.text :body
+      t.jsonb :json_subject
+      t.jsonb :json_body
+      t.timestamps
+      t.index [:procedure_id, :type], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -599,6 +599,18 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_20_081609) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "email_templates", force: :cascade do |t|
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.jsonb "json_body"
+    t.jsonb "json_subject"
+    t.bigint "procedure_id", null: false
+    t.string "subject"
+    t.string "type", null: false
+    t.datetime "updated_at", null: false
+    t.index ["procedure_id", "type"], name: "index_email_templates_on_procedure_id_and_type", unique: true
+  end
+
   create_table "etablissements", id: :serial, force: :cascade do |t|
     t.string "adresse"
     t.date "association_date_creation"
@@ -1544,6 +1556,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_20_081609) do
   add_foreign_key "dossiers", "users"
   add_foreign_key "dossiers_list_personnalisations", "procedures"
   add_foreign_key "dossiers_list_personnalisations", "users"
+  add_foreign_key "email_templates", "procedures", on_delete: :cascade
   add_foreign_key "experts", "users"
   add_foreign_key "experts_procedures", "experts"
   add_foreign_key "experts_procedures", "procedures"

--- a/spec/models/email_template_replica_spec.rb
+++ b/spec/models/email_template_replica_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+describe EmailTemplateReplica do
+  let(:procedure) { procedures.individual }
+
+  def replica_for(mail) = described_class.find_by(procedure_id: mail.procedure_id, type: mail.class.name)
+
+  it "replicates a newly customized template" do
+    mail = create(:email_depose, procedure:, subject: "Objet v1")
+
+    expect(replica_for(mail)).to have_attributes(subject: "Objet v1", body: mail.body)
+  end
+
+  # The copy task compares updated_at between the two tables, so the replica has
+  # to carry the legacy timestamps, not the time at which it was written.
+  it "replicates the legacy timestamps rather than the time of the copy" do
+    mail = create(:email_depose, procedure:)
+    legacy_time = 2.days.ago.change(usec: 0)
+    mail.update_columns(created_at: legacy_time, updated_at: legacy_time)
+    described_class.delete_replica(mail)
+
+    described_class.replicate(mail.reload)
+
+    expect(replica_for(mail)).to have_attributes(created_at: legacy_time, updated_at: legacy_time)
+  end
+
+  it "replicates a later edit of the same template" do
+    mail = create(:email_depose, procedure:, subject: "Objet v1")
+    mail.update!(subject: "Objet v2")
+
+    expect(replica_for(mail).subject).to eq("Objet v2")
+  end
+
+  it "replicates each type separately" do
+    email_depose = create(:email_depose, procedure:)
+    email_passe_en_instruction = create(:email_passe_en_instruction, procedure:)
+
+    expect(replica_for(email_depose).type).to eq("Emails::Depose")
+    expect(replica_for(email_passe_en_instruction).type).to eq("Emails::PasseEnInstruction")
+  end
+
+  it "deletes the replica when the legacy row is destroyed" do
+    mail = create(:email_depose, procedure:)
+
+    expect { mail.destroy! }.to change { replica_for(mail) }.to(nil)
+  end
+
+  # Nothing reads email_templates yet, so no association cleans up the replica:
+  # the legacy `dependent: :destroy` is what keeps the foreign key satisfiable.
+  # Reloaded on purpose — a procedure freshly loaded from the DB is what the
+  # deletion task actually destroys, and it has no cached association to rely on.
+  it "leaves no row behind when the procedure itself is destroyed" do
+    destroyable_procedure = create(:procedure)
+    create(:email_depose, procedure: destroyable_procedure)
+
+    expect { Procedure.find(destroyable_procedure.id).destroy! }.not_to raise_error
+    expect(described_class.where(procedure_id: destroyable_procedure.id)).to be_empty
+  end
+
+  # And if a legacy row ever vanishes without its callbacks (raw SQL, delete_all),
+  # the replica must not be what makes a procedure undeletable: without the
+  # ON DELETE CASCADE on the foreign key, this raises PG::ForeignKeyViolation.
+  it "does not make a procedure undeletable when the legacy row vanished without callbacks" do
+    destroyable_procedure = create(:procedure)
+    mail = create(:email_depose, procedure: destroyable_procedure)
+    Emails::Depose.where(id: mail.id).delete_all
+
+    expect { Procedure.find(destroyable_procedure.id).destroy! }.not_to raise_error
+    expect(described_class.where(procedure_id: destroyable_procedure.id)).to be_empty
+  end
+
+  # Guards the rolling deploy window, when pods reading email_templates and pods
+  # writing the legacy tables coexist: the most recently edited row wins.
+  it "does not downgrade a replica newer than the legacy row" do
+    mail = create(:email_depose, procedure:, subject: "Objet v1")
+    described_class.find_by(procedure_id: procedure.id, type: mail.class.name)
+      .update!(subject: "écrit après la bascule", updated_at: 1.hour.from_now)
+
+    described_class.replicate(mail)
+
+    expect(replica_for(mail).subject).to eq("écrit après la bascule")
+  end
+end

--- a/spec/tasks/maintenance/t20260721_copy_legacy_mail_tables_into_email_templates_task_spec.rb
+++ b/spec/tasks/maintenance/t20260721_copy_legacy_mail_tables_into_email_templates_task_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260721CopyLegacyMailTablesIntoEmailTemplatesTask do
+    let(:procedure) { procedures.individual }
+
+    def insert_legacy_initiated_mail(procedure_id, subject:, updated_at: Time.zone.now)
+      connection = ActiveRecord::Base.connection
+      connection.execute(<<~SQL.squish)
+        INSERT INTO initiated_mails (subject, body, procedure_id, created_at, updated_at)
+        VALUES (#{connection.quote(subject)}, #{connection.quote('legacy body')}, #{procedure_id}, NOW(), #{connection.quote(updated_at)})
+      SQL
+    end
+
+    def email_templates_count
+      ActiveRecord::Base.connection.select_value(<<~SQL.squish).to_i
+        SELECT COUNT(*) FROM email_templates
+        WHERE type = 'Emails::Depose' AND procedure_id = #{procedure.id}
+      SQL
+    end
+
+    def email_templates_subject
+      ActiveRecord::Base.connection.select_value(<<~SQL.squish)
+        SELECT subject FROM email_templates
+        WHERE type = 'Emails::Depose' AND procedure_id = #{procedure.id}
+      SQL
+    end
+
+    it "copies the legacy row into email_templates" do
+      insert_legacy_initiated_mail(procedure.id, subject: "legacy subject")
+
+      expect { described_class.process("initiated_mails") }.to change { email_templates_count }.from(0).to(1)
+    end
+
+    it "is idempotent: re-running does not duplicate or error" do
+      insert_legacy_initiated_mail(procedure.id, subject: "legacy subject")
+      described_class.process("initiated_mails")
+
+      expect { described_class.process("initiated_mails") }.not_to change { email_templates_count }
+    end
+
+    it "resyncs a legacy row edited after the first copy" do
+      insert_legacy_initiated_mail(procedure.id, subject: "legacy subject")
+      described_class.process("initiated_mails")
+
+      ActiveRecord::Base.connection.execute(<<~SQL.squish)
+        UPDATE initiated_mails SET subject = 'edited', updated_at = NOW() + interval '1 hour'
+        WHERE procedure_id = #{procedure.id}
+      SQL
+
+      described_class.process("initiated_mails")
+
+      expect(email_templates_subject).to eq("edited")
+    end
+
+    it "does not overwrite a newer email_templates row with stale legacy data" do
+      insert_legacy_initiated_mail(procedure.id, subject: "legacy subject")
+      described_class.process("initiated_mails")
+
+      ActiveRecord::Base.connection.execute(<<~SQL.squish)
+        UPDATE email_templates SET updated_at = NOW() + interval '1 hour', subject = 'newer'
+        WHERE type = 'Emails::Depose' AND procedure_id = #{procedure.id}
+      SQL
+
+      described_class.process("initiated_mails")
+
+      expect(email_templates_subject).to eq("newer")
+    end
+
+    it "skips legacy rows whose procedure no longer exists" do
+      connection = ActiveRecord::Base.connection
+      orphan_procedure_id = connection.select_value("SELECT COALESCE(MAX(id), 0) + 1000 FROM procedures").to_i
+      connection.execute(<<~SQL.squish)
+        INSERT INTO re_instructed_mails (subject, body, procedure_id, created_at, updated_at)
+        VALUES (#{connection.quote('orphan subject')}, #{connection.quote('orphan body')}, #{orphan_procedure_id}, NOW(), NOW())
+      SQL
+
+      expect { described_class.process("re_instructed_mails") }.not_to raise_error
+
+      count = connection.select_value(<<~SQL.squish).to_i
+        SELECT COUNT(*) FROM email_templates
+        WHERE type = 'Emails::RepasseEnInstruction' AND procedure_id = #{orphan_procedure_id}
+      SQL
+      expect(count).to eq(0)
+    end
+
+    # 5 of the 6 legacy tables have a nullable procedure_id, and email_templates
+    # requires it: the IN is what keeps those rows out.
+    it "skips legacy rows attached to no procedure" do
+      connection = ActiveRecord::Base.connection
+      connection.execute(<<~SQL.squish)
+        INSERT INTO initiated_mails (subject, body, procedure_id, created_at, updated_at)
+        VALUES (#{connection.quote('no procedure')}, #{connection.quote('legacy body')}, NULL, NOW(), NOW())
+      SQL
+
+      expect { described_class.process("initiated_mails") }.not_to raise_error
+
+      count = connection.select_value(<<~SQL.squish).to_i
+        SELECT COUNT(*) FROM email_templates WHERE subject = #{connection.quote('no procedure')}
+      SQL
+      expect(count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Deuxième des trois PR du chantier d'unification des modèles d'email : les 6 tables de modèles personnalisés (`initiated_mails`, `received_mails`, …) fusionnent dans une seule table STI `email_templates`. Prérequis de la refonte des emails automatiques des démarches déclaratives, et socle des évolutions à venir (emails ad-hoc, variantes par locale).

Celle-ci ne change aucun comportement : personne ne lit encore `email_templates`.

- création de la table (index unique `(procedure_id, type)`, FK en `on delete cascade`) ;
- copie des données existantes par maintenance task `run_on_first_deploy`, idempotente (upsert conditionnel sur `updated_at`, donc rejouable comme resync) ;
- écritures en Y vers tables legacy et `email_templates`, dans la transaction de l'écriture. Sans elle, un modèle d'email édité entre ce déploiement et celui de la bascule ne réapparaîtrait qu'après un re-run manuel de la task, et l'admin verrait entre-temps une version périmée — avec des emails envoyés en conséquence. Ce code disparaît avec les modèles legacy.

On a vérifié que malgré l'absence d'index unique on aucun doublon de template par procédure.


Ref #13332
A suivre : https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/13610
