### PR TITLE
Secu: confiner les ecritures de l'export ZIP au repertoire d'export

### DIFF
--- a/app/lib/download_manager/parallel_download_queue.rb
+++ b/app/lib/download_manager/parallel_download_queue.rb
@@ -4,13 +4,19 @@ module DownloadManager
   class ParallelDownloadQueue
     DOWNLOAD_MAX_PARALLEL = ENV.fetch('DOWNLOAD_MAX_PARALLEL') { 10 }
 
+    # Raised when the write path cannot be confined to the export directory (path
+    # traversal via `..` or an absolute path in an attacker-controlled template).
+    class PathTraversalError < StandardError; end
+
     attr_accessor :attachments,
                   :destination,
                   :on_error
 
     def initialize(attachments, destination)
       @attachments = attachments
-      @destination = Pathname.new(destination)
+      # expanded once, so the confinement check below compares two paths built the
+      # same way, and a relative destination cannot re-resolve if cwd moves
+      @destination = Pathname.new(destination).expand_path
     end
 
     def download_all
@@ -29,8 +35,7 @@ module DownloadManager
 
     # can't be used with typhoeus, otherwise block is closed before the request is run by hydra
     def download_one(attachment:, path_in_download_dir:, http_client:)
-      path = Pathname.new(path_in_download_dir)
-      attachment_path = destination.join(path.dirname, sanitize_filename(path.basename.to_s))
+      attachment_path = confined_attachment_path(path_in_download_dir)
 
       attachment_path.dirname.mkpath # defensive, do not write in undefined dir
 
@@ -50,6 +55,81 @@ module DownloadManager
     end
 
     private
+
+    # `path_in_download_dir` comes from a user-controlled export template
+    # (`ExportTemplate#attachment_path`), whose tags are substituted without
+    # escaping: both the directory part and the basename can carry hostile input.
+    # So we rebuild the path from explicitly filtered components — sanitizing every
+    # one of them, not just the basename — rather than let `Pathname#join`/
+    # `expand_path` resolve it for us:
+    #   - an absolute path would replace the `destination` prefix entirely
+    #   - a `..` that would climb out of the export dir is refused loudly, so a real
+    #     escape attempt stays visible (logged, reported, listed in the error report)
+    #     instead of being silently relocated somewhere inside the export
+    #   - a `..` absorbed within the export dir is dropped rather than resolved:
+    #     resolving it would collapse two paths that
+    #     `DownloadableFileService.deduplicate_paths` believes to be distinct onto
+    #     the same file. Dropping it keeps the attachment, under its own directory.
+    #
+    # The final check is an exact structural equality, not a prefix comparison: we
+    # require the expanded path to be *literally* the export dir followed by the
+    # components we chose. Comparing `..` against the literal string is not enough,
+    # because `File.expand_path` honours spellings a string comparison misses, and
+    # which ones it honours is platform dependent: on macOS it strips a leading
+    # UTF-8 BOM, so a component of "﻿.." traverses like ".." (on Linux it stays a
+    # plain directory name). Resolving it there would collapse two paths that
+    # `DownloadableFileService.deduplicate_paths` believes to be distinct onto the
+    # same file.
+    #
+    # The equality makes us safe on every platform without having to enumerate those
+    # spellings: either `expand_path` normalises something and the two sides differ,
+    # so we refuse, or it does not and the path is literally the export dir followed
+    # by sanitized components (which can no longer contain a separator), hence
+    # confined by construction. It also subsumes the sibling-directory case
+    # (`/tmp/export-evil` vs `/tmp/export`), and a basename that is empty or is
+    # itself `.`/`..` — none of those survive `expand_path` intact either.
+    def confined_attachment_path(path_in_download_dir)
+      path = Pathname.new(path_in_download_dir)
+
+      raise PathTraversalError, "refusing an absolute path: #{path_in_download_dir.inspect}" if path.absolute?
+
+      relative_path = File.join(
+        *confined_dir_components(path.dirname, path_in_download_dir),
+        sanitize_filename(path.basename.to_s)
+      )
+      expected = File.join(destination.to_s, relative_path)
+      resolved = destination.join(relative_path).expand_path
+
+      if resolved.to_s != expected
+        raise PathTraversalError, "refusing to write outside export dir: #{path_in_download_dir.inspect}"
+      end
+
+      resolved
+    end
+
+    # Walks the directory components once, tracking the depth relative to the export
+    # dir with `..` popping it: a depth going negative means the path climbs out and
+    # is refused. Otherwise `.`/`..` are dropped (not popped, see
+    # `confined_attachment_path`) and each remaining component is sanitized.
+    def confined_dir_components(dirname, path_in_download_dir)
+      depth = 0
+
+      dirname.each_filename.filter_map do |component|
+        next if component == '.'
+
+        if component == '..'
+          depth -= 1
+          if depth.negative?
+            raise PathTraversalError, "refusing to write outside export dir: #{path_in_download_dir.inspect}"
+          end
+
+          next
+        end
+
+        depth += 1
+        sanitize_filename(component).presence
+      end
+    end
 
     def sanitize_filename(original_filename)
       filename = ActiveStorage::Filename.new(original_filename).sanitized

