### PR TITLE
Tech: nettoie les méthodes restantes de TypeDeChamp

### DIFF
--- a/app/components/conditions/champs_conditions_component/champs_conditions_component.html.haml
+++ b/app/components/conditions/champs_conditions_component/champs_conditions_component.html.haml
@@ -1,4 +1,4 @@
-.flex.justify-start.section{ id: dom_id(@tdc.stable_self, :condition), data: {turbo_force: :server} }
+.flex.justify-start.section{ id: dom_id(@tdc, :condition), data: {turbo_force: :server} }
   = form_tag admin_procedure_condition_path(@procedure.id, @tdc.stable_id), method: :patch, class: 'form' do
     .conditionnel.fr-mt-4v
       .flex

--- a/app/components/editable_champ/champ_label_component/champ_label_component.html.erb
+++ b/app/components/editable_champ/champ_label_component/champ_label_component.html.erb
@@ -8,7 +8,7 @@
       <%= render SimpleFormatComponent.new(@champ.description, allow_a: true) %>
     </div>
   <% end %>
-  <% if @champ.type_de_champ.formatted_advanced? && @champ.type_de_champ.expression_reguliere_indications.present? %>
+  <% if @champ.formatted? && @champ.type_de_champ.formatted_advanced? && @champ.type_de_champ.expression_reguliere_indications.present? %>
     <div class="fr-hint-text" id="<%= @champ.describedby_id %>">
       <%= @champ.type_de_champ.expression_reguliere_indications %>
     </div>

--- a/app/components/procedure/errors_summary.rb
+++ b/app/components/procedure/errors_summary.rb
@@ -40,10 +40,10 @@ class Procedure::ErrorsSummary < ApplicationComponent
       edit_admin_procedure_ineligibilite_rules_path(@procedure)
     when :public_draft_type_de_champs
       tdc = error.options[:type_de_champ]
-      champs_admin_procedure_path(@procedure, anchor: dom_id(tdc.stable_self, :editor_error))
+      champs_admin_procedure_path(@procedure, anchor: dom_id(tdc, :editor_error))
     when :private_draft_type_de_champs
       tdc = error.options[:type_de_champ]
-      annotations_admin_procedure_path(@procedure, anchor: dom_id(tdc.stable_self, :editor_error))
+      annotations_admin_procedure_path(@procedure, anchor: dom_id(tdc, :editor_error))
     when :attestation_acceptation_template, :attestation_refus_template
       if error.detail[:value].version == 1
         edit_admin_procedure_attestation_template_path(@procedure)

--- a/app/components/procedure/instructeurs_options_component/instructeurs_options_component.html.haml
+++ b/app/components/procedure/instructeurs_options_component/instructeurs_options_component.html.haml
@@ -45,10 +45,7 @@
       %i.fr-mt-2w= t('.routing_configured_html', groupe_instructeurs_count: @procedure.groupe_instructeurs.count)
   - if @procedure.active_revision.conditionable_type_de_champs.none?
     %p.fr-mt-2w.fr-mb-0= t('.routing_configuration_notice_2_html')
-    %ul
-      - TypeDeChamp.humanized_conditionable_types_by_category.each do |category|
-        %li
-          = category.join(', ')
+    = render TypesDeChamp::ByCategoryListComponent.new(types: TypeDeChamp.conditionable_types)
     %p.fr-mt-2w= t('.routing_configuration_notice_3_html', path: champs_admin_procedure_path(@procedure))
   - elsif @procedure.groupe_instructeurs.active.one?
     = link_to t('.configure_routing'), options_admin_procedure_groupe_instructeurs_path(@procedure, state: :choix), class: 'fr-btn'

--- a/app/components/types_de_champ/by_category_list_component.rb
+++ b/app/components/types_de_champ/by_category_list_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class TypesDeChamp::ByCategoryListComponent < ApplicationComponent
+  def initialize(types:)
+    @types = types
+  end
+
+  private
+
+  def humanized_types_by_category
+    @types.group_by(&:category)
+      .sort_by { |category, _| TypeDeChamp::CATEGORIES.find_index(category) }
+      .map { |_, group| group.map { "« #{t(it.sti_name, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])} »" } }
+  end
+end

--- a/app/components/types_de_champ/by_category_list_component/by_category_list_component.html.erb
+++ b/app/components/types_de_champ/by_category_list_component/by_category_list_component.html.erb
@@ -1,0 +1,5 @@
+<ul>
+  <% humanized_types_by_category.each do |types| %>
+    <li><%= types.join(', ') %></li>
+  <% end %>
+</ul>

--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.erb
@@ -1,7 +1,7 @@
 <%= tag.li(**html_options.merge(class: ["type-de-champ flex column justify-start fr-mb-5v", html_options[:class]])) do %>
   <div
     class="type-de-champ-container"
-    id="<%= dom_id(type_de_champ.stable_self, :editor_error) %>"
+    id="<%= dom_id(type_de_champ, :editor_error) %>"
   >
     <% if @errors.present? %>
       <div class="types-de-champ-errors"><%= @errors %></div>

