### PR TITLE
Tech: supprime une exclusion Rubocop fantôme

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -645,8 +645,6 @@ Performance/CompareWithBlock:
 
 Performance/Count:
   Enabled: true
-  Exclude:
-    - 'app/services/administrateur_usage_statistics_service.rb'
 
 Performance/Detect:
   Enabled: true


### PR DESCRIPTION
`Performance/Count` excluait `app/services/administrateur_usage_statistics_service.rb`, fichier supprimé en mai 2022 par 9e0b3b642f (cleanup du tracking Sendinblue). L'exclusion ne protégeait donc plus rien depuis 3 ans.

Vérifié : plus aucune référence à ce fichier dans le repo, et `bundle exec rubocop --parallel` passe sans offense (3315 fichiers).

Point A5 de la liste de nettoyage dans l'esprit de #13695.