### PR TITLE
Tech: bascule du numéro de TVA vers la DGFIP et réactivation du TvaJob

### DIFF
--- a/app/jobs/api_entreprise/job.rb
+++ b/app/jobs/api_entreprise/job.rb
@@ -25,7 +25,7 @@ class APIEntreprise::Job < ApplicationJob
   PING_KEY_BY_JOB = {
     'EtablissementJob' => APIEntreprise::HealthChecker::PROVIDERS[:insee_sirene],
     'ExtraitKbisJob' => APIEntreprise::HealthChecker::PROVIDERS[:infogreffe_rcs],
-    'TvaJob' => APIEntreprise::HealthChecker::PROVIDERS[:european_commission_tva],
+    'TvaJob' => APIEntreprise::HealthChecker::PROVIDERS[:dgfip_numero_tva],
     'AssociationJob' => APIEntreprise::HealthChecker::PROVIDERS[:djepva_association],
     'ExercicesJob' => APIEntreprise::HealthChecker::PROVIDERS[:dgfip_chiffre_affaires],
     'EffectifsJob' => APIEntreprise::HealthChecker::PROVIDERS[:gip_mds_effectifs],

--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -5,7 +5,7 @@ class APIEntreprise::API
 
   ETABLISSEMENT_RESOURCE_NAME = "v4/insee/sirene/etablissements/%{id}"
   EXTRAIT_KBIS_NAME = "v3/infogreffe/rcs/unites_legales/%{id}/extrait_kbis"
-  TVA_NAME = "v3/european_commission/unites_legales/%{id}/numero_tva"
+  TVA_NAME = "v3/dgfip/unites_legales/%{id}/numero_tva"
   EXERCICES_RESOURCE_NAME = "v3/dgfip/etablissements/%{id}/chiffres_affaires"
   RNA_RESOURCE_NAME = "v4/djepva/api-association/associations/open_data/%{id}"
   EFFECTIFS_RESOURCE_NAME = "v3/gip_mds/etablissements/%{id}/effectifs_mensuels"

--- a/app/lib/api_entreprise/health_checker.rb
+++ b/app/lib/api_entreprise/health_checker.rb
@@ -8,7 +8,7 @@ module APIEntreprise::HealthChecker
   PROVIDERS = {
     insee_sirene: 'insee/sirene',
     infogreffe_rcs: 'infogreffe/rcs',
-    european_commission_tva: 'european_commission/numero_tva',
+    dgfip_numero_tva: 'dgfip/numero_tva',
     djepva_association: 'djepva/api-association',
     dgfip_chiffre_affaires: 'dgfip/chiffre_affaires',
     dgfip_attestation_fiscale: 'dgfip/attestation_fiscale',

--- a/app/lib/api_entreprise/tva_adapter.rb
+++ b/app/lib/api_entreprise/tva_adapter.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class APIEntreprise::TvaAdapter < APIEntreprise::Adapter
-  # Doc métier : https://entreprise.api.gouv.fr/catalogue/commission_europeenne/numero_tva
-  # Swagger : https://entreprise.api.gouv.fr/developpeurs/openapi#tag/Informations-generales/paths/~1v3~1european_commission~1unites_legales~1%7Bsiren%7D~1numero_tva/get
+  # Doc métier : https://entreprise.api.gouv.fr/catalogue/dgfip/numero_tva
+  # Swagger : https://entreprise.api.gouv.fr/developpeurs/openapi#tag/Informations-financieres/paths/~1v3~1dgfip~1unites_legales~1%7Bsiren%7D~1numero_tva/get
 
   private
 
@@ -18,7 +18,7 @@ class APIEntreprise::TvaAdapter < APIEntreprise::Adapter
 
       result = {}
       if data
-        result[:entreprise_numero_tva_intracommunautaire] = data[:tva_number]
+        result[:entreprise_numero_tva_intracommunautaire] = data[:numero_tva]
       end
       result
     end

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -69,12 +69,11 @@ class APIEntrepriseService
 
     def perform_later_fetch_jobs(etablissement, procedure_id, user_id, wait: nil)
       jobs = [
-        APIEntreprise::ExtraitKbisJob,
+        APIEntreprise::ExtraitKbisJob, APIEntreprise::TvaJob,
         APIEntreprise::AssociationJob, APIEntreprise::ExercicesJob,
         APIEntreprise::EffectifsJob, APIEntreprise::EffectifsAnnuelsJob, APIEntreprise::AttestationSocialeJob,
         APIEntreprise::BilansBdfJob,
       ]
-      jobs << APIEntreprise::TvaJob if Flipper.enabled?(:api_entreprise_tva_job)
       if etablissement.as_degraded_mode?
         jobs << APIEntreprise::EtablissementJob
       end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -7,15 +7,13 @@
 require 'flipper/adapters/active_record'
 require 'flipper/adapters/active_support_cache_store'
 
-def setup_features(features, enabled_by_default: [])
+def setup_features(features)
   existing = Flipper.preload_all.map { _1.name.to_sym }
   missing = features - existing
 
   missing.each do |feature|
     # Feature is disabled by default
     Flipper.add(feature.to_s)
-    # Enable on creation only: subsequent boots won't override an operator's choice
-    Flipper.enable(feature) if enabled_by_default.include?(feature)
   end
 end
 
@@ -36,7 +34,6 @@ features = [
   :switch_domain,
   :llm_nightly_improve_procedure,
   :ami_notifications,
-  :api_entreprise_tva_job,
   :dossier_vide_weasyprint,
   :usager_dossiers_alert_filters,
   :s3_storage,
@@ -65,7 +62,7 @@ end
 
 ActiveSupport.on_load(:active_record) do
   if database_exists? && ActiveRecord::Base.connection.data_source_exists?('flipper_features')
-    setup_features(features, enabled_by_default: [:api_entreprise_tva_job])
+    setup_features(features)
   end
 end
 

--- a/spec/fixtures/files/api_entreprise/tva.json
+++ b/spec/fixtures/files/api_entreprise/tva.json
@@ -1,7 +1,9 @@
 {
   "data": {
-    "tva_number": "FR48672039971"
+    "numero_tva": "FR48672039971"
   },
   "links": {},
-  "meta": {}
+  "meta": {
+    "date_derniere_mise_a_jour": "2026-08-25"
+  }
 }

--- a/spec/jobs/api_entreprise/job_spec.rb
+++ b/spec/jobs/api_entreprise/job_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe APIEntreprise::Job, type: :job do
     it 'returns the correct ping key for each job class' do
       expect(APIEntreprise::EtablissementJob.new.ping_key_for_job).to eq('insee/sirene')
       expect(APIEntreprise::ExtraitKbisJob.new.ping_key_for_job).to eq('infogreffe/rcs')
-      expect(APIEntreprise::TvaJob.new.ping_key_for_job).to eq('european_commission/numero_tva')
+      expect(APIEntreprise::TvaJob.new.ping_key_for_job).to eq('dgfip/numero_tva')
       expect(APIEntreprise::AssociationJob.new.ping_key_for_job).to eq('djepva/api-association')
       expect(APIEntreprise::ExercicesJob.new.ping_key_for_job).to eq('dgfip/chiffre_affaires')
       expect(APIEntreprise::EffectifsJob.new.ping_key_for_job).to eq('gip_mds/effectifs')

--- a/spec/jobs/api_entreprise/tva_job_spec.rb
+++ b/spec/jobs/api_entreprise/tva_job_spec.rb
@@ -11,7 +11,7 @@ describe APIEntreprise::TvaJob, type: :job do
   subject { APIEntreprise::TvaJob.new.perform(etablissement.id, procedure_id) }
 
   before do
-    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v3\/european_commission\/unites_legales\/#{siren}\/numero_tva/)
+    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v3\/dgfip\/unites_legales\/#{siren}\/numero_tva/)
       .to_return(body: body, status: status)
     allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end

--- a/spec/lib/api_entreprise/health_checker_spec.rb
+++ b/spec/lib/api_entreprise/health_checker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe APIEntreprise::HealthChecker do
   end
 
   describe '.provider_up?' do
-    let(:ping_key) { 'european_commission/numero_tva' }
+    let(:ping_key) { 'dgfip/numero_tva' }
 
     context 'when status is ok' do
       before { cache_status(ping_key, 'ok') }

--- a/spec/lib/api_entreprise/tva_adapter_spec.rb
+++ b/spec/lib/api_entreprise/tva_adapter_spec.rb
@@ -8,7 +8,7 @@ describe APIEntreprise::TvaAdapter do
   subject { adapter.to_params }
 
   before do
-    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v3\/european_commission\/unites_legales\/#{siren}\/numero_tva/)
+    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v3\/dgfip\/unites_legales\/#{siren}\/numero_tva/)
       .to_return(body: body, status: status)
     allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -3,7 +3,7 @@
 describe APIEntrepriseService do
   shared_examples 'schedule fetch of all etablissement params' do
     [
-      APIEntreprise::ExtraitKbisJob,
+      APIEntreprise::ExtraitKbisJob, APIEntreprise::TvaJob,
       APIEntreprise::AssociationJob, APIEntreprise::ExercicesJob,
       APIEntreprise::EffectifsJob, APIEntreprise::EffectifsAnnuelsJob, APIEntreprise::AttestationSocialeJob,
       APIEntreprise::BilansBdfJob,
@@ -45,22 +45,6 @@ describe APIEntrepriseService do
       end
 
       it_behaves_like 'schedule fetch of all etablissement params'
-
-      context 'when api_entreprise_tva_job feature is enabled' do
-        before { Flipper.enable(:api_entreprise_tva_job) }
-
-        it 'should enqueue TvaJob' do
-          expect { subject }.to have_enqueued_job(APIEntreprise::TvaJob)
-        end
-      end
-
-      context 'when api_entreprise_tva_job feature is disabled' do
-        before { Flipper.disable(:api_entreprise_tva_job) }
-
-        it 'should not enqueue TvaJob' do
-          expect { subject }.not_to have_enqueued_job(APIEntreprise::TvaJob)
-        end
-      end
     end
 
     context 'when etablissement api down' do


### PR DESCRIPTION
L'API TVA de la Commission européenne est [dépréciée depuis juin 2025](https://entreprise.api.gouv.fr/catalogue/commission_europeenne/numero_tva) et a disparu de la spec OpenAPI courante. Sa clé de ping n'existe plus non plus : le health check stockait donc une chaîne vide dans Redis, et `TvaJob` était vu comme définitivement down.

C'est ce qui avait motivé, en juin, l'arrêt de l'enqueue du job (#13264) puis son flag de désactivation (#13267) — on avait lu « fournisseur peu fiable » là où le vrai problème était une clé de ping périmée. Le commit `a42d9958` en garde la trace : 63k `RetryableError` pour `european_commission/numero_tva`, mises sous le tapis via `excluded_exceptions`.

**1er commit** — bascule vers [le fournisseur DGFIP](https://entreprise.api.gouv.fr/catalogue/dgfip/numero_tva) : ressource, clé de ping et adapter.

Le point d'attention : **le champ de réponse change** (`tva_number` → `numero_tva`). Changer seulement l'URL aurait stocké un numéro de TVA `nil` sans rien casser visiblement.

**2e commit** — la cause racine étant traitée, `TvaJob` repart avec ses jobs frères et le flag `api_entreprise_tva_job` disparaît. La ligne correspondante dans `flipper_features` reste en base : à supprimer depuis le manager.

Habilitation inchangée : les deux API sont « incluses par défaut », la spec ne déclare aucun scope par route (`jwt_bearer_token` partout), et aucun rôle de jeton ne garde la TVA côté app. Rien à redemander aux administrateurs. Quota identique aussi (250 req/min partagé).

Seule différence de comportement : on passe d'une vérification temps réel VIES à une extraction DGFIP en J+1, donc un SIREN absent de l'extraction renvoie une 404 — déjà traduite en résultat vide par `APIEntreprise::Adapter#to_params`.
