### PR TITLE
Tech: préférer le t local à I18n.t dans les vues, composants et contrôleurs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ require:
   - ./lib/cops/add_concurrent_index.rb
   - ./lib/cops/application_name.rb
   - ./lib/cops/adresse_electronique.rb
+  - ./lib/cops/global_i18n_translate.rb
   - ./lib/cops/unscoped.rb
   - ./lib/cops/rspec/consecutive_it_blocks.rb
 
@@ -51,6 +52,18 @@ DS/AdresseElectronique:
 
 DS/Unscoped:
   Enabled: true
+
+DS/GlobalI18nTranslate:
+  Enabled: true
+  Include:
+    - 'app/components/**/*'
+    - 'app/controllers/**/*'
+    - 'app/helpers/**/*'
+    - 'app/mailers/**/*'
+    - 'app/views/**/*'
+  Exclude:
+    # hints_for_champ and friends run before render, where the component `t` raises
+    - 'app/components/editable_champ/champ_label_content_component.rb'
 
 Bundler/DuplicatedGem:
   Enabled: true

--- a/app/components/attachment/hints_component.rb
+++ b/app/components/attachment/hints_component.rb
@@ -37,7 +37,7 @@ class Attachment::HintsComponent < ApplicationComponent
         []
       else
         families.filter_map do |key|
-          label = I18n.t("activerecord.attributes.type_de_champ.format_families.#{key}", default: key.to_s.humanize).downcase
+          label = t("activerecord.attributes.type_de_champ.format_families.#{key}", default: key.to_s.humanize).downcase
           top = FORMAT_FAMILY_TOP_FORMATS[key]
           all = FORMAT_FAMILY_EXAMPLES[key]
           next if top.nil?

--- a/app/components/dossiers/address_component.rb
+++ b/app/components/dossiers/address_component.rb
@@ -37,7 +37,7 @@ class Dossiers::AddressComponent < ApplicationComponent
     [
       [t('.address'), champ.to_s],
       [t('.insee_code'), champ.city_code],
-      [I18n.t('shared.dossiers.geo.department'), champ.departement_code_and_name],
+      [t('shared.dossiers.geo.department'), champ.departement_code_and_name],
     ]
   end
 

--- a/app/components/dossiers/commune_component.rb
+++ b/app/components/dossiers/commune_component.rb
@@ -26,8 +26,8 @@ class Dossiers::CommuneComponent < ApplicationComponent
     [
       [t('.municipality'), champ.to_s],
       [t('.insee_code'), champ.code],
-      [I18n.t('shared.dossiers.geo.department'), champ.departement_code_and_name],
-      [I18n.t('shared.dossiers.geo.region_code'), champ.code_region],
+      [t('shared.dossiers.geo.department'), champ.departement_code_and_name],
+      [t('shared.dossiers.geo.region_code'), champ.code_region],
     ]
   end
 

--- a/app/components/dossiers/departement_component.rb
+++ b/app/components/dossiers/departement_component.rb
@@ -19,8 +19,8 @@ class Dossiers::DepartementComponent < ApplicationComponent
 
   def data
     [
-      [I18n.t('shared.dossiers.geo.department'), champ.to_s],
-      [I18n.t('shared.dossiers.geo.region_code'), champ.code_region],
+      [t('shared.dossiers.geo.department'), champ.to_s],
+      [t('shared.dossiers.geo.region_code'), champ.code_region],
     ]
   end
 

--- a/app/components/dossiers/dossier_vide_pdf_component.rb
+++ b/app/components/dossiers/dossier_vide_pdf_component.rb
@@ -128,7 +128,7 @@ class Dossiers::DossierVidePdfComponent < ApplicationComponent
     end
   end
 
-  def operator_label(term) = I18n.t(term.class.name, scope: 'logic.operators').sub(/\A./, &:downcase)
+  def operator_label(term) = t(term.class.name, scope: 'logic.operators').sub(/\A./, &:downcase)
 
   # Human label of the compared value (e.g. a region code → its name), taken from
   # the referenced champ's options; falls back to the raw value.

--- a/app/components/dossiers/epci_component.rb
+++ b/app/components/dossiers/epci_component.rb
@@ -20,8 +20,8 @@ class Dossiers::EpciComponent < ApplicationComponent
   def data
     [
       ['EPCI', name],
-      [I18n.t('shared.dossiers.geo.department'), champ.departement_code_and_name],
-      [I18n.t('shared.dossiers.geo.region_code'), champ.code_region],
+      [t('shared.dossiers.geo.department'), champ.departement_code_and_name],
+      [t('shared.dossiers.geo.region_code'), champ.code_region],
     ]
   end
 

--- a/app/components/dsfr/input_errorable.rb
+++ b/app/components/dsfr/input_errorable.rb
@@ -68,9 +68,9 @@ module Dsfr
 
       def default_hint
         if I18n.exists?("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}")
-          I18n.t("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}", application_name: APPLICATION_NAME)
+          t("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}", application_name: APPLICATION_NAME)
         elsif I18n.exists?("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}_html")
