### PR TITLE
Tech: nettoyage, supprime la route GET de l'accusé de lecture

### DIFF
--- a/config/routes/usager.rb
+++ b/config/routes/usager.rb
@@ -78,9 +78,6 @@ scope module: 'users', defaults: { nav_bar_profile: :user } do
       get 'attestation_depot', format: :pdf
       get 'papertrail', to: 'dossiers#attestation_depot', format: :pdf
       post 'set_accuse_lecture_agreement_at'
-      # Deploy transition: legacy GET kept for in-flight pages still rendering the old form.
-      # TODO: remove once the deploy is stable (and un-pend the matching controller spec).
-      get 'set_accuse_lecture_agreement_at'
       get 'corbeille', to: 'dossiers#show_in_trash'
       get 'supprime', to: 'dossiers#show_deleted'
     end

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -2385,23 +2385,9 @@ describe Users::DossiersController, type: :controller do
 
     before { sign_in(user) }
 
-    context 'on a state-changing verb (POST)' do
-      it 'updates accuse_lecture_agreement_at' do
-        expect { post :set_accuse_lecture_agreement_at, params: { id: dossier.id } }
-          .to change { dossier.reload.accuse_lecture_agreement_at }.from(nil)
-      end
-    end
-
-    context 'on a safe HTTP verb (GET)' do
-      # Pending: the legacy GET route is intentionally kept during the deploy
-      # transition so in-flight pages rendering the old form keep working.
-      # Once the GET route is removed in the follow-up, un-pend this example
-      # — it should pass without further changes.
-      it 'does not update accuse_lecture_agreement_at via a GET request' do
-        pending 'GET route is kept during deploy transition; remove route then un-pend'
-        expect { get :set_accuse_lecture_agreement_at, params: { id: dossier.id } }
-          .not_to change { dossier.reload.accuse_lecture_agreement_at }
-      end
+    it 'updates accuse_lecture_agreement_at' do
+      expect { post :set_accuse_lecture_agreement_at, params: { id: dossier.id } }
+        .to change { dossier.reload.accuse_lecture_agreement_at }.from(nil)
     end
   end
 


### PR DESCRIPTION
La route GET avait été gardée en mai 2026 comme transition de déploiement, le temps que les pages déjà servies avec l'ancien formulaire continuent de fonctionner. Trois mois plus tard, le seul appelant (`Dossiers::AccuseLectureComponent`) soumet en `method: :post` : le GET est mort, et il exposait une action qui modifie l'état derrière un verbe sûr.

L'exemple laissé en `pending` en prévision de ce nettoyage est supprimé plutôt que réactivé : un controller spec appelle l'action directement via `ActionController::TestCase`, sans passer par le routeur, il ne peut donc pas vérifier une contrainte de verbe. Seul le POST reste couvert.