### PR TITLE
Tech: extraire les textes en dur de AdministrateurComponent vers i18n

### DIFF
--- a/app/components/groupe_gestionnaire/groupe_gestionnaire_administrateurs/administrateur_component.en.yml
+++ b/app/components/groupe_gestionnaire/groupe_gestionnaire_administrateurs/administrateur_component.en.yml
@@ -1,0 +1,9 @@
+---
+en:
+  c_est_vous: "%{email} (It's you!)"
+  remove_from_group: "Remove from group"
+  remove_confirm: "Remove « %{email} » from the administrators of « %{group_name} »?"
+  revoke_admin_access: "Revoke administrator access"
+  delete: "Delete"
+  cannot_delete_admin: "This administrator has procedures for which they are the sole admin and cannot be deleted"
+  delete_confirm: "Delete « %{email} » as an administrator?"

--- a/app/components/groupe_gestionnaire/groupe_gestionnaire_administrateurs/administrateur_component.fr.yml
+++ b/app/components/groupe_gestionnaire/groupe_gestionnaire_administrateurs/administrateur_component.fr.yml
@@ -1,0 +1,9 @@
+---
+fr:
+  c_est_vous: "%{email} (C’est vous !)"
+  remove_from_group: "Retirer du groupe"
+  remove_confirm: "Retirer « %{email} » des administrateurs de « %{group_name} » ?"
+  revoke_admin_access: "Révoquer l’accès administrateur"
+  delete: "Supprimer"
+  cannot_delete_admin: "Cet administrateur a des démarches dont il est le seul admin et ne peut être supprimé"
+  delete_confirm: "Supprimer « %{email} » en tant qu’administrateur ?"

--- a/app/components/groupe_gestionnaire/groupe_gestionnaire_administrateurs/administrateur_component.rb
+++ b/app/components/groupe_gestionnaire/groupe_gestionnaire_administrateurs/administrateur_component.rb
@@ -11,7 +11,7 @@ class GroupeGestionnaire::GroupeGestionnaireAdministrateurs::AdministrateurCompo
 
   def email
     if @administrateur == current_gestionnaire
-      "#{@administrateur.email} (C’est vous !)"
+      t(".c_est_vous", email: @administrateur.email)
     else
       @administrateur.email
     end
@@ -26,20 +26,20 @@ class GroupeGestionnaire::GroupeGestionnaireAdministrateurs::AdministrateurCompo
   end
 
   def remove_button
-    button_to "Retirer du groupe",
+    button_to t(".remove_from_group"),
       remove_gestionnaire_groupe_gestionnaire_administrateur_path(@groupe_gestionnaire, @administrateur),
       method: :delete,
       class: 'fr-btn fr-btn--sm fr-btn--tertiary',
-      form: { data: { turbo: true, turbo_confirm: "Retirer « #{@administrateur.email} » des administrateurs de « #{@groupe_gestionnaire.name} » ?" } }
+      form: { data: { turbo: true, turbo_confirm: t(".remove_confirm", email: @administrateur.email, group_name: @groupe_gestionnaire.name) } }
   end
 
   def destroy_button
-    button_to "Révoquer l’accès administrateur",
+    button_to t(".revoke_admin_access"),
       gestionnaire_groupe_gestionnaire_administrateur_path(@groupe_gestionnaire, @administrateur),
       method: :delete,
       disabled: !@administrateur.can_be_deleted?,
       class: 'fr-btn fr-btn--sm fr-btn--tertiary',
-      title: @administrateur.can_be_deleted? ? "Supprimer" : "Cet administrateur a des démarches dont il est le seul admin et ne peut être supprimé",
-      form: { data: { turbo: true, turbo_confirm: "Supprimer « #{@administrateur.email} » en tant qu’administrateur ?" } }
+      title: @administrateur.can_be_deleted? ? t(".delete") : t(".cannot_delete_admin"),
+      form: { data: { turbo: true, turbo_confirm: t(".delete_confirm", email: @administrateur.email) } }
   end
 end

