### PR TITLE
ETQ usager, aligner le style des combobox sur celui du Select

### DIFF
--- a/app/assets/stylesheets/combobox.scss
+++ b/app/assets/stylesheets/combobox.scss
@@ -61,55 +61,25 @@
     width: var(--trigger-width);
     top: unset;
 
+    // Les options et les titres de groupe reprennent le style du Select : la
+    // liste porte aussi les classes `dropdown-*` de
+    // react-aria/components/ListBox.css. Ne restent ici que la géométrie du
+    // menu et le curseur des options.
     .fr-menu__list {
-      display: block;
       width: unset;
       max-height: 300px;
-      overflow: auto;
       box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-      padding: 2px 2px 0 2px !important;
-      color: var(--text-default-blue-france);
-    }
-
-    .fr-ds-combobox__section-header {
-      margin-top: 8px;
-      padding: 6px 8px;
-      font-size: 1rem;
-      font-weight: bold;
-      color: var(--text-title-grey);
+      padding: 0;
     }
 
     .fr-menu__item {
-      padding: 4px 8px;
-      margin-bottom: 2px !important;
-      background-color: var(--background-alt-blue-france);
       cursor: pointer;
-      border: 1px solid transparent;
-
-      &[data-selected],
-      &[data-focused] {
-        background-color: var(--background-alt-blue-france-hover);
-        color: var(--text-action-high-blue-france);
-      }
-
-      &[data-selected] {
-        border: 1px solid var(--border-plain-info);
-      }
 
       &[aria-disabled='true'],
       &[data-disabled='true'],
       &.fr-menu__item--disabled {
-        background-color: var(--background-default-grey) !important;
-        color: var(--text-disabled-grey);
         cursor: not-allowed;
         pointer-events: none;
-        border-color: transparent;
-      }
-
-      &[aria-disabled='true'][data-focused],
-      &[data-disabled='true'][data-focused] {
-        background-color: var(--background-default-grey) !important;
-        color: var(--text-disabled-grey);
       }
     }
   }

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -541,11 +541,6 @@ textarea::placeholder,
 :not(.fr-translate) .fr-menu__list {
   padding: $default-spacer;
   overflow-y: auto;
-
-  .fr-menu__item {
-    list-style-type: none;
-    margin-bottom: $default-spacer;
-  }
 }
 
 .fr-fieldset__element {

--- a/app/javascript/components/ComboBox.tsx
+++ b/app/javascript/components/ComboBox.tsx
@@ -2,7 +2,6 @@ import type { ListBoxItemProps } from 'react-aria-components';
 import {
   ComboBox as AriaComboBox,
   ListBox,
-  ListBoxItem,
   ListBoxSection,
   Header,
   Popover,
@@ -35,6 +34,7 @@ import {
   MultiComboBoxProps,
   RemoteComboBoxProps
 } from './react-aria/props';
+import { DropdownItem } from './react-aria/components/ListBox';
 import { TagGroup } from './react-aria/components/TagGroup';
 
 function flattenSections(sections: Section[]): Item[] {
@@ -145,7 +145,7 @@ export function ComboBox({
       <Popover className="fr-ds-combobox__menu fr-menu" isOpen={isOpen}>
         <Virtualizer layout={ListLayout}>
           <ListBox
-            className="fr-menu__list"
+            className="fr-menu__list dropdown-listbox"
             renderEmptyState={() =>
               errorMessage ? (
                 <p className="fr-message fr-message--error fr-p-1w">
@@ -158,7 +158,7 @@ export function ComboBox({
               <Collection items={sections}>
                 {(section) => (
                   <ListBoxSection id={section.label}>
-                    <Header className="fr-ds-combobox__section-header">
+                    <Header className="dropdown-section-header">
                       {section.label}
                     </Header>
                     <Collection items={section.items}>{children}</Collection>
@@ -179,7 +179,7 @@ export function ComboBoxItem(props: ListBoxItemProps<Item>) {
   const { isDisabled, className, ...rest } = props;
 
   return (
-    <ListBoxItem
+    <DropdownItem
       {...rest}
       isDisabled={isDisabled}
       className={[

--- a/app/javascript/components/react-aria/components/ListBox.css
+++ b/app/javascript/components/react-aria/components/ListBox.css
@@ -67,8 +67,17 @@
     }
   }
 
-  &[data-pressed] {
+  /* Trois degrés, du plus discret au plus affirmé : la souris passe, la souris
+     appuie, et l'option qu'un Entrée validerait. Le Select déplace le focus
+     sous la souris, l'aplat bleu y suit donc le survol ; le combo garde le
+     focus sur ce que la frappe désigne, et le gris dit alors seulement quelle
+     rangée est cliquable — deux rangées bleues mentiraient sur la touche. */
+  &[data-hovered] {
     background: var(--highlight-hover);
+  }
+
+  &[data-pressed] {
+    background: var(--highlight-pressed);
   }
 
   &[data-focused] {

--- a/app/javascript/components/react-aria/components/ListBox.tsx
+++ b/app/javascript/components/react-aria/components/ListBox.tsx
@@ -30,12 +30,19 @@ export function DropdownListBox<T extends object>(props: ListBoxProps<T>) {
   return <AriaListBox {...props} className="dropdown-listbox" />;
 }
 
-export function DropdownItem(props: ListBoxItemProps) {
+export function DropdownItem({
+  className,
+  ...props
+}: ListBoxItemProps & { className?: string }) {
   const textValue =
     props.textValue ||
     (typeof props.children == 'string' ? props.children : undefined);
   return (
-    <ListBoxItem {...props} textValue={textValue} className="dropdown-item">
+    <ListBoxItem
+      {...props}
+      textValue={textValue}
+      className={className ? `dropdown-item ${className}` : 'dropdown-item'}
+    >
       {composeRenderProps(props.children, (children, { isSelected }) => (
         <>
           {isSelected && (

--- a/app/javascript/components/react-aria/components/theme.css
+++ b/app/javascript/components/react-aria/components/theme.css
@@ -1,7 +1,8 @@
 /* Map react-aria theme variables to DSFR design tokens */
 .react-aria-Select,
 .fr-ds-select_multiple,
-.select-popover {
+.select-popover,
+.fr-ds-combobox__menu {
   --text-color: var(--text-label-grey);
   --text-color-heading: var(--text-title-grey);
   --heading-background: var(--background-alt-grey);


### PR DESCRIPTION
Suite à #13298, qui a donné aux titres de groupe du Select leur bandeau. Le Select avait fait l'objet d'un revue a11y plus approfondie, et suivaient les maquettes de l'UX.

Ce qui change à l'écran, pour toutes les listes de suggestions (commune, adresse, référentiel, tags, limitation des démarches…) :

- titres de groupe en bandeau ;
- options transparentes et arrondies, au rythme du Select ;
- l'option qu'un Entrée validerait garde l'aplat bleu ;
- l'option déjà choisie était cernée d'une bordure bleue : elle prend la coche du Select, donc l'état n'est plus porté par la seule couleur (RGAA 3.1) ;
- le survol, qui ne se voyait plus une fois les rangées transparentes, prend le gris de survol du DSFR. Il reste subordonné au bleu : le Select déplace le focus sous la souris et l'y suit, le combo garde le focus sur ce que la frappe désigne — deux rangées bleues mentiraient sur la touche Entrée.

Au passage, la règle `.fr-menu__item` de `forms.scss` disparaît : elle ne visait que les options du combo (aucune vue n'utilise cette classe) et sa marge basse écrasait le rythme de la feuille partagée.

## Après

Titres de groupe (combo de limitation des démarches) :
<img width="730" height="327" alt="Capture d’écran 2026-08-26 à 10 09 35" src="https://github.com/user-attachments/assets/43628f8a-d5aa-4e97-8c63-2fd8aeb7f497" />



Champ commune :
<img width="417" height="412" alt="Capture d’écran 2026-08-26 à 10 07 46" src="https://github.com/user-attachments/assets/447ab904-6431-4202-a2e7-cf7abb048e5c" />

option active (rangée 1) et survol (rangée 2)
<img width="305" height="251" alt="Capture d’écran 2026-08-26 à 10 06 28" src="https://github.com/user-attachments/assets/c40a931a-cc66-480c-a76c-0d8bf64e371d" />


## Avant

![combobox-before3.png](https://gist.githubusercontent.com/colinux/4005f719a9cac93bf2570ea9a88a58b8/raw/combobox-before3.png)