### PR TITLE
Tech: renomme ExpertMailer#send_dossier_decision_v2

### DIFF
--- a/app/mailers/expert_mailer.rb
+++ b/app/mailers/expert_mailer.rb
@@ -3,17 +3,6 @@
 class ExpertMailer < ApplicationMailer
   layout 'mailers/layout'
 
-  # TODO: replace with v2 after MEP
-  def send_dossier_decision(avis_id)
-    @avis = Avis.eager_load(:dossier).find(avis_id)
-    @dossier = @avis.dossier
-    email = @avis.expert.email
-    @decision = decision_dossier(@dossier)
-    subject = t('.subject', dossier_id: @dossier.id, decision: @decision, libelle: @dossier.procedure.libelle)
-
-    mail(to: email, subject: subject)
-  end
-
   def send_dossier_decision_v2(avis)
     @avis = avis
     @dossier = @avis.dossier

--- a/app/mailers/expert_mailer.rb
+++ b/app/mailers/expert_mailer.rb
@@ -3,15 +3,20 @@
 class ExpertMailer < ApplicationMailer
   layout 'mailers/layout'
 
-  def send_dossier_decision_v2(avis)
+  def send_dossier_decision(avis)
     @avis = avis
     @dossier = @avis.dossier
     email = @avis.expert.email
     @decision = decision_dossier(@dossier)
-    subject = t('expert_mailer.send_dossier_decision.subject', dossier_id: @dossier.id, decision: @decision, libelle: @dossier.procedure.libelle)
+    subject = t('.subject', dossier_id: @dossier.id, decision: @decision, libelle: @dossier.procedure.libelle)
 
-    mail(template_name: 'send_dossier_decision', to: email, subject: subject)
+    mail(to: email, subject:)
   end
+
+  # Compat shim consuming the delivery jobs enqueued under the old action name
+  # before this rename was deployed. Remove once the Sidekiq retry set has
+  # drained (~3 weeks, the default 25 retries of PriorizedMailDeliveryJob).
+  def self.send_dossier_decision_v2(avis) = send_dossier_decision(avis)
 
   def self.critical_email?(action_name)
     false

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1276,7 +1276,7 @@ class Dossier < ApplicationRecord
       .then { |avis_ids| Avis.find(avis_ids) }
     # rubocop:enable Lint/UnusedBlockArgument
 
-    avis.each { |a| ExpertMailer.send_dossier_decision_v2(a).deliver_later }
+    avis.each { |a| ExpertMailer.send_dossier_decision(a).deliver_later }
   end
 
   def log_destroy

--- a/spec/mailers/expert_mailer_spec.rb
+++ b/spec/mailers/expert_mailer_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe ExpertMailer, type: :mailer do
+  describe '.send_dossier_decision' do
+    let(:mail) { described_class.send_dossier_decision(avis.answered).deliver_now }
+
+    it 'is addressed to the expert who gave the avis' do
+      expect(mail.to).to eq([experts.default.email])
+    end
+
+    it 'announces the decision in the subject' do
+      decision = I18n.t('users.dossiers.attestation_depot.states.accepte')
+
+      expect(mail.subject).to eq("Dossier n° #{dossiers.accepte.id} a été #{decision} - #{procedures.individual.libelle}")
+    end
+
+    it 'renders the send_dossier_decision template' do
+      body = mail.html_part.body.to_s
+
+      expect(body).to include(dossiers.accepte.id.to_s)
+      expect(body).to include(I18n.t('users.dossiers.attestation_depot.states.accepte'))
+    end
+  end
+
+  # TODO: remove alongside the ExpertMailer.send_dossier_decision_v2 shim, once
+  # the mail delivery jobs enqueued under the old action name have drained.
+  describe '.send_dossier_decision_v2 (compat shim)' do
+    it 'delivers the same mail as the new action name' do
+      shimmed = described_class.send_dossier_decision_v2(avis.answered).deliver_now
+      renamed = described_class.send_dossier_decision(avis.answered).deliver_now
+
+      expect(shimmed.to).to eq(renamed.to)
+      expect(shimmed.subject).to eq(renamed.subject)
+      expect(shimmed.html_part.body.to_s).to eq(renamed.html_part.body.to_s)
+    end
+
+    it 'lets a delivery job enqueued under the old action name go through' do
+      expect { PriorizedMailDeliveryJob.perform_now('ExpertMailer', 'send_dossier_decision_v2', 'deliver_now', args: [avis.answered]) }
+        .to change { ActionMailer::Base.deliveries.size }.by(1)
+    end
+  end
+end

--- a/spec/mailers/previews/expert_mailer_preview.rb
+++ b/spec/mailers/previews/expert_mailer_preview.rb
@@ -12,6 +12,6 @@ class ExpertMailerPreview < ActionMailer::Preview
 
     avis = Avis.new(id: 1, email: 'test@exemple.fr', claimant: instructeur, dossier:, experts_procedure:, expert:)
 
-    ExpertMailer.send_dossier_decision_v2(avis)
+    ExpertMailer.send_dossier_decision(avis)
   end
 end


### PR DESCRIPTION
Le suffixe `_v2` d'`ExpertMailer` datait du passage d'un `avis_id` à l'objet `avis` sérialisé par GlobalID (2022). La transition est finie depuis longtemps, mais le nom est resté et traînait deux contournements : un `template_name:` explicite et une clé i18n qualifiée au lieu du `t('.subject')` relatif.

## Changements

- Suppression de la v1 morte `send_dossier_decision(avis_id)`, marquée `# TODO: replace with v2 after MEP` depuis octobre 2022 et sans aucun appelant.
- `send_dossier_decision_v2` reprend le nom `send_dossier_decision` : le template et la clé i18n se résolvent à nouveau implicitement.
- `ExpertMailer` n'avait aucun spec — ajout de `spec/mailers/expert_mailer_spec.rb` (seeds Oaken).

## Le shim, et pourquoi il y a une PR de suivi

`deliver_later` sérialise le nom de l'action dans le job. Un job encore en file au moment de la MEP lèverait un `NoMethodError` après le renommage — et `PriorizedMailDeliveryJob` hérite d'`ActionMailer::MailDeliveryJob`, pas d'`ApplicationJob` : il retombe donc sur le retry Sidekiq par défaut, 25 tentatives étalées sur ~3 semaines.

`ExpertMailer.send_dossier_decision_v2` reste donc en place comme shim de compatibilité, en méthode de classe pour ne pas entrer dans `action_methods`. Un spec vérifie qu'un job enfilé sous l'ancien nom passe bien par `PriorizedMailDeliveryJob`.

Le retrait du shim fait l'objet de la PR #13746, à ne merger qu'après épuisement de la fenêtre de retry.