### PR TITLE
Tech: TypeDeChamp, polymorphisme (suite) — listes de l'éditeur, personnalisable, routable, callbacks

### DIFF
--- a/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
+++ b/app/components/dossiers/champs_rows_show_component/champs_rows_show_component.html.erb
@@ -75,7 +75,7 @@
               </p>
             <% when TypeDeChamp.type_champs.fetch(:referentiel) %>
               <%= render Dossiers::ReferentielComponent.new(champ:, profile: @profile) %>
-            <% when *TypeDeChamp::API_PART_FC_TDC %>
+            <% when *TypesDeChamp::FranceConnectTypeDeChamp::REGISTRY.keys.map(&:to_s) %>
               <%= render Dossiers::FranceConnectChampComponent.new(champ:, profile: @profile) %>
             <% else %>
               <div class="copy-zone" data-to-copy="<%= champ.to_s.strip %>">

--- a/app/components/editable_champ/editable_champ_component.rb
+++ b/app/components/editable_champ/editable_champ_component.rb
@@ -48,16 +48,6 @@ class EditableChamp::EditableChampComponent < ApplicationComponent
 
   private
 
-  def has_label?(champ)
-    types_without_label = TypeDeChamp::API_PART_FC_TDC + [
-      TypeDeChamp.type_champs.fetch(:header_section),
-      TypeDeChamp.type_champs.fetch(:explication),
-      TypeDeChamp.type_champs.fetch(:repetition),
-      TypeDeChamp.type_champs.fetch(:linked_drop_down_list),
-    ]
-    !types_without_label.include?(@champ.type_champ)
-  end
-
   def component_class
     if @champ.france_connect?
       EditableChamp::FranceConnectChampBaseComponent

--- a/app/components/editable_champ/editable_champ_component/editable_champ_component.html.haml
+++ b/app/components/editable_champ/editable_champ_component/editable_champ_component.html.haml
@@ -1,6 +1,6 @@
 .fr-fieldset__element{ **fieldset_element_attributes, "data-type": champ_component.class.name }
   = content_tag((champ_component.dsfr_champ_container), html_options) do
-    - if has_label?(@champ)
+    - if @champ.type_de_champ.has_label?
       = render EditableChamp::ChampLabelComponent.new form: @form, champ: @champ, seen_at: @seen_at, row_number: row_number_if_in_repetition
 
     = render champ_component

--- a/app/components/types_de_champ_editor/champ_component.rb
+++ b/app/components/types_de_champ_editor/champ_component.rb
@@ -13,21 +13,10 @@ class TypesDeChampEditor::ChampComponent < ApplicationComponent
   private
 
   delegate :type_de_champ, :revision, :procedure, to: :coordinate
+  delegate :libelle_configurable?, :description_configurable?, to: :type_de_champ
 
   def mandatory_configurable?
     type_de_champ.fillable? && !type_de_champ.must_be_mandatory? && !type_de_champ.cannot_be_mandatory?
-  end
-
-  def libelle_configurable?
-    !type_de_champ.type_champ.in?(TypeDeChamp::API_PART_FC_TDC)
-  end
-
-  def description_configurable?
-    !type_de_champ.type_champ.in?(
-      TypeDeChamp::API_PART_FC_TDC + [
-        TypeDeChamp.type_champs.fetch(:header_section),
-      ]
-    )
   end
 
   def type_de_champ_path
@@ -113,12 +102,8 @@ class TypesDeChampEditor::ChampComponent < ApplicationComponent
     }
   end
 
-  EXCLUDE_FROM_BLOCK = TypeDeChamp::API_PART_FC_TDC + [
-    TypeDeChamp.type_champs.fetch(:repetition),
-  ]
-
   def filter_block_type_champ(type_champ)
-    !coordinate.child? || !EXCLUDE_FROM_BLOCK.include?(type_champ)
+    !coordinate.child? || TypeDeChamp.find_sti_class(type_champ).allowed_in_repetition?
   end
 
   def filter_public_or_private_only_type_champ(type_champ)

--- a/app/components/types_de_champ_editor/champ_component.rb
+++ b/app/components/types_de_champ_editor/champ_component.rb
@@ -122,11 +122,8 @@ class TypesDeChampEditor::ChampComponent < ApplicationComponent
   end
 
   def filter_public_or_private_only_type_champ(type_champ)
-    if coordinate.private?
-      !TypeDeChamp::PUBLIC_ONLY_TYPES.include?(type_champ)
-    else
-      !TypeDeChamp::PRIVATE_ONLY_TYPES.include?(type_champ)
-    end
+    klass = TypeDeChamp.find_sti_class(type_champ)
+    coordinate.private? ? !klass.public_only? : !klass.private_only?
   end
 
   def filter_featured_type_champ(type_champ)

--- a/app/components/types_de_champ_editor/champ_component.rb
+++ b/app/components/types_de_champ_editor/champ_component.rb
@@ -130,8 +130,8 @@ class TypesDeChampEditor::ChampComponent < ApplicationComponent
   end
 
   def filter_featured_type_champ(type_champ)
-    feature_name = TypeDeChamp::FEATURE_FLAGS[type_champ.to_sym]
-    feature_name.blank? || procedure.feature_enabled?(feature_name)
+    feature_name = TypeDeChamp.find_sti_class(type_champ).feature_flag
+    feature_name.nil? || procedure.feature_enabled?(feature_name)
   end
 
   def filter_type_champ(type_champ)

--- a/app/components/types_de_champ_editor/champ_component.rb
+++ b/app/components/types_de_champ_editor/champ_component.rb
@@ -60,16 +60,17 @@ class TypesDeChampEditor::ChampComponent < ApplicationComponent
     cat_scope = "activerecord.attributes.type_de_champ.categorie"
     tdc_scope = "activerecord.attributes.type_de_champ.type_champs"
     TypeDeChamp.type_champs.keys
+      .map { TypeDeChamp.find_sti_class(_1) }
       .filter(&method(:filter_type_champ))
       .filter(&method(:filter_featured_type_champ))
       .filter(&method(:filter_block_type_champ))
       .filter(&method(:filter_public_or_private_only_type_champ))
-      .group_by { TypeDeChamp.category_for(_1) }
+      .group_by(&:category)
       .sort_by { |k, _v| TypeDeChamp::CATEGORIES.find_index(k) }
-      .to_h do |cat, tdc|
+      .to_h do |cat, klasses|
         [
           t(cat, scope: cat_scope),
-          tdc.map { [t(_1, scope: tdc_scope), _1, { disabled: !accepted_type_champs.include?(_1) }] },
+          klasses.map { [t(_1.sti_name, scope: tdc_scope), _1.sti_name, { disabled: !accepted_type_champs.include?(_1.sti_name) }] },
         ]
       end
   end
@@ -102,27 +103,20 @@ class TypesDeChampEditor::ChampComponent < ApplicationComponent
     }
   end
 
-  def filter_block_type_champ(type_champ)
-    !coordinate.child? || TypeDeChamp.find_sti_class(type_champ).allowed_in_repetition?
+  def filter_block_type_champ(klass)
+    !coordinate.child? || klass.allowed_in_repetition?
   end
 
