### PR TITLE
Tech: fiabilise les filtres sur les colonnes jsonpath

### DIFF
--- a/app/controllers/carte_controller.rb
+++ b/app/controllers/carte_controller.rb
@@ -17,9 +17,11 @@ class CarteController < ApplicationController
 
   def stats
     departements_sql = "select departement, count(procedures.id) as nb_demarches, sum(procedures.estimated_dossiers_count) as nb_dossiers from services inner join procedures on services.id = procedures.service_id where procedures.hidden_at is null and procedures.aasm_state in ('publiee', 'close', 'depubliee')"
-    departements_sql += " and procedures.published_at >= '#{@map_filter.year}-01-01' and procedures.published_at <= '#{@map_filter.year}-12-31'" if @map_filter.year.present?
+    if @map_filter.year.present?
+      departements_sql += ActiveRecord::Base.sanitize_sql([" and procedures.published_at between ? and ?", "#{@map_filter.year}-01-01", "#{@map_filter.year}-12-31"])
+    end
     departements_sql += " group by services.departement"
-    departements = ActiveRecord::Base.connection.execute(ActiveRecord::Base.sanitize_sql(departements_sql))
+    departements = ActiveRecord::Base.connection.execute(departements_sql)
     departements.to_a.reduce(Hash.new({ nb_demarches: 0, nb_dossiers: 0 })) do |h, v|
       h.merge(
         v["departement"] => {

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -164,9 +164,14 @@ module Instructeurs
         else
           0
         end
-      rescue ActiveRecord::StatementInvalid => e
-        raise e if !(e.message =~ /PG::UndefinedFunction/) # StatementInvalid is too generic, we'll add more cases if needed
-
+      # A timeout says nothing about the filters, and dropping them would cost the
+      # instructeur their whole setup over a transient hiccup.
+      rescue ActiveRecord::QueryCanceled
+        raise
+      # Filters are persisted before they are ever applied, so anything raised
+      # while applying them leaves the tab in a permanent 500 — with the button
+      # that would remove them on the very page that crashes.
+      rescue StandardError => e
         Sentry.capture_message(
           "Destroying invalid ProcedurePresentation",
           extra: {

--- a/app/models/column.rb
+++ b/app/models/column.rb
@@ -71,4 +71,8 @@ class Column
   def self.not_filled_option = [I18n.t('activerecord.attributes.type_de_champ.not_filled'), NOT_FILLED_VALUE]
 
   def column_id = "#{table}/#{column}"
+
+  private
+
+  def parse_datetime(value) = Time.zone.parse(value) rescue nil
 end

--- a/app/models/columns/champ_column.rb
+++ b/app/models/columns/champ_column.rb
@@ -50,15 +50,19 @@ class Columns::ChampColumn < Column
   end
 
   def filtered_ids_before_value(dossiers, values)
-    return dossiers.ids if values.first.blank?
+    end_date = parse_datetime(values.first)
 
-    filtered_ids_for_date_range(dossiers, ..Time.zone.parse(values.first).beginning_of_day)
+    return dossiers.ids if end_date.nil?
+
+    filtered_ids_for_date_range(dossiers, ..end_date.beginning_of_day)
   end
 
   def filtered_ids_after_value(dossiers, values)
-    return dossiers.ids if values.first.blank?
+    start_date = parse_datetime(values.first)
 
-    filtered_ids_for_date_range(dossiers, (Time.zone.parse(values.first).end_of_day..))
+    return dossiers.ids if start_date.nil?
+
+    filtered_ids_for_date_range(dossiers, (start_date.end_of_day..))
   end
 
   def filtered_ids_for_date_range(dossiers, range)

--- a/app/models/columns/champ_column.rb
+++ b/app/models/columns/champ_column.rb
@@ -249,6 +249,4 @@ class Columns::ChampColumn < Column
   end
 
   def parse_enums(value) = JSON.parse(value) rescue nil
-
-  def parse_datetime(value) = Time.zone.parse(value) rescue nil
 end

--- a/app/models/columns/dossier_column.rb
+++ b/app/models/columns/dossier_column.rb
@@ -40,15 +40,19 @@ class Columns::DossierColumn < Column
   end
 
   def filtered_ids_before_value(dossiers, values)
-    return dossiers.ids if values.first.blank?
+    end_date = parse_datetime(values.first)
 
-    filtered_ids_for_date_range(dossiers, ..Time.zone.parse(values.first).beginning_of_day)
+    return dossiers.ids if end_date.nil?
+
+    filtered_ids_for_date_range(dossiers, ..end_date.beginning_of_day)
   end
 
   def filtered_ids_after_value(dossiers, values)
-    return dossiers.ids if values.first.blank?
+    start_date = parse_datetime(values.first)
 
-    filtered_ids_for_date_range(dossiers, (Time.zone.parse(values.first).end_of_day..))
+    return dossiers.ids if start_date.nil?
+
+    filtered_ids_for_date_range(dossiers, (start_date.end_of_day..))
   end
 
   def filtered_ids_for_date_range(dossiers, range)
@@ -62,7 +66,7 @@ class Columns::DossierColumn < Column
     when 'self'
       if type == :date || type == :datetime
         dates = values
-          .filter_map { |v| Time.zone.parse(v).beginning_of_day rescue nil }
+          .filter_map { parse_datetime(_1)&.beginning_of_day }
 
         dossiers.filter_by_datetimes(column, dates)
       elsif type == :integer

--- a/app/models/columns/json_path_column.rb
+++ b/app/models/columns/json_path_column.rb
@@ -22,9 +22,9 @@ class Columns::JSONPathColumn < Columns::ChampColumn
   def filtered_ids(dossiers, filter)
     case filter
     in { operator: 'before', value: [end_date, *_] }
-      filtered_ids_for_date_range(dossiers, ..end_date&.then { Time.zone.parse(_1) }&.beginning_of_day)
+      filtered_ids_for_date_range(dossiers, ..parse_datetime(end_date)&.beginning_of_day)
     in { operator: 'after', value: [start_date, *_] }
-      filtered_ids_for_date_range(dossiers, (start_date&.then { Time.zone.parse(_1) }&.end_of_day..))
+      filtered_ids_for_date_range(dossiers, (parse_datetime(start_date)&.end_of_day..))
     in { operator: 'this_week' }
       filtered_ids_for_date_range(dossiers, Time.current.all_week)
     in { operator: 'this_month' }

--- a/app/models/columns/json_path_column.rb
+++ b/app/models/columns/json_path_column.rb
@@ -67,19 +67,22 @@ class Columns::JSONPathColumn < Columns::ChampColumn
 
       condition = sanitize_sql(%{champs.value_json @? '#{jsonpath_for_sql} ? (#{integers.map { |i| "@ == #{i}" }.join(" || ")})'})
     else
-      value = quote_string(jsonpath_escape(search_terms.join('|')))
-      condition = sanitize_sql(%{champs.value_json @? '#{jsonpath_for_sql} ? (@ like_regex "#{value}" flag "i")'})
+      # ["normal", "nom 'quote'", "un (terme)"] compiles to:
+      #
+      #   @ like_regex "normal" flag "iq"
+      #   || @ like_regex "nom ''quote''" flag "iq"  -- ' doubled by quote_string
+      #   || @ like_regex "un (terme)" flag "iq"     -- ( ) literal, thanks to q
+      #
+      # i keeps the match case-insensitive; q makes the pattern a literal
+      # substring, so a search term is matched rather than compiled as a regex,
+      # and none can be rejected any more. `|` being literal too, terms are
+      # OR-ed one at a time: a malformed one no longer takes the valid ones down.
+      matches = search_terms.map { %{@ like_regex "#{quote_string(jsonpath_escape(it))}" flag "iq"} }
+
+      condition = sanitize_sql(%{champs.value_json @? '#{jsonpath_for_sql} ? (#{matches.join(' || ')})'})
     end
 
     targeted_dossiers(dossiers, condition).ids
-
-  rescue ActiveRecord::StatementInvalid => e
-    if e.cause.is_a?(PG::InvalidRegularExpression)
-      Rails.logger.warn("filtered_ids fallback: Invalid regex — #{e.message}")
-      []
-    else
-      raise
-    end
   end
 
   # PostgreSQL's jsonpath parser rejects bare numeric member accessors (e.g. `$.row.4`),
@@ -96,9 +99,9 @@ class Columns::JSONPathColumn < Columns::ChampColumn
 
   def quote_string(string) = ActiveRecord::Base.connection.quote_string(string)
 
-  # `"` delimits the like_regex literal and `\` escapes inside it: left as-is, a
-  # search term containing either one breaks out of the literal and postgres
-  # rejects the whole jsonpath expression.
+  # `"` delimits the like_regex literal and `\` escapes inside it, `q` flag or
+  # not: left as-is, a search term containing either one breaks out of the
+  # literal and postgres rejects the whole jsonpath expression.
   def jsonpath_escape(string) = string.gsub(/["\\]/) { "\\#{it}" }
 
   def sanitize_sql(sql) = ActiveRecord::Base.sanitize_sql(sql)

--- a/app/models/columns/json_path_column.rb
+++ b/app/models/columns/json_path_column.rb
@@ -77,7 +77,10 @@ class Columns::JSONPathColumn < Columns::ChampColumn
       # substring, so a search term is matched rather than compiled as a regex,
       # and none can be rejected any more. `|` being literal too, terms are
       # OR-ed one at a time: a malformed one no longer takes the valid ones down.
-      matches = search_terms.map { %{@ like_regex "#{quote_string(jsonpath_escape(it))}" flag "iq"} }
+      #
+      # to_json writes the jsonpath string literal, quotes included: it escapes
+      # the `"` that would close it and the `\` that would escape inside it.
+      matches = search_terms.map { %{@ like_regex #{quote_string(it.to_json)} flag "iq"} }
 
       condition = %{champs.value_json @? '#{jsonpath_for_sql} ? (#{matches.join(' || ')})'}
     end
@@ -98,11 +101,6 @@ class Columns::JSONPathColumn < Columns::ChampColumn
   end
 
   def quote_string(string) = ActiveRecord::Base.connection.quote_string(string)
-
-  # `"` delimits the like_regex literal and `\` escapes inside it, `q` flag or
-  # not: left as-is, a search term containing either one breaks out of the
-  # literal and postgres rejects the whole jsonpath expression.
-  def jsonpath_escape(string) = string.gsub(/["\\]/) { "\\#{it}" }
 
   def targeted_dossiers(dossiers, condition)
     dossiers.with_type_de_champ(stable_id).where(condition)

--- a/app/models/columns/json_path_column.rb
+++ b/app/models/columns/json_path_column.rb
@@ -67,7 +67,7 @@ class Columns::JSONPathColumn < Columns::ChampColumn
 
       condition = sanitize_sql(%{champs.value_json @? '#{jsonpath_for_sql} ? (#{integers.map { |i| "@ == #{i}" }.join(" || ")})'})
     else
-      value = quote_string(search_terms.join('|'))
+      value = quote_string(jsonpath_escape(search_terms.join('|')))
       condition = sanitize_sql(%{champs.value_json @? '#{jsonpath_for_sql} ? (@ like_regex "#{value}" flag "i")'})
     end
 
@@ -95,6 +95,11 @@ class Columns::JSONPathColumn < Columns::ChampColumn
   end
 
   def quote_string(string) = ActiveRecord::Base.connection.quote_string(string)
+
+  # `"` delimits the like_regex literal and `\` escapes inside it: left as-is, a
+  # search term containing either one breaks out of the literal and postgres
+  # rejects the whole jsonpath expression.
+  def jsonpath_escape(string) = string.gsub(/["\\]/) { "\\#{it}" }
 
   def sanitize_sql(sql) = ActiveRecord::Base.sanitize_sql(sql)
 

--- a/app/models/columns/json_path_column.rb
+++ b/app/models/columns/json_path_column.rb
@@ -50,7 +50,7 @@ class Columns::JSONPathColumn < Columns::ChampColumn
     parts << %(@ >= "#{start_date}") if start_date
     parts << %(@ <= "#{end_date}") if end_date
 
-    condition = sanitize_sql(%{champs.value_json @? '#{jsonpath_for_sql} ? (#{parts.join(' && ')})'})
+    condition = %{champs.value_json @? '#{jsonpath_for_sql} ? (#{parts.join(' && ')})'}
 
     targeted_dossiers(dossiers, condition).ids
   end
@@ -65,7 +65,7 @@ class Columns::JSONPathColumn < Columns::ChampColumn
 
       return dossiers.ids if integers.empty?
 
-      condition = sanitize_sql(%{champs.value_json @? '#{jsonpath_for_sql} ? (#{integers.map { |i| "@ == #{i}" }.join(" || ")})'})
+      condition = %{champs.value_json @? '#{jsonpath_for_sql} ? (#{integers.map { |i| "@ == #{i}" }.join(" || ")})'}
     else
       # ["normal", "nom 'quote'", "un (terme)"] compiles to:
       #
@@ -79,7 +79,7 @@ class Columns::JSONPathColumn < Columns::ChampColumn
       # OR-ed one at a time: a malformed one no longer takes the valid ones down.
       matches = search_terms.map { %{@ like_regex "#{quote_string(jsonpath_escape(it))}" flag "iq"} }
 
-      condition = sanitize_sql(%{champs.value_json @? '#{jsonpath_for_sql} ? (#{matches.join(' || ')})'})
+      condition = %{champs.value_json @? '#{jsonpath_for_sql} ? (#{matches.join(' || ')})'}
     end
 
     targeted_dossiers(dossiers, condition).ids
@@ -103,8 +103,6 @@ class Columns::JSONPathColumn < Columns::ChampColumn
   # not: left as-is, a search term containing either one breaks out of the
   # literal and postgres rejects the whole jsonpath expression.
   def jsonpath_escape(string) = string.gsub(/["\\]/) { "\\#{it}" }
-
-  def sanitize_sql(sql) = ActiveRecord::Base.sanitize_sql(sql)
 
   def targeted_dossiers(dossiers, condition)
     dossiers.with_type_de_champ(stable_id).where(condition)

--- a/app/models/concerns/dossier_filtering_concern.rb
+++ b/app/models/concerns/dossier_filtering_concern.rb
@@ -47,6 +47,4 @@ module DossierFilteringConcern
       where("unaccent(#{table_column}) ILIKE ANY (ARRAY((SELECT unaccent(unnest(ARRAY[?])))))", safe_quoted_terms)
     }
   end
-
-  def sanitize_sql_like(q) = ActiveRecord::Base.sanitize_sql_like(q)
 end

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -609,16 +609,39 @@ describe Instructeurs::ProceduresController, type: :controller do
       end
 
       context 'when an error occurs in the DossierFilterService' do
-        before do
-          allow(DossierFilterService).to receive(:filtered_sorted_ids).and_raise(ActiveRecord::StatementInvalid.new('PG::UndefinedFunction'))
+        before { allow(DossierFilterService).to receive(:filtered_sorted_ids).and_raise(error) }
 
-          expect_any_instance_of(ProcedurePresentation).to receive(:destroy_filters_for!)
-          subject
+        shared_examples 'a filter the instructeur cannot get rid of' do
+          it 'resets the display instead of leaving the tab broken' do
+            expect_any_instance_of(ProcedurePresentation).to receive(:destroy_filters_for!)
+
+            subject
+
+            expect(response).to redirect_to(instructeur_procedure_path)
+            expect(flash.alert).to include('Votre affichage a dû être réinitialisé')
+          end
         end
 
-        it do
-          expect(response).to redirect_to(instructeur_procedure_path)
-          expect(flash.alert).to include('Votre affichage a dû être réinitialisé')
+        context 'because postgres rejects the filter' do
+          let(:error) { ActiveRecord::StatementInvalid.new('PG::UndefinedFunction') }
+
+          it_behaves_like 'a filter the instructeur cannot get rid of'
+        end
+
+        context 'because of anything else' do
+          let(:error) { NoMethodError.new("undefined method 'beginning_of_day' for nil") }
+
+          it_behaves_like 'a filter the instructeur cannot get rid of'
+        end
+
+        context 'because the query timed out, which says nothing about the filters' do
+          let(:error) { ActiveRecord::QueryCanceled.new('PG::QueryCanceled') }
+
+          it 'keeps them' do
+            expect_any_instance_of(ProcedurePresentation).not_to receive(:destroy_filters_for!)
+
+            expect { subject }.to raise_error(ActiveRecord::QueryCanceled)
+          end
         end
       end
 

--- a/spec/models/columns/champ_column_spec.rb
+++ b/spec/models/columns/champ_column_spec.rb
@@ -428,6 +428,26 @@ describe Columns::ChampColumn do
         end
       end
 
+      # update_filter neither whitelists the operator nor validates the date, so
+      # both of these reach the column.
+      context "when searching with a date the filter form let through" do
+        let(:dossier) { create(:dossier, :en_instruction, procedure:) }
+
+        before { dossier.champ_data.first.update!(value: "2025-02-13") }
+
+        context "out of range" do
+          let(:filter) { { operator: 'before', value: ['2024-13-45'] } }
+
+          it { expect(subject).to eq([dossier.id]) }
+        end
+
+        context "unparseable" do
+          let(:filter) { { operator: 'after', value: ['abc'] } }
+
+          it { expect(subject).to eq([dossier.id]) }
+        end
+      end
+
       context "when searching with this_month operator" do
         let(:filter) { { operator: 'this_month' } }
 
@@ -532,6 +552,26 @@ describe Columns::ChampColumn do
 
         it "returns the correct ids" do
           expect(subject).to eq([dossier2.id])
+        end
+      end
+
+      # update_filter neither whitelists the operator nor validates the date, so
+      # both of these reach the column.
+      context "when searching with a date the filter form let through" do
+        let(:dossier) { create(:dossier, :en_instruction, procedure:) }
+
+        before { dossier.champ_data.first.update!(value: "2025-02-13") }
+
+        context "out of range" do
+          let(:filter) { { operator: 'before', value: ['2024-13-45'] } }
+
+          it { expect(subject).to eq([dossier.id]) }
+        end
+
+        context "unparseable" do
+          let(:filter) { { operator: 'after', value: ['abc'] } }
+
+          it { expect(subject).to eq([dossier.id]) }
         end
       end
 

--- a/spec/models/columns/dossier_column_spec.rb
+++ b/spec/models/columns/dossier_column_spec.rb
@@ -173,6 +173,24 @@ describe Columns::DossierColumn do
         end
       end
 
+      # update_filter neither whitelists the operator nor validates the date, so
+      # both of these reach the column.
+      context 'when searching with a date the filter form let through' do
+        let!(:dossier) { travel_to(DateTime.parse("12/02/2025 09:19")) { create(:dossier, :en_instruction, procedure:) } }
+
+        context 'out of range' do
+          let(:search_terms) { { operator: 'before', value: ['2024-13-45'] } }
+
+          it { is_expected.to contain_exactly(dossier.id) }
+        end
+
+        context 'unparseable' do
+          let(:search_terms) { { operator: 'after', value: ['abc'] } }
+
+          it { is_expected.to contain_exactly(dossier.id) }
+        end
+      end
+
       context 'when searching with this_week operator' do
         let(:search_terms) { { operator: 'this_week' } }
 

--- a/spec/models/columns/json_path_column_spec.rb
+++ b/spec/models/columns/json_path_column_spec.rb
@@ -59,19 +59,22 @@ describe Columns::JSONPathColumn do
       end
     end
 
-    context 'with avanced search using special characters' do
+    context 'with search terms containing regex metacharacters' do
       let(:jsonpath) { '$.city_name' }
+      let(:dossiers) { Dossier.where(id: dossier.id) }
 
-      subject { column.filtered_ids(Dossier.all, { operator: 'match', value: ['*reno*', 'Lyon'] }) }
+      before { champ.update(value_json: { city_name: 'SARL (LES TROIS CHENES)' }) }
 
-      context 'when champ has value_json we catch Invalid Regex error and return []' do
-        before { champ.update(value_json: { city_name: 'Grenoble' }) }
-
-        it { is_expected.to eq([]) }
+      it 'matches the metacharacters literally' do
+        expect(column.filtered_ids(dossiers, { operator: 'match', value: ['SARL (LES TROIS CHENES)'] })).to eq([dossier.id])
       end
 
-      context 'when champ has no value_json we catch Invalid Regex error and return []' do
-        it { is_expected.to eq([]) }
+      it 'does not let a metacharacter stand for another character' do
+        expect(column.filtered_ids(dossiers, { operator: 'match', value: ['SARL .LES.'] })).to eq([])
+      end
+
+      it 'keeps the other terms when one of them would be a malformed regex' do
+        expect(column.filtered_ids(dossiers, { operator: 'match', value: ['*reno*', 'CHENES'] })).to eq([dossier.id])
       end
     end
 

--- a/spec/models/columns/json_path_column_spec.rb
+++ b/spec/models/columns/json_path_column_spec.rb
@@ -184,6 +184,21 @@ describe Columns::JSONPathColumn do
       end
     end
 
+    context 'with search terms containing jsonpath string delimiters' do
+      let(:jsonpath) { '$.city_name' }
+      let(:dossiers) { Dossier.where(id: dossier.id) }
+
+      before { champ.update(value_json: { city_name: 'Aix "la" Belle' }) }
+
+      it 'matches a term containing a double quote' do
+        expect(column.filtered_ids(dossiers, { operator: 'match', value: ['"la"'] })).to eq([dossier.id])
+      end
+
+      it 'does not blow up on a term ending with a backslash' do
+        expect(column.filtered_ids(dossiers, { operator: 'match', value: ['Aix\\'] })).to eq([])
+      end
+    end
+
     context 'with blank filter values' do
       let(:jsonpath) { '$.postal_code' }
       let(:dossier1) { create(:dossier, procedure:) }

--- a/spec/models/columns/json_path_column_spec.rb
+++ b/spec/models/columns/json_path_column_spec.rb
@@ -136,6 +136,18 @@ describe Columns::JSONPathColumn do
 
         it { is_expected.to include(dossier_in_range.id, dossier_out_range.id) }
       end
+
+      # update_filter does not validate the date, so this one reaches the column.
+      context 'with a date out of range' do
+        before do
+          dossier_in_range.champ_data.first.update(value_json: { issue_date: '2022-06-15' })
+          dossier_out_range.champ_data.first.update(value_json: { issue_date: '2020-06-15' })
+        end
+
+        subject { column.filtered_ids(Dossier.all, { operator: 'before', value: ['2024-13-45'] }) }
+
+        it { is_expected.to include(dossier_in_range.id, dossier_out_range.id) }
+      end
     end
 
     context 'with integer' do

--- a/spec/models/concerns/dossier_filtering_concern_spec.rb
+++ b/spec/models/concerns/dossier_filtering_concern_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe DossierFilteringConcern do
+  describe '.filter_ilike' do
+    let(:dossier) { dossiers.en_construction }
+    let(:scope) { Dossier.where(id: dossier.id).includes(:user) }
+
+    def filtering(term) = scope.filter_ilike('user', 'email', [term]).ids
+
+    it 'matches on a substring of the column' do
+      expect(filtering('usager@exemple.fr')).to eq([dossier.id])
+      expect(filtering('exemple')).to eq([dossier.id])
+    end
+
+    it 'escapes the ILIKE wildcards, so they match literally' do
+      expect(filtering('usager%exemple.fr')).to eq([])
+      expect(filtering('usager_exemple.fr')).to eq([])
+    end
+
+    # Quotes are neutralised by the bind parameter, not by sanitize_sql_like:
+    # the payload stays inside the string literal it is bound into.
+    it 'treats a quoted payload as data rather than SQL' do
+      payload = "usager@exemple.fr%') UNION SELECT email, encrypted_password, id FROM users--"
+
+      expect(filtering(payload)).to eq([])
+    end
+  end
+end

--- a/spec/services/dossier_filter_service_spec.rb
+++ b/spec/services/dossier_filter_service_spec.rb
@@ -1086,4 +1086,17 @@ describe DossierFilterService do
       end
     end
   end
+
+  describe '.sanitized_column' do
+    it 'resolves an association to its table name' do
+      expect(described_class.sanitized_column('user', 'email')).to eq('"users"."email"')
+    end
+
+    # table and column are the only parts of the ILIKE filter that are
+    # interpolated, so they have to stay identifiers whatever they contain.
+    it 'quotes a hostile identifier instead of letting it break out' do
+      expect(described_class.sanitized_column('users"; DROP TABLE users--', 'email'))
+        .to eq(%{"users""; DROP TABLE users--"."email"})
+    end
+  end
 end

--- a/spec/services/dossier_search_service_spec.rb
+++ b/spec/services/dossier_search_service_spec.rb
@@ -192,13 +192,17 @@ describe DossierSearchService do
   end
 
   describe '.to_tsquery' do
+    # `:*` makes each term a prefix match, `&` joins them.
     it 'builds a prefix matching query out of the terms' do
       expect(described_class.to_tsquery('Direction nicolas')).to eq('Direction:* & nicolas:*')
     end
 
-    # The quote would otherwise close the SQL literal the query is quoted into,
-    # the rest are tsquery operators postgres would parse rather than match.
-    it 'drops the characters postgres would not treat as text' do
+    # `& | ! ( ) : <` are tsquery operators and must go, or to_tsquery raises.
+    it 'drops the characters postgres would parse instead of matching' do
+      expect(described_class.to_tsquery('Dupont & Fils (13)')).to eq('Dupont:* & Fils:* & 13:*')
+    end
+
+    it 'drops quotes too, so an injection payload lands as plain terms' do
       expect(described_class.to_tsquery("Dupont') OR 1=1--")).to eq('Dupont:* & OR:* & 1=1--:*')
     end
   end

--- a/spec/services/dossier_search_service_spec.rb
+++ b/spec/services/dossier_search_service_spec.rb
@@ -190,4 +190,16 @@ describe DossierSearchService do
       end
     end
   end
+
+  describe '.to_tsquery' do
+    it 'builds a prefix matching query out of the terms' do
+      expect(described_class.to_tsquery('Direction nicolas')).to eq('Direction:* & nicolas:*')
+    end
+
+    # The quote would otherwise close the SQL literal the query is quoted into,
+    # the rest are tsquery operators postgres would parse rather than match.
+    it 'drops the characters postgres would not treat as text' do
+      expect(described_class.to_tsquery("Dupont') OR 1=1--")).to eq('Dupont:* & OR:* & 1=1--:*')
+    end
+  end
 end


### PR DESCRIPTION
Suite à un signalement d'injection SQL sur la recherche de dossiers (`/instructeurs/dossiers?search=`, puis `/search?search=`). Vérifié : **le signalement n'est pas valide** — aucun de ces endpoints n'existe, et les termes de recherche sont passés en bind param, pas interpolés.

La vérification a en revanche mis au jour plusieurs vrais bugs sur le filtrage des colonnes jsonpath, corrigés ici. Les trois premiers viennent de la relecture de @colinux.

## Ce que traverse un terme de filtre

Le terme tapé par l'instructeur est emboîté dans trois couches, chacune avec ses caractères dangereux :

| couche | délimiteur | protège | si absent |
|---|---|---|---|
| littéral SQL | `'` | `quote_string` | injection SQL |
| littéral jsonpath | `"` `\` | `to_json` | expression rejetée, filtre cassé |
| motif regex | — | `flag "q"` | résultats faux, en silence |

La couche 1 était déjà correcte — d'où l'invalidité du signalement. Les couches 2 et 3 étaient cassées.

## 1. Le terme était compilé en regex POSIX

```
SARL (LES TROIS CHENES)  ->  aucun résultat, les parenthèses lues comme un groupe
S.A.R.L                  ->  matche SXAXRXL
["*reno*", "CHENES"]     ->  [], un terme malformé rejetait tout le filtre
```

Déclenchable **sans rien taper** : les colonnes référentiel construisent leurs options depuis le CSV, donc choisir `Autre (préciser)` dans le select ne renvoyait aucun dossier.

`flag "iq"` rend le motif littéral, et les termes sont désormais OR-és un `like_regex` à la fois. Plus aucun motif ne pouvant être rejeté, le `rescue PG::InvalidRegularExpression` disparaît : il renvoyait `[]` en silence pendant que le filtre s'affichait comme actif.

## 2. Les délimiteurs jsonpath

Un `"` ou un `\` final fermait le littéral et Postgres rejetait toute l'expression. Le filtre étant **enregistré avant d'être appliqué**, l'onglet restait en 500 à chaque visite — le bouton de suppression du filtre se trouvant sur la page qui plante.

Reproduire sur `main` : champ SIRET, colonne « … – Raison sociale », valeur `SOCIETE "LES TROIS CHENES"` copiée-collée depuis un dossier.

## 3. L'onglet 500 définitif

Deux causes, deux correctifs :

- le `rescue` de `procedures#show` ne rattrapait que `PG::UndefinedFunction`, et le reconnaissait par une **regex sur le message d'exception** ; il rattrape maintenant tout ce que lève l'application d'un filtre persisté. Seul un `QueryCanceled` est re-levé : un timeout ne dit rien sur la validité des filtres, et les détruire ferait perdre sa configuration à l'instructeur ;
- une date de filtre invalide levait (`2024-13-45` → `ArgumentError`, `abc` → `NoMethodError` sur `nil`) dans les trois colonnes. Une date inutilisable ne filtre plus, comme le fait déjà le cas vide juste au-dessus.

**Changement de comportement visible** : un filtre invalide ne casse plus l'onglet, il réinitialise l'affichage avec le flash « Votre affichage a dû être réinitialisé ».

## 4. Tests de sécurité et nettoyage

Le quoting était correct, mais rien ne le vérifiait. Les trois points d'interpolation sont couverts (`filter_ilike`, `DossierFilterService.sanitized_column`, `DossierSearchService.to_tsquery`), et les tests ont été vérifiés discriminants par mutation du code de production.

Nettoyage au passage : `sanitize_sql` sur une String est un no-op qui donnait une fausse impression de protection ; la méthode d'instance `sanitize_sql_like` était morte (un scope résout vers la méthode de classe) ; `jsonpath_escape` réimplémentait `String#to_json`.

La prochaine fois qu'un rapport de ce type arrive, la réponse est dans la suite de tests plutôt que dans une console.
