### PR TITLE
ETQ instructeur, ne plus voir de badge « Modifié » fantôme sur les champs

### DIFF
--- a/app/components/dossiers/champs_rows_show_component.rb
+++ b/app/components/dossiers/champs_rows_show_component.rb
@@ -37,8 +37,8 @@ class Dossiers::ChampsRowsShowComponent < ApplicationComponent
     return if champ.dossier.depose_at.blank?
     return if champ.new_record?
 
-    if champ.updated_at > champ.dossier.depose_at
-      champ.updated_at
+    if champ.value_updated_at > champ.dossier.depose_at
+      champ.value_updated_at
     end
   end
 

--- a/app/components/editable_champ/champ_label_content_component.rb
+++ b/app/components/editable_champ/champ_label_content_component.rb
@@ -23,7 +23,7 @@ class EditableChamp::ChampLabelContentComponent < ApplicationComponent
   end
 
   def highlight?
-    @champ.updated_at.present? && @seen_at&.<(@champ.updated_at)
+    @champ.value_updated_at.present? && @seen_at&.<(@champ.value_updated_at)
   end
 
   def rebased?

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -348,12 +348,20 @@ class ChampData < ApplicationRecord
     save!
   end
 
+  # `value_updated_at` dates user-made changes only. Machinery also bumps
+  # `updated_at` (attachment purge touches, external data fetches, autosave),
+  # so displays like the "Modifié" badge must not trust it. Rows last modified
+  # before the column existed fall back to `updated_at`.
+  def value_updated_at
+    super || updated_at
+  end
+
   def update_timestamps
     return if public? && dossier.en_construction?
 
     updated_at = Time.zone.now
     attributes = { updated_at: }
-    update_columns(attributes) if persisted?
+    update_columns(attributes.merge(value_updated_at: updated_at)) if persisted?
 
     if private?
       attributes[:last_champ_private_updated_at] = updated_at

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -304,7 +304,7 @@ module DossierChampsConcern
       # move champ_data with changes from "main" to "history" stream
       champ_data.where(id: changed_ids, stream: Dossier::MAIN_STREAM).update_all(stream: history_stream)
       # move champ_data from "buffer" to "main"
-      champ_data.where(id: buffer_ids, stream:).update_all(stream: Dossier::MAIN_STREAM, updated_at: now, checkpoint: history_stream)
+      champ_data.where(id: buffer_ids, stream:).update_all(stream: Dossier::MAIN_STREAM, updated_at: now, value_updated_at: now, checkpoint: history_stream)
       update_champs_timestamps(buffer_champ_data, stream)
     end
 

--- a/app/tasks/maintenance/t20260805_backfill_champs_value_updated_at_from_checkpoint_task.rb
+++ b/app/tasks/maintenance/t20260805_backfill_champs_value_updated_at_from_checkpoint_task.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260805BackfillChampsValueUpdatedAtFromCheckpointTask < MaintenanceTasks::Task
+    # `champs.value_updated_at` date les modifications utilisateur ; elle n'est
+    # renseignée que depuis son introduction. Pour les champs déjà fusionnés
+    # depuis un buffer stream, l'instant exact de la fusion est encodé dans
+    # `checkpoint` (« history:<time> », le même `now` que l'`updated_at` posé
+    # par la fusion) : on le recopie pour que ces champs ne retombent plus sur
+    # `updated_at`, faussé par la mécanique interne (purge de pièces jointes,
+    # récupérations de données externes…).
+    #
+    # Les champs sans checkpoint (jamais modifiés après dépôt, ou fusionnés
+    # avant l'introduction de la colonne checkpoint le 2026-06-02) ne sont pas
+    # traités et conservent le repli sur `updated_at`.
+    #
+    # La table champs est volumineuse et les champs avec checkpoint y sont
+    # rares : filtrer dans `collection` ferait balayer des millions de lignes
+    # sans correspondance à chaque requête de curseur d'in_batches (statement
+    # timeout). On parcourt donc toute la table par plages de clé primaire et
+    # on filtre dans l'UPDATE de chaque lot, calculé entièrement en SQL.
+
+    include RunnableOnDeployConcern
+
+    run_on_first_deploy
+
+    BATCH_SIZE = 10_000
+
+    def collection
+      ChampData.in_batches(of: BATCH_SIZE)
+    end
+
+    def process(batch)
+      batch
+        .where(stream: Dossier::MAIN_STREAM, value_updated_at: nil)
+        .where.not(checkpoint: nil)
+        .update_all([
+          "value_updated_at = substring(checkpoint from ?)::timestamptz AT TIME ZONE 'UTC'",
+          Dossier::HISTORY_STREAM.length + 1,
+        ])
+    end
+
+    def count
+      # la table champs est volumineuse, le COUNT déclenche des PG statement timeout
+    end
+  end
+end