-  def filter_public_or_private_only_type_champ(type_champ)
-    klass = TypeDeChamp.find_sti_class(type_champ)
+  def filter_public_or_private_only_type_champ(klass)
     coordinate.private? ? !klass.public_only? : !klass.private_only?
   end
 
-  def filter_featured_type_champ(type_champ)
-    feature_name = TypeDeChamp.find_sti_class(type_champ).feature_flag
-    feature_name.nil? || procedure.feature_enabled?(feature_name)
+  def filter_featured_type_champ(klass)
+    klass.feature_flag.nil? || procedure.feature_enabled?(klass.feature_flag)
   end
 
-  def filter_type_champ(type_champ)
-    case type_champ
-    when TypeDeChamp.type_champs.fetch(:number)
-      has_legacy_number?
-    else
-      true
-    end
+  def filter_type_champ(klass)
+    klass != TypesDeChamp::NumberTypeDeChamp || has_legacy_number?
   end
 
   def has_legacy_number?

--- a/app/components/users/personnalisation_component.rb
+++ b/app/components/users/personnalisation_component.rb
@@ -11,7 +11,7 @@ class Users::PersonnalisationComponent < ApplicationComponent
   attr_reader :procedure, :personnalisation
 
   def select_options
-    groups = procedure.personnalisable_columns_by_section
+    groups = procedure.customizable_columns_by_section
 
     if groups.size == 1 && groups.first.first.nil?
       { items: items_for(groups.first.last) }

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -536,7 +536,7 @@ module Users
           if submitted_ids.empty?
             []
           else
-            columns_by_id = procedure.personnalisable_columns.index_by(&:id)
+            columns_by_id = procedure.customizable_columns.index_by(&:id)
             submitted_ids.filter_map { columns_by_id[_1] }
           end
         perso = current_user.dossiers_list_personnalisations.find_or_initialize_by(procedure_id:)
@@ -782,7 +782,7 @@ module Users
         .distinct
         .order(:libelle)
         .includes(published_revision: { revision_types_de_champ: :type_de_champ })
-        .filter { _1.personnalisable_columns_by_section.any? }
+        .filter { _1.customizable_columns_by_section.any? }
     end
 
     def redirect_if_hidden_or_deleted_dossier

--- a/app/models/concerns/columns_concern.rb
+++ b/app/models/concerns/columns_concern.rb
@@ -134,7 +134,7 @@ module ColumnsConcern
   def personnalisable_columns
     current_revision = published_revision || active_revision
     current_revision.root_types_de_champ_public
-      .filter { _1.type_champ.in?(TypeDeChamp::PERSONNALISABLE_TYPE_CHAMPS) }
+      .filter(&:customizable?)
       .filter { _1.condition.nil? }
       .filter_map { _1.personnalisation_column(procedure_id: id) }
       .uniq(&:stable_id)

--- a/app/models/concerns/columns_concern.rb
+++ b/app/models/concerns/columns_concern.rb
@@ -131,21 +131,21 @@ module ColumnsConcern
     all_revisions_types_de_champ.private_only.flat_map { _1.columns(procedure_id: id) }.filter(&:filterable)
   end
 
-  def personnalisable_columns
+  def customizable_columns
     current_revision = published_revision || active_revision
     current_revision.root_types_de_champ_public
       .filter(&:customizable?)
       .filter { _1.condition.nil? }
-      .filter_map { _1.personnalisation_column(procedure_id: id) }
+      .filter_map { _1.customization_column(procedure_id: id) }
       .uniq(&:stable_id)
   end
 
-  def personnalisable_columns_by_section
+  def customizable_columns_by_section
     current_revision = published_revision || active_revision
     tdcs_public = current_revision.root_types_de_champ_public
     auto_numbering = tdcs_public.none? { _1.header_section? && _1.libelle.match?(/^\d/) }
 
-    personnalisable_by_stable_id = personnalisable_columns.index_by(&:stable_id)
+    customizable_by_stable_id = customizable_columns.index_by(&:stable_id)
 
     current_section = [nil, nil]
     counters = []
@@ -164,7 +164,7 @@ module ColumnsConcern
         current_section = [type_de_champ.stable_id, label]
         next
       end
-      column = personnalisable_by_stable_id[type_de_champ.stable_id]
+      column = customizable_by_stable_id[type_de_champ.stable_id]
       next if column.nil?
 
       (grouped[current_section] ||= []) << column

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -31,6 +31,7 @@ class TypeDeChamp < ApplicationRecord
   def self.private_only? = false
   def self.public_only? = false
   def self.allowed_in_repetition? = true
+  def self.simple_routable? = false
 
   def self.category_for(type_champ)
     find_sti_class(type_champ).category
@@ -82,16 +83,6 @@ class TypeDeChamp < ApplicationRecord
   }
 
   enum :nature, %w[non_specifie titre_identite rib justificatif_domicile avis_impot].index_by(&:itself)
-
-  SIMPLE_ROUTABLE_TYPES = [
-    type_champs.fetch(:drop_down_list),
-    type_champs.fetch(:communes),
-    type_champs.fetch(:departements),
-    type_champs.fetch(:regions),
-    type_champs.fetch(:pays),
-    type_champs.fetch(:epci),
-    type_champs.fetch(:address),
-  ]
 
   store_accessor :options,
                  :cadastres,
@@ -550,7 +541,7 @@ class TypeDeChamp < ApplicationRecord
   def refresh_after_update? = true
 
   def simple_routable?
-    type_champ.in?(SIMPLE_ROUTABLE_TYPES) && !drop_down_advanced?
+    self.class.simple_routable? && !drop_down_advanced?
   end
 
   def conditionable?
@@ -564,13 +555,13 @@ class TypeDeChamp < ApplicationRecord
 
   def self.humanized_simple_routable_types_by_category
     Logic::ChampValue::MANAGED_TYPE_DE_CHAMP_BY_CATEGORY
-      .map { |_, v| v.filter_map { "« #{I18n.t(_1, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])} »" if _1.to_s.in?(SIMPLE_ROUTABLE_TYPES) } }
+      .map { |_, v| v.filter_map { "« #{I18n.t(_1, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])} »" if find_sti_class(_1).simple_routable? } }
       .reject(&:empty?)
   end
 
   def self.humanized_custom_routable_types_by_category
     Logic::ChampValue::MANAGED_TYPE_DE_CHAMP_BY_CATEGORY
-      .map { |_, v| v.filter_map { "« #{I18n.t(_1, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])} »" if !_1.to_s.in?(SIMPLE_ROUTABLE_TYPES) } }
+      .map { |_, v| v.filter_map { "« #{I18n.t(_1, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])} »" if !find_sti_class(_1).simple_routable? } }
       .reject(&:empty?)
   end
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -183,16 +183,11 @@ class TypeDeChamp < ApplicationRecord
 
   before_validation :check_mandatory
   before_validation :set_default_libelle, if: -> { type_champ_changed? }
-  before_validation :set_drop_down_list_options, if: -> { type_champ_changed? }
-  before_validation :reset_pj_format_options_if_forced_nature
-  before_validation :reset_repetition_limits_if_disabled
 
   normalizes :libelle, with: -> (value) { value.strip }
 
   before_save :remove_attachment, if: -> { type_champ_changed? }
   before_save :clean_referentiel
