### PR TITLE
Correctif: ETQ admin, 404 au lieu de 500 sur un champ déjà supprimé

### DIFF
--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -80,6 +80,10 @@ class ProcedureRevision < ApplicationRecord
   def find_and_ensure_exclusive_use(stable_id)
     coordinate, tdc = coordinate_and_tdc(stable_id)
 
+    # replayed request targeting a tdc no longer in this revision (deleted in
+    # another tab or by a previous request)
+    raise ActiveRecord::RecordNotFound if tdc.nil?
+
     if tdc.only_present_on_draft?
       tdc
     else

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -103,6 +103,19 @@ describe Administrateurs::TypesDeChampController, type: :controller do
       expect(morpheds).to eq([['updated', ['l1']], ['l3', ['l1', 'updated']]])
     end
 
+    context 'when the champ was already removed (replayed autosave)' do
+      let(:params) { default_params.merge(stable_id: @removed_stable_id) }
+
+      before do
+        @removed_stable_id = second_coordinate.stable_id
+        procedure.draft_revision.remove_type_de_champ(@removed_stable_id)
+      end
+
+      it 'raises RecordNotFound (rendered as 404) instead of a 500 (RAILS-JZE)' do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
     context "validate" do
       let(:params) { default_params.deep_merge(type_de_champ: { libelle: '' }) }
 

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -105,6 +105,18 @@ describe ProcedureRevision do
     end
   end
 
+  describe '#find_and_ensure_exclusive_use' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :text }]) }
+
+    it 'raises RecordNotFound when the stable_id is no longer in the revision (RAILS-JZE)' do
+      removed_stable_id = draft.root_types_de_champ_public.first.stable_id
+      draft.remove_type_de_champ(removed_stable_id)
+
+      expect { draft.find_and_ensure_exclusive_use(removed_stable_id) }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
   describe '#move_type_de_champ' do
     let(:procedure) { create(:procedure, types_de_champ_public: Array.new(4) { { type: :text } }) }
     let(:last_type_de_champ) { draft.root_types_de_champ_public.last }


### PR DESCRIPTION
L'éditeur de démarche autosauvegarde chaque champ ; une requête peut donc arriver après la suppression du champ (deux onglets ouverts — cas reproduit, requête rejouée, brouillon réinitialisé). `ProcedureRevision#find_and_ensure_exclusive_use` plantait alors en `NoMethodError` → 500.

- Lève `ActiveRecord::RecordNotFound` quand le `stable_id` n'est plus dans la révision → 404, pour tous les appelants (`TypesDeChampController`, `ReferentielsController`, `ConditionsController`).
- Sans impact visible pour l'admin (le JS de l'éditeur ignore la réponse) : supprime uniquement du bruit Sentry (156 événements depuis mars).

Fixes [RAILS-JZE](https://demarches-simplifiees.sentry.io/issues/RAILS-JZE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)