--- a/db/migrate/20260804120000_add_value_updated_at_to_champs.rb
+++ b/db/migrate/20260804120000_add_value_updated_at_to_champs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddValueUpdatedAtToChamps < ActiveRecord::Migration[8.0]
+  def change
+    add_column :champs, :value_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_28_120001) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_04_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -282,6 +282,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_28_120001) do
     t.text "updated_by"
     t.string "value"
     t.jsonb "value_json"
+    t.datetime "value_updated_at"
     t.index ["dossier_id", "stream", "stable_id", "row_id"], name: "index_champs_on_stream_and_public_id", unique: true, nulls_not_distinct: true
     t.index ["dossier_id"], name: "index_champs_on_dossier_id"
     t.index ["etablissement_id"], name: "index_champs_on_etablissement_id"

--- a/spec/components/dossiers/champs_rows_show_component_spec.rb
+++ b/spec/components/dossiers/champs_rows_show_component_spec.rb
@@ -34,6 +34,47 @@ RSpec.describe Dossiers::ChampsRowsShowComponent, type: :component do
     end
   end
 
+  describe "modified badge" do
+    let(:procedure) do
+      create(:procedure, :published, types_de_champ_public: [{ type: :text, libelle: "Texte" }])
+    end
+    let(:dossier) do
+      create(:dossier, :en_instruction, :with_populated_champs, procedure:).tap do |dossier|
+        dossier.update_columns(depose_at: 2.weeks.ago, last_champ_updated_at: nil)
+      end.reload
+    end
+    let(:champs) do
+      dossier.root_champs_public.tap { it.first.update_columns(champ_attributes) }
+    end
+    let(:component) { described_class.new(champs:, profile: "instructeur", seen_at: nil) }
+
+    context "when the champ was not modified since the dossier was deposited" do
+      let(:champ_attributes) { { updated_at: 3.weeks.ago, value_updated_at: 3.weeks.ago } }
+
+      it { expect(page).not_to have_text("Modifié le") }
+    end
+
+    context "when only machinery bumped updated_at after deposit (attachment purge, external data fetch…)" do
+      let(:champ_attributes) { { updated_at: 1.day.ago, value_updated_at: 3.weeks.ago } }
+
+      it { expect(page).not_to have_text("Modifié le") }
+    end
+
+    context "when the user modified the champ after deposit" do
+      let(:champ_attributes) { { updated_at: 1.day.ago, value_updated_at: 1.day.ago } }
+
+      it { expect(page).to have_text("Modifié le") }
+    end
+
+    context "when a legacy champ has no value_updated_at" do
+      let(:champ_attributes) { { updated_at: 1.day.ago, value_updated_at: nil } }
+
+      it "falls back to updated_at" do
+        expect(page).to have_text("Modifié le")
+      end
+    end
+  end
+
   describe "prefilled badge flex wrapper" do
     let(:dossier) { dossiers.en_construction }
     let(:prefill_attrs) { {} }

--- a/spec/models/champ_data_spec.rb
+++ b/spec/models/champ_data_spec.rb
@@ -627,6 +627,49 @@ describe ChampData do
     end
   end
 
