### PR TITLE
ETQ Admin : je veux que le libelle soit optionnel pour les champs explications

### DIFF
--- a/app/components/types_de_champ_editor/champ_component/champ_component.fr.yml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.fr.yml
@@ -6,6 +6,7 @@ fr:
   communes_warning_desc_html: "ne pas utiliser ce champ pour les <strong>communes de naissance</strong>."
   communes_info_link: "Comment fonctionne ce champ ?"
   libelle_label: "Libellé du champ"
+  libelle_label_optionnal: "Libellé du champ (optionnel)"
   mandatory_label: "Champ obligatoire"
   description_label: "Description du champ (optionnel)"
   header_section_hint: "Nous numérotons automatiquement les titres lorsqu’aucun de vos titres ne commence par un chiffre."

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
@@ -55,7 +55,7 @@
             <div class="cell">
               <div class="flex align-center">
                 <% if libelle_configurable? %>
-                  <%= form.label :libelle, t(".libelle_label"), class: "flex-grow", for: dom_id(type_de_champ, :libelle) %>
+                  <%= form.label :libelle, type_de_champ.libelle_optionnal? ? t(".libelle_label_optionnal") : t(".libelle_label"), class: "flex-grow", for: dom_id(type_de_champ, :libelle) %>
                 <% end %>
 
                 <% if mandatory_configurable? %>

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -303,6 +303,8 @@ class TypeDeChamp < ApplicationRecord
       default: I18n.t(type_champ, scope: [:activerecord, :attributes, :type_de_champ, :type_champs]), app_name: APPLICATION_NAME)
   end
 
+  def libelle_optionnal? = type_champ.in?([TypeDeChamp.type_champs.fetch(:explication)])
+
   def safe_referentiel_mapping
     Hash(referentiel_mapping).with_indifferent_access
   end

--- a/app/validators/types_de_champ/libelle_validator.rb
+++ b/app/validators/types_de_champ/libelle_validator.rb
@@ -2,7 +2,7 @@
 
 class TypesDeChamp::LibelleValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
-    types_de_champ.each do |tdc|
+    types_de_champ.reject(&:libelle_optionnal?).each do |tdc|
       validate_libelle(procedure, attribute, tdc)
     end
   end

--- a/spec/validators/types_de_champ/libelle_validator_spec.rb
+++ b/spec/validators/types_de_champ/libelle_validator_spec.rb
@@ -81,4 +81,14 @@ RSpec.describe TypesDeChamp::LibelleValidator do
       end
     end
   end
+
+  context 'with an explication type de champ' do
+    let(:types) { [type: :explication] }
+
+    before { type_de_champ.update(libelle: '') }
+
+    it 'does not add errors to the procedure' do
+      expect { subject }.not_to change { procedure.errors.count }
+    end
+  end
 end


### PR DESCRIPTION
suppression du caractère obligatoire du libelle sur un type de champ explication 

plusieurs demandes en ce sens, et vu avec Marlène : la nécessité de ce libelle peut selon les cas entrainer une redite avec les titres de section qui précèdent 