### PR TITLE
ETQ instructeur, je ne peux plus supprimer le message envoyé lors de la modification d'un dossier

### DIFF
--- a/app/components/message/dossier_modifier_par_instructeur_component.rb
+++ b/app/components/message/dossier_modifier_par_instructeur_component.rb
@@ -41,6 +41,6 @@ class Message::DossierModifierParInstructeurComponent < ApplicationComponent
 
   def self.create_commentaire(traitement)
     body = render(dossier: traitement.dossier, changed_columns: traitement.changed_columns, motivation: traitement.motivation)
-    CommentaireService.create!(traitement.instructeur, traitement.dossier, body:)
+    CommentaireService.create!(traitement.instructeur, traitement.dossier, body:, deletable: false)
   end
 end

--- a/app/controllers/instructeurs/commentaires_controller.rb
+++ b/app/controllers/instructeurs/commentaires_controller.rb
@@ -11,7 +11,7 @@ module Instructeurs
       connected_user = current_instructeur || current_expert
 
       if !commentaire.soft_deletable?(connected_user, cancel_correction: false)
-        flash.alert = t('.alert_acl')
+        flash.alert = t('.alert_not_deletable')
       else
         commentaire.soft_delete!
         set_notifications

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -99,7 +99,8 @@ class Commentaire < ApplicationRecord
   end
 
   def soft_deletable?(connected_user, cancel_correction: true)
-    sent_by?(connected_user) &&
+    deletable? &&
+      sent_by?(connected_user) &&
       (sent_by_instructeur? || sent_by_expert?) &&
       !discarded? &&
       (cancel_correction || !dossier_correction&.pending?)

--- a/config/locales/views/instructeurs/commentaires/en.yml
+++ b/config/locales/views/instructeurs/commentaires/en.yml
@@ -3,7 +3,7 @@ en:
     commentaires:
       destroy:
         notice: Your message had been deleted
-        alert_acl: "Can not destroy message: it does not belong to you"
+        alert_not_deletable: This message can not be destroyed
         alert_already_discarded: "Can not destroy message: it was already destroyed"
       cancel_correction:
         notice: The correction request has been cancelled

--- a/config/locales/views/instructeurs/commentaires/fr.yml
+++ b/config/locales/views/instructeurs/commentaires/fr.yml
@@ -3,7 +3,7 @@ fr:
     commentaires:
       destroy:
         notice: Votre message a été supprimé
-        alert_acl: Impossible de supprimer le message, celui-ci ne vous appartient pas
+        alert_not_deletable: Ce message ne peut pas être supprimé
         alert_already_discarded: Ce message a déjà été supprimé
       cancel_correction:
         notice: La demande de correction a été annulée

--- a/db/migrate/20260827093000_add_deletable_to_commentaires.rb
+++ b/db/migrate/20260827093000_add_deletable_to_commentaires.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDeletableToCommentaires < ActiveRecord::Migration[8.0]
+  def change
+    add_column :commentaires, :deletable, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_24_150328) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_27_093000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_catalog.plpgsql"
@@ -315,6 +315,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_24_150328) do
   create_table "commentaires", id: :serial, force: :cascade do |t|
     t.string "body"
     t.datetime "created_at", precision: nil, null: false
+    t.boolean "deletable", default: true, null: false
     t.datetime "discarded_at", precision: nil
     t.integer "dossier_id"
     t.string "email"

--- a/spec/components/dossiers/message_component_spec.rb
+++ b/spec/components/dossiers/message_component_spec.rb
@@ -212,6 +212,12 @@ RSpec.describe Dossiers::MessageComponent, type: :component do
           it { is_expected.not_to have_selector("form[action=\"#{form_url}\"]") }
         end
 
+        context 'when commentaire is not deletable' do
+          let(:commentaire) { create(:commentaire, instructeur:, deletable: false) }
+
+          it { is_expected.not_to have_button(component.t('.delete_button')) }
+        end
+
         context 'when commentaire is a pending correction' do
           let(:commentaire) { create(:commentaire, instructeur:, body: 'Please fix this') }
           before { create(:dossier_correction, commentaire:, dossier:) }

--- a/spec/components/message/dossier_modifier_par_instructeur_component_spec.rb
+++ b/spec/components/message/dossier_modifier_par_instructeur_component_spec.rb
@@ -35,6 +35,20 @@ RSpec.describe Message::DossierModifierParInstructeurComponent, type: :component
     end
   end
 
+  describe '.create_commentaire' do
+    let(:instructeur) { create(:instructeur) }
+
+    subject do
+      dossier.instructeur_submit_en_construction!(instructeur:)
+      dossier.commentaires.last
+    end
+
+    it 'creates a commentaire the instructeur cannot delete' do
+      expect(subject.instructeur).to eq(instructeur)
+      expect(subject.deletable).to be false
+    end
+  end
+
   describe '.render' do
     let(:changed_columns) { [] }
 

--- a/spec/models/commentaire_spec.rb
+++ b/spec/models/commentaire_spec.rb
@@ -226,6 +226,12 @@ describe Commentaire do
 
       it { expect(commentaire.soft_deletable?(instructeur)).to be false }
     end
+
+    context 'when the message is not deletable' do
+      before { commentaire.update!(deletable: false) }
+
+      it { expect(commentaire.soft_deletable?(instructeur)).to be false }
+    end
   end
 
   describe '#can_cancel_correction?' do


### PR DESCRIPTION
closes #13635 

Le message récapitulatif publié dans la messagerie quand un instructeur modifie le dossier d’un usager est attribué à cet instructeur, ce qui faisait apparaître le bouton Supprimer le message .

Une colonne commentaires.deletable (défaut true) permet de marquer ce message comme non supprimable. Le contrôle est posé dans Commentaire#soft_deletable?, ce qui couvre les trois points d’entrée : le bouton dans la messagerie, Instructeurs::CommentairesController#destroy et la mutation GraphQL dossierSupprimerMessage.

Le message reste attribué à l’instructeur, l’email de notification à l’usager est donc inchangé.

Les messages déjà envoyés ne sont pas rétroactivement protégés (pas de backfill).