### PR TITLE
ETQ instructeur, je peux filtrer sur les colonnes booléennes FranceConnect

### DIFF
--- a/app/models/column.rb
+++ b/app/models/column.rb
@@ -20,7 +20,13 @@ class Column
     @type = type
     @filterable = filterable
     @displayable = displayable
-    @options_for_select = options_for_select
+    # A boolean column is rendered as radio buttons built from these options,
+    # so oui/non is the default; checkbox passes its own coché/non coché pair.
+    @options_for_select = if type == :boolean && options_for_select.blank?
+      Champs::YesNoChamp.options
+    else
+      options_for_select
+    end
     @mandatory = mandatory
   end
 

--- a/app/models/columns/dossier_column.rb
+++ b/app/models/columns/dossier_column.rb
@@ -86,6 +86,10 @@ class Columns::DossierColumn < Column
         dossiers
           .includes(:etablissement)
           .where(etablissements: { column => values.filter_map { Integer(_1) rescue nil } })
+      elsif type == :boolean
+        dossiers
+          .includes(:etablissement)
+          .where(etablissements: { column => values })
       else
         dossiers
           .includes(:etablissement)

--- a/app/models/columns/france_connect_champ_column.rb
+++ b/app/models/columns/france_connect_champ_column.rb
@@ -37,6 +37,21 @@ class Columns::FranceConnectChampColumn < Columns::JSONPathColumn
     ['Date de début de droit', '$.api_part.date_debut_droit', :date],
   ]
 
+  # The filter UI renders a boolean column as radio buttons built from
+  # options_for_select: without options there is nothing to pick.
+  def initialize(type: :text, **args)
+    options_for_select = if type == :boolean
+      [
+        [I18n.t('activerecord.attributes.type_de_champ.type_champs.yes_no_true'), true],
+        [I18n.t('activerecord.attributes.type_de_champ.type_champs.yes_no_false'), false],
+      ]
+    else
+      []
+    end
+
+    super(type:, options_for_select:, **args)
+  end
+
   def targeted_dossiers(dossiers, condition)
     super(dossiers, condition).where(champs: { value: 'true' })
   end

--- a/app/models/columns/france_connect_champ_column.rb
+++ b/app/models/columns/france_connect_champ_column.rb
@@ -37,21 +37,6 @@ class Columns::FranceConnectChampColumn < Columns::JSONPathColumn
     ['Date de début de droit', '$.api_part.date_debut_droit', :date],
   ]
 
-  # The filter UI renders a boolean column as radio buttons built from
-  # options_for_select: without options there is nothing to pick.
-  def initialize(type: :text, **args)
-    options_for_select = if type == :boolean
-      [
-        [I18n.t('activerecord.attributes.type_de_champ.type_champs.yes_no_true'), true],
-        [I18n.t('activerecord.attributes.type_de_champ.type_champs.yes_no_false'), false],
-      ]
-    else
-      []
-    end
-
-    super(type:, options_for_select:, **args)
-  end
-
   def targeted_dossiers(dossiers, condition)
     super(dossiers, condition).where(champs: { value: 'true' })
   end

--- a/app/models/columns/json_path_column.rb
+++ b/app/models/columns/json_path_column.rb
@@ -66,6 +66,13 @@ class Columns::JSONPathColumn < Columns::ChampColumn
       return dossiers.ids if integers.empty?
 
       condition = %{champs.value_json @? '#{jsonpath_for_sql} ? (#{integers.map { |i| "@ == #{i}" }.join(" || ")})'}
+    elsif type == :boolean
+      # value_json holds a JSON boolean, which like_regex can never match.
+      booleans = search_terms & ['true', 'false']
+
+      return dossiers.ids if booleans.empty?
+
+      condition = %{champs.value_json @? '#{jsonpath_for_sql} ? (#{booleans.map { "@ == #{it}" }.join(" || ")})'}
     else
       # ["normal", "nom 'quote'", "un (terme)"] compiles to:
       #

--- a/app/models/columns/read_agreement_column.rb
+++ b/app/models/columns/read_agreement_column.rb
@@ -8,8 +8,7 @@ class Columns::ReadAgreementColumn < Columns::DossierColumn
       column: nil,
       label: "Décision vue par l’usager ?",
       type: :boolean,
-      displayable: false,
-      options_for_select: [[I18n.t('activerecord.attributes.type_de_champ.type_champs.yes_no_true'), true], [I18n.t('activerecord.attributes.type_de_champ.type_champs.yes_no_false'), false]]
+      displayable: false
     )
   end
 

--- a/app/models/concerns/columns_concern.rb
+++ b/app/models/concerns/columns_concern.rb
@@ -191,7 +191,7 @@ module ColumnsConcern
 
   def dossier_submitted_with_identity_provider_columns
     ['submitted_with_france_connect', 'submitted_with_pro_connect']
-      .map { |column| dossier_col(table: 'self', column:, type: :boolean, options_for_select: Champs::YesNoChamp.options) }
+      .map { |column| dossier_col(table: 'self', column:, type: :boolean) }
   end
 
   def traitements_email_column = dossier_col(table: 'traitements', column: 'instructeur_email', filterable: true, displayable: false)
@@ -261,7 +261,7 @@ module ColumnsConcern
     @individual_columns
       .concat ['nom', 'prenom'].map { |column| dossier_col(table: 'individual', column:) }
       .concat ['mandataire_last_name', 'mandataire_first_name'].map { |column| dossier_col(table: 'self', column:) }
