### PR TITLE
Tech: mettre en cache le PDF du dossier vide dans ActiveStorage

### DIFF
--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -183,7 +183,7 @@ module Users
       filename = "#{@procedure.libelle}.pdf"
 
       if @procedure.feature_enabled?(:dossier_vide_weasyprint)
-        send_data(generate_empty_pdf_weasyprint(revision), filename:, type: 'application/pdf')
+        send_data(dossier_vide_weasyprint_pdf(revision), filename:, type: 'application/pdf')
       else
         send_data(render_dossier_vide_prawn, filename:)
       end
@@ -193,7 +193,21 @@ module Users
       send_data(render_dossier_vide_prawn, filename:)
     end
 
-    def generate_empty_pdf_weasyprint(revision)
+    # A published PDF is cached in Active Storage, behind a cache key built from
+    # everything it depends on. The draft ("test") PDF is never cached.
+    def dossier_vide_weasyprint_pdf(revision)
+      return render_dossier_vide_weasyprint(revision) if revision.draft?
+
+      procedure = revision.procedure
+      cache_key = procedure.dossier_vide_pdf_cache_key_for(revision)
+
+      return procedure.dossier_vide_pdf.download if procedure.dossier_vide_pdf_fresh?(cache_key)
+
+      render_dossier_vide_weasyprint(revision)
+        .tap { procedure.store_dossier_vide_pdf(it, cache_key:) }
+    end
+
+    def render_dossier_vide_weasyprint(revision)
       html = render_to_string(
         Dossiers::DossierVidePdfComponent.new(revision:),
         layout: 'dossier_vide_pdf',

--- a/app/models/concerns/procedure_dossier_vide_pdf_concern.rb
+++ b/app/models/concerns/procedure_dossier_vide_pdf_concern.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Caches the generated "dossier vide" PDF (the printable empty form) in Active Storage
+module ProcedureDossierVidePdfConcern
+  extend ActiveSupport::Concern
+
+  included do
+    has_one_attached :dossier_vide_pdf
+  end
+
+  CACHE_KEY_METADATA = 'dossier_vide_pdf_cache_key'
+  # Bump when the PDF rendering changes (component, helpers, stylesheet) and the
+  # already cached PDF should be invalidated without waiting for the expiration.
+  CACHE_VERSION = 1
+  CACHE_EXPIRATION = 1.week
+
+  def dossier_vide_pdf_cache_key_for(revision)
+    ["v#{CACHE_VERSION}", *[self, revision, service].compact.map(&:cache_key_with_version)].join('/')
+  end
+
+  def dossier_vide_pdf_fresh?(cache_key)
+    blob = dossier_vide_pdf.blob
+    return false if blob.nil?
+
+    blob.metadata[CACHE_KEY_METADATA] == cache_key && blob.created_at.after?(CACHE_EXPIRATION.ago)
+  end
+
+  def store_dossier_vide_pdf(pdf, cache_key:)
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(pdf),
+      filename: "#{libelle}.pdf",
+      content_type: 'application/pdf',
+      metadata: {
+        'virus_scan_result' => ActiveStorage::VirusScanner::SAFE,
+        CACHE_KEY_METADATA => cache_key,
+      }
+    )
+
+    # Attaching touches the procedure, which would invalidate the key just stored
+    Procedure.no_touching { dossier_vide_pdf.attach(blob) }
+  end
+end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -13,6 +13,7 @@ class Procedure < ApplicationRecord
   include PiecesJointesListConcern
   include ColumnsConcern
   include RoutingRuleStatusesConcern
+  include ProcedureDossierVidePdfConcern
 
   include Discard::Model
   self.discard_column = :hidden_at

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -570,6 +570,100 @@ describe Users::CommencerController, type: :controller do
     end
   end
 
