### PR TITLE
ETQ usager, un seul message d'erreur sur le champ RNF

### DIFF
--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -25,6 +25,7 @@ module Dsfr
     def statutable?
       siret_support_status? ||
       rna_support_statut? ||
+      rnf_support_statut? ||
       referentiel_support_statut? ||
       address_support_statut? ||
       dossier_link_support_statut? ||
@@ -38,6 +39,10 @@ module Dsfr
 
     def rna_support_statut?
       type_de_champ.rna? && @champ.external_id.present?
+    end
+
+    def rnf_support_statut?
+      type_de_champ.rnf? && @champ.external_id.present?
     end
 
     def referentiel_support_statut?
@@ -86,6 +91,14 @@ module Dsfr
           { state: :warning, text: t(".rna.error") }
         elsif @champ.value.present?
           { state: :info, text: t(".rna.success", title: @champ.title, address: @champ.full_address) }
+        end
+      when TypeDeChamp.type_champs[:rnf]
+        if @champ.pending?
+          { state: :info, text: t(".rnf.pending") }
+        elsif @champ.external_error?
+          { state: :warning, text: t(".rnf.error") }
+        elsif @champ.data.present?
+          { state: :info, text: t(".rnf.success", title: @champ.title, address: @champ.full_address) }
         end
       when TypeDeChamp.type_champs[:dossier_link]
         dossier = Dossier.find_by(id: @champ.value)

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.en.yml
@@ -4,6 +4,10 @@ en:
     error: "An error occurred while retrieving RNA information."
     pending: "Search in progress for RNA %{value}…"
     success: "This RNA number is linked to: %{title}, %{address}."
+  rnf:
+    error: "No foundation found"
+    pending: "RNF verification pending"
+    success: "This RNF matches: %{title}, %{address}"
   siret:
     pending: "Search in progress for SIRET %{value}…"
     fetched_with_capital: "%{raison_sociale_or_name} %{forme_juridique} with a share capital of %{capital_sociale}"

--- a/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
+++ b/app/components/dsfr/input_status_message_component/input_status_message_component.fr.yml
@@ -4,6 +4,10 @@ fr:
     error: "Une erreur est survenue lors de la récupération des informations RNA."
     pending: "Recherche en cours pour le RNA %{value}…"
     success: "Ce RNA correspond à : %{title}, %{address}"
+  rnf:
+    error: "Aucune fondation trouvée"
+    pending: "Vérification du RNF en cours"
+    success: "Ce RNF correspond à : %{title}, %{address}"
   siret:
     pending: "Recherche en cours pour le SIRET %{value}…"
     fetched_with_capital: "%{raison_sociale_or_name} %{forme_juridique} au capital social de %{capital_sociale}"

--- a/app/components/editable_champ/rnf_component/rnf_component.en.yml
+++ b/app/components/editable_champ/rnf_component/rnf_component.en.yml
@@ -1,5 +1,0 @@
----
-en:
-  rnf_info_error: No foundation found
-  rnf_info_pending: RNF verification pending
-  rnf_info_success: "This RNF matches: %{title}, %{address}"

--- a/app/components/editable_champ/rnf_component/rnf_component.fr.yml
+++ b/app/components/editable_champ/rnf_component/rnf_component.fr.yml
@@ -1,5 +1,0 @@
----
-fr:
-  rnf_info_error: Aucune fondation trouvée
-  rnf_info_pending: Vérification du RNF en cours
-  rnf_info_success: "Ce RNF correspond à : %{title}, %{address}"

--- a/app/components/editable_champ/rnf_component/rnf_component.html.erb
+++ b/app/components/editable_champ/rnf_component/rnf_component.html.erb
@@ -1,13 +1,1 @@
 <%= @form.text_field :external_id, input_opts(id: @champ.focusable_input_id, required: @champ.required?, class: "width-33-desktop fr-input", aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }) %>
-
-<div class="rnf-info" id="<%= dom_id(@champ, :rnf_info) %>" role="status">
-  <% if @champ.external_error? %>
-    <p class="fr-error-text"><%= t('.rnf_info_error') %></p>
-  <% elsif @champ.pending? %>
-    <p class="fr-info-text"><%= t('.rnf_info_pending') %></p>
-  <% elsif @champ.data? %>
-    <p class="fr-info-text">
-      <%= t('.rnf_info_success', title: @champ.title, address: @champ.full_address) %>
-    </p>
-  <% end %>
-</div>

--- a/app/components/editable_champ/rnf_component/rnf_component.html.erb
+++ b/app/components/editable_champ/rnf_component/rnf_component.html.erb
@@ -1,0 +1,13 @@
+<%= @form.text_field :external_id, input_opts(id: @champ.focusable_input_id, required: @champ.required?, class: "width-33-desktop fr-input", aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }) %>
+
+<div class="rnf-info" id="<%= dom_id(@champ, :rnf_info) %>" role="status">
+  <% if @champ.external_error? %>
+    <p class="fr-error-text"><%= t('.rnf_info_error') %></p>
+  <% elsif @champ.pending? %>
+    <p class="fr-info-text"><%= t('.rnf_info_pending') %></p>
+  <% elsif @champ.data? %>
+    <p class="fr-info-text">
+      <%= t('.rnf_info_success', title: @champ.title, address: @champ.full_address) %>
+    </p>
+  <% end %>
+</div>

