### PR TITLE
[WIP] ETQ usager, je ne suis plus bloqué par une ancienne date invalide

### DIFF
--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -439,7 +439,10 @@ module DossierChampsConcern
 
     reset_champs_cache
 
-    data.save!
+    # An untouched champ must not be revalidated here: a legacy value stored
+    # before the current normalization rules would fail validation before the
+    # caller had a chance to assign the incoming value (RAILS-MC5)
+    data.save! if data.changed?
     data.type_de_champ = type_de_champ
     data
   end

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -517,6 +517,23 @@ RSpec.describe DossierChampsConcern do
         end
       end
 
+      context "champ with a stored value that predates the current normalization rules" do
+        let(:types_de_champ_public) { [{ type: :date, libelle: "Une date", stable_id: 990 }] }
+        let(:type_de_champ_public) { dossier.find_type_de_champ_by_stable_id(990) }
+
+        before do
+          # Raw SQL: any attribute write goes through the type cast, which
+          # would apply `normalizes` and hide the legacy value
+          ChampData.connection.exec_update("UPDATE champs SET value = $1 WHERE id = $2", nil, ["13/13/2023", dossier.champ_data.first.id])
+          dossier.reload
+        end
+
+        it "does not revalidate the untouched champ (RAILS-MC5)" do
+          expect { subject }.not_to raise_error
+          expect(subject.value).to eq("13/13/2023")
+        end
+      end
+
       context "champ carte" do
         let(:types_de_champ_public) { [{ type: :carte, libelle: "Un champ carte", stable_id: 996 }] }
         let(:type_de_champ_public) { dossier.find_type_de_champ_by_stable_id(996) }


### PR DESCRIPTION
Corrige [RAILS-MC5](https://demarches-simplifiees.sentry.io/issues/RAILS-MC5) (65 events depuis la release du 24/07).

**Cause** : `champ_upsert_by!` fait un `save!` du champ avant que la valeur saisie soit assignée. Depuis le passage de `DateChamp` à `normalizes` (74f2ba6da4), une valeur legacy non-ISO déjà en base n'est plus convertie à la volée : la validation `iso_8601` échoue sur l'ancienne valeur et l'usager ne peut plus jamais corriger son champ (422 systématique).

**Fix** : ne pas revalider un champ inchangé lors de l'upsert (`data.save! if data.changed?`). La nouvelle valeur, normalisée à l'assignation, écrase ensuite la valeur legacy via le save aval qui gère les erreurs normalement.

À suivre (hors scope) : maintenance task pour normaliser les valeurs date legacy en base, comme `BatchUpdateDatetimeValuesJob` l'avait fait pour les datetime en 2025.