### PR TITLE
Tech: supprime les flags Flipper obsolètes restés en base

### DIFF
--- a/app/tasks/maintenance/t20260827_remove_obsolete_flipper_features_task.rb
+++ b/app/tasks/maintenance/t20260827_remove_obsolete_flipper_features_task.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260827RemoveObsoleteFlipperFeaturesTask < MaintenanceTasks::Task
+    # Retirer un flag de config/initializers/flipper.rb ne le supprime pas de la
+    # base : setup_features ne calcule que `features - existing` et n'appelle que
+    # Flipper.add. Les lignes s'accumulent donc dans flipper_features et restent
+    # affichées aux opérateurs dans /manager/features, sans rien piloter.
+    #
+    # Les clés ci-dessous ont été relevées en production et confrontées au code :
+    # aucune n'y apparaît plus (vérifié au symbole entier, pas en sous-chaîne).
+    #
+    #   agent_connect_2fa              9f2979a563  2025-03-17
+    #   referentiel_type_de_champ      43470dae8d  2026-02-26
+    #   ocr                            e7b0017f76  2026-03-02
+    #   analyse_justificatif_domicile  1f5194ef6a  2026-07-06
+    #   export_avec_horodatage         607cc40a81  2026-08-25  (#13717)
+    #   api_entreprise_tva_job         010a7a57ef  2026-08-26
+    #   team_on_strike                 2c418f63a8  2020-09-14
+    #
+    # Attention : la fonctionnalité OCR n'est pas concernée. Elle vit toujours via
+    # OcrService et la colonne active_storage_blobs.ocr ; seul le flag est mort.
+    #
+    # export_with_horodatage est le nom mal orthographié que le code lisait avant
+    # #13717. Absent de la production, mais présent en développement, où la lecture
+    # a créé la ligne. On le nettoie aussi pour aligner les autres instances.
+    #
+    # Flipper.remove supprime la feature et tous ses gates via l'adaptateur
+    # configuré. L'opération est idempotente : une clé absente n'est pas une erreur.
+
+    include RunnableOnDeployConcern
+
+    run_on_first_deploy
+
+    OBSOLETE_FEATURES = [
+      :team_on_strike,
+      :agent_connect_2fa,
+      :referentiel_type_de_champ,
+      :ocr,
+      :analyse_justificatif_domicile,
+      :export_avec_horodatage,
+      :export_with_horodatage,
+      :api_entreprise_tva_job,
+    ].freeze
+
+    def collection
+      OBSOLETE_FEATURES
+    end
+
+    def process(feature_key)
+      Flipper.remove(feature_key)
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20260827_remove_obsolete_flipper_features_task_spec.rb
+++ b/spec/tasks/maintenance/t20260827_remove_obsolete_flipper_features_task_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260827RemoveObsoleteFlipperFeaturesTask do
+    let(:features) { Flipper::Adapters::ActiveRecord::Feature }
+    let(:gates) { Flipper::Adapters::ActiveRecord::Gate }
+
+    # En test l'adaptateur configuré est Flipper::Adapters::Memory, qui n'écrit
+    # rien en base. On bascule sur l'adaptateur ActiveRecord pour exercer le
+    # chemin réel de production. La bascule doit se faire dans un before et non
+    # un around : l'instance Flipper est initialisée paresseusement, et une
+    # affectation trop précoce est écrasée.
+    before do
+      @previous_flipper = Flipper.instance
+      Flipper.instance = Flipper.new(Flipper::Adapters::ActiveRecord.new)
+    end
+
+    after { Flipper.instance = @previous_flipper }
+
+    describe "the list itself" do
+      it 'never targets a flag the code still declares' do
+        declared = Rails.root.join('config/initializers/flipper.rb').read
+          .scan(/^\s*:(\w+),?\s*$/).flatten
+
+        expect(described_class::OBSOLETE_FEATURES.map(&:to_s) & declared).to be_empty
+      end
+    end
+
+    describe "#process" do
+      subject(:process) { described_class::OBSOLETE_FEATURES.each { described_class.process(it) } }
+
+      it 'removes every obsolete row' do
+        described_class::OBSOLETE_FEATURES.each { Flipper.add(it) }
+
+        expect { process }
+          .to change { features.where(key: described_class::OBSOLETE_FEATURES.map(&:to_s)).count }
+          .from(described_class::OBSOLETE_FEATURES.size).to(0)
+      end
+
+      it 'removes the gates left behind by fully-enabled flags' do
+        Flipper.enable(:api_entreprise_tva_job)
+        Flipper.enable_actor(:ocr, users.usager)
+
+        expect { process }
+          .to change { gates.where(feature_key: ['api_entreprise_tva_job', 'ocr']).count }.to(0)
+      end
+
+      it 'leaves the flags still in use alone' do
+        Flipper.add(:switch_domain)
+        Flipper.enable(:switch_domain)
+
+        expect { process }.not_to change { features.where(key: 'switch_domain').count }
+        expect(Flipper.enabled?(:switch_domain)).to be true
+      end
+
+      it 'is idempotent: a key already absent is not an error' do
+        expect { process }.not_to raise_error
+        expect { process }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
`setup_features` ne calcule que `features - existing` et n'appelle que `Flipper.add` : retirer un flag de `config/initializers/flipper.rb` laisse donc sa ligne en base. Elles s'accumulent depuis des années et restent affichées aux opérateurs dans `/manager/features` sans rien piloter.

Relevé en production : 26 lignes pour 19 flags déclarés. Les 7 en trop ne sont plus référencées nulle part dans le code, vérifié au symbole entier.

| Flag | Retiré du code | Commit |
|---|---|---|
| `team_on_strike` | 2020-09-14 | `2c418f63a8` |
| `agent_connect_2fa` | 2025-03-17 | `9f2979a563` |
| `referentiel_type_de_champ` | 2026-02-26 | `43470dae8d` |
| `ocr` | 2026-03-02 | `e7b0017f76` |
| `analyse_justificatif_domicile` | 2026-07-06 | `1f5194ef6a` |
| `export_avec_horodatage` | 2026-08-25 | `607cc40a81` (#13717) |
| `api_entreprise_tva_job` | 2026-08-26 | `010a7a57ef` |

La tâche y ajoute `export_with_horodatage`, le nom mal orthographié que le code lisait avant #13717 : absent de la production, mais présent en développement où la lecture a créé la ligne.

⚠️ **`ocr` ne concerne pas la fonctionnalité OCR**, toujours vivante via `OcrService` et la colonne `active_storage_blobs.ocr`. Seul le flag est mort, depuis `e7b0017f76`.

`Flipper.remove` supprime la feature et tous ses gates via l'adaptateur configuré. La tâche part au premier déploiement et est idempotente : une clé absente n'est pas une erreur, les instances qui n'ont jamais eu ces flags ne bronchent pas.

Une spec garde-fou relit la déclaration et échoue si la liste venait à cibler un flag encore actif.