### PR TITLE
ETQ usager, corrige la saisie des départements Ain/Lot/Var, des EPCI et du mode « Autre » des listes déroulantes

### DIFF
--- a/app/models/champs/drop_down_list_champ.rb
+++ b/app/models/champs/drop_down_list_champ.rb
@@ -50,7 +50,9 @@ class Champs::DropDownListChamp < ChampData
       self.other = true
       write_attribute(:value, nil)
     else
-      self.other = false
+      # a re-assignment of the current value is a replay (normalization, clone),
+      # not a user selection: it must not leave the "other" mode
+      self.other = false if value != read_attribute(:value)
       write_attribute(:value, value)
     end
   end

--- a/app/models/champs/epci_champ.rb
+++ b/app/models/champs/epci_champ.rb
@@ -59,13 +59,13 @@ class Champs::EpciChamp < Champs::TextChamp
     code
   end
 
-  def value=(code)
-    if code.blank? || !departement?
+  def value=(code_or_name)
+    if code_or_name.blank? || !departement?
       self.external_id = nil
       super(nil)
     else
-      self.external_id = code
-      super(APIGeoService.epci_name(code_departement, code))
+      self.external_id = APIGeoService.epci_code(code_departement, code_or_name) || code_or_name
+      super(APIGeoService.epci_name(code_departement, external_id))
     end
   end
 

--- a/app/services/api_geo_service.rb
+++ b/app/services/api_geo_service.rb
@@ -114,12 +114,16 @@ class APIGeoService
       departements.find { _1[:name] == name }&.dig(:code)
     end
 
-    # A 2 or 3 characters input is treated as a departement code, anything
-    # else as a departement name.
+    # A 2 or 3 characters input matching a departement code is treated as
+    # such, anything else as a departement name (Ain, Lot and Var are 3
+    # characters long).
     def resolve_departement(input)
-      if [2, 3].include?(input&.size)
-        Resolution.new(code: input, name: departement_name(input))
-      elsif input.present?
+      return if input.blank?
+
+      name = departement_name(input) if [2, 3].include?(input.size)
+      if name
+        Resolution.new(code: input, name:)
+      else
         Resolution.new(code: departement_code(input), name: input)
       end
     end

--- a/spec/models/champs/departement_champ_spec.rb
+++ b/spec/models/champs/departement_champ_spec.rb
@@ -94,6 +94,18 @@ describe Champs::DepartementChamp, type: :model do
       expect(champ.to_s).to eq('2B – Haute-Corse')
     end
 
+    it 'with a name as short as a code' do
+      champ.value = 'Var'
+      expect(champ).to have_attributes(external_id: '83', value: 'Var')
+    end
+
+    it 'with a name as short as a code, once saved' do
+      champ.value = '83'
+      expect(champ.value).to eq('Var')
+      champ.save!
+      expect(champ.reload).to have_attributes(external_id: '83', value: 'Var')
+    end
+
     it 'with nil' do
       champ.write_attribute(:value, 'Ain')
       champ.write_attribute(:external_id, '01')

--- a/spec/models/champs/drop_down_list_champ_spec.rb
+++ b/spec/models/champs/drop_down_list_champ_spec.rb
@@ -60,6 +60,23 @@ describe Champs::DropDownListChamp do
     end
   end
 
+  describe 'value' do
+    let(:other) { true }
+
+    it 'keeps the other flag when the free text is reassigned' do
+      champ.value = Champs::DropDownListChamp::OTHER
+      champ.value_other = 'something else'
+      champ.value = champ.value
+      expect(champ).to have_attributes(value: 'something else', other: true)
+    end
+
+    it 'leaves the other mode when an option is selected' do
+      champ.value = 'val1'
+      champ.save!
+      expect(champ.reload).to have_attributes(value: 'val1', other: false)
+    end
+  end
+
   describe '#drop_down_other?' do
     context 'when drop_down_other is nil' do
       it do

--- a/spec/models/champs/epci_champ_spec.rb
+++ b/spec/models/champs/epci_champ_spec.rb
@@ -163,6 +163,20 @@ describe Champs::EpciChamp, type: :model do
       expect(champ.departement?).to be_truthy
       expect(champ.to_s).to eq(epci[:name])
     end
