### PR TITLE
Tech: TypeDeChamp, polymorphisme (4) — conditions

### DIFF
--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -221,6 +221,9 @@ class ChampData < ApplicationRecord
     type_de_champ.champ_value(self) || ''
   end
 
+  # The value a condition compares, nil when conditions do not manage the type.
+  def condition_value = nil
+
   def last_write_type_champ
     TypeDeChamp::CHAMP_TYPE_TO_TYPE_CHAMP.fetch(type)
   end

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -224,6 +224,8 @@ class ChampData < ApplicationRecord
   # The value a condition compares, nil when conditions do not manage the type.
   def condition_value = nil
 
+  def blank_for_condition? = blank?
+
   def last_write_type_champ
     TypeDeChamp::CHAMP_TYPE_TO_TYPE_CHAMP.fetch(type)
   end

--- a/app/models/champs/address_champ.rb
+++ b/app/models/champs/address_champ.rb
@@ -252,6 +252,8 @@ class Champs::AddressChamp < Champs::TextChamp
     end
   end
 
+  def condition_value = { department_code: code_departement, region_code: code_region }
+
   private
 
   def format_label

--- a/app/models/champs/boolean_champ.rb
+++ b/app/models/champs/boolean_champ.rb
@@ -19,6 +19,8 @@ class Champs::BooleanChamp < ChampData
     end
   end
 
+  def condition_value = true?
+
   private
 
   def set_value_to_nil

--- a/app/models/champs/commune_champ.rb
+++ b/app/models/champs/commune_champ.rb
@@ -85,6 +85,8 @@ class Champs::CommuneChamp < Champs::TextChamp
     end
   end
 
+  def condition_value = { department_code: code_departement, region_code: code_region }
+
   private
 
   def safe_to_s

--- a/app/models/champs/decimal_number_champ.rb
+++ b/app/models/champs/decimal_number_champ.rb
@@ -4,4 +4,7 @@ class Champs::DecimalNumberChamp < ChampData
   validates_with NumberFormatValidator, if: :should_validate_in_current_context?
   validates_with NumberLimitValidator, if: :should_validate_in_current_context?
   normalizes :value, with: -> { NumberFormatValidator.normalize(it, decimal: true) }
+
+  # TODO expose raw typed value of champs
+  def condition_value = type_de_champ.champ_value_for_api(self, version: 1)
 end

--- a/app/models/champs/departement_champ.rb
+++ b/app/models/champs/departement_champ.rb
@@ -39,6 +39,8 @@ class Champs::DepartementChamp < Champs::TextChamp
     super(resolution&.name)
   end
 
+  def condition_value = { value: code, region_code: code_region }
+
   private
 
   def value_in_departement_names

--- a/app/models/champs/drop_down_list_champ.rb
+++ b/app/models/champs/drop_down_list_champ.rb
@@ -93,6 +93,9 @@ class Champs::DropDownListChamp < ChampData
 
   def condition_value = selected
 
+  # an « Autre » selection with no text is still a value
+  def blank_for_condition? = blank? && !other?
+
   private
 
   def referentiel_from(value)

--- a/app/models/champs/drop_down_list_champ.rb
+++ b/app/models/champs/drop_down_list_champ.rb
@@ -91,6 +91,8 @@ class Champs::DropDownListChamp < ChampData
     headers.map { [_1, Referentiel.header_to_path(_1)] }
   end
 
+  def condition_value = selected
+
   private
 
   def referentiel_from(value)

--- a/app/models/champs/epci_champ.rb
+++ b/app/models/champs/epci_champ.rb
@@ -75,6 +75,8 @@ class Champs::EpciChamp < Champs::TextChamp
     end
   end
 
+  def condition_value = { department_code: code_departement, region_code: code_region }
+
   private
 
   def on_departement_change

--- a/app/models/champs/integer_number_champ.rb
+++ b/app/models/champs/integer_number_champ.rb
@@ -4,4 +4,7 @@ class Champs::IntegerNumberChamp < ChampData
   validates_with NumberFormatValidator, if: :should_validate_in_current_context?
   validates_with NumberLimitValidator, if: :should_validate_in_current_context?
   normalizes :value, with: -> { NumberFormatValidator.normalize(it) }
+
+  # TODO expose raw typed value of champs
+  def condition_value = type_de_champ.champ_value_for_api(self, version: 1)
 end

--- a/app/models/champs/multiple_drop_down_list_champ.rb
+++ b/app/models/champs/multiple_drop_down_list_champ.rb
@@ -94,6 +94,8 @@ class Champs::MultipleDropDownListChamp < ChampData
     headers.map { |header| [header, Referentiel.header_to_path(header)] }
   end
 
+  def condition_value = selected_options
+
   private
 
   def referentiels_from(value)

