### PR TITLE
[WIP] ETQ usager, ne plus recevoir un 500 quand le stockage refuse la mise à jour des métadonnées

### DIFF
--- a/app/jobs/blob_update_service_metadata_job.rb
+++ b/app/jobs/blob_update_service_metadata_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# `ActiveStorage::Blob#update_service_metadata` pushes the content type and the
+# content disposition to the object storage. Rails calls it from an
+# `after_update_commit` callback: the record is already committed when it runs,
+# so a transient storage error (OVH Swift answering `409 Conflict` on the
+# metadata POST) used to turn an already successful user action — sending a
+# message with an attachment, for instance — into a HTTP 500.
+#
+# Doing it from a job keeps the storage round trip out of the request cycle and
+# gives it the Sidekiq retries it needs.
+class BlobUpdateServiceMetadataJob < ApplicationJob
+  use_sidekiq_retry
+
+  discard_on ActiveJob::DeserializationError
+  discard_on ActiveStorage::FileNotFoundError
+
+  def perform(blob)
+    blob.update_service_metadata_now
+  end
+end

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -113,6 +113,19 @@ ActiveSupport.on_load(:active_storage_blob) do
     def purge_later
       DelayedPurgeJob.perform_later(self)
     end
+
+    # Rails' own implementation of the `after_update_commit` callback, called by
+    # `BlobUpdateServiceMetadataJob`.
+    def update_service_metadata_now
+      service.update_metadata key, **service_metadata if service_metadata.any?
+    end
+
+    # The callback fires after the transaction has been committed, so raising
+    # here fails a request whose work is already done. Defer to a retryable job
+    # instead: see BlobUpdateServiceMetadataJob.
+    private def update_service_metadata
+      BlobUpdateServiceMetadataJob.perform_later(self) if service_metadata.any?
+    end
   end
 
   def self.generate_unique_secure_token(length: MINIMUM_TOKEN_LENGTH)

--- a/spec/jobs/blob_update_service_metadata_job_spec.rb
+++ b/spec/jobs/blob_update_service_metadata_job_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe BlobUpdateServiceMetadataJob, type: :job do
+  let(:file) { fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png') }
+  let(:procedure) { create(:procedure).tap { allow(_1).to receive(:valid?).and_return(true) } }
+  let(:blob) do
+    procedure.notice.attach(file)
+    procedure.notice.blob
+  end
+
+  describe 'the after_update_commit callback on ActiveStorage::Blob' do
+    it 'enqueues the job rather than calling the storage inside the request' do
+      expect(blob.service).not_to receive(:update_metadata)
+
+      expect { blob.update!(content_type: 'application/pdf') }
+        .to have_enqueued_job(BlobUpdateServiceMetadataJob).with(blob)
+    end
+
+    it 'does not fail the caller when the storage refuses the metadata update' do
+      blob # attach before stubbing
+      allow(blob.service).to receive(:update_metadata).and_raise(Excon::Error::Conflict.new('409'))
+
+      expect { blob.update!(content_type: 'application/pdf') }.not_to raise_error
+    end
+  end
+
+  describe '#perform' do
+    it 'pushes the metadata to the storage service' do
+      expect(blob.service).to receive(:update_metadata)
+        .with(blob.key, hash_including(content_type: blob.content_type))
+
+      BlobUpdateServiceMetadataJob.perform_now(blob)
+    end
+  end
+end


### PR DESCRIPTION
## Problème

Sentry [RAILS-MFB](https://demarches-simplifiees.sentry.io/issues/RAILS-MFB) : `Excon::Error::Conflict: Expected(202) <=> Actual(409 Conflict)` sur `Users::DossiersController#create_commentaire`.

La stack est parlante :

```
CommentaireService.build_and_save → message.save
  → commit_transaction → commit_records → committed!
    → ActiveStorage::Blob#update_service_metadata   (after_update_commit)
      → OpenStackService#update_metadata → POST …/ds_activestorage_backup/… → 409
```

Le commentaire (et sa pièce jointe) est **déjà committé en base** quand le callback tourne. Le 409 renvoyé par Swift remonte donc jusqu'à Puma : l'usager voit une **erreur 500** sur une action qui a réussi, et va probablement renvoyer son message.

## Solution

Sortir l'aller-retour vers le stockage du cycle de requête : le callback enfile `BlobUpdateServiceMetadataJob`, qui refait l'appel avec les retries Sidekiq (`use_sidekiq_retry`). Bonus : une requête HTTP synchrone en moins dans l'envoi de message.

## À creuser

L'origine du 409 côté OVH (le path pointe sur le conteneur `ds_activestorage_backup`) reste à comprendre — 1 seule occurrence pour l'instant. Cette PR traite la conséquence : ce callback ne doit pas pouvoir faire échouer une requête déjà committée.

Fixes RAILS-MFB

🤖 Generated with [Claude Code](https://claude.com/claude-code)