--- a/app/lib/download_manager/procedure_attachments_export.rb
+++ b/app/lib/download_manager/procedure_attachments_export.rb
@@ -10,10 +10,23 @@ module DownloadManager
     def initialize(procedure, attachments, destination)
       @procedure = procedure
       @errors = {}
+      @reported_error_classes = Set.new
       @queue = ParallelDownloadQueue.new(attachments, destination)
       @queue.on_error = proc do |attachment, path, error|
         errors[path] = [attachment, path]
         Rails.logger.error("Fail to download filename #{path} in procedure##{@procedure.id}, reason: #{error}")
+
+        # `on_error` gets an HTTP status code for a failed download (expected, and
+        # retried) but an exception for anything else — a traversing path from a
+        # malformed template, a filename ActiveStorage did not sanitize... Those are
+        # bugs, so alert rather than only log.
+        #
+        # Once per class per export: a bad template makes *every* path fail the same
+        # way, and we would otherwise emit one Sentry event per attachment for a
+        # single root cause.
+        if error.is_a?(Exception) && @reported_error_classes.add?(error.class)
+          Sentry.capture_exception(error, extra: { procedure_id: @procedure.id })
+        end
       end
     end
 

--- a/spec/lib/download_manager/parallel_download_queue_spec.rb
+++ b/spec/lib/download_manager/parallel_download_queue_spec.rb
@@ -9,6 +9,28 @@ describe DownloadManager::ParallelDownloadQueue do
 
   after { FileUtils.remove_entry_secure(test_dir) if Dir.exist?(test_dir) }
 
+  # the traversal specs target a dir we own and clean up: asserting on a shared
+  # location like Dir.tmpdir would leak an artifact and make them order dependent.
+  # `mktmpdir` is lazy inside a `let`, so this costs nothing to the other examples.
+  let(:outside_dir) { Dir.mktmpdir(nil, Dir.tmpdir) }
+  after { FileUtils.remove_entry_secure(outside_dir) if Dir.exist?(outside_dir) }
+
+  # FNM_DOTMATCH: several payloads produce dot-prefixed components, which a bare
+  # glob would silently skip
+  def files_written_in(dir)
+    Dir.glob(File.join(dir, '**', '*'), File::FNM_DOTMATCH).filter { File.file?(_1) }
+  end
+
+  def fake_attachment(id)
+    ActiveStorage::FakeAttachment.new(
+      file: StringIO.new('coucou'),
+      filename: "export-dossier.pdf",
+      name: 'pdf_export_for_instructeur',
+      id:,
+      created_at: Time.zone.now
+    )
+  end
+
   let(:downloadable_manager) { DownloadManager::ParallelDownloadQueue.new([attachment], download_to_dir) }
   let(:http_client) { instance_double(Typhoeus::Hydra) }
 
@@ -16,15 +38,7 @@ describe DownloadManager::ParallelDownloadQueue do
     subject { downloadable_manager.download_one(attachment: attachment, path_in_download_dir: destination, http_client:) }
 
     let(:destination) { 'lol.png' }
-    let(:attachment) do
-      ActiveStorage::FakeAttachment.new(
-        file: StringIO.new('coucou'),
-        filename: "export-dossier.pdf",
-        name: 'pdf_export_for_instructeur',
-        id: 1,
-        created_at: Time.zone.now
-      )
-    end
+    let(:attachment) { fake_attachment(1) }
 
     context 'with a ActiveStorage::FakeAttachment and it works' do
       it 'write attachment.file to disk' do
