### PR TITLE
ETQ admin, réparer le clonage des démarches ayant un email personnalisé

### DIFF
--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -115,6 +115,7 @@ module ProcedureCloneConcern
 
     transaction do
       procedure.save!
+      clone_email_templates(procedure) if options[:clone_email_templates]
       move_new_children_to_new_parent_coordinate(procedure.draft_revision)
     end
 
@@ -247,16 +248,23 @@ module ProcedureCloneConcern
       procedure.draft_revision.ineligibilite_message = nil
     end
 
-    if options[:clone_email_templates]
-      procedure.custom_email_templates = custom_email_templates.map(&:dup)
-    end
-
     if !same_admin?(admin)
       procedure.api_particulier_token = nil
       procedure.opendata = true
     end
 
     procedure
+  end
+
+  # Copied once the clone is persisted: the tags validator resolves tags against
+  # revisions in database, which don't exist before the save. Validation is
+  # skipped so a template referencing a since-removed champ is cloned as is.
+  def clone_email_templates(procedure)
+    custom_email_templates.each do |email_template|
+      copy = email_template.dup
+      copy.procedure = procedure
+      copy.save!(validate: false)
+    end
   end
 
   def cloneable_associations(options, admin)

--- a/spec/models/concerns/procedure_clone_concern_spec.rb
+++ b/spec/models/concerns/procedure_clone_concern_spec.rb
@@ -312,6 +312,31 @@ describe ProcedureCloneConcern, type: :model do
       expect(subject.email_depose_or_default.attributes).to eq Emails::Depose.default_for_procedure(subject).attributes
     end
 
+    context 'when an email template references a champ' do
+      let(:public_type_de_champs) { [{ libelle: 'Mon champ' }] }
+      let(:email_passe_en_instruction) { build(:email_passe_en_instruction, body: 'Bonjour --Mon champ--') }
+
+      it 'should duplicate it' do
+        expect(subject.email_passe_en_instruction.body).to eq('Bonjour --Mon champ--')
+      end
+
+      context 'and the champ has been removed since' do
+        before { procedure.email_passe_en_instruction.update_column(:body, 'Bonjour --Champ supprimé--') }
+
+        it 'should duplicate it anyway' do
+          expect(subject.email_passe_en_instruction.body).to eq('Bonjour --Champ supprimé--')
+        end
+      end
+    end
+
+    context 'when email templates are not cloned' do
+      let(:options) { super().merge(clone_email_templates: false) }
+
+      it 'should not duplicate email templates' do
+        expect(subject.custom_email_templates).to be_empty
+      end
+    end
+
     it 'should not duplicate specific related objects' do
       expect(subject.dossiers).to eq([])
     end


### PR DESCRIPTION
Depuis la bascule des emails personnalisés en STI, cloner une démarche dont un email personnalisé référence un champ du formulaire échoue en 422 (Sentry `RAILS-MH1` : 11 administrateurs en 6 heures), même quand le champ existe bel et bien.

Avec les six `has_one` d'avant, l'email était enregistré **après** la démarche : ses révisions existaient déjà en base, les balises se résolvaient, tout passait. Une collection, elle, est validée **avant** l'enregistrement du parent.


Quand la balise ne résout plus sur la source, le clone est bien créé et affiche la même alerte que sa source (« Des problèmes empêchent la publication de la démarche », avec le nom de la balise et le lien vers l'email) : il reste bloqué en publication tant qu'elle n'est pas corrigée, exactement comme la démarche d'origine.


Fix https://demarches-simplifiees.sentry.io/issues/7693081741/
