### PR TITLE
ETQ admin, corrige le libellé du champ en erreur sur l'URL du référentiel

### DIFF
--- a/config/locales/models/referentiel/en.yml
+++ b/config/locales/models/referentiel/en.yml
@@ -1,4 +1,4 @@
-fr:
+en:
   activerecord:
     errors:
       models:
@@ -11,7 +11,7 @@ fr:
       referentiel: 'Field type'
     attributes:
       referentiels/api_referentiel:
-        url: "URL of the API"
+        url_tiptap: "URL of the API"
         hint: "Expected format shown to the user"
         test_data: "Valid example used to test the API"
         hints:

--- a/config/locales/models/referentiel/fr.yml
+++ b/config/locales/models/referentiel/fr.yml
@@ -13,7 +13,7 @@ fr:
       referentiel: 'Type de champ'
     attributes:
       referentiels/api_referentiel:
-        url: "URL du référentiel"
+        url_tiptap: "URL du référentiel"
         hint: "Indications à fournir à l’usager concernant le format de saisie attendu"
         test_data: "Exemple de saisie valide (affiché à l’usager et utilisé pour tester la requête)"
         hints:

--- a/spec/models/api_referentiel_spec.rb
+++ b/spec/models/api_referentiel_spec.rb
@@ -136,6 +136,11 @@ describe Referentiels::APIReferentiel, type: :model do
           referentiel.valid?
           expect(referentiel.errors.where(:url_tiptap, :not_allowed)).to be_present
         end
+
+        it 'labels the attribute « URL du référentiel » in the full message' do
+          referentiel.valid?
+          expect(referentiel.errors.where(:url_tiptap, :not_allowed).first.full_message).to include("URL du référentiel")
+        end
       end
 
       context 'with only mentions and no text URL' do


### PR DESCRIPTION
Sur la page de configuration d'un champ Référentiel API, le message d'erreur de validation de l'URL affichait « Le champ « URL tiptap » … » au lieu de « Le champ « URL du référentiel » … ».

- Les validations du modèle sont passées de l'attribut `url` à `url_tiptap`, mais la clé de libellé dans les locales était restée sur `url` → renommée en `url_tiptap` (fr + en), avec un spec sur le `full_message`.
- Au passage : `config/locales/models/referentiel/en.yml` avait une racine `fr:` au lieu de `en:`, ses traductions anglaises n'étaient donc jamais chargées.

| Avant / Après |
|---|
| ![avant/après](https://gist.githubusercontent.com/mmagn/40b91c2c29eb0c086e283466c2729c4e/raw/before-after.png) |