### PR TITLE
ETQ usager, je peux de nouveau modifier un champ date contenant une ancienne valeur invalide

### DIFF
--- a/app/models/champs/date_champ.rb
+++ b/app/models/champs/date_champ.rb
@@ -5,6 +5,7 @@ class Champs::DateChamp < ChampData
 
   validates_with DateLimitValidator, if: :should_validate_in_current_context?
   normalizes :value, with: -> { DateDetectionUtils.convert_to_iso8601_date(it) }
+  before_validation :normalize_legacy_value
   before_save :clear_prefilled_from_france_connect_information_flag_if_modified
   validate :iso_8601
 
@@ -27,5 +28,20 @@ class Champs::DateChamp < ChampData
 
     # i18n-tasks-use t('errors.messages.not_a_date')
     errors.add :value, :not_a_date
+  end
+
+  # Normalization runs on assignment only: rows written before the current
+  # parsing rules can hold values that iso_8601 rejects, which would make any
+  # save fail before the caller assigns anything (RAILS-MC5).
+  def normalize_legacy_value
+    return if value.blank? || value_changed?
+    return if DateDetectionUtils.parsable_iso8601_date?(value)
+
+    Sentry.capture_message(
+      "DateChamp: legacy value dropped on save",
+      extra: { champ: id, dossier: dossier_id }
+    )
+    # Reassigning routes the stored value through the normalizer.
+    self.value = value
   end
 end

--- a/app/models/champs/datetime_champ.rb
+++ b/app/models/champs/datetime_champ.rb
@@ -3,6 +3,7 @@
 class Champs::DatetimeChamp < ChampData
   validates_with DateLimitValidator, if: :should_validate_in_current_context?
   normalizes :value, with: -> { DateDetectionUtils.convert_to_iso8601_datetime(it) }
+  before_validation :normalize_legacy_value
   validate :iso_8601
 
   def search_terms
@@ -16,5 +17,20 @@ class Champs::DatetimeChamp < ChampData
 
     # i18n-tasks-use t('errors.messages.not_a_datetime')
     errors.add :value, :not_a_datetime
+  end
+
+  # Normalization runs on assignment only: rows written before the current
+  # parsing rules can hold values that iso_8601 rejects, which would make any
+  # save fail before the caller assigns anything (RAILS-MC5).
+  def normalize_legacy_value
+    return if value.blank? || value_changed?
+    return if DateDetectionUtils.parsable_iso8601_datetime?(value)
+
+    Sentry.capture_message(
+      "DatetimeChamp: legacy value dropped on save",
+      extra: { champ: id, dossier: dossier_id }
+    )
+    # Reassigning routes the stored value through the normalizer.
+    self.value = value
   end
 end

--- a/spec/models/champs/date_champ_spec.rb
+++ b/spec/models/champs/date_champ_spec.rb
@@ -33,6 +33,36 @@ describe Champs::DateChamp do
     end
   end
 
+  # Rows written before the current parsing rules are never re-normalized on
+  # load; saving must drop them instead of failing the iso_8601 validation
+  # before the caller assigns anything (RAILS-MC5).
+  describe 'legacy value self-heal' do
+    before do
+      # Raw SQL fragment: a hash through update_all would run the normalizer.
+      dossier.champ_data.where(id: date_champ.id).update_all(["value = ?", "2021-06-31T00:00:00"])
+      date_champ.reload
+    end
+
+    it 'drops an unparsable stored value on save instead of failing validation' do
+      expect(Sentry).to receive(:capture_message)
+      expect(date_champ.save).to be(true)
+      expect(date_champ.reload.value).to be_nil
+    end
+
+    it 'lets a freshly assigned value win over the heal' do
+      date_champ.value = "31/12/2017"
+      expect(date_champ.save).to be(true)
+      expect(date_champ.reload.value).to eq("2017-12-31")
+    end
+
+    it 'leaves a parsable stored value alone' do
+      date_champ.update!(value: "2020-06-20")
+      expect(Sentry).not_to receive(:capture_message)
+      expect(date_champ.save).to be(true)
+      expect(date_champ.reload.value).to eq("2020-06-20")
+    end
+  end
+
   describe "#to_s" do
     it "format the date" do
       champ_with_value("2020-06-20")

--- a/spec/models/champs/datetime_champ_spec.rb
+++ b/spec/models/champs/datetime_champ_spec.rb
@@ -54,15 +54,15 @@ describe Champs::DatetimeChamp do
   end
 
   describe '#valid?' do
