### PR TITLE
ETQ admin, conserve la config d'autocomplétion du référentiel modifié

### DIFF
--- a/app/controllers/administrateurs/referentiels_controller.rb
+++ b/app/controllers/administrateurs/referentiels_controller.rb
@@ -20,7 +20,7 @@ module Administrateurs
     end
 
     def create
-      handle_referentiel_save(@type_de_champ.build_referentiel(referentiel_params_with_carried_credentials))
+      handle_referentiel_save(@type_de_champ.build_referentiel(referentiel_params_with_carried_attributes))
     end
 
     def update
@@ -154,10 +154,11 @@ module Administrateurs
       {}
     end
 
-    # When cloning an existing referentiel, the auth inputs are rendered as `disabled`
-    # to hide the secret, so the browser does not submit them. We carry the existing
-    # authentication_data over from the source so credentials are not lost on save.
-    def referentiel_params_with_carried_credentials
+    # When cloning an existing referentiel, some attributes are not submitted by the
+    # form and would be lost on save: the auth inputs are rendered as `disabled` to
+    # hide the secret, and the autocomplete configuration belongs to a later step of
+    # the wizard. We carry them over from the source.
+    def referentiel_params_with_carried_attributes
       attrs = referentiel_params.to_h
       source_id = params.dig(:referentiel, :referentiel_id).presence
       return attrs if source_id.blank?
@@ -168,6 +169,7 @@ module Administrateurs
       if attrs[:authentication_method] == 'header_token' && attrs[:authentication_data].blank?
         attrs[:authentication_data] = source.authentication_data
       end
+      attrs[:autocomplete_configuration] = source.autocomplete_configuration if source.autocomplete_configuration.present?
       attrs
     end
 

--- a/spec/controllers/administrateurs/referentiels_controller_spec.rb
+++ b/spec/controllers/administrateurs/referentiels_controller_spec.rb
@@ -244,6 +244,30 @@ describe Administrateurs::ReferentielsController, type: :controller do
         expect(new_referentiel.authentication_data.with_indifferent_access).to eq(original_authentication_data.with_indifferent_access)
       end
     end
+
+    context 'cloning an existing referentiel having an autocomplete configuration' do
+      let(:type_de_champ) { procedure.draft_revision.types_de_champ.first }
+      let!(:existing_referentiel) do
+        create(:api_referentiel, :autocomplete, types_de_champ: [type_de_champ], datasource: '$.')
+      end
+      let(:referentiel_params) do
+        {
+          type: 'Referentiels::APIReferentiel',
+          mode: 'autocomplete',
+          url_tiptap: existing_referentiel.url_tiptap.to_json,
+          test_data_tiptap: existing_referentiel.test_data_tiptap,
+          referentiel_id: existing_referentiel.id.to_s,
+        }
+      end
+
+      it 'carries over the autocomplete configuration from the source referentiel' do
+        post :create, params: { commit: 'Étape suivante', procedure_id: procedure.id, stable_id:, referentiel: referentiel_params }, format: :turbo_stream
+
+        new_referentiel = type_de_champ.reload.referentiel
+        expect(new_referentiel.id).not_to eq(existing_referentiel.id)
+        expect(new_referentiel.autocomplete_configuration).to eq(existing_referentiel.autocomplete_configuration)
+      end
+    end
   end
 
   describe '#create with tiptap' do


### PR DESCRIPTION
Sur une démarche publiée, modifier un référentiel passe par un flux « clone-on-edit » : `ReferentielsController#create` crée un nouveau référentiel pour ne pas muter celui de la révision publiée. Mais `autocomplete_configuration` (datasource + template tiptap) n'était pas recopié depuis la source : à chaque repassage dans l'assistant, l'écran de configuration de l'autocomplétion revenait vide et la configuration était perdue.

- Recopie `autocomplete_configuration` depuis le référentiel source au clone, sur le même mécanisme que celui déjà en place pour `authentication_data` (qui avait eu le même bug)
- Spec contrôleur sur le `create` avec `referentiel_id`

| Avant / Après |
|---|
| ![avant/après](https://gist.githubusercontent.com/mmagn/66e36af436cc1ee82cb2747c7b1da5fb/raw/avant-apres-autocomplete-config.png) |