### PR TITLE
Tech: supprime le ViewComponent orphelin EtablissementTitreComponent

### DIFF
--- a/app/components/editable_champ/etablissement_titre_component.rb
+++ b/app/components/editable_champ/etablissement_titre_component.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class EditableChamp::EtablissementTitreComponent < ApplicationComponent
-  include EtablissementHelper
-
-  def initialize(etablissement:)
-    @etablissement = etablissement
-  end
-end

--- a/app/components/editable_champ/etablissement_titre_component/etablissement_titre_component.html.haml
+++ b/app/components/editable_champ/etablissement_titre_component/etablissement_titre_component.html.haml
@@ -1,6 +1,0 @@
-%p.fr-info-text
-  = raison_sociale_or_name(@etablissement)
-  = @etablissement.entreprise_forme_juridique
-  - if @etablissement.entreprise_capital_social.present?
-    au capital social de
-    = pretty_currency(@etablissement.entreprise_capital_social)


### PR DESCRIPTION
`EditableChamp::EtablissementTitreComponent` est inatteignable : les composants
`EditableChamp::*` sont résolus par `constantize` dynamique à partir du
`type_champ`, or `etablissement_titre` n'existe pas dans l'enum.

Suppression de la classe et de son template sidecar. Aucune autre référence dans
le repo (ni appel, ni spec, ni preview) ; `EtablissementHelper` qu'il incluait
reste utilisé ailleurs.