### PR TITLE
ETQ admin, je vois le libellé « RPG » dans le résumé des modifications de ma démarche. ETQ usager, je peux selectionner des parcelles issues du RPG. 

### DIFF
--- a/app/javascript/components/shared/maplibre/styles/base.ts
+++ b/app/javascript/components/shared/maplibre/styles/base.ts
@@ -137,9 +137,9 @@ const OPTIONAL_LAYERS: { label: string; id: string; layers: string[][] }[] = [
 
 // `cadastre` and `rpg` back the two parcelle layers, and nothing else. Declare
 // them only when their layer is enabled, instead of in the base style: a source
-// that never loads (the RPG pmtiles archive currently 404s) leaves the style
-// permanently "not loaded", which downgrades subsequent setStyle() calls to a
-// full reload — aborting and refetching every tile in flight.
+// that never loads leaves the style permanently "not loaded", which downgrades
+// subsequent setStyle() calls to a full reload — aborting and refetching every
+// tile in flight.
 export function buildOptionalSources(
   ids: string[]
 ): StyleSpecification['sources'] {
@@ -154,7 +154,7 @@ export function buildOptionalSources(
   if (ids.includes('rpg')) {
     sources.rpg = {
       type: 'vector',
-      url: 'pmtiles://https://object.data.gouv.fr/pmtiles/rpg_2023.pmtiles'
+      url: 'pmtiles://https://pmtiles-data.s3.rbx.io.cloud.ovh.net/rpg_2023.pmtiles'
     };
   }
 

--- a/app/models/types_de_champ/carte_type_de_champ.rb
+++ b/app/models/types_de_champ/carte_type_de_champ.rb
@@ -15,6 +15,12 @@ class TypesDeChamp::CarteTypeDeChamp < TypeDeChamp
     :rpg,
   ]
 
+  # `cadastres` and `rpg` are backed by the same map layer ids: enabling both
+  # breaks the map, so they are mutually exclusive.
+  PARCELLE_LAYERS = [:cadastres, :rpg]
+
+  before_validation :ensure_exclusive_parcelle_layer
+
   def self.category = REFERENTIEL_EXTERNE
   def self.editable_option_keys = LAYERS
   def self.column_type = :geojson
@@ -81,5 +87,23 @@ class TypesDeChamp::CarteTypeDeChamp < TypeDeChamp
 
   def columns(procedure_id:, displayable: true, prefix: nil)
     []
+  end
+
+  private
+
+  # The editor disables one parcelle checkbox as soon as the other is checked, but a
+  # stale form (or the API) can still send both: keep the layer that was just enabled
+  # and disable the other one, so the map keeps working.
+  def ensure_exclusive_parcelle_layer
+    return if PARCELLE_LAYERS.any? { !layer_enabled?(it) }
+
+    previously_enabled = PARCELLE_LAYERS.filter { layer_enabled_before_change?(it) }
+    kept = (PARCELLE_LAYERS - previously_enabled).first || PARCELLE_LAYERS.first
+
+    self.options = options.merge((PARCELLE_LAYERS - [kept]).index_with { false })
+  end
+
+  def layer_enabled_before_change?(layer)
+    options_was.present? && options_was[layer].present? && options_was[layer] != '0'
   end
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
     # It's too complicated to be fixed right now (and it wouldn't add value: this is hardcoded in views, so not subject to injections)
     policy.style_src(:self, :unsafe_inline, "client.crisp.chat", "unpkg.com", "cdn.jsdelivr.net")
 
-    connect_whitelist = ["client.crisp.chat", "wss://client.relay.crisp.chat", "storage.crisp.chat", "integration.lasuite.numerique.gouv.fr", "app.franceconnect.gouv.fr", "openmaptiles.data.gouv.fr", "openmaptiles.geo.data.gouv.fr", "openmaptiles.github.io", "tiles.geo.api.gouv.fr", "data.geopf.fr", "object.data.gouv.fr"]
+    connect_whitelist = ["client.crisp.chat", "wss://client.relay.crisp.chat", "storage.crisp.chat", "integration.lasuite.numerique.gouv.fr", "app.franceconnect.gouv.fr", "openmaptiles.data.gouv.fr", "openmaptiles.geo.data.gouv.fr", "openmaptiles.github.io", "tiles.geo.api.gouv.fr", "data.geopf.fr", "pmtiles-data.s3.rbx.io.cloud.ovh.net"]
     connect_whitelist << ENV.fetch('APP_HOST')
     connect_whitelist << ENV.fetch('APP_HOST_LEGACY') if ENV.key?('APP_HOST_LEGACY') && ENV['APP_HOST_LEGACY'] != ENV['APP_HOST']
     connect_whitelist << "*.amazonaws.com" if Rails.configuration.active_storage.service == :amazon

--- a/config/locales/views/administrateurs/revision_changes/fr.yml
+++ b/config/locales/views/administrateurs/revision_changes/fr.yml
@@ -13,3 +13,4 @@ fr:
       zones_humides: Zones humides d’importance internationale
       znieff: ZNIEFF
       cadastres: Cadastre
+      rpg: RPG

--- a/spec/components/procedure/revision_changes_component_spec.rb
+++ b/spec/components/procedure/revision_changes_component_spec.rb
@@ -78,6 +78,41 @@ describe Procedure::RevisionChangesComponent, type: :component do
     end
   end
 
+  describe "carte layers changes" do
+    let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :carte, libelle: 'La carte' }]) }
+    let(:new_revision) { procedure.create_new_revision }
+    let(:tdc) { procedure.active_revision.root_types_de_champ_public.first }
+
+    subject do
+      render_inline(described_class.new(new_revision: new_revision.reload, previous_revision: procedure.active_revision))
+      page
+    end
+
+    # `cadastres` excluded: it is mutually exclusive with `rpg`
+    let(:known_layers) { TypesDeChamp::CarteTypeDeChamp.editable_option_keys }
+    let(:enabled_layers) { known_layers - [:cadastres] }
+
+    before do
+      updated_tdc = new_revision.find_and_ensure_exclusive_use(tdc.stable_id)
+      updated_tdc.update!(options: enabled_layers.index_with { true })
+    end
+
+    it "displays every added layer with its translated label" do
+      expect(subject).to have_text("Les référentiels cartographiques du champ")
+      expect(subject).not_to have_css(".translation_missing")
+
+      enabled_layers.each do |layer|
+        expect(subject).to have_text(I18n.t(layer, scope: [:administrateurs, :carte_layers]))
+      end
+    end
+
+    it "has a translation for every known layer" do
+      known_layers.each do |layer|
+        expect(I18n.exists?("administrateurs.carte_layers.#{layer}")).to be(true), "missing translation for carte layer #{layer}"
+      end
+    end
+  end
+
   describe "repetition limits changes" do
     let(:procedure) { create(:procedure, :published, types_de_champ_public: [{ type: :repetition, libelle: "Bloc" }]) }
     let(:new_revision) { procedure.create_new_revision }

