### PR TITLE
Tech: supprimer les html_safe redondants sur les traductions

### DIFF
--- a/app/components/dossiers/export_dropdown_component.rb
+++ b/app/components/dossiers/export_dropdown_component.rb
@@ -36,9 +36,9 @@ class Dossiers::ExportDropdownComponent < ApplicationComponent
 
   def include_archived_title
     if @archived_count > 1
-      t(".include_archived_plural", count: @archived_count)
+      t(".include_archived_plural_html", count: @archived_count)
     else
-      t(".include_archived_singular")
+      t(".include_archived_singular_html")
     end
   end
 

--- a/app/components/dossiers/export_dropdown_component/export_dropdown_component.en.yml
+++ b/app/components/dossiers/export_dropdown_component/export_dropdown_component.en.yml
@@ -25,5 +25,5 @@ en:
   select_template_label: Select the export template
   configure_templates: Configure export templates
   no_template: No template configured
-  include_archived_plural: <span>Include the <strong>%{count} dossiers to be archived</strong></span>
-  include_archived_singular: <span>Include the <strong>dossier to be archived</strong></span>
+  include_archived_plural_html: <span>Include the <strong>%{count} dossiers to be archived</strong></span>
+  include_archived_singular_html: <span>Include the <strong>dossier to be archived</strong></span>

--- a/app/components/dossiers/export_dropdown_component/export_dropdown_component.fr.yml
+++ b/app/components/dossiers/export_dropdown_component/export_dropdown_component.fr.yml
@@ -25,5 +25,5 @@ fr:
   select_template_label: Sélectionner le modèle d’export
   configure_templates: Configurer les modèles d’export
   no_template: Aucun modèle configuré
-  include_archived_plural: <span>Inclure les <strong>%{count} dossiers « à archiver »</strong></span>
-  include_archived_singular: <span>Inclure le <strong>dossier « à archiver »</strong></span>
+  include_archived_plural_html: <span>Inclure les <strong>%{count} dossiers « à archiver »</strong></span>
+  include_archived_singular_html: <span>Inclure le <strong>dossier « à archiver »</strong></span>

--- a/app/components/dsfr/toggle_component/toggle_component.html.erb
+++ b/app/components/dsfr/toggle_component/toggle_component.html.erb
@@ -1,6 +1,6 @@
 <div class="fr-toggle <%= no_label_class %> <%= extra_class_names %>">
   <%= @form.check_box target, check_box_options %>
-  <%= @form.label target, title || html_title&.html_safe, label_options %>
+  <%= @form.label target, title || html_title, label_options %>
 
   <% if hint -%>
     <p class="fr-hint-text"><%= hint %></p>

--- a/app/components/instructeurs/dossiers_navigation_component.rb
+++ b/app/components/instructeurs/dossiers_navigation_component.rb
@@ -24,7 +24,7 @@ class Instructeurs::DossiersNavigationComponent < ApplicationComponent
       options = { class: "fr-link no-wrap fr-text--sm fr-ml-3w fr-text-mention--grey" }
     end
 
-    tag.send(html_tag, t('.next').html_safe, **options)
+    tag.send(html_tag, t('.next'), **options)
   end
 
   def link_previous

--- a/app/views/administrate/application/_pagination.html.haml
+++ b/app/views/administrate/application/_pagination.html.haml
@@ -1,6 +1,6 @@
 - if resources.singleton_class.included_modules.include?(Kaminari::PaginatableWithoutCount)
   %nav.pagination
-    = link_to_prev_page resources, t("views.pagination.previous").html_safe, param_name: "_page"
-    = link_to_next_page resources, t("views.pagination.next").html_safe, param_name: "_page"
+    = link_to_prev_page resources, t("views.pagination.previous"), param_name: "_page"
+    = link_to_next_page resources, t("views.pagination.next"), param_name: "_page"
 - else
   = paginate resources, param_name: local_assigns.fetch(:param_name) { "_page" }

--- a/app/views/administrateurs/procedures/closing_notification.html.haml
+++ b/app/views/administrateurs/procedures/closing_notification.html.haml
@@ -9,9 +9,9 @@
     .fr-col-12.fr-col-offset-md-2.fr-col-md-8
       %h1= t('administrateurs.procedures.closing_notification.page_title')
       - if @procedure.closing_reason_other?