--- a/app/components/types_de_champ_editor/header_section_component/header_section_component.html.haml
+++ b/app/components/types_de_champ_editor/header_section_component/header_section_component.html.haml
@@ -1,4 +1,4 @@
-%div{ id: dom_id(@tdc.stable_self, :header_section) }
+%div{ id: dom_id(@tdc, :header_section) }
 - if errors?
   .errors-summary= errors
 = @form.label :header_section_level, "Niveau du titre", for: dom_id(@tdc, :header_section_level)

--- a/app/models/KeyableModel.rb
+++ b/app/models/KeyableModel.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-KeyableModel = Struct.new(:model_name, :to_key, :param_key, keyword_init: true)

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -106,7 +106,6 @@ class ChampData < ApplicationRecord
     :collapsible_explanation_text,
     :header_section_level_value,
     :current_section_level,
-    :non_fillable?,
     :fillable?,
     :mandatory?,
     :prefillable?,

--- a/app/models/concerns/estimated_duration_concern.rb
+++ b/app/models/concerns/estimated_duration_concern.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module EstimatedDurationConcern
+  extend ActiveSupport::Concern
+
+  FILL_DURATION_SHORT  = 10.seconds
+  FILL_DURATION_MEDIUM = 1.minute
+  FILL_DURATION_LONG   = 3.minutes
+  READ_WORDS_PER_SECOND = 140.0 / 60 # 140 words per minute
+
+  # Default estimated duration to fill the champ in a form, in seconds.
+  # May be overridden by subclasses.
+  def estimated_fill_duration(revision)
+    if fillable?
+      FILL_DURATION_SHORT
+    else
+      0.seconds
+    end
+  end
+
+  def estimated_read_duration
+    return 0.seconds if description.blank?
+
+    sanitizer = Rails::Html::Sanitizer.full_sanitizer.new
+    content = sanitizer.sanitize(description)
+
+    words = content.split(/\s+/).size
+
+    (words / READ_WORDS_PER_SECOND).round.seconds
+  end
+end

--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -93,8 +93,6 @@ module ProcedureCloneConcern
   def clone(options: nil, admin:)
     options = default_options.merge(options || {})
 
-    populate_champ_stable_ids
-
     procedure = self.deep_clone(include: cloneable_associations(options, admin)) do |original, kopy|
       ClonePiecesJustificativesService.clone_attachments(original, kopy)
       if original.is_a?(TypeDeChamp) && original.type_champ == 'referentiel'
@@ -147,15 +145,6 @@ module ProcedureCloneConcern
   end
 
   private
-
-  def populate_champ_stable_ids
-    TypeDeChamp
-      .joins(:revisions)
-      .where(procedure_revisions: { procedure_id: id }, stable_id: nil)
-      .find_each do |type_de_champ|
-        type_de_champ.update_column(:stable_id, type_de_champ.id)
-      end
-  end
 
   def same_admin?(admin)
     @same_admin ||= admin.owns?(self)

--- a/app/models/concerns/revision_describable_to_llm_concern.rb
+++ b/app/models/concerns/revision_describable_to_llm_concern.rb
@@ -30,6 +30,6 @@ module RevisionDescribableToLLMConcern
     return nil unless TYPES_WITH_OPTIONS.include?(tdc.type_champ)
     return nil if tdc.options.blank?
 
-    tdc.options.slice(*tdc.class.option_keys.map(&:to_s)).presence
+    tdc.clean_options.presence
   end
 end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -192,7 +192,6 @@ class TypeDeChamp < ApplicationRecord
 
   def cannot_be_mandatory? = false
 
-
   def public?
     !private?
   end
@@ -274,12 +273,6 @@ class TypeDeChamp < ApplicationRecord
 
   def public_id(row_id)
     self.class.public_id(stable_id, row_id)
-  end
-
-  def libelle_as_filename
-    libelle.gsub(/[[:space:]]+/, ' ')
-      .truncate(30, omission: '', separator: ' ')
-      .parameterize
   end
 
   def self.option_keys = []

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -8,8 +8,6 @@ class TypeDeChamp < ApplicationRecord
 
   include EstimatedDurationConcern
 
-  FILE_MAX_SIZE = 200.megabytes
-
   STRUCTURE = :structure
   ETAT_CIVIL = :etat_civil
   LOCALISATION = :localisation
@@ -261,7 +259,6 @@ class TypeDeChamp < ApplicationRecord
     options.slice(*self.class.option_keys.map(&:to_s))
   end
 
-  def max_file_size_bytes = FILE_MAX_SIZE
   def allowed_content_types = AUTHORIZED_CONTENT_TYPES
 
   def champ_value(champ)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -166,8 +166,6 @@ class TypeDeChamp < ApplicationRecord
 
   def fillable? = true
 
-  def non_fillable? = !fillable?
-
   def must_be_mandatory? = false
 
   def cannot_be_mandatory? = false
@@ -519,7 +517,7 @@ class TypeDeChamp < ApplicationRecord
   def check_mandatory
     return if mandatory_changed?
 