--- a/spec/models/types_de_champ/carte_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/carte_type_de_champ_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe TypesDeChamp::CarteTypeDeChamp do
+  describe 'parcelle layers exclusivity' do
+    let(:procedure) { create(:procedure, types_de_champ_public: [{ type: :carte, libelle: 'La carte' }]) }
+    let(:tdc) { procedure.active_revision.types_de_champ.first }
+
+    it 'keeps rpg when it is enabled on a carte already using cadastres' do
+      tdc.update!(editable_options: { cadastres: '1' })
+      tdc.update!(editable_options: { rpg: '1' })
+
+      expect(tdc.carte_optional_layers).to eq([:rpg])
+    end
+
+    it 'keeps cadastres when it is enabled on a carte already using rpg' do
+      tdc.update!(editable_options: { rpg: '1' })
+      tdc.update!(editable_options: { cadastres: '1' })
+
+      expect(tdc.carte_optional_layers).to eq([:cadastres])
+    end
+
+    it 'keeps cadastres when both layers are enabled at once' do
+      tdc.update!(editable_options: { cadastres: '1', rpg: '1' })
+
+      expect(tdc.carte_optional_layers).to eq([:cadastres])
+    end
+
+    it 'leaves the other layers untouched' do
+      tdc.update!(editable_options: { cadastres: '1', znieff: '1' })
+
+      expect(tdc.carte_optional_layers).to eq([:cadastres, :znieff])
+    end
+  end
+end


