### PR TITLE
ETQ usager, la liste de mes dossiers s'affiche plus rapidement

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -56,6 +56,7 @@ module Users
         @dossiers.load
       end
       load_personnalisation_data(@dossiers)
+      load_user_buffer_changes_data(@dossiers)
       @corbeille_count = current_user.dossiers.hidden_by_user.or(current_user.dossiers.hidden_by_expired).count
       @pending_transfers_count = current_user.dossier_transfers_received_pending.count
       @show_simple_list = params[:search].blank? && !@filter.active? && @total_count <= SIMPLE_LIST_THRESHOLD
@@ -559,6 +560,7 @@ module Users
         .page(page)
         .per(ITEMS_PER_PAGE)
       @total_count = @dossiers.total_count
+      load_user_buffer_changes_data(@dossiers)
     end
 
     private
@@ -742,6 +744,20 @@ module Users
         .find_each do |champ|
           (@champs_by_dossier_id[champ.dossier_id] ||= {})[champ.stable_id] = champ
         end
+    end
+
+    # Sur-ensemble des dossiers ayant des champs sur le stream « user:buffer » :
+    # une seule requête pour toute la page, au lieu de charger tous les champs
+    # de chaque dossier en_construction juste pour décider d'afficher la bannière
+    # « modifications non soumises ». Le composant fait ensuite la vérification
+    # précise (stable_id dans la révision) sur les seuls dossiers signalés.
+    def load_user_buffer_changes_data(dossiers)
+      dossier_ids = dossiers.filter(&:en_construction?).map(&:id)
+      @dossier_ids_with_user_buffer_changes = ChampData
+        .where(dossier_id: dossier_ids, stream: Dossier::USER_BUFFER_STREAM)
+        .distinct
+        .pluck(:dossier_id)
+        .to_set
     end
 
     def personnalisation_available?

--- a/app/views/users/dossiers/_dossiers_list.html.erb
+++ b/app/views/users/dossiers/_dossiers_list.html.erb
@@ -28,7 +28,7 @@
         <% end %>
       <% end %>
 
-      <% if dossier.en_construction? %>
+      <% if dossier.en_construction? && @dossier_ids_with_user_buffer_changes.include?(dossier.id) %>
         <%= render Dossiers::EnConstructionNotSubmittedComponent.new(dossier: dossier, user: current_user) %>
       <% end %>
 

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1900,6 +1900,26 @@ describe Users::DossiersController, type: :controller do
       expect(assigns(:pending_transfers_count)).to be_a(Integer)
     end
 
+    context 'user buffer changes prefilter' do
+      let(:procedure) { create(:procedure, :published, types_de_champ_public: [{}]) }
+      let!(:dossier_with_changes) { create(:dossier, :en_construction, user:, procedure:) }
+      let!(:dossier_without_changes) { create(:dossier, :en_construction, user:, procedure:) }
+      let!(:dossier_brouillon) { create(:dossier, user:, procedure:) }
+
+      before do
+        dossier_with_changes.with_update_stream(user) do
+          dossier_with_changes
+            .champ_for_update(dossier_with_changes.revision.root_types_de_champ_public.first, updated_by: user.email)
+            .update!(value: 'nouvelle valeur')
+        end
+      end
+
+      it 'flags only en_construction dossiers with unsubmitted user changes' do
+        get :index
+        expect(assigns(:dossier_ids_with_user_buffer_changes)).to eq(Set[dossier_with_changes.id])
+      end
+    end
+
     context 'filter panel-only request' do
       before { create_list(:dossier, 6, :en_construction, user: user) }
 

--- a/spec/views/users/dossiers/index.html.haml_spec.rb
+++ b/spec/views/users/dossiers/index.html.haml_spec.rb
@@ -19,6 +19,7 @@ describe 'users/dossiers/index', type: :view do
     assign(:corbeille_count, 0)
     assign(:pending_transfers_count, 0)
     assign(:counts, { procedure_ids: {}, states: {}, alerts: {}, shared_with_me: 0 })
+    assign(:dossier_ids_with_user_buffer_changes, Set.new)
 
     render
   end


### PR DESCRIPTION
## Contexte

Skylight signale un N+1 sur `Users::DossiersController#index` (60k requêtes/jour, présent sur 46 % des requêtes) : la bannière « modifications non soumises » (`Dossiers::EnConstructionNotSubmittedComponent#render?`) charge **tous les champs** de chaque dossier en construction de la page (~13 requêtes `SELECT champs WHERE dossier_id = ?` + instanciation ChampData, soit ~26 % du temps de rendu de la liste), uniquement pour décider d'afficher ou non la bannière.

## Correctif

Une seule requête indexée par page (`ChampData WHERE dossier_id IN (…) AND stream = 'user:buffer'`) présélectionne les dossiers concernés. C'est un sur-ensemble : le composant garde la vérification précise (stable_id dans la révision) pour les seuls dossiers signalés — aucun changement de comportement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)