### PR TITLE
ETQ admin, je peux changer le type d'une liste déroulante sans erreur 500

### DIFF
--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -39,9 +39,16 @@ module Administrateurs
         @morphed = [champ_component_from(@coordinate, focused: false, errors:)]
         flash.alert = errors
       else
-        type_de_champ = type_de_champ.becomes_type(type_de_champ_update_params['type_champ']) if changing_of_type?(type_de_champ)
+        update_params = type_de_champ_update_params
 
-        if type_de_champ.update(type_de_champ_update_params)
+        if changing_of_type?(type_de_champ)
+          type_de_champ = type_de_champ.becomes_type(update_params['type_champ'])
+          # the editor form submits the previous type's options along the new type,
+          # and the new type may not define them (drop_down -> yes_no)
+          update_params = update_params.except(*update_params.keys.reject { type_de_champ.respond_to?("#{it}=") })
+        end
+
+        if type_de_champ.update(update_params)
           reload_procedure_with_includes
           @morphed = if was_prefill_with_fc_information != type_de_champ.prefill_with_france_connect_information?
             draft.revision_types_de_champ.map { |c| champ_component_from(c) }

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -138,6 +138,23 @@ describe Administrateurs::TypesDeChampController, type: :controller do
       end
     end
 
+    context 'changing the type to one without the previous type options' do
+      let(:params) do
+        {
+          procedure_id: procedure.id,
+          stable_id: third_coordinate.stable_id,
+          # the editor form submits the options of the previous type along the new type
+          type_de_champ: { type_champ: 'yes_no', drop_down_options_from_text: "a\nb" },
+        }
+      end
+
+      it 'ignores the options unknown to the new type (RAILS-MF9)' do
+        is_expected.to have_http_status(:ok)
+        expect(flash.alert).to be_nil
+        expect(TypeDeChamp.where(id: third_coordinate.type_de_champ.id).pick(:type_champ)).to eq('yes_no')
+      end
+    end
+
     context 'rejected if type changed and routing involved' do
       let(:params) do
         default_params.deep_merge(type_de_champ: { type_champ: 'text', stable_id: third_coordinate.stable_id })


### PR DESCRIPTION
## Contexte

Depuis f8b48761b7, le changement de `type_champ` est sauvegardé via une instance de la sous-classe STI cible. Mais le formulaire de l'éditeur soumet encore les options du type précédent avec le nouveau type : quand le type cible ne les définit pas (liste déroulante → oui/non soumet `drop_down_options_from_text`), `update` levait `ActiveModel::UnknownAttributeError` (500 en prod, 3 admins touchés).

## Correction

Après le `becomes_type`, les params sont filtrés aux setters que le type cible accepte, ce qui restaure la tolérance d'avant pour les options résiduelles.

Fixes [RAILS-MF9](https://demarches-simplifiees.sentry.io/issues/7683173688/)