-        %h2.fr-h5= I18n.t('administrateurs.procedures.closing_notification.page_subtitle', closing_path: closing_details_path(@procedure.path)).html_safe
+        %h2.fr-h5= t('administrateurs.procedures.closing_notification.page_subtitle_html', closing_path: closing_details_path(@procedure.path))
       - else
-        %h2.fr-h5= I18n.t('administrateurs.procedures.closing_notification.page_subtitle_with_redirection', redirection_path: commencer_path(@procedure.replaced_by_procedure.path)).html_safe
+        %h2.fr-h5= t('administrateurs.procedures.closing_notification.page_subtitle_with_redirection_html', redirection_path: commencer_path(@procedure.replaced_by_procedure.path))
 
       = render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: 'fr-mb-2w') do |c|
         - c.with_body do

--- a/app/views/france_connect/confirm_email_merge_password.html.erb
+++ b/app/views/france_connect/confirm_email_merge_password.html.erb
@@ -3,7 +3,7 @@
     <div class="fr-col-12">
       <h1 class="text-center fr-mt-2v"><%= t('.title') %></h1>
 
-      <p><%= t('.intro_html', email: h(@merge_email)).html_safe %></p>
+      <p><%= t('.intro_html', email: h(@merge_email)) %></p>
 
       <%= form_with url: france_connect_send_email_merge_request_path, method: :post, class: 'fr-mt-4v fconnect-form' do %>
         <%= hidden_field_tag :merge_token, @fci.merge_token %>

--- a/app/views/instructeurs/procedures/_badge_preferences.html.haml
+++ b/app/views/instructeurs/procedures/_badge_preferences.html.haml
@@ -1,7 +1,7 @@
 = render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: 'fr-mb-3w') do |c|
   - c.with_body do
     %p
-      = t('.subtitle').html_safe
+      = t('.subtitle_html')
 
 = form_for instructeur_procedure, url: update_badge_notifications_instructeur_procedure_path(procedure), html: { class: 'form', data: { controller: 'enable-submit-if-form-changes', action: 'change->enable-submit-if-form-changes#onFormChange' } } do |form|
   - InstructeursProcedure::NOTIFICATION_COLUMNS.keys.each do |notification_type|

--- a/app/views/shared/dossiers/_edit.html.erb
+++ b/app/views/shared/dossiers/_edit.html.erb
@@ -39,7 +39,7 @@
           <%= render ::Dsfr::AlertComponent.new(state: :info, title: nil, size: :sm, heading_level: :p, extra_class_names: 'fr-mt-1w') do |c| %>
             <% c.with_body do %>
               <p class="fr-pb-0">
-                <%= t('views.shared.dossiers.edit.invite_notice').html_safe %>
+                <%= t('views.shared.dossiers.edit.invite_notice_html') %>
               </p>
             <% end %>
           <% end %>

--- a/app/views/shared/kaminari/_first_page.html.haml
+++ b/app/views/shared/kaminari/_first_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: 'fr-pagination__link fr-pagination__link--first', title: 'Première page', role: 'link'
+  = link_to_unless current_page.first?, t('views.pagination.first'), url, remote: remote, class: 'fr-pagination__link fr-pagination__link--first', title: 'Première page', role: 'link'

--- a/app/views/shared/kaminari/_last_page.html.haml
+++ b/app/views/shared/kaminari/_last_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, rel: 'next', remote: remote, class: 'fr-pagination__link fr-pagination__link--last', title: "Dernière page", role: 'link'
+  = link_to_unless current_page.last?, t('views.pagination.last'), url, rel: 'next', remote: remote, class: 'fr-pagination__link fr-pagination__link--last', title: "Dernière page", role: 'link'

--- a/app/views/shared/kaminari/_next_page.html.haml
+++ b/app/views/shared/kaminari/_next_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, class: 'fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label', role: 'link'
+  = link_to_unless current_page.last?, t('views.pagination.next'), url, rel: 'next', remote: remote, class: 'fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label', role: 'link'

