### PR TITLE
Correctif: ETQ admin, pouvoir conditionner un champ sur un champ pré-rempli

### DIFF
--- a/app/models/types_de_champ/pre_rempli_type_de_champ.rb
+++ b/app/models/types_de_champ/pre_rempli_type_de_champ.rb
@@ -4,6 +4,7 @@ class TypesDeChamp::PreRempliTypeDeChamp < TypeDeChamp
   def self.category = REFERENTIEL_EXTERNE
   def self.editable_option_keys = [:drop_down_options, :pre_rempli_hidden]
   def self.feature_flag = :pre_rempli_type_de_champ
+  def self.column_type = :enum
 
   include TypesDeChamp::DropDownOptionsConcern
 

--- a/spec/components/conditions/champs_conditions_component_spec.rb
+++ b/spec/components/conditions/champs_conditions_component_spec.rb
@@ -37,6 +37,20 @@ describe Conditions::ChampsConditionsComponent, type: :component do
       end
     end
 
+    context 'when the upper tdc is a pre_rempli' do
+      let(:upper_tdcs) { [create(:type_de_champ_pre_rempli, drop_down_options: ['a', 'b'])] }
+
+      context 'in champ_value mode' do
+        it { expect(page).to have_text('Logique conditionnelle') }
+      end
+
+      context 'in column_value mode' do
+        let(:column_mode) { true }
+
+        it { expect(page).to have_text('Logique conditionnelle') }
+      end
+    end
+
     context 'when there are upper tdc and a condition' do
       let(:upper_tdc) { create(:type_de_champ_number) }
       let(:upper_tdcs) { [upper_tdc] }

--- a/spec/models/types_de_champ/pre_rempli_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/pre_rempli_type_de_champ_spec.rb
@@ -31,6 +31,17 @@ describe TypesDeChamp::PreRempliTypeDeChamp do
     end
   end
 
+  describe '#columns' do
+    before { type_de_champ.update!(drop_down_options_from_text: "En cours\r\nIdée\r\nFait") }
+
+    it 'exposes an enum column, so the champ can be used as a condition source' do
+      column = type_de_champ.columns(procedure_id: procedure.id).sole
+
+      expect(column.type).to eq(:enum)
+      expect(column.options_for_select).to eq([["En cours", "En cours"], ["Idée", "Idée"], ["Fait", "Fait"]])
+    end
+  end
+
   describe '#pre_rempli_hidden?' do
     it 'returns false by default' do
       expect(type_de_champ.pre_rempli_hidden?).to be false


### PR DESCRIPTION
# Problème

Un champ « pré-rempli » n'apparaît pas dans la liste des sources de la logique conditionnelle : le bloc « Logique conditionnelle » ne s'affiche même pas quand le seul champ au-dessus est un pré-rempli.

L'éditeur de conditions a deux modes. En mode legacy (`champ_value`), les sources sont filtrées par `tdc.conditionable?`, qui s'appuie sur `Logic::ChampValue::MANAGED_TYPE_DE_CHAMP` où `:pre_rempli` figure bien — ça marche. En mode colonne, elles sont filtrées par `column.type.in?([:integer, :decimal, :enum, :enums, :boolean])`. Or `PreRempliTypeDeChamp` ne déclarait aucun `column_type` et retombait donc sur le `:text` par défaut → écarté de la liste.

Le mode colonne est le mode par défaut : une procédure n'est en legacy que si elle porte déjà une condition ou un routage en `ChampValue`. En pratique, ça ne marche donc pas sur une procédure neuve.

# Solution

Déclarer `def self.column_type = :enum`, comme la liste déroulante. `options_for_select` renvoyait déjà les paires attendues par une colonne enum, il n'y a rien d'autre à brancher.

## Effet de bord assumé

`:enum` change aussi le filtre instructeur sur cette colonne : multi-select limité aux options déclarées au lieu d'un texte libre, et égalité stricte au lieu d'un `ILIKE`. Un dossier pré-rempli avec une valeur hors liste deviendrait donc inatteignable via ce filtre.

Le pré-remplissage, lui, n'est pas contraint : `PrefillPreRempliTypeDeChamp` ne redéfinit pas `screened_value` et `Champs::PreRempliChamp` n'a pas de validation « valeur dans les options ». On part du principe que les options déclarées par l'admin sont exhaustives — c'est ce que suggère l'UI d'admin.

Generated with [Claude Code](https://claude.com/claude-code)