@@ -78,6 +92,133 @@ describe DownloadManager::ParallelDownloadQueue do
       end
     end
 
+    # A malicious export template lets an instructeur inject `..` sequences (or an
+    # absolute path) into the directory part of the download path. `Pathname#join`
+    # resolves `..` lexically, so the write escapes the export dir. The directory
+    # part is never sanitized (only the basename is), so the sink must refuse to
+    # write outside `destination`.
+    context 'with traversal-shaped input in the destination directory' do
+      {
+        'via a ../ traversal sequence' => -> { File.join('..', File.basename(outside_dir), 'pwned.txt') },
+        'via an absolute path' => -> { File.join(outside_dir, 'pwned.txt') },
+      }.each do |description, path|
+        context description do
+          let(:destination) { instance_exec(&path) }
+
+          it 'refuses to write outside the destination dir' do
+            expect { subject }.to raise_error(DownloadManager::ParallelDownloadQueue::PathTraversalError)
+            expect(files_written_in(outside_dir)).to be_empty
+          end
+        end
+      end
+
+      context 'with a sibling dir sharing the destination prefix' do
+        # /tmp/xxx-export vs /tmp/xxx : a naive string start_with? would let this pass
+        let(:destination) { File.join('..', "#{File.basename(test_dir)}-evil", 'pwned.txt') }
+
+        it 'refuses to write in a sibling dir that shares the prefix' do
+          sibling = "#{test_dir}-evil"
+          expect { subject }.to raise_error(DownloadManager::ParallelDownloadQueue::PathTraversalError)
+          expect(Dir.glob(File.join(sibling, '**', '*'))).to be_empty
+        ensure
+          FileUtils.remove_entry_secure(sibling) if sibling && Dir.exist?(sibling)
+        end
+      end
+
+      # Resolving this `..` would land on <export>/dossier-999/pj.txt, i.e. inside
+      # another dossier's folder — and would collide with the plain
+      # 'dossier-999/pj.txt' path that DownloadableFileService.deduplicate_paths
+      # believes to be distinct. The traversal component is dropped instead.
+      context 'via a ../ traversal that stays inside the export dir' do
+        let(:destination) { 'dossier-1/../dossier-999/pj.txt' }
+
+        it 'drops the traversal component instead of resolving it' do
+          subject
+
+          expect(File.exist?(File.join(download_to_dir, 'dossier-1/dossier-999/pj.txt'))).to be_truthy
+          expect(File.exist?(File.join(download_to_dir, 'dossier-999/pj.txt'))).to be_falsey
+        end
+      end
+
+      context 'via a path whose last component is a traversal' do
+        let(:destination) { 'dossier-1/..' }
+
+        it 'refuses to write on the export dir itself' do
+          expect { subject }.to raise_error(DownloadManager::ParallelDownloadQueue::PathTraversalError)
+          expect(File.directory?(download_to_dir)).to be_truthy
+        end
+      end
+
+      # A leading UTF-8 BOM is the one spelling of ".." that a String comparison
+      # misses while the platform may still honour it: File.expand_path strips it on
+      # macOS (so "﻿.." traverses exactly like "..") but not on Linux (where it
+      # stays a plain directory name for the kernel).
+      #
+      # We therefore assert the security property, not which branch fires: either
+      # expand_path normalises and the exact-equality check rejects the path, or it
+      # does not and the path is literally the export dir followed by the sanitized
+      # components we chose, hence confined by construction. Asserting the raise
+      # would pass on macOS and fail on Linux while the code is correct on both.
+      context 'via a BOM-prefixed traversal that expand_path may honour' do
+        let(:destination) { "﻿../pwned.txt" }
+
+        it 'never writes outside the destination dir' do
+          begin
+            subject
+          rescue DownloadManager::ParallelDownloadQueue::PathTraversalError
+            # refused outright: also a valid outcome
+          end
+
+          expect(files_written_in(outside_dir)).to be_empty
+        end
+      end
+
+      context 'via a BOM-prefixed traversal absorbed inside the export dir' do
+        let(:destination) { "dossier-1/﻿../dossier-999/pj.txt" }
+
+        it 'never collides with the plain dossier-999 path' do
+          begin
+            subject
+          rescue DownloadManager::ParallelDownloadQueue::PathTraversalError
+            # refused outright: also a valid outcome
+          end
+
+          expect(files_written_in(outside_dir)).to be_empty
+          expect(File.exist?(File.join(download_to_dir, 'dossier-999/pj.txt'))).to be_falsey
+        end
+      end
+
+      # These spellings are not path separators at the byte level, so they cannot
+      # traverse: they must stay literal components inside the export dir.
+      context 'via unicode look-alikes of the separator and of the dot' do
+        [
+          "..／pwned.txt",  # fullwidth solidus
+          "..∕pwned.txt",  # division slash
+          "．．/pwned.txt", # fullwidth full stop
+          "․․/pwned.txt", # one dot leader
+          '....//....//pwned.txt',
+          '%2e%2e%2fpwned.txt',
+          "..\\..\\pwned.txt",
+        ].each do |payload|
+          context "with #{payload.inspect}" do
+            let(:destination) { payload }
+
+            it 'keeps the write inside the export dir' do
+              subject
+
+              expect(files_written_in(outside_dir)).to be_empty
+              # FNM_DOTMATCH: several payloads produce dot-prefixed components,
+              # which a bare glob would silently skip
+              written = Dir.glob(File.join(download_to_dir, '**', '*'), File::FNM_DOTMATCH)
+                .filter { File.file?(_1) }
+              expect(written.size).to eq(1)
+              expect(written.first).to start_with(download_to_dir + File::SEPARATOR)
+            end
+          end
+        end
+      end
+    end
+
     context "download strategies" do
       subject { super(); http_client.run }
       let(:byte_size) { 1.kilobyte }
