### PR TITLE
Tech: migre 5 composants EditableChamp de HAML vers ERB

### DIFF
--- a/app/components/editable_champ/phone_component/phone_component.html.erb
+++ b/app/components/editable_champ/phone_component/phone_component.html.erb
@@ -1,0 +1,4 @@
+<%# Allowed @formats: %>
+<%# very light validation is made client-side %>
+<%# stronger validation is made server-side %>
+<%= @form.phone_field(:value, input_opts(id: @champ.focusable_input_id, autocomplete: @champ.dossier.for_tiers? ? "off" : "tel", aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, required: @champ.required?, pattern: "[^a-z^A-Z]+")) %>

--- a/app/components/editable_champ/phone_component/phone_component.html.haml
+++ b/app/components/editable_champ/phone_component/phone_component.html.haml
@@ -1,4 +1,0 @@
--# Allowed @formats:
--# very light validation is made client-side
--# stronger validation is made server-side
-= @form.phone_field(:value, input_opts(id: @champ.focusable_input_id, autocomplete: @champ.dossier.for_tiers? ? "off" : "tel", aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, required: @champ.required?, pattern: "[^a-z^A-Z]+"))

--- a/app/components/editable_champ/regions_component/regions_component.html.erb
+++ b/app/components/editable_champ/regions_component/regions_component.html.erb
@@ -1,0 +1,1 @@
+<%= @form.select :value, options, select_options, required: @champ.required?, id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, class: "width-33-desktop width-100-mobile fr-select" %>

--- a/app/components/editable_champ/regions_component/regions_component.html.haml
+++ b/app/components/editable_champ/regions_component/regions_component.html.haml
@@ -1,1 +1,0 @@
-= @form.select :value, options, select_options, required: @champ.required?, id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, class: "width-33-desktop width-100-mobile fr-select"

--- a/app/components/editable_champ/rna_component/rna_component.html.erb
+++ b/app/components/editable_champ/rna_component/rna_component.html.erb
@@ -1,0 +1,1 @@
+<%= @form.text_field(:external_id, input_opts( id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, data: { controller: 'format', format: 'deleteSpace' }, required: @champ.required?, pattern: "W[0-9A-Z]{9}", class: "width-33-desktop", maxlength: 10, size: nil)) %>

--- a/app/components/editable_champ/rna_component/rna_component.html.haml
+++ b/app/components/editable_champ/rna_component/rna_component.html.haml
@@ -1,1 +1,0 @@
-= @form.text_field(:external_id, input_opts( id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, data: { controller: 'format', format: 'deleteSpace' }, required: @champ.required?, pattern: "W[0-9A-Z]{9}", class: "width-33-desktop", maxlength: 10, size: nil))

--- a/app/components/editable_champ/siret_component/siret_component.html.erb
+++ b/app/components/editable_champ/siret_component/siret_component.html.erb
@@ -1,0 +1,1 @@
+<%= @form.text_field(:external_id, input_opts(value: pretty_siret(@champ.external_id), id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, data: { controller: 'format', format: 'siret' }, required: @champ.required?, class: "width-33-desktop")) %>

--- a/app/components/editable_champ/siret_component/siret_component.html.haml
+++ b/app/components/editable_champ/siret_component/siret_component.html.haml
@@ -1,1 +1,0 @@
-= @form.text_field(:external_id, input_opts(value: pretty_siret(@champ.external_id), id: @champ.focusable_input_id, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }, data: { controller: 'format', format: 'siret' }, required: @champ.required?, class: "width-33-desktop"))

--- a/app/components/editable_champ/text_component/text_component.html.erb
+++ b/app/components/editable_champ/text_component/text_component.html.erb
@@ -1,0 +1,1 @@
+<%= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, required: @champ.required?, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" })) %>

--- a/app/components/editable_champ/text_component/text_component.html.haml
+++ b/app/components/editable_champ/text_component/text_component.html.haml
@@ -1,1 +1,0 @@
-= @form.text_field(:value, input_opts(id: @champ.focusable_input_id, required: @champ.required?, aria: { **labelledby_id_attr, describedby: "#{@champ.describedby_id} #{@champ.error_id(:value)}" }))


### PR DESCRIPTION
Migration HAML → ERB de cinq templates de `app/components/editable_champ/`.

- `RegionsComponent`
- `RNAComponent`
- `SiretComponent`
- `TextComponent`
- `PhoneComponent`

Conversion mécanique via `haml_to_erb` puis `herb-format`, un commit par template. Le code Ruby est identique au caractère près. Seule intervention manuelle : `haml_to_erb` supprime les commentaires silencieux `-#`, ceux de `PhoneComponent` sont rétablis en `<%# … %>`.

Avec ce lot, il ne reste plus aucun template d'une ligne dans `editable_champ` : la suite (`DateComponent`, `HeaderSectionComponent`, `PieceJustificativeComponent`…) contient des blocs et des hash d'attributs, qui demandent une revue de conversion par template.

Pas de capture d'écran : ces composants n'ont pas de preview ViewComponent, ils ne se rendent qu'à l'intérieur d'un formulaire de dossier.