-    self.mandatory = false if non_fillable? || cannot_be_mandatory?
+    self.mandatory = false if !fillable? || cannot_be_mandatory?
     self.mandatory = true if must_be_mandatory?
   end
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -184,8 +184,6 @@ class TypeDeChamp < ApplicationRecord
     revision.coordinate_for(self)&.child?
   end
 
-  def formatted_advanced? = false
-
   def options_for_select = nil
 
   def previous_section_level(upper_tdcs)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -192,7 +192,6 @@ class TypeDeChamp < ApplicationRecord
 
   def cannot_be_mandatory? = false
 
-  def choice_type? = false
 
   def public?
     !private?

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -241,12 +241,8 @@ class TypeDeChamp < ApplicationRecord
     end
   end
 
-  def stable_self
-    KeyableModel.new(
-      to_key: [stable_id],
-      model_name: KeyableModel.new(param_key: model_name.param_key)
-    )
-  end
+  # dom ids follow the stable_id so they survive the revision clones
+  def to_key = ([stable_id] if stable_id)
 
   # We should refresh all champs after update except for champs using react or
   # custom refresh logic (RNA, SIRET, etc.)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -227,10 +227,6 @@ class TypeDeChamp < ApplicationRecord
     GraphQL::Schema::UniqueWithinType.encode('Champ', stable_id)
   end
 
-  def editable_options=(options)
-    self.options.merge!(options)
-  end
-
   def read_attribute_for_serialization(name)
     if name == 'id'
       stable_id

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -127,19 +127,6 @@ class TypeDeChamp < ApplicationRecord
     end
   end
 
-  def set_default_libelle
-    libelle_was_default = libelle == default_libelle(type_champ_was)
-    self.libelle = default_libelle(type_champ) if libelle.blank? || libelle_was_default
-  end
-
-  def default_libelle(type_champ)
-    return if type_champ.blank?
-
-    I18n.t(type_champ,
-      scope: [:activerecord, :attributes, :type_de_champ, :default_libelle],
-      default: I18n.t(type_champ, scope: [:activerecord, :attributes, :type_de_champ, :type_champs]), app_name: APPLICATION_NAME)
-  end
-
   def libelle_optionnal? = false
   def libelle_configurable? = true
   def description_configurable? = true
@@ -169,13 +156,6 @@ class TypeDeChamp < ApplicationRecord
   # validations and callbacks apply instead of the source type's.
   def becomes_type(new_type_champ)
     becomes(self.class.find_sti_class(new_type_champ))
-  end
-
-  def check_mandatory
-    return if mandatory_changed?
-
-    self.mandatory = false if non_fillable? || cannot_be_mandatory?
-    self.mandatory = true if must_be_mandatory?
   end
 
   def only_present_on_draft?
@@ -270,6 +250,7 @@ class TypeDeChamp < ApplicationRecord
       .sort_by { |category, _| CATEGORIES.find_index(category) }
       .map { |_, group| group.map { "« #{I18n.t(_1.sti_name, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])} »" } }
   end
+  private_class_method :humanized_types_by_category
 
   def public_id(row_id)
     self.class.public_id(stable_id, row_id)
@@ -523,6 +504,26 @@ class TypeDeChamp < ApplicationRecord
   def any_drop_down_list? = false
 
   private
+
+  def set_default_libelle
+    libelle_was_default = libelle == default_libelle(type_champ_was)
+    self.libelle = default_libelle(type_champ) if libelle.blank? || libelle_was_default
+  end
+
+  def default_libelle(type_champ)
+    return if type_champ.blank?
+
+    I18n.t(type_champ,
+      scope: [:activerecord, :attributes, :type_de_champ, :default_libelle],
+      default: I18n.t(type_champ, scope: [:activerecord, :attributes, :type_de_champ, :type_champs]), app_name: APPLICATION_NAME)
+  end
+
+  def check_mandatory
+    return if mandatory_changed?
+
+    self.mandatory = false if non_fillable? || cannot_be_mandatory?
+    self.mandatory = true if must_be_mandatory?
+  end
 
   # A value written by a multiple drop-down list, read after a type change.
   def champ_text_value(champ)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -502,16 +502,15 @@ class TypeDeChamp < ApplicationRecord
   private
 
   def set_default_libelle
-    libelle_was_default = libelle == default_libelle(type_champ_was)
-    self.libelle = default_libelle(type_champ) if libelle.blank? || libelle_was_default
-  end
+    old_default, new_default = [type_champ_was, type_champ].map do |type_champ|
+      next if type_champ.blank?
 
-  def default_libelle(type_champ)
-    return if type_champ.blank?
+      I18n.t(type_champ,
+        scope: [:activerecord, :attributes, :type_de_champ, :default_libelle],
+        default: I18n.t(type_champ, scope: [:activerecord, :attributes, :type_de_champ, :type_champs]), app_name: APPLICATION_NAME)
+    end
 