@@ -118,6 +259,38 @@ describe DownloadManager::ParallelDownloadQueue do
           expect(downloadable_manager).to have_received(:request_in_chunks) # ensure we're taking the chunks code path
         end
       end
+    end
+  end
+
+  # #download_all is the production entry point: it rescues per attachment, so a
+  # single unconfinable path must be reported and skipped without aborting the
+  # whole export.
+  describe '#download_all' do
+    subject { downloadable_manager.download_all }
+
+    let(:poisoned_path) { File.join('..', File.basename(outside_dir), 'pwned.txt') }
+
+    let(:downloadable_manager) do
+      DownloadManager::ParallelDownloadQueue.new(
+        [[legit_attachment, 'dossier-1/legit.txt'], [poisoned_attachment, poisoned_path]],
+        download_to_dir
+      )
+    end
+    let(:legit_attachment) { fake_attachment(1) }
+    let(:poisoned_attachment) { fake_attachment(2) }
+    let(:reported_errors) { [] }
+
+    before do
+      downloadable_manager.on_error = proc { |_attachment, path, error| reported_errors << [path, error] }
+    end
+
+    it 'reports the unconfinable path and still downloads the other attachments' do
+      subject
+
+      expect(reported_errors.map(&:first)).to eq([poisoned_path])
+      expect(reported_errors.first.last).to be_a(DownloadManager::ParallelDownloadQueue::PathTraversalError)
+      expect(File.exist?(File.join(download_to_dir, 'dossier-1/legit.txt'))).to be_truthy
+      expect(files_written_in(outside_dir)).to be_empty
     end
   end
 end


### PR DESCRIPTION
# Probleme

`ExportTemplate#attachment_path` construit le chemin de telechargement de chaque piece a partir d'un template tiptap (champ « Nom du dossier » / « PJ » du formulaire de template d'export ZIP). Les tags y sont substitues avec `escape: false`, et le texte du template ressort **litteralement** :

```
TiptapService text  =>  "../../../../../../tmp/ds-pwned"
```

Cote sink (`DownloadManager::ParallelDownloadQueue#download_one`), seul le *basename* etait assaini. La partie repertoire ne l'etait pas, et `Pathname#join` resout les `..` lexicalement tandis qu'un chemin absolu remplace entierement le prefixe. Un template piege permettait donc d'ecrire des pieces jointes **hors du repertoire d'export**, sur l'hote du worker Sidekiq.

Le vecteur n'est pas le nom du fichier uploade : ActiveStorage assainit le nom du blob a l'upload (`/` -> `-`), un usager ne peut pas injecter de separateur par la. Ce sont les templates d'export qui portent les separateurs et les `..`.