+
+    it 'with departement and name' do
+      champ.code_departement = '01'
+      champ.value = epci[:name]
+      expect(champ).to have_attributes(external_id: epci[:code], value: epci[:name])
+    end
+
+    it 'with departement and code, once saved' do
+      champ.update!(code_departement: '01')
+      champ.value = epci[:code]
+      expect(champ.value).to eq(epci[:name])
+      champ.save!
+      expect(champ.reload).to have_attributes(external_id: epci[:code], value: epci[:name])
+    end
   end
 
   describe 'double-write of canonical value_json keys' do

--- a/spec/models/champs/region_champ_spec.rb
+++ b/spec/models/champs/region_champ_spec.rb
@@ -73,6 +73,11 @@ describe Champs::RegionChamp, type: :model do
       expect(champ.to_s).to eq('Guadeloupe')
     end
 
+    it 'with name' do
+      champ.value = 'Auvergne-Rhône-Alpes'
+      expect(champ).to have_attributes(external_id: '84', value: 'Auvergne-Rhône-Alpes')
+    end
+
     it 'with nil' do
       champ.write_attribute(:value, 'Guadeloupe')
       champ.write_attribute(:external_id, '01')

--- a/spec/services/api_geo_service_spec.rb
+++ b/spec/services/api_geo_service_spec.rb
@@ -65,10 +65,11 @@ describe APIGeoService do
 
     it 'resolves a name to its code' do
       expect(APIGeoService.resolve_departement('Aisne')).to have_attributes(code: '02', name: 'Aisne', resolved?: true)
+      expect(APIGeoService.resolve_departement('Var')).to have_attributes(code: '83', name: 'Var', resolved?: true)
     end
 
     it 'keeps an unknown code or name partially resolved' do
-      expect(APIGeoService.resolve_departement('00')).to have_attributes(code: '00', name: nil, resolved?: false)
+      expect(APIGeoService.resolve_departement('00')).to have_attributes(code: nil, name: '00', resolved?: false)
       expect(APIGeoService.resolve_departement('value')).to have_attributes(code: nil, name: 'value', resolved?: false)
     end
 


### PR DESCRIPTION
Depuis la [montée en Rails 8.1](https://github.com/demarche-numerique/demarche.numerique.gouv.fr/releases/tag/2026-08-26-02) : 
- **champ département** : sélectionner « 83 – Var »  (ou autre département de 3 lettres) affiche l'erreur « _doit être un code de département valide_ »
- **champ EPCI**: les EPCI saisis sont enregistrés avec un `external_id` contenant le nom de l'EPCI au lieu de son code, et une `value` vide — le champ se vide silencieusement, sans message d'erreur.
- **champ liste déroulante avec « Autre »** : le flag `other` est réenregistré à `false` alors que l'usager est en mode « _Autre_ ». Sans effet visible dans la quasi-totalité des cas — `other?` retombe sur « _la valeur n'est pas dans les options_ » — sauf si le texte libre est identique à une option : le champ s'affiche alors comme une sélection normale. Aucune donnée perdue.

Cause: Certains de nos writers customs d'attributs n'étaient pas idempotents, et les changements internes de rails révèlent ce problème à cause de la normalisation qu'on fait sur `value`. (maintenant la normalisation repasse par le setter public)

Le correctif rend ces writers idempotents.

Conséquences :
- `APIGeoService.resolve_departement` ne traite plus un input de 2-3 caractères comme un code que s'il en est un ; un nom court (Ain, Lot, Var) est résolu comme nom. Un input court inconnu est désormais rapporté comme nom invalide plutôt que code invalide.
- `Champs::EpciChamp#value=` accepte un nom d'EPCI en plus de son code.

À noter : le coté encore plus étrange : en rails 8.1.3 le bug dépend de l'ordre des colonnes renvoyés par PG (corrigé en futur rails 8.1.4), donc le bug n'est reproductible ni chez moi ni en CI. Le déclencheur (`normalize_changed_in_place_attributes`) exige que `value` ait été lue, or `has_changes_to_save?` s'arrête au premier attribut modifié dans l'ordre physique des colonnes — `value` est en tête en production, mais loin derrière `external_id` sur une base recréée depuis `schema.rb`, que Rails 8.1 redump par ordre alphabétique. Les tests ajoutés vérifient donc l'idempotence explicitement, par ré-affectation.

La réparation des données déjà corrompues fera l'objet d'une tâche de maintenance à part.