+  describe '#update_timestamps' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text }]) }
+    let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+
+    it 'stamps value_updated_at along with updated_at' do
+      champ.update_columns(updated_at: 1.day.ago, value_updated_at: nil)
+
+      champ.update_timestamps
+
+      champ.reload
+      expect(champ.read_attribute(:value_updated_at)).to eq(champ.updated_at)
+      expect(dossier.reload.last_champ_updated_at).to eq(champ.updated_at)
+    end
+
+    it 'does not stamp public champs of a dossier en construction (deferred to buffer merge)' do
+      dossier.update_columns(state: Dossier.states.fetch(:en_construction), depose_at: Time.zone.now)
+      champ = dossier.reload.champ_data.first
+      champ.update_columns(updated_at: 1.day.ago, value_updated_at: nil)
+
+      champ.update_timestamps
+
+      expect(champ.reload.read_attribute(:value_updated_at)).to be_nil
+    end
+  end
+
+  describe '#value_updated_at' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text }]) }
+    let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+
+    it 'falls back to updated_at when the column is blank' do
+      champ.update_columns(value_updated_at: nil)
+      expect(champ.reload.value_updated_at).to eq(champ.updated_at)
+    end
+
+    it 'returns the column when present' do
+      time = 3.days.ago.change(usec: 0)
+      champ.update_columns(value_updated_at: time)
+      expect(champ.reload.value_updated_at).to eq(time)
+    end
+  end
+
   describe '#clone_value_from' do
     let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :siret }]) }
     let(:dossier) { create(:dossier, procedure:) }

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -1471,5 +1471,18 @@ RSpec.describe DossierChampsConcern do
       expect(dossier.history.map(&:stream)).to all(eq(history_stream))
       expect(dossier.champ_data.find { _1.stable_id == 99 && _1.main_stream? }.checkpoint).to eq(history_stream)
     end
+
+    it "stamps value_updated_at on merged champs" do
+      dossier.with_update_stream(dossier.user) do
+        dossier.public_champ_for_update('99', updated_by: dossier.user.email).assign_attributes(value: "Nouvelle valeur")
+      end
+      dossier.save!
+
+      dossier.merge_user_buffer_stream!
+
+      merged = dossier.champ_data.find { _1.stable_id == 99 && _1.main_stream? }.reload
+      expect(merged.read_attribute(:value_updated_at)).to eq(merged.updated_at)
+      expect(merged.read_attribute(:value_updated_at)).to be_present
+    end
   end
 end

--- a/spec/models/groupe_instructeur_spec.rb
+++ b/spec/models/groupe_instructeur_spec.rb
@@ -263,10 +263,11 @@ describe GroupeInstructeur, type: :model do
       end
 
       context 'with invalid routing rule (unknown stable_id)' do
+        let(:unknown_stable_id) { routed_procedure.published_revision.types_de_champ.map(&:stable_id).max + 1 }
         let(:gi) do
           create(:groupe_instructeur,
                  procedure: routed_procedure,
-                 routing_rule: ds_eq(champ_value(999), constant('Paris')))
+                 routing_rule: ds_eq(champ_value(unknown_stable_id), constant('Paris')))
         end
 
         it 'returns false for invalid routing rule' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -2061,10 +2061,11 @@ describe Procedure do
                procedure: procedure,
                routing_rule: ds_eq(champ_value(stable_id), constant('Paris')))
       end
+      let(:unknown_stable_id) { procedure.published_revision.types_de_champ.map(&:stable_id).max + 1 }
       let!(:gi_invalid) do
         create(:groupe_instructeur,
                procedure: procedure,
-               routing_rule: ds_eq(champ_value(999), constant('Invalid')),
+               routing_rule: ds_eq(champ_value(unknown_stable_id), constant('Invalid')),
                valid_routing_rule: true)
       end
 

--- a/spec/tasks/maintenance/t20251208backfill_unique_and_valid_routing_rule_in_groupe_instructeurs_task_spec.rb
+++ b/spec/tasks/maintenance/t20251208backfill_unique_and_valid_routing_rule_in_groupe_instructeurs_task_spec.rb
@@ -59,11 +59,12 @@ module Maintenance
       end
 
       context "when procedure has a group with invalid routing rule" do
+        let(:unknown_stable_id) { procedure.published_revision.types_de_champ.map(&:stable_id).max + 1 }
         let!(:gi1) do
           create(:groupe_instructeur,
                  procedure: procedure,
                  label: 'Groupe Invalid',
-                 routing_rule: ds_eq(champ_value(999), constant('Invalid')))
+                 routing_rule: ds_eq(champ_value(unknown_stable_id), constant('Invalid')))
         end
 
         it "maintains valid_routing_rule as false" do