-    it 'should not change the value' do
+    it 'self-heals a preexisting invalid value instead of failing (RAILS-MC5)' do
       sql = "UPDATE champs SET value = 'invalid' WHERE id = #{datetime_champ.id}"
       ActiveRecord::Base.connection.execute(sql)
       datetime_champ.reload
       expect(datetime_champ.value).to eq("invalid")
 
-      expect(datetime_champ.valid?).to be_falsey
-      error = datetime_champ.errors.first
-      expect(error.attribute).to eq(:value)
+      expect(Sentry).to receive(:capture_message)
+      expect(datetime_champ.valid?).to be_truthy
+      expect(datetime_champ.value).to be_nil
     end
   end
 

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -517,6 +517,36 @@ RSpec.describe DossierChampsConcern do
         end
       end
 
+      # Rows persisted before value normalization moved from before_validation
+      # to assignment time (74f2ba6da4) can hold values the current parser
+      # rejects; they are never re-normalized on load. The upsert save must
+      # self-heal them instead of tripping the iso_8601 validation before the
+      # caller has assigned anything (RAILS-MC5).
+      [
+        { type: :date, legacy_value: '2021-06-31T00:00:00' },
+        { type: :datetime, legacy_value: '12/06/2026 à 14h' },
+      ].each do |row|
+        type, legacy_value = row.values_at(:type, :legacy_value)
+
+        context "#{type} champ with a legacy non-ISO value" do
+          let(:types_de_champ_public) { [{ type:, libelle: "Un champ #{type}", stable_id: 99 }] }
+
+          before do
+            dossier.champ_for_update(type_de_champ_public, updated_by: dossier.user.email)
+            # Raw SQL fragment: a hash through update_all/update_column would
+            # run the value normalizer and defeat the simulation.
+            dossier.champ_data.where(stable_id: 99).update_all(["value = ?", legacy_value])
+            dossier.reload
+          end
+
+          it "drops the legacy value and returns the champ" do
+            champ = subject
+            expect(champ.value).to be_nil
+            expect(champ.reload.value).to be_nil
+          end
+        end
+      end
+
       context "champ carte" do
         let(:types_de_champ_public) { [{ type: :carte, libelle: "Un champ carte", stable_id: 996 }] }
         let(:type_de_champ_public) { dossier.find_type_de_champ_by_stable_id(996) }
@@ -614,6 +644,7 @@ RSpec.describe DossierChampsConcern do
     [
       { from: :text,     to: :linked_drop_down_list, assign: { primary_value: "primary" }, value: '["primary",""]', to_params: { drop_down_options: ["--primary--", "secondary"] } },
       { from: :textarea, to: :text,                  assign: { value: "test text" },       value: 'test text' },
+      { from: :text,     to: :date,                  assign: { value: "2026-08-03" },      value: '2026-08-03' },
       { from: :yes_no,   to: :checkbox,              assign: { value: "true" },            value: 'true' },
       { from: :regions,  to: :text,                  assign: { value: "test text" },       value: 'test text' },
     ].each do |row|


### PR DESCRIPTION
## Contexte (RAILS-MC5)

Depuis le passage de la normalisation des valeurs date/datetime de `before_validation` à `normalizes` (#74f2ba6da4), les valeurs persistées sous d'anciennes règles de parsing ne sont plus re-normalisées au chargement. La validation `iso_8601` (la seule non conditionnée par `should_validate_in_current_context?`) fait alors échouer **tout** save — y compris le save d'upsert de `champ_for_update`, qui lève `RecordInvalid` **avant** que la nouvelle valeur de l'usager ne soit assignée. L'usager ne peut donc plus jamais corriger le champ (107 événements / 6 usagers qui réessaient en boucle).

Aucun chemin de code actuel ne peut créer ces valeurs (saisie, préremplissage, référentiel, clone passent tous par le normalizer) : il s'agit de données historiques, antérieures aux règles de parsing actuelles.

## Correctif

Auto-réparation : un `before_validation` re-normalise la valeur stockée quand elle n'est plus parsable (convertie ou supprimée), avec un `Sentry.capture_message` pour garder la visibilité. La validation `iso_8601` reste non conditionnée.

Les specs incluent aussi la reproduction du scénario transformation de type `text -> date` (sans danger : `champ_upsert_by!` réinitialise la valeur).

Fixes RAILS-MC5

🤖 Generated with [Claude Code](https://claude.com/claude-code)