### PR TITLE
Correctif: ETQ usager, ne plus recharger deux fois les tuiles de la carte

### DIFF
--- a/app/javascript/components/shared/maplibre/MapLibre.tsx
+++ b/app/javascript/components/shared/maplibre/MapLibre.tsx
@@ -36,27 +36,30 @@ export function MapLibre({ children, layers }: MapLibreProps) {
   const isSupported = useMemo(() => isWebglSupported(), []);
   const containerRef = useRef<HTMLDivElement>(null);
   const visible = useElementVisible(containerRef);
+  const mapRef = useRef<Map | null>(null);
   const [map, setMap] = useState<Map | null>();
   const [styleControlElement, setStyleControlElement] =
     useState<HTMLElement | null>(null);
 
-  const onStyleChange = useCallback(
-    (style: StyleSpecification) => {
-      if (map) {
-        map.setStyle(style);
-      }
-    },
-    [map]
-  );
+  // Read the map from a ref rather than from state, so this callback keeps a
+  // stable identity: depending on the state would make useStyle replay
+  // setStyle() as soon as the map loads, with the very style the map was built
+  // with — recreating every source and refetching every tile for nothing.
+  const onStyleChange = useCallback((style: StyleSpecification) => {
+    mapRef.current?.setStyle(style);
+  }, []);
   const { style, ...mapStyleProps } = useStyle(layers, onStyleChange);
 
   useEffect(() => {
-    if (isSupported && visible && !map) {
+    // Guard on the ref, not on the state: the state is only set once `load`
+    // fires, so a re-render before then would build a second map.
+    if (isSupported && visible && !mapRef.current) {
       invariant(containerRef.current, 'Map container not found');
       const map = new Map({
         container: containerRef.current,
         style
       });
+      mapRef.current = map;
       map.addControl(new NavigationControl({}), 'top-right');
       const styleControl = new ReactControl();
       map.addControl(styleControl, 'bottom-left');
@@ -67,7 +70,7 @@ export function MapLibre({ children, layers }: MapLibreProps) {
         setStyleControlElement(styleControl.container);
       });
     }
-  }, [map, style, visible, isSupported]);
+  }, [style, visible, isSupported]);
 
   if (!isSupported) {
     return (

--- a/app/javascript/components/shared/maplibre/styles/base.ts
+++ b/app/javascript/components/shared/maplibre/styles/base.ts
@@ -135,6 +135,32 @@ const OPTIONAL_LAYERS: { label: string; id: string; layers: string[][] }[] = [
   }
 ];
 
+// `cadastre` and `rpg` back the two parcelle layers, and nothing else. Declare
+// them only when their layer is enabled, instead of in the base style: a source
+// that never loads (the RPG pmtiles archive currently 404s) leaves the style
+// permanently "not loaded", which downgrades subsequent setStyle() calls to a
+// full reload — aborting and refetching every tile in flight.
+export function buildOptionalSources(
+  ids: string[]
+): StyleSpecification['sources'] {
+  const sources: StyleSpecification['sources'] = {};
+
+  if (ids.includes('cadastres')) {
+    sources.cadastre = {
+      type: 'vector',
+      url: 'https://openmaptiles.geo.data.gouv.fr/data/cadastre.json'
+    };
+  }
+  if (ids.includes('rpg')) {
+    sources.rpg = {
+      type: 'vector',
+      url: 'pmtiles://https://object.data.gouv.fr/pmtiles/rpg_2023.pmtiles'
+    };
+  }
+
+  return sources;
+}
+
 function buildSources() {
   return Object.fromEntries(
     OPTIONAL_LAYERS.filter(({ id }) => id != 'cadastres' && id != 'rpg')
@@ -238,18 +264,10 @@ export const style: StyleSpecification = {
       [ignServiceURL('ORTHOIMAGERY.ORTHOPHOTOS', 'normal', 'image/jpeg')],
       'IGN-F/Géoportail'
     ),
-    cadastre: {
-      type: 'vector',
-      url: 'https://openmaptiles.geo.data.gouv.fr/data/cadastre.json'
-    },
     'plan-ign': rasterSource(
       [ignServiceURL('GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2', 'normal')],
       'IGN-F/Géoportail'
     ),
-    rpg: {
-      type: 'vector',
-      url: 'pmtiles://https://object.data.gouv.fr/pmtiles/rpg_2023.pmtiles'
-    },
     ...buildSources()
   },
   sprite: 'https://openmaptiles.github.io/osm-bright-gl-style/sprite',

--- a/app/javascript/components/shared/maplibre/styles/index.ts
+++ b/app/javascript/components/shared/maplibre/styles/index.ts
@@ -3,6 +3,7 @@ import type { LayerSpecification, StyleSpecification } from 'maplibre-gl';
 import {
   style as baseStyle,
   buildOptionalLayers,
+  buildOptionalSources,
   getLayerName,
   NBS
 } from './base';
@@ -30,6 +31,7 @@ export function getMapStyle(
   opacity: Record<string, number>
 ): StyleSpecification & { id: MapStyle } {
   const optionalLayers = buildOptionalLayers(layers, opacity);
+  const sources = { ...baseStyle.sources, ...buildOptionalSources(layers) };
 
   switch (id) {
     case 'ortho':
@@ -37,6 +39,7 @@ export function getMapStyle(
         ...baseStyle,
         id,
         name: 'Photographies aériennes',
+        sources,
         layers: [...(orthoLayers as LayerSpecification[]), ...optionalLayers]
       };
     case 'vector':
@@ -44,6 +47,7 @@ export function getMapStyle(
         ...baseStyle,
         id,
         name: 'Carte OSM',
+        sources,
         layers: [...(vectorLayers as LayerSpecification[]), ...optionalLayers]
       };
     default:
@@ -51,6 +55,7 @@ export function getMapStyle(
         ...baseStyle,
         id,
         name: 'Carte IGN',
+        sources,
         layers: [...ignLayers, ...optionalLayers]
       };
   }

--- a/app/javascript/components/shared/maplibre/styles/styles.test.ts
+++ b/app/javascript/components/shared/maplibre/styles/styles.test.ts
@@ -1,0 +1,40 @@
+import { suite, test, expect } from 'vitest';
+
+import { getMapStyle, type MapStyle } from './index';
+
+const STYLES: MapStyle[] = ['ortho', 'vector', 'ign'];
+// `cadastres` and `rpg` share layer ids, so they are never enabled together.
+const SELECTIONS = [[], ['cadastres'], ['rpg']];
+const OPACITY = { cadastres: 70, rpg: 70 };
+
+suite('getMapStyle', () => {
+  test('declares a parcelle source only when its layer is enabled', () => {
+    expect(getMapStyle('ortho', [], OPACITY).sources).not.toHaveProperty('rpg');
+    expect(getMapStyle('ortho', [], OPACITY).sources).not.toHaveProperty(
+      'cadastre'
+    );
+    expect(getMapStyle('ortho', ['rpg'], OPACITY).sources).toHaveProperty(
+      'rpg'
+    );
+    expect(getMapStyle('ortho', ['cadastres'], OPACITY).sources).toHaveProperty(
+      'cadastre'
+    );
+  });
+
+  test('never references a source it does not declare', () => {
+    for (const id of STYLES) {
+      for (const selection of SELECTIONS) {
+        const style = getMapStyle(id, selection, OPACITY);
+        const sources = Object.keys(style.sources);
+
+        for (const layer of style.layers) {
+          if ('source' in layer) {
+            expect(sources, `${id} / [${selection}] / ${layer.id}`).toContain(
+              layer.source
+            );
+          }
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
# Probleme

Sur toute carte, la console remonte une erreur et le reseau part en double :

~~~
XHRGET https://object.data.gouv.fr/pmtiles/rpg_2023.pmtiles [404 Not Found]
Error: Bad response code: 404
    getBytes ... addSource ... _load ... _updateStyle ... setStyle ... MapLibre.tsx:56
~~~

Deux causes qui se combinent.

**1.** Les sources `cadastre` et `rpg` etaient declarees dans le style de base, donc chargees a **chaque** ouverture de carte, meme quand leur couche n'etait pas activee. Or l'archive pmtiles du RPG n'existe plus cote data.gouv.fr :

~~~
$ curl https://object.data.gouv.fr/pmtiles/rpg_2023.pmtiles
<Error><Code>NoSuchKey</Code><Key>rpg_2023.pmtiles</Key><BucketName>pmtiles</BucketName></Error>
~~~

**2.** Une source qui n'aboutit jamais laisse le style MapLibre en etat « non charge ». Le `setStyle()` qui suit ne peut donc pas faire de diff et retombe sur un rechargement complet : toutes les sources sont recreees et les requetes en vol sont avortees. Dans les logs, 4 tuiles `data.geopf.fr` et les 8 tuiles `france-vector` sont demandees deux fois, et Firefox remonte les avortees en `NS_BINDING_ERROR`.

Impact : chaque carte paie une requete morte, double son trafic de tuiles et pollue la console.

# Solution

Les sources `cadastre` et `rpg` ne servent qu'aux couches parcelles — `ortho.json` et `vector.json` n'utilisent que `decoupage-administratif` / `openmaptiles` / `photographies-aeriennes`, et `ign.ts` que `plan-ign`. Elles passent donc par un `buildOptionalSources(ids)` appele par `getMapStyle`, sous la meme condition que `buildOptionalLayers` : source et couches apparaissent et disparaissent ensemble.

Au passage, `onStyleChange` lit desormais la carte via une ref plutot que via le state. Son identite ne change plus quand `setMap()` s'execute, ce qui supprime un `setStyle()` redondant rejoue au chargement avec le style qui venait justement de servir a construire la carte. Le garde de creation passe aussi sur la ref : le state n'etant pose qu'a l'evenement `load`, un re-render avant celui-ci construisait une seconde carte dans le meme conteneur.

Le test ajoute verifie, pour les 3 styles x 3 selections de couches, qu'aucune couche ne reference une source non declaree — c'est exactement le risque introduit par ce decoupage.

# Apres merge

L'URL du RPG reste a mettre a jour quand la nouvelle archive aura ete identifiee (une seule ligne, dans `buildOptionalSources`). En attendant la couche RPG reste non fonctionnelle, mais elle ne penalise plus les cartes qui ne l'utilisent pas.

Generated with [Claude Code](https://claude.com/claude-code)