### PR TITLE
Correctif: API v2, une demande de correction impossible ne doit plus passer pour un succès

### DIFF
--- a/app/graphql/mutations/dossier_envoyer_message.rb
+++ b/app/graphql/mutations/dossier_envoyer_message.rb
@@ -2,6 +2,8 @@
 
 module Mutations
   class DossierEnvoyerMessage < Mutations::BaseMutation
+    include DossierHelper
+
     description "Envoyer un message à l’usager du dossier."
 
     argument :dossier_id, ID, required: true, loads: Types::DossierType
@@ -18,7 +20,7 @@ module Mutations
 
       return { errors: message.errors.full_messages } if message.invalid?
 
-      if correction && dossier.may_flag_as_pending_correction?
+      if correction
         # flag_as_pending_correction! assigns the correction to the commentaire
         # in-memory, then saves it, so Commentaire#notify (after_create) enqueues
         # notify_pending_correction rather than notify_new_answer.
@@ -38,8 +40,22 @@ module Mutations
       end
     end
 
-    def authorized?(dossier:, instructeur:, **args)
+    def authorized?(dossier:, instructeur:, correction: nil, **args)
+      if correction.present? && !dossier.may_flag_as_pending_correction?
+        return false, { errors: [correction_error_message(dossier)] }
+      end
+
       dossier_authorized_for?(dossier, instructeur)
+    end
+
+    private
+
+    def correction_error_message(dossier)
+      if dossier.pending_corrections.exists?
+        "Une demande de correction est déjà en attente sur ce dossier"
+      else
+        "Le dossier ne peut pas faire l’objet d’une demande de correction car il est #{dossier_display_state(dossier, lower: true)}"
+      end
     end
   end
 end

--- a/app/graphql/mutations/dossier_repasser_en_construction.rb
+++ b/app/graphql/mutations/dossier_repasser_en_construction.rb
@@ -25,7 +25,7 @@ module Mutations
         return false, { errors: ["Le dossier est déjà #{dossier_display_state(dossier, lower: true)}"] }
       end
       if !dossier.can_repasser_en_construction?
-        return false, { errors: ["Le dossier ne peut pas repasser en construction car la démarche est en décision implicite (SVA/SVR). Demandez une correction à l’usager à la place."] }
+        return false, { errors: ["Le dossier ne peut pas repasser en construction car la démarche est en décision implicite (SVA/SVR). Utilisez la mutation `dossierEnvoyerMessage` avec l’argument `correction` pour demander une correction à l’usager."] }
       end
       dossier_authorized_for?(dossier, instructeur)
     end

--- a/spec/controllers/api/v2/graphql_controller_stored_mutations_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_mutations_spec.rb
@@ -846,6 +846,30 @@ describe API::V2::GraphqlController do
           expect(dossier.pending_correction).to be_dossier_incorrect
           expect(dossier.pending_correction.commentaire.body).to eq('Hello World!')
         end
+
+        context 'when a correction is already pending' do
+          let!(:dossier_correction) { create(:dossier_correction, dossier:) }
+
+          it 'returns a validation error instead of silently sending a plain message' do
+            expect(gql_errors).to be_nil
+            expect(gql_data[:dossierEnvoyerMessage][:message]).to be_nil
+            expect(gql_data[:dossierEnvoyerMessage][:errors])
+              .to eq([{ message: 'Une demande de correction est déjà en attente sur ce dossier' }])
+            expect(dossier.commentaires.where(body: 'Hello World!')).to be_empty
+          end
+        end
+
+        context 'when the dossier is terminated' do
+          let(:dossier) { dossiers.accepte }
+
+          it 'returns a validation error instead of silently sending a plain message' do
+            expect(gql_errors).to be_nil
+            expect(gql_data[:dossierEnvoyerMessage][:message]).to be_nil
+            expect(gql_data[:dossierEnvoyerMessage][:errors])
+              .to eq([{ message: 'Le dossier ne peut pas faire l’objet d’une demande de correction car il est accepté' }])
+            expect(dossier.commentaires.where(body: 'Hello World!')).to be_empty
+          end
+        end
       end
 
       context 'schema error' do

