### PR TITLE
Tech: supprime deux inflections type de champ devenues obsolètes

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -30,8 +30,6 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'FAQs'
   inflect.acronym 'OCR'
   inflect.irregular 'type_de_champ', 'types_de_champ'
-  inflect.irregular 'type_de_champ_private', 'types_de_champ_private'
-  inflect.irregular 'procedure_revision_type_de_champ', 'procedure_revision_types_de_champ'
   inflect.irregular 'assign_to', 'assign_tos'
   inflect.uncountable(['avis', 'pays', 'ars'])
 end


### PR DESCRIPTION
Suite de #13670, en réponse à [ce commentaire](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/13670).

- `procedure_revision_type_de_champ` : redondante — les irregulars matchent par suffixe, la règle `type_de_champ` couvre déjà ce cas.
- `type_de_champ_private` : plus rien ne pluralise/singularise ce terme depuis les renommages ; la clé `types_de_champ_private` du serializer API v1 est littérale (méthode et serializer explicites).

La règle `type_de_champ` est conservée : `TypeDeChamp` et `ProcedureRevisionTypeDeChamp` s'en servent pour inférer leurs tables legacy (`types_de_champ`, `procedure_revision_types_de_champ`).