-  before_save :clear_conflicting_date_options, if: :birthdate?
-  before_save :clear_prefill_with_france_connect_information_if_not_birthdate
 
   def libelle_with_parent(revision)
     if child?(revision)
@@ -895,17 +890,6 @@ class TypeDeChamp < ApplicationRecord
     ]
   end
 
-  def clear_conflicting_date_options
-    self.date_in_past = nil
-    self.range_date = nil
-    self.start_date = nil
-    self.end_date = nil
-  end
-
-  def clear_prefill_with_france_connect_information_if_not_birthdate
-    self.prefill_with_france_connect_information = nil if !birthdate?
-  end
-
   def families_to_content_types(families)
     return AUTHORIZED_CONTENT_TYPES if families.blank?
 
@@ -935,28 +919,6 @@ class TypeDeChamp < ApplicationRecord
   def clean_referentiel
     return if !persisted? || !type_champ_changed? || !referentiel_id?
     self.referentiel_id = nil
-  end
-
-  def set_drop_down_list_options
-    if (drop_down_list? || multiple_drop_down_list?) && drop_down_options.empty?
-      self.drop_down_options = ['Fromage', 'Dessert']
-    elsif linked_drop_down_list? && drop_down_options.none?(/^--.*--$/)
-      self.drop_down_options = ['--Fromage--', 'bleu de sassenage', 'picodon', '--Dessert--', 'éclair', 'tarte aux pommes']
-    end
-  end
-
-  def reset_repetition_limits_if_disabled
-    return unless type_champ == TypeDeChamp.type_champs.fetch(:repetition)
-    return if limit_repetitions?
-    self.min_repetitions = nil
-    self.max_repetitions = nil
-  end
-
-  def reset_pj_format_options_if_forced_nature
-    if titre_identite? || rib?
-      self.pj_limit_formats = nil
-      self.pj_format_families = []
-    end
   end
 
   def normalize_drop_down_options(options)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -35,6 +35,8 @@ class TypeDeChamp < ApplicationRecord
 
   def self.category = STANDARD
   def self.feature_flag = nil
+  def self.private_only? = false
+  def self.public_only? = false
 
   def self.category_for(type_champ)
     find_sti_class(type_champ).category
@@ -97,10 +99,6 @@ class TypeDeChamp < ApplicationRecord
     type_champs.fetch(:address),
   ]
 
-  PRIVATE_ONLY_TYPES = [
-    type_champs.fetch(:engagement_juridique),
-  ]
-
   API_PART_FC_TDC = [
     type_champs.fetch(:quotient_familial),
     type_champs.fetch(:etudiant_boursier),
@@ -108,8 +106,6 @@ class TypeDeChamp < ApplicationRecord
     type_champs.fetch(:aeeh),
     type_champs.fetch(:ars),
   ]
-
-  PUBLIC_ONLY_TYPES = API_PART_FC_TDC
 
   store_accessor :options,
                  :cadastres,

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -799,7 +799,7 @@ class TypeDeChamp < ApplicationRecord
     [canonical_column(procedure_id:, displayable:, prefix:)].compact
   end
 
-  def personnalisation_column(procedure_id:)
+  def customization_column(procedure_id:)
     columns(procedure_id:).find(&:displayable)
   end
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -7,13 +7,6 @@ class TypeDeChamp < ApplicationRecord
 
   FILE_MAX_SIZE = 200.megabytes
   IDENTITY_FILE_MAX_SIZE = 20.megabytes
-  PERSONNALISABLE_TYPE_CHAMPS = %w[
-    text integer_number decimal_number formatted date datetime
-    dossier_link drop_down_list multiple_drop_down_list linked_drop_down_list
-    civilite email phone siret rna rnf annuaire_education iban
-    address communes departements regions pays epci
-  ].freeze
-
   MINIMUM_TEXTAREA_CHARACTER_LIMIT_LENGTH = 400
 
   FILL_DURATION_SHORT  = 10.seconds
@@ -236,6 +229,7 @@ class TypeDeChamp < ApplicationRecord
   def libelle_configurable? = true
   def description_configurable? = true
   def has_label? = true
+  def customizable? = false
 
   def safe_referentiel_mapping
     Hash(referentiel_mapping).with_indifferent_access

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -37,6 +37,7 @@ class TypeDeChamp < ApplicationRecord
   def self.feature_flag = nil
   def self.private_only? = false
   def self.public_only? = false
+  def self.allowed_in_repetition? = true
 
   def self.category_for(type_champ)
     find_sti_class(type_champ).category
@@ -97,14 +98,6 @@ class TypeDeChamp < ApplicationRecord
     type_champs.fetch(:pays),
     type_champs.fetch(:epci),
     type_champs.fetch(:address),
-  ]
-
-  API_PART_FC_TDC = [
-    type_champs.fetch(:quotient_familial),
-    type_champs.fetch(:etudiant_boursier),
-    type_champs.fetch(:aah),
-    type_champs.fetch(:aeeh),
-    type_champs.fetch(:ars),
   ]
 
   store_accessor :options,
@@ -240,6 +233,9 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def libelle_optionnal? = false
+  def libelle_configurable? = true
+  def description_configurable? = true
+  def has_label? = true
 
   def safe_referentiel_mapping
     Hash(referentiel_mapping).with_indifferent_access

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -7,12 +7,6 @@ class TypeDeChamp < ApplicationRecord
 
   FILE_MAX_SIZE = 200.megabytes
   IDENTITY_FILE_MAX_SIZE = 20.megabytes
