### PR TITLE
Tech : le traitement d'image ne décode plus de fichier non vérifié

### DIFF
--- a/app/jobs/blob_processor_job.rb
+++ b/app/jobs/blob_processor_job.rb
@@ -94,7 +94,7 @@ class BlobProcessorJob < ApplicationJob
     load_opts = { access: :sequential }
     load_opts[:autorotate] = true if autorotate_needed
 
-    image = Vips::Image.new_from_file(tempfile.to_path, **load_opts)
+    image = TrustedVipsLoader.new_from_file(tempfile.to_path, **load_opts)
     image = WatermarkService.new.apply(image, format: blob.content_type) if watermark_needed
 
     write_opts = uninterlace_needed ? { interlace: false } : {}
@@ -131,14 +131,14 @@ class BlobProcessorJob < ApplicationJob
   end
 
   def autorotate_needed?(tempfile)
-    image = Vips::Image.new_from_file(tempfile.to_path)
+    image = TrustedVipsLoader.new_from_file(tempfile.to_path)
     image.get_fields.include?("orientation") && image.get("orientation") != 1
   rescue Vips::Error # unreadable metadata should not abort processing: skip the mutation instead
     false
   end
 
   def interlaced?(tempfile)
-    image = Vips::Image.new_from_file(tempfile.to_path)
+    image = TrustedVipsLoader.new_from_file(tempfile.to_path)
     image.get_fields.include?("interlaced") && image.get("interlaced") != 0
   rescue Vips::Error # unreadable metadata should not abort processing: skip the mutation instead
     false

--- a/app/lib/trusted_vips_loader.rb
+++ b/app/lib/trusted_vips_loader.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# libvips picks its decoder from a file's leading bytes, whatever content type we
+# recorded for the blob. It flags several of its decoders as unfuzzed, meaning they
+# are only meant for content we produced ourselves, and reading a user-supplied file
+# with one of them can have effects well beyond returning an image. From libvips 8.13
+# on they can be disabled outright; before that there is no such switch, so we ask
+# which decoder libvips would choose and refuse the ones listed below.
+#
+# Deliberately a deny list rather than an allow list. An allow list would also have
+# to name every decoder a legitimate upload may go through, and those names are read
+# from a newer libvips than the one we deploy — an entry we got wrong would reject
+# real files. This errs the other way: it only stops what we have named.
+module TrustedVipsLoader
+  # Reads MATLAB files, via a library whose format handling reaches well outside the
+  # file it was given. Nothing we accept is ever decoded by it.
+  BLOCKED_LOADERS = %w[
+    VipsForeignLoadMat
+  ].freeze
+
+  class << self
+    def new_from_file(source, **options)
+      ensure_allowed!(source)
+
+      Vips::Image.new_from_file(path_for(source), **options)
+    end
+
+    # Raised with the message UnreadableVipsSourceConcern already reads as "these bytes
+    # will never be an image", so a refused file is skipped rather than retried.
+    def ensure_allowed!(source)
+      return if allowed?(source)
+
+      raise Vips::Error, "#{path_for(source)} is not a known file format"
+    end
+
+    def allowed?(source)
+      !Vips.vips_foreign_find_load(path_for(source)).in?(BLOCKED_LOADERS)
+    end
+
+    private
+
+    def path_for(source)
+      source.respond_to?(:path) ? source.path.to_s : source.to_s
+    end
+  end
+end

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -61,6 +61,23 @@ ActiveSupport.on_load(:active_storage_blob) do
     end
   end
 
+  # Direct upload is the one path that stores the content type declared by the
+  # client without ever reading the file, and `identified` stays false until
+  # something does. Building a variant from such a blob means deciding it is an
+  # image on the uploader's word alone, so refuse: the image library picks its
+  # decoder from the bytes and will not agree with a type nobody checked.
+  def variable?
+    identified? && super
+  end
+
+  # Same for previews: the previewer is picked from the declared content type
+  # too, and it hands the bytes to pdftoppm or ffmpeg rather than to the image
+  # library. `representation` tries this before `variant`, so guarding only the
+  # latter would leave the wider decoder open.
+  def previewable?
+    identified? && super
+  end
+
   ActiveStorage::Blob.class_eval do
     def purge_later
       DelayedPurgeJob.perform_later(self)
@@ -99,6 +116,15 @@ Rails.application.reloader.to_prepare do
   class ActiveStorage::BaseController
     # same store as ApplicationController
     protect_from_forgery with: :exception, store: :cookie
+  end
+
+  # A blob we decline to transform is a missing representation, not a server
+  # error: the signed id and the variation key are both valid, they just do not
+  # compose into something we are willing to render.
+  class ActiveStorage::Representations::BaseController
+    rescue_from ActiveStorage::UnrepresentableError, ActiveStorage::InvariableError do
+      head :not_found
+    end
   end
 end
 

