### PR TITLE
Tech: convertir TypeDeChamp en STI

### DIFF
--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -38,15 +38,19 @@ module Administrateurs
         errors = "« #{type_de_champ.libelle} » est utilisé par un référentiel, vous ne pouvez pas modifier son type."
         @morphed = [champ_component_from(@coordinate, focused: false, errors:)]
         flash.alert = errors
-      elsif type_de_champ.update(type_de_champ_update_params)
-        reload_procedure_with_includes
-        @morphed = if was_prefill_with_fc_information != type_de_champ.prefill_with_france_connect_information?
-          draft.revision_types_de_champ.map { |c| champ_component_from(c) }
-        else
-          champ_components_starting_at(@coordinate)
-        end
       else
-        flash.alert = type_de_champ.errors.full_messages
+        type_de_champ = type_de_champ.becomes_type(type_de_champ_update_params['type_champ']) if changing_of_type?(type_de_champ)
+
+        if type_de_champ.update(type_de_champ_update_params)
+          reload_procedure_with_includes
+          @morphed = if was_prefill_with_fc_information != type_de_champ.prefill_with_france_connect_information?
+            draft.revision_types_de_champ.map { |c| champ_component_from(c) }
+          else
+            champ_components_starting_at(@coordinate)
+          end
+        else
+          flash.alert = type_de_champ.errors.full_messages
+        end
       end
     end
 

--- a/app/models/concerns/columns_concern.rb
+++ b/app/models/concerns/columns_concern.rb
@@ -280,9 +280,7 @@ module ColumnsConcern
   end
 
   def types_de_champ_columns
-    # type_champ is nil for legacy values removed from the enum: those rows
-    # load as plain TypeDeChamp, without columns.
-    all_revisions_types_de_champ.filter { _1.type_champ.present? }.flat_map { _1.columns(procedure_id: id) }
+    all_revisions_types_de_champ.flat_map { _1.columns(procedure_id: id) }
   end
 
   def dossier_col(**args) = Columns::DossierColumn.new(**(args.merge(procedure_id: id)))

--- a/app/models/concerns/columns_concern.rb
+++ b/app/models/concerns/columns_concern.rb
@@ -280,7 +280,9 @@ module ColumnsConcern
   end
 
   def types_de_champ_columns
-    all_revisions_types_de_champ.filter(&:dynamic_type).flat_map { _1.columns(procedure_id: id) }
+    # type_champ is nil for legacy values removed from the enum: those rows
+    # load as plain TypeDeChamp, without columns.
+    all_revisions_types_de_champ.filter { _1.type_champ.present? }.flat_map { _1.columns(procedure_id: id) }
   end
 
   def dossier_col(**args) = Columns::DossierColumn.new(**(args.merge(procedure_id: id)))

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -100,7 +100,9 @@ class Procedure < ApplicationRecord
         draft_revision.children_of(parent)
       end
     else
-      cache_key = ['all_revisions_types_de_champ', published_revision, parent, with_header_section, ActiveRecord::VERSION::STRING].compact
+      # 'sti': entries marshalled before the TypeDeChamp STI deserialize as the
+      # base class, without the typed behavior.
+      cache_key = ['all_revisions_types_de_champ', 'sti', published_revision, parent, with_header_section, ActiveRecord::VERSION::STRING].compact
       Rails.cache.fetch(cache_key, expires_in: 1.month) { published_revisions_types_de_champ(parent:, with_header_section:) }
     end
   end

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -318,6 +318,7 @@ class ProcedureRevision < ApplicationRecord
         stable_id, type_champ, options = payload.values_at(:stable_id, :type_champ, :options)
 
         tdc = find_and_ensure_exclusive_use(stable_id)
+        tdc = tdc.becomes_type(type_champ) if type_champ != tdc.type_champ
         update_params = { type_champ: }
         update_params[:options] = tdc.options.merge(options) if options.present?
         tdc.update(update_params)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class TypeDeChamp < ApplicationRecord
+  # STI on the historical type_champ column: values are enum strings ('text'),
+  # not class names, so find_sti_class/sti_name below translate both ways.
+  self.inheritance_column = :type_champ
+
   FILE_MAX_SIZE = 200.megabytes
   IDENTITY_FILE_MAX_SIZE = 20.megabytes
   FEATURE_FLAGS = {
@@ -197,8 +201,6 @@ class TypeDeChamp < ApplicationRecord
 
   belongs_to :referentiel, optional: true, inverse_of: :types_de_champ
 
-  delegate :estimated_fill_duration, :estimated_read_duration, :tags_for_template, :libelles_for_export, :libelle_for_export, :primary_options, :secondary_options, :columns, :canonical_column, :personnalisation_column, :info_columns, to: :dynamic_type
-
   class WithIndifferentAccess
     def self.load(options)
       options&.with_indifferent_access
@@ -213,7 +215,11 @@ class TypeDeChamp < ApplicationRecord
 
   serialize :condition, coder: LogicSerializer
 
-  attr_reader :dynamic_type
+  # Transitional: typed behavior now lives on the record itself; nil for
+  # legacy rows whose type_champ is no longer in the enum.
+  def dynamic_type
+    type_champ.present? ? self : nil
+  end
 
   scope :public_only, -> { where(private: false) }
   scope :private_only, -> { where(private: true) }
@@ -245,7 +251,6 @@ class TypeDeChamp < ApplicationRecord
     allow_blank: true,
   }
 
-  after_initialize :set_dynamic_type
   after_create :populate_stable_id
 
   before_validation :check_mandatory
@@ -261,15 +266,6 @@ class TypeDeChamp < ApplicationRecord
   before_save :clear_conflicting_date_options, if: :birthdate?
   before_save :clear_prefill_with_france_connect_information_if_not_birthdate
 
-  def valid?(context = nil)
-    super
-    if dynamic_type.present?
-      dynamic_type.valid?
-      errors.merge!(dynamic_type.errors)
-    end
-    errors.empty?
-  end
-
   def libelle_with_parent(revision)
     if child?(revision)
       parent_type_de_champ = revision.parent_of(self)
@@ -277,17 +273,6 @@ class TypeDeChamp < ApplicationRecord
     else
       libelle
     end
-  end
-
-  alias_method :validate, :valid?
-
-  def set_dynamic_type
-    @dynamic_type = type_champ.present? ? self.class.type_champ_to_class_name(type_champ).constantize.new(self) : nil
-  end
-
-  def type_champ=(value)
-    super(value)
-    set_dynamic_type
   end
 
   def set_default_libelle
@@ -839,25 +824,25 @@ class TypeDeChamp < ApplicationRecord
 
   def champ_value(champ)
     if champ_blank?(champ)
-      dynamic_type.champ_default_value
+      champ_default_value
     else
-      dynamic_type.typed_champ_value(champ)
+      typed_champ_value(champ)
     end
   end
 
   def champ_value_for_api(champ, version: 2)
     if champ_blank?(champ)
-      dynamic_type.champ_default_api_value(version)
+      champ_default_api_value(version)
     else
-      dynamic_type.typed_champ_value_for_api(champ, version:)
+      typed_champ_value_for_api(champ, version:)
     end
   end
 
   def champ_value_for_export(champ, path = :value)
     if champ_blank?(champ)
-      dynamic_type.champ_default_export_value(path)
+      champ_default_export_value(path)
     else
-      dynamic_type.typed_champ_value_for_export(champ, path)
+      typed_champ_value_for_export(champ, path)
     end
   end
 
@@ -865,7 +850,7 @@ class TypeDeChamp < ApplicationRecord
     if champ_blank?(champ)
       ''
     else
-      dynamic_type.typed_champ_value_for_tag(champ, path)
+      typed_champ_value_for_tag(champ, path)
     end
   end
 
@@ -874,7 +859,7 @@ class TypeDeChamp < ApplicationRecord
     return true if champ.nil?
     # type de champ on the revision changed
     if champ.is_type?(type_champ) || castable_on_change?(champ.last_write_type_champ, type_champ)
-      dynamic_type.typed_champ_blank?(champ)
+      typed_champ_blank?(champ)
     else
       true
     end
