### PR TITLE
Tech : segmentation des requêtes GraphQL par opération dans Skylight

### DIFF
--- a/app/controllers/api/v2/graphql_controller.rb
+++ b/app/controllers/api/v2/graphql_controller.rb
@@ -9,6 +9,8 @@ class API::V2::GraphqlController < API::V2::BaseController
     result = API::V2::Schema.execute(query:, variables:, context:, operation_name:)
     @query_info = result.context.query_info
 
+    rename_skylight_endpoint(result)
+
     render json: result
   rescue GraphQL::ParseError, JSON::ParserError => exception
     handle_parse_error(exception, :graphql_parse_failed)
@@ -27,6 +29,23 @@ class API::V2::GraphqlController < API::V2::BaseController
   end
 
   private
+
+  # Segment GraphQL traffic into per-operation Skylight endpoints, using the same
+  # naming as Skylight's official :graphql probe ("graphql:<operation>") but
+  # without the per-field tracing the probe would force on us (~16% of request
+  # wall time, see the probes comment in config/application.rb).
+  # Stored queries have a bounded set of operation names; custom integrator
+  # queries share a single bucket to keep endpoint cardinality under control.
+  def rename_skylight_endpoint(result)
+    trace = Skylight.instrumenter&.current_trace
+    return if trace.nil?
+
+    trace.endpoint = if params[:queryId].present?
+      "graphql:#{result.query.selected_operation&.name || 'anonymous'}"
+    else
+      "graphql:custom"
+    end
+  end
 
   def vernier_profile_requested?
     params[:profile].present?

--- a/config/application.rb
+++ b/config/application.rb
@@ -97,6 +97,8 @@ module TPS
     # resolution. On large API V2 responses (tens of thousands of fields) this
     # costs ~16% of request wall time for per-field granularity that is unreadable
     # at that scale — we keep only request-level spans from the controller/AR probes.
+    # The probe's per-operation endpoint naming is reimplemented without that cost
+    # in API::V2::GraphqlController#rename_skylight_endpoint.
     config.skylight.probes += [:active_job, :excon, :httpclient, :redis]
 
     # Custom Configuration

--- a/spec/controllers/api/v2/graphql_controller_skylight_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_skylight_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+describe API::V2::GraphqlController do
+  let_it_be(:admin) { administrateurs.default }
+  let_it_be(:generated_token) { APIToken.generate(admin) }
+  let_it_be(:procedure) { create(:procedure, :published, administrateurs: [admin]) }
+  let(:token) { generated_token.second }
+  let(:authorization_header) { ActionController::HttpAuthentication::Token.encode_credentials(token) }
+
+  before do
+    request.env['HTTP_AUTHORIZATION'] = authorization_header
+  end
+
+  describe 'skylight endpoint naming' do
+    let(:trace) { instance_double(Skylight::Trace) }
+
+    before do
+      allow(Skylight).to receive(:instrumenter)
+        .and_return(instance_double(Skylight::Instrumenter, current_trace: trace))
+    end
+
+    it 'names stored query traces after the operation' do
+      expect(trace).to receive(:endpoint=).with('graphql:getDemarcheDescriptor')
+
+      post :execute, params: { queryId: 'ds-query-v2', operationName: 'getDemarcheDescriptor', variables: { demarcheNumber: procedure.id } }, as: :json
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'buckets custom queries into a single endpoint' do
+      expect(trace).to receive(:endpoint=).with('graphql:custom')
+
+      post :execute, params: { query: "{ demarche(number: #{procedure.id}) { number } }" }, as: :json
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'still buckets custom queries that fail to parse' do
+      expect(trace).to receive(:endpoint=).with('graphql:custom')
+
+      post :execute, params: { query: '{ demarche(' }, as: :json
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Aujourd'hui tout le trafic API v2 (330k req/jour) apparaît dans Skylight sous un seul endpoint `API::V2::GraphqlController#execute (json)` : impossible de distinguer les opérations (getDemarche, getDossier, mutations…) ni de savoir quelle part des intégrateurs utilise les stored queries plutôt que des requêtes personnalisées.

La sonde `:graphql` officielle de Skylight ferait cette segmentation, mais elle impose `GraphQL::Tracing::ActiveSupportNotificationsTrace` (un événement par résolution de champ), mesuré à **~16 % du temps de requête** sur nos grosses réponses — c'est documenté dans `config/application.rb`, et c'est pour ça qu'elle n'est pas activée.

## Correctif

On reprend uniquement la partie utile de la sonde : le renommage de l'endpoint du trace (`Skylight::Trace#endpoint=`, la même API que le normalizer officiel), fait depuis le contrôleur, sans aucun tracing par champ :

- stored queries → `graphql:<operation>` (ensemble borné : getDemarche, getDossier, mutations…) ;
- requêtes personnalisées des intégrateurs → un seau unique `graphql:custom` (cardinalité maîtrisée, les noms d'opération étant contrôlés par les clients).

Chaque opération aura désormais son propre endpoint Skylight (trafic, p50/p95, agonie), et la part stored vs custom se lit directement dans la liste des endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)