### PR TITLE
Tech: ignore les erreurs de dépassement de pile des scripts injectés par les navigateurs iOS de Google

### DIFF
--- a/app/javascript/shared/track/sentry.ts
+++ b/app/javascript/shared/track/sentry.ts
@@ -5,6 +5,20 @@ const {
   sentry: { key, enabled, user, environment, browser, release }
 } = getConfig();
 
+// Google's iOS browsers (Chrome Mobile iOS, Google app) inject scripts into
+// every page that regularly overflow the call stack. These events carry no
+// attributable frame (filename is `undefined` or `<anonymous>`), unlike a
+// genuine stack overflow in our bundles, which always resolves to an http(s)
+// filename.
+const isInjectedScriptStackOverflow = (event: Sentry.Event): boolean => {
+  const exception = event.exception?.values?.at(-1);
+  if (!exception?.value?.includes('Maximum call stack size exceeded')) {
+    return false;
+  }
+  const frames = exception.stacktrace?.frames ?? [];
+  return !frames.some((frame) => frame.filename?.startsWith('http'));
+};
+
 // We need to check for key presence here as we do not have a dsn for browser yet
 if (enabled && key) {
   Sentry.init({
@@ -26,7 +40,13 @@ if (enabled && key) {
 
       // La gaufre script often triggers an error while loading other dependencies
       'NetworkError when attempting to fetch resource. (integration.lasuite.numerique.gouv.fr)'
-    ]
+    ],
+    beforeSend(event) {
+      if (isInjectedScriptStackOverflow(event)) {
+        return null;
+      }
+      return event;
+    }
   });
 
   const scope = Sentry.getCurrentScope();


### PR DESCRIPTION
## Contexte

L'issue Sentry [JAVASCRIPT-D2F](https://demarches-simplifiees.sentry.io/issues/JAVASCRIPT-D2F) (~12k événements / 30 jours, notre 2e source de bruit) provient à 100 % de Chrome Mobile iOS et de l'app Google : ces navigateurs injectent des scripts dans chaque page qui provoquent régulièrement des `RangeError: Maximum call stack size exceeded`. Aucun autre navigateur (dont Safari iOS, pourtant basé sur le même WebKit) n'est touché, l'erreur survient même sur des pages statiques (connexion, FAQ) et n'est corrélée à aucune release — ce n'est donc pas un bug de notre code.

## Solution

Un hook `beforeSend` ignore ces événements uniquement quand aucune frame de la stacktrace ne pointe vers un fichier `http(s)` : un vrai dépassement de pile dans nos bundles résout toujours vers une URL Vite et reste donc remonté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)