-    I18n.t(type_champ,
-      scope: [:activerecord, :attributes, :type_de_champ, :default_libelle],
-      default: I18n.t(type_champ, scope: [:activerecord, :attributes, :type_de_champ, :type_champs]), app_name: APPLICATION_NAME)
+    self.libelle = new_default if libelle.blank? || libelle == old_default
   end
 
   def check_mandatory

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -6,13 +6,10 @@ class TypeDeChamp < ApplicationRecord
   self.inheritance_column = :type_champ
   class_attribute :boolean_option_keys, default: [].freeze
 
+  include EstimatedDurationConcern
+
   FILE_MAX_SIZE = 200.megabytes
   MINIMUM_TEXTAREA_CHARACTER_LIMIT_LENGTH = 400
-
-  FILL_DURATION_SHORT  = 10.seconds
-  FILL_DURATION_MEDIUM = 1.minute
-  FILL_DURATION_LONG   = 3.minutes
-  READ_WORDS_PER_SECOND = 140.0 / 60 # 140 words per minute
 
   STRUCTURE = :structure
   ETAT_CIVIL = :etat_civil
@@ -398,27 +395,6 @@ class TypeDeChamp < ApplicationRecord
 
   def libelles_for_export
     paths.map { [_1[:libelle], _1[:path]] }
-  end
-
-  # Default estimated duration to fill the champ in a form, in seconds.
-  # May be overridden by subclasses.
-  def estimated_fill_duration(revision)
-    if fillable?
-      FILL_DURATION_SHORT
-    else
-      0.seconds
-    end
-  end
-
-  def estimated_read_duration
-    return 0.seconds if description.blank?
-
-    sanitizer = Rails::Html::Sanitizer.full_sanitizer.new
-    content = sanitizer.sanitize(description)
-
-    words = content.split(/\s+/).size
-
-    (words / READ_WORDS_PER_SECOND).round.seconds
   end
 
   def canonical_column(procedure_id:, displayable: true, prefix: nil)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -228,25 +228,6 @@ class TypeDeChamp < ApplicationRecord
   def condition_value_type = :unmanaged
   def condition_options = []
 
-  def self.humanized_conditionable_types_by_category
-    humanized_types_by_category(type_champ_classes.filter(&:conditionable?))
-  end
-
-  def self.humanized_simple_routable_types_by_category
-    humanized_types_by_category(type_champ_classes.filter { _1.conditionable? && _1.simple_routable? })
-  end
-
-  def self.humanized_custom_routable_types_by_category
-    humanized_types_by_category(type_champ_classes.filter { _1.conditionable? && !_1.simple_routable? })
-  end
-
-  def self.humanized_types_by_category(klasses)
-    klasses.group_by(&:category)
-      .sort_by { |category, _| CATEGORIES.find_index(category) }
-      .map { |_, group| group.map { "« #{I18n.t(_1.sti_name, scope: [:activerecord, :attributes, :type_de_champ, :type_champs])} »" } }
-  end
-  private_class_method :humanized_types_by_category
-
   def public_id(row_id)
     self.class.public_id(stable_id, row_id)
   end
@@ -454,6 +435,12 @@ class TypeDeChamp < ApplicationRecord
     def find_sti_class(type_name) = type_champ_to_class_name(type_name.to_s).constantize
 
     def type_champ_classes = type_champs.values.map { find_sti_class(_1) }
+
+    def conditionable_types = type_champ_classes.filter(&:conditionable?)
+
+    def simple_routable_types = conditionable_types.filter(&:simple_routable?)
+
+    def custom_routable_types = conditionable_types.reject(&:simple_routable?)
 
     def sti_name = CLASS_NAME_TO_TYPE_CHAMP[name]
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -9,7 +9,6 @@ class TypeDeChamp < ApplicationRecord
   include EstimatedDurationConcern
 
   FILE_MAX_SIZE = 200.megabytes
-  MINIMUM_TEXTAREA_CHARACTER_LIMIT_LENGTH = 400
 
   STRUCTURE = :structure
   ETAT_CIVIL = :etat_civil

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -110,7 +110,7 @@ class TypeDeChamp < ApplicationRecord
 
   after_create :populate_stable_id
 
-  before_validation :check_mandatory
+  before_validation :enforce_mandatory_constraints
   before_validation :set_default_libelle, if: -> { type_champ_changed? }
 
   normalizes :libelle, with: -> (value) { value.strip }
@@ -513,7 +513,7 @@ class TypeDeChamp < ApplicationRecord
     self.libelle = new_default if libelle.blank? || libelle == old_default
   end
 
-  def check_mandatory
+  def enforce_mandatory_constraints
     return if mandatory_changed?
 
     self.mandatory = false if !fillable? || cannot_be_mandatory?

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -178,6 +178,8 @@ class TypeDeChamp < ApplicationRecord
 
   def api_particulier? = false
 
+  def any_drop_down_list? = false
+
   def child?(revision)
     revision.coordinate_for(self)&.child?
   end
@@ -496,8 +498,6 @@ class TypeDeChamp < ApplicationRecord
 
   CHAMP_TYPE_TO_TYPE_CHAMP = type_champs.values.index_by { type_champ_to_champ_class_name(_1) }
   CLASS_NAME_TO_TYPE_CHAMP = type_champs.values.index_by { type_champ_to_class_name(_1) }