### PR DESCRIPTION
# Problème

Trois soucis autour du référentiel cartographique `rpg` :

1. La traduction `fr.administrateurs.carte_layers.rpg` n'avait jamais été ajoutée quand la couche a été introduite. Résultat, le résumé « Modifications en cours » affichait un `<span class="translation_missing">` en clair à l'admin.
2. `cadastres` et `rpg` s'appuient sur les mêmes identifiants de couche : les activer tous les deux casse la carte. L'éditeur désactive bien la case opposée côté UI, mais le modèle ne l'imposait pas — on peut donc enregistrer les deux (formulaire périmé, API).
3. **L'archive de tuiles n'est plus accessible.** `object.data.gouv.fr` est tombé le 18/08 et data.gouv nous a confirmé son décommissionnement à terme. La couche RPG ne s'affiche donc plus du tout pour les usagers.

# Solution

1. Ajout de `rpg: RPG` dans `config/locales/views/administrateurs/revision_changes/fr.yml` (libellé cohérent avec l'éditeur et la carte).
2. `TypesDeChamp::CarteTypeDeChamp` garde désormais une seule couche parcellaire : si les deux arrivent activées, on conserve celle qui vient d'être cochée et on désactive l'autre (à défaut `cadastres`). Choix d'une normalisation plutôt qu'une validation bloquante, pour ne pas rendre insauvegardables les champs déjà enregistrés avec les deux couches.
3. **Bascule vers le nouvel hôte.** L'archive vit maintenant sur le bucket OVH de data.gouv, dont les CORS ont été ouverts à notre demande. Vérifié par sondage, en GET comme en préflight : `Access-Control-Allow-Origin`, `Allow-Headers: range,if-match` et `Expose-Headers: etag`. C'est suffisant — `etag` est le seul en-tête de réponse que le client pmtiles lit réellement, le reste de ce qu'il consulte (`Content-Length`, `Cache-Control`) étant safelisté CORS. L'hôte est aussi échangé dans `connect_src`, sans quoi le changement passerait en développement (CSP en report-only) et casserait en production.

Même archive, mêmes identifiants de parcelles : **les dossiers déjà déposés s'affichent exactement comme avant.**

# Suite

Cette PR débloque les usagers, elle ne règle pas la dépendance de fond. Deux problèmes restent ouverts, documentés dans un plan de commits séparé :

- l'archive est un fichier de 1,32 Go hébergé par un tiers, plafonnée à z12 alors que la couche parcelles démarre à z15.5 ;
- une parcelle enregistrée n'est affichée que si son `id_parcel` existe encore dans les tuiles courantes. Or ces identifiants ne sont que partiellement stables entre campagnes — mesuré à 46–81 % de recouvrement entre 2023 et 2024. Tout changement de millésime ferait donc disparaître silencieusement une partie des parcelles des dossiers déposés.

La suite consiste à récupérer la géométrie authentique via le WFS de la Géoplateforme (en transposant le mécanisme `FetchCadastreRealGeometryJob` existant), puis à afficher les parcelles depuis cette géométrie plutôt que depuis les tuiles. La bascule vers les tuiles vectorielles IGN, qui supprimerait complètement l'hébergement, n'arrive qu'après — sans quoi elle casserait l'affichage des dossiers existants.
