### PR TITLE
Tech: migre 5 composants EditableChamp de HAML vers ERB

### DIFF
--- a/app/components/editable_champ/decimal_number_component/decimal_number_component.html.erb
+++ b/app/components/editable_champ/decimal_number_component/decimal_number_component.html.erb
@@ -1,0 +1,1 @@
+<%= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, required: @champ.required?, pattern: "-?[0-9]+([\.,][0-9]{1,3})?", inputmode: :decimal, data: { controller: 'format', format: :decimal })) %>

--- a/app/components/editable_champ/decimal_number_component/decimal_number_component.html.haml
+++ b/app/components/editable_champ/decimal_number_component/decimal_number_component.html.haml
@@ -1,1 +1,0 @@
-= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, required: @champ.required?, pattern: "-?[0-9]+([\.,][0-9]{1,3})?", inputmode: :decimal, data: { controller: 'format', format: :decimal }))

--- a/app/components/editable_champ/departements_component/departements_component.html.erb
+++ b/app/components/editable_champ/departements_component/departements_component.html.erb
@@ -1,0 +1,1 @@
+<%= @form.select :value, options, select_options, required: @champ.required?, id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, class: "fr-select" %>

--- a/app/components/editable_champ/departements_component/departements_component.html.haml
+++ b/app/components/editable_champ/departements_component/departements_component.html.haml
@@ -1,1 +1,0 @@
-= @form.select :value, options, select_options, required: @champ.required?, id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, class: "fr-select"

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.html.erb
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.html.erb
@@ -1,0 +1,1 @@
+<%= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, inputmode: :numeric, min: 1, pattern: "[0-9]{1,12}", autocomplete: 'off', required: @champ.required?, class: "width-33-desktop")) %>

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
@@ -1,1 +1,0 @@
-= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, inputmode: :numeric, min: 1, pattern: "[0-9]{1,12}", autocomplete: 'off', required: @champ.required?, class: "width-33-desktop"))

--- a/app/components/editable_champ/email_component/email_component.html.erb
+++ b/app/components/editable_champ/email_component/email_component.html.erb
@@ -1,0 +1,1 @@
+<%= @form.email_field(:value, input_opts(id: @champ.focusable_input_id, autocomplete: @champ.dossier.for_tiers? ? "off" : "email", aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, required: @champ.required?)) %>

--- a/app/components/editable_champ/email_component/email_component.html.haml
+++ b/app/components/editable_champ/email_component/email_component.html.haml
@@ -1,1 +1,0 @@
-= @form.email_field(:value, input_opts(id: @champ.focusable_input_id, autocomplete: @champ.dossier.for_tiers? ? "off" : "email", aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, required: @champ.required?))

--- a/app/components/editable_champ/engagement_juridique_component/engagement_juridique_component.html.erb
+++ b/app/components/editable_champ/engagement_juridique_component/engagement_juridique_component.html.erb
@@ -1,0 +1,1 @@
+<%= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, required: @champ.required?, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" })) %>

--- a/app/components/editable_champ/engagement_juridique_component/engagement_juridique_component.html.haml
+++ b/app/components/editable_champ/engagement_juridique_component/engagement_juridique_component.html.haml
@@ -1,1 +1,0 @@
-= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, required: @champ.required?, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }))


### PR DESCRIPTION
Migration HAML → ERB :

- `DecimalNumberComponent`
- `DepartementsComponent`
- `DossierLinkComponent`
- `EmailComponent`
- `EngagementJuridiqueComponent`

Conversion mécanique via `haml_to_erb` puis `herb-format` : le code Ruby est identique au caractère près, seul l'enrobage passe de `= ` à `<%= … %>`. Aucun attribut HAML, aucun double splat ni classe en tableau dans ces templates, donc pas de piège de conversion. Un commit par template.

Pas de capture d'écran : ces composants n'ont pas de preview ViewComponent (ils ne se rendent qu'à l'intérieur d'un formulaire de dossier).

