### PR TITLE
Tech: les traductions propres aux composants deviennent des clés relatives

### DIFF
--- a/app/components/dossiers/degraded_identite_entreprise_component.rb
+++ b/app/components/dossiers/degraded_identite_entreprise_component.rb
@@ -23,7 +23,7 @@ class Dossiers::DegradedIdentiteEntrepriseComponent < ApplicationComponent
   end
 
   def insee_down
-    texts = [t('insee_down')]
+    texts = [t('.insee_down')]
     texts << t('.dossier_blocked') if profile == 'instructeur'
 
     Dsfr::AlertComponent.new(state: :warning, size: :sm, extra_class_names: 'fr-mb-2w pull-left width-100').tap do

--- a/app/components/dossiers/degraded_identite_entreprise_component/degraded_identite_entreprise_component.en.yml
+++ b/app/components/dossiers/degraded_identite_entreprise_component/degraded_identite_entreprise_component.en.yml
@@ -2,3 +2,4 @@
 en:
   source: Business Directory
   dossier_blocked: It is not possible to accept or reject a file without this step.
+  insee_down: "INSEE is unavailable, company information will arrive within a few hours."

--- a/app/components/dossiers/degraded_identite_entreprise_component/degraded_identite_entreprise_component.fr.yml
+++ b/app/components/dossiers/degraded_identite_entreprise_component/degraded_identite_entreprise_component.fr.yml
@@ -2,3 +2,4 @@
 fr:
   source: Annuaire des Entreprises
   dossier_blocked: Il nʼest pas possible dʼaccepter ou de refuser un dossier sans cette étape.
+  insee_down: "LʼINSEE est indisponible, les informations sur lʼentreprise arriveront dʼici quelques heures."

--- a/app/components/dossiers/short_identite_entreprise_component.en.yml
+++ b/app/components/dossiers/short_identite_entreprise_component.en.yml
@@ -1,0 +1,2 @@
+en:
+  insee_down: "INSEE is unavailable, company information will arrive within a few hours."

--- a/app/components/dossiers/short_identite_entreprise_component.fr.yml
+++ b/app/components/dossiers/short_identite_entreprise_component.fr.yml
@@ -1,0 +1,2 @@
+fr:
+  insee_down: "LʼINSEE est indisponible, les informations sur lʼentreprise arriveront dʼici quelques heures."

--- a/app/components/dossiers/short_identite_entreprise_component.html.erb
+++ b/app/components/dossiers/short_identite_entreprise_component.html.erb
@@ -1,5 +1,5 @@
 <% if etablissement.as_degraded_mode? %>
-  <p><%= t('insee_down') %></p>
+  <p><%= t('.insee_down') %></p>
 <% else %>
   <% if etablissement.diffusable_commercialement == false %>
     <p>

--- a/app/components/dossiers/user_active_filters_component/user_active_filters_component.en.yml
+++ b/app/components/dossiers/user_active_filters_component/user_active_filters_component.en.yml
@@ -1,0 +1,3 @@
+en:
+  reset: "Reset filters"
+  remove_tag: "Remove filter: %{label}"

--- a/app/components/dossiers/user_active_filters_component/user_active_filters_component.fr.yml
+++ b/app/components/dossiers/user_active_filters_component/user_active_filters_component.fr.yml
@@ -1,0 +1,3 @@
+fr:
+  reset: "Réinitialiser les filtres"
+  remove_tag: "Retirer le filtre : %{label}"

--- a/app/components/dossiers/user_active_filters_component/user_active_filters_component.html.erb
+++ b/app/components/dossiers/user_active_filters_component/user_active_filters_component.html.erb
@@ -3,12 +3,12 @@
     <%= link_to dossiers_path(remove_params_for(tag)),
         class: 'user-active-filters__chip fr-tag fr-tag--sm fr-tag--dismiss',
         data: { turbo_frame: 'dossiers_list', turbo_action: 'advance' },
-        aria: { label: t('views.users.dossiers.index.active_filters.remove_tag', label: tag[:label]) } do %>
+        aria: { label: t('.remove_tag', label: tag[:label]) } do %>
       <%= tag[:label] %>
     <% end %>
   <% end %>
 
-  <%= link_to t('views.users.dossiers.index.active_filters.reset'),
+  <%= link_to t('.reset'),
       dossiers_path(reset_params),
       class: 'fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-ml-1w',
       data: { turbo_frame: 'dossiers_list', turbo_action: 'advance' } %>

