### PR TITLE
Tech: API v2, erreur métier au lieu d'un 500 sur dossierRepasserEnConstruction en SVA/SVR

### DIFF
--- a/app/graphql/mutations/dossier_repasser_en_construction.rb
+++ b/app/graphql/mutations/dossier_repasser_en_construction.rb
@@ -24,6 +24,9 @@ module Mutations
       if !dossier.en_instruction?
         return false, { errors: ["Le dossier est déjà #{dossier_display_state(dossier, lower: true)}"] }
       end
+      if !dossier.can_repasser_en_construction?
+        return false, { errors: ["Le dossier ne peut pas repasser en construction car la démarche est en décision implicite (SVA/SVR). Demandez une correction à l’usager à la place."] }
+      end
       dossier_authorized_for?(dossier, instructeur)
     end
   end

--- a/spec/controllers/api/v2/graphql_controller_stored_mutations_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_mutations_spec.rb
@@ -169,6 +169,21 @@ describe API::V2::GraphqlController do
         expect(gql_data[:dossierRepasserEnConstruction][:dossier][:id]).to eq(dossier.to_typed_id)
         expect(gql_data[:dossierRepasserEnConstruction][:dossier][:state]).to eq('en_construction')
       }
+
+      context 'when the procedure is sva' do
+        before_all { seed "cases/sva" }
+
+        let(:procedure) { procedures.sva }
+        let(:dossier) { create(:dossier, :en_instruction, procedure: procedures.sva) }
+
+        it 'returns a validation error instead of raising an invalid transition' do
+          expect(gql_errors).to be_nil
+          expect(gql_data[:dossierRepasserEnConstruction][:dossier]).to be_nil
+          expect(gql_data[:dossierRepasserEnConstruction][:errors].first[:message])
+            .to eq('Le dossier ne peut pas repasser en construction car la démarche est en décision implicite (SVA/SVR). Demandez une correction à l’usager à la place.')
+          expect(dossier.reload).to be_en_instruction
+        end
+      end
     end
 
     context 'dossierRepasserEnInstruction' do


### PR DESCRIPTION
## Problème

Sentry [RAILS-MFE](https://demarches-simplifiees.sentry.io/issues/RAILS-MFE) : `AASM::InvalidTransition` sur `API::V2::GraphqlController#execute`, 6 occurrences en 2 minutes pour un seul client API (retry en boucle).

Le `authorized?` de la mutation vérifie que le dossier est bien `en_instruction`, mais la transition AASM porte un **second garde** qui n'est jamais testé :

```ruby
transitions from: :en_instruction, to: :en_construction, guard: :can_repasser_en_construction?
# def can_repasser_en_construction? = !procedure.sva_svr_enabled?
```

Sur une démarche en décision implicite (SVA/SVR), `repasser_en_construction!` lève donc `AASM::InvalidTransition`, attrapée par le `rescue => exception` générique du contrôleur GraphQL → **HTTP 500 « Internal Server Error »** opaque. Le client ne comprend pas et retente.

## Solution

Vérifier `can_repasser_en_construction?` dans `authorized?` et renvoyer une erreur de validation qui oriente vers la demande de correction (`repasser_en_construction_with_pending_correction`, le chemin qui reste autorisé en SVA/SVR).

Fixes RAILS-MFE

🤖 Generated with [Claude Code](https://claude.com/claude-code)