### PR TITLE
Tech: épingler les invariants de types_de_champ_for_tags

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -109,6 +109,17 @@ class Procedure < ApplicationRecord
     all_revisions_types_de_champ.not_repetition
   end
 
+  # The template tag parser's vocabulary (mail templates, attestations,
+  # dossier submitted messages) — not the tag picker, which offers the active
+  # revision only. Two properties are load-bearing:
+  # - on a published procedure the draft revision is included, so tags for
+  #   not-yet-published champs parse on dossiers following the draft revision
+  #   (procedure preview);
+  # - every version of a type de champ is returned — no deduplication by
+  #   stable_id: legacy tags reference champs by libellé, so libellés from
+  #   older revisions must keep matching.
+  # Both are pinned in tags_substitution_concern_spec ('replace_tags' with
+  # revisions and with a draft-only champ).
   def types_de_champ_for_tags
     TypeDeChamp
       .fillable

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -547,6 +547,19 @@ describe TagsSubstitutionConcern, type: :model do
       end
     end
 
+    context 'when a champ only exists on the draft of a published procedure' do
+      let(:dossier) { create(:dossier, procedure:, revision: procedure.draft_revision) }
+
+      before do
+        procedure.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'champ à venir')
+        dossier.root_champs_public.find { it.libelle == 'champ à venir' }.update(value: 'valeur')
+      end
+
+      it 'parses and substitutes the tag on a dossier following the draft revision (preview)' do
+        expect(template_concern.send(:replace_tags, '--champ à venir--', dossier)).to eq('valeur')
+      end
+    end
+
     context 'when data contains malicious code' do
       let(:template) { '--libelleA-- --nom--' }
       context 'in individual data' do


### PR DESCRIPTION
## Quoi

`Procedure#types_de_champ_for_tags` est le vocabulaire du parseur de balises des modèles (courriers, attestations, messages de dépôt) — le sélecteur de balises, lui, lit la révision active. Deux propriétés de cette requête sont porteuses de comportement mais n'étaient ni documentées ni entièrement testées :

- **toutes les versions** d'un type de champ sont retournées (pas de déduplication par stable_id) : les balises historiques référencent les champs par libellé, un libellé d'une ancienne révision doit donc continuer à être reconnu après renommage ;
- **la révision brouillon est incluse** sur une démarche publiée : les balises de champs non encore publiés doivent être substituées sur les dossiers de prévisualisation qui suivent le brouillon.

Le cas « renommage » était déjà épinglé par une spec ; cette PR ajoute la spec du cas « champ uniquement au brouillon » et documente les deux invariants sur la requête, pour qu'un refactor bien intentionné (déduplication, restriction aux révisions publiées) ne casse pas silencieusement les courriers sortants.

Aucun changement de comportement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