-  FEATURE_FLAGS = {
-    engagement_juridique: :engagement_juridique_type_de_champ,
-    cojo: :cojo_type_de_champ,
-    pre_rempli: :pre_rempli_type_de_champ,
-  }
-
   PERSONNALISABLE_TYPE_CHAMPS = %w[
     text integer_number decimal_number formatted date datetime
     dossier_link drop_down_list multiple_drop_down_list linked_drop_down_list
@@ -40,6 +34,7 @@ class TypeDeChamp < ApplicationRecord
   CATEGORIES = [STRUCTURE, ETAT_CIVIL, LOCALISATION, PAIEMENT_IDENTIFICATION, STANDARD, PIECES_JOINTES, CHOICE, REFERENTIEL_EXTERNE, FRANCE_CONNECT]
 
   def self.category = STANDARD
+  def self.feature_flag = nil
 
   def self.category_for(type_champ)
     find_sti_class(type_champ).category

--- a/app/models/types_de_champ/address_type_de_champ.rb
+++ b/app/models/types_de_champ/address_type_de_champ.rb
@@ -2,6 +2,7 @@
 
 class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.category = LOCALISATION
+  def self.simple_routable? = true
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/civilite_type_de_champ.rb
+++ b/app/models/types_de_champ/civilite_type_de_champ.rb
@@ -6,4 +6,5 @@ class TypesDeChamp::CiviliteTypeDeChamp < TypeDeChamp
 
   def prefillable? = true
   def options_for_select = Champs::CiviliteChamp.options
+  def customizable? = true
 end

--- a/app/models/types_de_champ/cojo_type_de_champ.rb
+++ b/app/models/types_de_champ/cojo_type_de_champ.rb
@@ -5,6 +5,7 @@ class TypesDeChamp::COJOTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.feature_flag = :cojo_type_de_champ
 
   def prefillable? = false
+  def customizable? = false
 
   def typed_champ_value(champ)
     "#{champ.accreditation_number} – #{champ.accreditation_birthdate}"

--- a/app/models/types_de_champ/cojo_type_de_champ.rb
+++ b/app/models/types_de_champ/cojo_type_de_champ.rb
@@ -2,6 +2,7 @@
 
 class TypesDeChamp::COJOTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.category = REFERENTIEL_EXTERNE
+  def self.feature_flag = :cojo_type_de_champ
 
   def prefillable? = false
 

--- a/app/models/types_de_champ/commune_type_de_champ.rb
+++ b/app/models/types_de_champ/commune_type_de_champ.rb
@@ -40,7 +40,7 @@ class TypesDeChamp::CommuneTypeDeChamp < TypeDeChamp
       .concat(legacy_columns(procedure_id:, prefix:))
   end
 
-  def personnalisation_column(procedure_id:)
+  def customization_column(procedure_id:)
     addressable_columns(procedure_id:, only: [:city_name]).first
   end
 

--- a/app/models/types_de_champ/commune_type_de_champ.rb
+++ b/app/models/types_de_champ/commune_type_de_champ.rb
@@ -2,6 +2,7 @@
 
 class TypesDeChamp::CommuneTypeDeChamp < TypeDeChamp
   def self.category = LOCALISATION
+  def self.simple_routable? = true
 
   def prefillable? = true
   def customizable? = true

--- a/app/models/types_de_champ/commune_type_de_champ.rb
+++ b/app/models/types_de_champ/commune_type_de_champ.rb
@@ -4,6 +4,7 @@ class TypesDeChamp::CommuneTypeDeChamp < TypeDeChamp
   def self.category = LOCALISATION
 
   def prefillable? = true
+  def customizable? = true
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/date_type_de_champ.rb
+++ b/app/models/types_de_champ/date_type_de_champ.rb
@@ -5,6 +5,7 @@ class TypesDeChamp::DateTypeDeChamp < TypeDeChamp
   def self.column_type = :date
 
   def prefillable? = true
+  def customizable? = true
 
   def typed_champ_value(champ)
     I18n.l(Time.zone.parse(champ.value).to_date, format: :long)

--- a/app/models/types_de_champ/date_type_de_champ.rb
+++ b/app/models/types_de_champ/date_type_de_champ.rb
@@ -7,9 +7,25 @@ class TypesDeChamp::DateTypeDeChamp < TypeDeChamp
   def prefillable? = true
   def customizable? = true
 
+  before_save :clear_conflicting_options, if: :birthdate?
+  before_save :clear_prefill_with_france_connect_information, if: -> { !birthdate? }
+
   def typed_champ_value(champ)
     I18n.l(Time.zone.parse(champ.value).to_date, format: :long)
   rescue ArgumentError
     champ.value.presence || "" # old dossiers can have not parseable dates
+  end
+
+  private
+
+  def clear_conflicting_options
+    self.date_in_past = nil
+    self.range_date = nil
+    self.start_date = nil
+    self.end_date = nil
+  end
+
+  def clear_prefill_with_france_connect_information
+    self.prefill_with_france_connect_information = nil
   end
 end

--- a/app/models/types_de_champ/datetime_type_de_champ.rb
+++ b/app/models/types_de_champ/datetime_type_de_champ.rb
@@ -5,6 +5,7 @@ class TypesDeChamp::DatetimeTypeDeChamp < TypeDeChamp
   def self.column_type = :datetime
 
   def prefillable? = true
+  def customizable? = true
 
   def typed_champ_value(champ)
     I18n.l(Time.zone.parse(champ.value))

--- a/app/models/types_de_champ/decimal_number_type_de_champ.rb
+++ b/app/models/types_de_champ/decimal_number_type_de_champ.rb
@@ -5,6 +5,7 @@ class TypesDeChamp::DecimalNumberTypeDeChamp < TypeDeChamp
   def self.column_type = :decimal
 
   def prefillable? = true
+  def customizable? = true
 
   def typed_champ_value_for_export(champ, path = :value)
     champ_formatted_value(champ)

--- a/app/models/types_de_champ/departement_type_de_champ.rb
+++ b/app/models/types_de_champ/departement_type_de_champ.rb
@@ -3,6 +3,7 @@
 class TypesDeChamp::DepartementTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.category = LOCALISATION
   def self.column_type = :enum
+  def self.simple_routable? = true
 
   def options_for_select = APIGeoService.departement_options
 

--- a/app/models/types_de_champ/dossier_link_type_de_champ.rb
+++ b/app/models/types_de_champ/dossier_link_type_de_champ.rb
@@ -5,4 +5,5 @@ class TypesDeChamp::DossierLinkTypeDeChamp < TypeDeChamp
   def self.editable_option_keys = [:procedures_limit, :dossier_link_procedure_ids]
 
   def prefillable? = true
+  def customizable? = true
 end

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -12,6 +12,8 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypeDeChamp
   def any_drop_down_list? = true
   def customizable? = true
 
+  before_validation :set_default_drop_down_options, if: :type_champ_changed?
+
   def typed_champ_value(champ)
     if drop_down_advanced? && champ.respond_to?(:referentiel) && champ.referentiel.present?
       path = champ.referentiel_headers&.first&.second
@@ -81,6 +83,14 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypeDeChamp
       end
     else
       super
+    end
+  end
+
+  private
+
+  def set_default_drop_down_options
+    if drop_down_options.empty?
+      self.drop_down_options = ['Fromage', 'Dessert']
     end
   end
 end

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -9,6 +9,7 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypeDeChamp
   def options_for_select = options_for_select_with_other
   def choice_type? = true
   def any_drop_down_list? = true
+  def customizable? = true
 
   def typed_champ_value(champ)
     if drop_down_advanced? && champ.respond_to?(:referentiel) && champ.referentiel.present?

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -4,6 +4,7 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypeDeChamp
   def self.category = CHOICE
   def self.editable_option_keys = [:drop_down_other, :drop_down_options, :drop_down_mode]
   def self.column_type = :enum
+  def self.simple_routable? = true
 
   def prefillable? = true
   def options_for_select = options_for_select_with_other

--- a/app/models/types_de_champ/engagement_juridique_type_de_champ.rb
+++ b/app/models/types_de_champ/engagement_juridique_type_de_champ.rb
@@ -3,4 +3,5 @@
 class TypesDeChamp::EngagementJuridiqueTypeDeChamp < TypeDeChamp
   def self.category = REFERENTIEL_EXTERNE
   def self.feature_flag = :engagement_juridique_type_de_champ
+  def self.private_only? = true
 end

--- a/app/models/types_de_champ/engagement_juridique_type_de_champ.rb
+++ b/app/models/types_de_champ/engagement_juridique_type_de_champ.rb
@@ -2,4 +2,5 @@
 
 class TypesDeChamp::EngagementJuridiqueTypeDeChamp < TypeDeChamp
   def self.category = REFERENTIEL_EXTERNE
+  def self.feature_flag = :engagement_juridique_type_de_champ
 end

--- a/app/models/types_de_champ/epci_type_de_champ.rb
+++ b/app/models/types_de_champ/epci_type_de_champ.rb
@@ -2,6 +2,7 @@
 
 class TypesDeChamp::EpciTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.category = LOCALISATION
+  def self.simple_routable? = true
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/explication_type_de_champ.rb
+++ b/app/models/types_de_champ/explication_type_de_champ.rb
@@ -9,4 +9,5 @@ class TypesDeChamp::ExplicationTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def libelle_optionnal? = true
   def has_label? = false
   def tags_for_template = [].freeze
+  def customizable? = false
 end

--- a/app/models/types_de_champ/explication_type_de_champ.rb
+++ b/app/models/types_de_champ/explication_type_de_champ.rb
@@ -7,5 +7,6 @@ class TypesDeChamp::ExplicationTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def prefillable? = false
   def fillable? = false
   def libelle_optionnal? = true
+  def has_label? = false
   def tags_for_template = [].freeze
 end

--- a/app/models/types_de_champ/formatted_type_de_champ.rb
+++ b/app/models/types_de_champ/formatted_type_de_champ.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::FormattedTypeDeChamp < TypeDeChamp
+  def customizable? = true
+
   after_initialize :set_default_options
 
   def prefillable? = true

--- a/app/models/types_de_champ/france_connect_type_de_champ.rb
+++ b/app/models/types_de_champ/france_connect_type_de_champ.rb
@@ -2,6 +2,7 @@
 
 class TypesDeChamp::FranceConnectTypeDeChamp < TypeDeChamp
   def self.category = FRANCE_CONNECT
+  def self.public_only? = true
 
   def france_connect? = true
   def api_particulier? = true

--- a/app/models/types_de_champ/france_connect_type_de_champ.rb
+++ b/app/models/types_de_champ/france_connect_type_de_champ.rb
@@ -3,10 +3,14 @@
 class TypesDeChamp::FranceConnectTypeDeChamp < TypeDeChamp
   def self.category = FRANCE_CONNECT
   def self.public_only? = true
+  def self.allowed_in_repetition? = false
 
   def france_connect? = true
   def api_particulier? = true
   def must_be_mandatory? = true
+  def libelle_configurable? = false
+  def description_configurable? = false
+  def has_label? = false
 
   REGISTRY = {
     quotient_familial: {

--- a/app/models/types_de_champ/header_section_type_de_champ.rb
+++ b/app/models/types_de_champ/header_section_type_de_champ.rb
@@ -5,5 +5,7 @@ class TypesDeChamp::HeaderSectionTypeDeChamp < TypeDeChamp
   def self.editable_option_keys = [:header_section_level]
 
   def fillable? = false
+  def description_configurable? = false
+  def has_label? = false
   def tags_for_template = [].freeze
 end

--- a/app/models/types_de_champ/iban_type_de_champ.rb
+++ b/app/models/types_de_champ/iban_type_de_champ.rb
@@ -4,6 +4,7 @@ class TypesDeChamp::IbanTypeDeChamp < TypeDeChamp
   def self.category = PAIEMENT_IDENTIFICATION
 
   def prefillable? = true
+  def customizable? = true
 
   def estimated_fill_duration(revision)
     FILL_DURATION_MEDIUM

--- a/app/models/types_de_champ/integer_number_type_de_champ.rb
+++ b/app/models/types_de_champ/integer_number_type_de_champ.rb
@@ -5,6 +5,7 @@ class TypesDeChamp::IntegerNumberTypeDeChamp < TypeDeChamp
   def self.column_type = :integer
 
   def prefillable? = true
+  def customizable? = true
 
   def typed_champ_value_for_export(champ, path = :value)
     champ_formatted_value(champ)

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -9,6 +9,8 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypeDeChamp
   def has_label? = false
   def customizable? = true
 
+  before_validation :set_default_drop_down_options, if: :type_champ_changed?
+
   PRIMARY_PATTERN = /^--(.*)--$/
 
   validate :check_presence_of_primary_options
@@ -161,6 +163,12 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypeDeChamp
   def check_presence_of_primary_options
     if !PRIMARY_PATTERN.match?(drop_down_options.first)
       errors.add(libelle.presence || "La liste", "doit commencer par une entrée de menu primaire de la forme <code style='white-space: pre-wrap;'>--texte--</code>")
+    end
+  end
+
+  def set_default_drop_down_options
+    if drop_down_options.none?(PRIMARY_PATTERN)
+      self.drop_down_options = ['--Fromage--', 'bleu de sassenage', 'picodon', '--Dessert--', 'éclair', 'tarte aux pommes']
     end
   end
 end

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -6,6 +6,7 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypeDeChamp
 
   def options_for_select = options_for_select_with_other
   def any_drop_down_list? = true
+  def has_label? = false
 
   PRIMARY_PATTERN = /^--(.*)--$/
 

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -7,6 +7,7 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypeDeChamp
   def options_for_select = options_for_select_with_other
   def any_drop_down_list? = true
   def has_label? = false
+  def customizable? = true
 
   PRIMARY_PATTERN = /^--(.*)--$/
 

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -11,6 +11,8 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypeDeChamp
   def any_drop_down_list? = true
   def customizable? = true
 
+  before_validation :set_default_drop_down_options, if: :type_champ_changed?
+
   def typed_champ_value(champ)
     if drop_down_advanced? && champ.respond_to?(:referentiels) && champ.referentiels.present?
       champ.referentiels_items_user_values.join(', ')
@@ -65,5 +67,11 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypeDeChamp
 
   def selected_options(champ)
     self.class.parse_selected_options(champ)
+  end
+
+  def set_default_drop_down_options
+    if drop_down_options.empty?
+      self.drop_down_options = ['Fromage', 'Dessert']
+    end
   end
 end

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -9,6 +9,7 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypeDeChamp
   def options_for_select = options_for_select_with_other
   def choice_type? = true
   def any_drop_down_list? = true
+  def customizable? = true
 
   def typed_champ_value(champ)
     if drop_down_advanced? && champ.respond_to?(:referentiels) && champ.referentiels.present?

--- a/app/models/types_de_champ/pays_type_de_champ.rb
+++ b/app/models/types_de_champ/pays_type_de_champ.rb
@@ -3,6 +3,7 @@
 class TypesDeChamp::PaysTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.category = LOCALISATION
   def self.column_type = :enum
+  def self.simple_routable? = true
 
   def options_for_select = APIGeoService.country_options
 

--- a/app/models/types_de_champ/piece_justificative_type_de_champ.rb
+++ b/app/models/types_de_champ/piece_justificative_type_de_champ.rb
@@ -4,6 +4,8 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypeDeChamp
   def self.editable_option_keys = [:old_pj, :skip_pj_validation, :skip_content_type_pj_validation, :pj_limit_formats, :pj_format_families, :pj_auto_purge]
   def self.column_type = :attachments
 
+  before_validation :reset_format_options_if_forced_nature
+
   include AddressableColumnConcern
 
   def estimated_fill_duration(revision)
@@ -150,5 +152,14 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypeDeChamp
     end
 
     cs
+  end
+
+  private
+
+  def reset_format_options_if_forced_nature
+    if titre_identite? || rib?
+      self.pj_limit_formats = nil
+      self.pj_format_families = []
+    end
   end
 end

--- a/app/models/types_de_champ/pre_rempli_type_de_champ.rb
+++ b/app/models/types_de_champ/pre_rempli_type_de_champ.rb
@@ -3,6 +3,7 @@
 class TypesDeChamp::PreRempliTypeDeChamp < TypeDeChamp
   def self.category = REFERENTIEL_EXTERNE
   def self.editable_option_keys = [:drop_down_options, :pre_rempli_hidden]
+  def self.feature_flag = :pre_rempli_type_de_champ
 
   def prefillable? = true
   def options_for_select = Array.wrap(drop_down_options).uniq.map { [_1, _1] }

--- a/app/models/types_de_champ/region_type_de_champ.rb
+++ b/app/models/types_de_champ/region_type_de_champ.rb
@@ -3,6 +3,7 @@
 class TypesDeChamp::RegionTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.category = LOCALISATION
   def self.column_type = :enum
+  def self.simple_routable? = true
 
   def options_for_select = APIGeoService.region_options
 

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -3,8 +3,10 @@
 class TypesDeChamp::RepetitionTypeDeChamp < TypeDeChamp
   def self.category = STRUCTURE
   def self.editable_option_keys = [:limit_repetitions, :min_repetitions, :max_repetitions]
+  def self.allowed_in_repetition? = false
 
   def prefillable? = true
+  def has_label? = false
 
   def typed_champ_value_for_tag(champ, path = :value)
     return nil if path != :value

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -8,6 +8,8 @@ class TypesDeChamp::RepetitionTypeDeChamp < TypeDeChamp
   def prefillable? = true
   def has_label? = false
 
+  before_validation :reset_limits_if_disabled
+
   def typed_champ_value_for_tag(champ, path = :value)
     return nil if path != :value
     ChampPresentations::RepetitionPresentation.new(libelle, champ.dossier.project_rows_for(self))
@@ -45,4 +47,13 @@ class TypesDeChamp::RepetitionTypeDeChamp < TypeDeChamp
   end
 
   def typed_champ_blank?(champ) = champ.dossier.repetition_row_ids(self).blank?
+
+  private
+
+  def reset_limits_if_disabled
+    return if limit_repetitions?
+
+    self.min_repetitions = nil
+    self.max_repetitions = nil
+  end
 end

--- a/app/models/types_de_champ/rna_type_de_champ.rb
+++ b/app/models/types_de_champ/rna_type_de_champ.rb
@@ -3,6 +3,8 @@
 class TypesDeChamp::RNATypeDeChamp < TypeDeChamp
   def self.category = REFERENTIEL_EXTERNE
 
+  def customizable? = true
+
   include AddressableColumnConcern
 
   def estimated_fill_duration(revision)

--- a/app/models/types_de_champ/siret_type_de_champ.rb
+++ b/app/models/types_de_champ/siret_type_de_champ.rb
@@ -4,6 +4,7 @@ class TypesDeChamp::SiretTypeDeChamp < TypeDeChamp
   def self.category = PAIEMENT_IDENTIFICATION
 
   def prefillable? = true
+  def customizable? = true
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/text_type_de_champ.rb
+++ b/app/models/types_de_champ/text_type_de_champ.rb
@@ -2,6 +2,7 @@
 
 class TypesDeChamp::TextTypeDeChamp < TypeDeChamp
   def prefillable? = true
+  def customizable? = true
 
   def typed_champ_value_for_export(champ, path = :value)
     Sanitizers::Xml.sanitize(champ_text_value(champ))

--- a/app/models/types_de_champ/textarea_type_de_champ.rb
+++ b/app/models/types_de_champ/textarea_type_de_champ.rb
@@ -3,6 +3,8 @@
 class TypesDeChamp::TextareaTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.editable_option_keys = [:character_limit]
 
+  def customizable? = false
+
   def estimated_fill_duration(revision)
     FILL_DURATION_MEDIUM
   end

--- a/spec/components/types_de_champ_editor/champ_component_spec.rb
+++ b/spec/components/types_de_champ_editor/champ_component_spec.rb
@@ -20,6 +20,16 @@ describe TypesDeChampEditor::ChampComponent, type: :component do
       let(:tdc) { procedure.draft_revision.types_de_champ.first }
       let(:coordinate) { procedure.draft_revision.coordinate_for(tdc) }
 
+      context 'type behind a disabled feature flag' do
+        it { expect(page).not_to have_css('option[value="cojo"]') }
+      end
+
+      context 'type behind an enabled feature flag' do
+        let(:procedure) { create(:procedure, types_de_champ_public:).tap { Flipper.enable(:cojo_type_de_champ, _1) } }
+
+        it { expect(page).to have_css('option[value="cojo"]') }
+      end
+
       context 'drop down tdc not used for routing' do
         it do
           expect(page).not_to have_text(/utilisé pour\nle routage/)

--- a/spec/components/users/dossier_card_champs_component_spec.rb
+++ b/spec/components/users/dossier_card_champs_component_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Users::DossierCardChampsComponent, type: :component do
   let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :text, libelle: 'Titre' }]) }
   let(:dossier) { create(:dossier, :en_construction, procedure:, populate_champs: true) }
