### PR TITLE
ETQ usager, le bouton « Réessayer » d'un envoi de fichier ne remonte plus d'erreur non gérée

### DIFF
--- a/app/javascript/controllers/type_de_champ_editor_controller.ts
+++ b/app/javascript/controllers/type_de_champ_editor_controller.ts
@@ -59,7 +59,9 @@ export class TypeDeChampEditorController extends ApplicationController {
       file: (target) => {
         if (target.files?.length && target.name != 'referentiel_file') {
           const autoupload = new AutoUpload(target, target.files[0]);
-          autoupload.start();
+          // The error is already displayed above the input by `AutoUpload`;
+          // swallow the rejection so it is not reported as unhandled.
+          autoupload.start().catch(() => null);
         }
         if (target.files?.length && target.name == 'referentiel_file') {
           this.requestSubmitForm(target.form);

--- a/app/javascript/shared/activestorage/auto-upload.test.ts
+++ b/app/javascript/shared/activestorage/auto-upload.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
+
+import { errorFromDirectUploadMessage } from './file-upload-error';
+
+const { uploaderStart } = vi.hoisted(() => ({ uploaderStart: vi.fn() }));
+
+vi.mock('./uploader', () => ({
+  default: class {
+    directUpload = { id: 'test-id' };
+    progressBar = {
+      start: vi.fn(),
+      end: vi.fn(),
+      error: vi.fn(),
+      destroy: vi.fn()
+    };
+    start() {
+      return uploaderStart();
+    }
+  }
+}));
+
+// Imported after the mock so it picks up the fake Uploader.
+const { AutoUpload } = await import('./auto-upload');
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div class="attachment-field">
+      <input type="file" data-direct-upload-url="/rails/active_storage/direct_uploads" />
+      <div id="direct-upload-test-id" class="direct-upload direct-upload--error">
+        <button type="button" class="direct-upload__retry hidden"></button>
+        <div class="direct-upload__error"></div>
+      </div>
+    </div>
+  `;
+  return document.querySelector<HTMLInputElement>('input')!;
+}
+
+// A connectivity failure: the kind that offers a retry button.
+function storeError() {
+  return errorFromDirectUploadMessage(
+    'Error storing "attestation.pdf". Status: 0'
+  );
+}
+
+suite('AutoUpload retry', () => {
+  let input: HTMLInputElement;
+  let rejections: PromiseRejectionEvent[];
+
+  const collectRejection = (event: PromiseRejectionEvent) => {
+    event.preventDefault();
+    rejections.push(event);
+  };
+
+  beforeEach(() => {
+    input = setupDom();
+    rejections = [];
+    uploaderStart.mockReset();
+    window.addEventListener('unhandledrejection', collectRejection);
+  });
+
+  afterEach(() => {
+    window.removeEventListener('unhandledrejection', collectRejection);
+    document.body.innerHTML = '';
+  });
+
+  test('does not leak an unhandled rejection when the retried upload fails again', async () => {
+    uploaderStart.mockRejectedValue(storeError());
+
+    const autoUpload = new AutoUpload(
+      input,
+      new File(['x'], 'attestation.pdf')
+    );
+    await expect(autoUpload.start()).rejects.toThrowError(
+      'Error storing file.'
+    );
+
+    const retryButton = document.querySelector<HTMLButtonElement>(
+      '.direct-upload__retry'
+    )!;
+    expect(retryButton.classList.contains('hidden')).toBe(false);
+
+    retryButton.click();
+
+    await vi.waitFor(() => expect(uploaderStart).toHaveBeenCalledTimes(2));
+    // Let the microtask checkpoint run: that is when the browser decides a
+    // rejection is unhandled.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(rejections).toEqual([]);
+  });
+});

--- a/app/javascript/shared/activestorage/auto-upload.ts
+++ b/app/javascript/shared/activestorage/auto-upload.ts
@@ -125,8 +125,11 @@ export class AutoUpload {
           );
           errorZone?.classList.add('hidden');
 
-          // Restart the upload
-          this.start();
+          // Restart the upload. `start()` re-throws so its caller can react,
+          // but here there is no caller: `failed()` already displayed the
+          // error, and an uncaught rejection would be reported to Sentry as if
+          // nothing had handled it.
+          this.start().catch(() => null);
         },
         { once: true }
       );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,20 @@
+import { fileURLToPath } from 'node:url';
+
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  // `vite.config.ts` declares this alias relative to vite-plugin-ruby's root,
+  // and vitest does not load that config. Without it the dependency scan throws
+  // on the first test that reaches `@utils`, vite then skips pre-bundling
+  // altogether, and unrelated React tests get a null `react` module.
+  resolve: {
+    alias: {
+      '@utils': fileURLToPath(
+        new URL('./app/javascript/shared/utils.ts', import.meta.url)
+      )
+    }
+  },
   test: {
     globals: true,
     browser: {


### PR DESCRIPTION
## Problème

Sentry [JAVASCRIPT-F1J](https://demarches-simplifiees.sentry.io/issues/JAVASCRIPT-F1J) (`Error storing file.`) et [JAVASCRIPT-F1H](https://demarches-simplifiees.sentry.io/issues/JAVASCRIPT-F1H) (`Error creating file.`), toutes deux avec `mechanism: auto.browser.global_handlers.onunhandledrejection` : ce sont des **promesses rejetées non catchées**, pas des remontées volontaires.

Le chemin nominal est bien protégé : `autosave_controller.ts` fait `.catch()` et ne re-throw vers Sentry que les vraies erreurs client. Le trou est dans le bouton « Réessayer » installé par `AutoUpload#failed()` :

```ts
// app/javascript/shared/activestorage/auto-upload.ts
// Restart the upload
this.start();   // ← pas de .catch(), et start() re-throw
```

Donc : premier échec = géré (message + bouton) ; l'usager clique « Réessayer » ; **deuxième échec = unhandled rejection**. Ça explique le faible volume (1 event) au regard de la fréquence réelle des échecs d'envoi.

Même trou, sans retry, dans `type_de_champ_editor_controller.ts` côté admin.

## Solution

`.catch(() => null)` sur les deux appels : l'erreur est déjà affichée au-dessus de l'input par `AutoUpload#failed()`, il n'y a rien de plus à en faire.

Un test navigateur (`auto-upload.test.ts`) écoute `unhandledrejection` et échoue si le retry en laisse fuiter une — vérifié rouge sans le correctif.

Fixes JAVASCRIPT-F1J
Fixes JAVASCRIPT-F1H

🤖 Generated with [Claude Code](https://claude.com/claude-code)