--- a/app/components/dossiers/user_filter_panel_component/user_filter_panel_component.en.yml
+++ b/app/components/dossiers/user_filter_panel_component/user_filter_panel_component.en.yml
@@ -1,0 +1,4 @@
+en:
+  title: "Filter files"
+  close: "Close"
+  loading: "Loading filters…"

--- a/app/components/dossiers/user_filter_panel_component/user_filter_panel_component.fr.yml
+++ b/app/components/dossiers/user_filter_panel_component/user_filter_panel_component.fr.yml
@@ -1,0 +1,4 @@
+fr:
+  title: "Filtrer les dossiers"
+  close: "Fermer"
+  loading: "Chargement des filtres…"

--- a/app/components/dossiers/user_filter_panel_component/user_filter_panel_component.html.erb
+++ b/app/components/dossiers/user_filter_panel_component/user_filter_panel_component.html.erb
@@ -14,7 +14,7 @@
               class="fr-btn--close fr-btn"
               aria-controls="dossiers-filter-modal"
             >
-              <%= t('views.users.dossiers.index.filter_panel.close') %>
+              <%= t('.close') %>
             </button>
           </div>
 
@@ -23,7 +23,7 @@
               id="dossiers-filter-title"
               class="fr-modal__title fr-icon-arrow-right-line"
             >
-              <%= t('views.users.dossiers.index.filter_panel.title') %>
+              <%= t('.title') %>
             </h1>
 
             <turbo-frame id="<%= FRAME_ID %>">
@@ -31,7 +31,7 @@
                 <%= render Dossiers::UserFilterPanelFormComponent.new(filter: filter, filter_params: filter_params, procedures_for_select: procedures_for_select, has_invites: has_invites) %>
               <% else %>
                 <p class="fr-mb-0" aria-busy="true">
-                  <%= t('views.users.dossiers.index.filter_panel.loading') %>
+                  <%= t('.loading') %>
                 </p>
               <% end %>
             </turbo-frame>

--- a/app/components/dossiers/user_filter_panel_form_component/user_filter_panel_form_component.en.yml
+++ b/app/components/dossiers/user_filter_panel_form_component/user_filter_panel_form_component.en.yml
@@ -1,0 +1,13 @@
+en:
+  groups:
+    procedure: "By procedure"
+    state: "Processing state"
+    alert: "File alert"
+  procedure_placeholder: "Select a procedure"
+  from_created_at_date: "Created since"
+  from_depose_at_date: "Submitted since"
+  reset: "Reset"
+  apply:
+    zero: "No matching file"
+    one: "Show the file"
+    other: "Show %{count} files"

--- a/app/components/dossiers/user_filter_panel_form_component/user_filter_panel_form_component.fr.yml
+++ b/app/components/dossiers/user_filter_panel_form_component/user_filter_panel_form_component.fr.yml
@@ -1,0 +1,13 @@
+fr:
+  groups:
+    procedure: "Par démarche"
+    state: "État de traitement"
+    alert: "Alerte sur le dossier"
+  procedure_placeholder: "Sélectionnez une démarche"
+  from_created_at_date: "Créé depuis le"
+  from_depose_at_date: "Déposé depuis le"
+  reset: "Réinitialiser"
+  apply:
+    zero: "Aucun dossier ne correspond"
+    one: "Afficher le dossier"
+    other: "Afficher les %{count} dossiers"

--- a/app/components/dossiers/user_filter_panel_form_component/user_filter_panel_form_component.html.erb
+++ b/app/components/dossiers/user_filter_panel_form_component/user_filter_panel_form_component.html.erb
@@ -6,12 +6,12 @@
   <% if show_procedure_filter? %>
     <fieldset class="fr-fieldset">
       <legend class="fr-fieldset__legend">
-        <%= t('views.users.dossiers.index.filter_panel.groups.procedure') %>
+        <%= t('.groups.procedure') %>
       </legend>
 
       <div class="fr-fieldset__element">
         <%= select_tag :procedure_id,
-            options_for_select([[t('views.users.dossiers.index.filter_panel.procedure_placeholder'), '']] + procedures_for_select, filter_params[:procedure_id]),
+            options_for_select([[t('.procedure_placeholder'), '']] + procedures_for_select, filter_params[:procedure_id]),
             class: 'fr-select',
             data: { action: 'change->filter-preview#preview' } %>
       </div>
