### PR TITLE
Correctif: ETQ usager, le message d'erreur d'un fichier vide explique comment le débloquer

### DIFF
--- a/config/locales/active_storage_validations.en.yml
+++ b/config/locales/active_storage_validations.en.yml
@@ -5,4 +5,4 @@ en:
         one: is not of an accepted type (%{content_type}).
         other: is not of an accepted type (%{content_type}).
       file_size_out_of_range: is too big. The file must be at most %{max_size}.
-      file_empty: is empty (%{filename}). The uploaded file contains no data.
+      file_empty: is empty (%{filename}). If the file comes from an email app or an online storage service, download it to your device first, then try again.

--- a/config/locales/active_storage_validations.fr.yml
+++ b/config/locales/active_storage_validations.fr.yml
@@ -5,4 +5,4 @@ fr:
         one: n’est pas d’un type accepté (%{content_type}).
         other: n’est pas d’un type accepté (%{content_type}).
       file_size_out_of_range: est trop lourd(e). Le fichier doit faire au plus %{max_size}.
-      file_empty: est vide (%{filename}). Le fichier envoyé ne contient aucune donnée.
+      file_empty: est vide (%{filename}). Si le fichier provient d’une messagerie ou d’un espace de stockage en ligne, téléchargez-le d’abord sur votre appareil, puis réessayez.


### PR DESCRIPTION
# Problème

L'alerte Sentry [**RAILS-MEQ**](https://demarches-simplifiees.sentry.io/issues/RAILS-MEQ), posée avec la mitigation de la CVE-2026-66066 (#13659), a produit **58 events / 3 usagers en 48 h**. Aucun n'est malveillant : ce sont des fichiers de **0 octet**. `Blob#download_identifiable_chunk` retourne `""` pour un blob vide, Marcel déduit alors `image/jpeg` de la seule extension là où le magic ne peut rien confirmer — d'où le désaccord qui déclenche l'alerte.

Les noms de fichiers disent le reste : `Screenshot_20260812_112511_Gmail.jpg`, `Carte d'identité .jpg`, `attestation.jpg`. Des usagers joignent un document hébergé dans une messagerie ou un espace de stockage en ligne, que l'appareil n'a jamais matérialisé localement : le navigateur lit l'URI et envoie 0 octet.

`EmptyFileValidator` les rejette correctement, mais le message s'arrêtait au constat sans dire quoi faire. D'où ~19 réessais par personne — sur la messagerie d'un dossier en instruction, quelqu'un qui essaie d'envoyer sa carte d'identité à son instructeur.

# Solution

| | |
|---|---|
| **Avant** | est vide (%{filename}). Le fichier envoyé ne contient aucune donnée. |
| **Après** | est vide (%{filename}). Si le fichier provient d'une messagerie ou d'un espace de stockage en ligne, téléchargez-le d'abord sur votre appareil, puis réessayez. |

Pas de marques (Gmail, OneDrive…) : plus durable sur un service public, à rediscuter si vous préférez l'inverse. Le début du message est inchangé, les deux specs qui l'assertent passent.

Generated with [Claude Code](https://claude.com/claude-code)