### PR TITLE
Tech: supprime la colonne procedure_expires_when_termine_enabled

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -17,7 +17,7 @@ class Procedure < ApplicationRecord
   include Discard::Model
   self.discard_column = :hidden_at
 
-  self.ignored_columns += ["api_entreprise_token_expires_at", "pro_connect_restricted", "procedure_expires_when_termine_enabled"]
+  self.ignored_columns += ["api_entreprise_token_expires_at", "pro_connect_restricted"]
 
   default_scope -> { kept }
 

--- a/db/migrate/20260820081609_drop_procedure_expires_when_termine_enabled_from_procedures.rb
+++ b/db/migrate/20260820081609_drop_procedure_expires_when_termine_enabled_from_procedures.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DropProcedureExpiresWhenTermineEnabledFromProcedures < ActiveRecord::Migration[8.0]
+  def change
+    # Colonne ignorée via `ignored_columns` depuis la PR #13341, déployée le
+    # 2026-06-26 : plus aucun process ne la référence, le drop est sans impact.
+    safety_assured do
+      remove_column :procedures, :procedure_expires_when_termine_enabled, :boolean, default: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_19_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_20_081609) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_stat_statements"
@@ -1151,7 +1151,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_19_120000) do
     t.boolean "pro_connect_for_moral_procedure", default: false, null: false
     t.boolean "pro_connect_restricted", default: false, null: false
     t.string "pro_connect_restriction", default: "none", null: false
-    t.boolean "procedure_expires_when_termine_enabled", default: true
     t.datetime "published_at", precision: nil
     t.bigint "published_revision_id"
     t.boolean "rdv_enabled", default: false, null: false
@@ -1177,7 +1176,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_19_120000) do
     t.index ["parent_procedure_id"], name: "index_procedures_on_parent_procedure_id"
     t.index ["path", "closed_at", "hidden_at", "unpublished_at"], name: "procedure_path_uniqueness", unique: true
     t.index ["path", "closed_at", "hidden_at"], name: "index_procedures_on_path_and_closed_at_and_hidden_at", unique: true
-    t.index ["procedure_expires_when_termine_enabled"], name: "index_procedures_on_procedure_expires_when_termine_enabled"
     t.index ["published_revision_id"], name: "index_procedures_on_published_revision_id"
     t.index ["service_id"], name: "index_procedures_on_service_id"
     t.index ["tags"], name: "index_procedures_on_tags", using: :gin


### PR DESCRIPTION
# Probleme

La PR #13341 (mergee le 26/06/2026) a supprime le flag transitoire `procedure_expires_when_termine_enabled` et annoncait un deploiement en 2 etapes. L'etape 2 n'a jamais ete faite : la colonne et son index trainent en base depuis deux mois.

# Solution

`remove_column` + retrait de l'entree dans `ignored_columns`.

Les deux vont ensemble sans risque maintenant que l'etape 1 est deployee : les anciens process ignorent l'attribut, le nouveau code ne le lit plus. Meme approche que `DropIgnoredColumns` (a71e83dab, 09/2024).

Generated with [Claude Code](https://claude.com/claude-code)