--- a/app/models/champs/pays_champ.rb
+++ b/app/models/champs/pays_champ.rb
@@ -27,4 +27,6 @@ class Champs::PaysChamp < Champs::TextChamp
       value.present? ? value.to_s : ''
     end
   end
+
+  def condition_value = code
 end

--- a/app/models/champs/pre_rempli_champ.rb
+++ b/app/models/champs/pre_rempli_champ.rb
@@ -4,4 +4,6 @@ class Champs::PreRempliChamp < ChampData
   def selected
     value
   end
+
+  def condition_value = selected
 end

--- a/app/models/champs/region_champ.rb
+++ b/app/models/champs/region_champ.rb
@@ -25,6 +25,8 @@ class Champs::RegionChamp < Champs::TextChamp
     super(resolution&.name)
   end
 
+  def condition_value = code
+
   private
 
   def value_in_region_names

--- a/app/models/logic/champ_column_value.rb
+++ b/app/models/logic/champ_column_value.rb
@@ -14,7 +14,7 @@ class Logic::ChampColumnValue < Logic::Term
 
     return nil if targeted_champ.nil?
     return nil if !targeted_champ.visible?
-    return nil if targeted_champ.blank? && !targeted_champ.drop_down_other?
+    return nil if targeted_champ.blank_for_condition?
 
     column = targeted_column([targeted_champ.type_de_champ])
 

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -31,32 +31,7 @@ class Logic::ChampValue < Logic::Term
     return nil if !targeted_champ.visible?
     return nil if targeted_champ.blank? && !targeted_champ.drop_down_other?
 
-    case targeted_champ.type
-    when "Champs::YesNoChamp",
-      "Champs::CheckboxChamp"
-      targeted_champ.true?
-    when "Champs::IntegerNumberChamp", "Champs::DecimalNumberChamp"
-      # TODO expose raw typed value of champs
-      targeted_champ.type_de_champ.champ_value_for_api(targeted_champ, version: 1)
-    when "Champs::DropDownListChamp"
-      targeted_champ.selected
-    when "Champs::PreRempliChamp"
-      targeted_champ.selected
-    when "Champs::MultipleDropDownListChamp"
-      targeted_champ.selected_options
-    when "Champs::RegionChamp", "Champs::PaysChamp"
-      targeted_champ.code
-    when "Champs::DepartementChamp"
-      {
-        value: targeted_champ.code,
-        region_code: targeted_champ.code_region,
-      }
-    when "Champs::CommuneChamp", "Champs::EpciChamp", "Champs::AddressChamp"
-      {
-        department_code: targeted_champ.code_departement,
-        region_code: targeted_champ.code_region,
-      }
-    end
+    targeted_champ.condition_value
   end
 
   def to_s(type_de_champs) = type_de_champ(type_de_champs)&.libelle # TODO: gerer le cas ou un tdc est supprimé

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -17,11 +17,6 @@ class Logic::ChampValue < Logic::Term
     :pre_rempli
   )
 
