### PR TITLE
ETQ admin, optimisation des barres d'outils d'édition

### DIFF
--- a/app/assets/stylesheets/icons.scss
+++ b/app/assets/stylesheets/icons.scss
@@ -262,6 +262,14 @@
     }
   }
 
+  &-paragraph {
+    &:before,
+    &:after {
+      -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M12 6V21H10V16C6.68629 16 4 13.3137 4 10C4 6.68629 6.68629 4 10 4H20V6H17V21H15V6H12ZM10 6C7.79086 6 6 7.79086 6 10C6 12.2091 7.79086 14 10 14V6Z'%3E%3C/path%3E%3C/svg%3E");
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor'%3E%3Cpath d='M12 6V21H10V16C6.68629 16 4 13.3137 4 10C4 6.68629 6.68629 4 10 4H20V6H17V21H15V6H12ZM10 6C7.79086 6 6 7.79086 6 10C6 12.2091 7.79086 14 10 14V6Z'%3E%3C/path%3E%3C/svg%3E");
+    }
+  }
+
   &-pdf-2-line {
     &:before,
     &:after {

--- a/app/components/tiptap_editor_component.rb
+++ b/app/components/tiptap_editor_component.rb
@@ -11,6 +11,7 @@ class TiptapEditorComponent < ApplicationComponent
     'bulletList' => { label: 'Liste', title: 'Liste à puces', icon: 'fr-icon-list-unordered' },
     'orderedList' => { label: 'Numérotée', title: 'Liste numérotée', icon: 'fr-icon-list-ordered' },
     'hardBreak' => { label: 'Saut de ligne', title: 'Saut de ligne', icon: 'fr-icon-corner-down-left-line' },
+    'paragraph' => { label: 'Paragraphe', title: 'Paragraphe', icon: 'fr-icon-paragraph' },
   }.freeze
 
   attr_reader :form, :field_name, :preview_url, :actions, :tags, :label, :error_attribute

--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -47,6 +47,7 @@ module Administrateurs
         ],
         [
           ['Saut de ligne', 'hardBreak', 'corner-down-left-line'],
+          ['Paragraphe', 'paragraph', 'paragraph'],
           ['Saut de page', 'pageBreak', 'page-separator'],
         ],
         [

--- a/app/controllers/administrateurs/attestation_template_v2s_controller.rb
+++ b/app/controllers/administrateurs/attestation_template_v2s_controller.rb
@@ -34,12 +34,12 @@ module Administrateurs
       @buttons = [
         [
           ['Gras', 'bold', 'bold'],
-          ['Italic', 'italic', 'italic'],
+          ['Italique', 'italic', 'italic'],
         ],
         [
           ['Titre', 'title', :hidden], # only for "title" section, without any action possible
-          ['Sous titre', 'heading2', 'h-1'],
-          ['Titre de section', 'heading3', 'h-2'],
+          ['Titre', 'heading2', 'h-1'],
+          ['Sous-titre', 'heading3', 'h-2'],
         ],
         [
           ['Liste à puces', 'bulletList', 'list-unordered'],
@@ -52,12 +52,12 @@ module Administrateurs
         ],
         [
           ['Aligner à gauche', 'left', 'align-left'],
-          ['Aligner au centre', 'center', 'align-center'],
+          ['Centrer', 'center', 'align-center'],
           ['Aligner à droite', 'right', 'align-right'],
         ],
         [
-          ['Undo', 'undo', 'arrow-go-back-line'],
-          ['Redo', 'redo', 'arrow-go-forward-line'],
+          ['Annuler', 'undo', 'arrow-go-back-line'],
+          ['Rétablir', 'redo', 'arrow-go-forward-line'],
         ],
       ]
 

--- a/app/javascript/shared/tiptap/actions.test.ts
+++ b/app/javascript/shared/tiptap/actions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAction } from './actions';
+import { createEditor } from './editor';
+
+describe('paragraph action', () => {
+  it('splits the current block into a new paragraph like the Enter key', () => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+
+    const editor = createEditor({
+      editorElement: element,
+      content: {
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'Bonjour' }] }
+        ]
+      },
+      tags: [],
+      buttons: ['paragraph'],
+      onChange: () => {}
+    });
+
+    editor.commands.setTextSelection(4);
+
+    const button = document.createElement('button');
+    button.dataset.tiptapAction = 'paragraph';
+    getAction(editor, button).run();
+
+    expect(editor.getJSON().content).toEqual([
+      { type: 'paragraph', content: [{ type: 'text', text: 'Bon' }] },
+      { type: 'paragraph', content: [{ type: 'text', text: 'jour' }] }
+    ]);
+
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/app/javascript/shared/tiptap/actions.ts
+++ b/app/javascript/shared/tiptap/actions.ts
@@ -110,6 +110,14 @@ const EDITOR_ACTIONS: Record<string, (editor: Editor) => EditorAction> = {
       editor.isActive('header') ||
       editor.isActive('footer')
   }),
+  paragraph: (editor) => ({
+    run: () => editor.chain().focus().keyboardShortcut('Enter').run(),
+    isActive: () => false,
+    isDisabled: () =>
+      editor.isActive('title') ||
+      editor.isActive('header') ||
+      editor.isActive('footer')
+  }),
   link: (editor) => ({
     run: () => {
       // Link action is handled directly by the controller's menuButton method

--- a/app/views/administrateurs/email_templates/edit.html.erb
+++ b/app/views/administrateurs/email_templates/edit.html.erb
@@ -55,7 +55,7 @@
                   field_name: :tiptap_body,
                   preview_url:,
                   label: "Corps de l’email",
-                  actions: %w[bold italic heading2 heading3 bulletList orderedList hardBreak link],
+                  actions: %w[bold italic heading2 heading3 bulletList orderedList hardBreak paragraph link],
                   tags:,
                   error_attribute: :json_body) %>
           </div>

--- a/spec/components/tiptap_editor_component_spec.rb
+++ b/spec/components/tiptap_editor_component_spec.rb
@@ -28,6 +28,15 @@ describe TiptapEditorComponent, type: :component do
     end
   end
 
+  context "with the paragraph action" do
+    subject(:rendered) { render_inline(described_class.new(form:, field_name: :tiptap_body, label: "Message personnalisé", actions: %w[hardBreak paragraph])) }
+
+    it "renders the paragraph button with its icon" do
+      expect(rendered).to have_button("Paragraphe")
+      expect(rendered).to have_css('button.fr-icon-paragraph[data-tiptap-action="paragraph"][title="Paragraphe"]')
+    end
+  end
+
   it "does not render any tag button when tags: is not given" do
     expect(rendered).not_to have_css('[data-tiptap-target="tag"]')
   end


### PR DESCRIPTION
Bouton « Paragraphe » (équivalent touche Entrée) ajouté après « Saut de ligne » dans les éditeurs d’attestation et d’emails automatiques + harmonisation des infobulles de l’attestation (Italique, Titre, Sous-titre, Centrer, Annuler, Rétablir).

<img width="672" height="508" alt="image" src="https://github.com/user-attachments/assets/5874a9a6-65f7-4d3a-89d3-c02d54361cf8" />


Closes #13512