-  let(:column) { procedure.personnalisable_columns.first }
+  let(:column) { procedure.customizable_columns.first }
 
   it 'renders the formatted value with an info icon when the champ has a value' do
     champ = dossier.champs.find { _1.stable_id == column.stable_id }

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -3082,7 +3082,7 @@ describe Users::DossiersController, type: :controller do
   describe 'PATCH #update_personnalisation' do
     let(:user) { create(:user) }
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :text, libelle: 'Ville' }]) }
-    let(:column) { procedure.personnalisable_columns.first }
+    let(:column) { procedure.customizable_columns.first }
 
     before do
       Flipper.enable(:dossiers_list_personnalisation, user)
@@ -3104,7 +3104,7 @@ describe Users::DossiersController, type: :controller do
       invited_procedure = create(:procedure, :published, types_de_champ_public: [{ type: :text, libelle: 'Région' }])
       invited_dossier = create(:dossier, :en_construction, procedure: invited_procedure)
       create(:invite, dossier: invited_dossier, user:)
-      invited_column = invited_procedure.personnalisable_columns.first
+      invited_column = invited_procedure.customizable_columns.first
 
       patch :update_personnalisation, params: {
         personnalisations: { invited_procedure.id.to_s => { displayed_columns: [invited_column.id] } },
@@ -3185,7 +3185,7 @@ describe Users::DossiersController, type: :controller do
 
     let(:user) { create(:user) }
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :text, libelle: 'Titre' }]) }
-    let(:column) { procedure.personnalisable_columns.first }
+    let(:column) { procedure.customizable_columns.first }
 
     before do
       Flipper.enable(:dossiers_list_personnalisation, user)