--- a/app/views/shared/kaminari/_prev_page.html.haml
+++ b/app/views/shared/kaminari/_prev_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: 'fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label', role: 'link'
+  = link_to_unless current_page.first?, t('views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label', role: 'link'

--- a/app/views/users/dossiers/_dossiers_list.html.erb
+++ b/app/views/users/dossiers/_dossiers_list.html.erb
@@ -12,17 +12,17 @@
         <%= render Dsfr::AlertComponent.new(state: :info, size: :sm, extra_class_names: "fr-mb-2w") do |c| %>
           <% c.with_body do %>
             <% if dossier.brouillon? && can_recreate_a_dossier_from_a_procedure?(dossier.procedure) %>
-              <%= t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, class: 'fr-link', title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure'))).html_safe) %>
+              <%= t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, class: 'fr-link', title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure')))) %>
             <% elsif dossier.brouillon? %>
-              <%= t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, class: 'fr-link', title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details'))).html_safe) %>
+              <%= t('views.users.dossiers.dossiers_list.procedure_closed.brouillon.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, class: 'fr-link', title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details')))) %>
             <% elsif dossier.en_construction_ou_instruction? && can_recreate_a_dossier_from_a_procedure?(dossier.procedure) %>
-              <%= t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, class: 'fr-link', title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure'))).html_safe) %>
+              <%= t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, class: 'fr-link', title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure')))) %>
             <% elsif dossier.en_construction_ou_instruction? && !dossier.procedure.replaced_by_procedure.present? %>
-              <%= t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, class: 'fr-link', title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details'))).html_safe) %>
+              <%= t('views.users.dossiers.dossiers_list.procedure_closed.en_cours.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, class: 'fr-link', title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details')))) %>
             <% elsif dossier.termine? && can_recreate_a_dossier_from_a_procedure?(dossier.procedure) %>
-              <%= t('views.users.dossiers.dossiers_list.procedure_closed.termine.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.this_procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, class: 'fr-link', title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure'))).html_safe) %>
+              <%= t('views.users.dossiers.dossiers_list.procedure_closed.termine.internal_procedure_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.this_procedure'), commencer_path(dossier.procedure.replaced_by_procedure.path), **external_link_attributes, class: 'fr-link', title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_new_procedure')))) %>
             <% elsif dossier.termine? %>
-              <%= t('views.users.dossiers.dossiers_list.procedure_closed.termine.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, class: 'fr-link', title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details'))).html_safe) %>
+              <%= t('views.users.dossiers.dossiers_list.procedure_closed.termine.other_html', link: link_to(t('views.users.dossiers.dossiers_list.procedure_closed.more_details'), closing_details_path(dossier.procedure.path), **external_link_attributes, class: 'fr-link', title: new_tab_suffix(t('views.users.dossiers.dossiers_list.procedure_closed.title_closing_details')))) %>
             <% end %>
           <% end %>
         <% end %>
@@ -163,7 +163,7 @@
 
         <li>
           <%= t('views.users.dossiers.dossiers_list.no_result_search_back_html',
-                link: link_to(t('views.users.dossiers.dossiers_list.no_result_search_back_link'), dossiers_path, class: 'fr-link')).html_safe %>
+                link: link_to(t('views.users.dossiers.dossiers_list.no_result_search_back_link'), dossiers_path, class: 'fr-link')) %>
         </li>
       </ul>
     </div>

--- a/app/views/users/dossiers/transferer.html.haml
+++ b/app/views/users/dossiers/transferer.html.haml
@@ -9,7 +9,7 @@
         created_at: try_format_date(@dossier.created_at))
 
       .fr-highlight
-        %p= t(".irrevocable_html").html_safe
+        %p= t(".irrevocable_html")
 
       = form_for @transfer, url: transfer_dossier_path(@dossier), class: "fr-mt-4w" do |f|
         .fr-input-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -407,7 +407,7 @@ en:
         edit:
           autosave: Your file is automatically saved after each modification. You can close the window at any time and pick up where you left off later.
           autosave_submit: Your file is automatically saved. Submit it when you are finished.
-          invite_notice: You are invited to make amendments to this file but <strong>only the owner themselves can submit it</strong>.
+          invite_notice_html: You are invited to make amendments to this file but <strong>only the owner themselves can submit it</strong>.
         messages:
           form:
             send_message: "Send message"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -410,7 +410,7 @@ fr:
         edit:
           autosave: Votre dossier est enregistré automatiquement après chaque modification. Vous pouvez à tout moment fermer la fenêtre et reprendre plus tard là où vous en étiez.
           autosave_submit: Vos modifications sont automatiquement enregistrées. Déposez-les quand vous aurez terminé.
