### PR TITLE
Tech : corrige la typo includeAnotations de l'API GraphQL

### DIFF
--- a/app/controllers/api/v2/graphql_controller.rb
+++ b/app/controllers/api/v2/graphql_controller.rb
@@ -62,7 +62,15 @@ class API::V2::GraphqlController < API::V2::BaseController
   end
 
   def variables
-    ensure_hash(params[:variables])
+    variables = ensure_hash(params[:variables])
+
+    # The stored queries shipped with a misspelled includeAnotations variable
+    # for years; keep accepting it since clients rely on it.
+    if params[:queryId].present? && variables.key?('includeAnotations') && !variables.key?('includeAnnotations')
+      variables['includeAnnotations'] = variables['includeAnotations']
+    end
+
+    variables
   end
 
   def operation_name

--- a/app/graphql/api/v2/stored_query.rb
+++ b/app/graphql/api/v2/stored_query.rb
@@ -45,7 +45,7 @@ class API::V2::StoredQuery
     $includeRevisions: Boolean = false
     $includeService: Boolean = false
     $includeChamps: Boolean = true
-    $includeAnotations: Boolean = true
+    $includeAnnotations: Boolean = true
     $includeTraitements: Boolean = true
     $includeInstructeurs: Boolean = true
     $includeAvis: Boolean = false
@@ -162,7 +162,7 @@ class API::V2::StoredQuery
     $includePendingDeletedDossiers: Boolean = false
     $includeDeletedDossiers: Boolean = false
     $includeChamps: Boolean = true
-    $includeAnotations: Boolean = true
+    $includeAnnotations: Boolean = true
     $includeTraitements: Boolean = true
     $includeInstructeurs: Boolean = true
     $includeAvis: Boolean = false
@@ -236,7 +236,7 @@ class API::V2::StoredQuery
     $includeRevision: Boolean = false
     $includeService: Boolean = false
     $includeChamps: Boolean = true
-    $includeAnotations: Boolean = true
+    $includeAnnotations: Boolean = true
     $includeTraitements: Boolean = true
     $includeInstructeurs: Boolean = true
     $includeAvis: Boolean = false
@@ -347,7 +347,7 @@ class API::V2::StoredQuery
       ...ChampFragment
       ...RootChampFragment
     }
-    annotations @include(if: $includeAnotations) {
+    annotations @include(if: $includeAnnotations) {
       ...ChampFragment
       ...RootChampFragment
     }

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -225,6 +225,15 @@ describe API::V2::GraphqlController do
           expect(gql_data[:dossier][:annotations].map { it[:label] }).to eq(['un commentaire'])
         end
 
+        context 'with includeAnnotations: false' do
+          let(:variables) { { dossierNumber: dossier.id, includeAnnotations: false } }
+
+          it 'are not included' do
+            expect(gql_errors).to be_nil
+            expect(gql_data[:dossier][:annotations]).to be_nil
+          end
+        end
+
         context 'with the legacy misspelled includeAnotations: false' do
           let(:variables) { { dossierNumber: dossier.id, includeAnotations: false } }
 

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -216,6 +216,25 @@ describe API::V2::GraphqlController do
         }
       end
 
+      context 'annotations' do
+        let(:procedure) { create(:procedure, :published, :for_individual, types_de_champ_private: [{ libelle: 'un commentaire' }], administrateurs: [admin]) }
+        let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure:) }
+
+        it 'are included by default' do
+          expect(gql_errors).to be_nil
+          expect(gql_data[:dossier][:annotations].map { it[:label] }).to eq(['un commentaire'])
+        end
+
+        context 'with the legacy misspelled includeAnotations: false' do
+          let(:variables) { { dossierNumber: dossier.id, includeAnotations: false } }
+
+          it 'are not included' do
+            expect(gql_errors).to be_nil
+            expect(gql_data[:dossier][:annotations]).to be_nil
+          end
+        end
+      end
+
       context 'with entreprise' do
         let(:procedure) { procedures.entreprise }
         let(:dossier) { dossiers.avec_siret }

--- a/spec/graphql/api/v2/schema_spec.rb
+++ b/spec/graphql/api/v2/schema_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe API::V2::Schema do
     it 'admits the heaviest legitimate query with headroom' do
       complexity = complexity_of('getDemarche', {
         demarcheNumber: 1, includeDossiers: true, first: 100,
-        includeChamps: true, includeAnotations: true, includeTraitements: true,
+        includeChamps: true, includeAnnotations: true, includeTraitements: true,
         includeInstructeurs: true, includeAvis: true, includeMessages: true,
         includeCorrections: true, includeGeometry: true, includeGroupeInstructeurs: true,
         includeService: true, includeRevision: true, includeRevisions: true,


### PR DESCRIPTION
La stored query `ds-query-v2` déclare depuis 2022 une variable mal orthographiée `$includeAnotations` (un seul « n »), reprise telle quelle par le playground qui pré-remplit cette query chez tous les intégrateurs.

- Renomme la variable en `includeAnnotations` dans la stored query (et donc dans le playground).
- Conserve la compatibilité : graphql-ruby ignore silencieusement une variable fournie mais non déclarée, un renommage sec aurait donc réactivé les annotations chez les clients envoyant `includeAnotations: false`. Un shim dans le contrôleur recopie l'ancienne clé vers la nouvelle pour les stored queries.
- Ajoute des specs de bout en bout sur ce flag (aucune couverture existante) : comportement par défaut, nouvelle orthographe, et ancienne orthographe toujours supportée.

À noter : la doc externe (doc.demarches-simplifiees.fr) pourra être mise à jour à l'occasion, l'ancienne orthographe restant supportée.