### PR TITLE
Tech: migre 5 composants EditableChamp de HAML vers ERB

### DIFF
--- a/app/components/editable_champ/formatted_component/formatted_component.html.erb
+++ b/app/components/editable_champ/formatted_component/formatted_component.html.erb
@@ -1,0 +1,1 @@
+<%= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, required: @champ.required?, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" })) %>

--- a/app/components/editable_champ/formatted_component/formatted_component.html.haml
+++ b/app/components/editable_champ/formatted_component/formatted_component.html.haml
@@ -1,1 +1,0 @@
-= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, required: @champ.required?, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }))

--- a/app/components/editable_champ/iban_component/iban_component.html.erb
+++ b/app/components/editable_champ/iban_component/iban_component.html.erb
@@ -1,0 +1,2 @@
+<%# maxlength counts the space separator of the 4-digit groups %>
+<%= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, required: @champ.required?, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, data: { controller: 'format', format: 'iban' }, class: "width-66-desktop", maxlength: 34 + 9, size: nil)) %>

--- a/app/components/editable_champ/iban_component/iban_component.html.haml
+++ b/app/components/editable_champ/iban_component/iban_component.html.haml
@@ -1,1 +1,0 @@
-= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, required: @champ.required?, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, data: { controller: 'format', format: 'iban' }, class: "width-66-desktop", maxlength: 34 + 9, size: nil)) # count space separator of 4 digits-groups

--- a/app/components/editable_champ/integer_number_component/integer_number_component.html.erb
+++ b/app/components/editable_champ/integer_number_component/integer_number_component.html.erb
@@ -1,0 +1,1 @@
+<%= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, pattern: "-?[0-9]*", inputmode: :numeric, required: @champ.required?, data: { controller: 'format', format: :integer })) %>

--- a/app/components/editable_champ/integer_number_component/integer_number_component.html.haml
+++ b/app/components/editable_champ/integer_number_component/integer_number_component.html.haml
@@ -1,1 +1,0 @@
-= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, pattern: "-?[0-9]*", inputmode: :numeric, required: @champ.required?, data: { controller: 'format', format: :integer }))

--- a/app/components/editable_champ/number_component/number_component.html.erb
+++ b/app/components/editable_champ/number_component/number_component.html.erb
@@ -1,0 +1,1 @@
+<%= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, required: @champ.required?, pattern: "-?[0-9]*", inputmode: :decimal)) %>

--- a/app/components/editable_champ/number_component/number_component.html.haml
+++ b/app/components/editable_champ/number_component/number_component.html.haml
@@ -1,1 +1,0 @@
-= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, required: @champ.required?, pattern: "-?[0-9]*", inputmode: :decimal))

--- a/app/components/editable_champ/pays_component/pays_component.html.erb
+++ b/app/components/editable_champ/pays_component/pays_component.html.erb
@@ -1,0 +1,1 @@
+<%= @form.select :value, options, select_options, required: @champ.required?, id: @champ.focusable_input_id, autocomplete: @champ.dossier.for_tiers? ? "off" : "country-name", aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, class: "width-33-desktop width-100-mobile fr-select" %>

--- a/app/components/editable_champ/pays_component/pays_component.html.haml
+++ b/app/components/editable_champ/pays_component/pays_component.html.haml
@@ -1,1 +1,0 @@
-= @form.select :value, options, select_options, required: @champ.required?, id: @champ.focusable_input_id, autocomplete: @champ.dossier.for_tiers? ? "off" : "country-name", aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, class: "width-33-desktop width-100-mobile fr-select"


### PR DESCRIPTION
Migration HAML → ERB de cinq templates d'une ligne de `app/components/editable_champ/`.

- `FormattedComponent`
- `IbanComponent`
- `IntegerNumberComponent`
- `NumberComponent`
- `PaysComponent`

Conversion mécanique via `haml_to_erb` puis `herb-format`, un commit par template. Le code Ruby est identique au caractère près, à une exception près : sur `IbanComponent`, `haml_to_erb` a laissé le commentaire Ruby de fin de ligne *avant* le `%>` fermant, ce qui commentait la balise générée et rendait le template compilé syntaxiquement invalide. Le commentaire passe donc sur sa propre ligne `<%# … %>`.

À noter : ni `--check` ni `herb-lint` ne détectent ce cas — les deux passaient au vert sur le template cassé. Seule la compilation Erubi le révèle. Ça vaut le coup de garder ça en tête pour les templates HAML qui portent un commentaire Ruby en fin de ligne.

Pas de capture d'écran : ces composants n'ont pas de preview ViewComponent, ils ne se rendent qu'à l'intérieur d'un formulaire de dossier.