-
-  def any_drop_down_list? = false
 
   private
 

--- a/app/models/types_de_champ/carte_type_de_champ.rb
+++ b/app/models/types_de_champ/carte_type_de_champ.rb
@@ -41,6 +41,10 @@ class TypesDeChamp::CarteTypeDeChamp < TypeDeChamp
     end.sort
   end
 
+  def editable_options=(options)
+    self.options.merge!(options)
+  end
+
   def editable_options
     layers = LAYERS.map do |layer|
       disabled = case layer

--- a/app/models/types_de_champ/checkbox_type_de_champ.rb
+++ b/app/models/types_de_champ/checkbox_type_de_champ.rb
@@ -7,7 +7,6 @@ class TypesDeChamp::CheckboxTypeDeChamp < TypeDeChamp
 
   def prefillable? = true
   def options_for_select = Champs::CheckboxChamp.options
-  def choice_type? = true
   def condition_value_type = :boolean
 
   def typed_champ_value(champ)

--- a/app/models/types_de_champ/drop_down_base_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_base_type_de_champ.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::DropDownBaseTypeDeChamp < TypeDeChamp
-  store_accessor :options, :drop_down_options, :drop_down_mode
+  store_accessor :options, :drop_down_options
 
   def any_drop_down_list? = true
-  def drop_down_simple? = drop_down_mode != 'advanced'
-  def drop_down_advanced? = drop_down_mode == 'advanced'
+  # the editor offers the simple/advanced switch to the drop_down_list and the
+  # multiple_drop_down_list only: the other lists are always simple
+  def drop_down_mode = nil
+  def drop_down_simple? = !drop_down_advanced?
+  def drop_down_advanced? = false
   def drop_down_other? = false
 
   def revision_diff_options

--- a/app/models/types_de_champ/drop_down_base_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_base_type_de_champ.rb
@@ -3,6 +3,7 @@
 class TypesDeChamp::DropDownBaseTypeDeChamp < TypeDeChamp
   store_accessor :options, :drop_down_options, :drop_down_mode
 
+  def any_drop_down_list? = true
   def drop_down_simple? = drop_down_mode != 'advanced'
   def drop_down_advanced? = drop_down_mode == 'advanced'
   def drop_down_other? = false

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -11,7 +11,6 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypesDeChamp::DropDownBaseTypeDeCh
 
   def prefillable? = true
   def options_for_select = options_for_select_with_other
-  def choice_type? = true
   def any_drop_down_list? = true
   def conditionable? = !drop_down_advanced?
   def simple_routable? = !drop_down_advanced?

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -11,7 +11,6 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypesDeChamp::DropDownBaseTypeDeCh
 
   def prefillable? = true
   def options_for_select = options_for_select_with_other
-  def any_drop_down_list? = true
   def conditionable? = !drop_down_advanced?
   def simple_routable? = !drop_down_advanced?
   def condition_value_type = :enum

--- a/app/models/types_de_champ/drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/drop_down_list_type_de_champ.rb
@@ -7,9 +7,10 @@ class TypesDeChamp::DropDownListTypeDeChamp < TypesDeChamp::DropDownBaseTypeDeCh
   def self.simple_routable? = true
   def self.conditionable? = true
 
-  store_accessor :options, :drop_down_other
+  store_accessor :options, :drop_down_other, :drop_down_mode
 
   def prefillable? = true
+  def drop_down_advanced? = drop_down_mode == 'advanced'
   def options_for_select = options_for_select_with_other
   def conditionable? = !drop_down_advanced?
   def simple_routable? = !drop_down_advanced?

--- a/app/models/types_de_champ/france_connect_type_de_champ.rb
+++ b/app/models/types_de_champ/france_connect_type_de_champ.rb
@@ -58,6 +58,9 @@ class TypesDeChamp::FranceConnectTypeDeChamp < TypeDeChamp
     FILL_DURATION_MEDIUM
   end
 
+  # the justificatif uploaded when the data cannot be fetched
+  def max_file_size_bytes = TypesDeChamp::PieceJustificativeTypeDeChamp::FILE_MAX_SIZE
+
   def typed_champ_blank?(champ)
     return true if champ.fetched? && champ.fc_data_approved?.nil?
     return false if champ.fc_data_correct?

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -9,7 +9,6 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::DropDownBaseTy
   def revision_diff_options = super.merge(drop_down_secondary_libelle:, drop_down_secondary_description:)
 
   def options_for_select = options_for_select_with_other
-  def any_drop_down_list? = true
   def has_label? = false
   def customizable? = true
 

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -8,7 +8,6 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypesDeChamp::DropDownBase
 
   def prefillable? = true
   def options_for_select = options_for_select_with_other
-  def any_drop_down_list? = true
   def conditionable? = !drop_down_advanced?
   def condition_value_type = :enums
   def condition_options = options_for_select_with_other

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -8,7 +8,6 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypesDeChamp::DropDownBase
 
   def prefillable? = true
   def options_for_select = options_for_select_with_other