+  # Kept out of '#dossier_vide_pdf' on purpose: that group downloads the PDF in a
+  # `before` hook, which would count as an extra WeasyPrint call here.
+  describe '#dossier_vide_pdf caching' do
+    render_views
+
+    let(:procedure) { create(:procedure, :published, :with_service, :with_path) }
+
+    before do
+      Flipper.enable(:dossier_vide_weasyprint, procedure)
+      allow(WeasyprintService).to receive(:generate_pdf).and_return('%PDF-fake')
+    end
+
+    def download = get(:dossier_vide_pdf, params: { path: procedure.path })
+
+    it 'generates and stores the PDF on the first download' do
+      download
+
+      expect(WeasyprintService).to have_received(:generate_pdf).once
+      expect(procedure.reload.dossier_vide_pdf).to be_attached
+      expect(response.body).to eq('%PDF-fake')
+    end
+
+    it 'serves the stored PDF on the next download, without rendering it again' do
+      download
+      allow(Dossiers::DossierVidePdfComponent).to receive(:new).and_call_original
+
+      download
+
+      expect(WeasyprintService).to have_received(:generate_pdf).once
+      expect(Dossiers::DossierVidePdfComponent).not_to have_received(:new)
+      expect(response.body).to eq('%PDF-fake')
+    end
+
+    it 'regenerates once the cached PDF has expired' do
+      download
+      procedure.reload.dossier_vide_pdf.blob.update_column(:created_at, 8.days.ago)
+      download
+
+      expect(WeasyprintService).to have_received(:generate_pdf).twice
+    end
+
+    it 'regenerates when the presentation changes' do
+      download
+      procedure.update!(description: 'Une nouvelle présentation')
+      download
+
+      expect(WeasyprintService).to have_received(:generate_pdf).twice
+    end
+
+    it 'regenerates when the service changes' do
+      download
+      procedure.service.update!(adresse: '2 rue de la Paix, 75002 Paris')
+      download
+
+      expect(WeasyprintService).to have_received(:generate_pdf).twice
+    end
+
+    it 'regenerates when a new revision is published' do
+      download
+      procedure.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'Un champ de plus')
+      procedure.publish_revision!(procedure.administrateurs.first)
+      download
+
+      expect(WeasyprintService).to have_received(:generate_pdf).twice
+    end
+
+    it 'does not cache anything when WeasyPrint fails' do
+      allow(WeasyprintService).to receive(:generate_pdf).and_raise(WeasyprintService::Error)
+
+      download
+
+      expect(response).to have_http_status(:success)
+      expect(procedure.reload.dossier_vide_pdf).not_to be_attached
+    end
+  end
+
+  describe '#dossier_vide_pdf_test caching' do
+    render_views
+
+    let(:procedure) { create(:procedure, :with_service, :with_path) }
+
+    before do
+      Flipper.enable(:dossier_vide_weasyprint, procedure)
+      allow(WeasyprintService).to receive(:generate_pdf).and_return('%PDF-fake')
+      get :dossier_vide_pdf_test, params: { path: procedure.path }
+      get :dossier_vide_pdf_test, params: { path: procedure.path }
+    end
+
+    it 'never caches the draft PDF: it is content being edited' do
+      expect(WeasyprintService).to have_received(:generate_pdf).twice
+      expect(procedure.reload.dossier_vide_pdf).not_to be_attached
+    end
+  end
+
   describe '#commencer for moral procedure with pro_connect_for_moral_procedure flag' do
     render_views
     subject { get :commencer, params: { path: procedure.path } }