@@ -35,7 +35,7 @@
 
   <fieldset class="fr-fieldset">
     <legend class="fr-fieldset__legend">
-      <%= t('views.users.dossiers.index.filter_panel.groups.state') %>
+      <%= t('.groups.state') %>
     </legend>
 
     <% Users::DossierStateMapping::UI_STATES.each do |s| %>
@@ -55,7 +55,7 @@
   <% if alerts_enabled? %>
     <fieldset class="fr-fieldset">
       <legend class="fr-fieldset__legend">
-        <%= t('views.users.dossiers.index.filter_panel.groups.alert') %>
+        <%= t('.groups.alert') %>
       </legend>
 
       <% alert_keys.each do |a| %>
@@ -76,7 +76,7 @@
   <fieldset class="fr-fieldset">
     <div class="fr-fieldset__element">
       <label class="fr-label" for="from_created_at_date">
-        <%= t('views.users.dossiers.index.filter_panel.from_created_at_date') %>
+        <%= t('.from_created_at_date') %>
       </label>
 
       <%= date_field_tag :from_created_at_date, filter_params[:from_created_at_date], class: 'fr-input', data: { action: 'change->filter-preview#preview' } %>
@@ -86,7 +86,7 @@
   <fieldset class="fr-fieldset">
     <div class="fr-fieldset__element">
       <label class="fr-label" for="from_depose_at_date">
-        <%= t('views.users.dossiers.index.filter_panel.from_depose_at_date') %>
+        <%= t('.from_depose_at_date') %>
       </label>
 
       <%= date_field_tag :from_depose_at_date, filter_params[:from_depose_at_date], class: 'fr-input', data: { action: 'change->filter-preview#preview' } %>
@@ -94,11 +94,11 @@
   </fieldset>
 
   <div class="user-filter-panel__actions">
-    <%= link_to t('views.users.dossiers.index.filter_panel.reset'),
+    <%= link_to t('.reset'),
         dossiers_path(search: filter_params[:search]),
         class: 'fr-btn fr-btn--secondary',
         data: { turbo_frame: 'dossiers_list', turbo_action: 'advance' } %>
 
-    <%= submit_tag t('views.users.dossiers.index.filter_panel.apply', count: filter.total_count), class: 'fr-btn', disabled: apply_disabled? %>
+    <%= submit_tag t('.apply', count: filter.total_count), class: 'fr-btn', disabled: apply_disabled? %>
   </div>
 <% end %>

--- a/app/components/dossiers/user_search_component/user_search_component.en.yml
+++ b/app/components/dossiers/user_search_component/user_search_component.en.yml
@@ -1,0 +1,2 @@
+en:
+  open_filter_panel: "Filter files"

--- a/app/components/dossiers/user_search_component/user_search_component.fr.yml
+++ b/app/components/dossiers/user_search_component/user_search_component.fr.yml
@@ -1,0 +1,2 @@
+fr:
+  open_filter_panel: "Filtrer les dossiers"

--- a/app/components/dossiers/user_search_component/user_search_component.html.erb
+++ b/app/components/dossiers/user_search_component/user_search_component.html.erb
@@ -33,7 +33,7 @@
     data-lazy-frame-frame-id-value="<%= Dossiers::UserSearchComponent::FILTER_PANEL_FRAME_ID %>"
     data-lazy-frame-src-value="<%= filter_panel_src %>"
   >
-    <%= t('views.users.dossiers.index.filter_panel.open') %>
+    <%= t('.open_filter_panel') %>
 
     <% if active_filter_count.positive? %>
       <span class="user-search-bar__filter-count">

--- a/app/components/procedure/sva_svr_form_component.rb
+++ b/app/components/procedure/sva_svr_form_component.rb
@@ -19,29 +19,25 @@ class Procedure::SVASVRFormComponent < ApplicationComponent
   end
 
   def decision_buttons
