### PR TITLE
ETQ admin, je comprends pourquoi mes modèles d'email bloquent la publication de ma démarche

### DIFF
--- a/app/components/procedure/errors_summary.rb
+++ b/app/components/procedure/errors_summary.rb
@@ -3,6 +3,8 @@
 class Procedure::ErrorsSummary < ApplicationComponent
   ErrorDescriptor = Data.define(:anchor, :label, :error_message)
 
+  MAIL_TEMPLATE_ATTRIBUTES = [:initiated_mail, :received_mail, :closed_mail, :refused_mail, :without_continuation_mail, :re_instructed_mail].freeze
+
   def initialize(procedure:, validation_context:)
     @procedure = procedure
     @validation_context = validation_context
@@ -29,7 +31,7 @@ class Procedure::ErrorsSummary < ApplicationComponent
   end
 
   def errors
-    @procedure.errors.map { to_error_descriptor(_1) }
+    @procedure.errors.flat_map { to_error_descriptors(_1) }
   end
 
   def error_correction_page(error)
@@ -52,6 +54,15 @@ class Procedure::ErrorsSummary < ApplicationComponent
       klass = "Mails::#{error.attribute.to_s.classify}".constantize
       edit_admin_procedure_mail_template_path(@procedure, klass.const_get(:SLUG))
     end
+  end
+
+  def to_error_descriptors(error)
+    template_errors = error.attribute.in?(MAIL_TEMPLATE_ATTRIBUTES) ? error.detail[:value]&.errors : nil
+    return [to_error_descriptor(error)] if template_errors.blank?
+
+    anchor = error_correction_page(error)
+    label = error.base.class.human_attribute_name(error.attribute)
+    template_errors.map { ErrorDescriptor.new(anchor, label, _1.full_message) }
   end
 
   def to_error_descriptor(error)

--- a/config/locales/models/attestation_template/fr.yml
+++ b/config/locales/models/attestation_template/fr.yml
@@ -15,29 +15,10 @@ fr:
     errors:
       models:
         attestation_template:
-          tags_errors: &tags_errors
-            champ_missing:
-              one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
-            champ_missing_in_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
-            champ_missing_in_published_revision:
-              one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
-              other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer
-            champ_missing_in_published_and_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées. Supprimer les balises
-            champ_missing_in_previous_revision:
-              one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
-              other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises
           attributes:
             title:
               format: Le champ « Titre de l’attestation » %{message}
-              <<: *tags_errors
             body:
               format: Le champ « Contenu de l’attestation » %{message}
-              <<: *tags_errors
             json_body:
               format: Le champ « Contenu de l’attestation » %{message}
-              <<: *tags_errors

--- a/config/locales/models/closed_mail/fr.yml
+++ b/config/locales/models/closed_mail/fr.yml
@@ -30,3 +30,9 @@ fr:
             body:
               format: Le champ « Corps de l’email » %{message}
               <<: *tags_errors
+            json_subject:
+              format: Le champ « Objet de l’email » %{message}
+              <<: *tags_errors
+            json_body:
+              format: Le champ « Corps de l’email » %{message}
+              <<: *tags_errors

--- a/config/locales/models/closed_mail/fr.yml
+++ b/config/locales/models/closed_mail/fr.yml
@@ -7,32 +7,12 @@ fr:
     errors:
       models:
         mails/closed_mail:
-          tags_errors: &tags_errors
-            champ_missing:
-              one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
-            champ_missing_in_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer ces balises ou réinitialiser les modifications du formulaire puis recommencer
-            champ_missing_in_published_revision:
-              one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
-              other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer
-            champ_missing_in_published_and_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées. Supprimer les balises
-            champ_missing_in_previous_revision:
-              one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
-              other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises
           attributes:
             subject:
               format: Le champ « Objet de l’email » %{message}
-              <<: *tags_errors
             body:
               format: Le champ « Corps de l’email » %{message}
-              <<: *tags_errors
             json_subject:
               format: Le champ « Objet de l’email » %{message}