-  def choice_type? = true
   def any_drop_down_list? = true
   def conditionable? = !drop_down_advanced?
   def condition_value_type = :enums

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -6,7 +6,10 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypesDeChamp::DropDownBase
   def self.column_type = :enums
   def self.conditionable? = true
 
+  store_accessor :options, :drop_down_mode
+
   def prefillable? = true
+  def drop_down_advanced? = drop_down_mode == 'advanced'
   def options_for_select = options_for_select_with_other
   def conditionable? = !drop_down_advanced?
   def condition_value_type = :enums

--- a/app/models/types_de_champ/piece_justificative_type_de_champ.rb
+++ b/app/models/types_de_champ/piece_justificative_type_de_champ.rb
@@ -4,6 +4,7 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypeDeChamp
   def self.option_keys = [:old_pj, :skip_pj_validation, :skip_content_type_pj_validation, :pj_limit_formats, :pj_format_families, :pj_auto_purge]
   def self.column_type = :attachments
 
+  FILE_MAX_SIZE = 200.megabytes
   IDENTITY_FILE_MAX_SIZE = 20.megabytes
 
   enum :nature, %w[non_specifie titre_identite rib justificatif_domicile avis_impot].index_by(&:itself)

--- a/app/models/types_de_champ/piece_justificative_type_de_champ.rb
+++ b/app/models/types_de_champ/piece_justificative_type_de_champ.rb
@@ -30,6 +30,12 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypeDeChamp
 
   def tags_for_template = [].freeze
 
+  def libelle_as_filename
+    libelle.gsub(/[[:space:]]+/, ' ')
+      .truncate(30, omission: '', separator: ' ')
+      .parameterize
+  end
+
   def typed_champ_value_for_export(champ, path = :value)
     if titre_identite?
       champ.piece_justificative_file.attached? ? "présent" : "absent"

--- a/app/models/types_de_champ/textarea_type_de_champ.rb
+++ b/app/models/types_de_champ/textarea_type_de_champ.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TypesDeChamp::TextareaTypeDeChamp < TypesDeChamp::TextTypeDeChamp
+  MINIMUM_TEXTAREA_CHARACTER_LIMIT_LENGTH = 400
+
   def self.option_keys = [:character_limit]
 
   store_accessor :options, :character_limit

--- a/app/models/types_de_champ/yes_no_type_de_champ.rb
+++ b/app/models/types_de_champ/yes_no_type_de_champ.rb
@@ -6,7 +6,6 @@ class TypesDeChamp::YesNoTypeDeChamp < TypeDeChamp
   def self.conditionable? = true
 
   def prefillable? = true
-  def choice_type? = true
   def condition_value_type = :boolean
 
   def typed_champ_value(champ)

--- a/app/views/administrateurs/conditions/_update.turbo_stream.haml
+++ b/app/views/administrateurs/conditions/_update.turbo_stream.haml
@@ -11,9 +11,9 @@
 - rendered = render @condition_component
 
 - if rendered.present?
-  = turbo_stream.replace dom_id(@tdc.stable_self, :condition) do
+  = turbo_stream.replace dom_id(@tdc, :condition) do
     - rendered
 - else
-  = turbo_stream.remove dom_id(@tdc.stable_self, :condition)
+  = turbo_stream.remove dom_id(@tdc, :condition)
 
 = render AutosaveNoticeTurboStreamComponent.new

--- a/app/views/administrateurs/groupe_instructeurs/_custom_routing_modal.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/_custom_routing_modal.html.haml
@@ -14,7 +14,4 @@
                 Deux groupes par défaut ont été créés
               %p
                 Vous devez maintenant les renommer et leur attribuer des règles de routage à partir du ou des champs « routables » de votre formulaire, soit des champs de type :
-              %ul
-                - TypeDeChamp.humanized_conditionable_types_by_category.each do |category|
-                  %li
-                    = category.join(', ')
+              = render TypesDeChamp::ByCategoryListComponent.new(types: TypeDeChamp.conditionable_types)

--- a/app/views/administrateurs/groupe_instructeurs/simple_routing.html.haml
+++ b/app/views/administrateurs/groupe_instructeurs/simple_routing.html.haml
@@ -23,18 +23,12 @@
         %p
         Vous trouverez ci-dessous une liste de champs de votre formulaire à partir desquels configurer le routage de façon <strong>automatique</strong>. Les groupes d’instructeurs seront créés à partir des valeurs possibles du champ.
         Seuls les champs suivants sont ouverts à ce mode de configuration :
-        %ul
-          - TypeDeChamp.humanized_simple_routable_types_by_category.each do |category|
-            %li
-              = category.join(', ')
+        = render TypesDeChamp::ByCategoryListComponent.new(types: TypeDeChamp.simple_routable_types)
 
         %p
           Si besoin, vous pourrez ensuite affiner votre configuration de façon <strong>manuelle</strong>, également à partir des champs suivants :
 
