### PR TITLE
Tech: migre 5 composants courts de HAML vers ERB

### DIFF
--- a/app/components/editable_champ/header_section_component/header_section_component.html.erb
+++ b/app/components/editable_champ/header_section_component/header_section_component.html.erb
@@ -1,0 +1,3 @@
+<%= tag.send(tag_for_depth, class: header_section_classnames, id: @champ.input_group_id) do %>
+  <%= libelle %>
+<% end %>

--- a/app/components/editable_champ/header_section_component/header_section_component.html.haml
+++ b/app/components/editable_champ/header_section_component/header_section_component.html.haml
@@ -1,2 +1,0 @@
-= tag.send(tag_for_depth, class: header_section_classnames, id: @champ.input_group_id) do
-  = libelle

--- a/app/components/nested_forms/form_owner_component/form_owner_component.html.erb
+++ b/app/components/nested_forms/form_owner_component/form_owner_component.html.erb
@@ -1,0 +1,3 @@
+<% HTTP_METHODS.map do |http_method| %>
+  <%= form_tag('/', method: http_method, data: { 'turbo-method': http_method, turbo: true }, id: NestedForms::FormOwnerComponent.form_id(http_method)) {} %>
+<% end %>

--- a/app/components/nested_forms/form_owner_component/form_owner_component.html.haml
+++ b/app/components/nested_forms/form_owner_component/form_owner_component.html.haml
@@ -1,2 +1,0 @@
-- HTTP_METHODS.map do |http_method|
-  = form_tag('/', method: http_method, data: { 'turbo-method': http_method, turbo: true }, id: NestedForms::FormOwnerComponent.form_id(http_method)) {}

--- a/app/components/types_de_champ_editor/add_champ_button_component/add_champ_button_component.html.erb
+++ b/app/components/types_de_champ_editor/add_champ_button_component/add_champ_button_component.html.erb
@@ -1,0 +1,1 @@
+<%= button_to(button_title, admin_procedure_types_de_champ_path(procedure), button_options) %>

--- a/app/components/types_de_champ_editor/add_champ_button_component/add_champ_button_component.html.haml
+++ b/app/components/types_de_champ_editor/add_champ_button_component/add_champ_button_component.html.haml
@@ -1,1 +1,0 @@
-= button_to(button_title, admin_procedure_types_de_champ_path(procedure), button_options)

--- a/app/components/types_de_champ_editor/dossier_link_champ_component/dossier_link_champ_component.html.erb
+++ b/app/components/types_de_champ_editor/dossier_link_champ_component/dossier_link_champ_component.html.erb
@@ -1,0 +1,3 @@
+<react-fragment class="flex-1">
+  <%= render ReactComponent.new "ComboBox/MultiComboBox", **react_props %>
+</react-fragment>

--- a/app/components/types_de_champ_editor/dossier_link_champ_component/dossier_link_champ_component.html.haml
+++ b/app/components/types_de_champ_editor/dossier_link_champ_component/dossier_link_champ_component.html.haml
@@ -1,2 +1,0 @@
-%react-fragment.flex-1
-  = render ReactComponent.new "ComboBox/MultiComboBox", **react_props

--- a/app/components/types_de_champ_editor/select_champ_position_component/select_champ_position_component.html.erb
+++ b/app/components/types_de_champ_editor/select_champ_position_component/select_champ_position_component.html.erb
@@ -1,0 +1,3 @@
+<%= form_with(url: move_and_morph_admin_procedure_type_de_champ_path(@coordinate.revision.procedure, @coordinate.type_de_champ.stable_id), class: 'fr-ml-3w flex', method: :patch, data: { turbo: true }) do |f| %>
+  <%= select_tag :target_stable_id, options_for_select(options), id: describedby_id, class: 'fr-select', data: { 'select-champ-position-template-target': 'select', selected: @coordinate.stable_id } %>
+<% end %>

--- a/app/components/types_de_champ_editor/select_champ_position_component/select_champ_position_component.html.haml
+++ b/app/components/types_de_champ_editor/select_champ_position_component/select_champ_position_component.html.haml
@@ -1,2 +1,0 @@
-= form_with(url: move_and_morph_admin_procedure_type_de_champ_path(@coordinate.revision.procedure, @coordinate.type_de_champ.stable_id), class: 'fr-ml-3w flex', method: :patch, data: { turbo: true }) do |f|
-  = select_tag :target_stable_id, options_for_select(options), id: describedby_id, class: 'fr-select', data: { 'select-champ-position-template-target': 'select', selected: @coordinate.stable_id }


### PR DESCRIPTION
Migration HAML → ERB des cinq plus courts ViewComponents restants (1–2 lignes).

- `TypesDeChampEditor::AddChampButtonComponent`
- `TypesDeChampEditor::DossierLinkChampComponent`
- `EditableChamp::HeaderSectionComponent`
- `NestedForms::FormOwnerComponent`
- `TypesDeChampEditor::SelectChampPositionComponent`

Conversion mécanique via `haml_to_erb` puis `herb-format`, un commit par template, sans aucune retouche manuelle. Le code Ruby est identique au caractère près : aucun de ces templates n'a de hash d'attributs HAML `%tag{…}`, donc aucun des cas où le convertisseur change le rendu. Le seul élément HTML, `%react-fragment.flex-1`, devient `<react-fragment class="flex-1">`.

Trois des cinq contiennent un bloc (`tag.send(…) do`, `form_with(…) do |f|`, `HTTP_METHODS.map do`) ; le `<% end %>` est vérifié en compilant chaque template avec le compilateur ERB d'ActionView.

Vérification : `spec/components`, `spec/system/administrateurs/types_de_champ_spec.rb` et `spec/system/users/brouillon_spec.rb` passent (983 exemples). `FormOwnerComponent` est rendu sur quasiment toutes les pages d'édition, les deux composants de l'éditeur sont couverts par le spec système `types_de_champ`.

Pas de capture d'écran : aucun de ces composants n'a de preview ViewComponent, ils ne se rendent qu'à l'intérieur d'un formulaire ou de l'éditeur de champs.
