### PR TITLE
Tech : répare les champs département et EPCI corrompus par Rails 8.1

### DIFF
--- a/app/tasks/maintenance/t20260828_repair_departement_and_epci_champs_task.rb
+++ b/app/tasks/maintenance/t20260828_repair_departement_and_epci_champs_task.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260828RepairDepartementAndEpciChampsTask < MaintenanceTasks::Task
+    # Entre la mise en production de Rails 8.1 et son correctif, la
+    # normalisation de `value` repassait par les accesseurs publics : les
+    # writers des champs département et EPCI étaient rappelés avec leur propre
+    # sortie — un nom — et la ré-interprétaient comme un code, laissant le nom
+    # dans `external_id` et une `value` vide.
+    #
+    # `index_champs_on_type` imposerait une seule requête de plusieurs minutes,
+    # ni `external_id` ni `value` n'étant indexés : le découpage par stable_id
+    # borne chaque requête. Compter ~15 min de balayage, rejoué à chaque
+    # reprise du job.
+
+    include StatementsHelpersConcern
+
+    # mise en production de Rails 8.1 ; pas de borne haute, un buffer fusionné,
+    # un dossier cloné ou un simple ré-enregistrement donnent à une ligne
+    # corrompue un `updated_at` postérieur au correctif sans la réparer
+    CORRUPTED_SINCE = '2026-08-26 12:30'
+    DEPARTEMENT_NAMES_AS_SHORT_AS_A_CODE = %w[Ain Lot Var].freeze
+    EPCI_CODE_FORMAT = '^[0-9]{9}$'
+    SLICE_SIZE = 50
+    SLICE_TIMEOUT = '5min'
+
+    def collection
+      ChampData.where(id: corrupted_departement_ids + corrupted_epci_ids)
+    end
+
+    def process(champ)
+      case champ
+      when Champs::DepartementChamp then repair_departement(champ)
+      when Champs::EpciChamp then repair_epci(champ)
+      end
+    end
+
+    private
+
+    def corrupted_departement_ids
+      corrupted_ids(:departements, ChampData.where(value: nil, external_id: DEPARTEMENT_NAMES_AS_SHORT_AS_A_CODE))
+    end
+
+    def corrupted_epci_ids
+      corrupted_ids(:epci, ChampData.where(value: nil).where.not(external_id: [nil, '']).where("external_id !~ ?", EPCI_CODE_FORMAT))
+    end
+
+    def corrupted_ids(type_champ, corrupted)
+      corrupted = corrupted.where(updated_at: Time.zone.parse(CORRUPTED_SINCE)..)
+
+      stable_ids(type_champ).each_slice(SLICE_SIZE).flat_map do |slice|
+        with_statement_timeout(SLICE_TIMEOUT) { corrupted.where(stable_id: slice).pluck(:id) }
+      end
+    end
+
+    def stable_ids(type_champ)
+      TypeDeChamp.where(type_champ:).distinct.pluck(:stable_id).compact
+    end
+
+    def repair_departement(champ)
+      name = champ.external_id
+      code = APIGeoService.departement_code(name)
+      return if code.nil?
+
+      region_code = APIGeoService.region_code_by_departement(code)
+
+      champ.update_columns(
+        external_id: code,
+        value: name,
+        value_json: champ.value_json.to_h.merge('department_code' => code, 'region_code' => region_code, 'code_region' => region_code)
+      )
+      champ.dossier.index_search_terms_later
+    end
+
+    def repair_epci(champ)
+      # APIGeoService.epcis lève sans département exploitable
+      return if champ.code_departement.blank? || champ.code_departement == '99'
+
+      name = champ.external_id
+      code = APIGeoService.epci_code(champ.code_departement, name)
+      return if code.nil?
+
+      champ.update_columns(external_id: code, value: name)
+      champ.dossier.index_search_terms_later
+    end
+  end
+end

