### PR TITLE
Tech : bloque les loaders libvips non fuzzés

### DIFF
--- a/app/lib/trusted_vips_loader.rb
+++ b/app/lib/trusted_vips_loader.rb
@@ -7,15 +7,20 @@
 # on they can be disabled outright; before that there is no such switch, so we ask
 # which decoder libvips would choose and refuse the ones listed below.
 #
-# Deliberately a deny list rather than an allow list. An allow list would also have
-# to name every decoder a legitimate upload may go through, and those names are read
-# from a newer libvips than the one we deploy — an entry we got wrong would reject
-# real files. This errs the other way: it only stops what we have named.
+# Deliberately a deny list rather than an allow list: a wrong entry here is inert (it
+# never matches the class name libvips actually reports), while a wrong allow entry
+# would reject real uploads. The names are the exact loader classes present in our
+# deployed libvips 8.12.1, read off the build itself — they vary between versions
+# (this build exposes VipsForeignLoadPngFile; newer ones VipsForeignLoadPng).
 module TrustedVipsLoader
-  # Reads MATLAB files, via a library whose format handling reaches well outside the
-  # file it was given. Nothing we accept is ever decoded by it.
   BLOCKED_LOADERS = %w[
     VipsForeignLoadMat
+    VipsForeignLoadOpenslideFile
+    VipsForeignLoadSvgFile
+    VipsForeignLoadPdfFile
+    VipsForeignLoadPpmFile
+    VipsForeignLoadRadFile
+    VipsForeignLoadMagickFile
   ].freeze
 
   class << self

--- a/spec/config/vips_untrusted_loaders_spec.rb
+++ b/spec/config/vips_untrusted_loaders_spec.rb
@@ -48,3 +48,17 @@ describe "libvips untrusted loaders", :external_deps do
     end
   end
 end
+
+describe TrustedVipsLoader do
+  it "denies every unfuzzed loader present in our libvips build" do
+    expect(described_class::BLOCKED_LOADERS).to contain_exactly(
+      "VipsForeignLoadMat",
+      "VipsForeignLoadOpenslideFile",
+      "VipsForeignLoadSvgFile",
+      "VipsForeignLoadPdfFile",
+      "VipsForeignLoadPpmFile",
+      "VipsForeignLoadRadFile",
+      "VipsForeignLoadMagickFile"
+    )
+  end
+end

--- a/spec/lib/trusted_vips_loader_spec.rb
+++ b/spec/lib/trusted_vips_loader_spec.rb
@@ -25,16 +25,4 @@ describe TrustedVipsLoader, :external_deps do
 
     expect(described_class.new_from_file(File.open(path)).width).to be_positive
   end
-
-  # Pins the scope of the deny list: other decoders libvips flags as unfuzzed, such as
-  # the PDF one the watermark path can reach, are deliberately still let through, since
-  # naming them wrongly would reject real uploads. Only libvips 8.13 or later refuses
-  # the whole family, via Vips.block_untrusted.
-  describe "the decoders it lets through" do
-    it "does not refuse a PDF" do
-      path.binwrite(Rails.root.join("spec/fixtures/files/Contrat.pdf").binread)
-
-      expect(described_class).to be_allowed(path.to_s)
-    end
-  end
 end


### PR DESCRIPTION
Défense en profondeur : normalement ces types de fichiers ne devraient pas atteindre libvips car bloqués par la reconnaissance par octet d'entête + whiteliste des fichier `variable?`.

En particulier on retire poppler, car on ne produit actuellement pas de vignette pour les pdfs

Ce code deviendra inutile une fois passé dans une version de libvips plus récente