@@ -885,7 +870,7 @@ class TypeDeChamp < ApplicationRecord
     return true if champ.nil?
     # type de champ on the revision changed
     if champ.is_type?(type_champ) || castable_on_change?(champ.last_write_type_champ, type_champ)
-      mandatory? && dynamic_type.typed_champ_blank_or_invalid?(champ)
+      mandatory? && typed_champ_blank_or_invalid?(champ)
     else
       true
     end
@@ -911,9 +896,27 @@ class TypeDeChamp < ApplicationRecord
     def type_champ_to_class_name(type_champ)
       "TypesDeChamp::#{type_champ.classify}TypeDeChamp"
     end
+
+    def find_sti_class(type_name)
+      type_name = type_name.to_s
+      if type_champs.value?(type_name)
+        type_champ_to_class_name(type_name).constantize
+      else
+        # Legacy values removed from the enum load as plain TypeDeChamp.
+        TypeDeChamp
+      end
+    end
+
+    def sti_name = CLASS_NAME_TO_TYPE_CHAMP[name]
+
+    # Forms, params, dom ids and i18n keys expect 'type_de_champ' for every subclass.
+    def model_name
+      self == TypeDeChamp ? super : TypeDeChamp.model_name
+    end
   end
 
   CHAMP_TYPE_TO_TYPE_CHAMP = type_champs.values.index_by { type_champ_to_champ_class_name(_1) }