@@ -3218,8 +3218,8 @@ describe Users::DossiersController, type: :controller do
 
     before do
       Flipper.enable(:dossiers_list_personnalisation, user)
-      create(:dossiers_list_personnalisation, user:, procedure: procedure1, displayed_columns: [procedure1.personnalisable_columns.first])
-      create(:dossiers_list_personnalisation, user:, procedure: procedure2, displayed_columns: [procedure2.personnalisable_columns.first])
+      create(:dossiers_list_personnalisation, user:, procedure: procedure1, displayed_columns: [procedure1.customizable_columns.first])
+      create(:dossiers_list_personnalisation, user:, procedure: procedure2, displayed_columns: [procedure2.customizable_columns.first])
       sign_in(user)
     end
 
@@ -3253,7 +3253,7 @@ describe Users::DossiersController, type: :controller do
 
     def add_personnalised_procedure(libelle)
       procedure = create(:procedure, :published, types_de_champ_public: [{ type: :text, libelle: }])
-      create(:dossiers_list_personnalisation, user:, procedure:, displayed_columns: [procedure.personnalisable_columns.first])
+      create(:dossiers_list_personnalisation, user:, procedure:, displayed_columns: [procedure.customizable_columns.first])
       create_list(:dossier, 3, :en_construction, user:, procedure:, populate_champs: true)
     end
 
