### PR TITLE
ETQ usager, ne plus imprimer les listes de choix démesurées dans le dossier vide

### DIFF
--- a/app/assets/stylesheets/dossier_vide_pdf.scss
+++ b/app/assets/stylesheets/dossier_vide_pdf.scss
@@ -143,6 +143,31 @@ body#dossier-vide-pdf {
   .annex h3 {
     break-after: avoid;
   }
+  // Links are clickable in the PDF; underlined and in the État blue so they read as
+  // links on screen and stay legible once printed in black and white.
+  a {
+    color: #000091;
+    text-decoration: underline;
+  }
+  // Our own instructions are italic, but a spelled-out URL is not: slashes and hyphens
+  // are hard to read slanted. Admin rich text (.description) keeps its own styling.
+  .explanation a {
+    font-style: normal;
+  }
+
+  // A reference list to read, not a form to fill in: two columns in a smaller type keep
+  // one option per line while halving the page count and the renderer's memory. Column
+  // balancing degrades badly past a few thousand items, which MAX_PRINTABLE_OPTIONS
+  // already rules out.
+  .annex-options {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-size: 8.5pt;
+    line-height: 1.25;
+    column-count: 2;
+    column-gap: 6mm;
+  }
 
   .box {
     border: 1px solid #161616;

--- a/app/components/dossiers/dossier_vide_pdf_component.rb
+++ b/app/components/dossiers/dossier_vide_pdf_component.rb
@@ -38,9 +38,47 @@ class Dossiers::DossierVidePdfComponent < ApplicationComponent
     end
   end
 
+  # Past this volume a list is not a hand-written enumeration any more but a whole dataset
+  # pasted in (every commune, every school): printing it would run to hundreds of pages and
+  # blow up the PDF renderer, so we point to the online form instead — like a commune champ,
+  # which already prints none of its values. Calibrated above the p99 of production lists.
+  MAX_PRINTABLE_OPTIONS = 5_000
+
+  CHOICE_LIST_TYPES = [
+    TypeDeChamp.type_champs.fetch(:drop_down_list),
+    TypeDeChamp.type_champs.fetch(:multiple_drop_down_list),
+    TypeDeChamp.type_champs.fetch(:linked_drop_down_list),
+  ].freeze
+
+  # Second threshold above too_many_options?: past 20 options the list moves to an annex,
+  # past MAX_PRINTABLE_OPTIONS it is not printed at all.
+  def too_many_options_to_print?(type_de_champ)
+    return false if !type_de_champ.type_champ.in?(CHOICE_LIST_TYPES) || type_de_champ.drop_down_advanced?
+
+    type_de_champ.drop_down_options.size >= MAX_PRINTABLE_OPTIONS
+  end
+
+  # Write-in box referencing the online form: the applicant fills the box from the
+  # searchable list on the website rather than from an unprintable annex.
+  def online_reference_field(type_de_champ)
+    url = commencer_url(procedure.path)
+    reference = tag.p(class: 'explanation') do
+      safe_join([
+        "Cette liste comporte #{number_with_delimiter(type_de_champ.drop_down_options.size)} valeurs : " \
+        "elle n’est pas reproduite ici. Renseignez votre réponse en vous aidant du formulaire " \
+        "en ligne : ",
+        # The URL is its own link text so it stays usable once the form is printed.
+        tag.a(url, href: url),
+      ])
+    end
+    safe_join([libelle(type_de_champ), description(type_de_champ), reference, fillable_box(height: :block)].compact)
+  end
+
   REPETITION_OCCURRENCES = 3
 
   def render_champ(type_de_champ)
+    return online_reference_field(type_de_champ) if too_many_options_to_print?(type_de_champ)
+
     case type_de_champ.type_champ
     when TypeDeChamp.type_champs.fetch(:header_section)
       safe_join([header_section_heading(type_de_champ), description(type_de_champ)].compact)
@@ -229,7 +267,8 @@ class Dossiers::DossierVidePdfComponent < ApplicationComponent
   end
 
   # A plain reference list (no checkboxes): the applicant reads it to fill in the
-  # form and can skip printing it when it is long.
+  # form and can skip printing it when it is long. Laid out in two columns (see the
+  # stylesheet), which halves the page count without giving up one option per line.
   def render_annex(type_de_champ, number)
     items = type_de_champ.drop_down_options.map { |option| tag.li(option_label(option)) }
     safe_join([

--- a/spec/components/dossiers/dossier_vide_pdf_component_spec.rb
+++ b/spec/components/dossiers/dossier_vide_pdf_component_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Dossiers::DossierVidePdfComponent, type: :component do
       it 'lists every option as a plain list without checkboxes in an Annexes page' do
         expect(subject).to have_selector('section.annexes h2', text: 'Annexes')
         expect(subject).to have_selector('.annexes h3', text: 'Annexe 1 : Choix')
-        expect(subject).to have_selector('.annexes ul li', count: options.size)
+        expect(subject).to have_selector('.annexes ul.annex-options li', count: options.size)
         expect(subject).not_to have_selector('.annexes .checkbox')
       end
     end
@@ -257,8 +257,56 @@ RSpec.describe Dossiers::DossierVidePdfComponent, type: :component do
 
       it 'lists every option as a plain list without checkboxes' do
         expect(subject).to have_selector('.annexes h3', text: 'Annexe 1 : Choix')
-        expect(subject).to have_selector('.annexes ul li', count: options.size)
+        expect(subject).to have_selector('.annexes ul.annex-options li', count: options.size)
         expect(subject).not_to have_selector('.annexes .checkbox')
+      end
+    end
+
+    context 'list too large to print' do
+      let(:online_url) { Rails.application.routes.url_helpers.commencer_url(procedure.path) }
+
+      before { stub_const("#{described_class}::MAX_PRINTABLE_OPTIONS", 3) }
+
+      context 'drop_down_list' do
+        let(:types_de_champ_public) do
+          [{ type: :drop_down_list, libelle: 'Commune', options: ['Lyon', 'Paris', 'Rennes', 'Toulouse'] }]
+        end
+
+        it 'refers to the online form instead of printing the list' do
+          expect(subject).to have_selector('.champ .box')
+          expect(subject).to have_content('4 valeurs')
+          expect(subject).to have_selector("a[href='#{online_url}']", text: online_url)
+        end
+
+        it 'does not render an annex' do
+          expect(subject).not_to have_selector('section.annexes')
+          expect(subject).not_to have_content('Lyon')
+        end
+      end
+
+      context 'linked_drop_down_list' do
+        let(:types_de_champ_public) do
+          [{ type: :linked_drop_down_list, libelle: 'Lieu', options: ['--Rhône--', 'Lyon', 'Villeurbanne', '--Ille-et-Vilaine--', 'Rennes'] }]
+        end
+
+        it 'prints neither the primary nor the secondary options' do
+          expect(subject).to have_selector('.champ .box')
+          expect(subject).to have_content(online_url)
+          expect(subject).not_to have_content('Rhône')
+          expect(subject).not_to have_content('Lyon')
+        end
+      end
+    end
+
+    context 'linked_drop_down_list small enough to print' do
+      let(:types_de_champ_public) do
+        [{ type: :linked_drop_down_list, libelle: 'Lieu', options: ['--Rhône--', 'Lyon', 'Villeurbanne'] }]
+      end
+
+      it 'lists every level inline, as today' do
+        expect(subject).to have_content('Rhône')
+        expect(subject).to have_content('Lyon')
+        expect(subject).to have_selector('li.secondary', count: 2)
       end
     end
 


### PR DESCRIPTION
Une liste liée — 35 165 communes sur une démarche (démarche 29928) — produisait un PDF de ~735 pages et poussait le worker WeasyPrint à ~2 Go avant que le noyau ne le tue. Le fallback Prawn prenait alors le relais en imprimant les 1108 pages.

**Au-delà de 5 000 options, le formulaire renvoie vers la version en ligne** (lien cliquable) au lieu d'imprimer la liste, comme le fait déjà un champ commune, qui n'imprime aucune de ses valeurs. Le seuil est calibré au-dessus du p99 des listes en production (1 140) : il ne concerne que 0,49 % des démarches publiées portant une annexe, toutes des référentiels recopiés (35 000 à 48 000 options). Il s'applique aussi aux listes liées, qui n'avaient jusqu'ici aucun garde-fou et listaient tout dans le corps du formulaire.

**Les annexes passent sur deux colonnes en petit corps** : deux fois moins de pages et un style qui prend ~45 % de mémoire en moins. 

Sur la démarche concernée : **~735 pages / ~2 Go RAM → 13 pages / 92 Mo**. Tout ce qui est sous le seuil garde son rendu actuel.

<img width="712" height="378" alt="Capture d’écran 2026-08-24 à 15 17 10" src="https://github.com/user-attachments/assets/c78932ae-69b9-49cb-bfe8-a44da13ae402" />


<img width="684" height="497" alt="Capture d’écran 2026-08-24 à 15 13 45" src="https://github.com/user-attachments/assets/e41a4163-7311-4dbc-949c-011357c7a66b" />

