### PR TITLE
Tech: remplacer les raw() des vues par la convention _html

### DIFF
--- a/app/views/layouts/mailers/_bizdev_signature.html.haml
+++ b/app/views/layouts/mailers/_bizdev_signature.html.haml
@@ -9,4 +9,4 @@ Cordialement,
 Téléphone (standard) :
 = CONTACT_PHONE
 %br
-= safe_join(CONTACT_ADDRESS.split("\n"), raw('<br>'))
+= safe_join(CONTACT_ADDRESS.split("\n"), tag.br)

--- a/app/views/users/dossiers/show_deleted.html.haml
+++ b/app/views/users/dossiers/show_deleted.html.haml
@@ -15,4 +15,4 @@
                 %li= t('users.dossiers.show_deleted.reason_user_request')
                 %li= t('users.dossiers.show_deleted.reason_automatic')
 
-            %p= raw t('users.dossiers.show_deleted.history_link_html', history_link: deleted_dossiers_path)
+            %p= t('users.dossiers.show_deleted.history_link_html', history_link: deleted_dossiers_path)

--- a/app/views/users/dossiers/show_in_trash.html.haml
+++ b/app/views/users/dossiers/show_in_trash.html.haml
@@ -9,15 +9,15 @@
             %h1.fr-h2= t('users.dossiers.show_in_trash.title', numero: @hidden_dossier.id)
 
             - is_manual_brouillon = @hidden_dossier.brouillon? && @hidden_dossier.hidden_by_reason == 'user_request'
-            %p.fr-mb-4w= raw t('users.dossiers.show_in_trash.explanation_html', trash_link: trash_path)
+            %p.fr-mb-4w= t('users.dossiers.show_in_trash.explanation_html', trash_link: trash_path)
             .card.fr-mb-4w
               %ul
                 - if is_manual_brouillon
-                  %li= raw t('users.dossiers.show_in_trash.user_request_info_without_if')
+                  %li= t('users.dossiers.show_in_trash.user_request_info_without_if_html')
                 - else
                   %ul
-                    %li= raw t('users.dossiers.show_in_trash.user_request_info')
-                    %li= raw t('users.dossiers.show_in_trash.automatic_info')
+                    %li= t('users.dossiers.show_in_trash.user_request_info_html')
+                    %li= t('users.dossiers.show_in_trash.automatic_info_html')
 
             = link_to t('users.dossiers.show_in_trash.consult_trash'),
                       trash_path,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1056,9 +1056,9 @@ en:
         title: "File n° %{numero} has been moved to trash"
         explanation_html: "You can find this file from the <a href=\"%{trash_link}\" class=\"fr-link\">trash</a> tab of your account.<br>It is not currently viewable."
         consult_trash: "View trash"
-        user_request_info_without_if: "This file was moved to trash at your request:<br>You can still <strong>restore</strong> it."
-        user_request_info: "If this file was moved to trash at your request:<br>You can still <strong>restore</strong> it."
-        automatic_info: "If this file was moved to trash automatically because its maximum retention period has been reached:<br>We recommend <strong>downloading</strong> it as soon as possible before it is permanently deleted."
+        user_request_info_without_if_html: "This file was moved to trash at your request:<br>You can still <strong>restore</strong> it."
+        user_request_info_html: "If this file was moved to trash at your request:<br>You can still <strong>restore</strong> it."
+        automatic_info_html: "If this file was moved to trash automatically because its maximum retention period has been reached:<br>We recommend <strong>downloading</strong> it as soon as possible before it is permanently deleted."
       show_deleted:
         page_title: "File n° %{numero} - Permanently deleted"
         title: "File n° %{numero} has been deleted"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1077,9 +1077,9 @@ fr:
         title: "Le dossier n° %{numero} a été mis à la corbeille"
         explanation_html: "Vous pouvez retrouver ce dossier depuis l’onglet <a href=\"%{trash_link}\" class=\"fr-link\">corbeille</a> de votre compte.<br>Il n’est pas consultable actuellement."
         consult_trash: "Consulter la corbeille"
