### PR TITLE
Tech: nettoyage, supprime les routes expert de sign-up héritées

### DIFF
--- a/config/routes/expert.rb
+++ b/config/routes/expert.rb
@@ -22,11 +22,6 @@ scope module: 'experts', as: 'expert', defaults: { nav_bar_profile: :expert } do
 
           get 'sign_up' => 'avis#sign_up'
           post 'sign_up' => 'avis#update_expert'
-
-          # This redirections are ephemeral, to ensure that emails sent to experts before are still valid
-          # TODO : remove these lines after September, 2021
-          get 'sign_up/email/:email' => 'avis#sign_up', constraints: { email: /.*/ }, as: 'sign_up_legacy'
-          post 'sign_up/email/:email' => 'avis#update_expert', constraints: { email: /.*/ }, as: 'update_expert_legacy'
         end
       end
     end


### PR DESCRIPTION
- Ajoutées en juin 2021 pour que les liens déjà envoyés par mail aux experts restent valides, avec une note « remove these lines after September, 2021 ». Cinq ans plus tard, `sign_up_legacy_*` et `update_expert_legacy_*` n'apparaissent nulle part ailleurs que dans leur propre déclaration.
- Le flux courant n'est pas touché : l'adresse est passée en paramètre de requête à `sign_up_expert_avis_path` (`TargetedUserLink`, `avis_controller`, vue `sign_up`), et non comme segment d'URL — `params[:email]` reste donc renseigné.
- Effet de bord bienvenu : une adresse email ne transite plus dans un chemin d'URL, où elle finissait dans les logs serveur et proxy.