### PR TITLE
Correctif: répare la recherche de démarches dans le manager

### DIFF
--- a/app/dashboards/procedure_dashboard.rb
+++ b/app/dashboards/procedure_dashboard.rb
@@ -12,7 +12,9 @@ class ProcedureDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     published_types_de_champ_public: TypesDeChampCollectionField,
     published_types_de_champ_private: TypesDeChampCollectionField,
-    path: ProcedureLinkField,
+    # `path` n'est plus une colonne mais une méthode (le path canonique de la
+    # dernière ProcedurePath) : Administrate ne peut pas le chercher en SQL.
+    path: ProcedureLinkField.with_options(searchable: false),
     procedure_paths: Field::HasMany,
     aasm_state: ProcedureStateField,
     dossiers: Field::HasMany,

--- a/spec/controllers/manager/procedures_controller_spec.rb
+++ b/spec/controllers/manager/procedures_controller_spec.rb
@@ -117,6 +117,18 @@ describe Manager::ProceduresController, type: :controller do
           .to be < response.body.index("Procédure 2")
       end
     end
+
+    # Administrate construit une clause LIKE par attribut cherchable : un attribut
+    # qui n'est plus une colonne fait planter n'importe quelle recherche.
+    context 'search' do
+      let(:suffix) { SecureRandom.hex(4) }
+      let!(:procedure) { create(:procedure, administrateur:, libelle: "Demande de badge cachalot#{suffix}") }
+
+      before { get :index, params: { search: "cachalot#{suffix}" } }
+
+      # Une ligne du tableau Administrate porte un unique data-url vers la ressource.
+      it { expect(response.body.scan(%r{data-url=/manager/procedures/#{procedure.id}\b}).size).to eq(1) }
+    end
   end
 
   describe '#change_piece_justificative_template' do


### PR DESCRIPTION
Depuis #13695, toute recherche dans `/manager/procedures` renvoie un 500 (Sentry RAILS-MFC) : le dashboard déclarait toujours `path: ProcedureLinkField`, qui hérite de `Administrate::Field::String` et est donc cherchable. Administrate mappe chaque attribut cherchable directement sur un nom de colonne sans vérifier qu'elle existe, d'où un `LIKE` sur `procedures.path` disparue. Le SQL ne passait avant que parce que la colonne était encore là, simplement ignorée par AR.

`path` cesse donc d'être cherchable. L'affichage de la colonne « Lien démarche » ne bouge pas : il passe par la méthode Ruby, pas par du SQL.

**Pourquoi ne pas plutôt réparer la recherche par URL ?** Parce qu'elle ne fonctionnait déjà plus depuis le passage à `procedure_paths` (29/01/2025) : à partir de là `claim_path!` n'écrit plus que dans l'association, et `procedures.path` garde l'UUID posé à la création. Une démarche créée après cette date n'a jamais été trouvable par son URL dans le manager — silencieusement, sans erreur. Personne ne l'a signalé en 19 mois, donc on ne la restaure pas.

Le spec ajouté couvre la régression : Administrate génère une clause `LIKE` par attribut cherchable, donc n'importe quelle recherche suffit à rejouer le bug.