-    scope = ".decision_buttons"
-
     [
-      { label: t("disabled", scope:), value: "disabled", disabled: form_disabled? },
-      { label: t("sva", scope:), value: "sva", hint: t("sva_hint", scope:), disabled: form_disabled? },
-      { label: t("svr", scope:), value: "svr", hint: t("svr_hint", scope:), disabled: form_disabled? },
+      { label: t(".decision_buttons.disabled"), value: "disabled", disabled: form_disabled? },
+      { label: t(".decision_buttons.sva"), value: "sva", hint: t(".decision_buttons.sva_hint"), disabled: form_disabled? },
+      { label: t(".decision_buttons.svr"), value: "svr", hint: t(".decision_buttons.svr_hint"), disabled: form_disabled? },
     ]
   end
 
   def resume_buttons
-    scope = ".resume_buttons"
-
     [
       {
         value: "continue",
-        label: t("continue_label", scope: scope),
-        hint: t("continue_hint", scope: scope),
+        label: t(".resume_buttons.continue_label"),
+        hint: t(".resume_buttons.continue_hint"),
         disabled: form_disabled?,
       },
       {
         value: "reset",
-        label: t("reset_label", scope: scope),
-        hint: t("reset_hint", scope: scope),
+        label: t(".resume_buttons.reset_label"),
+        hint: t(".resume_buttons.reset_hint"),
         disabled: form_disabled?,
       },
     ]

--- a/app/components/procedure/sva_svr_form_component/sva_svr_form_component.en.yml
+++ b/app/components/procedure/sva_svr_form_component/sva_svr_form_component.en.yml
@@ -11,8 +11,6 @@ en:
     When an instructor asks for a file to be corrected, the countdown of the delay is interrupted.
     The delay resumes when the applicant resubmits their file stating that they have made the requested corrections.
     If the file has been declared incomplete, the delay will be reset, regardless of the configuration below.
-  submit: Save
-  cancel: Cancel
   decision_buttons:
     disabled: "Disabled"
     sva:  "Silence Equals Acceptation (SVA)"

--- a/app/components/procedure/sva_svr_form_component/sva_svr_form_component.fr.yml
+++ b/app/components/procedure/sva_svr_form_component/sva_svr_form_component.fr.yml
@@ -11,8 +11,6 @@ fr:
     Lorsqu’un instructeur demande de corriger un dossier, le décompte du délai est interrompu.
     Le délai reprend lorsque le demandeur redépose son dossier en déclarant avoir effectué les corrections demandées.
     Si le dossier avait été déclaré incomplet, le délai sera réinitialisé, quelle que soit la configuration ci-dessous.
-  submit: Enregistrer
-  cancel: Annuler
   decision_buttons:
     disabled: "Désactivé"
     sva:  "Silence Vaut Accord"

--- a/app/components/procedure/sva_svr_form_component/sva_svr_form_component.html.haml
+++ b/app/components/procedure/sva_svr_form_component/sva_svr_form_component.html.haml
@@ -30,7 +30,7 @@
           = f.number_field :period, class: 'fr-input', disabled: form_disabled?
       .fr-fieldset__element.fr-fieldset__element--inline
         .fr-select-group
-          = f.select :unit, options_for_select(SVASVRConfiguration.unit_options.map { [t(_1, scope: ".unit_labels"), _1] }, selected: configuration.unit), {}, class: 'fr-select', disabled: form_disabled?
+          = f.select :unit, options_for_select(SVASVRConfiguration.unit_options.map { [t(".unit_labels.#{_1}"), _1] }, selected: configuration.unit), {}, class: 'fr-select', disabled: form_disabled?
 
     %fieldset.fr-fieldset
       %legend.fr-fieldset__legend

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -113,8 +113,6 @@ ignore_unused:
   - 'procedure.instructeurs_management_component.notification_alert.*'
   # t(@champ.fc_data_not_found? ? '.piece_justificative_champ.data_not_found' : '...data_not_recovered')
   - 'editable_champ.france_connect_champ_base_component.piece_justificative_champ.*'
-  # t("...", scope: ".decision_buttons") / ".resume_buttons" / ".unit_labels" in sva_svr_form_component
-  - 'procedure.sva_svr_form_component.*'
   - 'errors.format'
   - 'user_mailer.*.subject'
   - 'groupe_gestionnaire_mailer.*.subject'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,6 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  insee_down: INSEE is unavailable, company information will arrive within a few hours.
   invisible_captcha:
     sentence_for_humans: 'If you are a human, ignore this field'
   clipboard:
