### PR TITLE
Tech: API v2, ne pas planter quand la démarche d'un objet a été masquée

### DIFF
--- a/app/graphql/api/v2/context.rb
+++ b/app/graphql/api/v2/context.rb
@@ -44,6 +44,12 @@ class API::V2::Context < GraphQL::Query::Context
   end
 
   def authorized_demarche?(demarche, opendata: false)
+    # `Procedure` has a `default_scope -> { kept }`, so `label.procedure`,
+    # `dossier.revision.procedure`, … return nil once the démarche is hidden,
+    # while the child rows still exist. Nothing can be authorized without a
+    # démarche to authorize against.
+    return false if demarche.nil?
+
     if internal_use?
       return true
     end

--- a/spec/controllers/api/v2/graphql_controller_stored_mutations_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_mutations_spec.rb
@@ -755,6 +755,18 @@ describe API::V2::GraphqlController do
           expect(gql_data[:dossierAjouterLabel][:errors]).to eq([{ message: "Ce label est déjà associé au dossier" }])
         }
       end
+
+      context 'when the procedure of the label has been hidden' do
+        let(:label) { create(:label, procedure: create(:procedure)) }
+
+        before { label.procedure.update_column(:hidden_at, Time.current) }
+
+        it 'returns an unauthorized error instead of raising on a nil procedure' do
+          expect(gql_data[:dossierAjouterLabel]).to be_nil
+          expect(gql_errors.first[:message]).to eq('An object of type Label was hidden due to permissions')
+          expect(gql_errors.first[:extensions][:code]).to eq('unauthorized')
+        end
+      end
     end
 
     context 'dossierSupprimerLabel' do


### PR DESCRIPTION
## Problème

Sentry [RAILS-MFD](https://demarches-simplifiees.sentry.io/issues/RAILS-MFD) : `NoMethodError: undefined method 'id' for nil` sur `API::V2::GraphqlController#execute`.

```ruby
# app/graphql/types/label_type.rb
context.authorized_demarche?(object.procedure)   # object.procedure == nil

# app/graphql/api/v2/context.rb:57
if self[:authorized][demarche.id].nil?           # 💥
```

`Procedure` est en soft-delete (`Discard`, colonne `hidden_at`) **avec un `default_scope -> { kept }`**. Dès que la démarche est masquée, `label.procedure` renvoie `nil` alors que la ligne `labels` existe toujours en base. Un client API qui envoie un `labelId` d'une démarche masquée obtient un **500**.

Le même piège existe sur les autres appelants de `authorized_demarche?` : `DeletedDossierType`, `GroupeInstructeurType`, `DossierType#demarche` (`object.revision.procedure`), `MessageType`, `RevisionType`.

## Solution

Garder sur `nil` directement dans `API::V2::Context#authorized_demarche?` : sans démarche, il n'y a rien à autoriser, donc `false`. L'objet est masqué par `unauthorized_object` (erreur `unauthorized` propre) au lieu de faire tomber la requête. Un seul point de correction couvre tous les appelants.

Fixes RAILS-MFD

🤖 Generated with [Claude Code](https://claude.com/claude-code)