--- a/app/components/llm/improve_structure_item_component.en.yml
+++ b/app/components/llm/improve_structure_item_component.en.yml
@@ -1,2 +1,6 @@
 en:
   step_title: "Form structure"
+  add_section: "Add section"
+  section_level: "(level %{header_section_level})"
+  reorganization: "Reorganization"
+  unchanged: "Unchanged"

--- a/app/components/llm/improve_structure_item_component.fr.yml
+++ b/app/components/llm/improve_structure_item_component.fr.yml
@@ -1,2 +1,6 @@
 fr:
   step_title: "Structure du formulaire"
+  add_section: "Ajout de section"
+  section_level: "(niveau %{header_section_level})"
+  reorganization: "Réorganisation"
+  unchanged: "Inchangé"

--- a/app/components/llm/improve_structure_item_component.html.erb
+++ b/app/components/llm/improve_structure_item_component.html.erb
@@ -5,16 +5,14 @@
         <% if op_kind == 'add' %>
           <span class="fr-badge fr-badge--green-menthe fr-mr-1w">
             <span class="fr-icon-add-line fr-icon--sm fr-mr-1v"></span>
-            Ajout de section
+            <%= t(".add_section") %>
           </span>
-          (niveau
-          <%= payload['header_section_level'] %>
-          )
+          <%= t(".section_level", header_section_level: payload['header_section_level']) %>
           <%= payload['libelle'] %>
         <% elsif op_kind == 'update' && original_tdc %>
           <span class="fr-badge fr-badge--green-bourgeon fr-mr-1w">
             <span class="fr-icon-arrow-up-down-line fr-icon--sm fr-mr-1v"></span>
-            Réorganisation
+            <%= t(".reorganization") %>
           </span>
           <%= original_tdc.libelle %>
         <% end %>
@@ -27,7 +25,7 @@
       <%= check_box_tag :noop, :noop, :noop, disabled: true %>
 
       <%= label_tag do %>
-        <span class="fr-badge fr-mr-1w"> Inchangé </span>
+        <span class="fr-badge fr-mr-1w"><%= t(".unchanged") %></span>
 
         <% if item.header_section? %>
           #

--- a/app/components/procedure/errors_summary.rb
+++ b/app/components/procedure/errors_summary.rb
@@ -13,14 +13,14 @@ class Procedure::ErrorsSummary < ApplicationComponent
   def title
     case @validation_context
     when :private_type_de_champs_editor
-      "Les annotations privées contiennent des erreurs"
+      t(".private_annotations_contain_errors")
     when :public_type_de_champs_editor
-      "Les champs du formulaire contiennent des erreurs"
+      t(".form_fields_contain_errors")
     when :publication
       if @procedure.publiee?
-        "Des problèmes empêchent la publication des modifications"
+        t(".problems_block_publishing_modifications")
       else
-        "Des problèmes empêchent la publication de la démarche"
+        t(".problems_block_publishing_procedure")
       end
     end
   end

--- a/app/components/procedure/errors_summary/errors_summary.en.yml
+++ b/app/components/procedure/errors_summary/errors_summary.en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  private_annotations_contain_errors: "Private annotations contain errors"
+  form_fields_contain_errors: "Form fields contain errors"
+  problems_block_publishing_modifications: "Problems prevent publishing changes"
+  problems_block_publishing_procedure: "Problems prevent publishing the procedure"

--- a/app/components/procedure/errors_summary/errors_summary.fr.yml
+++ b/app/components/procedure/errors_summary/errors_summary.fr.yml
@@ -1,0 +1,6 @@
+---
+fr:
+  private_annotations_contain_errors: "Les annotations privées contiennent des erreurs"
+  form_fields_contain_errors: "Les champs du formulaire contiennent des erreurs"
+  problems_block_publishing_modifications: "Des problèmes empêchent la publication des modifications"
+  problems_block_publishing_procedure: "Des problèmes empêchent la publication de la démarche"