@@ -3291,7 +3291,7 @@ describe Users::DossiersController, type: :controller do
 
     context 'when a persisted column can no longer be resolved' do
       before do
-        pays_column = procedure.personnalisable_columns.find { _1.label == 'Pays' }
+        pays_column = procedure.customizable_columns.find { _1.label == 'Pays' }
         draft_only_tdc = procedure.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'Futur champ')
         draft_only_column = draft_only_tdc.canonical_column(procedure_id: procedure.id)
         create(:dossiers_list_personnalisation, user:, procedure:, displayed_columns: [draft_only_column, pays_column])
@@ -3316,7 +3316,7 @@ describe Users::DossiersController, type: :controller do
 
     context 'when the personnalised champ is removed in a later published revision' do
       before do
-        ville_column = procedure.personnalisable_columns.find { _1.label == 'Ville' }
+        ville_column = procedure.customizable_columns.find { _1.label == 'Ville' }
         create(:dossiers_list_personnalisation, user:, procedure:, displayed_columns: [ville_column])
         dossiers = create_list(:dossier, 6, :en_construction, user:, procedure:, populate_champs: true)
         dossiers.first.champs.find { _1.stable_id == ville_column.stable_id }.update(value: 'Nantes')

--- a/spec/models/dossiers_list_personnalisation_spec.rb
+++ b/spec/models/dossiers_list_personnalisation_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe DossiersListPersonnalisation, type: :model do
   describe 'stale displayed_columns' do
     it 'ignores a column that can no longer be resolved and keeps the others' do
       procedure = create(:procedure, :published, types_de_champ_public: [{ type: :text, libelle: 'Pays' }])
-      pays_column = procedure.personnalisable_columns.find { _1.label == 'Pays' }
+      pays_column = procedure.customizable_columns.find { _1.label == 'Pays' }
       draft_only_tdc = procedure.draft_revision.add_type_de_champ(type_champ: :text, libelle: 'Ville')
       draft_only_column = draft_only_tdc.canonical_column(procedure_id: procedure.id)
       personnalisation = create(:dossiers_list_personnalisation, procedure:, displayed_columns: [draft_only_column, pays_column])
@@ -52,7 +52,7 @@ RSpec.describe DossiersListPersonnalisation, type: :model do
 
     it 'keeps a column whose champ was removed in a later published revision' do
       procedure = create(:procedure, :published, types_de_champ_public: [{ type: :text, libelle: 'Ville' }, { type: :text, libelle: 'Pays' }])
-      ville_column = procedure.personnalisable_columns.find { _1.label == 'Ville' }
+      ville_column = procedure.customizable_columns.find { _1.label == 'Ville' }
       personnalisation = create(:dossiers_list_personnalisation, procedure:, displayed_columns: [ville_column])
 
       procedure.draft_revision.remove_type_de_champ(ville_column.stable_id)

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -2261,7 +2261,7 @@ describe Procedure do
     end
   end
 
-  describe '#personnalisable_columns' do
+  describe '#customizable_columns' do
     include Logic
 
     let(:procedure) do
@@ -2280,27 +2280,27 @@ describe Procedure do
     end
 
     it 'includes proposable public champ types' do
-      expect(procedure.personnalisable_columns.map(&:label)).to include('Ville', 'Date arrivée')
+      expect(procedure.customizable_columns.map(&:label)).to include('Ville', 'Date arrivée')
     end
 
     it 'excludes non-proposable types (textarea, piece_justificative, yes_no, header_section)' do
-      labels = procedure.personnalisable_columns.map(&:label)
+      labels = procedure.customizable_columns.map(&:label)
       expect(labels).not_to include('Description', 'Justificatif', 'Accord', 'Section A')
     end
 
     it 'excludes private annotations' do
-      expect(procedure.personnalisable_columns.map(&:label)).not_to include('Note interne')
+      expect(procedure.customizable_columns.map(&:label)).not_to include('Note interne')
     end
 
     it 'returns Columns::ChampColumn instances carrying mandatory flag' do
-      expect(procedure.personnalisable_columns).to all(be_a(Columns::ChampColumn))
-      ville_column = procedure.personnalisable_columns.find { _1.label == 'Ville' }
+      expect(procedure.customizable_columns).to all(be_a(Columns::ChampColumn))
+      ville_column = procedure.customizable_columns.find { _1.label == 'Ville' }
       expect(ville_column.mandatory).to eq(true)
     end
 
     it 'returns a single entry for a multi-column champ like address' do
       procedure = create(:procedure, :published, types_de_champ_public: [{ type: :address, libelle: 'Domicile' }])
-      columns = procedure.personnalisable_columns.filter { _1.label.include?('Domicile') }
+      columns = procedure.customizable_columns.filter { _1.label.include?('Domicile') }
       expect(columns.size).to eq(1)
       expect(columns.first.tdc_type).to eq('address')
     end
@@ -2309,13 +2309,13 @@ describe Procedure do
       procedure = create(:procedure, :published, types_de_champ_public: [{ type: :communes, libelle: 'Ville de naissance' }])
       dossier = create(:dossier, :with_populated_champs, procedure:)
 
-      column = procedure.personnalisable_columns.sole
+      column = procedure.customizable_columns.sole
       expect(column.label).to eq('Ville de naissance – Commune')
       expect(column.value(dossier.champs.first)).to eq('Coye-la-Forêt')
     end
 
     it 'offers the canonical column for a single-column champ' do
-      ville_column = procedure.personnalisable_columns.find { _1.label == 'Ville' }
+      ville_column = procedure.customizable_columns.find { _1.label == 'Ville' }
       expect(ville_column.h_id[:column_id]).to eq("type_de_champ/#{ville_column.stable_id}")
     end
 
@@ -2326,7 +2326,7 @@ describe Procedure do
         { type: :text, libelle: 'Conditionné', condition: ds_eq(champ_value(1), constant(true)) },
       ])
 
