### PR TITLE
Tech: supprime quatre méthodes de helper mortes

### DIFF
--- a/app/helpers/archive_helper.rb
+++ b/app/helpers/archive_helper.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module ArchiveHelper
-  def can_generate_archive?(dossiers_termines, poids_total)
-    dossiers_termines.count < 100 && poids_total < 1.gigabyte
-  end
-
   def estimate_weight(archive, nb_dossiers_termines, average_dossier_weight)
     if archive.present? && archive.available?
       archive.file.byte_size

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -3,16 +3,6 @@
 module DossierHelper
   include EtablissementHelper
 
-  def button_or_label_class(dossier)
-    if dossier.accepte?
-      'accepted'
-    elsif dossier.sans_suite?
-      'without-continuation'
-    elsif dossier.refuse?
-      'refused'
-    end
-  end
-
   def highlight_if_unseen_class(seen_at, updated_at)
     if updated_at.present? && seen_at&.<(updated_at)
       "highlighted"

--- a/app/helpers/procedure_helper.rb
+++ b/app/helpers/procedure_helper.rb
@@ -23,17 +23,6 @@ module ProcedureHelper
     end
   end
 
-  def procedure_publish_label(procedure, key)
-    # i18n-tasks-use t('modal.publish.body.publish')
-    # i18n-tasks-use t('modal.publish.body.reopen')
-    # i18n-tasks-use t('modal.publish.submit.publish')
-    # i18n-tasks-use t('modal.publish.submit.reopen')
-    # i18n-tasks-use t('modal.publish.title.publish')
-    # i18n-tasks-use t('modal.publish.title.reopen')
-    action = procedure.close? ? :reopen : :publish
-    t(action, scope: [:modal, :publish, key])
-  end
-
   def procedure_auto_archive_date(procedure)
     I18n.l(procedure.auto_archive_on - 1.day, format: :long)
   end
@@ -44,13 +33,6 @@ module ProcedureHelper
 
   def procedure_auto_archive_datetime(procedure)
     procedure_auto_archive_date(procedure) + ' ' + procedure_auto_archive_time(procedure)
-  end
-
-  def can_send_groupe_message?(procedure)
-    groupe_instructeur_on_procedure_ids = procedure.groupe_instructeurs.active.ids.sort
-    groupe_instructeur_on_instructeur_ids = current_instructeur.groupe_instructeurs.active.where(procedure: procedure).ids.sort
-
-    groupe_instructeur_on_procedure_ids == groupe_instructeur_on_instructeur_ids
   end
 
   def url_or_email_to_lien_dpo(procedure)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -715,17 +715,6 @@ en:
       shared:
         email_can_take_a_while_html: <strong>Please note</strong> that this email can take up to 15 minutes to arrive.
         contact_us_if_any_trouble_html: 'You can contact us <a href="%{href}">through this form</a> if a problem still exists.'
-  modal:
-    publish:
-      title:
-        publish: Publish the procedure
-        reopen: Reopen the procedure
-      body:
-        publish: You are about to publish the procedure to the public.
-        reopen: You are about to reopen the procedure.
-      submit:
-        publish: Publish
-        reopen: Reopen
   activerecord:
     models:
       user:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -725,17 +725,6 @@ fr:
       shared:
         email_can_take_a_while_html: "<strong>Attention</strong>, ce courriel peut mettre jusqu’à <strong>15 minutes</strong> pour arriver."
         contact_us_if_any_trouble_html: 'En cas de difficultés, nous restons joignables <a href="%{href}">via ce formulaire</a>.'
-  modal:
-    publish:
-      title:
-        publish: Publier la démarche
-        reopen: Réactiver la démarche
-      body:
-        publish: Vous vous apprêtez à publier votre démarche au public.
-        reopen: Vous vous apprêtez à réactiver votre démarche.
-      submit:
-        publish: Publier
-        reopen: Réactiver
   activerecord:
     models:
       user:

--- a/spec/helpers/procedure_helper_spec.rb
+++ b/spec/helpers/procedure_helper_spec.rb
@@ -12,26 +12,6 @@ RSpec.describe ProcedureHelper, type: :helper do
     end
   end
 
-  describe 'can_send_groupe_message?' do
-    let(:procedure) { create(:procedure, groupe_instructeurs: [gi1, gi2]) }
-    let(:current_instructeur) { create(:instructeur) }
-    subject { can_send_groupe_message?(procedure) }
-
-    context 'when current_instructeur is in all procedure.groupes_instructeur' do
-      let(:gi1) { create(:groupe_instructeur, instructeurs: [current_instructeur]) }
-      let(:gi2) { create(:groupe_instructeur, instructeurs: [current_instructeur]) }
-      it { is_expected.to be_truthy }
-    end
-
-    context 'when current_instructeur is in all procedure.groupes_instructeur' do
-      let(:instructeur2) { create(:instructeur) }
-      let(:gi1) { create(:groupe_instructeur, instructeurs: [current_instructeur]) }
-      let(:gi2) { create(:groupe_instructeur, instructeurs: [instructeur2]) }
-
-      it { is_expected.to be_falsy }
-    end
-  end
-
   describe '#estimated_fill_duration_minutes' do
     subject { estimated_fill_duration_minutes(procedure.reload) }
 


### PR DESCRIPTION
Quatre méthodes de helper sans aucun appelant dans le repo.

- `DossierHelper#button_or_label_class`
- `ProcedureHelper#procedure_publish_label` et `#can_send_groupe_message?` (+ son bloc de spec)
- `ArchiveHelper#can_generate_archive?`

Les clés de locale `modal.publish.*` (fr + en) partent aussi : leur seul lecteur
était `procedure_publish_label`, qui les maintenait en vie via ses commentaires
`i18n-tasks-use`. Les laisser aurait fait échouer `i18n-tasks unused`. La racine
`modal:` ne contenait rien d'autre, elle disparaît entièrement.

`TurboStreamHelper::TagBuilder#enable_all` / `#disable_all` sont morts eux aussi
mais volontairement conservés : ils complètent une famille de builders
(`show_all`, `hide_all`, `focus_all`) qui, elle, est utilisée, et pourront
servir plus tard.

Vérifié : `rubocop` sur les fichiers touchés, les trois checks i18n-tasks de
`lint:ruby`, et `rspec spec/helpers` (157 exemples, 0 échec).