### PR TITLE
Tech: supprime le code mort filter_to_human et TypeDeChamp#column

### DIFF
--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -197,7 +197,7 @@ class TypeDeChamp < ApplicationRecord
 
   belongs_to :referentiel, optional: true, inverse_of: :types_de_champ
 
-  delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, :column, :canonical_column, :personnalisation_column, :info_columns, to: :dynamic_type
+  delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, :canonical_column, :personnalisation_column, :info_columns, to: :dynamic_type
 
   class WithIndifferentAccess
     def self.load(options)

--- a/app/models/types_de_champ/checkbox_type_de_champ.rb
+++ b/app/models/types_de_champ/checkbox_type_de_champ.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::CheckboxTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def filter_to_human(filter_value)
-    if filter_value == "true"
-      I18n.t('activerecord.attributes.type_de_champ.type_champs.checkbox_true')
-    elsif filter_value == "false"
-      I18n.t('activerecord.attributes.type_de_champ.type_champs.checkbox_false')
-    else
-      filter_value
-    end
-  end
-
   def champ_value(champ)
     champ_value_true?(champ) ? 'Oui' : 'Non'
   end

--- a/app/models/types_de_champ/departement_type_de_champ.rb
+++ b/app/models/types_de_champ/departement_type_de_champ.rb
@@ -8,10 +8,6 @@ class TypesDeChamp::DepartementTypeDeChamp < TypesDeChamp::TextTypeDeChamp
       .concat(legacy_columns(procedure_id:, prefix:))
   end
 
-  def filter_to_human(filter_value)
-    APIGeoService.departement_name(filter_value).presence || filter_value
-  end
-
   def champ_value(champ)
     "#{champ.code} – #{champ.name}"
   end

--- a/app/models/types_de_champ/region_type_de_champ.rb
+++ b/app/models/types_de_champ/region_type_de_champ.rb
@@ -8,10 +8,6 @@ class TypesDeChamp::RegionTypeDeChamp < TypesDeChamp::TextTypeDeChamp
       .concat(legacy_columns(procedure_id:, prefix:))
   end
 
-  def filter_to_human(filter_value)
-    APIGeoService.region_name(filter_value).presence || filter_value
-  end
-
   def champ_value(champ)
     champ.name
   end

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -53,10 +53,6 @@ class TypesDeChamp::TypeDeChampBase
     (words / READ_WORDS_PER_SECOND).round.seconds
   end
 
-  def filter_to_human(filter_value)
-    filter_value
-  end
-
   def champ_value(champ)
     champ.value.present? ? champ_text_value(champ) : champ_default_value
   end
@@ -129,10 +125,6 @@ class TypesDeChamp::TypeDeChampBase
     columns(procedure_id: procedure.id).filter_map do |column|
       column.label.sub(regex_prefix, '')
     end
-  end
-
-  def column(column_id)
-    columns(procedure_id: nil).find { it.h_id[:column_id] == column_id }
   end
 
   private

--- a/app/models/types_de_champ/yes_no_type_de_champ.rb
+++ b/app/models/types_de_champ/yes_no_type_de_champ.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::YesNoTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def filter_to_human(filter_value)
-    if filter_value == "true"
-      I18n.t('activerecord.attributes.type_de_champ.type_champs.yes_no_true')
-    elsif filter_value == "false"
-      I18n.t('activerecord.attributes.type_de_champ.type_champs.yes_no_false')
-    else
-      filter_value
-    end
-  end
-
   def champ_value(champ)
     champ_value_true?(champ) ? 'Oui' : 'Non'
   end

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -297,54 +297,6 @@ describe TypeDeChamp do
     end
   end
 
-  describe '#column' do
-    context 'with a fillable type de champ' do
-      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text, libelle: 'Mon texte' }]) }
-      let(:type_de_champ) { procedure.active_revision.types_de_champ.first }
-
-      it 'returns the column matching the given column_id' do
-        column = type_de_champ.column("type_de_champ/#{type_de_champ.stable_id}")
-
-        expect(column).to be_a(Columns::ChampColumn)
-        expect(column.label).to eq('Mon texte')
-        expect(column.h_id[:column_id]).to eq("type_de_champ/#{type_de_champ.stable_id}")
-      end
-
-      it 'returns nil when no column matches' do
-        expect(type_de_champ.column('type_de_champ/unknown')).to be_nil
-      end
-    end
-
-    context 'with an addressable type de champ exposing several columns' do
-      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :communes, libelle: 'Ma commune' }]) }
-      let(:type_de_champ) { procedure.active_revision.types_de_champ.first }
-
-      it 'returns the jsonpath column matching the given column_id' do
-        column = type_de_champ.column("type_de_champ/#{type_de_champ.stable_id}-$.postal_code")
-
-        expect(column).to be_a(Columns::JSONPathColumn)
-        expect(column.jsonpath).to eq('$.postal_code')
-      end
-
-      it 'resolves legacy (non displayable) columns too' do
-        column = type_de_champ.column("type_de_champ/#{type_de_champ.stable_id}-$.code_postal")
-
-        expect(column).to be_a(Columns::JSONPathColumn)
-        expect(column.jsonpath).to eq('$.code_postal')
-        expect(column.displayable).to be(false)
-      end
-    end
-
-    context 'with a non fillable type de champ' do
-      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :header_section, libelle: 'Titre' }]) }
-      let(:type_de_champ) { procedure.active_revision.types_de_champ.first }
-
-      it 'returns nil since it exposes no column' do
-        expect(type_de_champ.column("type_de_champ/#{type_de_champ.stable_id}")).to be_nil
-      end
-    end
-  end
-
   describe '#public_only' do
     let(:procedure) { create(:procedure, :with_type_de_champ, :with_type_de_champ_private) }
 


### PR DESCRIPTION
## Quoi

Deux familles de code mort, sans aucun appelant dans le dépôt :

- **`filter_to_human`** : la méthode de base sur `TypesDeChamp::TypeDeChampBase` et ses quatre surcharges (checkbox, yes/no, région, département). Aucun appel nulle part — les libellés humains des filtres passent par les colonnes depuis longtemps. Les clés i18n concernées (`checkbox_true`, `yes_no_true`, …) restent utilisées par ailleurs (options des champs, `ColumnValueFormatter`) et ne bougent pas.
- **`TypeDeChamp#column(column_id)`** : uniquement exercée par sa propre spec ; la spec et l'entrée dans la délégation `dynamic_type` partent avec.

Repéré pendant la revue de #13617, mais indépendant : le code est mort sur main aussi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)