-              <<: *tags_errors
             json_body:
               format: Le champ « Corps de l’email » %{message}
-              <<: *tags_errors

--- a/config/locales/models/closed_mail/fr.yml
+++ b/config/locales/models/closed_mail/fr.yml
@@ -12,8 +12,8 @@ fr:
               one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
               other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
             champ_missing_in_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer ces balises ou réinitialiser les modifications du formulaire puis recommencer
             champ_missing_in_published_revision:
               one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
               other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer

--- a/config/locales/models/initiated_mail/fr.yml
+++ b/config/locales/models/initiated_mail/fr.yml
@@ -7,32 +7,12 @@ fr:
     errors:
       models:
         mails/initiated_mail:
-          tags_errors: &tags_errors
-            champ_missing:
-              one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
-            champ_missing_in_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer ces balises ou réinitialiser les modifications du formulaire puis recommencer
-            champ_missing_in_published_revision:
-              one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
-              other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer
-            champ_missing_in_published_and_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées. Supprimer les balises
-            champ_missing_in_previous_revision:
-              one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
-              other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises
           attributes:
             subject:
               format: Le champ « Objet de l’email » %{message}
-              <<: *tags_errors
             body:
               format: Le champ « Corps de l’email » %{message}
-              <<: *tags_errors
             json_subject:
               format: Le champ « Objet de l’email » %{message}
-              <<: *tags_errors
             json_body:
               format: Le champ « Corps de l’email » %{message}
-              <<: *tags_errors

--- a/config/locales/models/initiated_mail/fr.yml
+++ b/config/locales/models/initiated_mail/fr.yml
@@ -12,8 +12,8 @@ fr:
               one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
               other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
             champ_missing_in_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer ces balises ou réinitialiser les modifications du formulaire puis recommencer
             champ_missing_in_published_revision:
               one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
               other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -61,11 +61,12 @@ en:
         declarative_with_state/accepte: Accepted
         api_entreprise_token: Token API Entreprise
         api_particulier_token: Token API Particulier
-        initiated_mail: File sorted for processing notification email
-        received_mail: File submitted notification email
-        closed_mail: File sorted as accepted notification email
-        refused_mail: File sorted as refused notification email
-        without_continuation_mail: File sorted with no further action notification email
+        initiated_mail: The “Acknowledgement of receipt” email template
+        received_mail: The “Acknowledgement of processing” email template
+        closed_mail: The “Acceptance” email template
+        refused_mail: The “Refusal” email template
+        without_continuation_mail: The “Closed with no further action” email template
+        re_instructed_mail: The “File re-examination” email template
         attestation_acceptation_template: Attestation template acceptation
         attestation_refus_template: Attestation template refused
         draft_revision: The form

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -68,11 +68,12 @@ fr:
         declarative_with_state/accepte: Accepté
         api_entreprise_token: Jeton API Entreprise
         api_particulier_token: Jeton API Particulier
-        initiated_mail: L’adresse électronique de notification de passage de dossier en instruction
-        received_mail: L’adresse électronique de notification de dépôt de dossier
-        closed_mail: L’adresse électronique de notification d’acceptation de dossier
-        refused_mail: L’adresse électronique de notification de refus de dossier
-        without_continuation_mail: L’adresse électronique de notification de classement sans suite de dossier
+        initiated_mail: Le modèle d’email « Accusé de réception »
+        received_mail: Le modèle d’email « Accusé de passage en instruction »
+        closed_mail: Le modèle d’email « Accusé d’acceptation »
+        refused_mail: Le modèle d’email « Accusé de refus »
+        without_continuation_mail: Le modèle d’email « Accusé de classement sans suite »
+        re_instructed_mail: Le modèle d’email « Réexamen du dossier »
         attestation_acceptation_template: Le modèle d’attestation d’acceptation
         attestation_refus_template: Le modèle d’attestation de refus
         draft_revision: Le formulaire