-        user_request_info_without_if: "Ce dossier a été mis à la corbeille à votre demande :<br>Vous pouvez encore le <strong>restaurer</strong>."
-        user_request_info: "Si ce dossier a été mis à la corbeille à votre demande :<br>Vous pouvez encore le <strong>restaurer</strong>."
-        automatic_info: "Si ce dossier a été mis à la corbeille automatiquement car son délai maximal de conservation a été atteint :<br>Nous vous invitons à le <strong>télécharger</strong> au plus vite avant qu’il ne soit supprimé définitivement."
+        user_request_info_without_if_html: "Ce dossier a été mis à la corbeille à votre demande :<br>Vous pouvez encore le <strong>restaurer</strong>."
+        user_request_info_html: "Si ce dossier a été mis à la corbeille à votre demande :<br>Vous pouvez encore le <strong>restaurer</strong>."
+        automatic_info_html: "Si ce dossier a été mis à la corbeille automatiquement car son délai maximal de conservation a été atteint :<br>Nous vous invitons à le <strong>télécharger</strong> au plus vite avant qu’il ne soit supprimé définitivement."
       show_deleted:
         page_title: "Dossier n° %{numero} - Supprimé définitivement"
         title: "Le dossier n° %{numero} a été supprimé"

--- a/spec/views/users/dossiers/show_deleted.html.haml_spec.rb
+++ b/spec/views/users/dossiers/show_deleted.html.haml_spec.rb
@@ -17,4 +17,8 @@ describe 'users/dossiers/show_deleted', type: :view do
     expect(rendered).to have_text('Il a été mis à la corbeille à votre demande')
     expect(rendered).to have_text('Il a été supprimé car son délai maximal')
   end
+
+  it 'links to the deleted dossiers history' do
+    expect(rendered).to have_link('Historique des dossiers supprimés', href: deleted_dossiers_path)
+  end
 end

--- a/spec/views/users/dossiers/show_in_trash.html.haml_spec.rb
+++ b/spec/views/users/dossiers/show_in_trash.html.haml_spec.rb
@@ -20,8 +20,12 @@ describe 'users/dossiers/show_in_trash', type: :view do
     end
 
     it 'displays the restore option' do
-      expect(rendered).to have_text('restaurer')
+      expect(rendered).to have_css('strong', text: 'restaurer')
       expect(rendered).not_to have_text('télécharger')
+    end
+
+    it 'renders the explanation markup' do
+      expect(rendered).to have_link('corbeille', href: trash_path)
     end
   end
 
@@ -39,8 +43,8 @@ describe 'users/dossiers/show_in_trash', type: :view do
     end
 
     it 'displays the restore and download options' do
-      expect(rendered).to have_text('restaurer')
-      expect(rendered).to have_text('télécharger')
+      expect(rendered).to have_css('strong', text: 'restaurer')
+      expect(rendered).to have_css('strong', text: 'télécharger')
     end
   end
 end


### PR DESCRIPTION
# Problème

Même chantier que #13689, autre syntaxe : `raw()` contourne l'échappement exactement comme `html_safe`, et Rubocop ne voit ni l'un ni l'autre dans les vues.

Sur les pages corbeille / dossier supprimé, cinq `raw t(…)` :

- deux portaient sur des clés déjà suffixées `_html`, où le helper `t` marque déjà la traduction safe — le `raw` était redondant ;
- trois portaient sur des clés qui contiennent du `<br>` et du `<strong>` **sans** le suffixe, donc un vrai contournement.

# Solution

Les trois clés concernées (`user_request_info`, `user_request_info_without_if`, `automatic_info`) sont renommées avec le suffixe `_html`, fr et en. Les cinq `raw` disparaissent : le helper de vue fait le travail.

Au passage, le `raw('<br>')` de la signature des mails devient `tag.br` (rendu identique, vérifié).

Les specs de vue existantes assertaient le texte (`have_text('restaurer')`), ce qui passe aussi bien si le `<strong>` est échappé. Elles assertent maintenant le markup — vérifié en cassant volontairement le rendu.

Generated with [Claude Code](https://claude.com/claude-code)