### PR TITLE
Correctif: ETQ usager, instructeur et admin, texte invisible en thème sombre

### DIFF
--- a/app/assets/stylesheets/dossier_vide_pdf.scss
+++ b/app/assets/stylesheets/dossier_vide_pdf.scss
@@ -31,146 +31,153 @@
   }
 }
 
-body {
+// This sheet is served standalone by the `dossier_vide_pdf` layout, but
+// `application.scss` also pulls the whole directory in with `require_tree .`.
+// Everything below must therefore stay scoped to the PDF's own <body>, or it
+// leaks into every page of the app — a bare `body { color: #161616 }` used to
+// win over the DSFR one (same specificity, loaded later) and painted the text
+// in the exact colour of the dark-theme background. Same convention as
+// `attestation.scss`, which scopes itself under `#attestation`.
+body#dossier-vide-pdf {
   font-family: 'Marianne', sans-serif;
   font-size: 10pt;
   color: #161616;
-}
 
-h1 {
-  font-size: 18pt;
-}
-h2 {
-  font-size: 14pt;
-  margin-top: 8mm;
-}
-h3 {
-  font-size: 12pt;
-}
-h4 {
-  font-size: 11pt;
-}
-h5 {
-  font-size: 10pt;
-}
+  h1 {
+    font-size: 18pt;
+  }
+  h2 {
+    font-size: 14pt;
+    margin-top: 8mm;
+  }
+  h3 {
+    font-size: 12pt;
+  }
+  h4 {
+    font-size: 11pt;
+  }
+  h5 {
+    font-size: 10pt;
+  }
 
-.logo {
-  display: block;
-  width: 100mm;
-  height: auto;
-  margin: 0 auto 8mm;
-}
+  .logo {
+    display: block;
+    width: 100mm;
+    height: auto;
+    margin: 0 auto 8mm;
+  }
 
-dl.header,
-dl.identity {
-  margin: 0 0 6mm;
-}
+  dl.header,
+  dl.identity {
+    margin: 0 0 6mm;
+  }
 