--- a/config/initializers/vips_untrusted_loaders.rb
+++ b/config/initializers/vips_untrusted_loaders.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# libvips chooses its decoder from a file's leading bytes, independently of the
+# content type we recorded. Several of its loaders are flagged "untrusted": they are
+# unfuzzed and only meant for content we produced ourselves, and handing them a
+# user-supplied file can do more than fail to produce an image.
+#
+# Stopping the handoff is the control that works, because it applies at the layer
+# that actually picks the decoder. Re-deriving the content type in Ruby does not
+# close it: Rails and libvips read the same bytes and disagree, and a third opinion
+# does not stop the handoff.
+
+# Active Storage funnels every variant through this one method, so guarding it covers
+# the whole variant path. Our own calls go through TrustedVipsLoader directly. Both
+# constants are resolved when the method runs rather than while this file loads, so
+# autoloading applies as usual and libvips is only needed once an image is decoded.
+module VipsLoaderGuard
+  def load_image(path_or_image, **options)
+    TrustedVipsLoader.ensure_allowed!(path_or_image) if !path_or_image.is_a?(::Vips::Image)
+
+    super
+  end
+end
+
+begin
+  require "vips"
+  require "image_processing/vips"
+rescue LoadError
+  # libvips is installed on the job servers only. Web processes never decode an
+  # image — they serve variants a job already produced — so there is nothing to
+  # guard here, and requiring it would break their boot.
+else
+  ImageProcessing::Vips::Processor.singleton_class.prepend(VipsLoaderGuard)
+
+  # From libvips 8.13 on, the same thing enforced inside libvips itself. It is
+  # stricter than the guard above — it covers call sites we did not think to wrap —
+  # so apply it whenever it exists and treat the Ruby guard as the fallback for
+  # older builds, which have no such switch at all.
+  if Vips.respond_to?(:block_untrusted)
+    Vips.block_untrusted(true)
+  else
+    libvips_version = "#{Vips.version(0)}.#{Vips.version(1)}.#{Vips.version(2)}"
+    message = "libvips #{libvips_version} cannot block untrusted loaders (8.13 or later required). " \
+              "Only the decoders named in TrustedVipsLoader::BLOCKED_LOADERS are refused; the rest of " \
+              "the unfuzzed family stays reachable until libvips is upgraded."
+
+    warn(message)
+    Rails.logger&.warn(message)
+  end
+end
+
+# Rails' default list also covers formats we never accept (BMP, ICO, PSD, HEIC),
+# whose loaders are unfuzzed and would now be refused anyway. Keep the types we
+# actually authorize. Independent of libvips being loadable here.
+Rails.application.config.active_storage.variable_content_types =
+  AUTHORIZED_IMAGE_TYPES & %w[image/jpeg image/png image/tiff image/webp image/gif]

--- a/spec/config/vips_untrusted_loaders_spec.rb
+++ b/spec/config/vips_untrusted_loaders_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "libvips untrusted loaders" do
+describe "libvips untrusted loaders", :external_deps do
   let(:path) { Rails.root.join("tmp/#{SecureRandom.hex}") }
   let(:unfuzzed_loader_bytes) { "MATLAB 5.0 MAT-file#{' ' * 512}" }
   let(:accepted_image_bytes) { Rails.root.join("spec/fixtures/files/logo_test_procedure.png").binread }
@@ -31,7 +31,9 @@ describe "libvips untrusted loaders" do
 
   # From 8.13 on, libvips enforces this itself, which also covers any call site we
   # forgot to route through TrustedVipsLoader.
-  describe "libvips-level blocking", if: Vips.respond_to?(:block_untrusted) do
+  # Evaluated while this file loads, which also happens in the CI job that has no
+  # libvips at all — hence the defined? guard alongside the version check.
+  describe "libvips-level blocking", if: defined?(Vips) && Vips.respond_to?(:block_untrusted) do
     it "refuses a file whose leading bytes select an unfuzzed loader" do
       path.binwrite(unfuzzed_loader_bytes)
 