--- a/config/locales/models/re_instructed_mail/fr.yml
+++ b/config/locales/models/re_instructed_mail/fr.yml
@@ -1,19 +1,19 @@
 fr:
   activerecord:
     attributes:
-      mails/initiated_mail:
+      mails/re_instructed_mail:
         subject: Objet de l’email
         rich_body: Corps de l’email
     errors:
       models:
-        mails/initiated_mail:
+        mails/re_instructed_mail:
           tags_errors: &tags_errors
             champ_missing:
               one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
               other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
             champ_missing_in_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer ces balises ou réinitialiser les modifications du formulaire puis recommencer
             champ_missing_in_published_revision:
               one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
               other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer

--- a/config/locales/models/re_instructed_mail/fr.yml
+++ b/config/locales/models/re_instructed_mail/fr.yml
@@ -7,32 +7,12 @@ fr:
     errors:
       models:
         mails/re_instructed_mail:
-          tags_errors: &tags_errors
-            champ_missing:
-              one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
-            champ_missing_in_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer ces balises ou réinitialiser les modifications du formulaire puis recommencer
-            champ_missing_in_published_revision:
-              one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
-              other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer
-            champ_missing_in_published_and_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées. Supprimer les balises
-            champ_missing_in_previous_revision:
-              one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
-              other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises
           attributes:
             subject:
               format: Le champ « Objet de l’email » %{message}
-              <<: *tags_errors
             body:
               format: Le champ « Corps de l’email » %{message}
-              <<: *tags_errors
             json_subject:
               format: Le champ « Objet de l’email » %{message}
-              <<: *tags_errors
             json_body:
               format: Le champ « Corps de l’email » %{message}
-              <<: *tags_errors

--- a/config/locales/models/received_mail/fr.yml
+++ b/config/locales/models/received_mail/fr.yml
@@ -30,3 +30,9 @@ fr:
             body:
               format: Le champ « Corps de l’email » %{message}
               <<: *tags_errors
+            json_subject:
+              format: Le champ « Objet de l’email » %{message}
+              <<: *tags_errors
+            json_body:
+              format: Le champ « Corps de l’email » %{message}
+              <<: *tags_errors

--- a/config/locales/models/received_mail/fr.yml
+++ b/config/locales/models/received_mail/fr.yml
@@ -7,32 +7,12 @@ fr:
     errors:
       models:
         mails/received_mail:
-          tags_errors: &tags_errors
-            champ_missing:
-              one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
-            champ_missing_in_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer ces balises ou réinitialiser les modifications du formulaire puis recommencer
-            champ_missing_in_published_revision:
-              one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
-              other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer
-            champ_missing_in_published_and_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées. Supprimer les balises
-            champ_missing_in_previous_revision:
-              one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
-              other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises
           attributes:
             subject:
               format: Le champ « Objet de l’email » %{message}
-              <<: *tags_errors
             body:
               format: Le champ « Corps de l’email » %{message}
-              <<: *tags_errors
             json_subject:
               format: Le champ « Objet de l’email » %{message}
-              <<: *tags_errors
             json_body:
               format: Le champ « Corps de l’email » %{message}
-              <<: *tags_errors

--- a/config/locales/models/received_mail/fr.yml
+++ b/config/locales/models/received_mail/fr.yml
@@ -12,8 +12,8 @@ fr:
               one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
               other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
             champ_missing_in_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer ces balises ou réinitialiser les modifications du formulaire puis recommencer
             champ_missing_in_published_revision:
               one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
               other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer

--- a/config/locales/models/refused_mail/fr.yml
+++ b/config/locales/models/refused_mail/fr.yml
@@ -30,3 +30,9 @@ fr:
             body:
               format: Le champ « Corps de l’email » %{message}
               <<: *tags_errors
+            json_subject:
+              format: Le champ « Objet de l’email » %{message}
+              <<: *tags_errors
+            json_body:
+              format: Le champ « Corps de l’email » %{message}
+              <<: *tags_errors