-        %ul
-          - TypeDeChamp.humanized_custom_routable_types_by_category.each do |category|
-            %li
-              = category.join(', ')
+        = render TypesDeChamp::ByCategoryListComponent.new(types: TypeDeChamp.custom_routable_types)
 
       = form_for :create_simple_routing,
         method: :post,

--- a/spec/components/types_de_champ/by_category_list_component_spec.rb
+++ b/spec/components/types_de_champ/by_category_list_component_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+describe TypesDeChamp::ByCategoryListComponent, type: :component do
+  before { render_inline(described_class.new(types: TypeDeChamp.conditionable_types)) }
+
+  it 'lists the types grouped by category, in the editor order' do
+    expect(page.all('li').map(&:text)).to eq([
+      "« Adresse », « Commune française actuelle », « Département », « Région », « Pays », « EPCI »",
+      "« Nombre décimal », « Nombre entier »",
+      "« Case à cocher seule », « Choix simple », « Choix multiple », « Oui/Non »",
+      "« Champ pré-rempli »",
+    ])
+  end
+end

--- a/spec/models/export_template_spec.rb
+++ b/spec/models/export_template_spec.rb
@@ -28,7 +28,7 @@ describe ExportTemplate do
     end
 
     context 'when pj does not exist' do
-      subject { export_template.pj(TypeDeChamp.new(libelle: 'hi', stable_id: 10)) }
+      subject { export_template.pj(TypesDeChamp::PieceJustificativeTypeDeChamp.new(libelle: 'hi', stable_id: 10)) }
 
       it { is_expected.to eq(ExportItem.default(stable_id: 10, prefix: "hi", enabled: false)) }
     end

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -750,19 +750,6 @@ describe TypeDeChamp do
     end
   end
 
-  describe '#humanized_conditionable_types_by_category' do
-    subject { TypeDeChamp.humanized_conditionable_types_by_category }
-
-    it 'groups the conditionable types by category, in the editor order' do
-      is_expected.to eq([
-        ["« Adresse »", "« Commune française actuelle »", "« Département »", "« Région »", "« Pays »", "« EPCI »"],
-        ["« Nombre décimal »", "« Nombre entier »"],
-        ["« Case à cocher seule »", "« Choix simple »", "« Choix multiple »", "« Oui/Non »"],
-        ["« Champ pré-rempli »"],
-      ])
-    end
-  end
-
   describe '#ocr_compatible?' do
     subject { type_de_champ.ocr_compatible? }
 

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -393,14 +393,6 @@ describe TypeDeChamp do
     end
   end
 
-  describe '#safe_filename' do
-    subject { build(:type_de_champ, libelle:).libelle_as_filename }
-
-    let(:libelle) { "  #/🐉 1 très  intéressant Bilan " }
-
-    it { is_expected.to eq("1-tres-interessant-bilan") }
-  end
-
   describe '#clean_options' do
     subject { procedure.published_revision.type_de_champs.first.options }
 

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -353,6 +353,18 @@ describe TypeDeChamp do
     end
   end
 
+  describe '.option_keys' do
+    # clean_options keeps these keys and drops the others at publication: a type
+    # must never be able to read an option it would lose there.
+    it 'lists every option a type can read' do
+      unlisted = TypeDeChamp.type_champ_classes.uniq.to_h do |klass|
+        [klass.name, Array(klass.stored_attributes[:options]).map(&:to_s) - klass.option_keys.map(&:to_s)]
+      end
+
+      expect(unlisted.reject { |_, keys| keys.empty? }).to eq({})
+    end
+  end
+
   describe '#clean_options' do
     subject { procedure.published_revision.type_de_champs.first.options }
 

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -181,46 +181,6 @@ describe TypeDeChamp do
   end
 
   describe 'piece_justificative nature and options' do
-    describe '#allowed_content_types' do
-      it 'returns jpeg/png for titre_identite' do
-        tdc = create(:type_de_champ_piece_justificative, nature: 'titre_identite')
-        expect(tdc.allowed_content_types).to match_array(['image/jpeg', 'image/png'])
-      end
-
-      ['rib', 'justificatif_domicile', 'avis_impot'].each do |ocr_nature|
-        it "restricts to doc and image types for #{ocr_nature}" do
-          tdc = create(:type_de_champ_piece_justificative, nature: ocr_nature)
-          expect(tdc.allowed_content_types).to include('application/pdf')
-          expect(tdc.allowed_content_types).to include('image/jpeg')
-          expect(tdc.allowed_content_types).not_to include('application/zip')
-        end
-      end
-
-      it 'restricts to selected families when pj_limit_formats enabled' do
-        tdc = create(:type_de_champ_piece_justificative, pj_limit_formats: '1', pj_format_families: ['document_texte'])
-        expect(tdc.allowed_content_types).to include('application/pdf')
-        expect(tdc.allowed_content_types).not_to include('application/zip')
-      end
-
-      it 'does not restrict when pj_limit_formats enabled but families empty' do
-        tdc = create(:type_de_champ_piece_justificative, pj_limit_formats: '1', pj_format_families: [])
-        expect(tdc.allowed_content_types).to include('application/pdf')
-        expect(tdc.allowed_content_types).to include('application/zip')
-      end
-    end
-
-    describe '#max_file_size_bytes' do
-      it 'is 20MB for titre_identite' do
-        tdc = create(:type_de_champ_piece_justificative, nature: 'titre_identite')
-        expect(tdc.max_file_size_bytes).to eq(20.megabytes)
-      end
-
-      it 'is 200MB by default' do
-        tdc = create(:type_de_champ_piece_justificative)
-        expect(tdc.max_file_size_bytes).to eq(TypeDeChamp::FILE_MAX_SIZE)
-      end
-    end
-
     describe '#pj_auto_purge?' do
       it 'is true for titre_identite' do
         tdc = create(:type_de_champ_piece_justificative, nature: 'titre_identite')

