### PR TITLE
Tech: fiabilise la fusion de comptes (avis perdus, crashs, notifications)

### DIFF
--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -11,8 +11,8 @@ class Administrateur < ApplicationRecord
   has_many :api_tokens, inverse_of: :administrateur, dependent: :destroy
   has_many :commentaire_groupe_gestionnaires, as: :sender
   has_and_belongs_to_many :default_zones, class_name: 'Zone', join_table: 'default_zones_administrateurs'
-  has_many :archives, as: :user_profile
-  has_many :exports, as: :user_profile
+  has_many :archives, as: :user_profile, dependent: :destroy
+  has_many :exports, as: :user_profile, dependent: :destroy
   belongs_to :user
   belongs_to :groupe_gestionnaire, optional: true
 

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -113,6 +113,8 @@ class Administrateur < ApplicationRecord
       i.administrateurs.delete(old_admin)
     end
 
+    # v1/v2 tokens are deliberately left behind (and destroyed with the old
+    # admin): we want their owners to migrate to v3 tokens.
     old_admin.api_tokens.where(version: 3..).find_each do |token|
       self.api_tokens << token
     end

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -69,7 +69,11 @@ class Expert < ApplicationRecord
 
     ExpertsProcedure
       .where(expert_id: old_expert.id, procedure: procedure_with_new)
-      .destroy_all
+      .find_each do |old_experts_procedure|
+        new_experts_procedure = ExpertsProcedure.find_by(expert_id: id, procedure_id: old_experts_procedure.procedure_id)
+        old_experts_procedure.avis.update_all(experts_procedure_id: new_experts_procedure.id)
+        old_experts_procedure.destroy
+      end
 
     old_expert.commentaires.update_all(expert_id: id)
 

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -72,6 +72,9 @@ class Expert < ApplicationRecord
       .find_each do |old_experts_procedure|
         new_experts_procedure = ExpertsProcedure.find_by(expert_id: id, procedure_id: old_experts_procedure.procedure_id)
         old_experts_procedure.avis.update_all(experts_procedure_id: new_experts_procedure.id)
+        if old_experts_procedure.revoked_at.nil? && new_experts_procedure.revoked_at.present?
+          new_experts_procedure.update(revoked_at: nil)
+        end
         old_experts_procedure.destroy
       end
 

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -270,6 +270,12 @@ class Instructeur < ApplicationRecord
     admin_with_new_instructeur.each do |admin|
       admin.instructeurs.delete(old_instructeur)
     end
+    old_instructeur.dossier_notifications.find_each do |notification|
+      unless dossier_notifications.exists?(dossier_id: notification.dossier_id, notification_type: notification.notification_type)
+        notification.update(instructeur_id: id)
+      end
+    end
+
     old_instructeur.commentaires.update_all(instructeur_id: id)
     old_instructeur.bulk_messages.update_all(instructeur_id: id)
     old_instructeur.rdvs.update_all(instructeur_id: id)

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -273,6 +273,9 @@ class Instructeur < ApplicationRecord
     old_instructeur.commentaires.update_all(instructeur_id: id)
     old_instructeur.bulk_messages.update_all(instructeur_id: id)
     old_instructeur.rdvs.update_all(instructeur_id: id)
+    # instructeur_id is a legacy column (exports are now owned through the
+    # polymorphic user_profile), but its foreign key would abort the merge
+    Export.where(instructeur: old_instructeur).update_all(instructeur_id: id)
 
     Avis
       .where(claimant_id: old_instructeur.id, claimant_type: Instructeur.name)

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -21,8 +21,8 @@ class Instructeur < ApplicationRecord
   has_many :previously_followed_dossiers, -> { distinct }, through: :previous_follows, source: :dossier
   has_many :trusted_device_tokens, dependent: :destroy
   has_many :bulk_messages, dependent: :destroy
-  has_many :exports, as: :user_profile
-  has_many :archives, as: :user_profile
+  has_many :exports, as: :user_profile, dependent: :destroy
+  has_many :archives, as: :user_profile, dependent: :destroy
   has_many :instructeurs_procedures, dependent: :destroy
   has_many :dossier_notifications, dependent: :destroy
   has_many :rdvs

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -25,6 +25,7 @@ class Instructeur < ApplicationRecord
   has_many :archives, as: :user_profile
   has_many :instructeurs_procedures, dependent: :destroy
   has_many :dossier_notifications, dependent: :destroy