-          invite_notice: En tant qu’invité, vous pouvez remplir ce formulaire – mais <strong>le titulaire du dossier doit le déposer lui-même</strong>.
+          invite_notice_html: En tant qu’invité, vous pouvez remplir ce formulaire – mais <strong>le titulaire du dossier doit le déposer lui-même</strong>.
         messages:
           form:
             send_message: "Envoyer le message"

--- a/config/locales/views/administrateurs/procedures/en.yml
+++ b/config/locales/views/administrateurs/procedures/en.yml
@@ -32,8 +32,8 @@ en:
           cancel: Cancel
       closing_notification:
         page_title: Alert users
-        page_subtitle: Your procedure has been successfully closed. The link of the procedure now redirects to this <a href="%{closing_path}" target="_blank" rel="noopener noreferrer">closing page</a>.
-        page_subtitle_with_redirection: Your procedure has been successfully closed. The link of the procedure now redirects to this <a href="%{redirection_path}" target="_blank" rel="noopener noreferrer">procedure</a>.
+        page_subtitle_html: Your procedure has been successfully closed. The link of the procedure now redirects to this <a href="%{closing_path}" target="_blank" rel="noopener noreferrer">closing page</a>.
+        page_subtitle_with_redirection_html: Your procedure has been successfully closed. The link of the procedure now redirects to this <a href="%{redirection_path}" target="_blank" rel="noopener noreferrer">procedure</a>.
         callout_content: You can continue to examine the submitted files. If you do not intend to examine these files, we invite you to inform users
         email_toggle_brouillon:
           one: You want to send an email to the user with a draft folder

--- a/config/locales/views/administrateurs/procedures/fr.yml
+++ b/config/locales/views/administrateurs/procedures/fr.yml
@@ -32,8 +32,8 @@ fr:
           cancel: Retour
       closing_notification:
         page_title: Alerter les usagers
-        page_subtitle: Votre démarche est close. Le lien de votre démarche redirige désormais vers cette <a href="%{closing_path}" target="_blank" rel="noopener noreferrer">page de fermeture</a>.
-        page_subtitle_with_redirection: Votre démarche est close. Le lien public redirige désormais vers cette <a href="%{redirection_path}" target="_blank" rel="noopener noreferrer">démarche</a>.
+        page_subtitle_html: Votre démarche est close. Le lien de votre démarche redirige désormais vers cette <a href="%{closing_path}" target="_blank" rel="noopener noreferrer">page de fermeture</a>.
+        page_subtitle_with_redirection_html: Votre démarche est close. Le lien public redirige désormais vers cette <a href="%{redirection_path}" target="_blank" rel="noopener noreferrer">démarche</a>.
         callout_content: Vous avez la possibilité de continuer à instruire les dossiers déposés. Si vous n’avez pas l’intention d’instruire ces dossiers, nous vous invitons à en informer les usagers.
         email_toggle_brouillon:
           one: Souhaitez-vous envoyer un email à l’utilisateur avec un dossier en brouillon ?

--- a/config/locales/views/instructeurs/procedures/notification_preferences/en.yml
+++ b/config/locales/views/instructeurs/procedures/notification_preferences/en.yml
@@ -11,7 +11,7 @@ en:
           save: Save
       badge_preferences:
         flash_notice: "Your notification badge preferences have been saved. They are currently being adjusted."
-        subtitle: On this page, configure <strong>the events you want to be reported</strong> on the files for this procedure.
+        subtitle_html: On this page, configure <strong>the events you want to be reported</strong> on the files for this procedure.
         legend_content:
           dossier_depose: Be notified when a file has been submitted for at least %{days} days and is not being followed up by an instructor
           dossier_modifie: Be informed when a user's file has been modified

--- a/config/locales/views/instructeurs/procedures/notification_preferences/fr.yml
+++ b/config/locales/views/instructeurs/procedures/notification_preferences/fr.yml
@@ -11,7 +11,7 @@ fr:
           save: Enregistrer
       badge_preferences:
         flash_notice: "Vos préférences pour les badges de notification sont enregistrées. Ceux-ci sont en cours d’ajustement."
-        subtitle: Configurez sur cette page <strong>les événements que vous souhaitez voir signalés</strong> sur les dossiers de cette démarche.
+        subtitle_html: Configurez sur cette page <strong>les événements que vous souhaitez voir signalés</strong> sur les dossiers de cette démarche.
         legend_content:
           dossier_depose: Être averti lorsqu’un dossier déposé depuis au moins %{days} jours n’est suivi par aucun instructeur
           dossier_modifie: Être informé lorsque l’usager a modifié son dossier


