### PR TITLE
Tech: fiabiliser bin/parallel-rspec (assets Sprockets périmés, URLs d'API dépendantes du .env)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,6 +4,13 @@ APP_HOST_LEGACY="test-legacy.host"
 AR_ENCRYPTION_PRIMARY_KEY="test-RgUyzplf0kehB5fyZpmCd37uvgb"
 AR_ENCRYPTION_KEY_DERIVATION_SALT="test-yyMmzM9cTSD1rs3Fq3hwt3hMNg4"
 
+# Les specs stubbent ces domaines (les valeurs par défaut de
+# config/initializers/02_urls.rb). On les fige ici pour que la suite ne dépende
+# pas du .env local : un .env pointant vers staging, ou l'API_PARTICULIER_URL
+# de config/env.example.optional (suffixée /api), fait échouer les stub_request.
+API_ADRESSE_URL="https://data.geopf.fr/geocodage"
+API_PARTICULIER_URL="https://particulier.api.gouv.fr"
+
 # Datagouv
 DATAGOUV_API_KEY="clesecrete"
 DATAGOUV_API_URL="https://www.data.gouv.fr/api/1"

--- a/bin/parallel-rspec
+++ b/bin/parallel-rspec
@@ -24,7 +24,13 @@ if [ "${1:-}" = "--setup" ]; then
 fi
 
 # Build assets once up front; otherwise every process would race to autobuild.
-bin/vite build
+# assets:precompile covers both pipelines: vite_ruby enhances it with
+# vite:build_all, and config.assets.compile is false in test so the Sprockets
+# bundle must be precompiled too — otherwise system specs run against a stale
+# application.css. Same step as .github/actions/ci-setup-assets in CI.
+# Both halves skip on a content digest, so an unchanged tree costs ~2.5s —
+# about 1s more than the vite build alone that this replaces.
+bin/rails assets:precompile
 
 # Processes are balanced with the runtimes recorded in
 # tmp/parallel_runtime_rspec.log by previous runs (parallel_tests' default


### PR DESCRIPTION
# Problème

Lancer `bin/parallel-rspec` en local donne des specs rouges alors que la CI est verte. Deux causes, indépendantes du code applicatif.

**1. Les assets Sprockets ne sont jamais précompilés.** Le script ne lance que `bin/vite build`, alors que `config.assets.compile` est à `false` en test. Les specs système tournent donc contre le dernier `application.css` écrit sur la machine — chez moi il datait de quatre mois. Une règle CSS récente absente du bundle ne casse pas le rendu de façon visible : elle casse silencieusement les specs qui s'appuient sur du comportement piloté par le CSS. Exemple concret, `list_dossiers_spec` « mobile search panel » : la media query `max-width: 767px` qui masque le formulaire desktop n'existait pas dans le bundle, donc le formulaire restait visible en 375px et l'assertion tombait.

La CI ne voit pas le problème : elle exécute `bin/rails assets:precompile` via `.github/actions/ci-setup-assets`, étape que le script local n'a pas.

**2. Les URLs d'API de test dépendent du `.env` de chacun.** Les specs stubbent les valeurs par défaut de `config/initializers/02_urls.rb`. La CI tombe juste **par hasard** : elle fait `cp config/env.example .env`, et `env.example` porte le bon `API_ADRESSE_URL` et **aucun** `API_PARTICULIER_URL`. En local, un `.env` qui pointe vers staging — ou simplement le `API_PARTICULIER_URL` de `config/env.example.optional`, qui est suffixé `/api` et ne matche donc pas la regex du stub — fait échouer `api_particulier/api_spec`, `users/address_spec` et `users/brouillon_spec` en `VCR::Errors::UnhandledHTTPRequestError`.

# Solution

`bin/vite build` → `bin/rails assets:precompile`. Ce n'est pas un ajout mais un remplacement : `vite_ruby` greffe `vite:build_all` sur `assets:precompile`, qui couvre donc les deux pipelines. C'est exactement l'étape que fait déjà la CI.

Et on fige les deux URLs dans `.env.test`, qui prime sur `.env` en environnement de test. La suite devient indépendante du `.env` de chaque dev, sans que personne ait à toucher son fichier local.

## Coût

Les deux moitiés s'arrêtent sur un digest de contenu, pas sur des mtimes (vérifié : un `touch` ne déclenche pas de rebuild, un vrai changement si).

| étape | arbre inchangé |
|---|---|
| `bin/vite build` (avant) | 1,87 / 1,76 / 1,66 s |
| `bin/rails assets:precompile` (après) | 3,10 / 2,42 / 2,56 s |

Environ **+1 s** sur une suite qui tourne en **266 s**, soit +0,4 %. Écarter `tmp/cache/assets` (8,7 Mo) ne change rien à la mesure : Sprockets s'arrête au manifeste, l'essentiel de la seconde est du boot Rails.

## Vérification

Suite complète après correctifs : **9610 exemples, 1 échec** — un flaky de combobox React Aria (`procedure_filters_spec:206`, `Element is not attached to the DOM`), vert au rejeu, sans rapport avec cette PR.

Le pin `.env.test` a été validé dans un worktree dont le `.env` est symlinké sur un `.env` pointant vers staging, et sans `.env.test.local` : 53 exemples verts sur les fichiers concernés.

## Hors périmètre

Deux autres causes d'échec local relevées au passage sont propres à la machine et ne se corrigent pas dans le dépôt : un `node_modules` périmé (`axe-core` manquant → toutes les specs a11y), et le `zip` d'Apple livré avec macOS, qui a perdu le support de `-UN=UTF8` utilisé par `DownloadableFileService` (`brew install zip` + PATH, ~11 specs export/archive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
