### PR TITLE
Tech: le health check API Entreprise ne casse plus sur une réponse non-JSON

### DIFF
--- a/app/lib/api_entreprise/health_checker.rb
+++ b/app/lib/api_entreprise/health_checker.rb
@@ -47,26 +47,32 @@ module APIEntreprise::HealthChecker
   end
 
   def self.store_response(ping_key, response)
-    status =
-      if response.timed_out? || response.code.zero? || response.body.blank?
-        # No usable response (timeout, connection error): on_complete is still
-        # invoked by Typhoeus with an empty body. Treat the provider as down (the
-        # same outage shows up sometimes as a 502 bad_gateway, sometimes as a
-        # timeout) so the circuit breaker reschedules jobs. Fail-safe: jobs only retry.
-        'no_response'
-      else
-        JSON.parse(response.body)['status']
-      end
+    status = parse_status(response)
 
     Kredis.redis.set(cache_key(ping_key), status, ex: CACHE_TTL.to_i)
     status
-  rescue JSON::ParserError => e
-    Rails.logger.error("HealthChecker: JSON parse error for #{ping_key}: #{e.message}")
-    Sentry.capture_exception(e)
-    nil
   rescue => e
     Rails.logger.error("HealthChecker: refresh failed for #{ping_key}: #{e.class} #{e.message}")
     Sentry.capture_exception(e)
     nil
+  end
+
+  # Anything outside UP_STATUSES marks the provider as down, so an unusable
+  # response falls back to a synthetic down status rather than raising: the
+  # circuit breaker reschedules the jobs. Fail-safe: jobs only retry.
+  def self.parse_status(response)
+    if response.timed_out? || response.code.zero? || response.body.blank?
+      # No usable response (timeout, connection error): on_complete is still
+      # invoked by Typhoeus with an empty body. The same outage shows up
+      # sometimes as a 502 bad_gateway, sometimes as a timeout.
+      'no_response'
+    else
+      # An outage is usually reported as JSON ({"status": "bad_gateway"}), but
+      # /ping also serves plain HTML error pages, and JSON without any status
+      # ({} on a 404). Both must read as down instead of flooding Sentry.
+      JSON.parse(response.body)['status'] || "http_#{response.code}"
+    end
+  rescue JSON::ParserError
+    "http_#{response.code}"
   end
 end

--- a/spec/lib/api_entreprise/health_checker_spec.rb
+++ b/spec/lib/api_entreprise/health_checker_spec.rb
@@ -90,15 +90,33 @@ RSpec.describe APIEntreprise::HealthChecker do
       end
     end
 
-    context 'when a provider returns invalid JSON' do
+    context 'when a provider returns an HTML error page' do
       before do
         stub_request(:get, "#{described_class::PING_BASE_URL}/insee/sirene")
-          .to_return(status: 200, body: 'not json')
+          .to_return(status: 500, body: '<!DOCTYPE html><html><body>500</body></html>')
       end
 
-      it 'captures exception in Sentry' do
-        expect(Sentry).to receive(:capture_exception)
+      it 'marks the provider as down without reporting to Sentry' do
+        expect(Sentry).not_to receive(:capture_exception)
+
         described_class.refresh_all!
+
+        expect(described_class.cached_status('insee/sirene')).to eq('http_500')
+        expect(described_class.provider_up?('insee/sirene')).to be false
+      end
+    end
+
+    context 'when a provider returns JSON without a status' do
+      before do
+        stub_request(:get, "#{described_class::PING_BASE_URL}/insee/sirene")
+          .to_return(status: 404, body: '{}')
+      end
+
+      it 'marks the provider as down' do
+        described_class.refresh_all!
+
+        expect(described_class.cached_status('insee/sirene')).to eq('http_404')
+        expect(described_class.provider_up?('insee/sirene')).to be false
       end
     end
   end


### PR DESCRIPTION
Le `/ping` d'API Entreprise ne répond pas toujours du JSON : depuis le 25/08, `banque_de_france/bilans` renvoie une 500 avec la page d'erreur HTML par défaut. `JSON.parse` explose donc à chaque passage du CRON (toutes les 2 min), ce qui remplit Sentry.

Surtout, le `rescue` sortait sans rien écrire dans Redis : le cache restait vide, `provider_up?` faisait du fail-open et répondait `true`. Le circuit breaker était donc aveugle précisément sur le provider en panne, et `BilansBdfJob` a continué à taper dessus.

Même angle mort que le fix de juin sur les timeouts : le garde-fou couvrait le corps vide, pas un corps non vide et non-JSON.

Le correctif retombe sur un statut synthétique `http_<code>`, hors de `UP_STATUSES` — le provider est vu down et les jobs sont replanifiés. Ça couvre aussi le cas d'un JSON sans `status` (`{}` sur une 404), qui stockait jusqu'ici une chaîne vide dans Redis.

Fixes RAILS-MGR