--- a/config/locales/models/refused_mail/fr.yml
+++ b/config/locales/models/refused_mail/fr.yml
@@ -1,7 +1,7 @@
 fr:
   activerecord:
     attributes:
-       mails/refused_mail:
+      mails/refused_mail:
         subject: Objet de l’email
         rich_body: Corps de l’email
     errors:

--- a/config/locales/models/refused_mail/fr.yml
+++ b/config/locales/models/refused_mail/fr.yml
@@ -12,8 +12,8 @@ fr:
               one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
               other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
             champ_missing_in_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer ces balises ou réinitialiser les modifications du formulaire puis recommencer
             champ_missing_in_published_revision:
               one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
               other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer

--- a/config/locales/models/refused_mail/fr.yml
+++ b/config/locales/models/refused_mail/fr.yml
@@ -7,32 +7,12 @@ fr:
     errors:
       models:
         mails/refused_mail:
-          tags_errors: &tags_errors
-            champ_missing:
-              one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
-            champ_missing_in_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer ces balises ou réinitialiser les modifications du formulaire puis recommencer
-            champ_missing_in_published_revision:
-              one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
-              other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer
-            champ_missing_in_published_and_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées. Supprimer les balises
-            champ_missing_in_previous_revision:
-              one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
-              other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises
           attributes:
             subject:
               format: Le champ « Objet de l’email » %{message}
-              <<: *tags_errors
             body:
               format: Le champ « Corps de l’email » %{message}
-              <<: *tags_errors
             json_subject:
               format: Le champ « Objet de l’email » %{message}
-              <<: *tags_errors
             json_body:
               format: Le champ « Corps de l’email » %{message}
-              <<: *tags_errors

--- a/config/locales/models/tags_validator/fr.yml
+++ b/config/locales/models/tags_validator/fr.yml
@@ -1,0 +1,21 @@
+fr:
+  activerecord:
+    errors:
+      # Fallback messages for TagsValidator (mail templates, attestations).
+      # Model-specific keys under errors.models.<model>.attributes take precedence.
+      messages:
+        champ_missing:
+          one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
+          other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
+        champ_missing_in_draft_revision:
+          one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
+          other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer ces balises ou réinitialiser les modifications du formulaire puis recommencer
+        champ_missing_in_published_revision:
+          one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+          other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer
+        champ_missing_in_published_and_draft_revision:
+          one: contient la balise "%{tags}" qui a été supprimée. Supprimer la balise
+          other: contient  %{count} balises (%{tags}) qui ont été supprimées. Supprimer les balises
+        champ_missing_in_previous_revision:
+          one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
+          other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises

--- a/config/locales/models/without_continuation_mail/fr.yml
+++ b/config/locales/models/without_continuation_mail/fr.yml
@@ -1,7 +1,7 @@
 fr:
   activerecord:
     attributes:
-      mails/received_mail:
+      mails/without_continuation_mail:
         subject: Objet de l’email
         rich_body: Corps de l’email
     errors:

--- a/config/locales/models/without_continuation_mail/fr.yml
+++ b/config/locales/models/without_continuation_mail/fr.yml
@@ -30,3 +30,9 @@ fr:
             body:
               format: Le champ « Corps de l’email » %{message}
               <<: *tags_errors
+            json_subject:
+              format: Le champ « Objet de l’email » %{message}
+              <<: *tags_errors
+            json_body:
+              format: Le champ « Corps de l’email » %{message}
+              <<: *tags_errors

--- a/config/locales/models/without_continuation_mail/fr.yml
+++ b/config/locales/models/without_continuation_mail/fr.yml
@@ -12,8 +12,8 @@ fr:
               one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
               other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
             champ_missing_in_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
+              one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
+              other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer ces balises ou réinitialiser les modifications du formulaire puis recommencer
             champ_missing_in_published_revision:
               one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
               other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer

