### PR TITLE
Tech: construire les attributs de la drop zone avec tag.attributes

### DIFF
--- a/app/components/attachment/file_field_component/file_field_component.html.erb
+++ b/app/components/attachment/file_field_component/file_field_component.html.erb
@@ -12,10 +12,7 @@
     <div id="<%= empty_component_id %>" data-turbo-force="server">
       <% if drop_zone == :integrated %>
         <%# Integrated drop zone (drag events on parent, they bubble naturally) %>
-        <div
-          <%= drop_zone_decorator.data_attributes.map { |k, v| "data-#{k.to_s.dasherize}='#{v}'" }.join(' ').html_safe %>
-          class="<%= drop_zone_decorator.css_class %>"
-        >
+        <div <%= tag.attributes(drop_zone_decorator.merge_into) %>>
           <div
             class="attachment-drop-area fr-p-2w"
             role="button"


### PR DESCRIPTION
# Probleme

Dans le cadre du grep global des `html_safe` demande par @LeSim en review de #13674, la zone de depot de fichiers construisait ses attributs HTML par interpolation de chaine, puis marquait le resultat `html_safe`. Autrement dit, l'echappement etait explicitement desactive sur une chaine assemblee a la main.

Aujourd'hui les valeurs viennent uniquement du code (nom du controller Stimulus, liste d'actions), donc rien n'est exploitable : ce n'est pas une faille, c'est un durcissement. Mais le motif ne tient que tant que personne ne fait passer une valeur dynamique par le decorateur, et c'etait le dernier vrai smell du lot.

# Solution

On laisse Rails faire le travail : `tag.attributes` serialise et echappe les valeurs, ce qui supprime le besoin de `html_safe`. On en profite pour reutiliser `DropZoneDecorator#merge_into`, methode existante et deja testee qui retourne la classe et le hash de data, au lieu de refaire la serialisation a la main.

Le rendu est equivalent une fois parse : le HTML brut contient desormais `&gt;` dans `data-action`, que le navigateur decode en `>`. `element.dataset.action` est donc identique et les bindings Stimulus sont inchanges. Verifie par un spec de rendu temporaire, et couvert par le spec systeme de drag & drop qui reste vert.

Generated with [Claude Code](https://claude.com/claude-code)