--- a/spec/tasks/maintenance/t20260828_repair_departement_and_epci_champs_task_spec.rb
+++ b/spec/tasks/maintenance/t20260828_repair_departement_and_epci_champs_task_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260828RepairDepartementAndEpciChampsTask do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :departements }, { type: :epci }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:departement_champ) { dossier.root_champs_public.find { _1.is_a?(Champs::DepartementChamp) } }
+    let(:epci_champ) { dossier.root_champs_public.find { _1.is_a?(Champs::EpciChamp) } }
+    let(:epci) { APIGeoService.epcis('01').first }
+    let(:during_incident) { Time.zone.parse('2026-08-27 10:00') }
+
+    def corrupt(champ, attributes)
+      champ.update_columns(attributes.merge(value: nil, updated_at: during_incident))
+    end
+
+    describe '#collection' do
+      it 'finds the corrupted champs' do
+        corrupt(departement_champ, external_id: 'Var')
+        corrupt(epci_champ, external_id: epci[:name])
+
+        expect(described_class.new.collection).to contain_exactly(departement_champ, epci_champ)
+      end
+
+      it 'ignores champs untouched since the incident started' do
+        corrupt(departement_champ, external_id: 'Var')
+        departement_champ.update_columns(updated_at: Time.zone.parse('2026-08-20 10:00'))
+
+        expect(described_class.new.collection).to be_empty
+      end
+    end
+
+    describe '#process' do
+      it 'restores the departement code and name' do
+        corrupt(departement_champ, external_id: 'Var', value_json: { 'code_region' => nil, 'region_code' => nil, 'department_code' => 'Var' })
+
+        described_class.process(departement_champ)
+
+        expect(departement_champ.reload).to have_attributes(external_id: '83', value: 'Var')
+        expect(departement_champ.value_json).to include('department_code' => '83', 'region_code' => '93', 'code_region' => '93')
+      end
+
+      it 'restores the EPCI code and name' do
+        epci_champ.update!(code_departement: '01')
+        corrupt(epci_champ, external_id: epci[:name])
+
+        described_class.process(epci_champ)
+
+        expect(epci_champ.reload).to have_attributes(external_id: epci[:code], value: epci[:name])
+      end
+
+      it 'leaves an EPCI without departement untouched' do
+        corrupt(epci_champ, external_id: 'CA Haut-Bugey Agglomération')
+
+        expect { described_class.process(epci_champ) }.not_to raise_error
+        expect(epci_champ.reload.value).to be_nil
+      end
+
+      it 'leaves an EPCI missing from the referentiel untouched' do
+        epci_champ.update!(code_departement: '01')
+        corrupt(epci_champ, external_id: 'CC Disparue')
+
+        described_class.process(epci_champ)
+
+        expect(epci_champ.reload).to have_attributes(external_id: 'CC Disparue', value: nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Suite de #13749, qui corrigeait la cause. Cette tâche de maintenance répare les lignes déjà abîmées : les champs département (Ain, Lot, Var) et EPCI saisis entre la mise en production de Rails 8.1 et celle du correctif portent le nom dans `external_id` et une `value` vide.

Comptés en production avant le correctif : 128 champs data département et 21 EPCI.

Quelques points pour la relecture :

- **Le balayage passe par les `stable_id` des types de champ concernés**, pas par `index_champs_on_type` : ni `external_id` ni `value` ne sont indexés, et une requête unique sur des millions de lignes ne tiendrait pas dans le `statement_timeout`. Le découpage en tranches de 50 `stable_id` borne chaque requête — mesuré à ~15 min au total, avec ~4 000 `stable_id` pour les départements.
- **`collection` renvoie une Relation** et non un tableau d'ids : le curseur de reprise de MaintenanceTasks porte alors sur la clé primaire. Avec un tableau, le curseur est un index de position et la collection est recalculée à chaque reprise — les lignes réparées en sortent, la liste rétrécit, et des lignes non traitées seraient sautées.
- **Pas de borne haute sur `updated_at`** : un buffer fusionné, un dossier cloné ou un simple ré-enregistrement donnent à une ligne corrompue un `updated_at` postérieur au correctif sans la réparer pour autant.
- **La réparation écrit en `update_columns`** pour ne pas toucher le dossier ni `value_updated_at`, qui ne date que les saisies usager. Un champ réparé est identique, attribut par attribut, à un champ correctement saisi — y compris les clés de `value_json`. La recherche est réindexée, un EPCI corrompu produisant des `search_terms` vides.
- Les lignes qu'aucun code ne résout (EPCI renommé ou fusionné depuis la saisie) sont laissées en l'état et loggées.

Lancement manuel après déploiement ; la tâche est ré-exécutable sans risque de double réparation.