--- a/config/locales/models/without_continuation_mail/fr.yml
+++ b/config/locales/models/without_continuation_mail/fr.yml
@@ -7,32 +7,12 @@ fr:
     errors:
       models:
         mails/without_continuation_mail:
-          tags_errors: &tags_errors
-            champ_missing:
-              one: contient la balise "%{tags}" qui n’existe pas. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui n’existent pas. Supprimer les balises
-            champ_missing_in_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées dans les modifications en cours du formulaire. Supprimer ces balises ou réinitialiser les modifications du formulaire puis recommencer
-            champ_missing_in_published_revision:
-              one: contient la balise "%{tags}" qui n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer
-              other: contient  %{count} balises (%{tags}) qui ne sont pas encore publiées. Publier la nouvelle version de la démarche et recommencer
-            champ_missing_in_published_and_draft_revision:
-              one: contient la balise "%{tags}" qui a été supprimée. Supprimer la balise
-              other: contient  %{count} balises (%{tags}) qui ont été supprimées. Supprimer les balises
-            champ_missing_in_previous_revision:
-              one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
-              other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises
           attributes:
             subject:
               format: Le champ « Objet de l’email » %{message}
-              <<: *tags_errors
             body:
               format: Le champ « Corps de l’email » %{message}
-              <<: *tags_errors
             json_subject:
               format: Le champ « Objet de l’email » %{message}
-              <<: *tags_errors
             json_body:
               format: Le champ « Corps de l’email » %{message}
-              <<: *tags_errors

--- a/spec/components/procedures/errors_summary_spec.rb
+++ b/spec/components/procedures/errors_summary_spec.rb
@@ -102,8 +102,26 @@ describe Procedure::ErrorsSummary, type: :component do
     it 'render error nicely' do
       expect(page).to have_selector("a", text: "Les règles d’inéligibilité")
       expect(page).to have_selector("a[href*='v2']", text: "Le modèle d’attestation")
-      expect(page).to have_selector("a", text: "Le modèle d’email « Accusé de réception »")
-      expect(page).to have_text("n’est pas valide", count: 2)
+      expect(page).to have_selector("a[href*='mail_templates']", text: "Le modèle d’email « Accusé de réception »")
+      expect(page).to have_text('contient la balise "invalidtag" qui n’existe pas')
+      expect(page).to have_text("n’est pas valide", count: 1)
+    end
+  end
+
+  describe 'render detailed error for mail template with tiptap body' do
+    let(:validation_context) { :publication }
+    let(:procedure) { create(:procedure, initiated_mail: build(:initiated_mail)) }
+
+    before do
+      procedure.initiated_mail.update_column(:json_body, { type: :doc, content: [{ type: :paragraph, content: [{ type: :mention, attrs: { id: "tdc999999", label: "Nom du projet" } }] }] })
+      subject
+    end
+
+    it 'renders the underlying tag error with a link to the template editor' do
+      expect(page).to have_selector("a[href*='mail_templates/initiated_mail']", text: "Le modèle d’email « Accusé de réception »")
+      expect(page).to have_text('contient la balise "Nom du projet" qui a été supprimée dans les modifications en cours du formulaire')
+      expect(page).to have_no_text(/translation missing/i)
+      expect(page).to have_no_text("n’est pas valide")
     end
   end
 

--- a/spec/components/procedures/errors_summary_spec.rb
+++ b/spec/components/procedures/errors_summary_spec.rb
@@ -102,7 +102,7 @@ describe Procedure::ErrorsSummary, type: :component do
     it 'render error nicely' do
       expect(page).to have_selector("a", text: "Les règles d’inéligibilité")
       expect(page).to have_selector("a[href*='v2']", text: "Le modèle d’attestation")
-      expect(page).to have_selector("a", text: "L’adresse électronique de notification de passage de dossier en instruction")
+      expect(page).to have_selector("a", text: "Le modèle d’email « Accusé de réception »")
       expect(page).to have_text("n’est pas valide", count: 2)
     end
   end

