### PR TITLE
Tech: corrige le flaky des specs de téléchargement de zip

### DIFF
--- a/spec/support/download_helpers.rb
+++ b/spec/support/download_helpers.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 
 module DownloadHelpers
-  TIMEOUT = 2
+  # Le zip est écrit dans Capybara.save_path pendant que le test attend. On ne
+  # peut pas se contenter de constater sa présence : le fichier final apparaît
+  # avant que le premier octet y soit écrit, et `Zip::File.open` sur un fichier
+  # de 0 octet lève « has zero size ». On attend donc que sa taille soit non
+  # nulle *et* stable d'un tour de boucle à l'autre.
+  TIMEOUT = 5
+  POLL = 0.1
+
+  # Certains navigateurs écrivent d'abord dans un fichier temporaire posé à côté
+  # du fichier final : .crdownload sous Chromium, .part sous Firefox.
+  PARTIAL_EXTENSIONS = ['.crdownload', '.part'].freeze
 
   extend self
 
@@ -20,19 +30,36 @@ module DownloadHelpers
 
   def wait_for_download
     Timeout.timeout(TIMEOUT) do
-      sleep 0.1 until downloaded?
+      previous_sizes = nil
+
+      until downloaded?(previous_sizes)
+        previous_sizes = sizes
+        sleep POLL
+      end
     end
-  end
-
-  def downloaded?
-    !downloading? && downloads.any?
-  end
-
-  def downloading?
-    downloads.grep(/\.part$/).any?
   end
 
   def clear_downloads
     FileUtils.rm_f(downloads)
+  end
+
+  private
+
+  def downloaded?(previous_sizes)
+    return false if downloading?
+
+    current = sizes
+    current.any? && current.all? && current == previous_sizes
+  end
+
+  def downloading?
+    Dir[Capybara.save_path.join("*")]
+      .any? { PARTIAL_EXTENSIONS.include?(File.extname(it)) }
+  end
+
+  # File.size? renvoie nil pour un fichier absent ou vide, ce qui suffit à
+  # disqualifier le tour de boucle sans avoir à gérer ENOENT séparément.
+  def sizes
+    downloads.map { File.size?(it) }
   end
 end


### PR DESCRIPTION
`DownloadHelpers.wait_for_download` rendait la main sur un zip encore vide, ce qui faisait tomber au hasard les specs système qui téléchargent une archive — dont [#13717](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/13717) la semaine dernière :

```
Zip::Error: File .../dossier-73.zip has zero size
```

## Le problème

```ruby
def downloads
  Dir[Capybara.save_path.join("*.zip")]   # ne liste que les .zip
end

def downloading?
  downloads.grep(/\.part$/).any?          # y cherche un .part
end
```

Un fichier ne peut pas se terminer à la fois par `.part` et par `.zip` : la liste fouillée ne pouvait jamais contenir de fichier partiel, donc `downloading?` renvoyait toujours `false`.

`downloaded?` se réduisait alors à « est-ce qu'un `.zip` existe ? ». Or le navigateur crée le fichier final **avant** d'y écrire le premier octet. La boucle sortait au premier tour, et `TIMEOUT = 2` n'y changeait rien : c'est un plafond d'attente, pas un plancher.

## Le correctif

On attend que le zip soit non vide **et** que sa taille cesse de bouger entre deux sondages. C'est indépendant du navigateur, ce qui compte ici puisque Playwright écrit lui-même dans `downloadsPath` et ne passe pas forcément par un fichier temporaire. La détection de `.crdownload` / `.part` est conservée comme garde-fou d'appoint.

`TIMEOUT` passe à 5 s : la stabilisation coûte désormais au moins deux sondages, et ce délai ne concerne que le cas d'un téléchargement réellement bloqué.

## Vérification

Contre une écriture lente simulée, avant/après : l'ancienne version rendait la main en **0,0 s** sur un fichier vide et ne levait jamais de timeout ; la nouvelle attend le contenu et lève si celui-ci n'arrive pas.

Les 20 examples système qui téléchargent un zip passent (`instruction_spec`, `expert_spec`).