-      expect(procedure.personnalisable_columns.map(&:label)).to eq(['Toujours visible'])
+      expect(procedure.customizable_columns.map(&:label)).to eq(['Toujours visible'])
     end
 
     it 'excludes a champ conditioned in the published revision even if unconditioned in an older revision' do
@@ -2339,7 +2339,7 @@ describe Procedure do
       procedure.publish_revision!(procedure.administrateurs.first)
       procedure.reload
 
-      expect(procedure.personnalisable_columns.map(&:label)).not_to include('Cible')
+      expect(procedure.customizable_columns.map(&:label)).not_to include('Cible')
     end
 
     it 'excludes a champ removed from the published revision even if present in an older revision' do
@@ -2351,11 +2351,11 @@ describe Procedure do
       procedure.publish_revision!(procedure.administrateurs.first)
       procedure.reload
 
-      expect(procedure.personnalisable_columns.map(&:label)).to eq(['Conservé'])
+      expect(procedure.customizable_columns.map(&:label)).to eq(['Conservé'])
     end
   end
 
-  describe '#personnalisable_columns_by_section' do
+  describe '#customizable_columns_by_section' do
     include Logic
 
     let(:procedure) do
@@ -2371,7 +2371,7 @@ describe Procedure do
     end
 
     it 'groups personnalisable columns under their preceding section, in form order' do
-      result = procedure.personnalisable_columns_by_section
+      result = procedure.customizable_columns_by_section
       labels = result.map { |_stable_id, section_label, columns| [section_label, columns.map(&:label)] }
 
       expect(labels).to eq([
@@ -2389,7 +2389,7 @@ describe Procedure do
         { type: :text, libelle: 'Court' },
       ])
 
-      sections = procedure.personnalisable_columns_by_section.map { |_stable_id, label, _columns| label }
+      sections = procedure.customizable_columns_by_section.map { |_stable_id, label, _columns| label }
       expect(sections).to eq(['2. Pleine'])
     end
 
@@ -2401,7 +2401,7 @@ describe Procedure do
         { type: :text, libelle: 'Champ enfant' },
       ])
 
-      sections = procedure.personnalisable_columns_by_section.map { |_stable_id, label, _columns| label }
+      sections = procedure.customizable_columns_by_section.map { |_stable_id, label, _columns| label }
       expect(sections).to eq(['1. Parent', '1.1. Enfant'])
     end
 
@@ -2413,12 +2413,12 @@ describe Procedure do
         { type: :text, libelle: 'Fonction' },
       ])
 
-      sections = procedure.personnalisable_columns_by_section.map { |_stable_id, label, _columns| label }
+      sections = procedure.customizable_columns_by_section.map { |_stable_id, label, _columns| label }
       expect(sections).to eq(['1. Identité', 'Représentant légal'])
     end
 
     it 'returns the section header stable_id as a stable key' do
-      stable_ids = procedure.personnalisable_columns_by_section.map(&:first)
+      stable_ids = procedure.customizable_columns_by_section.map(&:first)
       header_stable_ids = procedure.published_revision.root_types_de_champ_public.filter(&:header_section?).map(&:stable_id)
 
       expect(stable_ids).to eq([nil, *header_stable_ids])
@@ -2436,7 +2436,7 @@ describe Procedure do
           tdc_query_count += 1 if sql.include?("type_de_champs")
         },
         "sql.active_record"
-      ) { p.personnalisable_columns_by_section }
+      ) { p.customizable_columns_by_section }
 
       expect(revision_query_count).to eq(0)
       expect(tdc_query_count).to eq(0)
@@ -2449,7 +2449,7 @@ describe Procedure do
         { type: :text, libelle: 'Conditionné', condition: ds_eq(champ_value(1), constant(true)) },
       ])
 
-      labels = procedure.personnalisable_columns_by_section.flat_map { |_stable_id, _label, columns| columns.map(&:label) }
+      labels = procedure.customizable_columns_by_section.flat_map { |_stable_id, _label, columns| columns.map(&:label) }
       expect(labels).to eq(['Toujours visible'])
     end
   end

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -114,7 +114,7 @@ describe TypeDeChamp do
     end
 
     describe 'changing the type_champ from a drop_down_list' do
-      let(:tdc) { create(:type_de_champ_drop_down_list) }
+      let(:tdc) { create(:type_de_champ_drop_down_list).becomes_type(target_type_champ) }
 
       before do
         tdc.update(type_champ: target_type_champ)

--- a/spec/system/users/dossiers_personnalisation_spec.rb
+++ b/spec/system/users/dossiers_personnalisation_spec.rb
@@ -18,7 +18,7 @@ describe 'Usager personnalise la liste des dossiers', js: true do
 
   it 'shows the chosen champ values on the dossier cards' do
     perso_procedure = create(:procedure, :published, types_de_champ_public: [{ type: :text, libelle: 'Titre de la publication' }])
-    column = perso_procedure.personnalisable_columns.first
+    column = perso_procedure.customizable_columns.first
     create(:dossiers_list_personnalisation, user:, procedure: perso_procedure, displayed_columns: [column])
     dossiers = create_list(:dossier, 6, :en_construction, user:, procedure: perso_procedure, populate_champs: true)
     champ = dossiers.first.champs.find { _1.stable_id == column.stable_id }


### PR DESCRIPTION
## Quoi

Empilée sur #13663. Même recette, une propriété par commit :

- `feature_flag` (ex-`FEATURE_FLAGS`, 3 types) ;
- `private_only?` / `public_only?` (ex-`PRIVATE_ONLY_TYPES` / `PUBLIC_ONLY_TYPES`) ;
- exceptions France Connect de l'éditeur : `libelle_configurable?`, `description_configurable?`, `has_label?`, `allowed_in_repetition?` (ex-`API_PART_FC_TDC` / `EXCLUDE_FROM_BLOCK` dans les composants) ; le `case` d'affichage de `champs_rows_show` lit `FranceConnectTypeDeChamp::REGISTRY` ;
- `customizable?` (ex-`PERSONNALISABLE_TYPE_CHAMPS`, 24 types), et les méthodes de colonnes qui vont avec (`Procedure#customizable_columns`, `#customizable_columns_by_section`, `TypeDeChamp#customization_column`) — la fonctionnalité Personnalisation (`DossiersListPersonnalisation`, sa table, ses routes, le type AR `:personnalisation_column`) garde son nom ;
- `simple_routable?` (ex-`SIMPLE_ROUTABLE_TYPES`) ;
- callbacks par type (defaults drop-down, limites de répétition, formats PJ, options birthdate) descendus dans leur sous-classe ; les callbacks inter-types restent sur `TypeDeChamp`.

Après cette PR, l'éditeur de types de champ ne consulte plus aucune liste sur `TypeDeChamp` : il interroge la classe (`find_sti_class(type_champ)`) ou l'instance.

## Points pour la revue

- Chaque commit se relit seul.
- Dernier commit : les defaults drop-down sont injectés par la classe cible, donc un changement de type passe par `becomes_type` (comme l'app depuis #13662) ; la spec modèle qui faisait un `update(type_champ:)` en place a été alignée.
- Reste hors périmètre : `Logic::ChampValue::MANAGED_TYPE_DE_CHAMP` (PR suivante).

