### PR TITLE
Tech: déplace les méthodes relatives à la nature des pjs dans son type de champ

### DIFF
--- a/app/components/attachment/file_field_component.rb
+++ b/app/components/attachment/file_field_component.rb
@@ -109,7 +109,6 @@ class Attachment::FileFieldComponent < ApplicationComponent
     Attachment::HintsComponent.new(
       champ:,
       attached_file:,
-      show_identity_hint: champ&.titre_identite?,
       html_id: describedby_hint_id,
       max: @max
     )

--- a/app/components/attachment/hints_component.rb
+++ b/app/components/attachment/hints_component.rb
@@ -19,7 +19,7 @@ class Attachment::HintsComponent < ApplicationComponent
   end
 
   def show_identity_hint?
-    @champ&.titre_identite?
+    pj_champ? && @champ.titre_identite?
   end
 
   def render?
@@ -27,7 +27,7 @@ class Attachment::HintsComponent < ApplicationComponent
   end
 
   def format_families_info
-    @format_families_info ||= if champ.nil? || !champ.piece_justificative?
+    @format_families_info ||= if !pj_champ?
       []
     else
       tdc = champ.type_de_champ
@@ -52,7 +52,7 @@ class Attachment::HintsComponent < ApplicationComponent
   end
 
   def show_exhaustive_formats?
-    return false if champ.nil? || !champ.piece_justificative?
+    return false if !pj_champ?
 
     tdc = champ.type_de_champ
     tdc.titre_identite? || tdc.rib?
@@ -74,4 +74,8 @@ class Attachment::HintsComponent < ApplicationComponent
 
     "#{champ.focusable_input_id}-formats-tooltip"
   end
+
+  private
+
+  def pj_champ? = @champ&.piece_justificative?
 end

--- a/app/components/attachment/hints_component.rb
+++ b/app/components/attachment/hints_component.rb
@@ -7,10 +7,9 @@ class Attachment::HintsComponent < ApplicationComponent
 
   delegate :max_file_size, :allowed_extensions, to: :validation
 
-  def initialize(champ:, attached_file: nil, show_identity_hint: false, html_id: nil, max: nil)
+  def initialize(champ:, attached_file: nil, html_id: nil, max: nil)
     @champ = champ
     @attached_file = attached_file
-    @show_identity_hint = show_identity_hint
     @html_id = html_id
     @max = max
   end

--- a/app/components/dsfr/input_status_message_component.rb
+++ b/app/components/dsfr/input_status_message_component.rb
@@ -50,7 +50,10 @@ module Dsfr
     end
 
     def pjs_statut?
-      (@champ.rib? || @champ.justificatif_domicile? || @champ.avis_impot?) && !@champ.idle?
+      return false if !@champ.piece_justificative?
+      return false if @champ.idle?
+
+      @champ.ocr_compatible?
     end
 
     def address_support_statut?

--- a/app/controllers/instructeurs/champs_controller.rb
+++ b/app/controllers/instructeurs/champs_controller.rb
@@ -46,7 +46,7 @@ module Instructeurs
     def find_rib_type_de_champ!
       stable_id, row_id = params[:public_id].split("-")
       type_de_champ = @dossier.find_type_de_champ_by_stable_id(stable_id)
-      raise ActiveRecord::RecordNotFound unless type_de_champ&.rib?
+      raise ActiveRecord::RecordNotFound if !(type_de_champ&.piece_justificative? && type_de_champ.rib?)
       [type_de_champ, row_id]
     end
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -361,12 +361,6 @@ class TypeDeChamp < ApplicationRecord
     options.slice(*self.class.editable_option_keys.map(&:to_s))
   end
 
-  def titre_identite? = false
-  def rib? = false
-  def justificatif_domicile? = false
-  def avis_impot? = false
-  def ocr_compatible? = false
-
   def max_file_size_bytes = FILE_MAX_SIZE
   def allowed_content_types = AUTHORIZED_CONTENT_TYPES
 

--- a/spec/models/columns/champ_column_spec.rb
+++ b/spec/models/columns/champ_column_spec.rb
@@ -50,7 +50,7 @@ describe Columns::ChampColumn do
         expect_type_de_champ_values('yes_no', eq([true]))
         expect_type_de_champ_values('annuaire_education', eq([nil]))
         expect_type_de_champ_values('piece_justificative', be_an_instance_of(Array))
-        type_de_champ = types_de_champ.find(&:titre_identite?)
+        type_de_champ = types_de_champ.find { it.piece_justificative? && it.titre_identite? }
         champ = dossier.send(:filled_champ, type_de_champ)
         columns = type_de_champ.columns(procedure_id: procedure.id)
         expect(columns.map { _1.value(champ) }).to be_an_instance_of(Array)

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -3035,7 +3035,7 @@ describe Dossier, type: :model do
     end
 
     context 'when there is titre identite' do
-      let(:changed_champs) { dossier.champ_data.filter(&:titre_identite?) }
+      let(:changed_champs) { dossier.champ_data.filter { it.piece_justificative? && it.titre_identite? } }
 
       it do
         is_expected.to change(dossier, :last_champ_updated_at)

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -792,30 +792,22 @@ describe TypeDeChamp do
   describe '#ocr_compatible?' do
     subject { type_de_champ.ocr_compatible? }
 
-    context 'with a piece justificative' do
-      let(:type_de_champ) { build(:type_de_champ_piece_justificative, nature:) }
+    let(:type_de_champ) { build(:type_de_champ_piece_justificative, nature:) }
 
-      ['rib', 'justificatif_domicile', 'avis_impot'].each do |ocr_nature|
-        context "when nature is #{ocr_nature}" do
-          let(:nature) { ocr_nature }
+    ['rib', 'justificatif_domicile', 'avis_impot'].each do |ocr_nature|
+      context "when nature is #{ocr_nature}" do
+        let(:nature) { ocr_nature }
 
-          it { is_expected.to be(true) }
-        end
-      end
-
-      ['titre_identite', 'non_specifie'].each do |other_nature|
-        context "when nature is #{other_nature}" do
-          let(:nature) { other_nature }
-
-          it { is_expected.to be(false) }
-        end
+        it { is_expected.to be(true) }
       end
     end
 
-    context 'when the type de champ is not a piece justificative' do
-      let(:type_de_champ) { build(:type_de_champ_text) }
+    ['titre_identite', 'non_specifie'].each do |other_nature|
+      context "when nature is #{other_nature}" do
+        let(:nature) { other_nature }
 
-      it { is_expected.to be(false) }
+        it { is_expected.to be(false) }
+      end
     end
   end
 end


### PR DESCRIPTION
```
def titre_identite? = false
def rib? = false
def justificatif_domicile? = false
def avis_impot? = false
 ```

sont fournis gratuitement par l'enum `nature` sur pj_type_de_champ