--- a/spec/models/types_de_champ/france_connect_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/france_connect_type_de_champ_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 describe TypesDeChamp::FranceConnectTypeDeChamp do
+  describe '#max_file_size_bytes' do
+    it 'caps the fallback justificatif like a pièce justificative' do
+      expect(build(:type_de_champ_quotient_familial).max_file_size_bytes).to eq(200.megabytes)
+    end
+  end
+
   context "when type de champ is quotient_famiilial" do
     describe '#champ_blank?' do
       let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :quotient_familial }]) }

--- a/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 describe TypesDeChamp::PieceJustificativeTypeDeChamp do
+  describe '#libelle_as_filename' do
+    subject { build(:type_de_champ_piece_justificative, libelle:).libelle_as_filename }
+
+    let(:libelle) { "  #/🐉 1 très  intéressant Bilan " }
+
+    it { is_expected.to eq("1-tres-interessant-bilan") }
+  end
+
   describe '#columns' do
     let(:procedure) { create(:procedure) }
 

--- a/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
+++ b/spec/models/types_de_champ/piece_justificative_type_de_champ_spec.rb
@@ -96,4 +96,44 @@ describe TypesDeChamp::PieceJustificativeTypeDeChamp do
       expect(champ.type_de_champ.typed_champ_value_for_api(champ, version: 1)).to be_nil
     end
   end
+
+  describe '#allowed_content_types' do
+    it 'returns jpeg/png for titre_identite' do
+      tdc = create(:type_de_champ_piece_justificative, nature: 'titre_identite')
+      expect(tdc.allowed_content_types).to match_array(['image/jpeg', 'image/png'])
+    end
+
+    ['rib', 'justificatif_domicile', 'avis_impot'].each do |ocr_nature|
+      it "restricts to doc and image types for #{ocr_nature}" do
+        tdc = create(:type_de_champ_piece_justificative, nature: ocr_nature)
+        expect(tdc.allowed_content_types).to include('application/pdf')
+        expect(tdc.allowed_content_types).to include('image/jpeg')
+        expect(tdc.allowed_content_types).not_to include('application/zip')
+      end
+    end
+
+    it 'restricts to selected families when pj_limit_formats enabled' do
+      tdc = create(:type_de_champ_piece_justificative, pj_limit_formats: '1', pj_format_families: ['document_texte'])
+      expect(tdc.allowed_content_types).to include('application/pdf')
+      expect(tdc.allowed_content_types).not_to include('application/zip')
+    end
+
+    it 'does not restrict when pj_limit_formats enabled but families empty' do
+      tdc = create(:type_de_champ_piece_justificative, pj_limit_formats: '1', pj_format_families: [])
+      expect(tdc.allowed_content_types).to include('application/pdf')
+      expect(tdc.allowed_content_types).to include('application/zip')
+    end
+  end
+
+  describe '#max_file_size_bytes' do
+    it 'is 20MB for titre_identite' do
+      tdc = create(:type_de_champ_piece_justificative, nature: 'titre_identite')
+      expect(tdc.max_file_size_bytes).to eq(20.megabytes)
+    end
+
+    it 'is 200MB by default' do
+      tdc = create(:type_de_champ_piece_justificative)
+      expect(tdc.max_file_size_bytes).to eq(200.megabytes)
+    end
+  end
 end


### PR DESCRIPTION
Suite de #13727. Passe en revue des méthodes restantes de `TypeDeChamp` : déplacements vers les sous-classes, suppressions de code mort et simplifications natives.

- les `dom_id` par `stable_id` passent par un override natif de `to_key` (au lieu du duo `stable_self`/`KeyableModel`, supprimé)
- rejoignent leurs seuls utilisateurs : `editable_options=` (carte), `libelle_as_filename` et `max_file_size_bytes` (pièce justificative ; le justificatif de repli des champs FranceConnect reprend la même limite), `any_drop_down_list?` et `drop_down_mode` (listes déroulantes), la limite de caractères (zone de texte)
- code mort : `choice_type?`, `non_fillable?`, et le backfill `stable_id` du clonage (0 ligne NULL restante en base)
- les callbacks internes passent en privé ; le défaut `formatted_advanced?` quitte la base (garde chez l'appelant)
- extraits : les durées estimées dans un concern, la liste des types par catégorie dans un composant