--- a/spec/models/concerns/procedure_dossier_vide_pdf_concern_spec.rb
+++ b/spec/models/concerns/procedure_dossier_vide_pdf_concern_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+describe ProcedureDossierVidePdfConcern do
+  let(:procedure) { create(:procedure, :published, :with_service, libelle: 'Ma démarche') }
+  let(:revision) { procedure.published_revision }
+
+  describe '#dossier_vide_pdf_cache_key_for' do
+    it 'changes when the revision changes' do
+      before_key = procedure.dossier_vide_pdf_cache_key_for(revision)
+
+      expect(procedure.dossier_vide_pdf_cache_key_for(procedure.draft_revision)).not_to eq(before_key)
+    end
+
+    it 'changes when the procedure is updated' do
+      before_key = procedure.dossier_vide_pdf_cache_key_for(revision)
+      procedure.update!(description: 'Une nouvelle présentation')
+
+      expect(procedure.dossier_vide_pdf_cache_key_for(revision)).not_to eq(before_key)
+    end
+
+    it 'changes when the service is updated' do
+      before_key = procedure.dossier_vide_pdf_cache_key_for(revision)
+      procedure.service.update!(adresse: '2 rue de la Paix, 75002 Paris')
+
+      expect(procedure.reload.dossier_vide_pdf_cache_key_for(revision)).not_to eq(before_key)
+    end
+
+    it 'changes when the cache version is bumped, which is how rendering changes are caught' do
+      before_key = procedure.dossier_vide_pdf_cache_key_for(revision)
+      stub_const('ProcedureDossierVidePdfConcern::CACHE_VERSION', ProcedureDossierVidePdfConcern::CACHE_VERSION + 1)
+
+      expect(procedure.dossier_vide_pdf_cache_key_for(revision)).not_to eq(before_key)
+    end
+
+    it 'is stable when nothing changed' do
+      expect(procedure.dossier_vide_pdf_cache_key_for(revision))
+        .to eq(procedure.dossier_vide_pdf_cache_key_for(revision))
+    end
+
+    it 'works for a procedure without a service' do
+      procedure.update!(service: nil, organisation: 'Une organisation')
+
+      expect(procedure.dossier_vide_pdf_cache_key_for(revision)).to be_present
+    end
+  end
+
+  describe '#dossier_vide_pdf_fresh?' do
+    it 'is false when nothing has been cached yet' do
+      expect(procedure.dossier_vide_pdf_fresh?('key')).to be false
+    end
+
+    it 'is true when the cached PDF matches the key' do
+      procedure.store_dossier_vide_pdf('%PDF-fake', cache_key: 'key')
+
+      expect(procedure.dossier_vide_pdf_fresh?('key')).to be true
+    end
+
+    it 'is false when the key differs' do
+      procedure.store_dossier_vide_pdf('%PDF-fake', cache_key: 'key')
+
+      expect(procedure.dossier_vide_pdf_fresh?('other-key')).to be false
+    end
+
+    it 'is false once the cached PDF has expired' do
+      procedure.store_dossier_vide_pdf('%PDF-fake', cache_key: 'key')
+      procedure.dossier_vide_pdf.blob.update_column(:created_at, 8.days.ago)
+
+      expect(procedure.reload.dossier_vide_pdf_fresh?('key')).to be false
+    end
+  end
+
+  describe '#store_dossier_vide_pdf' do
+    it 'attaches the PDF, named after the procedure, with the key in its metadata' do
+      procedure.store_dossier_vide_pdf('%PDF-fake', cache_key: 'key')
+
+      expect(procedure.dossier_vide_pdf.download).to eq('%PDF-fake')
+      expect(procedure.dossier_vide_pdf.filename.to_s).to eq('Ma démarche.pdf')
+      expect(procedure.dossier_vide_pdf.blob.metadata[ProcedureDossierVidePdfConcern::CACHE_KEY_METADATA]).to eq('key')
+    end
+
+    it 'replaces a previously cached PDF' do
+      procedure.store_dossier_vide_pdf('%PDF-old', cache_key: 'key')
+      procedure.store_dossier_vide_pdf('%PDF-new', cache_key: 'other-key')
+
+      expect(procedure.reload.dossier_vide_pdf.download).to eq('%PDF-new')
+      expect(procedure.dossier_vide_pdf_fresh?('other-key')).to be true
+    end
+
+    it 'does not enqueue a virus scan: we generated this PDF ourselves' do
+      procedure.store_dossier_vide_pdf('%PDF-fake', cache_key: 'key')
+
+      expect(BlobProcessorJob).not_to have_been_enqueued
+    end
+
+    it 'does not bump updated_at, which would invalidate the key it just wrote' do
+      procedure # create it before measuring
+
+      expect { procedure.store_dossier_vide_pdf('%PDF-fake', cache_key: 'key') }
+        .not_to change { procedure.reload.updated_at }
+    end
+  end
+end


### PR DESCRIPTION
Suite de #13368. Le PDF du dossier vide est désormais servi depuis ActiveStorage au lieu d'être régénéré par WeasyPrint à chaque téléchargement.

Un PDF déjà généré ne peut pas être servi indéfiniment : après publication de la révision, libellé, description et organisation restent modifiables, et le service — d'où vient la mention « À envoyer à … » — est éditable à tout moment. On ajoute  donc une clé de cache aux métadata du bloc et avant un téléchargement on regarde si la clé a changé.

Points à noter pour la relecture :
- Le blob est créé avec virus_scan_result: SAFE, comme dans AttestationTemplate#generate, pour ne pas lancer BlobProcessorJob.
- La version « test » (brouillon) n'est pas cachée, et un repli Prawn n'écrit jamais dans le cache.