-      .concat ['for_tiers'].map { |column| dossier_col(table: 'self', column:, type: :boolean, options_for_select: Champs::YesNoChamp.options) }
+      .concat ['for_tiers'].map { |column| dossier_col(table: 'self', column:, type: :boolean) }
   end
 
   def moral_columns

--- a/app/models/types_de_champ/yes_no_type_de_champ.rb
+++ b/app/models/types_de_champ/yes_no_type_de_champ.rb
@@ -5,7 +5,6 @@ class TypesDeChamp::YesNoTypeDeChamp < TypeDeChamp
   def self.column_type = :boolean
 
   def prefillable? = true
-  def options_for_select = Champs::YesNoChamp.options
   def choice_type? = true
 
   def typed_champ_value(champ)

--- a/spec/models/columns/dossier_column_spec.rb
+++ b/spec/models/columns/dossier_column_spec.rb
@@ -100,6 +100,21 @@ describe Columns::DossierColumn do
   end
 
   describe '#filtered_ids' do
+    context 'for a boolean etablissement column (siege_social)' do
+      let(:procedure) { create(:procedure, for_individual: false) }
+      let(:column) { procedure.find_column(label: 'Établissement siège social') }
+      let!(:dossier) { create(:dossier, :en_instruction, :with_entreprise, procedure:) }
+
+      before { dossier.etablissement.update!(siege_social: true) }
+
+      def filtering(value) = column.filtered_ids(procedure.dossiers, { operator: 'match', value: })
+
+      it 'filters on the boolean' do
+        expect(filtering(['true'])).to eq([dossier.id])
+        expect(filtering(['false'])).to eq([])
+      end
+    end
+
     context 'for an integer etablissement column' do
       let(:procedure) { create(:procedure, for_individual: false) }
       let!(:dossier) { create(:dossier, :en_instruction, :with_entreprise, procedure:) }

--- a/spec/models/columns/dossier_column_spec.rb
+++ b/spec/models/columns/dossier_column_spec.rb
@@ -113,6 +113,10 @@ describe Columns::DossierColumn do
         expect(filtering(['true'])).to eq([dossier.id])
         expect(filtering(['false'])).to eq([])
       end
+
+      it 'offers the oui/non options the radio buttons are built from' do
+        expect(column.options_for_select).to eq(Champs::YesNoChamp.options)
+      end
     end
 
     context 'for an integer etablissement column' do

--- a/spec/models/types_de_champ/france_connect_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/france_connect_type_de_champ_spec.rb
@@ -88,6 +88,30 @@ describe TypesDeChamp::FranceConnectTypeDeChamp do
         expect(column_value('eb – Boursier')).to be(true)
         expect(column_value('eb – Radié')).to be(false)
       end
+
+      describe 'a boolean column' do
+        let(:column) { tdc_etudiant_boursier.columns(procedure_id: procedure.id).find { it.label == 'eb – Boursier' } }
+        let(:dossiers) { Dossier.where(id: dossier.id) }
+
+        def filtering(value) = column.filtered_ids(dossiers, { operator: 'match', value: })
+
+        # value_json stores a JSON boolean, which like_regex can never match:
+        # the filter needs a @ == true / @ == false comparison.
+        it 'filters on the stored boolean' do
+          expect(filtering(['true'])).to eq([dossier.id])
+          expect(filtering(['false'])).to eq([])
+        end
+
+        it 'ignores a value the radio buttons cannot produce' do
+          expect(filtering(['nimp'])).to eq([dossier.id])
+        end
+
+        # Radio buttons are built from options_for_select: without options the
+        # filter renders an empty radio list, no value can even be picked.
+        it 'offers oui/non options to build the radio buttons from' do
+          expect(column.options_for_select).to eq([['oui', true], ['non', false]])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Repéré pendant le tour des appelants de #13686 : les colonnes booléennes FranceConnect (« Boursier », « Radié », « Bénéficiaire de l'AAH »…) ne filtrent jamais rien, à deux niveaux.

## Le bug

**Côté UI** — une colonne `:boolean` est rendue en boutons radio construits depuis `options_for_select`, que ces colonnes ne fournissaient pas : la liste de radios est vide, aucune valeur ne peut être choisie.

**Côté SQL** — `value_json` stocke un booléen JSON, que `like_regex` ne peut pas matcher :

```sql
'{"b": true}'::jsonb @? '$.b ? (@ like_regex "true")'  -- false
'{"b": true}'::jsonb @? '$.b ? (@ == true)'            -- true
```

## Le fix

`JSONPathColumn` compile les valeurs booléennes en comparaisons `@ == true || @ == false`, sur le modèle de la branche `:integer` existante. Les valeurs sont whitelistées à `true`/`false` ; toute autre valeur signifie « rien à filtrer », comme pour les entiers non parsables.

## Second commit : oui/non par défaut pour toute colonne booléenne

Chaque site booléen répétait la même paire d'options (`ReadAgreementColumn`, `columns_concern` deux fois, et le premier commit ajoutait la sienne). `Column` fournit maintenant `Champs::YesNoChamp.options` par défaut quand une colonne booléenne n'en reçoit pas — checkbox garde sa paire « coché/non coché », d'où le paramètre conservé.

Ce défaut a révélé un cousin du bug FC : « Établissement siège social », filtrable depuis toujours mais rendu en liste de radios vide. Une fois cliquable, son filtre passait par `filter_ilike` → `unaccent(boolean)` n'existe pas. Il filtre désormais par un `where`, comme les colonnes etablissement entières.

Fait suite à #13686 : le fix étend la branche `:integer` de la méthode qu'elle a réécrite.
