### PR TITLE
Tech: documenter zip dans les dépendances, et le piège du zip livré par macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ Would you like to make changes or improvements? Read our [contribution guide](CO
 - postgresql (version >= 15)
 - libvips-dev (image processing and watermark generation)
 - gsfonts (fonts for watermark text rendering)
+- zip (Info-ZIP 3.0 or later, used to build the export and archive files)
+
+  On macOS the system `/usr/bin/zip` is an Apple build that dropped support for
+  the `-UN=UTF8` flag, which we pass to keep accented filenames intact. Export
+  and archive specs then fail with `zip error: Invalid command arguments (short
+  option 'N' not supported)`. Install Info-ZIP and put it first in your `PATH`:
+
+      brew install zip
+      echo 'export PATH="/opt/homebrew/opt/zip/bin:$PATH"' >> ~/.zshrc
 
 - redis
 


### PR DESCRIPTION
# Problème

`zip` n'apparaît nulle part dans les dépendances du README, alors que l'application shell-out dessus pour construire **tous** les exports et archives :

```ruby
# app/services/downloadable_file_service.rb:22
system 'zip', '-0', '-r', '-UN=UTF8', zip_path, EXPORT_DIRNAME, chdir: tmp_dir
```

C'est le seul site d'usage, mais il est sur un chemin de production : `ProcedureExportService`, `ProcedureArchiveService`, `ExportJob`. Un environnement sans `zip` casse la fonctionnalité sans que rien ne l'ait annoncé.

Le flag `-UN=UTF8` ajoute une contrainte que le README ne dit pas non plus : il faut un vrai Info-ZIP. **macOS ne le fournit plus.** Le `/usr/bin/zip` livré avec le système est un build Apple qui a perdu le support de l'option :

```
zip error: Invalid command arguments (short option 'N' not supported)
```

Concrètement, une dizaine de specs export/archive échouent sur un Mac à jour, avec un message qui ne mentionne ni `zip`, ni macOS, ni le flag en cause — donc introuvable sans savoir déjà ce qu'on cherche.

# Solution

Lister `zip` dans `### Technical dependencies` → `#### All environments`, à côté de `libvips-dev` et `gsfonts` : c'est une dépendance runtime, pas un outil de test.

Le contournement macOS est documenté juste en dessous, avec le message d'erreur littéral pour qu'une recherche le trouve :

    brew install zip
    echo 'export PATH="/opt/homebrew/opt/zip/bin:$PATH"' >> ~/.zshrc

La formule est *keg-only* — Homebrew ne la lie pas dans `/opt/homebrew/bin` puisque macOS fournit déjà un `zip` — d'où la ligne de `PATH`, sans laquelle l'installation seule ne change rien.

## Ce que cette PR ne fait pas

Elle documente un contournement plutôt que de supprimer la contrainte. Se passer de `-UN=UTF8` — via `rubyzip`, déjà au Gemfile, ou en détectant le support du flag à l'exécution — touche le nommage des fichiers accentués dans les exports livrés aux usagers. Ça mérite son propre arbitrage ; en attendant, autant que le piège soit écrit quelque part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