--- a/app/components/tiptap_editor_component.rb
+++ b/app/components/tiptap_editor_component.rb
@@ -4,14 +4,14 @@ class TiptapEditorComponent < ApplicationComponent
   DEFAULT_ACTIONS = %w[bold italic bulletList orderedList link].freeze
 
   BUTTONS = {
-    'bold' => { label: 'Gras', title: 'Gras', icon: 'fr-icon-bold' },
-    'italic' => { label: 'Italique', title: 'Italique', icon: 'fr-icon-italic' },
-    'heading2' => { label: 'Titre', title: 'Titre', icon: 'fr-icon-h-1' },
-    'heading3' => { label: 'Sous-titre', title: 'Sous-titre', icon: 'fr-icon-h-2' },
-    'bulletList' => { label: 'Liste', title: 'Liste à puces', icon: 'fr-icon-list-unordered' },
-    'orderedList' => { label: 'Numérotée', title: 'Liste numérotée', icon: 'fr-icon-list-ordered' },
-    'hardBreak' => { label: 'Saut de ligne', title: 'Saut de ligne', icon: 'fr-icon-corner-down-left-line' },
-    'paragraph' => { label: 'Paragraphe', title: 'Paragraphe', icon: 'fr-icon-paragraph' },
+    'bold' => { icon: 'fr-icon-bold' },
+    'italic' => { icon: 'fr-icon-italic' },
+    'heading2' => { icon: 'fr-icon-h-1' },
+    'heading3' => { icon: 'fr-icon-h-2' },
+    'bulletList' => { icon: 'fr-icon-list-unordered' },
+    'orderedList' => { icon: 'fr-icon-list-ordered' },
+    'hardBreak' => { icon: 'fr-icon-corner-down-left-line' },
+    'paragraph' => { icon: 'fr-icon-paragraph' },
   }.freeze
 
   attr_reader :form, :field_name, :preview_url, :actions, :tags, :label, :error_attribute
@@ -36,7 +36,13 @@ class TiptapEditorComponent < ApplicationComponent
   end
 
   def simple_buttons
-    actions.filter_map { |action| BUTTONS[action]&.merge(action: action) }
+    actions.filter_map do |action|
+      if (button = BUTTONS[action])
+        label = t(".buttons.#{action}.label")
+        title = t(".buttons.#{action}.title")
+        button.merge(action: action, label: label, title: title)
+      end
+    end
   end
 
   def link?

--- a/app/components/tiptap_editor_component/tiptap_editor_component.en.yml
+++ b/app/components/tiptap_editor_component/tiptap_editor_component.en.yml
@@ -1,0 +1,41 @@
+en:
+  buttons:
+    bold:
+      label: "Bold"
+      title: "Bold"
+    italic:
+      label: "Italic"
+      title: "Italic"
+    heading2:
+      label: "Heading"
+      title: "Heading"
+    heading3:
+      label: "Sub-heading"
+      title: "Sub-heading"
+    bulletList:
+      label: "List"
+      title: "Bullet list"
+    orderedList:
+      label: "Numbered"
+      title: "Numbered list"
+    hardBreak:
+      label: "Line break"
+      title: "Line break"
+    paragraph:
+      label: "Paragraph"
+      title: "Paragraph"
+  link_button: "Link"
+  link_button_title: "Add a link to the selected text"
+  hint_formatting: "Use the buttons above to format your message or add a link."
+  hint_tags_html: "Type the <strong class=\"fr-text-title--grey\">@</strong> character followed by the tag name"
+  hint_tags_insert: " to insert data."
+  hint_tags_or_buttons: ", or click the buttons below."
+  tags_available: "Available tags"
+  insert_link: "Insert a link"
+  link_label: "Link label:"
+  link_url_label: "Link URL"
+  link_url_hint: "Enter the target URL of the link. Example: https://example.com"
+  link_url_error: "The link URL must start with https://"
+  remove_link: "Remove link"
+  cancel: "Cancel"
+  create_link: "Create link"