### PR DESCRIPTION
# Probleme

Demande de @LeSim en review de #13674 : « il faudrait un de ces jours que l'on fasse un gros grep de `html_safe` et qu'on voit si on ne peut pas les sécuriser ».

Le grep remonte 34 occurrences. **La moitié ne sécurise rien du tout** : ce sont des no-op qui noient dans le bruit les `html_safe` qui, eux, méritent une relecture. On passe de 34 à 13.

# Solution

Trois commits séparés, du plus anodin au moins anodin.

### 1. Supprimer les 16 `html_safe` sans effet

Deux familles :

- **Traductions sans aucun HTML.** `views.pagination.next` vaut `Suivant`, `last` vaut `Dernier`, etc. dans les deux locales. Rien à marquer comme sûr. Concerne les 4 partiels Kaminari, la pagination Administrate et `DossiersNavigationComponent`.
- **Clé déjà en `_html` passée au helper de vue `t`.** Rails la marque déjà `html_safe` tout seul. Dans `_dossiers_list`, le `.html_safe` portait même sur un `link_to`, qui renvoie déjà un `SafeBuffer`.

Aucun fichier de locale touché, rendu strictement identique.

### 2 et 3. Renommer en `_html` les 5 traductions qui portent vraiment du markup

| Clé | Markup |
|---|---|
| `views.shared.dossiers.edit.invite_notice` | `<strong>` |
| `instructeurs.procedures.badge_preferences.subtitle` | `<strong>` |
| `administrateurs.procedures.closing_notification.page_subtitle` | `<a href>` |
| `…closing_notification.page_subtitle_with_redirection` | `<a href>` |
| `ExportDropdownComponent` — `include_archived_plural` / `_singular` | `<span>`, `<strong>` |

Le suffixe `_html` déplace l'information là où elle est utile — dans le fichier de traduction, visible du traducteur — plutôt qu'au point d'appel.

Deux conséquences au passage :

- Sur `closing_notification`, l'appel passe de `I18n.t` à `t` : **la convention `_html` vit dans le helper ActionView, pas dans `I18n.t`**. Sans ce changement la clé serait échappée et le lien s'afficherait en toutes lettres.
- `Dsfr::ToggleComponent` peut faire confiance au titre qu'on lui passe et laisser tomber son `&.html_safe` défensif (un seul appelant).

# Ce qui reste, et pourquoi

13 `html_safe`, tous volontaires :

- `faq/show` et `Redcarpet::TrustedRenderer` : markdown versionné dans `doc/faqs/`, jamais du contenu utilisateur. Un `sanitize` naïf serait ici une régression — `config/application.rb:52` retire `a` et `img` de l'allowlist globale, donc tous les liens et images des 45 pages FAQ sauteraient.
- `SimpleFormatComponent` est **déjà sanitizé** ; le `.html_safe` ne fait que restaurer le drapeau que `autolink` perd, `gsub` faisant partie des `UNSAFE_STRING_METHODS` de `SafeBuffer`.
- `I18n.t('…_html').html_safe` hors contexte de vue (modèles de prefill, `input_errorable`) : le `.html_safe` est **porteur**, pas redondant.
- HTML assemblé en Ruby (`join` qui perd le drapeau) ou imposé par le framework (`field_error_proc`, monkey patch `DateTimeSelector`).
- `file_field_component.html.erb:16` construit ses attributs par interpolation de chaîne sans échappement. C'est le seul vrai smell du lot — les valeurs viennent du code et non de l'utilisateur aujourd'hui, mais ça mérite son propre passage, hors de cette PR de nettoyage.

# Verifications

- `i18n-tasks missing` et `unused` : sorties **strictement identiques** à `main` (les échecs de `i18n-tasks health` sont préexistants et inchangés).
- Specs vertes sur les zones touchées, dont `procedure_closing_spec`, `transfer_dossier_spec`, `_edit.html.haml_spec`, `export_dropdown_component_spec` et `toggle_component_spec`.
- Les 5 renommages vérifiés par rendu réel : titre `html_safe`, markup présent en tant qu'éléments (`<strong>`, `<a href>`) et non en texte échappé.
- Brakeman : 0 warning.

Generated with [Claude Code](https://claude.com/claude-code)