-  MANAGED_TYPE_DE_CHAMP_BY_CATEGORY = MANAGED_TYPE_DE_CHAMP.keys.map(&:to_sym)
-    .each_with_object(Hash.new { |h, k| h[k] = [] }) do |type, h|
-    h[TypeDeChamp.category_for(type)] << type
-  end
-
   CHAMP_VALUE_TYPE = {
     boolean: :boolean, # from yes_no or checkbox champ
     number: :number, # from integer or decimal number champ

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -1,22 +1,6 @@
 # frozen_string_literal: true
 
 class Logic::ChampValue < Logic::Term
-  MANAGED_TYPE_DE_CHAMP = TypeDeChamp.type_champs.slice(
-    :yes_no,
-    :checkbox,
-    :integer_number,
-    :decimal_number,
-    :drop_down_list,
-    :multiple_drop_down_list,
-    :address,
-    :communes,
-    :epci,
-    :departements,
-    :regions,
-    :pays,
-    :pre_rempli
-  )
-
   CHAMP_VALUE_TYPE = {
     boolean: :boolean, # from yes_no or checkbox champ
     number: :number, # from integer or decimal number champ
@@ -105,16 +89,12 @@ class Logic::ChampValue < Logic::Term
   end
 
   def options(type_de_champs, operator_name = nil)
-    tdc = type_de_champ(type_de_champs)
-
-    if operator_name.in?([Logic::InRegionOperator.name, Logic::NotInRegionOperator.name]) || tdc.type_champ == MANAGED_TYPE_DE_CHAMP.fetch(:regions)
+    if operator_name.in?([Logic::InRegionOperator.name, Logic::NotInRegionOperator.name])
       APIGeoService.region_options
-    elsif operator_name.in?([Logic::InDepartementOperator.name, Logic::NotInDepartementOperator.name]) || tdc.type_champ.in?([MANAGED_TYPE_DE_CHAMP.fetch(:communes), MANAGED_TYPE_DE_CHAMP.fetch(:epci), MANAGED_TYPE_DE_CHAMP.fetch(:departements), MANAGED_TYPE_DE_CHAMP.fetch(:address)])
+    elsif operator_name.in?([Logic::InDepartementOperator.name, Logic::NotInDepartementOperator.name])
       APIGeoService.departement_options
-    elsif tdc.type_champ == MANAGED_TYPE_DE_CHAMP.fetch(:pays)
-      APIGeoService.countries.map { ["#{_1[:name]} – #{_1[:code]}", _1[:code]] }
     else
-      tdc.options_for_select_with_other
+      type_de_champ(type_de_champs).condition_options
     end
   end
 

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -78,29 +78,7 @@ class Logic::ChampValue < Logic::Term
   def to_s(type_de_champs) = type_de_champ(type_de_champs)&.libelle # TODO: gerer le cas ou un tdc est supprimé
 
   def type(type_de_champs)
-    case type_de_champ(type_de_champs)&.type_champ # TODO: gerer le cas ou un tdc est supprimé
-    when MANAGED_TYPE_DE_CHAMP.fetch(:yes_no),
-      MANAGED_TYPE_DE_CHAMP.fetch(:checkbox)
-      CHAMP_VALUE_TYPE.fetch(:boolean)
-    when MANAGED_TYPE_DE_CHAMP.fetch(:integer_number), MANAGED_TYPE_DE_CHAMP.fetch(:decimal_number)
-      CHAMP_VALUE_TYPE.fetch(:number)
-    when MANAGED_TYPE_DE_CHAMP.fetch(:drop_down_list),
-      MANAGED_TYPE_DE_CHAMP.fetch(:regions), MANAGED_TYPE_DE_CHAMP.fetch(:pays),
-      MANAGED_TYPE_DE_CHAMP.fetch(:pre_rempli)
-      CHAMP_VALUE_TYPE.fetch(:enum)
-    when MANAGED_TYPE_DE_CHAMP.fetch(:communes)
-      CHAMP_VALUE_TYPE.fetch(:commune_enum)
-    when MANAGED_TYPE_DE_CHAMP.fetch(:epci)
-      CHAMP_VALUE_TYPE.fetch(:epci_enum)
-    when MANAGED_TYPE_DE_CHAMP.fetch(:departements)
-      CHAMP_VALUE_TYPE.fetch(:departement_enum)
-    when MANAGED_TYPE_DE_CHAMP.fetch(:address)
-      CHAMP_VALUE_TYPE.fetch(:address)
-    when MANAGED_TYPE_DE_CHAMP.fetch(:multiple_drop_down_list)
-      CHAMP_VALUE_TYPE.fetch(:enums)
-    else
-      CHAMP_VALUE_TYPE.fetch(:unmanaged)
-    end
+    type_de_champ(type_de_champs)&.condition_value_type || CHAMP_VALUE_TYPE.fetch(:unmanaged)
   end
 
   def errors(type_de_champs)

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -29,7 +29,7 @@ class Logic::ChampValue < Logic::Term
 
     return nil if targeted_champ.nil?
     return nil if !targeted_champ.visible?
-    return nil if targeted_champ.blank? && !targeted_champ.drop_down_other?
+    return nil if targeted_champ.blank_for_condition?
 
     targeted_champ.condition_value
   end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -31,6 +31,7 @@ class TypeDeChamp < ApplicationRecord
   def self.public_only? = false
   def self.allowed_in_repetition? = true
   def self.simple_routable? = false
+  def self.conditionable? = false
 
   def self.category_for(type_champ)
     find_sti_class(type_champ).category
@@ -331,7 +332,7 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def conditionable?
-    Logic::ChampValue::MANAGED_TYPE_DE_CHAMP.values.include?(type_champ) && !drop_down_advanced?
+    self.class.conditionable? && !drop_down_advanced?
   end
 
   def self.humanized_conditionable_types_by_category
@@ -566,6 +567,8 @@ class TypeDeChamp < ApplicationRecord
     end
 
     def find_sti_class(type_name) = type_champ_to_class_name(type_name.to_s).constantize
+
+    def type_champ_classes = type_champs.values.map { find_sti_class(_1) }
 
     def sti_name = CLASS_NAME_TO_TYPE_CHAMP[name]
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -273,8 +273,6 @@ class TypeDeChamp < ApplicationRecord
 
   def formatted_advanced? = false
 
-  def drop_down_advanced? = false
-
   def options_for_select = nil
 
   def previous_section_level(upper_tdcs)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -332,6 +332,7 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def condition_value_type = :unmanaged
+  def condition_options = []
 
   def self.humanized_conditionable_types_by_category
     humanized_types_by_category(type_champ_classes.filter(&:conditionable?))

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -241,8 +241,6 @@ class TypeDeChamp < ApplicationRecord
     revisions.one? && revisions.first.draft?
   end
 
-  def drop_down_other? = false
-
   def prefill_with_france_connect_information? = false
 
   def prefillable? = false

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -33,10 +33,6 @@ class TypeDeChamp < ApplicationRecord
   def self.simple_routable? = false
   def self.conditionable? = false
 
-  def self.category_for(type_champ)
-    find_sti_class(type_champ).category
-  end
-
   enum :type_champ, {
     engagement_juridique: 'engagement_juridique',
     header_section: 'header_section',
@@ -336,20 +332,21 @@ class TypeDeChamp < ApplicationRecord
   end
 
   def self.humanized_conditionable_types_by_category
-    Logic::ChampValue::MANAGED_TYPE_DE_CHAMP_BY_CATEGORY
-      .map { |_, v| v.map { "« #{I18n.t(_1, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])} »" } }
+    humanized_types_by_category(type_champ_classes.filter(&:conditionable?))
   end
 
   def self.humanized_simple_routable_types_by_category
-    Logic::ChampValue::MANAGED_TYPE_DE_CHAMP_BY_CATEGORY
-      .map { |_, v| v.filter_map { "« #{I18n.t(_1, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])} »" if find_sti_class(_1).simple_routable? } }
-      .reject(&:empty?)
+    humanized_types_by_category(type_champ_classes.filter { _1.conditionable? && _1.simple_routable? })
   end
 
   def self.humanized_custom_routable_types_by_category
-    Logic::ChampValue::MANAGED_TYPE_DE_CHAMP_BY_CATEGORY
-      .map { |_, v| v.filter_map { "« #{I18n.t(_1, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])} »" if !find_sti_class(_1).simple_routable? } }
-      .reject(&:empty?)
+    humanized_types_by_category(type_champ_classes.filter { _1.conditionable? && !_1.simple_routable? })
+  end
+
+  def self.humanized_types_by_category(klasses)
+    klasses.group_by(&:category)
+      .sort_by { |category, _| CATEGORIES.find_index(category) }
+      .map { |_, group| group.map { "« #{I18n.t(_1.sti_name, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])} »" } }
   end
 
   def public_id(row_id)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -323,13 +323,9 @@ class TypeDeChamp < ApplicationRecord
   # custom refresh logic (RNA, SIRET, etc.)
   def refresh_after_update? = true
 
-  def simple_routable?
-    self.class.simple_routable? && !drop_down_advanced?
-  end
+  def simple_routable? = self.class.simple_routable?
 
-  def conditionable?
-    self.class.conditionable? && !drop_down_advanced?
-  end
+  def conditionable? = self.class.conditionable?
 
   def condition_value_type = :unmanaged
   def condition_options = []

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -331,6 +331,8 @@ class TypeDeChamp < ApplicationRecord
     self.class.conditionable? && !drop_down_advanced?
   end
 
+  def condition_value_type = :unmanaged
+
   def self.humanized_conditionable_types_by_category
     humanized_types_by_category(type_champ_classes.filter(&:conditionable?))
   end

--- a/app/models/types_de_champ/address_type_de_champ.rb
+++ b/app/models/types_de_champ/address_type_de_champ.rb
@@ -3,6 +3,7 @@
 class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.category = LOCALISATION
   def self.simple_routable? = true
+  def self.conditionable? = true
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/address_type_de_champ.rb
+++ b/app/models/types_de_champ/address_type_de_champ.rb
@@ -6,6 +6,7 @@ class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.conditionable? = true
 
   def condition_value_type = :address
+  def condition_options = APIGeoService.departement_options
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/address_type_de_champ.rb
+++ b/app/models/types_de_champ/address_type_de_champ.rb
@@ -5,6 +5,8 @@ class TypesDeChamp::AddressTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.simple_routable? = true
   def self.conditionable? = true
 
+  def condition_value_type = :address
+
   include AddressableColumnConcern
 
   def libelles_for_export

--- a/app/models/types_de_champ/checkbox_type_de_champ.rb
+++ b/app/models/types_de_champ/checkbox_type_de_champ.rb
@@ -8,6 +8,7 @@ class TypesDeChamp::CheckboxTypeDeChamp < TypeDeChamp
   def prefillable? = true
   def options_for_select = Champs::CheckboxChamp.options
   def choice_type? = true
+  def condition_value_type = :boolean
 
   def typed_champ_value(champ)
     champ_value_true?(champ) ? 'Oui' : 'Non'

--- a/app/models/types_de_champ/checkbox_type_de_champ.rb
+++ b/app/models/types_de_champ/checkbox_type_de_champ.rb
@@ -3,6 +3,7 @@
 class TypesDeChamp::CheckboxTypeDeChamp < TypeDeChamp
   def self.category = CHOICE
   def self.column_type = :boolean
+  def self.conditionable? = true
 
   def prefillable? = true
   def options_for_select = Champs::CheckboxChamp.options

--- a/app/models/types_de_champ/commune_type_de_champ.rb
+++ b/app/models/types_de_champ/commune_type_de_champ.rb
@@ -7,6 +7,7 @@ class TypesDeChamp::CommuneTypeDeChamp < TypeDeChamp
 
   def prefillable? = true
   def customizable? = true
+  def condition_value_type = :commune_enum
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/commune_type_de_champ.rb
+++ b/app/models/types_de_champ/commune_type_de_champ.rb
@@ -3,6 +3,7 @@
 class TypesDeChamp::CommuneTypeDeChamp < TypeDeChamp
   def self.category = LOCALISATION
   def self.simple_routable? = true
+  def self.conditionable? = true
 
   def prefillable? = true
   def customizable? = true

--- a/app/models/types_de_champ/commune_type_de_champ.rb
+++ b/app/models/types_de_champ/commune_type_de_champ.rb
@@ -8,6 +8,7 @@ class TypesDeChamp::CommuneTypeDeChamp < TypeDeChamp
   def prefillable? = true
   def customizable? = true
   def condition_value_type = :commune_enum
+  def condition_options = APIGeoService.departement_options
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/decimal_number_type_de_champ.rb
+++ b/app/models/types_de_champ/decimal_number_type_de_champ.rb
@@ -7,6 +7,7 @@ class TypesDeChamp::DecimalNumberTypeDeChamp < TypeDeChamp
 
   def prefillable? = true
   def customizable? = true
+  def condition_value_type = :number
   boolean_options :positive_number, :range_number
 
   def typed_champ_value_for_export(champ, path = :value)

--- a/app/models/types_de_champ/decimal_number_type_de_champ.rb
+++ b/app/models/types_de_champ/decimal_number_type_de_champ.rb
@@ -3,6 +3,7 @@
 class TypesDeChamp::DecimalNumberTypeDeChamp < TypeDeChamp
   def self.editable_option_keys = [:positive_number, :min_number, :max_number, :range_number]
   def self.column_type = :decimal
+  def self.conditionable? = true
 
   def prefillable? = true
   def customizable? = true

--- a/app/models/types_de_champ/departement_type_de_champ.rb
+++ b/app/models/types_de_champ/departement_type_de_champ.rb
@@ -4,6 +4,7 @@ class TypesDeChamp::DepartementTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.category = LOCALISATION
   def self.column_type = :enum
   def self.simple_routable? = true
+  def self.conditionable? = true
 
   def options_for_select = APIGeoService.departement_options
 

--- a/app/models/types_de_champ/departement_type_de_champ.rb
+++ b/app/models/types_de_champ/departement_type_de_champ.rb
@@ -7,6 +7,7 @@ class TypesDeChamp::DepartementTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.conditionable? = true
 
   def options_for_select = APIGeoService.departement_options
+  def condition_value_type = :departement_enum
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/departement_type_de_champ.rb
+++ b/app/models/types_de_champ/departement_type_de_champ.rb
@@ -8,6 +8,7 @@ class TypesDeChamp::DepartementTypeDeChamp < TypesDeChamp::TextTypeDeChamp
 
   def options_for_select = APIGeoService.departement_options
   def condition_value_type = :departement_enum
+  def condition_options = APIGeoService.departement_options
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -5,6 +5,7 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypeDeChamp
   def self.editable_option_keys = [:drop_down_other, :drop_down_options, :drop_down_mode]
   def self.column_type = :enum
   def self.simple_routable? = true
+  def self.conditionable? = true
 
   include TypesDeChamp::DropDownOptionsConcern
 

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -7,9 +7,6 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypeDeChamp
   def self.simple_routable? = true
   def self.conditionable? = true
 
-  def condition_value_type = :enum
-  def condition_options = options_for_select_with_other
-
   include TypesDeChamp::DropDownOptionsConcern
 
   def prefillable? = true
@@ -18,6 +15,10 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypeDeChamp
   def any_drop_down_list? = true
   def drop_down_simple? = drop_down_mode != 'advanced'
   def drop_down_advanced? = drop_down_mode == 'advanced'
+  def conditionable? = !drop_down_advanced?
+  def simple_routable? = !drop_down_advanced?
+  def condition_value_type = :enum
+  def condition_options = options_for_select_with_other
   boolean_options :drop_down_other
   def value_is_in_options?(checked_value) = options_for_select.any? { _1.last == checked_value }
   def customizable? = true

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -7,6 +7,8 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypeDeChamp
   def self.simple_routable? = true
   def self.conditionable? = true
 
+  def condition_value_type = :enum
+
   include TypesDeChamp::DropDownOptionsConcern
 
   def prefillable? = true

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -8,6 +8,7 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypeDeChamp
   def self.conditionable? = true
 
   def condition_value_type = :enum
+  def condition_options = options_for_select_with_other
 
   include TypesDeChamp::DropDownOptionsConcern
 

--- a/app/models/types_de_champ/drop_down_options_concern.rb
+++ b/app/models/types_de_champ/drop_down_options_concern.rb
@@ -2,6 +2,7 @@
 
 module TypesDeChamp::DropDownOptionsConcern
   def drop_down_advanced? = false
+  def drop_down_other? = false
 
   def drop_down_options
     if drop_down_advanced?

--- a/app/models/types_de_champ/drop_down_options_concern.rb
+++ b/app/models/types_de_champ/drop_down_options_concern.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module TypesDeChamp::DropDownOptionsConcern
+  def drop_down_advanced? = false
+
   def drop_down_options
     if drop_down_advanced?
       Array.wrap(referentiel&.drop_down_options)

--- a/app/models/types_de_champ/epci_type_de_champ.rb
+++ b/app/models/types_de_champ/epci_type_de_champ.rb
@@ -6,6 +6,7 @@ class TypesDeChamp::EpciTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.conditionable? = true
 
   def condition_value_type = :epci_enum
+  def condition_options = APIGeoService.departement_options
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/epci_type_de_champ.rb
+++ b/app/models/types_de_champ/epci_type_de_champ.rb
@@ -5,6 +5,8 @@ class TypesDeChamp::EpciTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.simple_routable? = true
   def self.conditionable? = true
 
+  def condition_value_type = :epci_enum
+
   include AddressableColumnConcern
 
   def columns(procedure_id:, displayable: true, prefix: nil)

--- a/app/models/types_de_champ/epci_type_de_champ.rb
+++ b/app/models/types_de_champ/epci_type_de_champ.rb
@@ -3,6 +3,7 @@
 class TypesDeChamp::EpciTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.category = LOCALISATION
   def self.simple_routable? = true
+  def self.conditionable? = true
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/integer_number_type_de_champ.rb
+++ b/app/models/types_de_champ/integer_number_type_de_champ.rb
@@ -7,6 +7,7 @@ class TypesDeChamp::IntegerNumberTypeDeChamp < TypeDeChamp
 
   def prefillable? = true
   def customizable? = true
+  def condition_value_type = :number
   boolean_options :positive_number, :range_number
 
   def typed_champ_value_for_export(champ, path = :value)

--- a/app/models/types_de_champ/integer_number_type_de_champ.rb
+++ b/app/models/types_de_champ/integer_number_type_de_champ.rb
@@ -3,6 +3,7 @@
 class TypesDeChamp::IntegerNumberTypeDeChamp < TypeDeChamp
   def self.editable_option_keys = [:positive_number, :min_number, :max_number, :range_number]
   def self.column_type = :integer
+  def self.conditionable? = true
 
   def prefillable? = true
   def customizable? = true

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -6,9 +6,6 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypeDeChamp
   def self.column_type = :enums
   def self.conditionable? = true
 
-  def condition_value_type = :enums
-  def condition_options = options_for_select_with_other
-
   include TypesDeChamp::DropDownOptionsConcern
 
   def prefillable? = true
@@ -17,6 +14,9 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypeDeChamp
   def any_drop_down_list? = true
   def drop_down_simple? = drop_down_mode != 'advanced'
   def drop_down_advanced? = drop_down_mode == 'advanced'
+  def conditionable? = !drop_down_advanced?
+  def condition_value_type = :enums
+  def condition_options = options_for_select_with_other
   def customizable? = true
 
   before_validation :set_default_drop_down_options, if: :type_champ_changed?

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -7,6 +7,7 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypeDeChamp
   def self.conditionable? = true
 
   def condition_value_type = :enums
+  def condition_options = options_for_select_with_other
 
   include TypesDeChamp::DropDownOptionsConcern
 

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -6,6 +6,8 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypeDeChamp
   def self.column_type = :enums
   def self.conditionable? = true
 
+  def condition_value_type = :enums
+
   include TypesDeChamp::DropDownOptionsConcern
 
   def prefillable? = true

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -4,6 +4,7 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypeDeChamp
   def self.category = CHOICE
   def self.editable_option_keys = [:drop_down_options, :drop_down_mode]
   def self.column_type = :enums
+  def self.conditionable? = true
 
   include TypesDeChamp::DropDownOptionsConcern
 

--- a/app/models/types_de_champ/pays_type_de_champ.rb
+++ b/app/models/types_de_champ/pays_type_de_champ.rb
@@ -4,6 +4,7 @@ class TypesDeChamp::PaysTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.category = LOCALISATION
   def self.column_type = :enum
   def self.simple_routable? = true
+  def self.conditionable? = true
 
   def options_for_select = APIGeoService.country_options
 

--- a/app/models/types_de_champ/pays_type_de_champ.rb
+++ b/app/models/types_de_champ/pays_type_de_champ.rb
@@ -8,6 +8,7 @@ class TypesDeChamp::PaysTypeDeChamp < TypesDeChamp::TextTypeDeChamp
 
   def options_for_select = APIGeoService.country_options
   def condition_value_type = :enum
+  def condition_options = APIGeoService.countries.map { ["#{_1[:name]} – #{_1[:code]}", _1[:code]] }
 
   def typed_champ_value(champ)
     champ.name

--- a/app/models/types_de_champ/pays_type_de_champ.rb
+++ b/app/models/types_de_champ/pays_type_de_champ.rb
@@ -7,6 +7,7 @@ class TypesDeChamp::PaysTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.conditionable? = true
 
   def options_for_select = APIGeoService.country_options
+  def condition_value_type = :enum
 
   def typed_champ_value(champ)
     champ.name

--- a/app/models/types_de_champ/pre_rempli_type_de_champ.rb
+++ b/app/models/types_de_champ/pre_rempli_type_de_champ.rb
@@ -7,6 +7,8 @@ class TypesDeChamp::PreRempliTypeDeChamp < TypeDeChamp
   def self.column_type = :enum
   def self.conditionable? = true
 
+  def condition_value_type = :enum
+
   include TypesDeChamp::DropDownOptionsConcern
 
   def prefillable? = true

--- a/app/models/types_de_champ/pre_rempli_type_de_champ.rb
+++ b/app/models/types_de_champ/pre_rempli_type_de_champ.rb
@@ -5,6 +5,7 @@ class TypesDeChamp::PreRempliTypeDeChamp < TypeDeChamp
   def self.editable_option_keys = [:drop_down_options, :pre_rempli_hidden]
   def self.feature_flag = :pre_rempli_type_de_champ
   def self.column_type = :enum
+  def self.conditionable? = true
 
   include TypesDeChamp::DropDownOptionsConcern
 

--- a/app/models/types_de_champ/pre_rempli_type_de_champ.rb
+++ b/app/models/types_de_champ/pre_rempli_type_de_champ.rb
@@ -8,6 +8,7 @@ class TypesDeChamp::PreRempliTypeDeChamp < TypeDeChamp
   def self.conditionable? = true
 
   def condition_value_type = :enum
+  def condition_options = options_for_select_with_other
 
   include TypesDeChamp::DropDownOptionsConcern
 

--- a/app/models/types_de_champ/region_type_de_champ.rb
+++ b/app/models/types_de_champ/region_type_de_champ.rb
@@ -7,6 +7,7 @@ class TypesDeChamp::RegionTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.conditionable? = true
 
   def options_for_select = APIGeoService.region_options
+  def condition_value_type = :enum
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/region_type_de_champ.rb
+++ b/app/models/types_de_champ/region_type_de_champ.rb
@@ -8,6 +8,7 @@ class TypesDeChamp::RegionTypeDeChamp < TypesDeChamp::TextTypeDeChamp
 
   def options_for_select = APIGeoService.region_options
   def condition_value_type = :enum
+  def condition_options = APIGeoService.region_options
 
   include AddressableColumnConcern
 

--- a/app/models/types_de_champ/region_type_de_champ.rb
+++ b/app/models/types_de_champ/region_type_de_champ.rb
@@ -4,6 +4,7 @@ class TypesDeChamp::RegionTypeDeChamp < TypesDeChamp::TextTypeDeChamp
   def self.category = LOCALISATION
   def self.column_type = :enum
   def self.simple_routable? = true
+  def self.conditionable? = true
 
   def options_for_select = APIGeoService.region_options
 

--- a/app/models/types_de_champ/yes_no_type_de_champ.rb
+++ b/app/models/types_de_champ/yes_no_type_de_champ.rb
@@ -7,6 +7,7 @@ class TypesDeChamp::YesNoTypeDeChamp < TypeDeChamp
 
   def prefillable? = true
   def choice_type? = true
+  def condition_value_type = :boolean
 
   def typed_champ_value(champ)
     champ_value_true?(champ) ? 'Oui' : 'Non'

--- a/app/models/types_de_champ/yes_no_type_de_champ.rb
+++ b/app/models/types_de_champ/yes_no_type_de_champ.rb
@@ -3,6 +3,7 @@
 class TypesDeChamp::YesNoTypeDeChamp < TypeDeChamp
   def self.category = CHOICE
   def self.column_type = :boolean
+  def self.conditionable? = true
 
   def prefillable? = true
   def choice_type? = true

--- a/app/views/administrateurs/ineligibilite_rules/edit.html.haml
+++ b/app/views/administrateurs/ineligibilite_rules/edit.html.haml
@@ -22,8 +22,8 @@
         %p.fr-mt-2w.fr-mb-2w
           Pour configurer l’inéligibilité des dossiers, votre formulaire doit comporter au moins un champ supportant les conditions d’inéligibilité. Il vous faut donc ajouter au moins un des champs suivant à votre formulaire :
           %ul
-            - Logic::ChampValue::MANAGED_TYPE_DE_CHAMP.values.each do
-              %li= "« #{t(_1, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])} »"
+            - TypeDeChamp.type_champ_classes.filter(&:conditionable?).each do
+              %li= "« #{t(_1.sti_name, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])} »"
         %p.fr-mt-2w
           = link_to 'Ajouter un champ supportant les conditions d’inéligibilité', champs_admin_procedure_path(@procedure), class: 'fr-link fr-icon-arrow-right-line fr-link--icon-right'
           = render Procedure::FixedFooterComponent.new(procedure: @procedure)

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -779,14 +779,14 @@ describe TypeDeChamp do
   describe '#humanized_conditionable_types_by_category' do
     subject { TypeDeChamp.humanized_conditionable_types_by_category }
 
-    it {
-  is_expected.to eq([
-    ["« Oui/Non »", "« Case à cocher seule »", "« Choix simple »", "« Choix multiple »"],
-    ["« Nombre entier »", "« Nombre décimal »"],
-    ["« Adresse »", "« Commune française actuelle »", "« EPCI »", "« Département »", "« Région »", "« Pays »"],
-    ["« Champ pré-rempli »"],
-  ])
-}
+    it 'groups the conditionable types by category, in the editor order' do
+      is_expected.to eq([
+        ["« Adresse »", "« Commune française actuelle »", "« Département »", "« Région »", "« Pays »", "« EPCI »"],
+        ["« Nombre décimal »", "« Nombre entier »"],
+        ["« Case à cocher seule »", "« Choix simple »", "« Choix multiple »", "« Oui/Non »"],
+        ["« Champ pré-rempli »"],
+      ])
+    end
   end
 
   describe '#ocr_compatible?' do


### PR DESCRIPTION
## Quoi

Empilée sur #13676. Dernières tables de dispatch : celles de `Logic::ChampValue` (140 → 85 lignes).

- `conditionable?` : `MANAGED_TYPE_DE_CHAMP` (13 types) devient un prédicat de classe, l'instance gardant l'exclusion des listes déroulantes avancées. `TypeDeChamp.type_champ_classes` (enum → classes) sert à la vue qui liste les types supportés ;
- les 3 listes humanisées (modale routage custom, écran routage simple, options instructeurs) filtrent les classes sur `conditionable?`/`simple_routable?` et groupent sur `category` : `MANAGED_TYPE_DE_CHAMP_BY_CATEGORY` et le dernier appelant de `category_for` disparaissent ;
- `condition_value_type` : le `case` type_champ → `CHAMP_VALUE_TYPE` devient une méthode, `:unmanaged` par défaut ;
- `condition_options` : les types géo répondent leur liste API Geo (commune, EPCI et adresse se comparent par département), les listes déroulantes leurs options. `Logic::ChampValue` garde les deux branches **par opérateur** (`in_region`, `in_departement` imposent leur liste quel que soit le type) ;
- `condition_value` : `compute` dispatchait sur le nom de classe du **champ** — c'est du polymorphisme côté champ, il descend dans `ChampData` et ses sous-classes (`nil` par défaut). `Logic::ChampValue` garde ce qui relève de la condition : champ absent, invisible ou vide.

## Points pour la revue

- **Changement visible** : les 3 listes humanisées sortent désormais dans l'ordre des catégories de l'éditeur (`CATEGORIES`) puis de l'enum, au lieu de l'ordre de la constante supprimée. Mêmes listes, autre ordre d'affichage ; la spec est mise à jour.
- Correspondance vérifiée type par type (`condition_value_type`, `condition_options`, `condition_value`) contre l'ancien `case` avant/après.
- Après cette PR, `type_de_champ.rb` n'a plus de dispatch par type : template method, défauts polymorphes et générique.