### PR TITLE
ETQ admin, récupérer l'historique des réaffectations d'un dossier via l'API

### DIFF
--- a/app/graphql/api/v2/stored_query.rb
+++ b/app/graphql/api/v2/stored_query.rb
@@ -53,6 +53,7 @@ class API::V2::StoredQuery
     $includeCorrections: Boolean = false
     $includeGeometry: Boolean = false
     $includeLabels: Boolean = false
+    $includeAssignments: Boolean = false
   ) {
     demarche(number: $demarcheNumber) {
       id
@@ -170,6 +171,7 @@ class API::V2::StoredQuery
     $includeCorrections: Boolean = false
     $includeGeometry: Boolean = false
     $includeLabels: Boolean = false
+    $includeAssignments: Boolean = false
   ) {
     groupeInstructeur(number: $groupeInstructeurNumber) {
       id
@@ -244,6 +246,7 @@ class API::V2::StoredQuery
     $includeCorrections: Boolean = false
     $includeGeometry: Boolean = false
     $includeLabels: Boolean = false
+    $includeAssignments: Boolean = false
   ) {
     dossier(number: $dossierNumber) {
       ...DossierFragment
@@ -360,6 +363,9 @@ class API::V2::StoredQuery
     labels @include(if: $includeLabels) {
       ...LabelFragment
     }
+    assignments @include(if: $includeAssignments) {
+      ...DossierAssignmentFragment
+    }
   }
 
   fragment DemarcheDescriptorFragment on DemarcheDescriptor {
@@ -398,6 +404,16 @@ class API::V2::StoredQuery
     id
     name
     color
+  }
+
+  fragment DossierAssignmentFragment on DossierAssignment {
+    mode
+    assignedAt
+    assignedBy
+    groupeInstructeurNumber
+    groupeInstructeurLabel
+    previousGroupeInstructeurNumber
+    previousGroupeInstructeurLabel
   }
 
   fragment RevisionFragment on Revision {

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1952,6 +1952,16 @@ type Dossier {
   archived: Boolean!
 
   """
+  Historique des affectations du dossier à un groupe instructeur.
+  """
+  assignments(
+    """
+    Ne retourne que les affectations de ce type.
+    """
+    mode: DossierAssignmentMode
+  ): [DossierAssignment!]!
+
+  """
   L’URL de l’attestation au format PDF.
   """
   attestation: File
@@ -2203,6 +2213,68 @@ type DossierArchiverPayload {
   clientMutationId: String
   dossier: Dossier
   errors: [ValidationError!]
+}
+
+"""
+Une affectation d’un dossier à un groupe instructeur
+"""
+type DossierAssignment {
+  """
+  Date de l’affectation.
+  """
+  assignedAt: ISO8601DateTime!
+
+  """
+  Email de l’agent à l’origine de l’affectation.
+  """
+  assignedBy: String
+
+  """
+  Libellé du groupe instructeur affecté, au moment de l’affectation.
+  """
+  groupeInstructeurLabel: String!
+
+  """
+  Numéro du groupe instructeur affecté. Null si le groupe a depuis été supprimé.
+  """
+  groupeInstructeurNumber: Int
+
+  """
+  Origine de l’affectation.
+  """
+  mode: DossierAssignmentMode!
+
+  """
+  Libellé du groupe instructeur précédent, au moment de l’affectation.
+  """
+  previousGroupeInstructeurLabel: String
+
+  """
+  Numéro du groupe instructeur précédent. Null s’il s’agit de la première affectation ou si le groupe a depuis été supprimé.
+  """
+  previousGroupeInstructeurNumber: Int
+}
+
+enum DossierAssignmentMode {
+  """
+  Affectation par le routage automatique de la démarche
+  """
+  auto
+
+  """
+  Réaffectation en masse suite à une modification du routage
+  """
+  bulk_routing
+
+  """
+  Réaffectation manuelle par un instructeur ou un administrateur
+  """
+  manual
+
+  """
+  Affectation technique effectuée par la plateforme
+  """
+  tech
 }
 
 """

--- a/app/graphql/types/dossier_assignment_type.rb
+++ b/app/graphql/types/dossier_assignment_type.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Types
+  class DossierAssignmentType < Types::BaseObject
+    class DossierAssignmentMode < Types::BaseEnum
+      # i18n-tasks-use t('activerecord.attributes.dossier_assignment.modes.auto'), t('activerecord.attributes.dossier_assignment.modes.manual'), t('activerecord.attributes.dossier_assignment.modes.tech'), t('activerecord.attributes.dossier_assignment.modes.bulk_routing')
+      DossierAssignment.modes.each_key do |mode|
+        value(mode, I18n.t(mode, scope: [:activerecord, :attributes, :dossier_assignment, :modes]), value: mode)
+      end
+    end
+
+    description "Une affectation d’un dossier à un groupe instructeur"
+
+    field :mode, DossierAssignmentMode, "Origine de l’affectation.", null: false
+    field :assigned_at, GraphQL::Types::ISO8601DateTime, "Date de l’affectation.", null: false
+    field :assigned_by, String, "Email de l’agent à l’origine de l’affectation.", null: true
+    field :groupe_instructeur_number, Int, "Numéro du groupe instructeur affecté. Null si le groupe a depuis été supprimé.", null: true, method: :groupe_instructeur_id
+    field :groupe_instructeur_label, String, "Libellé du groupe instructeur affecté, au moment de l’affectation.", null: false
+    field :previous_groupe_instructeur_number, Int, "Numéro du groupe instructeur précédent. Null s’il s’agit de la première affectation ou si le groupe a depuis été supprimé.", null: true, method: :previous_groupe_instructeur_id
+    field :previous_groupe_instructeur_label, String, "Libellé du groupe instructeur précédent, au moment de l’affectation.", null: true
+
+    # les colonnes dénormalisées portent le libellé historique : on ne passe pas
+    # par les associations, qui donneraient le libellé courant (et un N+1).
+    def groupe_instructeur_label = object[:groupe_instructeur_label]
+
+    def previous_groupe_instructeur_label = object[:previous_groupe_instructeur_label]
+  end
+end

--- a/app/graphql/types/dossier_type.rb
+++ b/app/graphql/types/dossier_type.rb
@@ -82,6 +82,9 @@ module Types
       argument :id, ID, required: false
     end
     field :traitements, [Types::TraitementType], null: false
+    field :assignments, [Types::DossierAssignmentType], "Historique des affectations du dossier à un groupe instructeur.", null: false do
+      argument :mode, Types::DossierAssignmentType::DossierAssignmentMode, "Ne retourne que les affectations de ce type.", required: false
+    end
     field :labels, [Types::LabelType], "Labels associés au dossier", null: false
 
     def state
@@ -146,6 +149,11 @@ module Types
 
     def traitements
       dataloader.with(Sources::Association, :traitements).load(object)
+    end
+
+    def assignments(mode: nil)
+      records = dataloader.with(Sources::Association, :dossier_assignments).load(object)
+      mode.present? ? records.filter { it.mode == mode } : records
     end
 
     def messages(id: nil)

--- a/config/locales/models/dossier_assignment/en.yml
+++ b/config/locales/models/dossier_assignment/en.yml
@@ -1,0 +1,9 @@
+en:
+  activerecord:
+    attributes:
+      dossier_assignment:
+        modes:
+          auto: "Assigned by the procedure automatic routing"
+          manual: "Manually reassigned by an instructeur or an administrateur"
+          tech: "Technical assignment performed by the platform"
+          bulk_routing: "Bulk reassignment following a routing change"

--- a/config/locales/models/dossier_assignment/fr.yml
+++ b/config/locales/models/dossier_assignment/fr.yml
@@ -1,0 +1,9 @@
+fr:
+  activerecord:
+    attributes:
+      dossier_assignment:
+        modes:
+          auto: "Affectation par le routage automatique de la démarche"
+          manual: "Réaffectation manuelle par un instructeur ou un administrateur"
+          tech: "Affectation technique effectuée par la plateforme"
+          bulk_routing: "Réaffectation en masse suite à une modification du routage"

--- a/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
@@ -26,7 +26,7 @@ describe API::V2::GraphqlController do
 
   describe 'demarche.dossiers' do
     let(:operation_name) { 'getDemarche' }
-    let(:variables) { { demarcheNumber: procedure.id, includeDossiers: true, includeTraitements: true, includeRevision: true, includeRevisions: true, includeMessages: true } }
+    let(:variables) { { demarcheNumber: procedure.id, includeDossiers: true, includeTraitements: true, includeRevision: true, includeRevisions: true, includeMessages: true, includeAssignments: true } }
     let(:dossier) { create(:dossier, :en_construction, :with_individual, :with_populated_champs, :with_commentaires, procedure:) }
     let(:dossiers_en_instruction) { create_list(:dossier, dossiers_per_state, :en_instruction, :with_individual, :with_populated_champs, :with_commentaires, procedure:) }
     let(:dossiers_accepte) { create_list(:dossier, dossiers_per_state, :accepte, :with_individual, :with_populated_champs, :with_commentaires, procedure:) }

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -207,6 +207,21 @@ describe API::V2::GraphqlController do
         }
       end
 
+      context 'include Assignments' do
+        let(:variables) { { dossierNumber: dossier.id, includeAssignments: true } }
+        let(:groupe_instructeur) { create(:groupe_instructeur, procedure:) }
+
+        before { dossier.assign_to_groupe_instructeur(groupe_instructeur, DossierAssignment.modes.fetch(:manual)) }
+
+        it {
+          expect(gql_errors).to be_nil
+          expect(gql_data[:dossier][:assignments].last).to include(
+            mode: 'manual',
+            groupeInstructeurLabel: groupe_instructeur.label
+          )
+        }
+      end
+
       context 'not found' do
         let(:variables) { { dossierNumber: 0 } }
 

--- a/spec/graphql/dossier_spec.rb
+++ b/spec/graphql/dossier_spec.rb
@@ -502,6 +502,66 @@ RSpec.describe Types::DossierType, type: :graphql do
     }
   end
 
+  describe 'dossier with assignments' do
+    let(:procedure) { create(:procedure, :published, :routee, :for_individual) }
+    let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure:) }
+    let(:instructeur) { create(:instructeur) }
+    let(:autre_groupe) { procedure.groupe_instructeurs.last }
+    let(:query) { DOSSIER_WITH_ASSIGNMENTS_QUERY }
+    let(:variables) { { number: dossier.id } }
+
+    before do
+      dossier.assign_to_groupe_instructeur(autre_groupe, DossierAssignment.modes.fetch(:manual), instructeur)
+      dossier.assign_to_groupe_instructeur(procedure.defaut_groupe_instructeur, DossierAssignment.modes.fetch(:auto))
+    end
+
+    it 'returns the assignment history' do
+      expect(errors).to be_nil
+
+      assignment = data[:dossier][:assignments].find { it[:mode] == 'manual' }
+      expect(assignment).to eq(
+        {
+          mode: 'manual',
+          assignedAt: dossier.dossier_assignments.manual.last.assigned_at.iso8601,
+          assignedBy: instructeur.email,
+          groupeInstructeurNumber: autre_groupe.id,
+          groupeInstructeurLabel: 'deuxième groupe',
+          previousGroupeInstructeurNumber: procedure.defaut_groupe_instructeur.id,
+          previousGroupeInstructeurLabel: procedure.defaut_groupe_instructeur.label,
+        }
+      )
+    end
+
+    it 'returns assignments in chronological order' do
+      expect(data[:dossier][:assignments].map { it[:mode] }.last(2)).to eq(['manual', 'auto'])
+    end
+
+    context 'when filtering on a mode' do
+      let(:variables) { { number: dossier.id, mode: 'manual' } }
+
+      it { expect(data[:dossier][:assignments].map { it[:mode] }).to eq(['manual']) }
+    end
+
+    context 'when the groupe instructeur has been renamed' do
+      before { autre_groupe.update!(label: 'nouveau nom') }
+
+      it 'keeps the label as it was at assignment time' do
+        assignment = data[:dossier][:assignments].find { it[:mode] == 'manual' }
+        expect(assignment[:groupeInstructeurLabel]).to eq('deuxième groupe')
+      end
+    end
+
+    context 'when the groupe instructeur has been deleted' do
+      before { autre_groupe.destroy! }
+
+      it 'keeps the historical label but has no number' do
+        assignment = data[:dossier][:assignments].find { it[:mode] == 'manual' }
+        expect(assignment[:groupeInstructeurNumber]).to be_nil
+        expect(assignment[:groupeInstructeurLabel]).to eq('deuxième groupe')
+      end
+    end
+  end
+
   describe 'dossier with date and datetime champs' do
     let(:procedure) { create(:procedure, :published, public_type_de_champs: [{ type: :date }, { type: :datetime }]) }
     let(:dossier) { create(:dossier, :en_construction, procedure:) }
@@ -1105,6 +1165,22 @@ RSpec.describe Types::DossierType, type: :graphql do
           id
           name
           color
+        }
+      }
+    }
+  GRAPHQL
+
+  DOSSIER_WITH_ASSIGNMENTS_QUERY = <<-GRAPHQL
+    query($number: Int!, $mode: DossierAssignmentMode) {
+      dossier(number: $number) {
+        assignments(mode: $mode) {
+          mode
+          assignedAt
+          assignedBy
+          groupeInstructeurNumber
+          groupeInstructeurLabel
+          previousGroupeInstructeurNumber
+          previousGroupeInstructeurLabel
         }
       }
     }


### PR DESCRIPTION
Suite à une [demande support](https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_4f755ec5-c9f7-4736-855d-794206995c2b/) : un utilisateur de l'API n'a aucun moyen de savoir qu'un dossier a été réaffecté, ni quand. Seul le groupe instructeur courant est exposé, alors que l'historique existe déjà en base (`dossier_assignments`) et est affiché dans l'interface instructeur.

Ajoute un champ `assignments` sur `Dossier` :

```graphql
assignments(mode: manual) {
  mode
  assignedAt
  assignedBy
  previousGroupeInstructeurNumber
  previousGroupeInstructeurLabel
  groupeInstructeurNumber
  groupeInstructeurLabel
}
```