@@ -579,31 +578,14 @@ en:
             open: "Search"
             panel_title: "Search"
           filter_panel:
-            open: "Filter files"
-            title: "Filter files"
-            close: "Close"
-            loading: "Loading filters…"
             groups:
-              procedure: "By procedure"
               shared_with_me: "Shared with me"
-              state: "Processing state"
-              alert: "File alert"
-            procedure_placeholder: "Select a procedure"
             alerts:
               nouveau_message: "New message"
               message_avec_attente_de_reponse: "Message pending response"
               a_corriger: "Needs correction"
               expire_bientot: "Expires soon"
-            from_created_at_date: "Created since"
-            from_depose_at_date: "Submitted since"
-            reset: "Reset"
-            apply:
-              zero: "No matching file"
-              one: "Show the file"
-              other: "Show %{count} files"
           active_filters:
-            reset: "Reset filters"
-            remove_tag: "Remove filter: %{label}"
             from_created_at_date_tag: "Created since %{date}"
             from_depose_at_date_tag: "Submitted since %{date}"
         dossiers_list:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -20,7 +20,6 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 fr:
-  insee_down: LʼINSEE est indisponible, les informations sur lʼentreprise arriveront dʼici quelques heures.
   invisible_captcha:
     sentence_for_humans: 'Si vous êtes un humain, laissez ce champ vide'
   clipboard:
@@ -589,31 +588,14 @@ fr:
             open: "Rechercher"
             panel_title: "Rechercher"
           filter_panel:
-            open: "Filtrer les dossiers"
-            title: "Filtrer les dossiers"
-            close: "Fermer"
-            loading: "Chargement des filtres…"
             groups:
-              procedure: "Par démarche"
               shared_with_me: "Partagé avec moi"
-              state: "État de traitement"
-              alert: "Alerte sur le dossier"
-            procedure_placeholder: "Sélectionnez une démarche"
             alerts:
               nouveau_message: "Nouveau message"
               message_avec_attente_de_reponse: "Message avec attente de réponse"
               a_corriger: "À corriger"
               expire_bientot: "Expire bientôt"
-            from_created_at_date: "Créé depuis le"
-            from_depose_at_date: "Déposé depuis le"
-            reset: "Réinitialiser"
-            apply:
-              zero: "Aucun dossier ne correspond"
-              one: "Afficher le dossier"
-              other: "Afficher les %{count} dossiers"
           active_filters:
-            reset: "Réinitialiser les filtres"
-            remove_tag: "Retirer le filtre : %{label}"
             from_created_at_date_tag: "Créé depuis le %{date}"
             from_depose_at_date_tag: "Déposé depuis le %{date}"
         dossiers_list:


### PR DESCRIPTION
## Contexte

Suite de #13650 (PR empilée — à merger après elle). L'audit des clés absolues dans `app/components` a distingué trois familles : le vocabulaire partagé (`utils.*`, `views.shared.actions.*`, …) qui reste absolu à juste titre, les clés partagées avec des vues Haml encore vivantes (qui migreront avec elles), et des clés **exclusives à un composant** restées dans leur ancien scope de vue après extraction. Cette PR migre la troisième famille.

## Ce que fait cette PR

- `views.users.dossiers.index.filter_panel.*` → réparties dans les sidecars de `user_search_component`, `user_filter_panel_component` et `user_filter_panel_form_component`
- `views.users.dossiers.index.active_filters.{reset,remove_tag}` → `user_active_filters_component`
- `insee_down` (clé à la **racine** du namespace !) → sidecars de `short_identite_entreprise` et `degraded_identite_entreprise`
- `sva_svr_form_component` : réécriture des `t("x", scope: ".y")` en clés relatives simples — le scanner les voit désormais, l'entrée `ignore_unused` disparaît, et deux clés mortes (`submit`, `cancel`) détectées au passage sont supprimées

Les clés aussi utilisées par `Users::DossierFilterService` (`filter_panel.alerts.*`, `groups.shared_with_me`, `active_filters.*_tag`) restent dans `config/locales` : les traductions sidecar ne sont pas visibles du backend I18n global.

Vérifié : les trois checks i18n-tasks verts, specs des composants concernés vertes (25 exemples), rendu smoke-testé pour `insee_down`, valeurs copiées à l'octet près (apostrophes typographiques).

🤖 Generated with [Claude Code](https://claude.com/claude-code)