--- a/app/components/tiptap_editor_component/tiptap_editor_component.fr.yml
+++ b/app/components/tiptap_editor_component/tiptap_editor_component.fr.yml
@@ -1,0 +1,41 @@
+fr:
+  buttons:
+    bold:
+      label: "Gras"
+      title: "Gras"
+    italic:
+      label: "Italique"
+      title: "Italique"
+    heading2:
+      label: "Titre"
+      title: "Titre"
+    heading3:
+      label: "Sous-titre"
+      title: "Sous-titre"
+    bulletList:
+      label: "Liste"
+      title: "Liste à puces"
+    orderedList:
+      label: "Numérotée"
+      title: "Liste numérotée"
+    hardBreak:
+      label: "Saut de ligne"
+      title: "Saut de ligne"
+    paragraph:
+      label: "Paragraphe"
+      title: "Paragraphe"
+  link_button: "Lien"
+  link_button_title: "Ajouter un lien sur le texte sélectionné"
+  hint_formatting: "Utilisez les boutons ci-dessus pour mettre en forme votre message ou ajouter un lien."
+  hint_tags_html: "Tapez le caractère <strong class=\"fr-text-title--grey\">@</strong> suivi du nom de la balise"
+  hint_tags_insert: " pour insérer une donnée."
+  hint_tags_or_buttons: ", ou cliquez sur les boutons ci-dessous."
+  tags_available: "Balises disponibles"
+  insert_link: "Insérer un lien"
+  link_label: "Intitulé du lien :"
+  link_url_label: "Adresse du lien"
+  link_url_hint: "Indiquer l’url cible du lien. Exemple : https://jeunes.gouv.fr"
+  link_url_error: "L’adresse du lien doit commencer par https://"
+  remove_link: "Supprimer le lien"
+  cancel: "Annuler"
+  create_link: "Créer le lien"

--- a/app/components/tiptap_editor_component/tiptap_editor_component.html.erb
+++ b/app/components/tiptap_editor_component/tiptap_editor_component.html.erb
@@ -22,20 +22,19 @@
         <button
           class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-link"
           type="button"
-          title="Ajouter un lien sur le texte sélectionné"
+          title="<%= t('.link_button_title') %>"
           aria-controls="tiptap-link-modal"
           data-fr-opened="false"
           data-action="click->tiptap#menuButton"
           data-tiptap-target="button"
           data-tiptap-action="link"
         >
-          Lien
+          <%= t('.link_button') %>
         </button>
       <% end %>
     </div>
     <p class="fr-hint-text">
-      Utilisez les boutons ci-dessus pour mettre en forme votre message ou
-      ajouter un lien.
+      <%= t('.hint_formatting') %>
     </p>
   <% end %>
 
@@ -50,9 +49,7 @@
 
   <% if tags? %>
     <p class="fr-hint-text fr-mt-1w">
-      Tapez le caractère <strong class="fr-text-title--grey">@</strong> suivi du
-      nom de la
-      balise<%= collapsed_tags? ? ' pour insérer une donnée.' : ', ou cliquez sur les boutons ci-dessous.' %>
+      <%= t('.hint_tags_html') %><%= collapsed_tags? ? t('.hint_tags_insert') : t('.hint_tags_or_buttons') %>
     </p>
     <% if collapsed_tags? %>
       <div class="tiptap-tags-collapse fr-mt-1w">
@@ -65,7 +62,7 @@
           aria-controls="<%= tags_collapse_id %>"
           aria-expanded="false"
         >
-          Balises disponibles
+          <%= t('.tags_available') %>
         </button>
 
         <div class="fr-collapse" id="<%= tags_collapse_id %>">
@@ -75,7 +72,7 @@
         </div>
       </div>
     <% else %>
-      <p class="fr-h6 fr-mt-2w fr-mb-1w">Balises disponibles</p>
+      <p class="fr-h6 fr-mt-2w fr-mb-1w"><%= t('.tags_available') %></p>
       <div class="tags-buttons-panel">
         <%= render TagsButtonListComponent.new(tags: tags) %>
       </div>