-          I18n.t("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}_html", application_name: APPLICATION_NAME).html_safe
+          t("activerecord.attributes.#{object.class.name.underscore}.hints.#{@attribute}_html", application_name: APPLICATION_NAME)
         end
       end
 

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -105,7 +105,7 @@ module Dsfr
         deleted_dossier = DeletedDossier.find_by(dossier_id: @champ.value) if dossier.nil?
         if deleted_dossier.present?
           {
-            state: :info, text: I18n.t('shared.champs.dossier_link.hidden',
+            state: :info, text: t('shared.champs.dossier_link.hidden',
                                        depose_at: l(deleted_dossier.depose_at),
                                        procedure_libelle: deleted_dossier.procedure.libelle,
                                        hidden_at: l(deleted_dossier.deleted_at.to_date)),
@@ -113,14 +113,14 @@ module Dsfr
         elsif dossier.present?
           if dossier.hidden_by_expired_at.present?
             {
-              state: :info, text: I18n.t('shared.champs.dossier_link.expired',
+              state: :info, text: t('shared.champs.dossier_link.expired',
                                          depose_at: l(dossier.depose_at.to_date),
                                          procedure_libelle: dossier.procedure.libelle,
                                          expired_at: l(dossier.hidden_by_expired_at.to_date)),
             }
           elsif dossier.hidden_by_user_at.present?
             {
-              state: :info, text: I18n.t('shared.champs.dossier_link.hidden',
+              state: :info, text: t('shared.champs.dossier_link.hidden',
                                          depose_at: l(dossier.depose_at.to_date),
                                          procedure_libelle: dossier.procedure.libelle,
                                          hidden_at: l(dossier.hidden_by_user_at.to_date)),

--- a/app/components/instructeurs/cell_component.rb
+++ b/app/components/instructeurs/cell_component.rb
@@ -51,7 +51,8 @@ class Instructeurs::CellComponent < ApplicationComponent
 
     if dossier.for_tiers
       prenom, nom = dossier&.individual&.prenom, dossier&.individual&.nom
-      safe_join([email, I18n.t('views.instructeurs.dossiers.acts_on_behalf'), prenom, nom], ' ')
+      # I18n.t: this method runs before render, where the component `t` is unavailable
+      safe_join([email, I18n.t('views.instructeurs.dossiers.acts_on_behalf'), prenom, nom], ' ') # rubocop:disable DS/GlobalI18nTranslate
     else
       html_escape(email)
     end
@@ -59,7 +60,7 @@ class Instructeurs::CellComponent < ApplicationComponent
 
   def sum_up_avis(avis)
     result = avis.map(&:question_answer)&.compact&.tally
-      &.map { |k, v| I18n.t("helpers.label.question_answer_with_count.#{k}", count: v) }
+      &.map { |k, v| I18n.t("helpers.label.question_answer_with_count.#{k}", count: v) } # rubocop:disable DS/GlobalI18nTranslate
 
     result ? safe_join(result, ' / ') : nil
   end

--- a/app/components/llm/improve_types_item_component.rb
+++ b/app/components/llm/improve_types_item_component.rb
@@ -10,7 +10,7 @@ class LLM::ImproveTypesItemComponent < LLM::SuggestionItemComponent
   end
 
   def type_champ_label(type_champ)
-    I18n.t(type_champ, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])
+    t(type_champ, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])
   end
 
   def new_type_champ_label

--- a/app/components/manager/dossier_champ_row_component/dossier_champ_row_component.html.haml
+++ b/app/components/manager/dossier_champ_row_component/dossier_champ_row_component.html.haml
@@ -4,7 +4,7 @@
     - if row.mandatory?
       %span.mandatory *
   %td{ class: cell_class }
-    = I18n.t("activerecord.attributes.type_de_champ.type_champs.#{row.type_champ}")
+    = t("activerecord.attributes.type_de_champ.type_champs.#{row.type_champ}")
 
   %td{ class: cell_class }
     = icon

--- a/app/components/referentiels/referentiel_display_base_component.rb
+++ b/app/components/referentiels/referentiel_display_base_component.rb
@@ -34,9 +34,9 @@ class Referentiels::ReferentielDisplayBaseComponent < ApplicationComponent
     in [:datetime, value]
       I18n.l(DateTime.parse(DateDetectionUtils.convert_to_iso8601_datetime(value)), format: :long_with_time) rescue nil
     in [:boolean, TrueClass => value]
-      I18n.t('utils.yes')
+      t('utils.yes')
     in [:boolean, FalseClass => value]
-      I18n.t('utils.no')
+      t('utils.no')
     in [:array, Array => value] if ReferentielMappingUtils.array_of_supported_simple_types?(value)
       Array(value).compact.join(", ")
     in [:string | :decimal_number | :integer_number, String | Float | Integer => value]

--- a/app/components/types_de_champ_editor/champ_piece_justificative_component.rb
+++ b/app/components/types_de_champ_editor/champ_piece_justificative_component.rb
@@ -29,7 +29,7 @@ class TypesDeChampEditor::ChampPieceJustificativeComponent < TypesDeChampEditor:
     FORMAT_FAMILIES.keys.map do |key|
       [
         key,
-        I18n.t("activerecord.attributes.type_de_champ.format_families.#{key}"),
+        t("activerecord.attributes.type_de_champ.format_families.#{key}"),
         key.to_s.in?(type_de_champ.pj_format_families),
         FORMAT_FAMILY_EXAMPLES[key],
       ]

--- a/app/controllers/administrateurs/administrateur_controller.rb
+++ b/app/controllers/administrateurs/administrateur_controller.rb
@@ -67,9 +67,9 @@ module Administrateurs
       procedures = missing_siret_services
       if procedures.any?
         errors = []
-        errors << I18n.t('shared.procedures.no_siret')
+        errors << t('shared.procedures.no_siret')
         procedures.each do |p|
-          errors << I18n.t('shared.procedures.add_siret_to_service_without_siret_html', link: edit_admin_service_path(p.service, procedure_id: p.id), nom: p.service.nom)
+          errors << t('shared.procedures.add_siret_to_service_without_siret_html', link: edit_admin_service_path(p.service, procedure_id: p.id), nom: p.service.nom)
         end
         flash.now.alert = errors
       end
@@ -88,9 +88,9 @@ module Administrateurs
       procedures = missing_service
       if procedures.any?
         errors = []
-        errors << I18n.t('shared.procedures.no_service')
+        errors << t('shared.procedures.no_service')
         procedures.each do |p|
-          errors << I18n.t('shared.procedures.add_service_html', link: admin_services_path(procedure_id: p.id), id: p.id)
+          errors << t('shared.procedures.add_service_html', link: admin_services_path(procedure_id: p.id), id: p.id)
         end
         flash.now.alert = errors
       end

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -405,7 +405,7 @@ module Administrateurs
 
     def close
       @published_procedures = current_administrateur.procedures.publiees.where.not(id: @procedure.id).to_h { |p| ["#{p.libelle} (#{p.id})", p.id] }
-      @closing_reason_options = Procedure.closing_reasons.values.map { |reason| [I18n.t("activerecord.attributes.procedure.closing_reasons.#{reason}", app_name: Current.application_name), reason] }
+      @closing_reason_options = Procedure.closing_reasons.values.map { |reason| [t("activerecord.attributes.procedure.closing_reasons.#{reason}", app_name: Current.application_name), reason] }
     end
 
     def confirmation

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -152,7 +152,7 @@ class ApplicationController < ActionController::Base
   def display_csrf_retry_message
     return unless params[:csrf_retry] == '1'
 
-    flash.now[:alert] = I18n.t('errors.csrf_retry.message')
+    flash.now[:alert] = t('errors.csrf_retry.message')
   end
 
   def authenticate_logged_user!

--- a/app/controllers/concerns/avis_creation_concern.rb
+++ b/app/controllers/concerns/avis_creation_concern.rb
@@ -31,7 +31,7 @@ module AvisCreationConcern
   def handle_empty_emails
     if avis_emails.empty?
       email_label = User.human_attribute_name(:email)
-      flash.now[:alert] = format(I18n.t('errors.format'), attribute: email_label, message: I18n.t('errors.messages.blank'))
+      flash.now[:alert] = format(t('errors.format'), attribute: email_label, message: t('errors.messages.blank'))
       true
     end
   end

--- a/app/controllers/concerns/requires_fresh_super_admin_otp.rb
+++ b/app/controllers/concerns/requires_fresh_super_admin_otp.rb
@@ -11,7 +11,7 @@ module RequiresFreshSuperAdminOtp
     code = params[:otp_attempt].to_s.strip
     return if code.present? && current_super_admin.validate_and_consume_otp!(code)
 
-    flash[:error] = I18n.t("manager.fresh_otp.invalid_code")
+    flash[:error] = t("manager.fresh_otp.invalid_code")
     redirect_back_or_to(manager_root_path)
   end
 end

--- a/app/controllers/france_connect_controller.rb
+++ b/app/controllers/france_connect_controller.rb
@@ -144,7 +144,7 @@ class FranceConnectController < ApplicationController
     if @user.confirmation_sent_at && 2.days.ago < @user.confirmation_sent_at
       @user.update(email_verified_at: Time.zone.now, confirmation_token: nil)
       @user.after_confirmation
-      redirect_to destination_path(@user), notice: I18n.t('france_connect.flash.email_confirmed')
+      redirect_to destination_path(@user), notice: t('france_connect.flash.email_confirmed')
       return
     end
 
@@ -152,9 +152,9 @@ class FranceConnectController < ApplicationController
 
     if fci
       fci.send_custom_confirmation_instructions
-      redirect_to root_path, notice: I18n.t('france_connect.flash.confirmation_mail_resent')
+      redirect_to root_path, notice: t('france_connect.flash.confirmation_mail_resent')
     else
-      redirect_to root_path, alert: I18n.t('france_connect.flash.confirmation_mail_resent_error')
+      redirect_to root_path, alert: t('france_connect.flash.confirmation_mail_resent_error')
     end
   end
 
@@ -197,12 +197,12 @@ class FranceConnectController < ApplicationController
     @user = User.find_by(confirmation_token: params[:token])
 
     if @user.nil?
-      return redirect_to root_path, alert: I18n.t('france_connect.flash.user_not_found')
+      return redirect_to root_path, alert: t('france_connect.flash.user_not_found')
     end
 
     if user_signed_in? && current_user != @user
       sign_out :user
-      redirect_to new_user_session_path, alert: I18n.t('france_connect.flash.redirect_new_user_session')
+      redirect_to new_user_session_path, alert: t('france_connect.flash.redirect_new_user_session')
     end
   end
 
@@ -212,7 +212,7 @@ class FranceConnectController < ApplicationController
     @fci = FranceConnectInformation.find_by(email_merge_token: params[:email_merge_token])
 
     if @fci.nil? || !@fci.valid_for_email_merge?
-      flash.alert = I18n.t('france_connect.flash.merger_token_expired', application_name: Current.application_name)
+      flash.alert = t('france_connect.flash.merger_token_expired', application_name: Current.application_name)
 
       redirect_to root_path
     else
@@ -224,7 +224,7 @@ class FranceConnectController < ApplicationController
     @fci = FranceConnectInformation.find_by(merge_token: params[:merge_token])
 
     if @fci.nil? || !@fci.valid_for_merge?
-      flash.alert = I18n.t('france_connect.flash.merger_token_expired', application_name: Current.application_name)
+      flash.alert = t('france_connect.flash.merger_token_expired', application_name: Current.application_name)
 
       redirect_to root_path
     end

--- a/app/controllers/gestionnaires/groupe_gestionnaire_administrateurs_controller.rb
+++ b/app/controllers/gestionnaires/groupe_gestionnaire_administrateurs_controller.rb
@@ -38,24 +38,24 @@ module Gestionnaires
       end
 
       if administrateurs_already_in_groupe_gestionnaire.present?
-        flash[:alert] = I18n.t('activerecord.errors.administrateurs_already_in_groupe_gestionnaire',
+        flash[:alert] = t('activerecord.errors.administrateurs_already_in_groupe_gestionnaire',
           count: administrateurs_already_in_groupe_gestionnaire.size,
           emails: administrateurs_already_in_groupe_gestionnaire)
       end
 
       if invalid_emails.present?
-        flash[:alert] = I18n.t('activerecord.wrong_address',
+        flash[:alert] = t('activerecord.wrong_address',
           count: invalid_emails.size,
           emails: invalid_emails.join(', '))
       end
       if administrateurs_duplicate.present?
-        flash[:alert] = I18n.t('activerecord.errors.duplicate_email',
+        flash[:alert] = t('activerecord.errors.duplicate_email',
           count: invalid_emails.size,
           emails: administrateurs_duplicate.map(&:email).join(', '))
       end
 
       if administrateurs_to_add.present?
-        flash[:notice] = I18n.t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_administrateur.create')
+        flash[:notice] = t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_administrateur.create')
 
         GroupeGestionnaireMailer
           .notify_added_administrateurs(@groupe_gestionnaire, administrateurs_to_add, current_gestionnaire.email)
@@ -72,19 +72,19 @@ module Gestionnaires
       case result
       in Dry::Monads::Result::Success
         logger.info("L’administrateur #{@administrateur.id} est supprimé par le gestionnaire #{current_gestionnaire.id} depuis le groupe gestionnaire #{@groupe_gestionnaire.id}")
-        flash[:notice] = I18n.t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_administrateur.destroy', email: @administrateur.email)
+        flash[:notice] = t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_administrateur.destroy', email: @administrateur.email)
         GroupeGestionnaireMailer
           .notify_removed_administrateur(@groupe_gestionnaire, @administrateur.email, current_gestionnaire.email)
           .deliver_later
       in Dry::Monads::Result::Failure(reason)
-        flash[:alert] = I18n.t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_administrateur.cannot_be_deleted', email: @administrateur.email)
+        flash[:alert] = t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_administrateur.cannot_be_deleted', email: @administrateur.email)
       end
     end
 
     def remove
       @administrateur = @groupe_gestionnaire.administrateurs.find(params[:id])
       @administrateur.update(groupe_gestionnaire_id: nil)
-      flash[:notice] = I18n.t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_administrateur.remove', email: @administrateur.email)
+      flash[:notice] = t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_administrateur.remove', email: @administrateur.email)
       GroupeGestionnaireMailer
         .notify_removed_administrateur(@groupe_gestionnaire, @administrateur.email, current_gestionnaire.email)
         .deliver_later

--- a/app/controllers/gestionnaires/groupe_gestionnaire_gestionnaires_controller.rb
+++ b/app/controllers/gestionnaires/groupe_gestionnaire_gestionnaires_controller.rb
@@ -29,18 +29,18 @@ module Gestionnaires
       gestionnaires_to_add.each { @groupe_gestionnaire.add_gestionnaire(_1) }
 
       if invalid_emails.present?
-        flash[:alert] = I18n.t('activerecord.wrong_address',
+        flash[:alert] = t('activerecord.wrong_address',
           count: invalid_emails.size,
           emails: invalid_emails.join(', '))
       end
       if gestionnaires_duplicate.present?
-        flash[:alert] = I18n.t('activerecord.errors.duplicate_email',
+        flash[:alert] = t('activerecord.errors.duplicate_email',
           count: invalid_emails.size,
           emails: gestionnaires_duplicate.map(&:email).join(', '))
       end
 
       if gestionnaires_to_add.present?
-        flash[:notice] = I18n.t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_gestionnaire.create')
+        flash[:notice] = t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_gestionnaire.create')
 
         GroupeGestionnaireMailer
           .notify_added_gestionnaires(@groupe_gestionnaire, gestionnaires_to_add, current_gestionnaire.email)
@@ -52,17 +52,17 @@ module Gestionnaires
 
     def destroy
       if @groupe_gestionnaire.is_root? && @groupe_gestionnaire.gestionnaires.one?
-        flash[:alert] = I18n.t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_gestionnaire.destroy_at_least_one')
+        flash[:alert] = t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_gestionnaire.destroy_at_least_one')
       else
         @gestionnaire = @groupe_gestionnaire.gestionnaires.find(params[:id])
 
         if !@gestionnaire.groupe_gestionnaires.destroy(@groupe_gestionnaire)
-          flash[:alert] = I18n.t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_gestionnaire.not_in_groupe_gestionnaire', email: @gestionnaire.email)
+          flash[:alert] = t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_gestionnaire.not_in_groupe_gestionnaire', email: @gestionnaire.email)
         else
           if @gestionnaire.groupe_gestionnaires.empty?
             @gestionnaire.destroy
           end
-          flash[:notice] = I18n.t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_gestionnaire.destroy', email: @gestionnaire.email)
+          flash[:notice] = t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_gestionnaire.destroy', email: @gestionnaire.email)
           GroupeGestionnaireMailer
             .notify_removed_gestionnaire(@groupe_gestionnaire, @gestionnaire.email, current_gestionnaire.email)
             .deliver_later

--- a/app/controllers/instructeurs/batch_operations_controller.rb
+++ b/app/controllers/instructeurs/batch_operations_controller.rb
@@ -29,11 +29,11 @@ module Instructeurs
       email_label = User.human_attribute_name(:email)
 
       if emails.empty?
-        avis.errors.add(:base, format(I18n.t('errors.format'), attribute: email_label, message: I18n.t('errors.messages.blank')))
+        avis.errors.add(:base, format(t('errors.format'), attribute: email_label, message: t('errors.messages.blank')))
       end
 
       invalid_emails.each do |email|
-        avis.errors.add(:base, format(I18n.t('errors.format'), attribute: email_label, message: "est invalide : #{email}"))
+        avis.errors.add(:base, format(t('errors.format'), attribute: email_label, message: "est invalide : #{email}"))
       end
 
       batch = avis.errors.empty? ? BatchOperation.safe_create!(batch_operation_avis_params) : nil

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -182,7 +182,7 @@ module Instructeurs
 
     def archive
       if !dossier.termine?
-        flash.alert = I18n.t('activerecord.errors.models.dossier.cannot_archive')
+        flash.alert = t('activerecord.errors.models.dossier.cannot_archive')
       else
         dossier.archiver!(current_instructeur)
       end

--- a/app/controllers/manager/administrateurs_controller.rb
+++ b/app/controllers/manager/administrateurs_controller.rb
@@ -31,7 +31,7 @@ module Manager
         logger.info("L’administrateur #{administrateur.id} est supprimé par #{current_super_admin.id}")
         flash[:notice] = "L’administrateur #{administrateur.id} est supprimé"
       in Dry::Monads::Result::Failure(reason)
-        flash[:alert] = I18n.t(reason, scope: "manager.administrateurs.delete")
+        flash[:alert] = t(reason, scope: "manager.administrateurs.delete")
       end
 
       redirect_to manager_administrateurs_path

--- a/app/controllers/manager/groupe_gestionnaires_controller.rb
+++ b/app/controllers/manager/groupe_gestionnaires_controller.rb
@@ -25,18 +25,18 @@ module Manager
       gestionnaires_to_add.each { groupe_gestionnaire.add_gestionnaire(_1) }
 
       if invalid_emails.present?
-        flash[:alert] = I18n.t('activerecord.wrong_address',
+        flash[:alert] = t('activerecord.wrong_address',
           count: invalid_emails.size,
           emails: invalid_emails.join(', '))
       end
       if gestionnaires_duplicate.present?
-        flash[:alert] = I18n.t('activerecord.errors.duplicate_email',
+        flash[:alert] = t('activerecord.errors.duplicate_email',
           count: invalid_emails.size,
           emails: gestionnaires_duplicate.map(&:email).join(', '))
       end
 
       if gestionnaires_to_add.present?
-        flash[:notice] = I18n.t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_gestionnaire.create')
+        flash[:notice] = t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_gestionnaire.create')
 
         GroupeGestionnaireMailer
           .notify_added_gestionnaires(groupe_gestionnaire, gestionnaires_to_add, current_super_admin.email)
@@ -49,17 +49,17 @@ module Manager
     def remove_gestionnaire
       groupe_gestionnaire = GroupeGestionnaire.find(params[:id])
       if groupe_gestionnaire.is_root? && groupe_gestionnaire.gestionnaires.one?
-        flash[:alert] = I18n.t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_gestionnaire.destroy_at_least_one')
+        flash[:alert] = t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_gestionnaire.destroy_at_least_one')
       else
         gestionnaire = Gestionnaire.find(params[:gestionnaire][:id])
 
         if !groupe_gestionnaire.in?(gestionnaire.groupe_gestionnaires) || !gestionnaire.groupe_gestionnaires.destroy(groupe_gestionnaire)
-          flash[:alert] = I18n.t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_gestionnaire.not_in_groupe_gestionnaire', email: gestionnaire.email)
+          flash[:alert] = t('groupe_gestionnaires.flash.alert.groupe_gestionnaire_gestionnaire.not_in_groupe_gestionnaire', email: gestionnaire.email)
         else
           if gestionnaire.groupe_gestionnaires.empty?
             gestionnaire.destroy
           end
-          flash[:notice] = I18n.t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_gestionnaire.destroy', email: gestionnaire.email)
+          flash[:notice] = t('groupe_gestionnaires.flash.notice.groupe_gestionnaire_gestionnaire.destroy', email: gestionnaire.email)
           GroupeGestionnaireMailer
             .notify_removed_gestionnaire(groupe_gestionnaire, gestionnaire.email, current_super_admin.email)
             .deliver_later

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -116,7 +116,7 @@ module Users
       @dossier = dossier
       pdf = @dossier.generate_or_reuse_attestation_depot
       send_data pdf,
-        filename: I18n.t('users.dossiers.show.attestation_depot.filename', dossier_id: @dossier.id),
+        filename: t('users.dossiers.show.attestation_depot.filename', dossier_id: @dossier.id),
         type: 'application/pdf',
         disposition: 'attachment'
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -138,7 +138,7 @@ class Users::SessionsController < Devise::SessionsController
 
   # Pro connect callback
   def logout
-    redirect_to root_path, notice: I18n.t('devise.sessions.signed_out')
+    redirect_to root_path, notice: t('devise.sessions.signed_out')
   end
 
   # calling current_user in a before_action will trigger the warden authentication (devise behavior)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -117,11 +117,11 @@ module ApplicationHelper
 
     case date
     when today
-      I18n.t('dates.today')
+      t('dates.today')
     when today - 1
-      I18n.t('dates.yesterday')
+      t('dates.yesterday')
     when (today - 6)..(today - 2)
-      I18n.t('dates.days_ago', count: (today - date).to_i)
+      t('dates.days_ago', count: (today - date).to_i)
     else
       I18n.l(date, format: :long)
     end
@@ -136,7 +136,8 @@ module ApplicationHelper
   end
 
   def new_tab_suffix(title)
-    [title, I18n.t('utils.new_tab')].compact.join(' — ')
+    # I18n.t: also called from Redcarpet::BareRenderer, outside any view context
+    [title, I18n.t('utils.new_tab')].compact.join(' — ') # rubocop:disable DS/GlobalI18nTranslate
   end
 
   def download_details(attachment)

--- a/app/helpers/attestation_depot_helper.rb
+++ b/app/helpers/attestation_depot_helper.rb
@@ -16,6 +16,6 @@ module AttestationDepotHelper
     # i18n-tasks-use t('users.dossiers.attestation_depot.states.accepte')
     # i18n-tasks-use t('users.dossiers.attestation_depot.states.refuse')
     # i18n-tasks-use t('users.dossiers.attestation_depot.states.sans_suite')
-    I18n.t("users.dossiers.attestation_depot.states.#{dossier.state}")
+    t("users.dossiers.attestation_depot.states.#{dossier.state}")
   end
 end

--- a/app/helpers/commentaire_helper.rb
+++ b/app/helpers/commentaire_helper.rb
@@ -9,9 +9,9 @@ module CommentaireHelper
 
   def commentaire_answer_action(commentaire, connected_user)
     if commentaire.sent_by?(connected_user)
-      I18n.t('helpers.commentaire.send_message_to_instructeur')
+      t('helpers.commentaire.send_message_to_instructeur')
     else
-      I18n.t('helpers.commentaire.reply_in_mailbox')
+      t('helpers.commentaire.reply_in_mailbox')
     end
   end
 

--- a/app/helpers/conservation_de_donnees_helper.rb
+++ b/app/helpers/conservation_de_donnees_helper.rb
@@ -9,7 +9,7 @@ module ConservationDeDonneesHelper
 
   def conservation_dans_ds(procedure)
     if procedure.duree_conservation_dossiers_dans_ds.present?
-      I18n.t('users.procedure_footer.legals.data_retention',
+      t('users.procedure_footer.legals.data_retention',
              duree_conservation_dossiers_dans_ds: procedure.duree_conservation_dossiers_dans_ds)
     end
   end

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -102,10 +102,10 @@ module DossierHelper
 
   def deletion_reason_badge(reason)
     if reason.present?
-      status_text = I18n.t(reason, scope: 'activerecord.attributes.deleted_dossier.reason')
+      status_text = t(reason, scope: 'activerecord.attributes.deleted_dossier.reason')
       status_class = reason.tr('_', '-')
     else
-      status_text = I18n.t('activerecord.attributes.deleted_dossier.reason.unknown')
+      status_text = t('activerecord.attributes.deleted_dossier.reason.unknown')
       status_class = 'unknown'
     end
 

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -243,7 +243,7 @@ class DossierMailer < ApplicationMailer
     if interpolations[:state]
       mailer_scope = self.class.mailer_name.tr('/', '.')
       state = interpolations[:state].in?(Dossier::TERMINE) ? 'termine' : interpolations[:state]
-      I18n.t("subject_#{state}", **interpolations.merge(scope: [mailer_scope, action_name]))
+      t("subject_#{state}", **interpolations.merge(scope: [mailer_scope, action_name]))
     else
       super
     end

--- a/app/views/administrateurs/groupe_instructeurs/simple_routing.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/simple_routing.html.haml
@@ -44,7 +44,7 @@
         .card.fr-pb-0{ data: { 'action': "click->enable-submit-if-checked#click" } }
           .notice
             Sélectionner le champ à partir duquel créer des groupes d’instructeurs
-          - buttons_content = @procedure.active_revision.simple_routable_types_de_champ.map { |tdc| { label: tdc.libelle, value: tdc.stable_id, hint: "[#{I18n.t(tdc.type_champ, scope: 'activerecord.attributes.type_de_champ.type_champs')}]", tooltip: (tdc.drop_down_options.join(", ") if tdc.drop_down_list?)} }
+          - buttons_content = @procedure.active_revision.simple_routable_types_de_champ.map { |tdc| { label: tdc.libelle, value: tdc.stable_id, hint: "[#{t(tdc.type_champ, scope: 'activerecord.attributes.type_de_champ.type_champs')}]", tooltip: (tdc.drop_down_options.join(", ") if tdc.drop_down_list?)} }
           = render Dsfr::RadioButtonListComponent.new(form: f,
             target: :stable_id,
             buttons: buttons_content)

--- a/app/views/administrateurs/services/_form.html.haml
+++ b/app/views/administrateurs/services/_form.html.haml
@@ -31,7 +31,7 @@
       Type d’organisme
       = render EditableChamp::AsteriskMandatoryComponent.new
 
-    = f.select :type_organisme, Service.type_organismes.keys.map { |key| [ I18n.t("type_organisme.#{key}"), key] }, { include_blank: true }, { class: "fr-select" , required: true }
+    = f.select :type_organisme, Service.type_organismes.keys.map { |key| [ t("type_organisme.#{key}"), key] }, { include_blank: true }, { class: "fr-select" , required: true }
 
   = render Dsfr::CalloutComponent.new(title: "Informations de contact") do |c|
     - c.with_body do

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -14,7 +14,7 @@
 
         %fieldset.fr-mb-0.fr-fieldset
           %legend.fr-fieldset__legend
-            %h1.fr-h2= I18n.t('views.users.passwords.edit.subtitle')
+            %h1.fr-h2= t('views.users.passwords.edit.subtitle')
 
           .fr-fieldset__element
             %p.fr-text--sm= t('utils.asterisk_html')

--- a/app/views/fields/enum_field/_form.html.erb
+++ b/app/views/fields/enum_field/_form.html.erb
@@ -5,7 +5,7 @@
         field.attribute,
         options_for_select(
           f.object.class.public_send(field.attribute.to_s.pluralize).map do |k, _v|
-            [I18n.t("activerecord.attributes.#{f.object.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{k}", default: k.humanize), k]
+            [t("activerecord.attributes.#{f.object.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{k}", default: k.humanize), k]
           end,
           f.object.public_send(field.attribute.to_s)
         ),

--- a/app/views/fields/enum_field/_index.html.erb
+++ b/app/views/fields/enum_field/_index.html.erb
@@ -1,1 +1,1 @@
-<%= I18n.t("activerecord.attributes.#{field.resource.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{field.data}", default: field.to_s) %>
+<%= t("activerecord.attributes.#{field.resource.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{field.data}", default: field.to_s) %>

--- a/app/views/fields/enum_field/_show.html.erb
+++ b/app/views/fields/enum_field/_show.html.erb
@@ -1,1 +1,1 @@
-<%= I18n.t("activerecord.attributes.#{field.resource.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{field.data}", default: field.to_s) %>
+<%= t("activerecord.attributes.#{field.resource.class.name.underscore}.#{field.attribute.to_s.pluralize}.#{field.data}", default: field.to_s) %>

--- a/app/views/fields/types_de_champ_collection_field/_type_champ_line.html.erb
+++ b/app/views/fields/types_de_champ_collection_field/_type_champ_line.html.erb
@@ -8,7 +8,7 @@
   </td>
 
   <td class="cell-data">
-    <%= I18n.t("activerecord.attributes.type_de_champ.type_champs.#{type_de_champ.type_champ}") %>
+    <%= t("activerecord.attributes.type_de_champ.type_champs.#{type_de_champ.type_champ}") %>
   </td>
 
   <td class="cell-data">

--- a/app/views/manager/administrateurs/_form.html.erb
+++ b/app/views/manager/administrateurs/_form.html.erb
@@ -32,7 +32,7 @@
           <% hint_key = "administrate.field_hints.#{page.resource_name}.#{attribute.name}" %>
 
           <% if I18n.exists?(hint_key) %>
-            <div class="field-unit__hint"><%= I18n.t(hint_key) %></div>
+            <div class="field-unit__hint"><%= t(hint_key) %></div>
           <% end %>
         </div>
       <% end %>

--- a/app/views/shared/dossiers/_update_contact_information.html.haml
+++ b/app/views/shared/dossiers/_update_contact_information.html.haml
@@ -1,16 +1,16 @@
 #contact_information.fr-text--xs
   - service_or_contact_information = dossier&.service_or_contact_information || procedure.service
   - if service_or_contact_information.present?
-    %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.managed_by.header')
+    %h3.fr-footer__top-cat= t('users.procedure_footer.managed_by.header')
     %div{ lang: :fr }
       = service_or_contact_information.pretty_nom
       = render SimpleFormatComponent.new(service_or_contact_information.adresse, class_names_map: {paragraph: 'fr-text--xs'})
   %h3.fr-footer__top-cat
     - if dossier.present? && dossier.depose_at.present?
-      = I18n.t('help_dropdown.help_filled_dossier')
+      = t('help_dropdown.help_filled_dossier')
     - elsif dossier.present?
-      = I18n.t('help_dropdown.help_brouillon_title')
+      = t('help_dropdown.help_brouillon_title')
     - else
-      = I18n.t('help_dropdown.procedure_title')
+      = t('help_dropdown.procedure_title')
   - if service_or_contact_information.present?
     = render Procedure::ServiceListContactComponent.new(service_or_contact_information: service_or_contact_information, dossier: dossier, footer: true)

--- a/app/views/users/_procedure_footer.html.haml
+++ b/app/views/users/_procedure_footer.html.haml
@@ -9,7 +9,7 @@
         - politiques = politiques_conservation_de_donnees(procedure)
         - if politiques.present?
           .fr-col-12.fr-col-sm-4.fr-col-md-4
-            %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.legals.header')
+            %h3.fr-footer__top-cat= t('users.procedure_footer.legals.header')
             %ul.fr-footer__top-list
               - politiques.each do |politique|
                 %li
@@ -18,33 +18,33 @@
               - if procedure.deliberation.attached?
                 %li
                   = link_to url_for(procedure.deliberation), rel: 'noopener', class: 'fr-footer__link' do
-                    = I18n.t("users.procedure_footer.legals.terms")
+                    = t("users.procedure_footer.legals.terms")
               - elsif procedure.cadre_juridique&.starts_with?("http")
                 %li
-                  = link_to I18n.t("users.procedure_footer.legals.terms"), procedure.cadre_juridique, class: 'fr-footer__link', **external_link_attributes
+                  = link_to t("users.procedure_footer.legals.terms"), procedure.cadre_juridique, class: 'fr-footer__link', **external_link_attributes
 
               - if procedure.lien_dpo.present?
                 %li
                   = link_to url_or_email_to_lien_dpo(procedure), rel: 'noopener', class: 'fr-footer__link' do
-                    = I18n.t("users.procedure_footer.legals.dpo")
+                    = t("users.procedure_footer.legals.dpo")
               %li
-                = link_to I18n.t('users.procedure_footer.contact.stats.link'), statistiques_path(procedure.path), class: 'fr-footer__link', rel: 'noopener'
+                = link_to t('users.procedure_footer.contact.stats.link'), statistiques_path(procedure.path), class: 'fr-footer__link', rel: 'noopener'
 
 
         .fr-col-12.fr-col-sm-4.fr-col-md-4
           - unless procedure.close?
-            %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.dematerialisation.header')
+            %h3.fr-footer__top-cat= t('users.procedure_footer.dematerialisation.header')
             .fr-download
-              = link_to I18n.t('users.procedure_footer.dematerialisation.title_1'), commencer_dossier_vide_for_revision_path(procedure.active_revision), download: 'true', class: 'fr-download__link'
-          %h3.fr-footer__top-cat= I18n.t('users.procedure_footer.support.header')
+              = link_to t('users.procedure_footer.dematerialisation.title_1'), commencer_dossier_vide_for_revision_path(procedure.active_revision), download: 'true', class: 'fr-download__link'
+          %h3.fr-footer__top-cat= t('users.procedure_footer.support.header')
           %ul.fr-footer__top-list
             - if procedure.zones.none? { |z| z.acronym == 'MI' }
               %li
-                = link_to I18n.t('users.procedure_footer.support_links.france_service.title'), t("users.procedure_footer.support_links.france_service.url"),
+                = link_to t('users.procedure_footer.support_links.france_service.title'), t("users.procedure_footer.support_links.france_service.url"),
                   title: new_tab_suffix(t("users.procedure_footer.support_links.france_service.title")), class: "fr-footer__link", **external_link_attributes
 
             %li
-              = link_to I18n.t('users.procedure_footer.support_links.carte_inclusion.title'), t("users.procedure_footer.support_links.carte_inclusion.url"),
+              = link_to t('users.procedure_footer.support_links.carte_inclusion.title'), t("users.procedure_footer.support_links.carte_inclusion.url"),
                 title: new_tab_suffix(t("users.procedure_footer.support_links.carte_inclusion.title")), class: "fr-footer__link", **external_link_attributes
 
   .fr-footer__bottom.fr-mt-0

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -14,7 +14,7 @@
 
     %fieldset.fr-mb-0.fr-fieldset{ aria: { labelledby: 'create-account-legend' } }
       %legend.fr-fieldset__legend#create-account-legend
-        %h2.fr-h6= I18n.t('views.registrations.new.subtitle')
+        %h2.fr-h6= t('views.registrations.new.subtitle')
 
       - banner = banner_for(:login_page)
       - if banner&.active?

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -17,7 +17,7 @@
 
     %fieldset.fr-mb-0.fr-fieldset{ aria: { labelledby: 'new-account-legend' } }
       %legend.fr-fieldset__legend#new-account-legend
-        %h2.fr-h6= I18n.t('views.users.sessions.new.subtitle')
+        %h2.fr-h6= t('views.users.sessions.new.subtitle')
 
       - banner = banner_for(:login_page)
       - if banner&.active?

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -31,9 +31,10 @@ data:
 
   # External locale data (e.g. gems).
   # This data is not considered unused and is never written to.
+  # Resolved via Gem::Specification (not `bundle info`, which fails outside a Bundler context):
   external:
-    - '<%= %x[bundle info --path administrate].chomp %>/config/locales/*%{locale}.yml'
-    - '<%= %x[bundle info --path devise-i18n].chomp %>/rails/locales/*%{locale}.yml'
+    - '<%= Gem::Specification.find_by_name("administrate").gem_dir %>/config/locales/*%{locale}.yml'
+    - '<%= Gem::Specification.find_by_name("devise-i18n").gem_dir %>/rails/locales/*%{locale}.yml'
 
   ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
   # router: conservative_router

--- a/lib/cops/global_i18n_translate.rb
+++ b/lib/cops/global_i18n_translate.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+if defined?(RuboCop)
+  module RuboCop
+    module Cop
+      module DS
+        # In code with a locally-bound translation helper (views, components,
+        # controllers, helpers, mailers), `t` must be preferred over `I18n.t`:
+        # it resolves relative keys, marks missing translations, and makes
+        # `_html` keys html_safe while still escaping interpolated arguments.
+        # `I18n.t` belongs in models, jobs and services — or anywhere a
+        # `locale:` override is passed explicitly.
+        class GlobalI18nTranslate < Base
+          MSG = 'Use the locally-bound `t` instead of `I18n.t` (relative keys, ' \
+                'missing-translation markers, safe `_html` handling). ' \
+                'Reserve `I18n.t` for models/jobs/services or explicit `locale:` overrides.'
+
+          def_node_matcher :global_translate?, <<~PATTERN
+            (send (const {nil? cbase} :I18n) {:t :t! :translate :translate!} ...)
+          PATTERN
+
+          def_node_matcher :locale_override?, <<~PATTERN
+            (send _ _ ... (hash <(pair (sym :locale) _) ...>))
+          PATTERN
+
+          def on_send(node)
+            return unless global_translate?(node)
+            return if locale_override?(node)
+            # Class methods have no instance translation helper (ViewComponent's
+            # class-level `t` only reads the sidecar backend, never global keys).
+            return if class_method_context?(node)
+
+            add_offense(node)
+          end
+
+          private
+
+          def class_method_context?(node)
+            node.each_ancestor(:def, :defs, :sclass).first&.type&.then { it != :def } || false
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Suite de #13651 (PR empilée). Dans le code lié à une vue, le `t` local apporte ce que `I18n.t` n'a pas : résolution des clés relatives, marquage des traductions manquantes, et clés `_html` marquées html_safe **avec échappement des arguments interpolés**. ~110 appels `I18n.t` traînaient dans ces couches.

## Ce que fait cette PR

- **Swap mécanique** `I18n.t` → `t` dans `app/{views,components,controllers,helpers,mailers}` (48 fichiers). Au passage, `Dsfr::InputErrorable` perd son `.html_safe` manuel — le helper marque la clé `_html` et échappe `application_name` correctement.
- **Nouveau cop `DS/GlobalI18nTranslate`** qui interdit `I18n.t` dans ces couches, avec deux exemptions automatiques : `locale:` explicite, et méthodes de classe (le `t` de classe de ViewComponent ne lit que le sidecar, jamais les clés globales).
- **Trois sites gardent `I18n.t`** (disable inline documenté) : méthodes de composants appelées avant le rendu (`CellComponent`, `ChampLabelContentComponent` — le `t` de ViewComponent lève `TranslateCalledBeforeRenderError`), et `ApplicationHelper#new_tab_suffix`, appelé par `Redcarpet::BareRenderer` hors de tout contexte de vue.
- **Correction bonus** : les locales externes d'i18n-tasks (administrate, devise-i18n) sont résolues via `Gem::Specification` au lieu de `bundle info`, qui échouait silencieusement hors contexte Bundler — le swap a rendu l'usage des clés `administrate.*` visible du scanner, ce qui a révélé le problème.

Vérifié : RuboCop (cop testé positif/négatif), haml-lint, herb, les trois checks i18n-tasks, et 1105 exemples de specs (composants, helpers, contrôleurs touchés) verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)