### PR TITLE
[WIP] Tech: supprime le shim ExpertMailer#send_dossier_decision_v2

### DIFF
--- a/app/mailers/expert_mailer.rb
+++ b/app/mailers/expert_mailer.rb
@@ -13,11 +13,6 @@ class ExpertMailer < ApplicationMailer
     mail(to: email, subject:)
   end
 
-  # Compat shim consuming the delivery jobs enqueued under the old action name
-  # before this rename was deployed. Remove once the Sidekiq retry set has
-  # drained (~3 weeks, the default 25 retries of PriorizedMailDeliveryJob).
-  def self.send_dossier_decision_v2(avis) = send_dossier_decision(avis)
-
   def self.critical_email?(action_name)
     false
   end

--- a/spec/mailers/expert_mailer_spec.rb
+++ b/spec/mailers/expert_mailer_spec.rb
@@ -21,22 +21,4 @@ RSpec.describe ExpertMailer, type: :mailer do
       expect(body).to include(I18n.t('users.dossiers.attestation_depot.states.accepte'))
     end
   end
-
-  # TODO: remove alongside the ExpertMailer.send_dossier_decision_v2 shim, once
-  # the mail delivery jobs enqueued under the old action name have drained.
-  describe '.send_dossier_decision_v2 (compat shim)' do
-    it 'delivers the same mail as the new action name' do
-      shimmed = described_class.send_dossier_decision_v2(avis.answered).deliver_now
-      renamed = described_class.send_dossier_decision(avis.answered).deliver_now
-
-      expect(shimmed.to).to eq(renamed.to)
-      expect(shimmed.subject).to eq(renamed.subject)
-      expect(shimmed.html_part.body.to_s).to eq(renamed.html_part.body.to_s)
-    end
-
-    it 'lets a delivery job enqueued under the old action name go through' do
-      expect { PriorizedMailDeliveryJob.perform_now('ExpertMailer', 'send_dossier_decision_v2', 'deliver_now', args: [avis.answered]) }
-        .to change { ActionMailer::Base.deliveries.size }.by(1)
-    end
-  end
 end


### PR DESCRIPTION
Suite de #13745. Retire le shim de compatibilité `ExpertMailer.send_dossier_decision_v2` et le spec qui le couvre.

## ⛔ Ne pas merger avant

**21 jours après la mise en production de #13745**, et pas avant.

Le shim consomme les jobs de livraison enfilés sous l'ancien nom d'action. `PriorizedMailDeliveryJob` hérite d'`ActionMailer::MailDeliveryJob` et non d'`ApplicationJob` : il retombe donc sur le retry Sidekiq par défaut, soit 25 tentatives étalées sur ~21 jours. Tant que cette fenêtre n'est pas close, un job peut encore porter `send_dossier_decision_v2` et lèverait un `NoMethodError`.

- MEP de #13745 : `à compléter`
- Mergeable à partir du : `à compléter (MEP + 21 j)`

## Vérification à lancer avant merge

En console Rails sur la prod :

```ruby
require 'sidekiq/api'

stale = ->(set) { set.count { |job| job.value.include?('send_dossier_decision_v2') } }

{
  'queue:default'  => stale[Sidekiq::Queue.new('default')],
  'queue:critical' => stale[Sidekiq::Queue.new('critical')],
  'retry'          => stale[Sidekiq::RetrySet.new],
  'scheduled'      => stale[Sidekiq::ScheduledSet.new],
  'dead'           => stale[Sidekiq::DeadSet.new]
}
```

Attendu : `0` partout. `job.value` est la charge utile JSON brute du job — la recherche par sous-chaîne est donc insensible au format exact de sérialisation d'ActiveJob.

> [!WARNING]
> Le shim n'existe que sur la branche de #13745, donc cette branche porte forcément aussi ses 2 commits : **tant que #13745 n'est pas mergée, le diff ci-dessous montre 3 commits**, et merger cette PR en premier embarquerait le renommage. Une fois #13745 mergée dans `main`, le diff se réduit tout seul aux 23 lignes supprimées du shim.