### PR TITLE
Tech: supprime deux N+1 sur la démarche dans l'API GraphQL v2

### DIFF
--- a/app/graphql/types/deleted_dossier_type.rb
+++ b/app/graphql/types/deleted_dossier_type.rb
@@ -19,7 +19,7 @@ module Types
     field :date_supression, GraphQL::Types::ISO8601DateTime, "Date de suppression.", null: false
 
     def self.authorized?(object, context)
-      context.authorized_demarche?(object.procedure)
+      context.authorized_demarche?(context.dataloader.with(Sources::Association, :procedure).load(object))
     end
 
     def date_supression

--- a/app/graphql/types/label_type.rb
+++ b/app/graphql/types/label_type.rb
@@ -15,6 +15,6 @@ class Types::LabelType < Types::BaseObject
   field :color, Types::LabelColorEnum, null: false, description: "Couleur du label"
 
   def self.authorized?(object, context)
-    context.authorized_demarche?(object.procedure)
+    context.authorized_demarche?(context.dataloader.with(Sources::Association, :procedure).load(object))
   end
 end


### PR DESCRIPTION
Deux N+1 dans l'API GraphQL v2, même cause : un hook `authorized?` qui lit `object.procedure` sur des enregistrements non préchargés.

**`DeletedDossierType`** — aucun des quatre resolvers qui exposent ce type (`deletedDossiers` et `pendingDeletedDossiers`, sur une démarche comme sur un groupe instructeur) ne préchargeait la démarche : une requête par nœud. Skylight remonte ~51 répétitions par requête sur `graphql:custom`.

**`LabelType`** — même forme, et `DossierType#labels` ne précharge que les labels : une requête de plus par label dès que `labels` est demandé sur une liste de dossiers. `Procedure#labels` déclare `inverse_of`, donc lister les labels d'une démarche est déjà plat ; ceux d'un dossier passent par `dossier_labels`, où cet inverse ne joue pas.

Le préchargement passe par `Sources::Association`, comme les associations déjà résolues dans `DossierType`. Posé dans `authorized?` plutôt que dans chaque resolver, il couvre tous les points d'entrée de ces types.

Ref #13554 — ces deux findings n'y figuraient pas.