--- a/spec/controllers/api/v2/graphql_controller_stored_mutations_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_mutations_spec.rb
@@ -180,7 +180,7 @@ describe API::V2::GraphqlController do
           expect(gql_errors).to be_nil
           expect(gql_data[:dossierRepasserEnConstruction][:dossier]).to be_nil
           expect(gql_data[:dossierRepasserEnConstruction][:errors].first[:message])
-            .to eq('Le dossier ne peut pas repasser en construction car la démarche est en décision implicite (SVA/SVR). Demandez une correction à l’usager à la place.')
+            .to eq('Le dossier ne peut pas repasser en construction car la démarche est en décision implicite (SVA/SVR). Utilisez la mutation `dossierEnvoyerMessage` avec l’argument `correction` pour demander une correction à l’usager.')
           expect(dossier.reload).to be_en_instruction
         end
       end


### PR DESCRIPTION
follows: https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/13710

# Problème

#13710 a corrigé le 500 opaque de `dossierRepasserEnConstruction` en SVA/SVR, en orientant le client vers la demande de correction — le chemin qui reste ouvert en décision implicite.

**1. L'erreur de #13710 ne nomme pas la mutation à utiliser.** Elle dit « Demandez une correction à l'usager à la place », et laisse le client API deviner quel appel fait ça.

**2. `dossierEnvoyerMessage(correction:)` peut renvoyer un faux succès.** Même angle mort que le 500, en plus discret puisque rien ne remonte dans Sentry :

```ruby
if correction && dossier.may_flag_as_pending_correction?
  dossier.flag_as_pending_correction!(message, correction)
else
  message.save! # le client a demandé une correction, il obtient un message ordinaire
end
```

Quand la demande est impossible — une correction est déjà en attente, ou le dossier n'est plus ni `en_construction` ni `en_instruction` — l'argument `correction` est ignoré, un message ordinaire part, et **le payload renvoyé est un succès**. Le client croit avoir renvoyé le dossier en construction ; le dossier n'a pas bougé. C'est le scénario vers lequel #13710 envoie désormais les clients SVA/SVR, d'où l'enchaînement.

# Solution

Le message d'erreur de #13710 pointe maintenant l'appel exact, sur le modèle du `deprecation_reason` de `dossierSupprimerMessage` qui renvoie déjà vers `dossierAnnulerDemandeCorrection` :

> …décision implicite (SVA/SVR). Utilisez la mutation `dossierEnvoyerMessage` avec l'argument `correction` pour demander une correction à l'usager.

Et la garde `may_flag_as_pending_correction?` remonte du `resolve` vers le `authorized?` de `dossierEnvoyerMessage`, où elle produit une erreur de validation au lieu d'une dégradation silencieuse :

| `dossierEnvoyerMessage(correction:)` | Avant | Après |
|---|---|---|
| correction déjà en attente | message ordinaire + succès | « Une demande de correction est déjà en attente sur ce dossier » |
| dossier terminé | message ordinaire + succès | « Le dossier ne peut pas faire l'objet d'une demande de correction car il est accepté » |

L'argument `correction` reste `required: false` : rien ne change pour qui envoie un message normal. Il devient simplement contraignant lorsqu'il est fourni — soit le dossier repasse en construction, soit le client obtient une erreur.

## Pourquoi pas une mutation dédiée ?

L'option d'une `dossierDemanderCorrection` a été écartée : une demande de correction *est* structurellement un commentaire (`DossierCorrection` porte un `belongs_to :commentaire`), donc la mutation prendrait les mêmes arguments, ferait le même appel et renverrait le même `Message`. On paierait un cycle de dépréciation sur une API publique pour un renommage. Rendre l'argument existant contraignant règle le vrai problème — l'opacité — sans toucher à la surface publique.

## Note de release

Changement de comportement observable : un `dossierEnvoyerMessage(correction:)` qui renvoyait `success` en ignorant la correction renvoie désormais une erreur de validation.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