+  CLASS_NAME_TO_TYPE_CHAMP = type_champs.values.index_by { type_champ_to_class_name(_1) }
 
   def any_drop_down_list?
     type_champ.in?([

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -915,15 +915,7 @@ class TypeDeChamp < ApplicationRecord
       "TypesDeChamp::#{type_champ.classify}TypeDeChamp"
     end
 
-    def find_sti_class(type_name)
-      type_name = type_name.to_s
-      if type_champs.value?(type_name)
-        type_champ_to_class_name(type_name).constantize
-      else
-        # Legacy values removed from the enum load as plain TypeDeChamp.
-        TypeDeChamp
-      end
-    end
+    def find_sti_class(type_name) = type_champ_to_class_name(type_name.to_s).constantize
 
     def sti_name = CLASS_NAME_TO_TYPE_CHAMP[name]
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -841,7 +841,7 @@ class TypeDeChamp < ApplicationRecord
     if champ_blank?(champ)
       dynamic_type.champ_default_value
     else
-      dynamic_type.champ_value(champ)
+      dynamic_type.typed_champ_value(champ)
     end
   end
 
@@ -849,7 +849,7 @@ class TypeDeChamp < ApplicationRecord
     if champ_blank?(champ)
       dynamic_type.champ_default_api_value(version)
     else
-      dynamic_type.champ_value_for_api(champ, version:)
+      dynamic_type.typed_champ_value_for_api(champ, version:)
     end
   end
 
@@ -857,7 +857,7 @@ class TypeDeChamp < ApplicationRecord
     if champ_blank?(champ)
       dynamic_type.champ_default_export_value(path)
     else
-      dynamic_type.champ_value_for_export(champ, path)
+      dynamic_type.typed_champ_value_for_export(champ, path)
     end
   end
 
@@ -865,7 +865,7 @@ class TypeDeChamp < ApplicationRecord
     if champ_blank?(champ)
       ''
     else
-      dynamic_type.champ_value_for_tag(champ, path)
+      dynamic_type.typed_champ_value_for_tag(champ, path)
     end
   end
 
@@ -874,7 +874,7 @@ class TypeDeChamp < ApplicationRecord
     return true if champ.nil?
     # type de champ on the revision changed
     if champ.is_type?(type_champ) || castable_on_change?(champ.last_write_type_champ, type_champ)
-      dynamic_type.champ_blank?(champ)
+      dynamic_type.typed_champ_blank?(champ)
     else
       true
     end
@@ -885,7 +885,7 @@ class TypeDeChamp < ApplicationRecord
     return true if champ.nil?
     # type de champ on the revision changed
     if champ.is_type?(type_champ) || castable_on_change?(champ.last_write_type_champ, type_champ)
-      mandatory? && dynamic_type.champ_blank_or_invalid?(champ)
+      mandatory? && dynamic_type.typed_champ_blank_or_invalid?(champ)
     else
       true
     end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -330,6 +330,13 @@ class TypeDeChamp < ApplicationRecord
     champ_class.new(params_for_champ.merge(params))
   end
 
+  # Changing type_champ cannot change the class of an already-instantiated
+  # record: save the change through an instance of the target subclass, so its
+  # validations and callbacks apply instead of the source type's.
+  def becomes_type(new_type_champ)
+    becomes(self.class.find_sti_class(new_type_champ))
+  end
+
   def check_mandatory
     return if mandatory_changed?
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -636,7 +636,7 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def carte_optional_layers
-    TypesDeChamp::CarteTypeDeChamp::LAYERS.filter_map do |layer|
+    CARTE_LAYERS.filter_map do |layer|
       layer_enabled?(layer) ? layer : nil
     end.sort
   end
@@ -650,7 +650,7 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def editable_options
-    layers = TypesDeChamp::CarteTypeDeChamp::LAYERS.map do |layer|
+    layers = CARTE_LAYERS.map do |layer|
       disabled = case layer
       when :cadastres
         layer_enabled?(:rpg)
@@ -753,6 +753,23 @@ class TypeDeChamp < ApplicationRecord
       .parameterize
   end
 
+  # Kept here rather than on TypesDeChamp::CarteTypeDeChamp: that subclass now
+  # inherits from TypeDeChamp, so referencing it from this class body would close
+  # an autoload cycle.
+  CARTE_LAYERS = [
+    :unesco,
+    :arretes_protection,
+    :conservatoire_littoral,
+    :reserves_chasse_faune_sauvage,
+    :reserves_biologiques,
+    :reserves_naturelles,
+    :natura_2000,
+    :zones_humides,
+    :znieff,
+    :cadastres,
+    :rpg,
+  ]
+
   OPTS_BY_TYPE = {
     type_champs.fetch(:header_section) => [:header_section_level],
     type_champs.fetch(:explication) => [:collapsible_explanation_enabled, :collapsible_explanation_text],
@@ -761,7 +778,7 @@ class TypeDeChamp < ApplicationRecord
     type_champs.fetch(:decimal_number) => [:positive_number, :min_number, :max_number, :range_number],
     type_champs.fetch(:date) => [:birthdate, :prefill_with_france_connect_information, :date_in_past, :start_date, :end_date, :range_date],
     type_champs.fetch(:datetime) => [:date_in_past, :start_date, :end_date, :range_date],
-    type_champs.fetch(:carte) => TypesDeChamp::CarteTypeDeChamp::LAYERS,
+    type_champs.fetch(:carte) => CARTE_LAYERS,
     type_champs.fetch(:drop_down_list) => [:drop_down_other, :drop_down_options, :drop_down_mode],
     type_champs.fetch(:multiple_drop_down_list) => [:drop_down_options, :drop_down_mode],
     type_champs.fetch(:linked_drop_down_list) => [:drop_down_options, :drop_down_secondary_libelle, :drop_down_secondary_description],

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -215,12 +215,6 @@ class TypeDeChamp < ApplicationRecord
 
   serialize :condition, coder: LogicSerializer
 
-  # Transitional: typed behavior now lives on the record itself; nil for
-  # legacy rows whose type_champ is no longer in the enum.
-  def dynamic_type
-    type_champ.present? ? self : nil
-  end
-
   scope :public_only, -> { where(private: false) }
   scope :private_only, -> { where(private: true) }
   scope :repetition, -> { where(type_champ: type_champs.fetch(:repetition)) }

--- a/app/models/types_de_champ/address_type_de_champ.rb
+++ b/app/models/types_de_champ/address_type_de_champ.rb
@@ -8,18 +8,18 @@ class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     [[path[:libelle], path[:path]]]
   end
 
-  def champ_value(champ)
+  def typed_champ_value(champ)
     champ.address_label.presence || ''
   end
 
-  def champ_value_for_api(champ, version: 2)
-    champ_value(champ)
+  def typed_champ_value_for_api(champ, version: 2)
+    typed_champ_value(champ)
   end
 
-  def champ_value_for_tag(champ, path = :value)
+  def typed_champ_value_for_tag(champ, path = :value)
     case path
     when :value
-      champ_value(champ)
+      typed_champ_value(champ)
     when :departement
       champ.departement_code_and_name || ''
     when :commune
@@ -27,10 +27,10 @@ class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     end
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     case path
     when :value
-      champ_value(champ)
+      typed_champ_value(champ)
     when :departement
       champ.departement_code_and_name
     when :commune
@@ -38,7 +38,7 @@ class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     end
   end
 
-  def champ_blank?(champ)
+  def typed_champ_blank?(champ)
     if champ.migrated_legacy_address?
       champ.value.blank?
     else

--- a/app/models/types_de_champ/carte_type_de_champ.rb
+++ b/app/models/types_de_champ/carte_type_de_champ.rb
@@ -19,21 +19,21 @@ class TypesDeChamp::CarteTypeDeChamp < TypesDeChamp::TypeDeChampBase
     FILL_DURATION_LONG
   end
 
-  def champ_value_for_tag(champ, path = :value)
+  def typed_champ_value_for_tag(champ, path = :value)
     return nil if path != :value
     return '' if champ.geo_areas.blank?
     ChampPresentations::CartePresentation.new(champ.geo_areas)
   end
 
-  def champ_value_for_api(champ, version: 2)
+  def typed_champ_value_for_api(champ, version: 2)
     nil
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     champ.geo_areas.map(&:label).join("\n")
   end
 
-  def champ_blank?(champ) = champ.geo_areas.blank?
+  def typed_champ_blank?(champ) = champ.geo_areas.blank?
 
   def canonical_column(procedure_id:, displayable: true, prefix: nil)
     Columns::GeoJSONColumn.new(

--- a/app/models/types_de_champ/carte_type_de_champ.rb
+++ b/app/models/types_de_champ/carte_type_de_champ.rb
@@ -1,20 +1,6 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::CarteTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  LAYERS = [
-    :unesco,
-    :arretes_protection,
-    :conservatoire_littoral,
-    :reserves_chasse_faune_sauvage,
-    :reserves_biologiques,
-    :reserves_naturelles,
-    :natura_2000,
-    :zones_humides,
-    :znieff,
-    :cadastres,
-    :rpg,
-  ]
-
   def estimated_fill_duration(revision)
     FILL_DURATION_LONG
   end

--- a/app/models/types_de_champ/checkbox_type_de_champ.rb
+++ b/app/models/types_de_champ/checkbox_type_de_champ.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::CheckboxTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def champ_value(champ)
+  def typed_champ_value(champ)
     champ_value_true?(champ) ? 'Oui' : 'Non'
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     champ_value_true?(champ) ? 'on' : 'off'
   end
 
-  def champ_value_for_api(champ, version: 2)
+  def typed_champ_value_for_api(champ, version: 2)
     case version
     when 2
       champ_value_true?(champ).to_s
@@ -35,7 +35,7 @@ class TypesDeChamp::CheckboxTypeDeChamp < TypesDeChamp::TypeDeChampBase
     end
   end
 
-  def champ_blank_or_invalid?(champ) = !champ_value_true?(champ)
+  def typed_champ_blank_or_invalid?(champ) = !champ_value_true?(champ)
 
   private
 

--- a/app/models/types_de_champ/cojo_type_de_champ.rb
+++ b/app/models/types_de_champ/cojo_type_de_champ.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::COJOTypeDeChamp < TypesDeChamp::TextTypeDeChamp
-  def champ_value(champ)
+  def typed_champ_value(champ)
     "#{champ.accreditation_number} – #{champ.accreditation_birthdate}"
   end
 
-  def champ_blank?(champ) = champ.accreditation_success != true
+  def typed_champ_blank?(champ) = champ.accreditation_success != true
 end

--- a/app/models/types_de_champ/commune_type_de_champ.rb
+++ b/app/models/types_de_champ/commune_type_de_champ.rb
@@ -3,10 +3,10 @@
 class TypesDeChamp::CommuneTypeDeChamp < TypesDeChamp::TypeDeChampBase
   include AddressableColumnConcern
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     case path
     when :value
-      champ_value(champ)
+      typed_champ_value(champ)
     when :departement
       champ.departement_code_and_name || ''
     when :code
@@ -14,10 +14,10 @@ class TypesDeChamp::CommuneTypeDeChamp < TypesDeChamp::TypeDeChampBase
     end
   end
 
-  def champ_value_for_tag(champ, path = :value)
+  def typed_champ_value_for_tag(champ, path = :value)
     case path
     when :value
-      champ_value(champ)
+      typed_champ_value(champ)
     when :departement
       champ.departement_code_and_name || ''
     when :code
@@ -25,7 +25,7 @@ class TypesDeChamp::CommuneTypeDeChamp < TypesDeChamp::TypeDeChampBase
     end
   end
 
-  def champ_value(champ)
+  def typed_champ_value(champ)
     champ.code_postal? ? "#{champ.name} (#{champ.code_postal})" : champ.name
   end
 

--- a/app/models/types_de_champ/date_type_de_champ.rb
+++ b/app/models/types_de_champ/date_type_de_champ.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::DateTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def champ_value(champ)
+  def typed_champ_value(champ)
     I18n.l(Time.zone.parse(champ.value).to_date, format: :long)
   rescue ArgumentError
     champ.value.presence || "" # old dossiers can have not parseable dates

--- a/app/models/types_de_champ/datetime_type_de_champ.rb
+++ b/app/models/types_de_champ/datetime_type_de_champ.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::DatetimeTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def champ_value(champ)
+  def typed_champ_value(champ)
     I18n.l(Time.zone.parse(champ.value))
   end
 end

--- a/app/models/types_de_champ/decimal_number_type_de_champ.rb
+++ b/app/models/types_de_champ/decimal_number_type_de_champ.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::DecimalNumberTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     champ_formatted_value(champ)
   end
 
-  def champ_value_for_api(champ, version: 2)
+  def typed_champ_value_for_api(champ, version: 2)
     case version
     when 1
       champ_formatted_value(champ)

--- a/app/models/types_de_champ/departement_type_de_champ.rb
+++ b/app/models/types_de_champ/departement_type_de_champ.rb
@@ -8,11 +8,11 @@ class TypesDeChamp::DepartementTypeDeChamp < TypesDeChamp::TextTypeDeChamp
       .concat(legacy_columns(procedure_id:, prefix:))
   end
 
-  def champ_value(champ)
+  def typed_champ_value(champ)
     "#{champ.code} – #{champ.name}"
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     case path
     when :code
       champ.code
@@ -21,21 +21,21 @@ class TypesDeChamp::DepartementTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     end
   end
 
-  def champ_value_for_tag(champ, path = :value)
+  def typed_champ_value_for_tag(champ, path = :value)
     case path
     when :code
       champ.code
     when :value
-      champ_value(champ)
+      typed_champ_value(champ)
     end
   end
 
-  def champ_value_for_api(champ, version: 2)
+  def typed_champ_value_for_api(champ, version: 2)
     case version
     when 2
-      champ_value(champ).tr('–', '-')
+      typed_champ_value(champ).tr('–', '-')
     else
-      champ_value(champ)
+      typed_champ_value(champ)
     end
   end
 

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::DropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def champ_value(champ)
+  def typed_champ_value(champ)
     if drop_down_advanced? && champ.respond_to?(:referentiel) && champ.referentiel.present?
       path = champ.referentiel_headers&.first&.second
       champ.referentiel_item_value(path)
@@ -10,7 +10,7 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBase
     end
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     if drop_down_advanced? && path != :value
       champ.referentiel_item_value(path)
     else
@@ -18,7 +18,7 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBase
     end
   end
 
-  def champ_value_for_tag(champ, path = :value)
+  def typed_champ_value_for_tag(champ, path = :value)
     if drop_down_advanced? && path != :value
       champ.referentiel_item_value(path)
     else

--- a/app/models/types_de_champ/epci_type_de_champ.rb
+++ b/app/models/types_de_champ/epci_type_de_champ.rb
@@ -7,10 +7,10 @@ class TypesDeChamp::EpciTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     super.concat(addressable_columns(procedure_id:, displayable:, prefix:, only: [:department_code, :region_code]))
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     case path
     when :value
-      champ_value(champ)
+      typed_champ_value(champ)
     when :code
       champ.code
     when :departement
@@ -18,10 +18,10 @@ class TypesDeChamp::EpciTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     end
   end
 
-  def champ_value_for_tag(champ, path = :value)
+  def typed_champ_value_for_tag(champ, path = :value)
     case path
     when :value
-      champ_value(champ)
+      typed_champ_value(champ)
     when :code
       champ.code
     when :departement

--- a/app/models/types_de_champ/formatted_type_de_champ.rb
+++ b/app/models/types_de_champ/formatted_type_de_champ.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::FormattedTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def initialize(*args)
-    super
-    if @type_de_champ.options&.empty?
-      @type_de_champ.options = { formatted_mode: 'simple', letters_accepted: true, numbers_accepted: true, special_characters_accepted: true }
-    end
-  end
+  after_initialize :set_default_options
 
   def typed_champ_value_for_export(champ, path = :value)
     Sanitizers::Xml.sanitize(champ_text_value(champ))
+  end
+
+  private
+
+  def set_default_options
+    if options&.empty?
+      self.options = { formatted_mode: 'simple', letters_accepted: true, numbers_accepted: true, special_characters_accepted: true }
+    end
   end
 end

--- a/app/models/types_de_champ/formatted_type_de_champ.rb
+++ b/app/models/types_de_champ/formatted_type_de_champ.rb
@@ -8,7 +8,7 @@ class TypesDeChamp::FormattedTypeDeChamp < TypesDeChamp::TypeDeChampBase
     end
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     Sanitizers::Xml.sanitize(champ_text_value(champ))
   end
 end

--- a/app/models/types_de_champ/france_connect_type_de_champ.rb
+++ b/app/models/types_de_champ/france_connect_type_de_champ.rb
@@ -47,7 +47,7 @@ class TypesDeChamp::FranceConnectTypeDeChamp < TypesDeChamp::TypeDeChampBase
     FILL_DURATION_MEDIUM
   end
 
-  def champ_blank?(champ)
+  def typed_champ_blank?(champ)
     return true if champ.fetched? && champ.fc_data_approved?.nil?
     return false if champ.fc_data_correct?
 
@@ -56,7 +56,7 @@ class TypesDeChamp::FranceConnectTypeDeChamp < TypesDeChamp::TypeDeChampBase
     end
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     ''
   end
 

--- a/app/models/types_de_champ/iban_type_de_champ.rb
+++ b/app/models/types_de_champ/iban_type_de_champ.rb
@@ -5,7 +5,7 @@ class TypesDeChamp::IbanTypeDeChamp < TypesDeChamp::TypeDeChampBase
     FILL_DURATION_MEDIUM
   end
 
-  def champ_value_for_api(champ, version: 2)
-    champ_value(champ).gsub(/\s+/, '')
+  def typed_champ_value_for_api(champ, version: 2)
+    typed_champ_value(champ).gsub(/\s+/, '')
   end
 end

--- a/app/models/types_de_champ/integer_number_type_de_champ.rb
+++ b/app/models/types_de_champ/integer_number_type_de_champ.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::IntegerNumberTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     champ_formatted_value(champ)
   end
 
-  def champ_value_for_api(champ, version: 2)
+  def typed_champ_value_for_api(champ, version: 2)
     case version
     when 1
       champ_formatted_value(champ)

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -22,22 +22,22 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
     unpack_options.to_h
   end
 
-  def champ_value(champ)
+  def typed_champ_value(champ)
     [primary_value(champ), secondary_value(champ)].compact_blank.join(' / ')
   end
 
-  def champ_value_for_tag(champ, path = :value)
+  def typed_champ_value_for_tag(champ, path = :value)
     case path
     when :primary
       primary_value(champ)
     when :secondary
       secondary_value(champ)
     when :value
-      champ_value(champ)
+      typed_champ_value(champ)
     end
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     case path
     when :primary
       primary_value(champ)
@@ -48,7 +48,7 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
     end
   end
 
-  def champ_value_for_api(champ, version: 2)
+  def typed_champ_value_for_api(champ, version: 2)
     case version
     when 1
       { primary: primary_value(champ), secondary: secondary_value(champ) }
@@ -57,11 +57,11 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
     end
   end
 
-  def champ_blank?(champ)
+  def typed_champ_blank?(champ)
     primary_value(champ).blank? && secondary_value(champ).blank?
   end
 
-  def champ_blank_or_invalid?(champ)
+  def typed_champ_blank_or_invalid?(champ)
     primary_value(champ).blank? ||
       (has_secondary_options_for_primary?(champ) && secondary_value(champ).blank?)
   end

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def champ_value(champ)
+  def typed_champ_value(champ)
     if drop_down_advanced? && champ.respond_to?(:referentiels) && champ.referentiels.present?
       champ.referentiels_items_user_values.join(', ')
     else
@@ -9,11 +9,11 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampB
     end
   end
 
-  def champ_value_for_export(champ, path = :value)
-    path == :value ? champ_value(champ).presence : super
+  def typed_champ_value_for_export(champ, path = :value)
+    path == :value ? typed_champ_value(champ).presence : super
   end
 
-  def champ_value_for_tag(champ, path = :value)
+  def typed_champ_value_for_tag(champ, path = :value)
     ChampPresentations::MultipleDropDownListPresentation.new(selected_options(champ))
   end
 
@@ -37,7 +37,7 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampB
     end
   end
 
-  def champ_blank?(champ) = selected_options(champ).blank?
+  def typed_champ_blank?(champ) = selected_options(champ).blank?
 
   def self.parse_selected_options(champ)
     return [] if champ.value.blank?

--- a/app/models/types_de_champ/pays_type_de_champ.rb
+++ b/app/models/types_de_champ/pays_type_de_champ.rb
@@ -1,29 +1,29 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::PaysTypeDeChamp < TypesDeChamp::TextTypeDeChamp
-  def champ_value(champ)
+  def typed_champ_value(champ)
     champ.name
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     case path
     when :value
-      champ_value(champ)
+      typed_champ_value(champ)
     when :code
       champ.code
     end
   end
 
-  def champ_value_for_tag(champ, path = :value)
+  def typed_champ_value_for_tag(champ, path = :value)
     case path
     when :value
-      champ_value(champ)
+      typed_champ_value(champ)
     when :code
       champ.code
     end
   end
 
-  def champ_blank?(champ)
+  def typed_champ_blank?(champ)
     champ.value.blank? && champ.external_id.blank?
   end
 

--- a/app/models/types_de_champ/phone_type_de_champ.rb
+++ b/app/models/types_de_champ/phone_type_de_champ.rb
@@ -22,7 +22,7 @@ class TypesDeChamp::PhoneTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   # See issue #6996.
   DEFAULT_COUNTRY_CODES = [:FR, :GP, :GF, :MQ, :RE, :YT, :NC, :PF].freeze
 
-  def champ_value(champ)
+  def typed_champ_value(champ)
     if Phonelib.valid_for_countries?(champ.value, DEFAULT_COUNTRY_CODES)
       Phonelib.parse_for_countries(champ.value, DEFAULT_COUNTRY_CODES).full_national
     else

--- a/app/models/types_de_champ/piece_justificative_type_de_champ.rb
+++ b/app/models/types_de_champ/piece_justificative_type_de_champ.rb
@@ -9,7 +9,7 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBas
 
   def tags_for_template = [].freeze
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     if titre_identite?
       champ.piece_justificative_file.attached? ? "présent" : "absent"
     else
@@ -17,7 +17,7 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBas
     end
   end
 
-  def champ_value_for_api(champ, version: 2)
+  def typed_champ_value_for_api(champ, version: 2)
     return if version == 2
 
     # API v1 don't support multiple PJ
@@ -31,7 +31,7 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBas
     end
   end
 
-  def champ_blank?(champ) = champ.piece_justificative_file.blank?
+  def typed_champ_blank?(champ) = champ.piece_justificative_file.blank?
 
   def canonical_column(procedure_id:, displayable: true, prefix: nil)
     if titre_identite?

--- a/app/models/types_de_champ/region_type_de_champ.rb
+++ b/app/models/types_de_champ/region_type_de_champ.rb
@@ -8,23 +8,23 @@ class TypesDeChamp::RegionTypeDeChamp < TypesDeChamp::TextTypeDeChamp
       .concat(legacy_columns(procedure_id:, prefix:))
   end
 
-  def champ_value(champ)
+  def typed_champ_value(champ)
     champ.name
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     case path
     when :value
-      champ_value(champ)
+      typed_champ_value(champ)
     when :code
       champ.code
     end
   end
 
-  def champ_value_for_tag(champ, path = :value)
+  def typed_champ_value_for_tag(champ, path = :value)
     case path
     when :value
-      champ_value(champ)
+      typed_champ_value(champ)
     when :code
       champ.code
     end

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -3,13 +3,13 @@
 class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
   def typed_champ_value_for_tag(champ, path = :value)
     return nil if path != :value
-    ChampPresentations::RepetitionPresentation.new(libelle, champ.dossier.project_rows_for(@type_de_champ))
+    ChampPresentations::RepetitionPresentation.new(libelle, champ.dossier.project_rows_for(self))
   end
 
   def estimated_fill_duration(revision)
     estimated_rows_in_repetition = 2.5
 
-    children = revision.children_of(@type_de_champ)
+    children = revision.children_of(self)
 
     estimated_row_duration = children.map { _1.estimated_fill_duration(revision) }.sum
     estimated_children_read_duration = children.map(&:estimated_read_duration).sum
@@ -33,9 +33,9 @@ class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
     prefix = prefix.present? ? "(#{prefix} #{libelle})" : libelle
 
     Procedure.find(procedure_id)
-      .all_revisions_types_de_champ(parent: @type_de_champ)
+      .all_revisions_types_de_champ(parent: self)
       .flat_map { it.columns(procedure_id:, displayable: false, prefix:) }
   end
 
-  def typed_champ_blank?(champ) = champ.dossier.repetition_row_ids(@type_de_champ).blank?
+  def typed_champ_blank?(champ) = champ.dossier.repetition_row_ids(self).blank?
 end

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def champ_value_for_tag(champ, path = :value)
+  def typed_champ_value_for_tag(champ, path = :value)
     return nil if path != :value
     ChampPresentations::RepetitionPresentation.new(libelle, champ.dossier.project_rows_for(@type_de_champ))
   end
@@ -37,5 +37,5 @@ class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
       .flat_map { it.columns(procedure_id:, displayable: false, prefix:) }
   end
 
-  def champ_blank?(champ) = champ.dossier.repetition_row_ids(@type_de_champ).blank?
+  def typed_champ_blank?(champ) = champ.dossier.repetition_row_ids(@type_de_champ).blank?
 end

--- a/app/models/types_de_champ/rna_type_de_champ.rb
+++ b/app/models/types_de_champ/rna_type_de_champ.rb
@@ -7,7 +7,7 @@ class TypesDeChamp::RNATypeDeChamp < TypesDeChamp::TypeDeChampBase
     FILL_DURATION_MEDIUM
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     champ.identifier
   end
 

--- a/app/models/types_de_champ/rnf_type_de_champ.rb
+++ b/app/models/types_de_champ/rnf_type_de_champ.rb
@@ -3,7 +3,7 @@
 class TypesDeChamp::RNFTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   include AddressableColumnConcern
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     case path
     when :value
       champ.rnf_id
@@ -18,7 +18,7 @@ class TypesDeChamp::RNFTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     end
   end
 
-  def champ_value_for_tag(champ, path = :value)
+  def typed_champ_value_for_tag(champ, path = :value)
     case path
     when :value
       champ.rnf_id
@@ -33,7 +33,7 @@ class TypesDeChamp::RNFTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     end
   end
 
-  def champ_blank?(champ) = champ.external_id.blank?
+  def typed_champ_blank?(champ) = champ.external_id.blank?
 
   def columns(procedure_id:, displayable: true, prefix: nil)
     super

--- a/app/models/types_de_champ/siret_type_de_champ.rb
+++ b/app/models/types_de_champ/siret_type_de_champ.rb
@@ -7,7 +7,7 @@ class TypesDeChamp::SiretTypeDeChamp < TypesDeChamp::TypeDeChampBase
     FILL_DURATION_MEDIUM
   end
 
-  def champ_blank_or_invalid?(champ) = Siret.new(siret: champ.value).invalid?
+  def typed_champ_blank_or_invalid?(champ) = Siret.new(siret: champ.value).invalid?
 
   def columns(procedure_id:, displayable: true, prefix: nil)
     super

--- a/app/models/types_de_champ/text_type_de_champ.rb
+++ b/app/models/types_de_champ/text_type_de_champ.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::TextTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     Sanitizers::Xml.sanitize(champ_text_value(champ))
   end
 end

--- a/app/models/types_de_champ/textarea_type_de_champ.rb
+++ b/app/models/types_de_champ/textarea_type_de_champ.rb
@@ -5,7 +5,7 @@ class TypesDeChamp::TextareaTypeDeChamp < TypesDeChamp::TextTypeDeChamp
     FILL_DURATION_MEDIUM
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     Sanitizers::Xml.sanitize(champ_text_value(champ))
   end
 end

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -53,25 +53,25 @@ class TypesDeChamp::TypeDeChampBase
     (words / READ_WORDS_PER_SECOND).round.seconds
   end
 
-  def champ_value(champ)
+  def typed_champ_value(champ)
     champ.value.present? ? champ_text_value(champ) : champ_default_value
   end
 
-  def champ_value_for_api(champ, version: 2)
+  def typed_champ_value_for_api(champ, version: 2)
     case version
     when 2
-      champ_value(champ)
+      typed_champ_value(champ)
     else
       champ.value.presence || champ_default_api_value(version)
     end
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     path == :value ? champ_text_value(champ).presence : champ_default_export_value(path)
   end
 
-  def champ_value_for_tag(champ, path = :value)
-    path == :value ? champ_value(champ) : nil
+  def typed_champ_value_for_tag(champ, path = :value)
+    path == :value ? typed_champ_value(champ) : nil
   end
 
   def champ_default_value
@@ -91,8 +91,8 @@ class TypesDeChamp::TypeDeChampBase
     end
   end
 
-  def champ_blank?(champ) = champ.value.blank?
-  def champ_blank_or_invalid?(champ) = champ_blank?(champ)
+  def typed_champ_blank?(champ) = champ.value.blank?
+  def typed_champ_blank_or_invalid?(champ) = typed_champ_blank?(champ)
 
   def canonical_column(procedure_id:, displayable: true, prefix: nil)
     return nil unless fillable?

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -1,21 +1,13 @@
 # frozen_string_literal: true
 
-class TypesDeChamp::TypeDeChampBase
-  include ActiveModel::Validations
-
-  delegate :description, :libelle, :mandatory, :mandatory?, :stable_id, :fillable?, :public?, :type_champ, :options_for_select, :drop_down_options, :drop_down_other?, :drop_down_advanced?, :referentiel, :rib?, :justificatif_domicile?, :avis_impot?, :titre_identite?, :ocr_compatible?, to: :@type_de_champ
-
+class TypesDeChamp::TypeDeChampBase < TypeDeChamp
   FILL_DURATION_SHORT  = 10.seconds
   FILL_DURATION_MEDIUM = 1.minute
   FILL_DURATION_LONG   = 3.minutes
   READ_WORDS_PER_SECOND = 140.0 / 60 # 140 words per minute
 
-  def initialize(type_de_champ)
-    @type_de_champ = type_de_champ
-  end
-
   def tags_for_template
-    type_de_champ = @type_de_champ
+    type_de_champ = self
     conditional = type_de_champ.condition.present?
     paths.map do |path|
       path.merge(
@@ -132,7 +124,7 @@ class TypesDeChamp::TypeDeChampBase
   def champ_text_value(champ)
     if champ.is_type?(TypeDeChamp.type_champs.fetch(:multiple_drop_down_list))
       values = TypesDeChamp::MultipleDropDownListTypeDeChamp.parse_selected_options(champ)
-      if @type_de_champ.drop_down_list?
+      if drop_down_list?
         values.first
       else
         values.join(', ')

--- a/app/models/types_de_champ/yes_no_type_de_champ.rb
+++ b/app/models/types_de_champ/yes_no_type_de_champ.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::YesNoTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def champ_value(champ)
+  def typed_champ_value(champ)
     champ_value_true?(champ) ? 'Oui' : 'Non'
   end
 
-  def champ_value_for_export(champ, path = :value)
+  def typed_champ_value_for_export(champ, path = :value)
     champ_value_true?(champ) ? 'Oui' : 'Non'
   end
 
-  def champ_value_for_api(champ, version: 2)
+  def typed_champ_value_for_api(champ, version: 2)
     case version
     when 2
       champ_value_true?(champ).to_s

--- a/app/tasks/maintenance/t20260817_convert_legacy_api_particulier_champs_to_text_task.rb
+++ b/app/tasks/maintenance/t20260817_convert_legacy_api_particulier_champs_to_text_task.rb
@@ -12,16 +12,19 @@ module Maintenance
     # `external_id` (JSON) ou, pour les plus anciens, dans `value_json` : ils sont
     # recopiés en clair dans `value`. Les données récupérées auprès de l'API
     # restent dans `data`.
+    #
+    # TypeDeChamp est en STI sur `type_champ` : une valeur hors enum n'a pas de
+    # classe et ne peut pas être instanciée, on travaille donc sur les ids.
 
     LEGACY_TYPE_CHAMPS = ['cnaf', 'dgfip', 'mesri', 'pole_emploi'].freeze
 
     def collection
-      TypeDeChamp.where(type_champ: LEGACY_TYPE_CHAMPS)
+      TypeDeChamp.where(type_champ: LEGACY_TYPE_CHAMPS).pluck(:id, :stable_id)
     end
 
-    def process(type_de_champ)
+    def process((id, stable_id))
       ChampData
-        .where(stable_id: type_de_champ.stable_id, type: ChampData::REMOVED_TYPES)
+        .where(stable_id:, type: ChampData::REMOVED_TYPES)
         .find_each do |champ|
           champ.update_columns(
             type: 'Champs::TextChamp',
@@ -32,11 +35,7 @@ module Maintenance
           )
         end
 
-      type_de_champ.update_columns(type_champ: TypeDeChamp.type_champs.fetch(:text))
-    end
-
-    def count
-      collection.count
+      TypeDeChamp.where(id:).update_all(type_champ: TypeDeChamp.type_champs.fetch(:text))
     end
 
     private

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -113,6 +113,31 @@ describe Administrateurs::TypesDeChampController, type: :controller do
       end
     end
 
+    context 'changing the type to formatted' do
+      let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :textarea, libelle: 'l1' }]) }
+      let(:params) do
+        {
+          procedure_id: procedure.id,
+          stable_id: first_coordinate.stable_id,
+          # the editor form submits the options of the previous type along the new type
+          type_de_champ: { type_champ: 'formatted', character_limit: '' },
+        }
+      end
+
+      it 'persists the formatted default options' do
+        is_expected.to have_http_status(:ok)
+
+        options = TypeDeChamp.where(id: first_coordinate.type_de_champ.id).pick(:options)
+        expect(options).to eq({
+          'character_limit' => '',
+          'formatted_mode' => 'simple',
+          'letters_accepted' => true,
+          'numbers_accepted' => true,
+          'special_characters_accepted' => true,
+        })
+      end
+    end
+
     context 'rejected if type changed and routing involved' do
       let(:params) do
         default_params.deep_merge(type_de_champ: { type_champ: 'text', stable_id: third_coordinate.stable_id })

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -4,6 +4,9 @@ FactoryBot.define do
   sequence(:stable_id) { |n| 100_000 + n }
 
   factory :type_de_champ do
+    # STI: attributes must go through new so the subclass is picked from type_champ.
+    initialize_with { TypeDeChamp.new(attributes) }
+
     sequence(:libelle) { |n| "Libelle du champ #{n}" }
     sequence(:description) { |n| "description du champ #{n}" }
     type_champ { TypeDeChamp.type_champs.fetch(:text) }

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -2319,21 +2319,6 @@ describe Procedure do
       expect(ville_column.h_id[:column_id]).to eq("type_de_champ/#{ville_column.stable_id}")
     end
 
-    it 'does not raise and skips champs whose type_champ is unknown (legacy value)' do
-      procedure = create(:procedure, :published, types_de_champ_public: [
-        { type: :text, libelle: 'Champ valide' },
-        { type: :text, libelle: 'Champ legacy' },
-      ])
-      legacy_tdc_id = procedure.published_revision.root_types_de_champ_public.find { _1.libelle == 'Champ legacy' }.id
-      TypeDeChamp.where(id: legacy_tdc_id).update_all(type_champ: 'titre_identite')
-      expect(TypeDeChamp.find(legacy_tdc_id)).to be_an_instance_of(TypeDeChamp)
-      procedure.reload
-
-      expect { procedure.personnalisable_columns }.not_to raise_error
-      expect(procedure.personnalisable_columns.map(&:label)).not_to include('Champ legacy')
-      expect(procedure.personnalisable_columns.map(&:label)).to include('Champ valide')
-    end
-
     it 'excludes champs that carry a condition' do
       procedure = create(:procedure, :published, types_de_champ_public: [
         { type: :yes_no, libelle: 'Gate', stable_id: 1 },
@@ -2457,22 +2442,6 @@ describe Procedure do
       expect(tdc_query_count).to eq(0)
     end
 
-    it 'does not raise and skips champs whose type_champ is unknown (legacy value)' do
-      procedure = create(:procedure, :published, types_de_champ_public: [
-        { type: :text, libelle: 'Champ valide' },
-        { type: :text, libelle: 'Champ legacy' },
-      ])
-      legacy_tdc_id = procedure.published_revision.root_types_de_champ_public.find { _1.libelle == 'Champ legacy' }.id
-      TypeDeChamp.where(id: legacy_tdc_id).update_all(type_champ: 'titre_identite')
-      expect(TypeDeChamp.find(legacy_tdc_id)).to be_an_instance_of(TypeDeChamp)
-      procedure.reload
-
-      expect { procedure.personnalisable_columns_by_section }.not_to raise_error
-      all_column_labels = procedure.personnalisable_columns_by_section.flat_map { |_stable_id, _label, cols| cols.map(&:label) }
-      expect(all_column_labels).not_to include('Champ legacy')
-      expect(all_column_labels).to include('Champ valide')
-    end
-
     it 'excludes champs that carry a condition' do
       procedure = create(:procedure, :published, types_de_champ_public: [
         { type: :yes_no, libelle: 'Gate', stable_id: 1 },
@@ -2482,26 +2451,6 @@ describe Procedure do
 
       labels = procedure.personnalisable_columns_by_section.flat_map { |_stable_id, _label, columns| columns.map(&:label) }
       expect(labels).to eq(['Toujours visible'])
-    end
-  end
-
-  describe '#columns' do
-    it 'does not raise and skips champs with unknown type_champ (legacy value)' do
-      procedure = create(:procedure, :published, types_de_champ_public: [
-        { type: :text, libelle: 'Champ valide' },
-        { type: :text, libelle: 'Champ legacy' },
-      ])
-      valid_tdc = procedure.published_revision.root_types_de_champ_public.find { _1.libelle == 'Champ valide' }
-      legacy_tdc_id = procedure.published_revision.root_types_de_champ_public.find { _1.libelle == 'Champ legacy' }.id
-      TypeDeChamp.where(id: legacy_tdc_id).update_all(type_champ: 'titre_identite')
-      expect(TypeDeChamp.find(legacy_tdc_id)).to be_an_instance_of(TypeDeChamp)
-      procedure.reload
-      Current.procedure_columns = nil
-
-      expect { procedure.columns }.not_to raise_error
-      expect(procedure.columns.map(&:label)).not_to include('Champ legacy')
-      h_id = { procedure_id: procedure.id, column_id: "type_de_champ/#{valid_tdc.stable_id}" }
-      expect { procedure.find_column(h_id:) }.not_to raise_error
     end
   end
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -2326,7 +2326,7 @@ describe Procedure do
       ])
       legacy_tdc_id = procedure.published_revision.root_types_de_champ_public.find { _1.libelle == 'Champ legacy' }.id
       TypeDeChamp.where(id: legacy_tdc_id).update_all(type_champ: 'titre_identite')
-      expect(TypeDeChamp.find(legacy_tdc_id).dynamic_type).to be_nil
+      expect(TypeDeChamp.find(legacy_tdc_id)).to be_an_instance_of(TypeDeChamp)
       procedure.reload
 
       expect { procedure.personnalisable_columns }.not_to raise_error
@@ -2464,7 +2464,7 @@ describe Procedure do
       ])
       legacy_tdc_id = procedure.published_revision.root_types_de_champ_public.find { _1.libelle == 'Champ legacy' }.id
       TypeDeChamp.where(id: legacy_tdc_id).update_all(type_champ: 'titre_identite')
-      expect(TypeDeChamp.find(legacy_tdc_id).dynamic_type).to be_nil
+      expect(TypeDeChamp.find(legacy_tdc_id)).to be_an_instance_of(TypeDeChamp)
       procedure.reload
 
       expect { procedure.personnalisable_columns_by_section }.not_to raise_error
@@ -2494,7 +2494,7 @@ describe Procedure do
       valid_tdc = procedure.published_revision.root_types_de_champ_public.find { _1.libelle == 'Champ valide' }
       legacy_tdc_id = procedure.published_revision.root_types_de_champ_public.find { _1.libelle == 'Champ legacy' }.id
       TypeDeChamp.where(id: legacy_tdc_id).update_all(type_champ: 'titre_identite')
-      expect(TypeDeChamp.find(legacy_tdc_id).dynamic_type).to be_nil
+      expect(TypeDeChamp.find(legacy_tdc_id)).to be_an_instance_of(TypeDeChamp)
       procedure.reload
       Current.procedure_columns = nil
 

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -159,6 +159,27 @@ describe TypeDeChamp do
     end
   end
 
+  describe '#becomes_type' do
+    it 'runs the target type validations instead of the source ones' do
+      tdc = create(:type_de_champ_linked_drop_down_list)
+      tdc.update_column(:options, { 'drop_down_options' => ['pas de primaire'] })
+      tdc = TypeDeChamp.find(tdc.id)
+
+      expect(tdc).to be_invalid
+      expect(tdc.becomes_type('text').update(type_champ: 'text')).to be true
+    end
+
+    it 'runs the target type callbacks, persisting the formatted default options' do
+      tdc = create(:type_de_champ_text)
+
+      morphed = tdc.becomes_type('formatted')
+      morphed.update!(type_champ: 'formatted')
+
+      expect(morphed).to be_an_instance_of(TypesDeChamp::FormattedTypeDeChamp)
+      expect(morphed.reload.options['formatted_mode']).to eq('simple')
+    end
+  end
+
   describe 'piece_justificative nature and options' do
     describe '#allowed_content_types' do
       it 'returns jpeg/png for titre_identite' do

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -148,23 +148,13 @@ describe TypeDeChamp do
       end
     end
 
-    context 'delegate validation to dynamic type' do
-      subject { build(:type_de_champ_text) }
-      let(:dynamic_type) do
-        Class.new(TypesDeChamp::TypeDeChampBase) do
-          validate :never_valid
-
-          def never_valid
-            errors.add(:troll, 'always invalid')
-          end
-        end.new(subject)
-      end
-
-      before { subject.instance_variable_set(:@dynamic_type, dynamic_type) }
+    context "runs the STI subclass validations" do
+      subject { create(:type_de_champ_linked_drop_down_list).tap { _1.drop_down_options = ["pas de primaire"] } }
 
       it do
+        is_expected.to be_an_instance_of(TypesDeChamp::LinkedDropDownListTypeDeChamp)
         is_expected.to be_invalid
-        expect(subject.errors.full_messages.to_sentence).to eq("Le champ « Troll » always invalid")
+        expect(subject.errors.full_messages.to_sentence).to include("doit commencer par une entrée de menu primaire")
       end
     end
   end

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -16,7 +16,7 @@ describe TypeDeChamp do
       it do
         dossier.revision.root_types_de_champ_public.each do |type_de_champ|
           champ = dossier.project_champ(type_de_champ)
-          expect(type_de_champ.dynamic_type.class.name).to match(/^TypesDeChamp::/)
+          expect(type_de_champ.class.name).to match(/^TypesDeChamp::/)
           expect(champ.class.name).to match(/^Champs::/)
         end
       end

--- a/spec/models/types_de_champ/formatted_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/formatted_type_de_champ_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe TypesDeChamp::FormattedTypeDeChamp do
+  describe 'default options' do
+    let(:type_de_champ) { create(:type_de_champ_formatted) }
+
+    it 'are injected when loading a row whose options are empty' do
+      TypeDeChamp.where(id: type_de_champ.id).update_all(options: {})
+
+      reloaded = TypeDeChamp.find(type_de_champ.id)
+
+      expect(reloaded.formatted_mode).to eq('simple')
+      expect(reloaded.letters_accepted).to eq(true)
+      expect(reloaded.numbers_accepted).to eq(true)
+      expect(reloaded.special_characters_accepted).to eq(true)
+    end
+
+    it 'do not overwrite the persisted options' do
+      type_de_champ.update!(formatted_mode: 'advanced', expression_reguliere: '\d+')
+
+      reloaded = TypeDeChamp.find(type_de_champ.id)
+
+      expect(reloaded.formatted_mode).to eq('advanced')
+      expect(reloaded.expression_reguliere).to eq('\d+')
+    end
+  end
+end

--- a/spec/models/types_de_champ/linked_drop_down_list_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/linked_drop_down_list_type_de_champ_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 describe TypesDeChamp::LinkedDropDownListTypeDeChamp do
-  let(:type_de_champ) { build(:type_de_champ_linked_drop_down_list, drop_down_options: menu_options) }
+  # On creation (type_champ_changed?) set_drop_down_list_options would overwrite an invalid menu.
+  let(:type_de_champ) { create(:type_de_champ_linked_drop_down_list).tap { _1.drop_down_options = menu_options } }
 
-  subject { type_de_champ.dynamic_type }
+  subject { type_de_champ }
 
   describe 'validation' do
     context 'It must start with one primary option' do

--- a/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
@@ -6,7 +6,7 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
 
     it 'adds RIB columns' do
       tdc = create(:type_de_champ_piece_justificative, procedure:, nature: 'rib')
-      cols = tdc.dynamic_type.columns(procedure_id: procedure.id, displayable: true)
+      cols = tdc.columns(procedure_id: procedure.id, displayable: true)
       labels = cols.map(&:label)
       expect(labels.any? { _1.include?('Titulaire') }).to be true
       expect(labels.any? { _1.include?('IBAN') }).to be true
@@ -16,7 +16,7 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
 
     it 'adds justificatif de domicile columns with i18n labels' do
       tdc = create(:type_de_champ_piece_justificative, procedure:, nature: 'justificatif_domicile')
-      cols = tdc.dynamic_type.columns(procedure_id: procedure.id, displayable: true)
+      cols = tdc.columns(procedure_id: procedure.id, displayable: true)
       labels = cols.map(&:label)
       expect(labels.any? { _1.include?('Bénéficiaire') }).to be true
       expect(labels.any? { _1.include?('Adresse') }).to be true
@@ -25,7 +25,7 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
 
     it 'adds avis impot columns with i18n labels' do
       tdc = create(:type_de_champ_piece_justificative, procedure:, nature: 'avis_impot')
-      cols = tdc.dynamic_type.columns(procedure_id: procedure.id, displayable: true)
+      cols = tdc.columns(procedure_id: procedure.id, displayable: true)
       labels = cols.map(&:label)
       expect(labels.any? { _1.include?('Déclarant 1') }).to be true
       expect(labels.any? { _1.include?('Référence de l’avis') }).to be true

--- a/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
@@ -43,12 +43,12 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
       let(:type_de_champ) { champ.type_de_champ }
 
       it 'returns "absent" when no file attached' do
-        expect(type_de_champ.dynamic_type.typed_champ_value_for_export(champ)).to eq('absent')
+        expect(type_de_champ.typed_champ_value_for_export(champ)).to eq('absent')
       end
 
       it 'returns "présent" when file attached' do
         champ.piece_justificative_file.attach(fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png'))
-        expect(type_de_champ.dynamic_type.typed_champ_value_for_export(champ)).to eq('présent')
+        expect(type_de_champ.typed_champ_value_for_export(champ)).to eq('présent')
       end
     end
 
@@ -60,11 +60,11 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
 
       it 'returns filenames' do
         champ.piece_justificative_file.attach(fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png'))
-        expect(type_de_champ.dynamic_type.typed_champ_value_for_export(champ)).to include('logo_test_procedure.png')
+        expect(type_de_champ.typed_champ_value_for_export(champ)).to include('logo_test_procedure.png')
       end
 
       it 'returns empty string when no file' do
-        expect(type_de_champ.dynamic_type.typed_champ_value_for_export(champ)).to eq('')
+        expect(type_de_champ.typed_champ_value_for_export(champ)).to eq('')
       end
     end
   end
@@ -79,13 +79,13 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
     it 'returns url for first file in v1 when safe' do
       champ.piece_justificative_file.attach(fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png'))
       champ.piece_justificative_file.first.blob.update(virus_scan_result: ActiveStorage::VirusScanner::SAFE)
-      expect(champ.type_de_champ.dynamic_type.typed_champ_value_for_api(champ, version: 1)).to include('/rails/active_storage/')
+      expect(champ.type_de_champ.typed_champ_value_for_api(champ, version: 1)).to include('/rails/active_storage/')
     end
 
     it 'returns nil when infected' do
       champ.piece_justificative_file.attach(fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png'))
       champ.piece_justificative_file.first.blob.update(virus_scan_result: ActiveStorage::VirusScanner::INFECTED)
-      expect(champ.type_de_champ.dynamic_type.typed_champ_value_for_api(champ, version: 1)).to be_nil
+      expect(champ.type_de_champ.typed_champ_value_for_api(champ, version: 1)).to be_nil
     end
   end
 end

--- a/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
@@ -43,12 +43,12 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
       let(:type_de_champ) { champ.type_de_champ }
 
       it 'returns "absent" when no file attached' do
-        expect(type_de_champ.dynamic_type.champ_value_for_export(champ)).to eq('absent')
+        expect(type_de_champ.dynamic_type.typed_champ_value_for_export(champ)).to eq('absent')
       end
 
       it 'returns "présent" when file attached' do
         champ.piece_justificative_file.attach(fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png'))
-        expect(type_de_champ.dynamic_type.champ_value_for_export(champ)).to eq('présent')
+        expect(type_de_champ.dynamic_type.typed_champ_value_for_export(champ)).to eq('présent')
       end
     end
 
@@ -60,11 +60,11 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
 
       it 'returns filenames' do
         champ.piece_justificative_file.attach(fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png'))
-        expect(type_de_champ.dynamic_type.champ_value_for_export(champ)).to include('logo_test_procedure.png')
+        expect(type_de_champ.dynamic_type.typed_champ_value_for_export(champ)).to include('logo_test_procedure.png')
       end
 
       it 'returns empty string when no file' do
-        expect(type_de_champ.dynamic_type.champ_value_for_export(champ)).to eq('')
+        expect(type_de_champ.dynamic_type.typed_champ_value_for_export(champ)).to eq('')
       end
     end
   end
@@ -79,13 +79,13 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
     it 'returns url for first file in v1 when safe' do
       champ.piece_justificative_file.attach(fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png'))
       champ.piece_justificative_file.first.blob.update(virus_scan_result: ActiveStorage::VirusScanner::SAFE)
-      expect(champ.type_de_champ.dynamic_type.champ_value_for_api(champ, version: 1)).to include('/rails/active_storage/')
+      expect(champ.type_de_champ.dynamic_type.typed_champ_value_for_api(champ, version: 1)).to include('/rails/active_storage/')
     end
 
     it 'returns nil when infected' do
       champ.piece_justificative_file.attach(fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png'))
       champ.piece_justificative_file.first.blob.update(virus_scan_result: ActiveStorage::VirusScanner::INFECTED)
-      expect(champ.type_de_champ.dynamic_type.champ_value_for_api(champ, version: 1)).to be_nil
+      expect(champ.type_de_champ.dynamic_type.typed_champ_value_for_api(champ, version: 1)).to be_nil
     end
   end
 end

--- a/spec/tasks/maintenance/t20260817_convert_legacy_api_particulier_champs_to_text_task_spec.rb
+++ b/spec/tasks/maintenance/t20260817_convert_legacy_api_particulier_champs_to_text_task_spec.rb
@@ -21,17 +21,22 @@ module Maintenance
       type_de_champ.update_columns(type_champ: 'cnaf')
     end
 
+    # the enum casts unknown values to nil, read the column as stored
+    def raw_type_champ
+      TypeDeChamp.connection.select_value("SELECT type_champ FROM types_de_champ WHERE id = #{type_de_champ.id}")
+    end
+
     describe "#collection" do
-      it "returns the legacy types de champ" do
-        expect(described_class.new.collection).to contain_exactly(type_de_champ)
+      it "returns the ids of the legacy types de champ" do
+        expect(described_class.new.collection).to contain_exactly([type_de_champ.id, type_de_champ.stable_id])
       end
     end
 
     describe "#process" do
-      subject(:process) { described_class.process(TypeDeChamp.find(type_de_champ.id)) }
+      subject(:process) { described_class.process([type_de_champ.id, type_de_champ.stable_id]) }
 
       it "converts the type de champ to text" do
-        expect { process }.to change { TypeDeChamp.find(type_de_champ.id).type_champ }.from(nil).to('text')
+        expect { process }.to change { raw_type_champ }.from('cnaf').to('text')
       end
 
       it "converts the champ to text, keeping the identifiers as value and the fetched data" do


### PR DESCRIPTION
## Quoi

Conversion de `TypeDeChamp` en STI sur la colonne `type_champ` existante — **aucune migration** :

- renommage préalable des méthodes polymorphes en `typed_*` pour libérer les noms des wrappers publics (commit 1, mécanique) ;
- les délégateurs `TypesDeChamp::*` deviennent des sous-classes STI : un objet au lieu de deux, validations et callbacks AR standards, symétrie avec la STI de `ChampData` (commit 2) ;
- suppression du shim transitoire `dynamic_type` (commit 3) ;
- `becomes_type` : le changement de type d'un tdc persisté applique désormais les validations/callbacks du type cible, plus celles du type source (commit 4) ;
- versionnage de la clé du cache `all_revisions_types_de_champ` (commit 5) : il stocke des records `TypeDeChamp` marshallés pendant 1 mois, et les entrées écrites avant la STI se désérialiseraient en classe de base sans le comportement typé ;
- déplacement de la constante des couches carte sur `TypeDeChamp` pour éviter un cycle d'autoload (commit 6) ;
- suppression du fallback pour les `type_champ` legacy (commit 7) : les dernières lignes hors enum ont été converties en texte par #13666, `find_sti_class` lève désormais sur une valeur inconnue.

## Points pour la revue

- `find_sti_class`/`sti_name` traduisent valeurs d'enum ↔ classes.
- `model_name` épinglé à `TypeDeChamp` (même approche que `ChampData`) : formulaires, params, dom_id et i18n inchangés.
- Aucune écriture différente en base : rolling deploy et revert sans contrainte.
- Prérequis : #13666 passée en prod (déjà fait).