--- a/spec/config/vips_untrusted_loaders_spec.rb
+++ b/spec/config/vips_untrusted_loaders_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+describe "libvips untrusted loaders" do
+  let(:path) { Rails.root.join("tmp/#{SecureRandom.hex}") }
+  let(:unfuzzed_loader_bytes) { "MATLAB 5.0 MAT-file#{' ' * 512}" }
+  let(:accepted_image_bytes) { Rails.root.join("spec/fixtures/files/logo_test_procedure.png").binread }
+
+  after { FileUtils.rm_f(path) }
+
+  # Active Storage funnels every variant through ImageProcessing, so this holds on
+  # any libvips version — including the builds before 8.13, which cannot refuse
+  # these loaders themselves and rely entirely on TrustedVipsLoader.
+  describe "building a variant" do
+    before { Vips.block_untrusted(false) if Vips.respond_to?(:block_untrusted) }
+
+    after { Vips.block_untrusted(true) if Vips.respond_to?(:block_untrusted) }
+
+    it "refuses a file whose leading bytes select an unfuzzed loader" do
+      path.binwrite(unfuzzed_loader_bytes)
+
+      expect { ImageProcessing::Vips.source(path.to_s).convert("png").call }
+        .to raise_error(Vips::Error, /is not a known file format/)
+    end
+
+    it "still accepts an image format we authorize" do
+      path.binwrite(accepted_image_bytes)
+
+      expect(ImageProcessing::Vips.source(path.to_s).resize_to_limit(50, 50).call).to be_present
+    end
+  end
+
+  # From 8.13 on, libvips enforces this itself, which also covers any call site we
+  # forgot to route through TrustedVipsLoader.
+  describe "libvips-level blocking", if: Vips.respond_to?(:block_untrusted) do
+    it "refuses a file whose leading bytes select an unfuzzed loader" do
+      path.binwrite(unfuzzed_loader_bytes)
+
+      expect { Vips::Image.new_from_file(path.to_s, access: :sequential) }
+        .to raise_error(Vips::Error, /is not a known file format/)
+    end
+
+    it "still accepts an image format we authorize" do
+      path.binwrite(accepted_image_bytes)
+
+      expect(Vips::Image.new_from_file(path.to_s, access: :sequential).width).to be_positive
+    end
+  end
+end

--- a/spec/lib/trusted_vips_loader_spec.rb
+++ b/spec/lib/trusted_vips_loader_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+describe TrustedVipsLoader do
+  let(:path) { Rails.root.join("tmp/#{SecureRandom.hex}") }
+
+  after { FileUtils.rm_f(path) }
+
+  # These ten bytes are all libvips reads to route a file to the MATLAB decoder,
+  # whatever the file is named or declared as.
+  it "refuses a file whose leading bytes select the MATLAB decoder" do
+    path.binwrite("MATLAB 5.0 MAT-file#{' ' * 512}")
+
+    expect { described_class.new_from_file(path.to_s) }
+      .to raise_error(Vips::Error, /is not a known file format/)
+  end
+
+  it "loads an image format we accept" do
+    path.binwrite(Rails.root.join("spec/fixtures/files/logo_test_procedure.png").binread)
+
+    expect(described_class.new_from_file(path.to_s).width).to be_positive
+  end
+
+  it "accepts a source responding to path" do
+    path.binwrite(Rails.root.join("spec/fixtures/files/logo_test_procedure.png").binread)
+
+    expect(described_class.new_from_file(File.open(path)).width).to be_positive
+  end
+
+  # Pins the scope of the deny list: other decoders libvips flags as unfuzzed, such as
+  # the PDF one the watermark path can reach, are deliberately still let through, since
+  # naming them wrongly would reject real uploads. Only libvips 8.13 or later refuses
+  # the whole family, via Vips.block_untrusted.
+  describe "the decoders it lets through" do
+    it "does not refuse a PDF" do
+      path.binwrite(Rails.root.join("spec/fixtures/files/Contrat.pdf").binread)
+
+      expect(described_class).to be_allowed(path.to_s)
+    end
+  end
+end

--- a/spec/lib/trusted_vips_loader_spec.rb
+++ b/spec/lib/trusted_vips_loader_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe TrustedVipsLoader do
+describe TrustedVipsLoader, :external_deps do
   let(:path) { Rails.root.join("tmp/#{SecureRandom.hex}") }
 
   after { FileUtils.rm_f(path) }