@@ -119,12 +116,12 @@
               <div class="fr-modal__content">
                 <h1 id="tiptap-link-modal-title" class="fr-modal__title">
                   <span class="fr-icon-link fr-mr-1v" aria-hidden="true"></span>
-                  Insérer un lien
+                  <%= t('.insert_link') %>
                 </h1>
 
                 <div data-tiptap-target="linkFormContent">
                   <p class="fr-text--sm fr-mb-2w">
-                    Intitulé du lien :
+                    <%= t('.link_label') %>
                     <strong data-tiptap-target="linkSelectedText"></strong>
                   </p>
 
@@ -133,8 +130,11 @@
                     data-tiptap-target="linkInputGroup"
                   >
                     <label class="fr-label" for="tiptap-link-url-input">
-                      Adresse du lien
-                      <span class="fr-hint-text">Indiquer l’url cible du lien. Exemple : https://jeunes.gouv.fr</span>
+                      <%= t('.link_url_label') %>
+
+                      <span class="fr-hint-text">
+                        <%= t('.link_url_hint') %>
+                      </span>
                     </label>
 
                     <input
@@ -150,7 +150,7 @@
                       class="fr-error-text fr-hidden"
                       data-tiptap-target="linkErrorText"
                     >
-                      L’adresse du lien doit commencer par https://
+                      <%= t('.link_url_error') %>
                     </p>
                   </div>
                 </div>
@@ -168,7 +168,7 @@
                     data-action="click->tiptap#clearLinkInput"
                     data-tiptap-target="removeLinkButton"
                   >
-                    Supprimer le lien
+                    <%= t('.remove_link') %>
                   </button>
 
                   <div class="fr-btns-group fr-btns-group--inline fr-btns-group--inline-lg">
@@ -177,7 +177,7 @@
                       type="button"
                       data-action="click->tiptap#closeLinkModal"
                     >
-                      Annuler
+                      <%= t('.cancel') %>
                     </button>
 
                     <button
@@ -186,7 +186,7 @@
                       data-action="click->tiptap#confirmLink"
                       data-tiptap-target="linkConfirmButton"
                     >
-                      Créer le lien
+                      <%= t('.create_link') %>
                     </button>
                   </div>
                 </div>


### PR DESCRIPTION
# Probleme

Textes francais en dur dans `app/components/groupe_gestionnaire/groupe_gestionnaire_administrateurs/administrateur_component.rb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 7 cles i18n vers `app/components/groupe_gestionnaire/groupe_gestionnaire_administrateurs/administrateur_component.fr.yml` et `administrateur_component.en.yml`.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `c_est_vous` | `"%{email} (C'est vous !)"` | `"%{email} (It's you!)"` |
| `remove_from_group` | `"Retirer du groupe"` | `"Remove from group"` |
| `remove_confirm` | `"Retirer « %{email} » des administrateurs de « %{group_name} » ?"` | `"Remove « %{email} » from the administrators of « %{group_name} »?"` |
| `revoke_admin_access` | `"Révoquer l'accès administrateur"` | `"Revoke administrator access"` |
| `delete` | `"Supprimer"` | `"Delete"` |
| `cannot_delete_admin` | `"Cet administrateur a des démarches dont il est le seul admin et ne peut être supprimé"` | `"This administrator has procedures for which they are the sole admin and cannot be deleted"` |
| `delete_confirm` | `"Supprimer « %{email} » en tant qu'administrateur ?"` | `"Delete « %{email} » as an administrator?"` |

### Validation visuelle

⚠️ Aucun preview ViewComponent ou page reelle disponible pour ce composant — les screenshots n'ont pas pu etre captures.

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante (FR + EN)
- [x] Apostrophes typographiques verifiees
- [x] Tests passes (6 exemples, 0 echec)
- [x] Rubocop OK
- [x] Screenshots — non disponibles (pas de preview)

Generated with [Claude Code](https://claude.com/claude-code)

---

# Probleme

Textes francais en dur dans `app/components/llm/improve_structure_item_component.html.erb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 4 cles i18n vers `app/components/llm/improve_structure_item_component.fr.yml` et `app/components/llm/improve_structure_item_component.en.yml`.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `add_section` | "Ajout de section" | "Add section" |
| `section_level` | "(niveau %{header_section_level})" | "(level %{header_section_level})" |
| `reorganization` | "Réorganisation" | "Reorganization" |
| `unchanged` | "Inchangé" | "Unchanged" |