--- a/spec/models/concerns/mail_template_concern_spec.rb
+++ b/spec/models/concerns/mail_template_concern_spec.rb
@@ -299,6 +299,21 @@ describe MailTemplateConcern do
       }
       expect(mail).not_to be_valid
       expect(mail.errors[:json_body]).to be_present
+      expect(mail.errors.full_messages_for(:json_body).first).to include("Le champ « Corps de l’email »")
+      expect(mail.errors.full_messages_for(:json_body).first).not_to match(/translation missing/i)
+    end
+
+    [Mails::InitiatedMail, Mails::ReceivedMail, Mails::ClosedMail, Mails::RefusedMail, Mails::WithoutContinuationMail, Mails::ReInstructedMail].each do |klass|
+      it "produit des messages d’erreur traduits pour #{klass.name}" do
+        template = klass.default_for_procedure(procedure)
+        template.json_subject = { "type" => "doc", "content" => [{ "type" => "paragraph", "content" => [{ "type" => "mention", "attrs" => { "id" => "tdc999999", "label" => "champ fantôme" } }] }] }
+        template.json_body = template.json_subject
+        expect(template).not_to be_valid
+        expect(template.errors.full_messages).to be_present
+        template.errors.full_messages.each do |message|
+          expect(message).not_to match(/translation missing/i)
+        end
+      end
     end
 
     it 'json_body vide reste valide' do

--- a/spec/models/mail_template_spec.rb
+++ b/spec/models/mail_template_spec.rb
@@ -60,7 +60,7 @@ describe Mails::InitiatedMail, type: :model do
         procedure.draft_revision.remove_type_de_champ(type_de_champ.stable_id)
       end
 
-      it { expect(subject.errors.full_messages).to eq(["Le champ « Corps de l’email » contient la balise \"nom\" qui a été supprimée mais la suppression n’est pas encore publiée. Publier la nouvelle version de la démarche et recommencer"]) }
+      it { expect(subject.errors.full_messages).to eq(["Le champ « Corps de l’email » contient la balise \"nom\" qui a été supprimée dans les modifications en cours du formulaire. Supprimer cette balise ou réinitialiser les modifications du formulaire puis recommencer"]) }
     end
 
     context 'template with removed tag' do


### PR DESCRIPTION
Bugs remontés au support (démarche ARS Nouvelle-Aquitaine) : un modèle d'email contenant une balise d'un champ supprimé du formulaire affichait un « Translation missing » brut, et la publication était bloquée par des erreurs incompréhensibles (« L'adresse électronique de notification de passage de dossier en instruction n'est pas valide »).

- Ajoute les messages d'erreur manquants pour `json_body`/`json_subject` (validation tiptap ajoutée sans ses locales) + crée la locale d'erreurs absente de `ReInstructedMail`
- Corrige les labels des modèles d'email sur `Procedure` : régression « email » → « adresse électronique », **et** inversion initiated/received (fr + en)
- Le bandeau d'erreurs de publication affiche désormais l'erreur précise du modèle (quelle balise, quoi faire) avec le lien vers son éditeur, au lieu de « n'est pas valide »
- Reformule `champ_missing_in_draft_revision`, qui conseillait de publier… alors que la publication est bloquée

| Avant | Après |
|---|---|
| <img width="1200" height="684" alt="bug2-publication-errors-adresse-electronique" src="https://github.com/user-attachments/assets/a724a7e3-6e7b-4e4f-99ac-bb36e4f30c84" /> | <img width="1200" height="684" alt="after-bug2-publication-errors" src="https://github.com/user-attachments/assets/5dd0da04-ffd3-45e8-b4e1-d0d1994fab67" /> |
| <img width="1129" height="276" alt="image" src="https://github.com/user-attachments/assets/12972d9f-f197-4c23-b816-4ec50501b126" /> | <img width="1186" height="459" alt="Capture d’écran 2026-08-03 à 15 26 15" src="https://github.com/user-attachments/assets/69bdddc0-7ac1-4e03-bbe1-7077517a5410" /> |