--- a/app/components/editable_champ/rnf_component/rnf_component.html.haml
+++ b/app/components/editable_champ/rnf_component/rnf_component.html.haml
@@ -1,9 +1,0 @@
-= @form.text_field :external_id, input_opts(id: @champ.focusable_input_id, required: @champ.required?, class: "width-33-desktop fr-input", aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" })
-
-.rnf-info{ id: dom_id(@champ, :rnf_info), role: 'status' }
-  - if @champ.external_error?
-    %p.fr-error-text= t('.rnf_info_error')
-  - elsif @champ.pending?
-    %p.fr-info-text= t('.rnf_info_pending')
-  - elsif @champ.data?
-    %p.fr-info-text= t('.rnf_info_success', title: @champ.title, address: @champ.full_address)

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -159,7 +159,7 @@ class ChampData < ApplicationRecord
   # Dsfr::InputStatusMessageComponent) and therefore need a persistent
   # live region to announce it to screen readers.
   def status_announceable?
-    siret? || rna? || referentiel? || dossier_link? || piece_justificative?
+    siret? || rna? || rnf? || referentiel? || dossier_link? || piece_justificative?
   end
 
   def prefilled_from_france_connect_information?

--- a/spec/components/editable_champ/rnf_component_spec.rb
+++ b/spec/components/editable_champ/rnf_component_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe EditableChamp::RNFComponent, type: :component do
+  let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf, libelle: 'Numéro RNF' }]) }
+  let(:dossier) { create(:dossier, procedure:) }
+  let(:champ) { dossier.champ_data.first }
+
+  def render_full_champ
+    component = nil
+    ActionView::Base.empty.form_for(champ, url: '/') do |form|
+      component = EditableChamp::EditableChampComponent.new(champ:, form:)
+    end
+    render_inline(component)
+  end
+
+  context 'when the RNF lookup failed and the dossier has been validated' do
+    before do
+      champ.update_columns(external_id: '075-FDD-00003-0', external_state: 'external_error')
+      champ.send(:save_external_error, StandardError.new('NotFound'), 404)
+      champ.reload
+      dossier.validate(:champs_public_value)
+    end
+
+    it 'renders a single error message (no duplicate status text)' do
+      render_full_champ
+
+      expect(page).to have_css('.fr-message--error', text: 'Résultat introuvable', count: 1)
+      expect(page).to have_no_text('Aucune fondation trouvée')
+    end
+  end
+end

--- a/spec/components/input_status_message_component_spec.rb
+++ b/spec/components/input_status_message_component_spec.rb
@@ -43,6 +43,43 @@ RSpec.describe Dsfr::InputStatusMessageComponent, type: :component do
       end
     end
 
+    context 'with rnf champs' do
+      let(:types_de_champ_public) { [{ type: :rnf }] }
+      let(:state) { :idle }
+
+      before do
+        allow(champ).to receive(:pending?).and_return(state == :pending)
+        allow(champ).to receive(:external_error?).and_return(state == :external_error)
+        allow(champ).to receive(:external_id).and_return('075-FDD-00003-01')
+      end
+
+      context 'when the lookup is pending' do
+        let(:state) { :pending }
+
+        it 'renders the pending message' do
+          expect(subject).to have_css('.fr-message--info', text: 'Vérification du RNF en cours')
+        end
+      end
+
+      context 'when the lookup failed' do
+        let(:state) { :external_error }
+
+        it 'renders a warning message' do
+          expect(subject).to have_css('.fr-message--warning', text: 'Aucune fondation trouvée')
+        end
+      end
+
+      context 'when the foundation was found' do
+        before do
+          allow(champ).to receive(:data).and_return({ 'title' => 'Fondation de France', 'address' => { 'label' => '40 Avenue Hoche, 75008 Paris' } })
+        end
+
+        it 'renders the success message' do
+          expect(subject).to have_css('.fr-message--info', text: 'Ce RNF correspond à : Fondation de France, 40 Avenue Hoche, 75008 Paris')
+        end
+      end
+    end
+
     context 'with dossier_link champs' do
       let(:types_de_champ_public) { [{ type: :dossier_link }] }
       let(:linked_dossier) { create(:dossier, :en_construction) }

--- a/spec/models/champs/rnf_champ_spec.rb
+++ b/spec/models/champs/rnf_champ_spec.rb
@@ -8,6 +8,14 @@ describe Champs::RNFChamp, type: :model do
   let(:body) { Rails.root.join('spec', 'fixtures', 'files', 'api_rnf', "#{response_type}.json").read }
   let(:response_type) { 'valid' }
 
+  describe '#status_announceable?' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.root_champs_public.find(&:rnf?) }
+
+    it { expect(champ.status_announceable?).to be(true) }
+  end
+
   describe '#valid?' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :rnf }]) }
     let(:dossier) { create(:dossier, procedure:) }


### PR DESCRIPTION
Suite de #12686 : le champ RNF affichait deux messages d'erreur quand la fondation n'était pas trouvée (« Aucune fondation trouvée » + « Résultat introuvable. Vérifiez vos informations. »), là où le RNA n'en affiche qu'un.

Le composant RNF avait son propre bloc de statut (`.rnf-info`) qui réagissait à `external_error?` en plus de l'erreur de validation rendue par le composant de statut partagé, sans précédence possible entre les deux.

- le statut RNF (recherche en cours, échec, succès) passe par `Dsfr::InputStatusMessageComponent`, comme le RNA depuis 03fd23dc87 — l'erreur de validation prend le pas sur le message de statut
- suppression du bloc `.rnf-info` et de ses locales (mêmes textes conservés côté composant partagé)
- le champ RNF devient `status_announceable?` pour préserver l'annonce du résultat aux lecteurs d'écran
- conversion préalable du template HAML → ERB en commit dédié

Comparaison des états RNA / RNF après correction :

![Comparaison RNA / RNF](https://gist.githubusercontent.com/mmagn/d08ad2ded947464e4a9db03be1db5b97/raw/comparaison_rna_rnf.png)