### PR TITLE
Tech : batch des lectures de champs par établissement dans l'API GraphQL (PersonneMorale.address)

### DIFF
--- a/app/graphql/types/personne_morale_type.rb
+++ b/app/graphql/types/personne_morale_type.rb
@@ -118,7 +118,7 @@ module Types
     field :complement_adresse, String, null: true, deprecation_reason: "Utilisez le champ `address` à la place."
 
     def address
-      address = object.champ_data&.value_json
+      address = dataloader.with(Sources::Association, :champ_data).load(object)&.value_json
       if address.blank? || !address.key?("departement_code")
         address = APIGeoService.parse_etablissement_address(object)
       end

--- a/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
@@ -63,4 +63,44 @@ describe API::V2::GraphqlController do
       end
     end
   end
+
+  describe 'demarche.dossiers with entreprise demandeur' do
+    let_it_be(:procedure_entreprise) { create(:procedure, :published, :with_service, administrateurs: [admin], types_de_champ_public: [{}]) }
+
+    # A custom query without champs skips the DossierPreloader (which marks the
+    # demandeur's champ_data association as loaded), so PersonneMorale.address
+    # has to resolve champ_data itself — it must batch instead of one query per dossier.
+    let(:query) do
+      <<~GRAPHQL
+        query($demarcheNumber: Int!) {
+          demarche(number: $demarcheNumber) {
+            dossiers {
+              nodes {
+                demandeur {
+                  ... on PersonneMorale { siret address { label } }
+                }
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+    let(:variables) { { demarcheNumber: procedure_entreprise.id } }
+
+    subject { post :execute, params: { query:, variables: }, as: :json }
+
+    it "batches etablissement champ_data lookups (PersonneMorale.address)" do
+      create_list(:dossier, 5, :en_construction, :with_entreprise, procedure: procedure_entreprise)
+
+      etablissement_champ_queries = []
+      callback = lambda do |_name, _started, _finished, _unique_id, payload|
+        etablissement_champ_queries << payload[:sql] if payload[:sql]&.include?('"champs"."etablissement_id"')
+      end
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { subject }
+
+      expect(gql_errors).to be_nil
+      expect(gql_data[:demarche][:dossiers][:nodes].count).to eq(5)
+      expect(etablissement_champ_queries.size).to be <= 1
+    end
+  end
 end


### PR DESCRIPTION
## Contexte

Skylight signale un N+1 sur `API::V2::GraphqlController#execute` : `SELECT champs WHERE etablissement_id = ? LIMIT 1`, en moyenne **69 répétitions** par requête concernée (max 100). Le résolveur `PersonneMorale.address` lit `object.champ_data` directement, une requête par établissement.

La stored query `ds-query-v2` est protégée par le `DossierPreloader` (qui marque l'association `champ_data` du demandeur comme chargée), mais les requêtes GraphQL personnalisées qui sélectionnent `demandeur` sans `champs` ne passent pas par le preloader et déclenchent le N+1.

## Correctif

Le résolveur passe par le dataloader d'association (`Sources::Association`), comme les autres résolveurs du schéma : une seule requête batchée par vague de résolution. Aucun changement de comportement (le dataloader court-circuite les associations déjà chargées).

Un test de régression reproduit le scénario réel (requête personnalisée sans champs, 5 dossiers avec demandeur entreprise) : il échoue avant le correctif (5 requêtes) et passe après (1 requête).

🤖 Generated with [Claude Code](https://claude.com/claude-code)