-.field-pair {
-  display: flex;
-  gap: 4mm;
-  margin-bottom: 2mm;
+  .field-pair {
+    display: flex;
+    gap: 4mm;
+    margin-bottom: 2mm;
 
-  dt {
-    width: 45mm;
+    dt {
+      width: 45mm;
+      font-weight: bold;
+    }
+    dd {
+      flex: 1;
+    }
+  }
+
+  .label {
     font-weight: bold;
+    margin-bottom: 1.5mm;
   }
-  dd {
-    flex: 1;
+  // Keep a label (and any description/instruction that follows it) attached to the
+  // field below it, so a page break never leaves the label stranded from its box.
+  .label,
+  .description,
+  .explanation,
+  .condition {
+    break-after: avoid;
   }
-}
+  // Champ descriptions stay italic to read as helper text; the procedure
+  // presentation (.presentation) keeps the admin's own formatting instead.
+  .description,
+  .explanation,
+  .condition,
+  .mailing {
+    font-style: italic;
+  }
+  // Admin rich text is rendered as markdown (SimpleFormat), so each authored line
+  // becomes a <p>: drop the browser default paragraph margins and keep tight,
+  // even spacing between them.
+  .presentation p,
+  .description p,
+  .explication p {
+    margin: 0;
+  }
+  .presentation p + p,
+  .description p + p,
+  .explication p + p {
+    margin-top: 1.5mm;
+  }
+  .explanation,
+  .condition {
+    margin-top: 1mm;
+    margin-bottom: 1.5mm;
+  }
 
-.label {
-  font-weight: bold;
-  margin-bottom: 1.5mm;
-}
-// Keep a label (and any description/instruction that follows it) attached to the
-// field below it, so a page break never leaves the label stranded from its box.
-.label,
-.description,
-.explanation,
-.condition {
-  break-after: avoid;
-}
-// Champ descriptions stay italic to read as helper text; the procedure
-// presentation (.presentation) keeps the admin's own formatting instead.
-.description,
-.explanation,
-.condition,
-.mailing {
-  font-style: italic;
-}
-// Admin rich text is rendered as markdown (SimpleFormat), so each authored line
-// becomes a <p>: drop the browser default paragraph margins and keep tight,
-// even spacing between them.
-.presentation p,
-.description p,
-.explication p {
-  margin: 0;
-}
-.presentation p + p,
-.description p + p,
-.explication p + p {
-  margin-top: 1.5mm;
-}
-.explanation,
-.condition {
-  margin-top: 1mm;
-  margin-bottom: 1.5mm;
-}
+  .champ {
+    margin-bottom: 7mm;
+  }
+  // Light shading grouping a conditional field (label + instruction + box).
+  .champ--conditional {
+    padding: 3mm;
+    background-color: #f6f6f6;
+  }
 
-.champ {
-  margin-bottom: 7mm;
-}
-// Light shading grouping a conditional field (label + instruction + box).
-.champ--conditional {
-  padding: 3mm;
-  background-color: #f6f6f6;
-}
+  .annexes {
+    page-break-before: always;
+  }
+  .annex {
+    margin-bottom: 6mm;
+  }
+  .annex h3 {
+    break-after: avoid;
+  }
 
-.annexes {
-  page-break-before: always;
-}
-.annex {
-  margin-bottom: 6mm;
-}
-.annex h3 {
-  break-after: avoid;
-}
+  .box {
+    border: 1px solid #161616;
+  }
+  .box--line {
+    height: 6mm;
+  }
+  .box--block {
+    height: 22mm;
+  }
 
-.box {
-  border: 1px solid #161616;
-}
-.box--line {
-  height: 6mm;
-}
-.box--block {
-  height: 22mm;
-}
+  ul.options {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  ul.options li {
+    margin-bottom: 1mm;
+  }
+  ul.options li.secondary {
+    padding-left: 6mm;
+  }
 
-ul.options {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-ul.options li {
-  margin-bottom: 1mm;
-}
-ul.options li.secondary {
-  padding-left: 6mm;
-}
-
-.option {
-  display: inline-flex;
-  align-items: center;
-  gap: 2mm;
-  // Centre the checkbox on the line instead of letting it hang above the
-  // baseline, which otherwise inflates the gap above and between checkboxes.
-  vertical-align: middle;
-}
-.checkbox {
-  display: inline-block;
-  width: 3mm;
-  height: 3mm;
-  border: 1px solid #161616;
+  .option {
+    display: inline-flex;
+    align-items: center;
+    gap: 2mm;
+    // Centre the checkbox on the line instead of letting it hang above the
+    // baseline, which otherwise inflates the gap above and between checkboxes.
+    vertical-align: middle;
+  }
+  .checkbox {
+    display: inline-block;
+    width: 3mm;
+    height: 3mm;
+    border: 1px solid #161616;
+  }
 }


### PR DESCRIPTION
# Problème

Deux signalements support de texte « noir sur noir ». Le texte du `body` est
littéralement invisible en thème sombre, sur **toutes** les pages de l'application.

Le layout est en `data-fr-scheme="system"`, donc les usagers dont l'OS est en
sombre basculent sans l'avoir choisi : ils n'ont aucun moyen évident de
comprendre ce qui se passe.

## Cause

`app/assets/stylesheets/application.scss` est un simple `require_tree .`. Toute
la feuille de style du PDF « dossier vide » se retrouve donc concaténée dans
l'`application.css` servi sur chaque page (`layouts/application.html.erb:71`).

Or cette feuille déclarait un sélecteur `body` nu :

```scss
body {
  font-family: 'Marianne', sans-serif;
  font-size: 10pt;
  color: #161616;
}
```

Le DSFR pose `body { color: var(--text-default-grey) }` (`core.css:1727`).
Spécificité identique (0,0,1), mais Sprockets est chargé **après** Vite/DSFR →
la règle du PDF gagne. Et `#161616`, c'est exactement
`--background-default-grey` en thème sombre. Le texte était donc peint dans la
couleur de son propre fond.

Introduit par 2e6d6f72e3 (« feat: add layout and stylesheet for empty dossier
PDF »). Attention à la chronologie, elle explique pourquoi ça sort maintenant :

| | |
|---|---|
| Commit écrit | 2026-06-29 |
| Rebasé | 2026-07-29 |
| Mergé (#13368 `feat/dossier-vide-pdf-weasyprint`) | **2026-08-20 10:21 UTC** |
| Déployé (release `2026-08-20-01`) | **2026-08-20 14:58 UTC** |

La branche est restée ouverte près de deux mois. La release précédente
`2026-08-18-03` ne contenait pas le commit : la régression est donc bien
arrivée avec la mise en prod du 20 août, le jour même du merge.

La fuite ne se limitait pas au `body` : `h1`–`h5` (tailles en `pt`) et surtout
des classes très génériques passaient en global.

| Sélecteur qui fuyait | Fichiers de vues concernés |
|---|---|
| `.label` | 138 |
| `.checkbox` | 16 |
| `.champ` | 10 |
| `.logo` | 8 |

# Solution

Scoper la feuille sous `body#dossier-vide-pdf`. L'id est déjà posé par le
layout du PDF, et c'est la convention déjà suivie par `attestation.scss`, qui
imbrique tout sous `#attestation`. Les `@font-face` et `@page` restent au
niveau racine, comme il se doit.

Contraste mesuré via `getComputedStyle` sur le bundle réellement compilé,
rendu dans un navigateur :

| | fond | texte | contraste |
|---|---|---|---|
| Avant — sombre | `#161616` | `#161616` | **1.00** ❌ |
| Après — sombre | `#161616` | `#cecece` | **11.50** ✅ |
| Après — clair | `#ffffff` | `#3a3a3a` | 11.37 ✅ |

Seuil RGAA 4.1.3 : 4.5:1.

## Garde-fou

`spec/assets/standalone_stylesheets_spec.rb` vérifie que les feuilles
autonomes (`dossier_vide_pdf`, `attestation`, `manager`) ne déclarent aucun
sélecteur d'élément nu au niveau racine — puisque `require_tree .` les fusionne
toutes dans le bundle global. Le spec a été validé en réintroduisant la règle
fautive : il échoue bien.

## Pourquoi cette approche ?

Sortir la feuille du `require_tree` aurait été plus radical, mais Sprockets ne
sait pas exclure un fichier d'un `require_tree`, et déplacer la feuille hors du
répertoire casserait le `//= link dossier_vide_pdf.css` du manifest. Le scoping
est le correctif minimal, et il aligne la feuille sur la convention déjà en
place pour l'attestation.

## Suite indispensable — à ne pas merger seule

⚠️ **Cette PR, seule, introduit une régression sur deux écrans.**

Le `body { color: #161616 }` qui fuit est ce qui rend aujourd'hui lisibles les
quelques cartes à fond blanc en dur. En rétablissant la couleur de texte du
DSFR (`#cecece` en sombre), ces cartes passent de « noir sur blanc » à « gris
pâle sur blanc ». Mesuré :

| Sélecteur | Prod aujourd'hui | Avec cette PR seule | Avec la branche de suite |
|---|---|---|---|
| `.quote` (témoignages accueil) | 18.10 ✅ | **1.57 ❌** | 11.50 ✅ |
| `.form .radios label` (`/patron`) | 18.10 ✅ | **1.57 ❌** | 11.50 ✅ |

La branche `fix-dark-theme-contrast` est empilée sur celle-ci et corrige les
deux. **Les deux doivent partir dans la même release** (ou être fusionnées).

Elle traite aussi un défaut préexistant, indépendant de cette PR :
`.service-name` (liste des démarches usager) est à 3.15 en sombre, sous le
seuil RGAA de 4.5:1. Le correctif passe à `--text-mention-grey`, qui vaut #666
en clair — strictement identique au `$dark-grey` remplacé — et #929292 en
sombre, soit 5.82.

Elle supprime enfin 9 règles de CSS mort repérées pendant l'audit, dont
`.print-menu` (le markup pose un *id*, la CSS cible une *classe*, et
`Dropdown::MenuComponent` ne construit que `['dropdown-content'] + …`) et tout
le reliquat d'Algolia autocomplete.

## Cas écartés après mesure

L'audit initial annonçait « 12 autres couleurs en dur ». Après vérification que
chaque sélecteur correspond à du markup réel, et mesure du contraste dans un
navigateur, trois cas tombent :

- `.list-header` — 3.15, mais `h2` en 32px/700, donc grand texte, seuil 3:1 →
  conforme. Passé au token quand même, par robustesse.
- `.ds-ctrl button` (contrôles carte) — porte aussi
  `.maplibregl-ctrl-group`, que maplibre garde en `background: #fff` dans tous
  les thèmes. `#666` y mesure 5.74 → conforme, et le token le ferait *chuter* à
  3. Laissé tel quel, avec un commentaire.
- `mail_template_edit.scss` / `toggle-switch.scss` — fond blanc derrière une
  `<iframe>` autonome, et curseur décoratif sans texte. Aucun texte concerné.

Generated with [Claude Code](https://claude.com/claude-code)
