### PR TITLE
Tech: convertit les champs API Particulier legacy (cnaf, dgfip, mesri, pole_emploi) en champs texte

### DIFF
--- a/app/tasks/maintenance/t20260817_convert_legacy_api_particulier_champs_to_text_task.rb
+++ b/app/tasks/maintenance/t20260817_convert_legacy_api_particulier_champs_to_text_task.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260817ConvertLegacyAPIParticulierChampsToTextTask < MaintenanceTasks::Task
+    # Les types de champ API Particulier v1 (cnaf, dgfip, mesri, pole_emploi) ont été
+    # retirés du code mais leurs lignes existent toujours en base : `type_champ`
+    # n'est plus dans l'enum (lu comme nil) et les champs portent des classes STI
+    # supprimées (voir ChampData::REMOVED_TYPES).
+    #
+    # On les convertit en champ texte. Les identifiants saisis par l'usager
+    # (numéro d'allocataire, code postal, numéro fiscal…) étaient stockés dans
+    # `external_id` (JSON) ou, pour les plus anciens, dans `value_json` : ils sont
+    # recopiés en clair dans `value`. Les données récupérées auprès de l'API
+    # restent dans `data`.
+
+    LEGACY_TYPE_CHAMPS = ['cnaf', 'dgfip', 'mesri', 'pole_emploi'].freeze
+
+    def collection
+      TypeDeChamp.where(type_champ: LEGACY_TYPE_CHAMPS)
+    end
+
+    def process(type_de_champ)
+      ChampData
+        .where(stable_id: type_de_champ.stable_id, type: ChampData::REMOVED_TYPES)
+        .find_each do |champ|
+          champ.update_columns(
+            type: 'Champs::TextChamp',
+            value: legacy_value(champ),
+            value_json: nil,
+            external_id: nil,
+            external_state: nil
+          )
+        end
+
+      type_de_champ.update_columns(type_champ: TypeDeChamp.type_champs.fetch(:text))
+    end
+
+    def count
+      collection.count
+    end
+
+    private
+
+    def legacy_value(champ)
+      identifiers = champ.value_json.to_h.merge(parse_external_id(champ.external_id))
+
+      identifiers.compact_blank.map { |key, value| "#{key.humanize} : #{value}" }.join(', ').presence
+    end
+
+    def parse_external_id(external_id)
+      return {} if external_id.blank?
+
+      JSON.parse(external_id)
+    rescue JSON::ParserError
+      { 'identifiant' => external_id }
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20260817_convert_legacy_api_particulier_champs_to_text_task_spec.rb
+++ b/spec/tasks/maintenance/t20260817_convert_legacy_api_particulier_champs_to_text_task_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260817ConvertLegacyAPIParticulierChampsToTextTask do
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :text }]) }
+    let(:type_de_champ) { procedure.published_revision.types_de_champ.first }
+    let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+    let(:cnaf_data) { { 'quotient_familial' => { 'quotientFamilial' => 1234 } } }
+
+    before do
+      champ.update_columns(
+        type: 'Champs::CnafChamp',
+        value: nil,
+        external_id: { numero_allocataire: '1234567', code_postal: '75001' }.to_json,
+        external_state: 'fetched',
+        data: cnaf_data
+      )
+      type_de_champ.update_columns(type_champ: 'cnaf')
+    end
+
+    describe "#collection" do
+      it "returns the legacy types de champ" do
+        expect(described_class.new.collection).to contain_exactly(type_de_champ)
+      end
+    end
+
+    describe "#process" do
+      subject(:process) { described_class.process(TypeDeChamp.find(type_de_champ.id)) }
+
+      it "converts the type de champ to text" do
+        expect { process }.to change { TypeDeChamp.find(type_de_champ.id).type_champ }.from(nil).to('text')
+      end
+
+      it "converts the champ to text, keeping the identifiers as value and the fetched data" do
+        process
+
+        converted = Champs::TextChamp.find(champ.id)
+        expect(converted.value).to eq('Numero allocataire : 1234567, Code postal : 75001')
+        expect(converted.data).to eq(cnaf_data)
+        expect(converted.external_id).to be_nil
+        expect(converted.external_state).to eq('idle')
+      end
+
+      it "reads identifiers stored in value_json by the oldest rows" do
+        champ.update_columns(external_id: nil, value_json: { 'numero_allocataire' => '7654321', 'code_postal' => '13001' })
+
+        process
+
+        expect(Champs::TextChamp.find(champ.id).value).to eq('Code postal : 13001, Numero allocataire : 7654321')
+      end
+
+      it "leaves value nil when nothing was filled" do
+        champ.update_columns(external_id: nil, external_state: nil, data: nil)
+
+        process
+
+        expect(Champs::TextChamp.find(champ.id).value).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Les types de champ API Particulier v1 (`cnaf`, `dgfip`, `mesri`, `pole_emploi`) ont été retirés du code, mais leurs lignes existent toujours en base : `type_champ` n'est plus dans l'enum (lu comme `nil`) et les champs portent des classes STI supprimées (`ChampData::REMOVED_TYPES`).

## Ce que fait la tâche

`Maintenance::T20260817ConvertLegacyAPIParticulierChampsToTextTask` (lancement manuel) :
- pour chaque type de champ legacy, les champs de même `stable_id` passent en `Champs::TextChamp` : les identifiants saisis par l'usager (`external_id` en JSON, ou `value_json` pour les lignes les plus anciennes) sont recopiés en clair dans `value` (`Numero allocataire : 1234567, Code postal : 75001`), `external_id`/`external_state`/`value_json` sont remis à nil, `data` (payload API) est conservé ;
- puis `type_champ` passe à `text`.

Idempotente. Une fois passée, `ChampData::REMOVED_TYPES` pourra être supprimé.

Voir aussi #13662 (STI sur TypeDeChamp), qui n'aura plus besoin de gérer ces valeurs hors enum.