### PR TITLE
Tech: ignorer la config lefthook locale (+ partage de mon setup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,9 @@ public/graphql/schema
 CLAUDE.local.md
 /.playwright-mcp
 
+# Hooks git locaux (lefthook n'est pas une dépendance du projet)
+lefthook.yml
+lefthook-local.yml
+
 # git worktrees
 .worktrees/


### PR DESCRIPTION
# Problème

J'utilise lefthook, je me dis ca pourrait interesser d'autres gens a l'avoir ds le gitignore et le setup

# Solution

Ajouter `lefthook.yml` et `lefthook-local.yml` au `.gitignore`. Rien d'autre : chacun reste libre d'utiliser lefthook ou pas.

# Bonus : mon setup lefthook, si ça intéresse

Installation (une fois) :

```bash
brew install lefthook   # ou: go install github.com/evilmartians/lefthook@latest
lefthook install        # pose les hooks dans .git/hooks
```

Puis `lefthook.yml` à la racine (désormais ignoré) :

```yaml
# Les jobs correcteurs ne parlent que s'ils échouent : `herb-lint` affiche à
# chaque exécution un bandeau « New rules available » qu'aucun flag ne tait.
output:
  - summary
  - failure

pre-commit:
  parallel: true
  jobs:
    # Piped : `rubocop -A` réécrit les fichiers, la passe de vérification doit
    # les lire après.
    - name: ruby
      group:
        piped: true
        jobs:
          # Correction : seul un Fatal arrête le commit, le reste est corrigé
          # sur place et restagé.
          - name: rubocop
            run: bundle exec rubocop -A --force-exclusion --fail-level=F {staged_files}
            glob: "*.rb"
            stage_fixed: true

          # Les cops de sûreté de sortie n'ont pas d'autocorrection : sans un
          # fail level à eux, ils s'affichent et le commit passe quand même.
          # `--fail-level=C` sur le job principal bloquerait sur n'importe
          # quelle convention non corrigeable du dépôt, d'où ce job dédié.
          - name: rubocop-output-safety
            run: bundle exec rubocop --force-exclusion --only DS/I18nOutputSafety,Rails/OutputSafety --fail-level=C {staged_files}
            glob: "*.rb"

    # Piped : herb-format réécrit les fichiers, herb-lint doit les lire après.
    - name: erb
      group:
        piped: true
        jobs:
          - name: herb-format
            run: bun herb-format {staged_files}
            glob: "*.html.erb"
            stage_fixed: true

          # Attrape `raw` et `.html_safe` dans les sorties ERB, que RuboCop ne
          # lit pas.
          - name: herb-lint
            run: bun herb-lint {staged_files}
            glob: "*.html.erb"

    # Même angle mort côté HAML, via le linter maison OutputSafetyLinter.
    - name: haml-lint
      run: bundle exec haml-lint {staged_files}
      glob: "*.html.haml"

    - name: apostrophe
      run: bundle exec rake lint:apostrophe:fix
      glob: "config/locales/**/*.{yml,yaml}"
      stage_fixed: true

    - name: eslint
      run: bun eslint --fix {staged_files}
      glob: "*.{ts,tsx,js,jsx}"
      stage_fixed: true

    - name: prettier
      run: bun prettier --write {staged_files}
      # Pas de `**/` : lefthook l'interprète comme « au moins un sous-répertoire »,
      # or l'arbo est plate. `*` traverse déjà les séparateurs.
      glob: "app/assets/stylesheets/*.{css,scss}"
      stage_fixed: true
```

Les trois idées qui font que ça reste utilisable au quotidien :

| Idée | Pourquoi |
|------|----------|
| `stage_fixed: true` | Les jobs correcteurs (`rubocop -A`, `herb-format`, `prettier`, `eslint --fix`) réécrivent et restagent : le commit part corrigé au lieu d'être refusé. |
| `--fail-level=F` + un job dédié pour la sûreté de sortie | Un `--fail-level=C` global bloquerait sur n'importe quelle convention non autocorrigeable du dépôt. Les cops `DS/I18nOutputSafety` et `Rails/OutputSafety` (et leurs équivalents `herb-lint` / `haml-lint`) n'ont pas d'autocorrection : sans leur propre seuil, ils s'afficheraient et le commit passerait quand même. |
| `{staged_files}` + `glob:` | On ne lint que ce qu'on commite, en parallèle : quelques secondes, pas la suite complète. |

`lefthook uninstall` pour tout enlever, et `LEFTHOOK=0 git commit` pour sauter les hooks ponctuellement.

## Et dans les worktrees ?

Je travaille beaucoup en `git worktree`, et un worktree fraîchement créé n'a évidemment pas de `lefthook.yml` — puisque justement il n'est pas versionné. D'où un `post-checkout` qui fait le fanout.

Point clé : les worktrees **partagent** le répertoire de hooks du dépôt principal (`.git/hooks`, le *git common dir*). Un seul hook installé côté dépôt principal se déclenche donc aussi pour chaque `git worktree add` — pas besoin de l'installer worktree par worktree.

```
   config perso (hors repo)
            │  install.sh
            ▼
   dépôt principal : lefthook.yml + .git/hooks/post-checkout
            │  git worktree add  →  post-checkout
            ▼
   worktree : lefthook.yml copié + `lefthook install`
```

L'extrait qui fait le travail, dans `post-checkout` :

```bash
# Config lefthook : le repo principal est le point de distribution vers ses
# worktrees.
if [ -f "$main_repo/lefthook.yml" ]; then
  cp "$main_repo/lefthook.yml" "$worktree_path/lefthook.yml"
else
  echo "⚠️  Pas de lefthook.yml dans le repo principal"
fi
if command -v lefthook &>/dev/null; then
  (cd "$worktree_path" && lefthook install >/dev/null 2>&1) && echo "==> lefthook installé"
fi
```

Le hook commence par `[ "$git_dir" = "$git_common_dir" ] && exit 0` pour ne rien faire dans le dépôt principal, et sort tôt pendant un rebase (le checkout final le déclencherait pour rien). Il en profite pour le reste de la mise en route d'un worktree : symlink du `.env`, base de test dédiée (`tps_test_<worktree>`) écrite dans `.env.test.local`, `bundle install` + `bun install`.

C'est une copie, pas un symlink : `lefthook install` veut un vrai fichier à la racine, et un `.gitignore` qui laisse traîner une copie par worktree n'est un problème pour personne — d'où cette PR. La diffusion est à sens unique : j'édite la source, je relance `install.sh`, les worktrees suivants suivent. Éditer la copie d'un worktree ne sert à rien, elle est écrasée au checkout suivant.

Generated with [Claude Code](https://claude.com/claude-code)