--- a/spec/requests/active_storage/representations_spec.rb
+++ b/spec/requests/active_storage/representations_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+describe "ActiveStorage representations", type: :request do
+  # Direct upload is the one path that persists the content type declared by the
+  # client without ever reading the file, so `identified` stays false. These bytes
+  # are not a PNG: the image library picks its decoder from the leading bytes, not
+  # from the content_type column.
+  let(:bytes) { "MATLAB 5.0 MAT-file#{' ' * 512}" }
+
+  let(:blob) do
+    ActiveStorage::Blob.create_before_direct_upload!(
+      filename: "image.png",
+      byte_size: bytes.bytesize,
+      checksum: Digest::MD5.base64digest(bytes),
+      content_type: "image/png"
+    ).tap { it.service.upload(it.key, StringIO.new(bytes)) }
+  end
+
+  let(:variation_key) { ActiveStorage::Variation.encode(resize_to_limit: [100, 100]) }
+
+  subject(:representation_request) do
+    get rails_blob_representation_path(
+      signed_blob_id: blob.signed_id,
+      variation_key:,
+      filename: blob.filename
+    )
+  end
+
+  describe "a blob whose declared content type was never checked against its bytes" do
+    it "is not variable" do
+      expect(blob).not_to be_variable
+    end
+
+    it "does not build a variant" do
+      expect { representation_request }.not_to change { ActiveStorage::VariantRecord.count }
+    end
+
+    it "responds with not found" do
+      representation_request
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  # The previewers are selected from the declared content type as well, and they
+  # hand the bytes to pdftoppm and ffmpeg rather than to the image library.
+  ["application/pdf", "video/mp4"].each do |declared_content_type|
+    describe "a blob declared as #{declared_content_type} whose bytes were never checked" do
+      let(:blob) do
+        ActiveStorage::Blob.create_before_direct_upload!(
+          filename: "file",
+          byte_size: bytes.bytesize,
+          checksum: Digest::MD5.base64digest(bytes),
+          content_type: declared_content_type
+        ).tap { it.service.upload(it.key, StringIO.new(bytes)) }
+      end
+
+      it "is not previewable" do
+        expect(blob).not_to be_previewable
+      end
+
+      it "responds with not found" do
+        representation_request
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "a blob whose content type was identified from its bytes" do
+    let(:bytes) { Rails.root.join("spec/fixtures/files/logo_test_procedure.png").read }
+
+    before { blob.identify }
+
+    it "is variable" do
+      expect(blob).to be_variable
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20260120fix_restored_dossiers_that_remain_expired_task_spec.rb
+++ b/spec/tasks/maintenance/t20260120fix_restored_dossiers_that_remain_expired_task_spec.rb
@@ -17,6 +17,13 @@ module Maintenance
     end
 
     describe "#process" do
+      # Each expectation below compares a date built by adding months to another
+      # against `1.month.from_now`. Month arithmetic clamps the day when the target
+      # month is shorter, so run on a 31st, `8.months.ago` lands on a 30th and the
+      # comparison misses by a day — which happens four days a year. Pin the clock
+      # to a day short enough that no offset can clamp it.
+      before { travel_to(Time.zone.local(2026, 1, 15, 12)) }
+
       let!(:procedure) { create(:procedure, duree_conservation_dossiers_dans_ds: 6) }
 
       subject(:process) { described_class.process(dossier) }


### PR DESCRIPTION
libvips choisit son décodeur d'après les premiers octets du fichier, sans tenir compte du content type enregistré par Rails. Il signale par ailleurs plusieurs de ses décodeurs comme non fuzzés : ils ne sont prévus que pour du contenu qu'on produit soi-même.

## Changements

**Ne plus transformer un blob dont le type n'a jamais été vérifié.** `variable?` et `previewable?` exigent désormais `identified?`. Un blob créé par direct upload et jamais attaché conserve le type déclaré par le client : il n'est plus transformable, ni par libvips ni par les previewers (`pdftoppm`, `ffmpeg`). L'endpoint de représentation répond 404 au lieu de 500.

**Refuser les décodeurs sans rapport avec nos formats.** `TrustedVipsLoader` demande à libvips quel décodeur il choisirait et refuse ceux qu'on liste — sur les appels de `BlobProcessorJob` comme sur le chemin des variantes d'Active Storage. À partir de libvips 8.13, `Vips.block_untrusted(true)` prend le relais et couvre toute la famille des décodeurs non fuzzés.

## Points d'attention

- La production tourne en libvips 8.12, qui n'a aucun mécanisme de blocage : seul `TrustedVipsLoader` protège, et il ne couvre que les décodeurs nommés. **Passer libvips en 8.13+ reste l'objectif** — c'est aussi un prérequis de la prochaine mise à jour de Rails, qui refuse de démarrer en dessous.
- libvips n'étant installé que sur les serveurs de jobs, les `require` sont enveloppés dans un `rescue LoadError` pour ne pas casser le boot des serveurs web, et les specs qui décodent une image portent le tag `:external_deps`.
- Un fichier refusé lève une `Vips::Error` dont le message est déjà reconnu par `UnreadableVipsSourceConcern` : mutation sautée, job terminé normalement, pas de retry.
- `variable_content_types` est réduit aux types réellement autorisés.

## Hors sujet mais inclus

Le dernier commit corrige un test sans rapport, `T20260120fixRestoredDossiersThatRemainExpiredTask`, qui échouait sur cette branche : il comparait une date construite par ajout de mois à `1.month.from_now`, et l'arithmétique des mois rabote le jour quand le mois cible est plus court. Il tombait les 31 mai, 31 juillet, 31 octobre et 31 décembre — dont aujourd'hui. L'horloge est désormais figée sur une date que rien ne peut raboter.