+  has_many :rdvs
 
   has_one :rdv_connection, dependent: :destroy
 
@@ -271,6 +272,7 @@ class Instructeur < ApplicationRecord
     end
     old_instructeur.commentaires.update_all(instructeur_id: id)
     old_instructeur.bulk_messages.update_all(instructeur_id: id)
+    old_instructeur.rdvs.update_all(instructeur_id: id)
 
     Avis
       .where(claimant_id: old_instructeur.id, claimant_type: Instructeur.name)

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -270,6 +270,11 @@ class Instructeur < ApplicationRecord
     admin_with_new_instructeur.each do |admin|
       admin.instructeurs.delete(old_instructeur)
     end
+    old_instructeur
+      .instructeurs_procedures
+      .where.not(procedure_id: instructeurs_procedures.pluck(:procedure_id))
+      .update_all(instructeur_id: id)
+
     old_instructeur.dossier_notifications.find_each do |notification|
       unless dossier_notifications.exists?(dossier_id: notification.dossier_id, notification_type: notification.notification_type)
         notification.update(instructeur_id: id)

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -258,6 +258,10 @@ class Instructeur < ApplicationRecord
       .where.not(dossier_id: follows.pluck(:dossier_id))
       .update_all(instructeur_id: id)
 
+    old_instructeur
+      .previous_follows
+      .update_all(instructeur_id: id)
+
     admin_with_new_instructeur, admin_without_new_instructeur = old_instructeur
       .administrateurs
       .partition { |admin| admin.instructeurs.exists?(id) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -296,6 +296,7 @@ class User < ApplicationRecord
       old_user.merge_logs.update_all(user_id: id)
       old_user.targeted_user_links.update_all(user_id: id)
       old_user.contact_forms.update_all(user_id: id)
+      old_user.deleted_dossiers.update_all(user_id: id)
 
       # Move or merge old user's roles to the user
       [

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,7 @@ class User < ApplicationRecord
   has_many :dossiers_invites, through: :invites, source: :dossier
   has_many :deleted_dossiers
   has_many :merge_logs, dependent: :destroy
+  has_many :contact_forms, dependent: :nullify
   has_many :requested_merge_from, class_name: 'User', dependent: :nullify, inverse_of: :requested_merge_into, foreign_key: :requested_merge_into_id
   has_many :france_connect_informations, dependent: :destroy
   has_many :pro_connect_informations, dependent: :destroy
@@ -294,6 +295,7 @@ class User < ApplicationRecord
       old_user.invites.update_all(user_id: id)
       old_user.merge_logs.update_all(user_id: id)
       old_user.targeted_user_links.update_all(user_id: id)
+      old_user.contact_forms.update_all(user_id: id)
 
       # Move or merge old user's roles to the user
       [

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -304,7 +304,7 @@ describe Administrateur, type: :model do
   end
 
   describe 'when an administrateur is destroyed' do
-    let(:administrateur) { create(:administrateur) }
+    let(:administrateur) { administrateurs.blank }
     let!(:export) { create(:export, user_profile: administrateur) }
     let!(:archive) { create(:archive, user_profile: administrateur) }
 

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -302,4 +302,17 @@ describe Administrateur, type: :model do
 
     it { expect(administrateur.commentaire_seen_at).to eq now }
   end
+
+  describe 'when an administrateur is destroyed' do
+    let(:administrateur) { create(:administrateur) }
+    let!(:export) { create(:export, user_profile: administrateur) }
+    let!(:archive) { create(:archive, user_profile: administrateur) }
+
+    it 'destroys its exports and archives' do
+      administrateur.destroy!
+
+      expect(Export.exists?(export.id)).to eq(false)
+      expect(Archive.exists?(archive.id)).to eq(false)
+    end
+  end
 end

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -86,6 +86,18 @@ RSpec.describe Expert, type: :model do
       end
     end
 
+    context 'when the old expert has an active access and the new expert a revoked one' do
+      let(:procedure) { create(:procedure) }
+      let!(:old_experts_procedure) { create(:experts_procedure, expert: old_expert, procedure:) }
+      let!(:new_experts_procedure) { create(:experts_procedure, expert: new_expert, procedure:, revoked_at: 1.day.ago) }
+
+      before { subject }
+
+      it 'reactivates the surviving experts_procedure' do
+        expect(new_experts_procedure.reload.revoked_at).to eq(nil)
+      end
+    end
+
     context 'when an old expert has a commentaire' do
       let(:dossier) { create(:dossier) }
       let(:commentaire) { CommentaireService.create(old_expert, dossier, body: "Mon commentaire") }

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -70,24 +70,22 @@ RSpec.describe Expert, type: :model do
     end
 
     context 'when both experts access a procedure and the old expert has an avis to give' do
-      let(:procedure) { create(:procedure) }
-      let(:old_experts_procedure) { create(:experts_procedure, expert: old_expert, procedure:) }
-      let(:new_experts_procedure) { create(:experts_procedure, expert: new_expert, procedure:) }
-      let!(:avis) { create(:avis, dossier: create(:dossier, procedure:), experts_procedure: old_experts_procedure) }
+      let(:old_expert) { experts.default }
+      let(:new_expert) { experts.second }
+      let!(:old_experts_procedure) { experts_procedures.default }
+      let!(:new_experts_procedure) { experts_procedures.second }
+      let!(:pending_avis) { avis.pending }
 
-      before do
-        new_experts_procedure
-        subject
-      end
+      before { subject }
 
       it 'transfers the avis to the new expert and removes the old experts_procedure' do
-        expect(avis.reload.experts_procedure).to eq(new_experts_procedure)
+        expect(pending_avis.reload.experts_procedure).to eq(new_experts_procedure)
         expect(ExpertsProcedure.exists?(old_experts_procedure.id)).to eq(false)
       end
     end
 
     context 'when the old expert has an active access and the new expert a revoked one' do
-      let(:procedure) { create(:procedure) }
+      let(:procedure) { procedures.individual }
       let!(:old_experts_procedure) { create(:experts_procedure, expert: old_expert, procedure:) }
       let!(:new_experts_procedure) { create(:experts_procedure, expert: new_expert, procedure:, revoked_at: 1.day.ago) }
 

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -69,6 +69,23 @@ RSpec.describe Expert, type: :model do
       end
     end
 
+    context 'when both experts access a procedure and the old expert has an avis to give' do
+      let(:procedure) { create(:procedure) }
+      let(:old_experts_procedure) { create(:experts_procedure, expert: old_expert, procedure:) }
+      let(:new_experts_procedure) { create(:experts_procedure, expert: new_expert, procedure:) }
+      let!(:avis) { create(:avis, dossier: create(:dossier, procedure:), experts_procedure: old_experts_procedure) }
+
+      before do
+        new_experts_procedure
+        subject
+      end
+
+      it 'transfers the avis to the new expert and removes the old experts_procedure' do
+        expect(avis.reload.experts_procedure).to eq(new_experts_procedure)
+        expect(ExpertsProcedure.exists?(old_experts_procedure.id)).to eq(false)
+      end
+    end
+
     context 'when an old expert has a commentaire' do
       let(:dossier) { create(:dossier) }
       let(:commentaire) { CommentaireService.create(old_expert, dossier, body: "Mon commentaire") }

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -765,6 +765,29 @@ describe Instructeur, type: :model do
       end
     end
 
+    context 'when the old instructeur has a dossier notification' do
+      let!(:notification) { create(:dossier_notification, instructeur: old_instructeur) }
+
+      before { subject }
+
+      it 'transfers the notification to the new instructeur' do
+        expect(notification.reload.instructeur).to eq(new_instructeur)
+      end
+    end
+
+    context 'when both instructeurs have the same notification on the same dossier' do
+      let(:dossier) { create(:dossier) }
+      let!(:old_notification) { create(:dossier_notification, instructeur: old_instructeur, dossier:) }
+      let!(:new_notification) { create(:dossier_notification, instructeur: new_instructeur, dossier:) }
+
+      before { subject }
+
+      it 'keeps the new instructeur notification and leaves the duplicate behind' do
+        expect(new_notification.reload.instructeur).to eq(new_instructeur)
+        expect(old_notification.reload.instructeur).to eq(old_instructeur)
+      end
+    end
+
     context 'when old instructeur has avis' do
       let(:avis) { create(:avis, claimant: old_instructeur) }
       before do

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -718,6 +718,16 @@ describe Instructeur, type: :model do
       end
     end
 
+    context 'when the old instructeur previously followed a dossier' do
+      let!(:previous_follow) { create(:follow, instructeur: old_instructeur, unfollowed_at: 1.day.ago) }
+
+      before { subject }
+
+      it 'transfers the previous follow to the new instructeur' do
+        expect(previous_follow.reload.instructeur_id).to eq(new_instructeur.id)
+      end
+    end
+
     context 'when the old instructeur is on on admin list' do
       let(:administrateur) { administrateurs.default }
 

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -835,6 +835,19 @@ describe Instructeur, type: :model do
     end
   end
 
+  describe 'when an instructeur is destroyed' do
+    let(:instructeur) { create(:instructeur) }
+    let!(:export) { create(:export, user_profile: instructeur) }
+    let!(:archive) { create(:archive, user_profile: instructeur) }
+
+    it 'destroys its exports and archives' do
+      instructeur.destroy!
+
+      expect(Export.exists?(export.id)).to eq(false)
+      expect(Archive.exists?(archive.id)).to eq(false)
+    end
+  end
+
   private
 
   def assign(procedure_to_assign, instructeur_assigne: instructeur)

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -755,6 +755,16 @@ describe Instructeur, type: :model do
       end
     end
 
+    context 'when the old instructeur is referenced by a legacy export' do
+      let!(:export) { create(:export, instructeur: old_instructeur) }
+
+      before { subject }
+
+      it 'transfers the legacy reference to the new instructeur' do
+        expect(export.reload.instructeur).to eq(new_instructeur)
+      end
+    end
+
     context 'when old instructeur has avis' do
       let(:avis) { create(:avis, claimant: old_instructeur) }
       before do

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -788,6 +788,30 @@ describe Instructeur, type: :model do
       end
     end
 
+    context 'when the old instructeur has per-procedure settings' do
+      let!(:instructeurs_procedure) { create(:instructeurs_procedure, instructeur: old_instructeur, daily_email_summary: true) }
+
+      before { subject }
+
+      it 'transfers the settings to the new instructeur' do
+        expect(instructeurs_procedure.reload.instructeur).to eq(new_instructeur)
+        expect(instructeurs_procedure.daily_email_summary).to eq(true)
+      end
+    end
+
+    context 'when both instructeurs have settings on the same procedure' do
+      let(:procedure) { create(:procedure) }
+      let!(:old_settings) { create(:instructeurs_procedure, instructeur: old_instructeur, procedure:) }
+      let!(:new_settings) { create(:instructeurs_procedure, instructeur: new_instructeur, procedure:) }
+
+      before { subject }
+
+      it 'keeps the new instructeur settings and leaves the duplicate behind' do
+        expect(new_settings.reload.instructeur).to eq(new_instructeur)
+        expect(old_settings.reload.instructeur).to eq(old_instructeur)
+      end
+    end
+
     context 'when old instructeur has avis' do
       let(:avis) { create(:avis, claimant: old_instructeur) }
       before do

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -745,6 +745,16 @@ describe Instructeur, type: :model do
       end
     end
 
+    context 'when the old instructeur has a rdv' do
+      let!(:rdv) { create(:rdv, instructeur: old_instructeur) }
+
+      before { subject }
+
+      it 'transfers the rdv to the new instructeur' do
+        expect(rdv.reload.instructeur).to eq(new_instructeur)
+      end
+    end
+
     context 'when old instructeur has avis' do
       let(:avis) { create(:avis, claimant: old_instructeur) }
       before do

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -786,7 +786,7 @@ describe Instructeur, type: :model do
     end
 
     context 'when both instructeurs have the same notification on the same dossier' do
-      let(:dossier) { create(:dossier) }
+      let(:dossier) { dossiers.en_construction }
       let!(:old_notification) { create(:dossier_notification, instructeur: old_instructeur, dossier:) }
       let!(:new_notification) { create(:dossier_notification, instructeur: new_instructeur, dossier:) }
 
@@ -810,7 +810,7 @@ describe Instructeur, type: :model do
     end
 
     context 'when both instructeurs have settings on the same procedure' do
-      let(:procedure) { create(:procedure) }
+      let(:procedure) { procedures.individual }
       let!(:old_settings) { create(:instructeurs_procedure, instructeur: old_instructeur, procedure:) }
       let!(:new_settings) { create(:instructeurs_procedure, instructeur: new_instructeur, procedure:) }
 
@@ -836,7 +836,7 @@ describe Instructeur, type: :model do
   end
 
   describe 'when an instructeur is destroyed' do
-    let(:instructeur) { create(:instructeur) }
+    let(:instructeur) { instructeurs.default }
     let!(:export) { create(:export, user_profile: instructeur) }
     let!(:archive) { create(:archive, user_profile: instructeur) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -576,6 +576,16 @@ describe User, type: :model do
       end
     end
 
+    context 'and the old account has a contact_form' do
+      let!(:contact_form) { create(:contact_form, user: old_user) }
+
+      it 'transfers the contact_form' do
+        subject
+
+        expect(contact_form.reload.user).to eq(targeted_user)
+      end
+    end
+
     context 'and the old account had targeted_user_links' do
       let(:expert) { create(:expert, user: old_user) }
       let(:expert_procedure) { create(:experts_procedure, expert: expert) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -576,6 +576,16 @@ describe User, type: :model do
       end
     end
 
+    context 'and the old account has a deleted_dossier' do
+      let!(:deleted_dossier) { create(:deleted_dossier, user_id: old_user.id) }
+
+      it 'transfers the deleted_dossier' do
+        subject
+
+        expect(deleted_dossier.reload.user_id).to eq(targeted_user.id)
+      end
+    end
+
     context 'and the old account has a contact_form' do
       let!(:contact_form) { create(:contact_form, user: old_user) }
 


### PR DESCRIPTION
## Contexte

Cas support : un expert quittant son poste a demandé le changement de son email vers l'adresse d'un collègue, ce qui déclenche une fusion de comptes. Les deux comptes étant experts sur la même procédure, `Expert#merge` a détruit les `ExpertsProcedure` en doublon **et, par cascade, tous les avis de l'ancien expert — y compris les avis à rendre**.

L'audit du processus de fusion a révélé d'autres pertes de données silencieuses ainsi que des cas où la fusion plante entièrement (violation de clé étrangère au `destroy` de l'ancien compte).

## Corrections (un commit par sujet, spec + patch)

**Avis / experts**
- les avis sont repointés vers l'`ExpertsProcedure` survivante au lieu d'être détruits ;
- si l'accès du survivant était révoqué et celui de l'ancien actif, l'accès est réactivé.

**Crashs de la fusion** (`ActiveRecord::InvalidForeignKey`)
- `rdvs.instructeur_id` : les RDV sont transférés ;
- `contact_forms.user_id` : transférées à la fusion, `dependent: :nullify` à la suppression de compte ;
- `exports.instructeur_id` (colonne héritée) : références repointées.

**Pertes silencieuses côté instructeur**
- `dossier_notifications` transférées (le survivant gagne en cas de doublon) ;
- `instructeurs_procedures` (préférences de notification par procédure) transférées ;
- `previous_follows` (historique des dossiers suivis) transférés.

**Divers**
- tokens API v1/v2 : comportement inchangé (non transférés), l'intention — forcer la migration vers v3 — est maintenant documentée ;
- `exports`/`archives` : `dependent: :destroy` sur le `user_profile` pour ne plus laisser d'orphelins ;
- `deleted_dossiers` (pas d'email dénormalisé, seulement un `user_id`) : transférés.

## Non couvert (volontairement)

- Le rôle `gestionnaire` reste détruit sans fusion (à traiter séparément si besoin).
- Les avis déjà détruits en prod ne sont pas restaurés par cette PR (backup ou ré-invitation).