### Validation visuelle — RESULTAT

Screenshots non disponibles — le composant est rendu uniquement dans le tunnel simplify (authentification administrateur requise, procedure/tunnel specifiques). Aucun preview ViewComponent disponible.

### Couverture :
- ⏭️ Pas de preview accessible pour ce composant (tunnel admin only)

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante
- [x] Apostrophes typographiques verifiees
- [x] Rubocop OK
- [x] Screenshots non disponibles (skip documente)

Generated with [Claude Code](https://claude.com/claude-code)

---

# Probleme

Textes francais en dur dans `app/components/tiptap_editor_component.rb` et `app/components/tiptap_editor_component.html.erb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 29 cles i18n vers `app/components/tiptap_editor_component.fr.yml` et `app/components/tiptap_editor_component.en.yml`.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `buttons.bold.label` | "Gras" | "Bold" |
| `buttons.bold.title` | "Gras" | "Bold" |
| `buttons.italic.label` | "Italique" | "Italic" |
| `buttons.italic.title` | "Italique" | "Italic" |
| `buttons.heading2.label` | "Titre" | "Heading" |
| `buttons.heading2.title` | "Titre" | "Heading" |
| `buttons.heading3.label` | "Sous-titre" | "Sub-heading" |
| `buttons.heading3.title` | "Sous-titre" | "Sub-heading" |
| `buttons.bulletList.label` | "Liste" | "List" |
| `buttons.bulletList.title` | "Liste à puces" | "Bullet list" |
| `buttons.orderedList.label` | "Numérotée" | "Numbered" |
| `buttons.orderedList.title` | "Liste numérotée" | "Numbered list" |
| `buttons.hardBreak.label` | "Saut de ligne" | "Line break" |
| `buttons.hardBreak.title` | "Saut de ligne" | "Line break" |
| `link_button` | "Lien" | "Link" |
| `link_button_title` | "Ajouter un lien sur le texte sélectionné" | "Add a link to the selected text" |
| `hint_formatting` | "Utilisez les boutons ci-dessus pour mettre en forme votre message ou ajouter un lien." | "Use the buttons above to format your message or add a link." |
| `hint_tags_html` | "Tapez le caractère <strong>@</strong> suivi du nom de la balise" | "Type the <strong>@</strong> character followed by the tag name" |
| `hint_tags_insert` | " pour insérer une donnée." | " to insert data." |
| `hint_tags_or_buttons` | ", ou cliquez sur les boutons ci-dessous." | ", or click the buttons below." |
| `tags_available` | "Balises disponibles" | "Available tags" |
| `insert_link` | "Insérer un lien" | "Insert a link" |
| `link_label` | "Intitulé du lien :" | "Link label :" |
| `link_url_label` | "Adresse du lien" | "Link URL" |
| `link_url_hint` | "Indiquer l'url cible du lien. Exemple : https://jeunes.gouv.fr" | "Enter the target URL of the link. Example: https://example.com" |
| `link_url_error` | "L'adresse du lien doit commencer par https://" | "The link URL must start with https://" |
| `remove_link` | "Supprimer le lien" | "Remove link" |
| `cancel` | "Annuler" | "Cancel" |
| `create_link` | "Créer le lien" | "Create link" |

### Validation visuelle

Screenshots non disponibles — aucun preview ViewComponent n'existe pour ce composant, et la page reelle (`/admin/procedures/:procedure_id/email_templates/:id/edit`) necessite une procedure et un template email en base.

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante
- [x] Apostrophes typographiques verifiees
- [x] Tests passes (6 exemples, 0 echecs)
- [x] Rubocop OK

Generated with [Claude Code](https://claude.com/claude-code)