Reproduit en local : le fichier atterrit bien en dehors de l'arbre zippe (et donc absent du ZIP livre).

# Solution

Le chemin n'est plus « resolu » puis compare par prefixe : il est **reconstruit** a partir de composants explicitement filtres, puis on refuse tout ce qui n'atterrit pas exactement la ou on a decide d'ecrire.

| Cas | Comportement |
|---|---|
| Chemin absolu | Refuse (il remplacerait le prefixe `destination`) |
| `..` qui sort du repertoire d'export | Refuse bruyamment — une vraie tentative reste visible |
| `..` absorbe a l'interieur | Composant droppe, pas resolu (voir ci-dessous) |
| Tous les composants | Assainis, plus seulement le basename |

**Pourquoi dropper le `..` absorbe plutot que le resoudre ?** `DownloadableFileService.deduplicate_paths` existe pour garantir qu'aucune piece n'en ecrase une autre silencieusement, mais il deduplique sur la chaine *brute*. Resoudre `dossier-1/../dossier-999/pj.txt` le ferait collisionner avec `dossier-999/pj.txt` — deux chemins bruts distincts, un seul fichier final, une piece ecrasee et deposee sous le dossier d'un autre usager. En droppant le composant, le chemin reste injectif et la piece est conservee.

**Pourquoi une egalite structurelle exacte plutot qu'un `start_with?` ?** Comparer les composants au litteral `".."` ne suffit pas, et les graphies qu'`File.expand_path` honore sont **dependantes de la plateforme** : sur macOS il supprime un BOM UTF-8 en tete de composant puis honore le `..`, sur Linux non (le BOM y reste un nom de repertoire ordinaire).

Une premiere version du correctif se faisait contourner par la sur macOS : `dossier-1/<BOM>../dossier-999/pj.txt` rouvrait la collision decrite plus haut.

L'egalite exacte nous met a l'abri **sur toutes les plateformes sans avoir a enumerer ces graphies** : soit `expand_path` normalise quelque chose et les deux cotes different, donc on refuse ; soit il ne normalise pas et le chemin est litteralement le repertoire d'export suivi des composants assainis (qui ne peuvent plus contenir de separateur), donc confine par construction. Ca subsume aussi le repertoire frere (`/tmp/export-evil` vs `/tmp/export`) et un basename vide ou valant `.` / `..`.

Les specs BOM assertent donc la **propriete de securite** (rien n'est ecrit hors du repertoire d'export, aucune collision avec le chemin simple) et non le mecanisme : asserter le refus passait en local et echouait en CI alors que le code est correct des deux cotes.

## Exploration des vecteurs

44 charges fuzzees contre le sink reel : `..` classiques/profonds, absolus, `....//`, `%2e%2e%2f` simple et double encodage, `..\..\`, UTF-8 surlong (`C0 AE`, `C0 AF`, `E0 80 AE`), solidus pleine largeur U+FF0F, division slash U+2215, fraction slash U+2044, point pleine largeur U+FF0E, one-dot-leader U+2024, point ideographique U+3002, override RTL U+202E, ZWSP U+200B, BOM U+FEFF, NBSP, NFD combinant, U+2028, octet nul, `~`, `$HOME`, composants de 300 octets, 50 segments. Resultat : **aucune evasion**. Les look-alikes Unicode du separateur ne sont pas des separateurs au niveau octet et restent des composants litteraux confines.

Note : les sequences UTF-8 invalides et l'octet nul levent un `ArgumentError` plutot qu'un `PathTraversalError`. Ca echoue ferme (rescue par `download_all`) et c'est inatteignable en production, Postgres refusant l'UTF-8 invalide et les octets nuls dans ses colonnes texte.

## Observabilite

`PathTraversalError` est route vers `on_error` par attachement, donc un template piege ne fait echouer que son propre fichier et l'export aboutit. `on_error` recoit un code HTTP pour un echec de telechargement ordinaire, mais une exception pour tout le reste : les exceptions sont desormais remontees a Sentry avec le `procedure_id`, **une fois par classe et par export** — un template casse fait echouer toutes les pieces de la meme facon, on ne veut pas un evenement par piece.

L'arborescence de sous-repertoires legitime continue de fonctionner.

Generated with [Claude Code](https://claude.com/claude-code)