--- a/spec/tasks/maintenance/t20260805_backfill_champs_value_updated_at_from_checkpoint_task_spec.rb
+++ b/spec/tasks/maintenance/t20260805_backfill_champs_value_updated_at_from_checkpoint_task_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260805BackfillChampsValueUpdatedAtFromCheckpointTask do
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :text }]) }
+    let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+
+    describe "#process" do
+      subject(:process) { described_class.process(ChampData.where(id: champ.id)) }
+
+      it "copies the merge time embedded in the checkpoint without touching updated_at" do
+        champ.update_columns(checkpoint: "history:2026-07-01 10:00:00 +0200", value_updated_at: nil)
+
+        expect { process }.not_to change { champ.reload.updated_at }
+        expect(champ.reload.read_attribute(:value_updated_at)).to eq(Time.zone.parse("2026-07-01 10:00:00 +0200"))
+      end
+
+      it "skips champs without checkpoint" do
+        champ.update_columns(checkpoint: nil, value_updated_at: nil)
+
+        expect { process }.not_to change { champ.reload.read_attribute(:value_updated_at) }.from(nil)
+      end
+
+      it "skips champs already stamped" do
+        already = 1.week.ago.change(usec: 0)
+        champ.update_columns(checkpoint: "history:2026-07-01 10:00:00 +0200", value_updated_at: already)
+
+        expect { process }.not_to change { champ.reload.read_attribute(:value_updated_at) }.from(already)
+      end
+
+      it "skips champs outside the main stream" do
+        champ.update_columns(checkpoint: "history:2026-07-01 10:00:00 +0200", value_updated_at: nil, stream: "history:2026-07-02 10:00:00 +0200")
+
+        expect { process }.not_to change { champ.reload.read_attribute(:value_updated_at) }.from(nil)
+      end
+
+      it "stamps the same instant the merge wrote to updated_at" do
+        dossier.with_update_stream(dossier.user) do
+          dossier.public_champ_for_update(champ.stable_id.to_s, updated_by: dossier.user.email).assign_attributes(value: "Nouvelle valeur")
+        end
+        dossier.save!
+        dossier.merge_user_buffer_stream!
+
+        merged = dossier.champ_data.find { _1.stable_id == champ.stable_id && _1.main_stream? }.reload
+        merged.update_column(:value_updated_at, nil) # simulate a pre-column legacy row
+
+        described_class.process(ChampData.where(id: merged.id))
+
+        expect(merged.reload.read_attribute(:value_updated_at)).to be_within(1.second).of(merged.updated_at)
+      end
+    end
+
+    describe "#collection" do
+      it "enumerates primary-key batches without filtering (filters live in each batch's UPDATE)" do
+        expect(described_class.new.collection).to be_a(ActiveRecord::Batches::BatchEnumerator)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Signalement : sur certains dossiers en instruction, des champs affichent le badge « Modifié » alors que l'usager n'a rien modifié, avec `champs.updated_at` désynchronisé de `dossiers.last_champ_updated_at`.

Cause : le badge se base sur `champ.updated_at > dossier.depose_at`, or de la mécanique interne peut avancer `updated_at` sans modification utilisateur :
- la purge d'une pièce jointe `touch` son champ (ex. `T20260728PurgeEmptyAttachmentsTask`, qui explique les signalements récents) ;
- les récupérations de données externes (`fetch!`, OCR via `BlobProcessorJob`, `T20260623backfillRNAExternalStateTask`) ;
- l'autosave de champs incidemment marqués dirty.

## Correctif

Nouvelle colonne `champs.value_updated_at`, horodatée uniquement par les modifications utilisateur : `ChampData#update_timestamps` (brouillon, annotations privées, PJ/carte/répétition) et la fusion des buffer streams (`merge_buffer_champ_data`). Le badge de la demande et le surlignage du formulaire lisent cette colonne, avec repli sur `updated_at` pour les lignes antérieures à la colonne.

Une tâche de maintenance (exécutée au déploiement, idempotente) rétro-remplit `value_updated_at` depuis l'instant de fusion encodé dans `checkpoint` pour les champs fusionnés depuis le 2026-06-02. Les champs sans checkpoint conservent le repli sur `updated_at` ; une tâche de réparation des badges fantômes restants (dossiers sans modification réelle post-dépôt) pourra suivre.

Contient aussi un correctif de spec flaky : `champ_value(999)` comme stable_id « inconnu » entre en collision avec la séquence globale selon l'ordre d'exécution (échec CI shard 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)