### PR TITLE
[WIP] ETQ usager, je peux suivre mes démarches dans l'application AMI

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -49,3 +49,8 @@ S3_BUCKET=a_bucket
 S3_FORCE_PATH_STYLE="true"
 S3_ENDPOINT="http://a_endpoint.com"
 
+
+# AMI is never reached from the test suite: dotenv also loads a real .env locally
+AMI_API_URL=""
+AMI_API_USER=""
+AMI_API_PASSWORD=""

--- a/app/assets/images/ami/illustration.svg
+++ b/app/assets/images/ami/illustration.svg
@@ -1,0 +1,13 @@
+<!-- Illustration provisoire, en attente de l'asset définitif fourni par AMI -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" width="96" height="96" role="presentation" focusable="false">
+  <rect x="20" y="8" width="42" height="80" rx="6" fill="none" stroke="#000091" stroke-width="3" />
+  <rect x="27" y="20" width="28" height="4" rx="2" fill="#000091" />
+  <rect x="27" y="30" width="28" height="4" rx="2" fill="#000091" opacity="0.5" />
+  <rect x="27" y="40" width="18" height="4" rx="2" fill="#000091" opacity="0.5" />
+  <circle cx="41" cy="78" r="3" fill="#000091" />
+  <g transform="translate(58 46)">
+    <rect width="8" height="24" fill="#000091" />
+    <rect x="8" width="8" height="24" fill="#FFFFFF" stroke="#CECECE" stroke-width="0.5" />
+    <rect x="16" width="8" height="24" fill="#E1000F" />
+  </g>
+</svg>

--- a/app/assets/stylesheets/ami_follow.scss
+++ b/app/assets/stylesheets/ami_follow.scss
@@ -24,3 +24,37 @@
     text-align: center;
   }
 }
+
+// Réserve la place de la ligne de consentement pendant son chargement, pour
+// que l'encart ne se remplisse pas par à-coups.
+.ami-consent__skeleton {
+  display: block;
+  width: 16rem;
+  max-width: 100%;
+  height: 1.5rem;
+  border-radius: 0.25rem;
+  background-color: var(--background-contrast-grey);
+  background-image: linear-gradient(
+    90deg,
+    transparent,
+    var(--background-default-grey),
+    transparent
+  );
+  background-repeat: no-repeat;
+  background-size: 50% 100%;
+  animation: ami-consent-skeleton 1.4s ease-in-out infinite;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+@keyframes ami-consent-skeleton {
+  0% {
+    background-position: -100% 0;
+  }
+
+  100% {
+    background-position: 200% 0;
+  }
+}

--- a/app/assets/stylesheets/ami_follow.scss
+++ b/app/assets/stylesheets/ami_follow.scss
@@ -1,0 +1,26 @@
+.ami-follow {
+  border: 1px solid var(--border-default-grey);
+
+  &__intro {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    text-align: center;
+    background-color: var(--background-alt-blue-france);
+  }
+
+  &__illustration {
+    width: 6rem;
+    height: auto;
+  }
+
+  &__actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+}

--- a/app/components/dossiers/ami_consent_state_component.rb
+++ b/app/components/dossiers/ami_consent_state_component.rb
@@ -7,11 +7,15 @@ class Dossiers::AmiConsentStateComponent < ApplicationComponent
   # :unavailable quand on ne peut pas lui demander
   STATUSES = [:loading, :granted, :not_granted, :unknown, :unavailable].freeze
 
-  def initialize(status:, error: false, focus: false)
+  def initialize(status:, dossier: nil, error: false, focus: false)
     @status = status
+    @dossier = dossier
     @error = error
     @focus = focus
   end
+
+  # Le consentement se donne en envoyant l'événement du dossier affiché.
+  def form_path = create_ami_consent_dossier_path(@dossier)
 
   def render? = @status != :unavailable
 

--- a/app/components/dossiers/ami_consent_state_component.rb
+++ b/app/components/dossiers/ami_consent_state_component.rb
@@ -5,7 +5,7 @@
 class Dossiers::AmiConsentStateComponent < ApplicationComponent
   # :loading tant qu'AMI n'a pas répondu, :unknown quand il n'a pas su répondre,
   # :unavailable quand on ne peut pas lui demander
-  STATUSES = [:loading, :granted, :not_granted, :unknown, :unavailable].freeze
+  STATUSES = [:loading, :granted, :not_granted, :unknown, :unavailable, :error].freeze
 
   def initialize(status:, dossier: nil, focus: false)
     @status = status
@@ -21,6 +21,8 @@ class Dossiers::AmiConsentStateComponent < ApplicationComponent
   def loading? = @status == :loading
 
   def granted? = @status == :granted
+
+  def error? = @status == :error
 
   def app_name = Ami::APP_NAME
 

--- a/app/components/dossiers/ami_consent_state_component.rb
+++ b/app/components/dossiers/ami_consent_state_component.rb
@@ -3,17 +3,17 @@
 # Partie de l'encart AMI qui dépend du consentement de l'usager : elle est
 # chargée puis rafraîchie dans un turbo-frame, l'état venant d'AMI.
 class Dossiers::AmiConsentStateComponent < ApplicationComponent
-  # :loading tant qu'AMI n'a pas répondu, :unknown quand il n'a pas su répondre,
-  # :unavailable quand on ne peut pas lui demander
-  STATUSES = [:loading, :granted, :not_granted, :unknown, :unavailable, :error].freeze
-
+  # status vient de Ami::ConsentStatus (:loading tant qu'AMI n'a pas répondu,
+  # :unknown quand il n'a pas su répondre, :unavailable quand on ne peut pas lui
+  # demander) ou de Ami::GrantConsent (:error quand l'écriture a échoué).
   def initialize(status:, dossier: nil, focus: false)
     @status = status
     @dossier = dossier
     @focus = focus
   end
 
-  # Le consentement se donne en envoyant l'événement du dossier affiché.
+  # Le consentement vaut pour toutes les démarches, mais se donne depuis le
+  # dossier affiché, dont l'événement suit l'acceptation.
   def form_path = create_ami_consent_dossier_path(@dossier)
 
   def render? = @status != :unavailable

--- a/app/components/dossiers/ami_consent_state_component.rb
+++ b/app/components/dossiers/ami_consent_state_component.rb
@@ -3,14 +3,17 @@
 # Partie de l'encart AMI qui dépend du consentement de l'usager : elle est
 # chargée puis rafraîchie dans un turbo-frame, l'état venant d'AMI.
 class Dossiers::AmiConsentStateComponent < ApplicationComponent
-  # :loading tant qu'AMI n'a pas répondu, :unknown quand il n'a pas su répondre
-  STATUSES = [:loading, :granted, :not_granted, :unknown].freeze
+  # :loading tant qu'AMI n'a pas répondu, :unknown quand il n'a pas su répondre,
+  # :unavailable quand on ne peut pas lui demander
+  STATUSES = [:loading, :granted, :not_granted, :unknown, :unavailable].freeze
 
   def initialize(status:, error: false, focus: false)
     @status = status
     @error = error
     @focus = focus
   end
+
+  def render? = @status != :unavailable
 
   def loading? = @status == :loading
 

--- a/app/components/dossiers/ami_consent_state_component.rb
+++ b/app/components/dossiers/ami_consent_state_component.rb
@@ -7,10 +7,9 @@ class Dossiers::AmiConsentStateComponent < ApplicationComponent
   # :unavailable quand on ne peut pas lui demander
   STATUSES = [:loading, :granted, :not_granted, :unknown, :unavailable].freeze
 
-  def initialize(status:, dossier: nil, error: false, focus: false)
+  def initialize(status:, dossier: nil, focus: false)
     @status = status
     @dossier = dossier
-    @error = error
     @focus = focus
   end
 
@@ -22,8 +21,6 @@ class Dossiers::AmiConsentStateComponent < ApplicationComponent
   def loading? = @status == :loading
 
   def granted? = @status == :granted
-
-  def error? = @error.present?
 
   def app_name = Ami::APP_NAME
 

--- a/app/components/dossiers/ami_consent_state_component.rb
+++ b/app/components/dossiers/ami_consent_state_component.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Partie de l'encart AMI qui dépend du consentement de l'usager : elle est
+# chargée puis rafraîchie dans un turbo-frame, l'état venant d'AMI.
+class Dossiers::AmiConsentStateComponent < ApplicationComponent
+  # :loading tant qu'AMI n'a pas répondu, :unknown quand il n'a pas su répondre
+  STATUSES = [:loading, :granted, :not_granted, :unknown].freeze
+
+  def initialize(status:, error: false, focus: false)
+    @status = status
+    @error = error
+    @focus = focus
+  end
+
+  def loading? = @status == :loading
+
+  def granted? = @status == :granted
+
+  def error? = @error.present?
+
+  def app_name = Ami::APP_NAME
+
+  # Le focus n'est déplacé qu'après une action de l'usager, jamais au
+  # chargement de la page.
+  def granted_attributes
+    return {} if !@focus
+
+    { tabindex: "-1", data: { controller: "autofocus" } }
+  end
+end

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.en.yml
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  loading: Loading your follow-up preferences…
+  grant: I want to follow my procedures on %{app_name}
+  granted: You follow your procedures on %{app_name}
+  error: This service is temporarily unavailable. You can try again later, or turn on follow-up from the app.

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.en.yml
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.en.yml
@@ -3,4 +3,3 @@ en:
   loading: Loading your follow-up preferences…
   grant: I want to follow my procedures on %{app_name}
   granted: You follow your procedures on %{app_name}
-  error: This service is temporarily unavailable. You can try again later, or turn on follow-up from the app.

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.en.yml
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.en.yml
@@ -3,3 +3,4 @@ en:
   loading: Loading your follow-up preferences…
   grant: I want to follow my procedures on %{app_name}
   granted: You follow your procedures on %{app_name}
+  error: Your choice could not be saved. You can try again.

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.fr.yml
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.fr.yml
@@ -3,4 +3,4 @@ fr:
   loading: Chargement de vos préférences de suivi…
   grant: Je souhaite suivre mes démarches sur %{app_name}
   granted: Vous suivez vos démarches sur %{app_name}
-  error: "L'enregistrement de votre choix a échoué. Vous pouvez réessayer."
+  error: "L’enregistrement de votre choix a échoué. Vous pouvez réessayer."

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.fr.yml
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.fr.yml
@@ -3,4 +3,3 @@ fr:
   loading: Chargement de vos préférences de suivi…
   grant: Je souhaite suivre mes démarches sur %{app_name}
   granted: Vous suivez vos démarches sur %{app_name}
-  error: Ce service est momentanément indisponible. Vous pourrez réessayer plus tard, ou activer le suivi depuis l’application.

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.fr.yml
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.fr.yml
@@ -1,0 +1,6 @@
+---
+fr:
+  loading: Chargement de vos préférences de suivi…
+  grant: Je souhaite suivre mes démarches sur %{app_name}
+  granted: Vous suivez vos démarches sur %{app_name}
+  error: Ce service est momentanément indisponible. Vous pourrez réessayer plus tard, ou activer le suivi depuis l’application.

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.fr.yml
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.fr.yml
@@ -3,3 +3,4 @@ fr:
   loading: Chargement de vos préférences de suivi…
   grant: Je souhaite suivre mes démarches sur %{app_name}
   granted: Vous suivez vos démarches sur %{app_name}
+  error: "L'enregistrement de votre choix a échoué. Vous pouvez réessayer."

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
@@ -2,11 +2,6 @@
   <p class="fr-sr-only" aria-busy="true"><%= t('.loading') %></p>
   <span class="ami-consent__skeleton" aria-hidden="true"></span>
 <% else %>
-  <% if error? %>
-    <div class="fr-alert fr-alert--warning fr-alert--sm fr-mb-2w" role="alert">
-      <p><%= t('.error') %></p>
-    </div>
-  <% end %>
   <% if granted? %>
     <%= tag.p(class: "ami-consent__granted fr-mb-0", **granted_attributes) do %>
       <span class="fr-icon-check-line fr-icon--sm" aria-hidden="true"></span>

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
@@ -14,7 +14,7 @@
       <%= t('.granted', app_name:) %>
     <% end %>
   <% else %>
-    <%= form_with url: create_ami_consent_path, method: :post, data: { turbo: true } do %>
+    <%= form_with url: form_path, method: :post, data: { turbo: true } do %>
       <button
         type="submit"
         class="

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
@@ -1,5 +1,6 @@
 <% if loading? %>
   <p class="fr-sr-only" aria-busy="true"><%= t('.loading') %></p>
+  <span class="ami-consent__skeleton" aria-hidden="true"></span>
 <% else %>
   <% if error? %>
     <div class="fr-alert fr-alert--warning fr-alert--sm fr-mb-2w" role="alert">

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
@@ -8,12 +8,13 @@
     <%= t('.granted', app_name:) %>
   <% end %>
 <% else %>
-  <%# Le turbo-frame parent porte déjà aria-live="polite" : un role="alert"
-      ici ferait annoncer le message deux fois. %>
+  <%#
+    Le turbo-frame parent porte déjà aria-live="polite" : un role="alert"
+    ici ferait annoncer le message deux fois.
+  %>
   <% if error? %>
     <p class="fr-error-text fr-mt-0"><%= t('.error') %></p>
   <% end %>
-
   <%= form_with url: form_path, method: :post, data: { turbo: true } do %>
     <button
       type="submit"

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
@@ -9,6 +9,12 @@
       <%= t('.granted', app_name:) %>
     <% end %>
   <% else %>
+    <%# Le turbo-frame parent porte déjà aria-live="polite" : un role="alert"
+        ici ferait annoncer le message deux fois. %>
+    <% if error? %>
+      <p class="fr-error-text fr-mt-0"><%= t('.error') %></p>
+    <% end %>
+
     <%= form_with url: form_path, method: :post, data: { turbo: true } do %>
       <button
         type="submit"

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
@@ -1,30 +1,28 @@
 <% if loading? %>
   <p class="fr-sr-only" aria-busy="true"><%= t('.loading') %></p>
   <span class="ami-consent__skeleton" aria-hidden="true"></span>
+<% elsif granted? %>
+  <%= tag.p(class: "ami-consent__granted fr-mb-0", **granted_attributes) do %>
+    <span class="fr-icon-check-line fr-icon--sm" aria-hidden="true"></span>
+
+    <%= t('.granted', app_name:) %>
+  <% end %>
 <% else %>
-  <% if granted? %>
-    <%= tag.p(class: "ami-consent__granted fr-mb-0", **granted_attributes) do %>
-      <span class="fr-icon-check-line fr-icon--sm" aria-hidden="true"></span>
+  <%# Le turbo-frame parent porte déjà aria-live="polite" : un role="alert"
+      ici ferait annoncer le message deux fois. %>
+  <% if error? %>
+    <p class="fr-error-text fr-mt-0"><%= t('.error') %></p>
+  <% end %>
 
-      <%= t('.granted', app_name:) %>
-    <% end %>
-  <% else %>
-    <%# Le turbo-frame parent porte déjà aria-live="polite" : un role="alert"
-        ici ferait annoncer le message deux fois. %>
-    <% if error? %>
-      <p class="fr-error-text fr-mt-0"><%= t('.error') %></p>
-    <% end %>
-
-    <%= form_with url: form_path, method: :post, data: { turbo: true } do %>
-      <button
-        type="submit"
-        class="
-          fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left
-          fr-icon-notification-3-line
-        "
-      >
-        <%= t('.grant', app_name:) %>
-      </button>
-    <% end %>
+  <%= form_with url: form_path, method: :post, data: { turbo: true } do %>
+    <button
+      type="submit"
+      class="
+        fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left
+        fr-icon-notification-3-line
+      "
+    >
+      <%= t('.grant', app_name:) %>
+    </button>
   <% end %>
 <% end %>

--- a/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
+++ b/app/components/dossiers/ami_consent_state_component/ami_consent_state_component.html.erb
@@ -1,0 +1,28 @@
+<% if loading? %>
+  <p class="fr-sr-only" aria-busy="true"><%= t('.loading') %></p>
+<% else %>
+  <% if error? %>
+    <div class="fr-alert fr-alert--warning fr-alert--sm fr-mb-2w" role="alert">
+      <p><%= t('.error') %></p>
+    </div>
+  <% end %>
+  <% if granted? %>
+    <%= tag.p(class: "ami-consent__granted fr-mb-0", **granted_attributes) do %>
+      <span class="fr-icon-check-line fr-icon--sm" aria-hidden="true"></span>
+
+      <%= t('.granted', app_name:) %>
+    <% end %>
+  <% else %>
+    <%= form_with url: create_ami_consent_path, method: :post, data: { turbo: true } do %>
+      <button
+        type="submit"
+        class="
+          fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left
+          fr-icon-notification-3-line
+        "
+      >
+        <%= t('.grant', app_name:) %>
+      </button>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/dossiers/ami_follow_component.rb
+++ b/app/components/dossiers/ami_follow_component.rb
@@ -23,6 +23,10 @@ class Dossiers::AmiFollowComponent < ApplicationComponent
 
   def app_url = Ami::APP_URL
 
+  def consent_path = ami_consent_dossier_path(@dossier)
+
+  def dossier = @dossier
+
   def modal_id = MODAL_ID
 
   def title_id = "#{MODAL_ID}-title"

--- a/app/components/dossiers/ami_follow_component.rb
+++ b/app/components/dossiers/ami_follow_component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Encart proposant à l'usager de suivre ses démarches dans l'application
+# mobile AMI, et de la télécharger. La partie qui dépend du consentement est
+# chargée à part, cf. Dossiers::AmiConsentStateComponent.
+class Dossiers::AmiFollowComponent < ApplicationComponent
+  MODAL_ID = "ami-info-modal"
+
+  def initialize(dossier:)
+    @dossier = dossier
+  end
+
+  # Le partiel de la page de dépôt sert aussi d'aperçu à l'administrateur,
+  # sans dossier. Le consentement demande une identité France Connect.
+  def render?
+    @dossier.present? &&
+      @dossier.procedure.feature_enabled?(:ami_notifications) &&
+      Ami::RecipientFcHash.call(@dossier.user).present?
+  end
+
+  def app_name = Ami::APP_NAME
+
+  def app_url = Ami::APP_URL
+
+  def modal_id = MODAL_ID
+
+  def title_id = "#{MODAL_ID}-title"
+end

--- a/app/components/dossiers/ami_follow_component.rb
+++ b/app/components/dossiers/ami_follow_component.rb
@@ -15,6 +15,7 @@ class Dossiers::AmiFollowComponent < ApplicationComponent
   def render?
     @dossier.present? &&
       @dossier.procedure.feature_enabled?(:ami_notifications) &&
+      Ami::Client.new.configured? &&
       Ami::RecipientFcHash.call(@dossier.user).present?
   end
 

--- a/app/components/dossiers/ami_follow_component/ami_follow_component.en.yml
+++ b/app/components/dossiers/ami_follow_component/ami_follow_component.en.yml
@@ -1,0 +1,11 @@
+---
+en:
+  title: Follow your procedures on %{app_name}, the official and free mobile app of the French administration
+  see_in_app: Open in the app
+  more_info: All the information about the app
+  modal:
+    title: All the information about %{app_name}
+    body_html: |
+      <p class="fr-text--bold">You can change your procedure follow-up preferences in the app at any time.</p>
+      <p>The official and free mobile app of the French administration is operated by the direction de l’information légale et administrative and the direction interministérielle du numérique (Services du Premier Ministre). It lets you <strong>follow all your procedures</strong>, receive <strong>personalised alerts</strong> and <strong>talk to the administrations</strong> from <strong>a single mobile app</strong>.</p>
+      <p>See the “Données personnelles et sécurité” page on the Service Public website and in the app for more information.</p>

--- a/app/components/dossiers/ami_follow_component/ami_follow_component.fr.yml
+++ b/app/components/dossiers/ami_follow_component/ami_follow_component.fr.yml
@@ -1,0 +1,11 @@
+---
+fr:
+  title: Suivez vos démarches depuis %{app_name}, l’application mobile officielle et gratuite de l’administration française
+  see_in_app: Voir dans l’application
+  more_info: Toutes les infos sur l’application
+  modal:
+    title: Toutes les infos sur %{app_name}
+    body_html: |
+      <p class="fr-text--bold">Vous pouvez à tout moment changer vos préférences de suivi des démarches dans l’application.</p>
+      <p>L’application mobile gratuite et officielle de l’administration française est un service opéré par la direction de l’information légale et administrative et la direction interministérielle du numérique (Services du Premier Ministre), qui permet de <strong>suivre toutes vos démarches</strong>, recevoir des <strong>alertes personnalisées</strong> et <strong>communiquer avec les administrations</strong> dans <strong>une seule application mobile</strong> !</p>
+      <p>Consultez la page « Données personnelles et sécurité » sur le site Service Public et dans l’application pour plus d’informations.</p>

--- a/app/components/dossiers/ami_follow_component/ami_follow_component.html.erb
+++ b/app/components/dossiers/ami_follow_component/ami_follow_component.html.erb
@@ -1,0 +1,72 @@
+<section class="ami-follow fr-mb-5w" aria-labelledby="ami-follow-title">
+  <div class="fr-grid-row">
+    <div class="fr-col-12 fr-col-md-6 fr-p-3w ami-follow__intro">
+      <%= image_tag 'ami/illustration.svg', alt: '', class: 'ami-follow__illustration' %>
+
+      <p id="ami-follow-title" class="fr-text--bold fr-mb-0">
+        <%= t('.title', app_name:) %>
+      </p>
+    </div>
+
+    <div class="fr-col-12 fr-col-md-6 fr-p-3w ami-follow__actions">
+      <%= helpers.turbo_frame_tag "ami-consent", src: ami_consent_path, loading: :lazy, "aria-live": "polite" do %>
+        <%= render Dossiers::AmiConsentStateComponent.new(status: :loading) %>
+      <% end %>
+
+      <p class="fr-my-2w">
+        <%= link_to app_url, class: 'fr-btn fr-btn--icon-left fr-icon-smartphone-line', title: helpers.new_tab_suffix(t('.see_in_app')), **helpers.external_link_attributes do %>
+          <%= t('.see_in_app') %>
+        <% end %>
+      </p>
+
+      <button
+        class="fr-btn fr-btn--tertiary-no-outline fr-btn--sm"
+        type="button"
+        aria-controls="<%= modal_id %>"
+        aria-haspopup="dialog"
+        data-fr-opened="false"
+      >
+        <%= t('.more_info') %>
+      </button>
+    </div>
+  </div>
+
+  <dialog
+    id="<%= modal_id %>"
+    class="fr-modal"
+    role="dialog"
+    aria-labelledby="<%= title_id %>"
+  >
+    <div class="fr-container fr-container--fluid fr-container-md">
+      <div class="fr-grid-row fr-grid-row--center">
+        <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
+          <div class="fr-modal__body">
+            <div class="fr-modal__header">
+              <button
+                class="fr-btn--close fr-btn"
+                type="button"
+                aria-controls="<%= modal_id %>"
+                title="<%= t('utils.modal_close_alt') %>"
+              >
+                <%= t('utils.modal_close') %>
+              </button>
+            </div>
+
+            <div class="fr-modal__content">
+              <h1 id="<%= title_id %>" class="fr-modal__title">
+                <span
+                  class="fr-icon-information-line fr-icon--lg"
+                  aria-hidden="true"
+                ></span>
+
+                <%= t('.modal.title', app_name:) %>
+              </h1>
+
+              <%= t('.modal.body_html', app_name:) %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </dialog>
+</section>

--- a/app/components/dossiers/ami_follow_component/ami_follow_component.html.erb
+++ b/app/components/dossiers/ami_follow_component/ami_follow_component.html.erb
@@ -9,8 +9,8 @@
     </div>
 
     <div class="fr-col-12 fr-col-md-6 fr-p-3w ami-follow__actions">
-      <%= helpers.turbo_frame_tag "ami-consent", src: ami_consent_path, loading: :lazy, "aria-live": "polite" do %>
-        <%= render Dossiers::AmiConsentStateComponent.new(status: :loading) %>
+      <%= helpers.turbo_frame_tag "ami-consent", src: consent_path, loading: :lazy, "aria-live": "polite" do %>
+        <%= render Dossiers::AmiConsentStateComponent.new(status: :loading, dossier:) %>
       <% end %>
 
       <p class="fr-my-2w">

--- a/app/controllers/users/ami_consents_controller.rb
+++ b/app/controllers/users/ami_consents_controller.rb
@@ -3,11 +3,8 @@
 module Users
   # Consentement de l'usager au suivi de ses démarches dans l'application
   # mobile AMI. Il vaut pour toutes ses démarches, mais se donne depuis un
-  # dossier : faute d'écriture côté AMI, c'est l'envoi de l'événement de ce
-  # dossier qui vaut consentement.
+  # dossier, dont l'événement est envoyé dans la foulée de l'acceptation.
   class AmiConsentsController < UserController
-    include Dry::Monads[:result]
-
     before_action :set_dossier
     before_action :ensure_consent_available
 
@@ -18,13 +15,8 @@ module Users
     # Mieux vaut avouer l'échec que confirmer un suivi qui n'existe pas : le
     # bouton reste alors affiché, avec un message, pour permettre un nouvel essai.
     def create
-      case Ami::GrantConsent.call(dossier: @dossier)
-      in Success(_)
-        @status = :granted
-        @focus = true
-      in Failure(_)
-        @status = :error
-      end
+      @status = Ami::GrantConsent.call(dossier: @dossier, fc_hash:)
+      @focus = @status == :granted
 
       render :show
     end

--- a/app/controllers/users/ami_consents_controller.rb
+++ b/app/controllers/users/ami_consents_controller.rb
@@ -10,7 +10,7 @@ module Users
     before_action :ensure_consent_available
 
     def show
-      @status = Ami::ConsentStatus.call(current_user)
+      @status = Ami::ConsentStatus.call(fc_hash)
     end
 
     def create
@@ -31,10 +31,12 @@ module Users
     # On répond toujours par le turbo-frame, même vide : une réponse sans frame
     # afficherait « Content missing » à la place de l'encart.
     def ensure_consent_available
-      return if Ami::Client.new.configured? && Ami::RecipientFcHash.call(current_user).present?
+      return if Ami::Client.new.configured? && fc_hash.present?
 
       @status = :unavailable
       render :show
     end
+
+    def fc_hash = @fc_hash ||= Ami::RecipientFcHash.call(current_user)
   end
 end

--- a/app/controllers/users/ami_consents_controller.rb
+++ b/app/controllers/users/ami_consents_controller.rb
@@ -6,6 +6,8 @@ module Users
   # dossier : faute d'écriture côté AMI, c'est l'envoi de l'événement de ce
   # dossier qui vaut consentement.
   class AmiConsentsController < UserController
+    include Dry::Monads[:result]
+
     before_action :set_dossier
     before_action :ensure_consent_available
 
@@ -13,13 +15,16 @@ module Users
       @status = Ami::ConsentStatus.call(fc_hash)
     end
 
-    # Bascule optimiste : on confirme le suivi sans attendre qu'AMI ait accepté
-    # l'événement, d'où le retour ignoré.
+    # Mieux vaut avouer l'échec que confirmer un suivi qui n'existe pas : le
+    # bouton reste alors affiché, avec un message, pour permettre un nouvel essai.
     def create
-      Ami::GrantConsent.call(dossier: @dossier)
-
-      @status = :granted
-      @focus = true
+      case Ami::GrantConsent.call(dossier: @dossier)
+      in Success(_)
+        @status = :granted
+        @focus = true
+      in Failure(_)
+        @status = :error
+      end
 
       render :show
     end

--- a/app/controllers/users/ami_consents_controller.rb
+++ b/app/controllers/users/ami_consents_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Users
+  # Consentement de l'usager au suivi de ses démarches dans l'application
+  # mobile AMI. La ressource porte sur l'usager lui-même, et non sur un
+  # dossier : le consentement vaut pour toutes ses démarches.
+  class AmiConsentsController < UserController
+    include Dry::Monads[:result]
+
+    before_action :ensure_consent_available
+
+    def show
+      @status = Ami::ConsentStatus.call(current_user)
+    end
+
+    def create
+      case Ami::GrantConsent.call(current_user)
+      in Success(_)
+        @status = :granted
+        @focus = true
+      in Failure(_)
+        @status = :not_granted
+        @error = true
+      end
+
+      render :show
+    end
+
+    private
+
+    def ensure_consent_available
+      return if Ami::Client.new.configured? && Ami::RecipientFcHash.call(current_user).present?
+
+      head :no_content
+    end
+  end
+end

--- a/app/controllers/users/ami_consents_controller.rb
+++ b/app/controllers/users/ami_consents_controller.rb
@@ -6,8 +6,6 @@ module Users
   # dossier : faute d'écriture côté AMI, c'est l'envoi de l'événement de ce
   # dossier qui vaut consentement.
   class AmiConsentsController < UserController
-    include Dry::Monads[:result]
-
     before_action :set_dossier
     before_action :ensure_consent_available
 
@@ -15,15 +13,13 @@ module Users
       @status = Ami::ConsentStatus.call(fc_hash)
     end
 
+    # Bascule optimiste : on confirme le suivi sans attendre qu'AMI ait accepté
+    # l'événement, d'où le retour ignoré.
     def create
-      case Ami::GrantConsent.call(current_user)
-      in Success(_)
-        @status = :granted
-        @focus = true
-      in Failure(_)
-        @status = :not_granted
-        @error = true
-      end
+      Ami::GrantConsent.call(dossier: @dossier)
+
+      @status = :granted
+      @focus = true
 
       render :show
     end
@@ -38,7 +34,9 @@ module Users
     # On répond toujours par le turbo-frame, même vide : une réponse sans frame
     # afficherait « Content missing » à la place de l'encart.
     def ensure_consent_available
-      return if Ami::Client.new.configured? && fc_hash.present?
+      return if Ami::Client.new.configured? &&
+        @dossier.procedure.feature_enabled?(:ami_notifications) &&
+        fc_hash.present?
 
       @status = :unavailable
       render :show

--- a/app/controllers/users/ami_consents_controller.rb
+++ b/app/controllers/users/ami_consents_controller.rb
@@ -28,10 +28,13 @@ module Users
 
     private
 
+    # On répond toujours par le turbo-frame, même vide : une réponse sans frame
+    # afficherait « Content missing » à la place de l'encart.
     def ensure_consent_available
       return if Ami::Client.new.configured? && Ami::RecipientFcHash.call(current_user).present?
 
-      head :no_content
+      @status = :unavailable
+      render :show
     end
   end
 end

--- a/app/controllers/users/ami_consents_controller.rb
+++ b/app/controllers/users/ami_consents_controller.rb
@@ -2,11 +2,13 @@
 
 module Users
   # Consentement de l'usager au suivi de ses démarches dans l'application
-  # mobile AMI. La ressource porte sur l'usager lui-même, et non sur un
-  # dossier : le consentement vaut pour toutes ses démarches.
+  # mobile AMI. Il vaut pour toutes ses démarches, mais se donne depuis un
+  # dossier : faute d'écriture côté AMI, c'est l'envoi de l'événement de ce
+  # dossier qui vaut consentement.
   class AmiConsentsController < UserController
     include Dry::Monads[:result]
 
+    before_action :set_dossier
     before_action :ensure_consent_available
 
     def show
@@ -27,6 +29,11 @@ module Users
     end
 
     private
+
+    # current_user.dossiers exclut les dossiers où l'usager est seulement
+    # invité : le consentement porte sur son identité France Connect, pas sur
+    # celle du propriétaire du dossier.
+    def set_dossier = @dossier = current_user.dossiers.find(params[:id])
 
     # On répond toujours par le turbo-frame, même vide : une réponse sans frame
     # afficherait « Content missing » à la place de l'encart.

--- a/app/jobs/ami/send_notification_job.rb
+++ b/app/jobs/ami/send_notification_job.rb
@@ -9,10 +9,9 @@ class Ami::SendNotificationJob < ApplicationJob
 
   queue_as :default
 
-  # grant_consent: cet envoi vaut consentement chez AMI, où le premier
-  # événement reçu fait foi tant que l'écriture du consentement n'existe pas.
-  # On ne vérifie donc pas le consentement, faute de quoi ce premier envoi
-  # n'aurait jamais lieu.
+  # grant_consent: l'usager vient d'accorder son consentement, inutile de le
+  # relire — AMI pourrait ne pas l'avoir encore propagé, et une lecture en 404
+  # ferait abandonner l'envoi silencieusement.
   def perform(payload, context = {}, grant_consent: false)
     Sentry.set_tags(context)
 

--- a/app/jobs/ami/send_notification_job.rb
+++ b/app/jobs/ami/send_notification_job.rb
@@ -9,15 +9,15 @@ class Ami::SendNotificationJob < ApplicationJob
 
   queue_as :default
 
-  # grant_consent: l'usager vient d'accorder son consentement, inutile de le
-  # relire — AMI pourrait ne pas l'avoir encore propagé, et une lecture en 404
-  # ferait abandonner l'envoi silencieusement.
-  def perform(payload, context = {}, grant_consent: false)
+  # skip_consent_check: l'usager vient d'accorder son consentement, inutile de
+  # le relire — AMI pourrait ne pas l'avoir encore propagé, et une lecture en
+  # 404 ferait abandonner l'envoi silencieusement.
+  def perform(payload, context = {}, skip_consent_check: false)
     Sentry.set_tags(context)
 
     fc_hash = payload[:recipient_fc_hash]
     return if fc_hash.blank?
-    return if !grant_consent && !consent_granted?(fc_hash, context)
+    return if !skip_consent_check && !consent_granted?(fc_hash, context)
 
     Rails.logger.debug { "AMI notification sending for dossier #{context[:dossier]}" }
 

--- a/app/jobs/ami/send_notification_job.rb
+++ b/app/jobs/ami/send_notification_job.rb
@@ -3,14 +3,22 @@
 class Ami::SendNotificationJob < ApplicationJob
   include Dry::Monads[:result]
 
-  discard_on ActiveRecord::RecordNotFound
+  class ConsentCheckError < StandardError; end
 
-  use_sidekiq_retry
+  use_sidekiq_retry(report_after_attempts: 8)
 
   queue_as :default
 
-  def perform(payload, context = {})
+  # grant_consent: cet envoi vaut consentement chez AMI, où le premier
+  # événement reçu fait foi tant que l'écriture du consentement n'existe pas.
+  # On ne vérifie donc pas le consentement, faute de quoi ce premier envoi
+  # n'aurait jamais lieu.
+  def perform(payload, context = {}, grant_consent: false)
     Sentry.set_tags(context)
+
+    fc_hash = payload[:recipient_fc_hash]
+    return if fc_hash.blank?
+    return if !grant_consent && !consent_granted?(fc_hash, context)
 
     Rails.logger.debug { "AMI notification sending for dossier #{context[:dossier]}" }
 
@@ -22,6 +30,23 @@ class Ami::SendNotificationJob < ApplicationJob
     in Failure(error)
       Rails.logger.error("AMI notification failed for dossier #{context[:dossier]}: #{error}")
       raise "AMI notification failed for dossier #{context[:dossier]}: #{error}"
+    end
+  end
+
+  private
+
+  # Ne rien envoyer sans consentement est délibéré : le contenu de la
+  # notification ne doit pas parvenir à AMI tant que l'usager n'a pas accepté.
+  def consent_granted?(fc_hash, context)
+    case Ami::ConsentStatus.call(fc_hash)
+    when :granted
+      true
+    when :not_granted, :unavailable
+      Rails.logger.debug { "AMI notification skipped for dossier #{context[:dossier]}: no consent" }
+      false
+    else
+      # AMI n'a pas su répondre : on ne devine pas, on laisse Sidekiq retenter.
+      raise ConsentCheckError, "AMI consent check failed for dossier #{context[:dossier]}"
     end
   end
 end

--- a/app/services/ami.rb
+++ b/app/services/ami.rb
@@ -7,11 +7,4 @@ module Ami
   # TODO: URL provisoire, à remplacer par l'écran de téléchargement (universal
   # link) que doit nous fournir l'équipe AMI
   APP_URL = "https://ami.numerique.gouv.fr"
-
-  # AMI n'expose pas encore d'écriture du consentement. En attendant, c'est le
-  # premier événement envoyé qui vaut consentement ; il suffira d'activer cette
-  # variable le jour où l'endpoint existera.
-  def self.grant_consent_endpoint_available?
-    ENV.enabled?("AMI_GRANT_CONSENT_ENDPOINT_AVAILABLE")
-  end
 end

--- a/app/services/ami.rb
+++ b/app/services/ami.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Ami
+  # TODO: nom public de l'application, à figer avec l'équipe AMI
+  APP_NAME = "AMI"
+
+  # TODO: URL provisoire, à remplacer par l'écran de téléchargement (universal
+  # link) que doit nous fournir l'équipe AMI
+  APP_URL = "https://ami.numerique.gouv.fr"
+end

--- a/app/services/ami.rb
+++ b/app/services/ami.rb
@@ -7,4 +7,11 @@ module Ami
   # TODO: URL provisoire, à remplacer par l'écran de téléchargement (universal
   # link) que doit nous fournir l'équipe AMI
   APP_URL = "https://ami.numerique.gouv.fr"
+
+  # AMI n'expose pas encore d'écriture du consentement. En attendant, c'est le
+  # premier événement envoyé qui vaut consentement ; il suffira d'activer cette
+  # variable le jour où l'endpoint existera.
+  def self.grant_consent_endpoint_available?
+    ENV.enabled?("AMI_GRANT_CONSENT_ENDPOINT_AVAILABLE")
+  end
 end

--- a/app/services/ami/client.rb
+++ b/app/services/ami/client.rb
@@ -6,10 +6,44 @@ module Ami
 
     EVENT_PATH = "/api/v2/event"
 
+    CONSENT_READ_PATH = "/api/v1/consent"
+    CONSENT_READ_TIMEOUT = 3
+
+    # TODO: l'endpoint d'écriture du consentement n'est pas encore publié dans
+    # le schéma d'AMI (https://ami-back-staging.osc-fr1.scalingo.io/schema).
+    # Seules ces constantes et consent_payload seront à ajuster quand il le sera.
+    CONSENT_WRITE_PATH = "/api/v1/consent"
+    CONSENT_WRITE_METHOD = :post
+    CONSENT_WRITE_TIMEOUT = 5
+
     # PUT et non POST : l'événement est identifié par le partenaire et l'objet
     # associé, donc un rejeu ne crée pas de doublon (200 s'il existait, 201 sinon).
     def send_notification(payload)
       handle_result(call_api(url: build_url(EVENT_PATH), json: payload, method: :put))
+    end
+
+    # Succès si l'usager a consenti au suivi de ses démarches, échec en 404 sinon.
+    def consent(fc_hash)
+      handle_bodyless_result(
+        call_api(
+          url: build_url("#{CONSENT_READ_PATH}/#{fc_hash}"),
+          method: :get,
+          timeout: CONSENT_READ_TIMEOUT
+        )
+      )
+    end
+
+    # Transmet un consentement. Il n'existe volontairement pas de méthode de
+    # révocation : celle-ci se fait uniquement depuis l'application mobile.
+    def grant_consent(fc_hash)
+      handle_bodyless_result(
+        call_api(
+          url: build_url(CONSENT_WRITE_PATH),
+          json: consent_payload(fc_hash),
+          method: CONSENT_WRITE_METHOD,
+          timeout: CONSENT_WRITE_TIMEOUT
+        )
+      )
     end
 
     def configured?
@@ -51,6 +85,8 @@ module Ami
     def api_password = ENV.fetch("AMI_API_PASSWORD", nil)
     def credentials = "#{api_user}:#{api_password}"
 
+    def consent_payload(fc_hash) = { recipient_fc_hash: fc_hash }
+
     def build_url(path)
       uri = URI(api_url)
       uri.path = path
@@ -63,6 +99,17 @@ module Ami
         Success(body)
       in Failure(API::Client::Error => error)
         Failure(error)
+      end
+    end
+
+    # Les endpoints de consentement répondent sans corps : API::Client échoue
+    # alors à parser le JSON et renvoie un échec, bien que l'appel ait réussi.
+    def handle_bodyless_result(result)
+      case handle_result(result)
+      in Failure(API::Client::Error => error) if error.type == :json && error.code.in?(200..299)
+        Success(nil)
+      in other
+        other
       end
     end
   end

--- a/app/services/ami/client.rb
+++ b/app/services/ami/client.rb
@@ -6,15 +6,15 @@ module Ami
 
     EVENT_PATH = "/api/v2/event"
 
-    CONSENT_READ_PATH = "/api/v1/consent"
+    # Lecture et écriture partagent le même chemin, le hash France Connect
+    # identifiant l'usager côté AMI.
+    CONSENT_PATH = "/api/v1/consent"
     CONSENT_READ_TIMEOUT = 3
-
-    # TODO: l'endpoint d'écriture du consentement n'est pas encore publié dans
-    # le schéma d'AMI (https://ami-back-staging.osc-fr1.scalingo.io/schema).
-    # Seules ces constantes et consent_payload seront à ajuster quand il le sera.
-    CONSENT_WRITE_PATH = "/api/v1/consent"
-    CONSENT_WRITE_METHOD = :post
     CONSENT_WRITE_TIMEOUT = 5
+
+    # Le contrat accepte aussi consent: false, qui révoque. On ne l'expose pas :
+    # la révocation se fait depuis l'application mobile.
+    CONSENT_GRANTED_PAYLOAD = { consent: true }.freeze
 
     # PUT et non POST : l'événement est identifié par le partenaire et l'objet
     # associé, donc un rejeu ne crée pas de doublon (200 s'il existait, 201 sinon).
@@ -25,11 +25,7 @@ module Ami
     # Succès si l'usager a consenti au suivi de ses démarches, échec en 404 sinon.
     def consent(fc_hash)
       handle_bodyless_result(
-        call_api(
-          url: build_url("#{CONSENT_READ_PATH}/#{fc_hash}"),
-          method: :get,
-          timeout: CONSENT_READ_TIMEOUT
-        )
+        call_api(url: consent_url(fc_hash), method: :get, timeout: CONSENT_READ_TIMEOUT)
       )
     end
 
@@ -38,9 +34,9 @@ module Ami
     def grant_consent(fc_hash)
       handle_bodyless_result(
         call_api(
-          url: build_url(CONSENT_WRITE_PATH),
-          json: consent_payload(fc_hash),
-          method: CONSENT_WRITE_METHOD,
+          url: consent_url(fc_hash),
+          json: CONSENT_GRANTED_PAYLOAD,
+          method: :post,
           timeout: CONSENT_WRITE_TIMEOUT
         )
       )
@@ -85,7 +81,7 @@ module Ami
     def api_password = ENV.fetch("AMI_API_PASSWORD", nil)
     def credentials = "#{api_user}:#{api_password}"
 
-    def consent_payload(fc_hash) = { recipient_fc_hash: fc_hash }
+    def consent_url(fc_hash) = build_url("#{CONSENT_PATH}/#{fc_hash}")
 
     def build_url(path)
       uri = URI(api_url)

--- a/app/services/ami/client.rb
+++ b/app/services/ami/client.rb
@@ -98,8 +98,10 @@ module Ami
       end
     end
 
-    # Les endpoints de consentement répondent sans corps : API::Client échoue
-    # alors à parser le JSON et renvoie un échec, bien que l'appel ait réussi.
+    # Le contrat promet un corps aux deux endpoints de consentement, mais AMI a
+    # déjà répondu vide : API::Client échoue alors à parser le JSON et renvoie
+    # un échec, bien que l'appel ait réussi. Filet à retirer une fois le
+    # comportement réel confirmé avec l'équipe AMI.
     def handle_bodyless_result(result)
       case handle_result(result)
       in Failure(API::Client::Error => error) if error.type == :json && error.code.in?(200..299)

--- a/app/services/ami/consent_status.rb
+++ b/app/services/ami/consent_status.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Ami
+  # L'usager a-t-il consenti au suivi de ses démarches dans l'application mobile ?
+  #
+  # Pas de cache pour l'instant : interroger AMI à chaque affichage garantit
+  # qu'une révocation faite depuis l'application est prise en compte aussitôt.
+  class ConsentStatus
+    include Dry::Monads[:result]
+
+    def self.call(user) = new(user).call
+
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      return :unknown if fc_hash.blank?
+      return :unknown if !client.configured?
+
+      case client.consent(fc_hash)
+      in Success(_)
+        :granted
+      in Failure(API::Client::Error => error) if error.code == 404
+        :not_granted
+      in Failure(API::Client::Error => error)
+        Sentry.capture_message("Ami::ConsentStatus failed: #{error.type} code: #{error.code}")
+        :unknown
+      end
+    end
+
+    private
+
+    attr_reader :user
+
+    def fc_hash = @fc_hash ||= RecipientFcHash.call(user)
+    def client = @client ||= Client.new
+  end
+end

--- a/app/services/ami/consent_status.rb
+++ b/app/services/ami/consent_status.rb
@@ -21,6 +21,10 @@ module Ami
       return :unavailable if !client.configured?
 
       case client.consent(fc_hash)
+      # AMI répond 404 quand le consentement manque, mais son schéma déclare
+      # aussi consent_datetime nullable en 200 : on couvre les deux.
+      in Success(Hash => body) if body[:consent_datetime].blank?
+        :not_granted
       in Success(_)
         :granted
       in Failure(API::Client::Error => error) if error.code == 404

--- a/app/services/ami/consent_status.rb
+++ b/app/services/ami/consent_status.rb
@@ -2,21 +2,23 @@
 
 module Ami
   # L'usager a-t-il consenti au suivi de ses démarches dans l'application mobile ?
+  # Prend le hash France Connect, seul identifiant connu d'AMI, que ses deux
+  # appelants (le job d'envoi et le contrôleur) ont déjà sous la main.
   #
-  # Pas de cache pour l'instant : interroger AMI à chaque affichage garantit
-  # qu'une révocation faite depuis l'application est prise en compte aussitôt.
+  # Pas de cache : interroger AMI à chaque fois garantit qu'une révocation faite
+  # depuis l'application est prise en compte aussitôt.
   class ConsentStatus
     include Dry::Monads[:result]
 
-    def self.call(user) = new(user).call
+    def self.call(fc_hash) = new(fc_hash).call
 
-    def initialize(user)
-      @user = user
+    def initialize(fc_hash)
+      @fc_hash = fc_hash
     end
 
     def call
-      return :unknown if fc_hash.blank?
-      return :unknown if !client.configured?
+      return :unavailable if fc_hash.blank?
+      return :unavailable if !client.configured?
 
       case client.consent(fc_hash)
       in Success(_)
@@ -24,16 +26,17 @@ module Ami
       in Failure(API::Client::Error => error) if error.code == 404
         :not_granted
       in Failure(API::Client::Error => error)
-        Sentry.capture_message("Ami::ConsentStatus failed: #{error.type} code: #{error.code}")
+        # Pas de remontée Sentry ici : l'appelant décide quoi en faire, et le
+        # job lève, ce qui suffit à signaler une panne d'AMI.
+        Rails.logger.warn("Ami::ConsentStatus failed: #{error.type} code: #{error.code}")
         :unknown
       end
     end
 
     private
 
-    attr_reader :user
+    attr_reader :fc_hash
 
-    def fc_hash = @fc_hash ||= RecipientFcHash.call(user)
     def client = @client ||= Client.new
   end
 end

--- a/app/services/ami/create_notification_service.rb
+++ b/app/services/ami/create_notification_service.rb
@@ -23,8 +23,8 @@ module Ami
       @grant_consent = grant_consent
     end
 
-    # grant_consent: cet envoi vaut consentement chez AMI, où le premier
-    # événement reçu fait foi tant que l'écriture du consentement n'existe pas.
+    # grant_consent: le consentement vient d'être accordé, le job n'a pas à le
+    # revérifier avant d'envoyer.
     def self.call(dossier:, trigger: :dossier_state_change, state: nil, grant_consent: false)
       new(dossier:, trigger:, state:, grant_consent:).call
     end

--- a/app/services/ami/create_notification_service.rb
+++ b/app/services/ami/create_notification_service.rb
@@ -14,19 +14,19 @@ module Ami
       sans_suite: "closed",
     }.freeze
 
-    attr_reader :dossier, :state, :trigger, :grant_consent
+    attr_reader :dossier, :state, :trigger, :skip_consent_check
 
-    def initialize(dossier:, trigger:, state:, grant_consent: false)
+    def initialize(dossier:, trigger:, state:, skip_consent_check: false)
       @dossier = dossier
       @state = (state || dossier.state).to_sym
       @trigger = trigger.to_sym
-      @grant_consent = grant_consent
+      @skip_consent_check = skip_consent_check
     end
 
-    # grant_consent: le consentement vient d'être accordé, le job n'a pas à le
+    # skip_consent_check: le consentement vient d'être accordé, le job n'a pas à le
     # revérifier avant d'envoyer.
-    def self.call(dossier:, trigger: :dossier_state_change, state: nil, grant_consent: false)
-      new(dossier:, trigger:, state:, grant_consent:).call
+    def self.call(dossier:, trigger: :dossier_state_change, state: nil, skip_consent_check: false)
+      new(dossier:, trigger:, state:, skip_consent_check:).call
     end
 
     def call
@@ -40,7 +40,7 @@ module Ami
       payload = create_notification_payload(event_date: Time.zone.now.iso8601)
       return if payload[:recipient_fc_hash].blank?
 
-      Ami::SendNotificationJob.perform_later(payload, context, grant_consent:)
+      Ami::SendNotificationJob.perform_later(payload, context, skip_consent_check:)
     end
 
     # Contrat de PUT /api/v2/event : event_date remplace send_date et

--- a/app/services/ami/create_notification_service.rb
+++ b/app/services/ami/create_notification_service.rb
@@ -14,16 +14,19 @@ module Ami
       sans_suite: "closed",
     }.freeze
 
-    attr_reader :dossier, :state, :trigger
+    attr_reader :dossier, :state, :trigger, :grant_consent
 
-    def initialize(dossier:, trigger:, state:)
+    def initialize(dossier:, trigger:, state:, grant_consent: false)
       @dossier = dossier
       @state = (state || dossier.state).to_sym
       @trigger = trigger.to_sym
+      @grant_consent = grant_consent
     end
 
-    def self.call(dossier:, trigger: :dossier_state_change, state: nil)
-      new(dossier:, trigger:, state:).call
+    # grant_consent: cet envoi vaut consentement chez AMI, où le premier
+    # événement reçu fait foi tant que l'écriture du consentement n'existe pas.
+    def self.call(dossier:, trigger: :dossier_state_change, state: nil, grant_consent: false)
+      new(dossier:, trigger:, state:, grant_consent:).call
     end
 
     def call
@@ -37,7 +40,7 @@ module Ami
       payload = create_notification_payload(event_date: Time.zone.now.iso8601)
       return if payload[:recipient_fc_hash].blank?
 
-      Ami::SendNotificationJob.perform_later(payload, context)
+      Ami::SendNotificationJob.perform_later(payload, context, grant_consent:)
     end
 
     # Contrat de PUT /api/v2/event : event_date remplace send_date et

--- a/app/services/ami/grant_consent.rb
+++ b/app/services/ami/grant_consent.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 module Ami
-  # L'usager accepte de suivre ses démarches dans l'application mobile.
-  #
-  # Tant qu'AMI n'expose pas d'écriture du consentement, c'est le premier
-  # événement reçu qui fait foi : on envoie donc l'événement du dossier depuis
-  # lequel l'usager accepte, en court-circuitant la vérification qui, sinon,
-  # interdirait à jamais ce premier envoi.
+  # L'usager accepte de suivre ses démarches dans l'application mobile : on
+  # enregistre son consentement auprès d'AMI, puis on lui envoie l'événement du
+  # dossier depuis lequel il a accepté.
   #
   # Il n'existe volontairement pas de service de révocation : elle se fait
   # depuis les préférences de l'application mobile.
+  #
+  # Retourne le Result de l'écriture du consentement, dont l'appelant a besoin
+  # pour savoir quoi afficher.
   class GrantConsent
     def self.call(dossier:) = new(dossier).call
 
@@ -18,11 +18,16 @@ module Ami
     end
 
     def call
-      if Ami.grant_consent_endpoint_available?
-        Client.new.grant_consent(RecipientFcHash.call(dossier.user))
-      else
-        CreateNotificationService.call(dossier:, grant_consent: true)
-      end
+      result = Client.new.grant_consent(RecipientFcHash.call(dossier.user))
+      # Sans consentement enregistré, l'événement n'a pas à partir : son contenu
+      # ne doit pas parvenir à AMI.
+      return result if result.failure?
+
+      # grant_consent: le consentement vient d'être accordé, le job n'a pas à le
+      # revérifier — AMI pourrait ne pas l'avoir encore propagé.
+      CreateNotificationService.call(dossier:, grant_consent: true)
+
+      result
     end
 
     private

--- a/app/services/ami/grant_consent.rb
+++ b/app/services/ami/grant_consent.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Ami
+  # Transmet à AMI le consentement de l'usager au suivi de ses démarches.
+  #
+  # Il n'existe volontairement pas de service de révocation : celle-ci doit se
+  # faire depuis les préférences de l'application mobile, et nous ne devons
+  # jamais envoyer d'événement de refus.
+  class GrantConsent
+    include Dry::Monads[:result]
+
+    def self.call(user) = new(user).call
+
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      return Failure(:no_france_connect_identity) if fc_hash.blank?
+      return Failure(:not_configured) if !client.configured?
+
+      client.grant_consent(fc_hash)
+    end
+
+    private
+
+    attr_reader :user
+
+    def fc_hash = @fc_hash ||= RecipientFcHash.call(user)
+    def client = @client ||= Client.new
+  end
+end

--- a/app/services/ami/grant_consent.rb
+++ b/app/services/ami/grant_consent.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
 module Ami
-  # Transmet à AMI le consentement de l'usager au suivi de ses démarches.
+  # L'usager accepte de suivre ses démarches dans l'application mobile.
   #
-  # Il n'existe volontairement pas de service de révocation : celle-ci doit se
-  # faire depuis les préférences de l'application mobile, et nous ne devons
-  # jamais envoyer d'événement de refus.
+  # Tant qu'AMI n'expose pas d'écriture du consentement, c'est le premier
+  # événement reçu qui fait foi : on envoie donc l'événement du dossier depuis
+  # lequel l'usager accepte, en court-circuitant la vérification qui, sinon,
+  # interdirait à jamais ce premier envoi.
+  #
+  # Il n'existe volontairement pas de service de révocation : elle se fait
+  # depuis les préférences de l'application mobile.
   class GrantConsent
-    include Dry::Monads[:result]
+    def self.call(dossier:) = new(dossier).call
 
-    def self.call(user) = new(user).call
-
-    def initialize(user)
-      @user = user
+    def initialize(dossier)
+      @dossier = dossier
     end
 
     def call
-      return Failure(:no_france_connect_identity) if fc_hash.blank?
-      return Failure(:not_configured) if !client.configured?
-
-      client.grant_consent(fc_hash)
+      if Ami.grant_consent_endpoint_available?
+        Client.new.grant_consent(RecipientFcHash.call(dossier.user))
+      else
+        CreateNotificationService.call(dossier:, grant_consent: true)
+      end
     end
 
     private
 
-    attr_reader :user
-
-    def fc_hash = @fc_hash ||= RecipientFcHash.call(user)
-    def client = @client ||= Client.new
+    attr_reader :dossier
   end
 end

--- a/app/services/ami/grant_consent.rb
+++ b/app/services/ami/grant_consent.rb
@@ -8,30 +8,39 @@ module Ami
   # Il n'existe volontairement pas de service de révocation : elle se fait
   # depuis les préférences de l'application mobile.
   #
-  # Retourne le Result de l'écriture du consentement, dont l'appelant a besoin
-  # pour savoir quoi afficher.
+  # Retourne un statut du même vocabulaire que ConsentStatus, prêt pour
+  # AmiConsentStateComponent : :granted ou :error.
   class GrantConsent
-    def self.call(dossier:) = new(dossier).call
+    include Dry::Monads[:result]
 
-    def initialize(dossier)
+    def self.call(dossier:, fc_hash: nil) = new(dossier, fc_hash).call
+
+    def initialize(dossier, fc_hash = nil)
       @dossier = dossier
+      @fc_hash = fc_hash
     end
 
     def call
-      result = Client.new.grant_consent(RecipientFcHash.call(dossier.user))
-      # Sans consentement enregistré, l'événement n'a pas à partir : son contenu
-      # ne doit pas parvenir à AMI.
-      return result if result.failure?
-
-      # grant_consent: le consentement vient d'être accordé, le job n'a pas à le
-      # revérifier — AMI pourrait ne pas l'avoir encore propagé.
-      CreateNotificationService.call(dossier:, grant_consent: true)
-
-      result
+      case Client.new.grant_consent(fc_hash)
+      in Success(_)
+        # skip_consent_check: le consentement vient d'être accordé, le job n'a
+        # pas à le relire — AMI pourrait ne pas l'avoir encore propagé.
+        CreateNotificationService.call(dossier:, skip_consent_check: true)
+        :granted
+      in Failure(API::Client::Error => error)
+        # Sans consentement enregistré, l'événement n'a pas à partir : son
+        # contenu ne doit pas parvenir à AMI.
+        Rails.logger.warn("Ami::GrantConsent failed: #{error.type} code: #{error.code}")
+        :error
+      end
     end
 
     private
 
     attr_reader :dossier
+
+    # L'appelant a déjà le hash sous la main la plupart du temps : le recalculer
+    # coûterait une requête de plus.
+    def fc_hash = @fc_hash ||= RecipientFcHash.call(dossier.user)
   end
 end

--- a/app/views/users/ami_consents/show.html.erb
+++ b/app/views/users/ami_consents/show.html.erb
@@ -1,3 +1,3 @@
 <%= turbo_frame_tag "ami-consent", "aria-live": "polite" do %>
-  <%= render Dossiers::AmiConsentStateComponent.new(status: @status, dossier: @dossier, error: @error, focus: @focus) %>
+  <%= render Dossiers::AmiConsentStateComponent.new(status: @status, dossier: @dossier, focus: @focus) %>
 <% end %>

--- a/app/views/users/ami_consents/show.html.erb
+++ b/app/views/users/ami_consents/show.html.erb
@@ -1,3 +1,3 @@
 <%= turbo_frame_tag "ami-consent", "aria-live": "polite" do %>
-  <%= render Dossiers::AmiConsentStateComponent.new(status: @status, error: @error, focus: @focus) %>
+  <%= render Dossiers::AmiConsentStateComponent.new(status: @status, dossier: @dossier, error: @error, focus: @focus) %>
 <% end %>

--- a/app/views/users/ami_consents/show.html.erb
+++ b/app/views/users/ami_consents/show.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag "ami-consent", "aria-live": "polite" do %>
+  <%= render Dossiers::AmiConsentStateComponent.new(status: @status, error: @error, focus: @focus) %>
+<% end %>

--- a/app/views/users/dossiers/_merci.html.erb
+++ b/app/views/users/dossiers/_merci.html.erb
@@ -42,6 +42,8 @@
           <%= link_to t('views.users.dossiers.merci.acces_dossier'), dossier ? dossier_path(dossier) : "#dossier", class: 'fr-btn fr-mx-2w' %>
         </p>
 
+        <%= render Dossiers::AmiFollowComponent.new(dossier:) %>
+
         <hr class="fr-hr">
 
         <p>

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -376,3 +376,6 @@ DOCUMENT_IA_KEY=""
 AMI_API_URL=""
 AMI_API_USER=""
 AMI_API_PASSWORD=""
+# Until AMI ships a consent write, the first notification sent grants the consent.
+# Enable once the endpoint exists.
+AMI_GRANT_CONSENT_ENDPOINT_AVAILABLE=""

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -376,6 +376,3 @@ DOCUMENT_IA_KEY=""
 AMI_API_URL=""
 AMI_API_USER=""
 AMI_API_PASSWORD=""
-# Until AMI ships a consent write, the first notification sent grants the consent.
-# Enable once the endpoint exists.
-AMI_GRANT_CONSENT_ENDPOINT_AVAILABLE=""

--- a/config/routes/usager.rb
+++ b/config/routes/usager.rb
@@ -93,6 +93,9 @@ scope module: 'users', defaults: { nav_bar_profile: :user } do
   get 'personnalisation', to: 'dossiers#personnalisation', as: :personnalisation
   patch 'personnalisation', to: 'dossiers#update_personnalisation'
 
+  get 'suivi-ami' => 'ami_consents#show', as: :ami_consent
+  post 'suivi-ami' => 'ami_consents#create', as: :create_ami_consent
+
   get 'profil' => 'profil#show'
   patch 'update_email' => 'profil#update_email'
   post 'transfer_all_dossiers' => 'profil#transfer_all_dossiers'

--- a/config/routes/usager.rb
+++ b/config/routes/usager.rb
@@ -67,6 +67,8 @@ scope module: 'users', defaults: { nav_bar_profile: :user } do
       get 'champs/:stable_id', to: 'dossiers#champ', as: :champ
       patch 'champs/:stable_id/revert_prefill', to: 'dossiers#revert_prefill', as: :revert_prefill_champ
       get 'merci'
+      get 'ami-consent', to: 'ami_consents#show', as: :ami_consent
+      post 'ami-consent', to: 'ami_consents#create', as: :create_ami_consent
       get 'demande'
       get 'messagerie'
       get 'rendez-vous'
@@ -92,9 +94,6 @@ scope module: 'users', defaults: { nav_bar_profile: :user } do
   get 'transferts' => 'dossiers#transfer_requests'
   get 'personnalisation', to: 'dossiers#personnalisation', as: :personnalisation
   patch 'personnalisation', to: 'dossiers#update_personnalisation'
-
-  get 'suivi-ami' => 'ami_consents#show', as: :ami_consent
-  post 'suivi-ami' => 'ami_consents#create', as: :create_ami_consent
 
   get 'profil' => 'profil#show'
   patch 'update_email' => 'profil#update_email'

--- a/spec/components/dossiers/ami_consent_state_component_spec.rb
+++ b/spec/components/dossiers/ami_consent_state_component_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe Dossiers::AmiConsentStateComponent, type: :component do
     end
   end
 
+  context 'when AMI cannot be asked at all' do
+    let(:status) { :unavailable }
+
+    it 'renders nothing, leaving the frame empty' do
+      render_component
+
+      expect(page).not_to have_button
+      expect(page).not_to have_css('p')
+    end
+  end
+
   context 'when the user has not consented' do
     let(:status) { :not_granted }
 

--- a/spec/components/dossiers/ami_consent_state_component_spec.rb
+++ b/spec/components/dossiers/ami_consent_state_component_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe Dossiers::AmiConsentStateComponent, type: :component do
       expect(page).to have_css('.fr-sr-only')
       expect(page).not_to have_button
     end
+
+    it 'holds the place with a skeleton, hidden from assistive technologies' do
+      render_component
+
+      expect(page).to have_css('.ami-consent__skeleton[aria-hidden="true"]')
+    end
   end
 
   context 'when AMI cannot be asked at all' do

--- a/spec/components/dossiers/ami_consent_state_component_spec.rb
+++ b/spec/components/dossiers/ami_consent_state_component_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Dossiers::AmiConsentStateComponent, type: :component do
-  subject(:render_component) { render_inline(described_class.new(status:, **options)) }
+  subject(:render_component) { render_inline(described_class.new(status:, dossier:, **options)) }
 
+  let(:dossier) { dossiers.en_construction }
   let(:options) { {} }
 
   context 'while AMI has not answered yet' do
@@ -41,7 +42,7 @@ RSpec.describe Dossiers::AmiConsentStateComponent, type: :component do
 
       expect(page).to have_button(text: /Je souhaite suivre mes démarches/)
       expect(page).to have_css('.fr-icon-notification-3-line')
-      expect(page).to have_css("form[action='/suivi-ami'][data-turbo='true']")
+      expect(page).to have_css("form[action='/dossiers/#{dossier.id}/ami-consent'][data-turbo='true']")
     end
   end
 

--- a/spec/components/dossiers/ami_consent_state_component_spec.rb
+++ b/spec/components/dossiers/ami_consent_state_component_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe Dossiers::AmiConsentStateComponent, type: :component do
+  subject(:render_component) { render_inline(described_class.new(status:, **options)) }
+
+  let(:options) { {} }
+
+  context 'while AMI has not answered yet' do
+    let(:status) { :loading }
+
+    it 'announces the loading without offering the consent yet' do
+      render_component
+
+      expect(page).to have_css('.fr-sr-only')
+      expect(page).not_to have_button
+    end
+  end
+
+  context 'when the user has not consented' do
+    let(:status) { :not_granted }
+
+    it 'offers to follow the procedures in the app' do
+      render_component
+
+      expect(page).to have_button(text: /Je souhaite suivre mes démarches/)
+      expect(page).to have_css('.fr-icon-notification-3-line')
+      expect(page).to have_css("form[action='/suivi-ami'][data-turbo='true']")
+    end
+  end
+
+  context 'when AMI could not answer' do
+    let(:status) { :unknown }
+
+    it 'falls back on offering the consent' do
+      render_component
+
+      expect(page).to have_button(text: /Je souhaite suivre mes démarches/)
+    end
+  end
+
+  context 'when the user has consented' do
+    let(:status) { :granted }
+
+    it 'confirms the follow-up instead of offering it' do
+      render_component
+
+      expect(page).to have_text('Vous suivez vos démarches')
+      expect(page).to have_css('.fr-icon-check-line')
+      expect(page).not_to have_button
+    end
+
+    it 'does not steal the focus on page load' do
+      render_component
+
+      expect(page).not_to have_css('[data-controller="autofocus"]')
+    end
+
+    context 'right after the user consented' do
+      let(:options) { { focus: true } }
+
+      it 'moves the focus to the confirmation' do
+        render_component
+
+        expect(page).to have_css('[data-controller="autofocus"][tabindex="-1"]')
+      end
+    end
+  end
+
+  context 'when the call to AMI failed' do
+    let(:status) { :not_granted }
+    let(:options) { { error: true } }
+
+    it 'warns the user and keeps the consent available' do
+      render_component
+
+      expect(page).to have_css('[role="alert"]')
+      expect(page).to have_button(text: /Je souhaite suivre mes démarches/)
+    end
+  end
+end

--- a/spec/components/dossiers/ami_consent_state_component_spec.rb
+++ b/spec/components/dossiers/ami_consent_state_component_spec.rb
@@ -83,16 +83,4 @@ RSpec.describe Dossiers::AmiConsentStateComponent, type: :component do
       end
     end
   end
-
-  context 'when the call to AMI failed' do
-    let(:status) { :not_granted }
-    let(:options) { { error: true } }
-
-    it 'warns the user and keeps the consent available' do
-      render_component
-
-      expect(page).to have_css('[role="alert"]')
-      expect(page).to have_button(text: /Je souhaite suivre mes démarches/)
-    end
-  end
 end

--- a/spec/components/dossiers/ami_consent_state_component_spec.rb
+++ b/spec/components/dossiers/ami_consent_state_component_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe Dossiers::AmiConsentStateComponent, type: :component do
     end
   end
 
+  context 'when the consent could not be saved' do
+    let(:status) { :error }
+
+    it 'says so and lets the user try again' do
+      render_component
+
+      expect(page).to have_css('.fr-error-text')
+      expect(page).to have_button(text: /Je souhaite suivre mes démarches/)
+    end
+  end
+
   context 'when AMI could not answer' do
     let(:status) { :unknown }
 

--- a/spec/components/dossiers/ami_follow_component_spec.rb
+++ b/spec/components/dossiers/ami_follow_component_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Dossiers::AmiFollowComponent, type: :component do
 
   before do
     allow_any_instance_of(Procedure).to receive(:feature_enabled?).with(:ami_notifications).and_return(true)
+    allow_any_instance_of(Ami::Client).to receive(:configured?).and_return(true)
     allow(Ami::RecipientFcHash).to receive(:call).and_return("abc123")
   end
 
@@ -54,6 +55,16 @@ RSpec.describe Dossiers::AmiFollowComponent, type: :component do
 
   context 'when the user has no France Connect identity' do
     before { allow(Ami::RecipientFcHash).to receive(:call).and_return(nil) }
+
+    it 'renders nothing' do
+      render_component
+
+      expect(page).not_to have_css('.ami-follow')
+    end
+  end
+
+  context 'when AMI is not configured' do
+    before { allow_any_instance_of(Ami::Client).to receive(:configured?).and_return(false) }
 
     it 'renders nothing' do
       render_component

--- a/spec/components/dossiers/ami_follow_component_spec.rb
+++ b/spec/components/dossiers/ami_follow_component_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe Dossiers::AmiFollowComponent, type: :component do
+  subject(:render_component) { render_inline(described_class.new(dossier:)) }
+
+  let(:dossier) { dossiers.en_construction }
+
+  before do
+    allow_any_instance_of(Procedure).to receive(:feature_enabled?).with(:ami_notifications).and_return(true)
+    allow(Ami::RecipientFcHash).to receive(:call).and_return("abc123")
+  end
+
+  it 'promotes the app and offers to download it' do
+    render_component
+
+    expect(page).to have_css('.ami-follow')
+    expect(page).to have_text(Ami::APP_NAME)
+    expect(page).to have_link(href: Ami::APP_URL)
+    expect(page).to have_css("a[target='_blank'][rel='noopener noreferrer']")
+  end
+
+  it 'loads the consent state aside from the page' do
+    render_component
+
+    expect(page).to have_css("turbo-frame#ami-consent[src='/suivi-ami'][loading='lazy']")
+  end
+
+  it 'opens the app information in a modal' do
+    render_component
+
+    expect(page).to have_css("button[aria-controls='ami-info-modal'][aria-haspopup='dialog']")
+    expect(page).to have_css('dialog#ami-info-modal.fr-modal')
+  end
+
+  context 'when previewing the page as an administrateur, without a dossier' do
+    let(:dossier) { nil }
+
+    it 'renders nothing' do
+      render_component
+
+      expect(page).not_to have_css('.ami-follow')
+    end
+  end
+
+  context 'when the procedure does not send AMI notifications' do
+    before { allow_any_instance_of(Procedure).to receive(:feature_enabled?).with(:ami_notifications).and_return(false) }
+
+    it 'renders nothing' do
+      render_component
+
+      expect(page).not_to have_css('.ami-follow')
+    end
+  end
+
+  context 'when the user has no France Connect identity' do
+    before { allow(Ami::RecipientFcHash).to receive(:call).and_return(nil) }
+
+    it 'renders nothing' do
+      render_component
+
+      expect(page).not_to have_css('.ami-follow')
+    end
+  end
+end

--- a/spec/components/dossiers/ami_follow_component_spec.rb
+++ b/spec/components/dossiers/ami_follow_component_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Dossiers::AmiFollowComponent, type: :component do
   it 'loads the consent state aside from the page' do
     render_component
 
-    expect(page).to have_css("turbo-frame#ami-consent[src='/suivi-ami'][loading='lazy']")
+    expect(page).to have_css("turbo-frame#ami-consent[src='/dossiers/#{dossier.id}/ami-consent'][loading='lazy']")
   end
 
   it 'opens the app information in a modal' do

--- a/spec/components/previews/dossiers/ami_consent_state_component_preview.rb
+++ b/spec/components/previews/dossiers/ami_consent_state_component_preview.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Dossiers::AmiConsentStateComponentPreview < ViewComponent::Preview
+  def loading
+    render(Dossiers::AmiConsentStateComponent.new(status: :loading))
+  end
+
+  def not_granted
+    render(Dossiers::AmiConsentStateComponent.new(status: :not_granted))
+  end
+
+  def granted
+    render(Dossiers::AmiConsentStateComponent.new(status: :granted))
+  end
+
+  def error
+    render(Dossiers::AmiConsentStateComponent.new(status: :not_granted, error: true))
+  end
+end

--- a/spec/components/previews/dossiers/ami_consent_state_component_preview.rb
+++ b/spec/components/previews/dossiers/ami_consent_state_component_preview.rb
@@ -6,14 +6,16 @@ class Dossiers::AmiConsentStateComponentPreview < ViewComponent::Preview
   end
 
   def not_granted
-    render(Dossiers::AmiConsentStateComponent.new(status: :not_granted))
+    render(Dossiers::AmiConsentStateComponent.new(status: :not_granted, dossier: previewed_dossier))
   end
 
   def granted
     render(Dossiers::AmiConsentStateComponent.new(status: :granted))
   end
 
-  def error
-    render(Dossiers::AmiConsentStateComponent.new(status: :not_granted, error: true))
-  end
+  private
+
+  # Le formulaire a besoin d'un dossier pour construire son action, mais rien
+  # d'autre : un dossier non persisté suffit à cette preview.
+  def previewed_dossier = Dossier.new(id: 1)
 end

--- a/spec/components/previews/dossiers/ami_follow_component_preview.rb
+++ b/spec/components/previews/dossiers/ami_follow_component_preview.rb
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
 
 class Dossiers::AmiFollowComponentPreview < ViewComponent::Preview
-  # La zone de consentement se charge à part, dans son turbo-frame : hors d'une
-  # session connectée elle reste vide ici, cf. AmiConsentStateComponentPreview
-  # pour ses différents états.
+  # La zone de consentement se charge à part, dans son turbo-frame : elle reste
+  # vide ici, cf. AmiConsentStateComponentPreview pour ses différents états.
   def default
     render(previewed_component)
   end
 
   private
 
-  # L'encart ne s'affiche qu'avec une démarche notifiant AMI et une identité
-  # France Connect, que cette preview n'a pas : on force son affichage.
+  # L'encart demande une démarche notifiant AMI et une identité France Connect,
+  # que cette preview n'a pas : on force son affichage, et on la prive de
+  # l'adresse du turbo-frame, qu'elle ne pourrait pas charger sans session.
   def previewed_component
     Dossiers::AmiFollowComponent.new(dossier: nil).tap do |component|
       component.define_singleton_method(:render?) { true }
+      component.define_singleton_method(:ami_consent_path) { nil }
     end
   end
 end

--- a/spec/components/previews/dossiers/ami_follow_component_preview.rb
+++ b/spec/components/previews/dossiers/ami_follow_component_preview.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Dossiers::AmiFollowComponentPreview < ViewComponent::Preview
+  # La zone de consentement se charge à part, dans son turbo-frame : hors d'une
+  # session connectée elle reste vide ici, cf. AmiConsentStateComponentPreview
+  # pour ses différents états.
+  def default
+    render(previewed_component)
+  end
+
+  private
+
+  # L'encart ne s'affiche qu'avec une démarche notifiant AMI et une identité
+  # France Connect, que cette preview n'a pas : on force son affichage.
+  def previewed_component
+    Dossiers::AmiFollowComponent.new(dossier: nil).tap do |component|
+      component.define_singleton_method(:render?) { true }
+    end
+  end
+end

--- a/spec/components/previews/dossiers/ami_follow_component_preview.rb
+++ b/spec/components/previews/dossiers/ami_follow_component_preview.rb
@@ -15,7 +15,7 @@ class Dossiers::AmiFollowComponentPreview < ViewComponent::Preview
   def previewed_component
     Dossiers::AmiFollowComponent.new(dossier: nil).tap do |component|
       component.define_singleton_method(:render?) { true }
-      component.define_singleton_method(:ami_consent_path) { nil }
+      component.define_singleton_method(:consent_path) { nil }
     end
   end
 end

--- a/spec/controllers/users/ami_consents_controller_spec.rb
+++ b/spec/controllers/users/ami_consents_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
       before { sign_in(user) }
 
       it 'renders the consent state in its turbo frame' do
-        allow(Ami::ConsentStatus).to receive(:call).with(user).and_return(:granted)
+        allow(Ami::ConsentStatus).to receive(:call).with("abc123").and_return(:granted)
 
         expect(show).to have_http_status(:ok)
         expect(response.body).to include('turbo-frame')

--- a/spec/controllers/users/ami_consents_controller_spec.rb
+++ b/spec/controllers/users/ami_consents_controller_spec.rb
@@ -28,16 +28,26 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
         expect(response.body).to include('Vous suivez vos démarches')
       end
 
+      # Une réponse sans turbo-frame afficherait « Content missing » à la place
+      # de l'encart : on répond toujours par le frame, vide le cas échéant.
       context 'when the user has no France Connect identity' do
         before { allow(Ami::RecipientFcHash).to receive(:call).and_return(nil) }
 
-        it { expect(show).to have_http_status(:no_content) }
+        it 'answers an empty frame' do
+          expect(show).to have_http_status(:ok)
+          expect(response.body).to include('turbo-frame')
+          expect(response.body).not_to include('Je souhaite suivre mes démarches')
+        end
       end
 
       context 'when AMI is not configured' do
         before { allow_any_instance_of(Ami::Client).to receive(:configured?).and_return(false) }
 
-        it { expect(show).to have_http_status(:no_content) }
+        it 'answers an empty frame' do
+          expect(show).to have_http_status(:ok)
+          expect(response.body).to include('turbo-frame')
+          expect(response.body).not_to include('Je souhaite suivre mes démarches')
+        end
       end
     end
   end

--- a/spec/controllers/users/ami_consents_controller_spec.rb
+++ b/spec/controllers/users/ami_consents_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
 
   before do
     allow_any_instance_of(Ami::Client).to receive(:configured?).and_return(true)
+    allow_any_instance_of(Procedure).to receive(:feature_enabled?).with(:ami_notifications).and_return(true)
     allow(Ami::RecipientFcHash).to receive(:call).and_return("abc123")
   end
 
@@ -51,6 +52,17 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
         end
       end
 
+      # Sans le drapeau, l'événement serait écarté juste après : ne pas
+      # promettre un suivi qui n'aura pas lieu.
+      context 'when the procedure does not notify AMI' do
+        before { allow_any_instance_of(Procedure).to receive(:feature_enabled?).with(:ami_notifications).and_return(false) }
+
+        it 'answers an empty frame' do
+          expect(show).to have_http_status(:ok)
+          expect(response.body).not_to include('Je souhaite suivre mes démarches')
+        end
+      end
+
       context 'with a dossier belonging to someone else' do
         let(:dossier) { create(:dossier, :en_construction) }
 
@@ -72,29 +84,22 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
   describe 'POST #create' do
     subject(:create_consent) { post :create, params: { id: dossier.id } }
 
-    before { sign_in(user) }
-
-    context 'when AMI accepts the consent' do
-      before { allow(Ami::GrantConsent).to receive(:call).with(user).and_return(Dry::Monads::Success(nil)) }
-
-      it 'confirms the follow-up and moves the focus to it' do
-        expect(create_consent).to have_http_status(:ok)
-        expect(response.body).to include('Vous suivez vos démarches')
-        expect(response.body).to include('autofocus')
-      end
+    before do
+      sign_in(user)
+      allow(Ami::GrantConsent).to receive(:call)
     end
 
-    context 'when AMI is unreachable' do
-      before do
-        allow(Ami::GrantConsent).to receive(:call).with(user)
-          .and_return(Dry::Monads::Failure(API::Client::Error[:timeout, 0, true, "Operation timed out"]))
-      end
+    it 'grants the consent from the dossier being viewed' do
+      create_consent
 
-      it 'warns the user without failing, and keeps the consent available' do
-        expect(create_consent).to have_http_status(:ok)
-        expect(response.body).to include('momentanément indisponible')
-        expect(response.body).to include('Je souhaite suivre mes démarches')
-      end
+      expect(Ami::GrantConsent).to have_received(:call).with(dossier:)
+    end
+
+    # Bascule optimiste : on ne fait pas patienter l'usager le temps qu'AMI réponde.
+    it 'confirms the follow-up right away and moves the focus to it' do
+      expect(create_consent).to have_http_status(:ok)
+      expect(response.body).to include('Vous suivez vos démarches')
+      expect(response.body).to include('autofocus')
     end
   end
 end

--- a/spec/controllers/users/ami_consents_controller_spec.rb
+++ b/spec/controllers/users/ami_consents_controller_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe Users::AmiConsentsController, type: :controller do
+  render_views
+
+  let(:user) { users.usager }
+
+  before do
+    allow_any_instance_of(Ami::Client).to receive(:configured?).and_return(true)
+    allow(Ami::RecipientFcHash).to receive(:call).and_return("abc123")
+  end
+
+  describe 'GET #show' do
+    subject(:show) { get :show }
+
+    context 'when the user is not signed in' do
+      it { expect(show).to redirect_to(new_user_session_path) }
+    end
+
+    context 'when the user is signed in' do
+      before { sign_in(user) }
+
+      it 'renders the consent state in its turbo frame' do
+        allow(Ami::ConsentStatus).to receive(:call).with(user).and_return(:granted)
+
+        expect(show).to have_http_status(:ok)
+        expect(response.body).to include('turbo-frame')
+        expect(response.body).to include('Vous suivez vos démarches')
+      end
+
+      context 'when the user has no France Connect identity' do
+        before { allow(Ami::RecipientFcHash).to receive(:call).and_return(nil) }
+
+        it { expect(show).to have_http_status(:no_content) }
+      end
+
+      context 'when AMI is not configured' do
+        before { allow_any_instance_of(Ami::Client).to receive(:configured?).and_return(false) }
+
+        it { expect(show).to have_http_status(:no_content) }
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    subject(:create) { post :create }
+
+    before { sign_in(user) }
+
+    context 'when AMI accepts the consent' do
+      before { allow(Ami::GrantConsent).to receive(:call).with(user).and_return(Dry::Monads::Success(nil)) }
+
+      it 'confirms the follow-up and moves the focus to it' do
+        expect(create).to have_http_status(:ok)
+        expect(response.body).to include('Vous suivez vos démarches')
+        expect(response.body).to include('autofocus')
+      end
+    end
+
+    context 'when AMI is unreachable' do
+      before do
+        allow(Ami::GrantConsent).to receive(:call).with(user)
+          .and_return(Dry::Monads::Failure(API::Client::Error[:timeout, 0, true, "Operation timed out"]))
+      end
+
+      it 'warns the user without failing, and keeps the consent available' do
+        expect(create).to have_http_status(:ok)
+        expect(response.body).to include('momentanément indisponible')
+        expect(response.body).to include('Je souhaite suivre mes démarches')
+      end
+    end
+  end
+end

--- a/spec/controllers/users/ami_consents_controller_spec.rb
+++ b/spec/controllers/users/ami_consents_controller_spec.rb
@@ -86,13 +86,13 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
 
     before do
       sign_in(user)
-      allow(Ami::GrantConsent).to receive(:call).and_return(Dry::Monads::Success(nil))
+      allow(Ami::GrantConsent).to receive(:call).and_return(:granted)
     end
 
-    it 'grants the consent from the dossier being viewed' do
+    it 'grants the consent from the dossier being viewed, reusing the hash it already has' do
       create_consent
 
-      expect(Ami::GrantConsent).to have_received(:call).with(dossier:)
+      expect(Ami::GrantConsent).to have_received(:call).with(dossier:, fc_hash: "abc123")
     end
 
     it 'confirms the follow-up and moves the focus to it' do
@@ -103,8 +103,7 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
 
     context 'when AMI refused the consent' do
       before do
-        allow(Ami::GrantConsent).to receive(:call)
-          .and_return(Dry::Monads::Failure(API::Client::Error[:http, 500, true, "Boom"]))
+        allow(Ami::GrantConsent).to receive(:call).and_return(:error)
       end
 
       # Mieux vaut avouer l'échec que confirmer un suivi qui n'existe pas.

--- a/spec/controllers/users/ami_consents_controller_spec.rb
+++ b/spec/controllers/users/ami_consents_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
 
     before do
       sign_in(user)
-      allow(Ami::GrantConsent).to receive(:call)
+      allow(Ami::GrantConsent).to receive(:call).and_return(Dry::Monads::Success(nil))
     end
 
     it 'grants the consent from the dossier being viewed' do
@@ -95,11 +95,25 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
       expect(Ami::GrantConsent).to have_received(:call).with(dossier:)
     end
 
-    # Bascule optimiste : on ne fait pas patienter l'usager le temps qu'AMI réponde.
-    it 'confirms the follow-up right away and moves the focus to it' do
+    it 'confirms the follow-up and moves the focus to it' do
       expect(create_consent).to have_http_status(:ok)
       expect(response.body).to include('Vous suivez vos démarches')
       expect(response.body).to include('autofocus')
+    end
+
+    context 'when AMI refused the consent' do
+      before do
+        allow(Ami::GrantConsent).to receive(:call)
+          .and_return(Dry::Monads::Failure(API::Client::Error[:http, 500, true, "Boom"]))
+      end
+
+      # Mieux vaut avouer l'échec que confirmer un suivi qui n'existe pas.
+      it 'says the consent could not be saved and offers to try again' do
+        expect(create_consent).to have_http_status(:ok)
+        expect(response.body).not_to include('Vous suivez vos démarches')
+        expect(response.body).to include('fr-error-text')
+        expect(response.body).to include('Je souhaite suivre mes démarches')
+      end
     end
   end
 end

--- a/spec/controllers/users/ami_consents_controller_spec.rb
+++ b/spec/controllers/users/ami_consents_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
   render_views
 
   let(:user) { users.usager }
+  let(:dossier) { dossiers.en_construction }
 
   before do
     allow_any_instance_of(Ami::Client).to receive(:configured?).and_return(true)
@@ -11,7 +12,7 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
   end
 
   describe 'GET #show' do
-    subject(:show) { get :show }
+    subject(:show) { get :show, params: { id: dossier.id } }
 
     context 'when the user is not signed in' do
       it { expect(show).to redirect_to(new_user_session_path) }
@@ -49,11 +50,27 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
           expect(response.body).not_to include('Je souhaite suivre mes démarches')
         end
       end
+
+      context 'with a dossier belonging to someone else' do
+        let(:dossier) { create(:dossier, :en_construction) }
+
+        it { expect { show }.to raise_error(ActiveRecord::RecordNotFound) }
+      end
+
+      # Le consentement engage l'identité France Connect de celui qui clique :
+      # un invité ne peut pas le donner depuis le dossier d'un autre.
+      context 'with a dossier the user is only invited to' do
+        let(:dossier) { create(:dossier, :en_construction) }
+
+        before { create(:invite, dossier:, user:) }
+
+        it { expect { show }.to raise_error(ActiveRecord::RecordNotFound) }
+      end
     end
   end
 
   describe 'POST #create' do
-    subject(:create) { post :create }
+    subject(:create_consent) { post :create, params: { id: dossier.id } }
 
     before { sign_in(user) }
 
@@ -61,7 +78,7 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
       before { allow(Ami::GrantConsent).to receive(:call).with(user).and_return(Dry::Monads::Success(nil)) }
 
       it 'confirms the follow-up and moves the focus to it' do
-        expect(create).to have_http_status(:ok)
+        expect(create_consent).to have_http_status(:ok)
         expect(response.body).to include('Vous suivez vos démarches')
         expect(response.body).to include('autofocus')
       end
@@ -74,7 +91,7 @@ RSpec.describe Users::AmiConsentsController, type: :controller do
       end
 
       it 'warns the user without failing, and keeps the consent available' do
-        expect(create).to have_http_status(:ok)
+        expect(create_consent).to have_http_status(:ok)
         expect(response.body).to include('momentanément indisponible')
         expect(response.body).to include('Je souhaite suivre mes démarches')
       end

--- a/spec/jobs/ami/send_notification_job_spec.rb
+++ b/spec/jobs/ami/send_notification_job_spec.rb
@@ -5,17 +5,56 @@ require 'rails_helper'
 RSpec.describe Ami::SendNotificationJob, type: :job do
   let(:client) { instance_double(Ami::Client, send_notification: result) }
   let(:payload) { { item_type: "dossier", item_id: "42", recipient_fc_hash: "abc123" } }
-  let(:context) { { procedure_id: 12, dossier_id: 42, state: :en_instruction } }
+  let(:context) { { procedure: 12, dossier: 42, state: :en_instruction } }
   let(:result) { Dry::Monads::Success({ ok: true }) }
 
   before do
     allow(Ami::Client).to receive(:new).and_return(client)
+    allow(Ami::ConsentStatus).to receive(:call).with("abc123").and_return(:granted)
   end
 
-  it 'sends payload' do
+  it 'sends payload when the user consented' do
     described_class.perform_now(payload, context)
 
     expect(client).to have_received(:send_notification).with(payload)
+  end
+
+  it 'sends nothing when the user did not consent' do
+    allow(Ami::ConsentStatus).to receive(:call).and_return(:not_granted)
+
+    expect { described_class.perform_now(payload, context) }.not_to raise_error
+    expect(client).not_to have_received(:send_notification)
+  end
+
+  it 'sends nothing when the consent cannot be asked' do
+    allow(Ami::ConsentStatus).to receive(:call).and_return(:unavailable)
+
+    expect { described_class.perform_now(payload, context) }.not_to raise_error
+    expect(client).not_to have_received(:send_notification)
+  end
+
+  # Retrying is the only way not to lose the notification, and we must not
+  # guess a consent we could not read.
+  it 'sends nothing and raises when AMI could not answer the consent' do
+    allow(Ami::ConsentStatus).to receive(:call).and_return(:unknown)
+
+    expect { described_class.perform_now(payload, context) }.to raise_error(described_class::ConsentCheckError)
+    expect(client).not_to have_received(:send_notification)
+  end
+
+  # The first notification is what grants the consent, so asking beforehand
+  # would keep it from ever being sent.
+  it 'sends without asking when the notification carries the consent' do
+    described_class.perform_now(payload, context, grant_consent: true)
+
+    expect(client).to have_received(:send_notification).with(payload)
+    expect(Ami::ConsentStatus).not_to have_received(:call)
+  end
+
+  it 'sends nothing without a France Connect identity' do
+    described_class.perform_now(payload.merge(recipient_fc_hash: nil), context)
+
+    expect(client).not_to have_received(:send_notification)
   end
 
   it 'captures and swallows non-retryable errors' do

--- a/spec/jobs/ami/send_notification_job_spec.rb
+++ b/spec/jobs/ami/send_notification_job_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Ami::SendNotificationJob, type: :job do
   # The first notification is what grants the consent, so asking beforehand
   # would keep it from ever being sent.
   it 'sends without asking when the notification carries the consent' do
-    described_class.perform_now(payload, context, grant_consent: true)
+    described_class.perform_now(payload, context, skip_consent_check: true)
 
     expect(client).to have_received(:send_notification).with(payload)
     expect(Ami::ConsentStatus).not_to have_received(:call)

--- a/spec/services/ami/client_spec.rb
+++ b/spec/services/ami/client_spec.rb
@@ -119,19 +119,29 @@ RSpec.describe Ami::Client do
   describe '#grant_consent' do
     it 'sends the consent of a France Connect identity' do
       allow(api_client).to receive(:call).and_return(
-        Dry::Monads::Failure(API::Client::Error[:json, 201, false, "unexpected end of input"])
+        Dry::Monads::Success(API::Client::OK[{ message: "Consent given" }, double])
       )
 
       result = service.grant_consent("abc123")
 
       expect(api_client).to have_received(:call).with(
-        url: URI("https://ami.example.org#{described_class::CONSENT_WRITE_PATH}"),
-        json: { recipient_fc_hash: "abc123" },
-        method: described_class::CONSENT_WRITE_METHOD,
+        url: URI("https://ami.example.org#{described_class::CONSENT_PATH}/abc123"),
+        json: { consent: true },
+        method: :post,
         userpwd: "ami-user:ami-password",
         timeout: described_class::CONSENT_WRITE_TIMEOUT
       )
       expect(result).to be_success
+    end
+
+    # AMI a répondu sans corps par le passé ; le contrat en promet un désormais,
+    # mais requalifier reste inoffensif et couvre les deux formes.
+    it 'accepts an empty body' do
+      allow(api_client).to receive(:call).and_return(
+        Dry::Monads::Failure(API::Client::Error[:json, 201, false, "unexpected end of input"])
+      )
+
+      expect(service.grant_consent("abc123")).to be_success
     end
 
     it 'returns failure when AMI rejects the call' do

--- a/spec/services/ami/client_spec.rb
+++ b/spec/services/ami/client_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Ami::Client do
   describe '#grant_consent' do
     it 'sends the consent of a France Connect identity' do
       allow(api_client).to receive(:call).and_return(
-        Dry::Monads::Success(API::Client::OK[{ message: "Consent given" }, double])
+        Dry::Monads::Success(API::Client::OK[{ message: "Consent given" }, response])
       )
 
       result = service.grant_consent("abc123")
@@ -134,9 +134,9 @@ RSpec.describe Ami::Client do
       expect(result).to be_success
     end
 
-    # AMI a répondu sans corps par le passé ; le contrat en promet un désormais,
-    # mais requalifier reste inoffensif et couvre les deux formes.
-    it 'accepts an empty body' do
+    # Épingle la borne haute de la plage requalifiée par handle_bodyless_result :
+    # un 201 sans corps est un succès, pas un échec de parsing.
+    it 'accepts an empty body on a 201' do
       allow(api_client).to receive(:call).and_return(
         Dry::Monads::Failure(API::Client::Error[:json, 201, false, "unexpected end of input"])
       )

--- a/spec/services/ami/client_spec.rb
+++ b/spec/services/ami/client_spec.rb
@@ -78,6 +78,71 @@ RSpec.describe Ami::Client do
     end
   end
 
+  describe '#consent' do
+    it 'reads the consent of a France Connect identity' do
+      allow(api_client).to receive(:call).and_return(
+        Dry::Monads::Success(API::Client::OK[{}, response])
+      )
+
+      result = service.consent("abc123")
+
+      expect(api_client).to have_received(:call).with(
+        url: URI("https://ami.example.org/api/v1/consent/abc123"),
+        method: :get,
+        userpwd: "ami-user:ami-password",
+        timeout: described_class::CONSENT_READ_TIMEOUT
+      )
+      expect(result).to be_success
+    end
+
+    # AMI answers 200 without a body, which API::Client cannot parse as JSON
+    it 'returns success when AMI answers 200 with an empty body' do
+      allow(api_client).to receive(:call).and_return(
+        Dry::Monads::Failure(API::Client::Error[:json, 200, false, "unexpected end of input"])
+      )
+
+      expect(service.consent("abc123")).to be_success
+    end
+
+    it 'returns failure when AMI answers 404' do
+      allow(api_client).to receive(:call).and_return(
+        Dry::Monads::Failure(API::Client::Error[:http, 404, false, "Not found"])
+      )
+
+      result = service.consent("abc123")
+
+      expect(result).to be_failure
+      expect(result.failure.code).to eq(404)
+    end
+  end
+
+  describe '#grant_consent' do
+    it 'sends the consent of a France Connect identity' do
+      allow(api_client).to receive(:call).and_return(
+        Dry::Monads::Failure(API::Client::Error[:json, 201, false, "unexpected end of input"])
+      )
+
+      result = service.grant_consent("abc123")
+
+      expect(api_client).to have_received(:call).with(
+        url: URI("https://ami.example.org#{described_class::CONSENT_WRITE_PATH}"),
+        json: { recipient_fc_hash: "abc123" },
+        method: described_class::CONSENT_WRITE_METHOD,
+        userpwd: "ami-user:ami-password",
+        timeout: described_class::CONSENT_WRITE_TIMEOUT
+      )
+      expect(result).to be_success
+    end
+
+    it 'returns failure when AMI rejects the call' do
+      allow(api_client).to receive(:call).and_return(
+        Dry::Monads::Failure(API::Client::Error[:http, 500, true, "Boom"])
+      )
+
+      expect(service.grant_consent("abc123")).to be_failure
+    end
+  end
+
   it 'returns retryable failure when API times out' do
     timeout_error = API::Client::HTTPError.new(
       double(

--- a/spec/services/ami/consent_status_spec.rb
+++ b/spec/services/ami/consent_status_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Ami::ConsentStatus do
+  let(:user) { build(:user) }
+  let(:client) { instance_double(Ami::Client, configured?: true) }
+
+  before do
+    allow(Ami::Client).to receive(:new).and_return(client)
+    allow(Ami::RecipientFcHash).to receive(:call).with(user).and_return("abc123")
+  end
+
+  it 'is unknown when the user has no France Connect identity' do
+    allow(Ami::RecipientFcHash).to receive(:call).with(user).and_return(nil)
+
+    expect(described_class.call(user)).to eq(:unknown)
+    expect(client).not_to have_received(:configured?)
+  end
+
+  it 'is unknown when the client is not configured' do
+    allow(client).to receive(:configured?).and_return(false)
+
+    expect(described_class.call(user)).to eq(:unknown)
+  end
+
+  it 'is granted when AMI answers a success' do
+    allow(client).to receive(:consent).with("abc123").and_return(Dry::Monads::Success(nil))
+
+    expect(described_class.call(user)).to eq(:granted)
+  end
+
+  it 'is not granted when AMI answers a 404' do
+    allow(client).to receive(:consent).with("abc123")
+      .and_return(Dry::Monads::Failure(API::Client::Error[:http, 404, false, "Not found"]))
+
+    expect(described_class.call(user)).to eq(:not_granted)
+  end
+
+  it 'is unknown and reported when AMI fails' do
+    allow(Sentry).to receive(:capture_message)
+    allow(client).to receive(:consent).with("abc123")
+      .and_return(Dry::Monads::Failure(API::Client::Error[:timeout, 0, true, "Operation timed out"]))
+
+    expect(described_class.call(user)).to eq(:unknown)
+    expect(Sentry).to have_received(:capture_message)
+  end
+end

--- a/spec/services/ami/consent_status_spec.rb
+++ b/spec/services/ami/consent_status_spec.rb
@@ -3,46 +3,38 @@
 require 'rails_helper'
 
 RSpec.describe Ami::ConsentStatus do
-  let(:user) { build(:user) }
   let(:client) { instance_double(Ami::Client, configured?: true) }
 
-  before do
-    allow(Ami::Client).to receive(:new).and_return(client)
-    allow(Ami::RecipientFcHash).to receive(:call).with(user).and_return("abc123")
-  end
+  before { allow(Ami::Client).to receive(:new).and_return(client) }
 
-  it 'is unknown when the user has no France Connect identity' do
-    allow(Ami::RecipientFcHash).to receive(:call).with(user).and_return(nil)
-
-    expect(described_class.call(user)).to eq(:unknown)
+  it 'cannot be asked without a France Connect identity' do
+    expect(described_class.call(nil)).to eq(:unavailable)
     expect(client).not_to have_received(:configured?)
   end
 
-  it 'is unknown when the client is not configured' do
+  it 'cannot be asked when the client is not configured' do
     allow(client).to receive(:configured?).and_return(false)
 
-    expect(described_class.call(user)).to eq(:unknown)
+    expect(described_class.call("abc123")).to eq(:unavailable)
   end
 
   it 'is granted when AMI answers a success' do
     allow(client).to receive(:consent).with("abc123").and_return(Dry::Monads::Success(nil))
 
-    expect(described_class.call(user)).to eq(:granted)
+    expect(described_class.call("abc123")).to eq(:granted)
   end
 
   it 'is not granted when AMI answers a 404' do
     allow(client).to receive(:consent).with("abc123")
       .and_return(Dry::Monads::Failure(API::Client::Error[:http, 404, false, "Not found"]))
 
-    expect(described_class.call(user)).to eq(:not_granted)
+    expect(described_class.call("abc123")).to eq(:not_granted)
   end
 
-  it 'is unknown and reported when AMI fails' do
-    allow(Sentry).to receive(:capture_message)
+  it 'is unknown when AMI could not answer' do
     allow(client).to receive(:consent).with("abc123")
       .and_return(Dry::Monads::Failure(API::Client::Error[:timeout, 0, true, "Operation timed out"]))
 
-    expect(described_class.call(user)).to eq(:unknown)
-    expect(Sentry).to have_received(:capture_message)
+    expect(described_class.call("abc123")).to eq(:unknown)
   end
 end

--- a/spec/services/ami/consent_status_spec.rb
+++ b/spec/services/ami/consent_status_spec.rb
@@ -18,7 +18,23 @@ RSpec.describe Ami::ConsentStatus do
     expect(described_class.call("abc123")).to eq(:unavailable)
   end
 
-  it 'is granted when AMI answers a success' do
+  it 'is granted when AMI dates the consent' do
+    allow(client).to receive(:consent).with("abc123")
+      .and_return(Dry::Monads::Success(consent_datetime: "2026-08-28T10:00:00Z"))
+
+    expect(described_class.call("abc123")).to eq(:granted)
+  end
+
+  # Le schéma déclare consent_datetime nullable en 200 alors que la description
+  # promet un 404 : on couvre les deux lectures du contrat.
+  it 'is not granted when AMI answers a success without a date' do
+    allow(client).to receive(:consent).with("abc123")
+      .and_return(Dry::Monads::Success(consent_datetime: nil))
+
+    expect(described_class.call("abc123")).to eq(:not_granted)
+  end
+
+  it 'is granted when AMI answers a success without a body' do
     allow(client).to receive(:consent).with("abc123").and_return(Dry::Monads::Success(nil))
 
     expect(described_class.call("abc123")).to eq(:granted)

--- a/spec/services/ami/create_notification_service_spec.rb
+++ b/spec/services/ami/create_notification_service_spec.rb
@@ -28,15 +28,15 @@ RSpec.describe Ami::CreateNotificationService do
     end
 
     it 'lets the notification carry the consent when asked to' do
-      described_class.call(dossier:, grant_consent: true)
+      described_class.call(dossier:, skip_consent_check: true)
 
-      expect(Ami::SendNotificationJob).to have_been_enqueued.with(anything, anything, grant_consent: true)
+      expect(Ami::SendNotificationJob).to have_been_enqueued.with(anything, anything, skip_consent_check: true)
     end
 
     it 'does not carry the consent by default' do
       described_class.call(dossier:)
 
-      expect(Ami::SendNotificationJob).to have_been_enqueued.with(anything, anything, grant_consent: false)
+      expect(Ami::SendNotificationJob).to have_been_enqueued.with(anything, anything, skip_consent_check: false)
     end
 
     it 'does not enqueue when feature flag is disabled' do

--- a/spec/services/ami/create_notification_service_spec.rb
+++ b/spec/services/ami/create_notification_service_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe Ami::CreateNotificationService do
       expect(args.second.dig("state", "value")).to eq(dossier.state)
     end
 
+    it 'lets the notification carry the consent when asked to' do
+      described_class.call(dossier:, grant_consent: true)
+
+      expect(Ami::SendNotificationJob).to have_been_enqueued.with(anything, anything, grant_consent: true)
+    end
+
+    it 'does not carry the consent by default' do
+      described_class.call(dossier:)
+
+      expect(Ami::SendNotificationJob).to have_been_enqueued.with(anything, anything, grant_consent: false)
+    end
+
     it 'does not enqueue when feature flag is disabled' do
       allow_any_instance_of(Procedure).to receive(:feature_enabled?).with(:ami_notifications).and_return(false)
 

--- a/spec/services/ami/grant_consent_spec.rb
+++ b/spec/services/ami/grant_consent_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Ami::GrantConsent do
 
   before do
     allow(Ami::Client).to receive(:new).and_return(client)
-    allow(Ami::RecipientFcHash).to receive(:call).and_return("abc123")
     allow(Ami::CreateNotificationService).to receive(:call)
   end
 
@@ -16,10 +15,18 @@ RSpec.describe Ami::GrantConsent do
     let(:result) { Dry::Monads::Success(message: "Consent given") }
 
     it 'grants the consent, then sends the dossier event' do
-      expect(described_class.call(dossier:)).to be_success
+      expect(described_class.call(dossier:, fc_hash: "abc123")).to eq(:granted)
 
       expect(client).to have_received(:grant_consent).with("abc123")
-      expect(Ami::CreateNotificationService).to have_received(:call).with(dossier:, grant_consent: true)
+      expect(Ami::CreateNotificationService).to have_received(:call).with(dossier:, skip_consent_check: true)
+    end
+
+    it 'computes the hash itself when the caller has none' do
+      allow(Ami::RecipientFcHash).to receive(:call).with(dossier.user).and_return("def456")
+
+      described_class.call(dossier:)
+
+      expect(client).to have_received(:grant_consent).with("def456")
     end
   end
 
@@ -28,8 +35,8 @@ RSpec.describe Ami::GrantConsent do
 
     # Sans consentement enregistré, l'événement n'a pas à partir : son contenu
     # ne doit pas parvenir à AMI.
-    it 'returns the failure and sends no event' do
-      expect(described_class.call(dossier:)).to be_failure
+    it 'reports the error and sends no event' do
+      expect(described_class.call(dossier:, fc_hash: "abc123")).to eq(:error)
 
       expect(Ami::CreateNotificationService).not_to have_received(:call)
     end

--- a/spec/services/ami/grant_consent_spec.rb
+++ b/spec/services/ami/grant_consent_spec.rb
@@ -4,34 +4,33 @@ require 'rails_helper'
 
 RSpec.describe Ami::GrantConsent do
   let(:dossier) { dossiers.en_construction }
+  let(:client) { instance_double(Ami::Client, grant_consent: result) }
 
-  # Tant qu'AMI n'expose pas d'écriture, c'est le premier événement qui fait foi.
-  context 'while AMI has no consent write' do
-    before { allow(Ami).to receive(:grant_consent_endpoint_available?).and_return(false) }
+  before do
+    allow(Ami::Client).to receive(:new).and_return(client)
+    allow(Ami::RecipientFcHash).to receive(:call).and_return("abc123")
+    allow(Ami::CreateNotificationService).to receive(:call)
+  end
 
-    it 'sends the dossier event, carrying the consent along' do
-      allow(Ami::CreateNotificationService).to receive(:call)
+  context 'when AMI accepts the consent' do
+    let(:result) { Dry::Monads::Success(message: "Consent given") }
 
-      described_class.call(dossier:)
+    it 'grants the consent, then sends the dossier event' do
+      expect(described_class.call(dossier:)).to be_success
 
+      expect(client).to have_received(:grant_consent).with("abc123")
       expect(Ami::CreateNotificationService).to have_received(:call).with(dossier:, grant_consent: true)
     end
   end
 
-  context 'once AMI exposes a consent write' do
-    let(:client) { instance_double(Ami::Client, grant_consent: Dry::Monads::Success(nil)) }
+  context 'when AMI rejects the consent' do
+    let(:result) { Dry::Monads::Failure(API::Client::Error[:http, 500, true, "Boom"]) }
 
-    before do
-      allow(Ami).to receive(:grant_consent_endpoint_available?).and_return(true)
-      allow(Ami::Client).to receive(:new).and_return(client)
-      allow(Ami::RecipientFcHash).to receive(:call).and_return("abc123")
-      allow(Ami::CreateNotificationService).to receive(:call)
-    end
+    # Sans consentement enregistré, l'événement n'a pas à partir : son contenu
+    # ne doit pas parvenir à AMI.
+    it 'returns the failure and sends no event' do
+      expect(described_class.call(dossier:)).to be_failure
 
-    it 'writes the consent instead of sending an event' do
-      described_class.call(dossier:)
-
-      expect(client).to have_received(:grant_consent).with("abc123")
       expect(Ami::CreateNotificationService).not_to have_received(:call)
     end
   end

--- a/spec/services/ami/grant_consent_spec.rb
+++ b/spec/services/ami/grant_consent_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Ami::GrantConsent do
+  let(:user) { build(:user) }
+  let(:client) { instance_double(Ami::Client, configured?: true) }
+
+  before do
+    allow(Ami::Client).to receive(:new).and_return(client)
+    allow(Ami::RecipientFcHash).to receive(:call).with(user).and_return("abc123")
+  end
+
+  it 'fails without calling AMI when the user has no France Connect identity' do
+    allow(Ami::RecipientFcHash).to receive(:call).with(user).and_return(nil)
+
+    expect(described_class.call(user)).to be_failure
+  end
+
+  it 'fails when the client is not configured' do
+    allow(client).to receive(:configured?).and_return(false)
+
+    expect(described_class.call(user)).to be_failure
+  end
+
+  it 'succeeds when AMI accepts the consent' do
+    allow(client).to receive(:grant_consent).with("abc123").and_return(Dry::Monads::Success(nil))
+
+    expect(described_class.call(user)).to be_success
+  end
+
+  it 'fails and relays the error when AMI rejects the call' do
+    error = API::Client::Error[:http, 500, true, "Boom"]
+    allow(client).to receive(:grant_consent).with("abc123").and_return(Dry::Monads::Failure(error))
+
+    result = described_class.call(user)
+
+    expect(result).to be_failure
+    expect(result.failure).to eq(error)
+  end
+end

--- a/spec/services/ami/grant_consent_spec.rb
+++ b/spec/services/ami/grant_consent_spec.rb
@@ -3,39 +3,36 @@
 require 'rails_helper'
 
 RSpec.describe Ami::GrantConsent do
-  let(:user) { build(:user) }
-  let(:client) { instance_double(Ami::Client, configured?: true) }
+  let(:dossier) { dossiers.en_construction }
 
-  before do
-    allow(Ami::Client).to receive(:new).and_return(client)
-    allow(Ami::RecipientFcHash).to receive(:call).with(user).and_return("abc123")
+  # Tant qu'AMI n'expose pas d'écriture, c'est le premier événement qui fait foi.
+  context 'while AMI has no consent write' do
+    before { allow(Ami).to receive(:grant_consent_endpoint_available?).and_return(false) }
+
+    it 'sends the dossier event, carrying the consent along' do
+      allow(Ami::CreateNotificationService).to receive(:call)
+
+      described_class.call(dossier:)
+
+      expect(Ami::CreateNotificationService).to have_received(:call).with(dossier:, grant_consent: true)
+    end
   end
 
-  it 'fails without calling AMI when the user has no France Connect identity' do
-    allow(Ami::RecipientFcHash).to receive(:call).with(user).and_return(nil)
+  context 'once AMI exposes a consent write' do
+    let(:client) { instance_double(Ami::Client, grant_consent: Dry::Monads::Success(nil)) }
 
-    expect(described_class.call(user)).to be_failure
-  end
+    before do
+      allow(Ami).to receive(:grant_consent_endpoint_available?).and_return(true)
+      allow(Ami::Client).to receive(:new).and_return(client)
+      allow(Ami::RecipientFcHash).to receive(:call).and_return("abc123")
+      allow(Ami::CreateNotificationService).to receive(:call)
+    end
 
-  it 'fails when the client is not configured' do
-    allow(client).to receive(:configured?).and_return(false)
+    it 'writes the consent instead of sending an event' do
+      described_class.call(dossier:)
 
-    expect(described_class.call(user)).to be_failure
-  end
-
-  it 'succeeds when AMI accepts the consent' do
-    allow(client).to receive(:grant_consent).with("abc123").and_return(Dry::Monads::Success(nil))
-
-    expect(described_class.call(user)).to be_success
-  end
-
-  it 'fails and relays the error when AMI rejects the call' do
-    error = API::Client::Error[:http, 500, true, "Boom"]
-    allow(client).to receive(:grant_consent).with("abc123").and_return(Dry::Monads::Failure(error))
-
-    result = described_class.call(user)
-
-    expect(result).to be_failure
-    expect(result.failure).to eq(error)
+      expect(client).to have_received(:grant_consent).with("abc123")
+      expect(Ami::CreateNotificationService).not_to have_received(:call)
+    end
   end
 end

--- a/spec/system/users/ami_follow_spec.rb
+++ b/spec/system/users/ami_follow_spec.rb
@@ -10,7 +10,7 @@ describe 'The user, once their dossier is submitted', js: true do
     allow(Ami::RecipientFcHash).to receive(:call).and_return("abc123")
     allow_any_instance_of(Ami::Client).to receive(:configured?).and_return(true)
     allow(Ami::ConsentStatus).to receive(:call).and_return(:not_granted)
-    allow(Ami::GrantConsent).to receive(:call)
+    allow(Ami::GrantConsent).to receive(:call).and_return(Dry::Monads::Success(nil))
 
     login_as user, scope: :user
     visit merci_dossier_path(dossier)
@@ -35,6 +35,17 @@ describe 'The user, once their dossier is submitted', js: true do
 
     expect(page).to have_text("Vous suivez vos démarches sur #{Ami::APP_NAME}")
     expect(Ami::GrantConsent).to have_received(:call).with(dossier:)
+  end
+
+  scenario 'is told when AMI could not save the consent, and can try again' do
+    allow(Ami::GrantConsent).to receive(:call)
+      .and_return(Dry::Monads::Failure(API::Client::Error[:http, 500, true, "Boom"]))
+
+    click_on "Je souhaite suivre mes démarches sur #{Ami::APP_NAME}"
+
+    expect(page).to have_text('Vous pouvez réessayer')
+    expect(page).to have_button("Je souhaite suivre mes démarches sur #{Ami::APP_NAME}")
+    expect(page).not_to have_text("Vous suivez vos démarches sur #{Ami::APP_NAME}")
   end
 
   scenario 'reads what the app is about in a modal' do

--- a/spec/system/users/ami_follow_spec.rb
+++ b/spec/system/users/ami_follow_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+describe 'The user, once their dossier is submitted', js: true do
+  let(:user) { create(:user) }
+  let(:procedure) { create(:procedure, :published, :for_individual) }
+  let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure:, user:) }
+
+  before do
+    Flipper.enable(:ami_notifications, procedure)
+    allow(Ami::RecipientFcHash).to receive(:call).and_return("abc123")
+    allow_any_instance_of(Ami::Client).to receive(:configured?).and_return(true)
+    allow(Ami::ConsentStatus).to receive(:call).and_return(:not_granted)
+
+    login_as user, scope: :user
+    visit merci_dossier_path(dossier)
+  end
+
+  after { Flipper.disable(:ami_notifications, procedure) }
+
+  context 'when AMI accepts the consent' do
+    before { allow(Ami::GrantConsent).to receive(:call).and_return(Dry::Monads::Success(nil)) }
+
+    scenario 'consents to follow their procedures in the app, without leaving the page' do
+      expect(page).to have_button("Je souhaite suivre mes démarches sur #{Ami::APP_NAME}")
+
+      click_on "Je souhaite suivre mes démarches sur #{Ami::APP_NAME}"
+
+      expect(page).to have_text("Vous suivez vos démarches sur #{Ami::APP_NAME}")
+      expect(page).not_to have_button("Je souhaite suivre mes démarches sur #{Ami::APP_NAME}")
+      expect(page).to have_current_path(merci_dossier_path(dossier))
+      expect(page).to have_text('Déposer un autre dossier')
+    end
+  end
+
+  context 'when AMI is unreachable' do
+    before do
+      allow(Ami::GrantConsent).to receive(:call)
+        .and_return(Dry::Monads::Failure(API::Client::Error[:timeout, 0, true, "Operation timed out"]))
+    end
+
+    scenario 'is warned and can try again' do
+      click_on "Je souhaite suivre mes démarches sur #{Ami::APP_NAME}"
+
+      expect(page).to have_text('momentanément indisponible')
+      expect(page).to have_button("Je souhaite suivre mes démarches sur #{Ami::APP_NAME}")
+    end
+  end
+
+  scenario 'reads what the app is about in a modal' do
+    click_on 'Toutes les infos sur l’application'
+
+    expect(page).to have_css('#ami-info-modal', visible: true)
+    expect(page).to have_text('changer vos préférences de suivi des démarches')
+  end
+end

--- a/spec/system/users/ami_follow_spec.rb
+++ b/spec/system/users/ami_follow_spec.rb
@@ -10,7 +10,7 @@ describe 'The user, once their dossier is submitted', js: true do
     allow(Ami::RecipientFcHash).to receive(:call).and_return("abc123")
     allow_any_instance_of(Ami::Client).to receive(:configured?).and_return(true)
     allow(Ami::ConsentStatus).to receive(:call).and_return(:not_granted)
-    allow(Ami::GrantConsent).to receive(:call).and_return(Dry::Monads::Success(nil))
+    allow(Ami::GrantConsent).to receive(:call).and_return(:granted)
 
     login_as user, scope: :user
     visit merci_dossier_path(dossier)
@@ -34,18 +34,7 @@ describe 'The user, once their dossier is submitted', js: true do
     click_on "Je souhaite suivre mes démarches sur #{Ami::APP_NAME}"
 
     expect(page).to have_text("Vous suivez vos démarches sur #{Ami::APP_NAME}")
-    expect(Ami::GrantConsent).to have_received(:call).with(dossier:)
-  end
-
-  scenario 'is told when AMI could not save the consent, and can try again' do
-    allow(Ami::GrantConsent).to receive(:call)
-      .and_return(Dry::Monads::Failure(API::Client::Error[:http, 500, true, "Boom"]))
-
-    click_on "Je souhaite suivre mes démarches sur #{Ami::APP_NAME}"
-
-    expect(page).to have_text('Vous pouvez réessayer')
-    expect(page).to have_button("Je souhaite suivre mes démarches sur #{Ami::APP_NAME}")
-    expect(page).not_to have_text("Vous suivez vos démarches sur #{Ami::APP_NAME}")
+    expect(Ami::GrantConsent).to have_received(:call).with(dossier:, fc_hash: "abc123")
   end
 
   scenario 'reads what the app is about in a modal' do

--- a/spec/system/users/ami_follow_spec.rb
+++ b/spec/system/users/ami_follow_spec.rb
@@ -10,6 +10,7 @@ describe 'The user, once their dossier is submitted', js: true do
     allow(Ami::RecipientFcHash).to receive(:call).and_return("abc123")
     allow_any_instance_of(Ami::Client).to receive(:configured?).and_return(true)
     allow(Ami::ConsentStatus).to receive(:call).and_return(:not_granted)
+    allow(Ami::GrantConsent).to receive(:call)
 
     login_as user, scope: :user
     visit merci_dossier_path(dossier)
@@ -17,33 +18,23 @@ describe 'The user, once their dossier is submitted', js: true do
 
   after { Flipper.disable(:ami_notifications, procedure) }
 
-  context 'when AMI accepts the consent' do
-    before { allow(Ami::GrantConsent).to receive(:call).and_return(Dry::Monads::Success(nil)) }
+  scenario 'consents to follow their procedures in the app, without leaving the page' do
+    expect(page).to have_button("Je souhaite suivre mes démarches sur #{Ami::APP_NAME}")
 
-    scenario 'consents to follow their procedures in the app, without leaving the page' do
-      expect(page).to have_button("Je souhaite suivre mes démarches sur #{Ami::APP_NAME}")
+    click_on "Je souhaite suivre mes démarches sur #{Ami::APP_NAME}"
 
-      click_on "Je souhaite suivre mes démarches sur #{Ami::APP_NAME}"
-
-      expect(page).to have_text("Vous suivez vos démarches sur #{Ami::APP_NAME}")
-      expect(page).not_to have_button("Je souhaite suivre mes démarches sur #{Ami::APP_NAME}")
-      expect(page).to have_current_path(merci_dossier_path(dossier))
-      expect(page).to have_text('Déposer un autre dossier')
-    end
+    expect(page).to have_text("Vous suivez vos démarches sur #{Ami::APP_NAME}")
+    expect(page).not_to have_button("Je souhaite suivre mes démarches sur #{Ami::APP_NAME}")
+    expect(page).to have_current_path(merci_dossier_path(dossier))
+    expect(page).to have_text('Déposer un autre dossier')
   end
 
-  context 'when AMI is unreachable' do
-    before do
-      allow(Ami::GrantConsent).to receive(:call)
-        .and_return(Dry::Monads::Failure(API::Client::Error[:timeout, 0, true, "Operation timed out"]))
-    end
+  # Le consentement passe par l'envoi de l'événement du dossier affiché.
+  scenario 'sends the event of the dossier being viewed' do
+    click_on "Je souhaite suivre mes démarches sur #{Ami::APP_NAME}"
 
-    scenario 'is warned and can try again' do
-      click_on "Je souhaite suivre mes démarches sur #{Ami::APP_NAME}"
-
-      expect(page).to have_text('momentanément indisponible')
-      expect(page).to have_button("Je souhaite suivre mes démarches sur #{Ami::APP_NAME}")
-    end
+    expect(page).to have_text("Vous suivez vos démarches sur #{Ami::APP_NAME}")
+    expect(Ami::GrantConsent).to have_received(:call).with(dossier:)
   end
 
   scenario 'reads what the app is about in a modal' do


### PR DESCRIPTION
AMI est l'application mobile interministérielle. Les notifications AMI existaient
déjà, pilotées par le flag `ami_notifications` par démarche ; ce qui manquait,
c'est le consentement explicite de l'usager.

## Le parcours

Une fois son dossier déposé, l'usager voit un encart lui proposant de suivre ses
démarches dans l'application. L'état du consentement est chargé à part, dans un
turbo-frame paresseux, pour ne pas retarder l'affichage de la page. Au clic, le
consentement est enregistré chez AMI, puis l'événement du dossier part dans la
foulée. Tout se passe sans quitter la page.

Le consentement vaut pour toutes les démarches de l'usager, mais se donne depuis
un dossier. La révocation, elle, se fait uniquement depuis l'application mobile.

## Côté API

- `POST /api/v1/consent/{fc_hash}` enregistre le consentement.
- `GET /api/v1/consent/{fc_hash}` le vérifie **avant chaque envoi d'événement** :
  sans consentement, le contenu de la notification ne part pas.
- Les événements passent sur `PUT /api/v2/event` (`event_date` remplace
  `send_date`, `content_link` remplace `item_external_url`). PUT et non POST :
  l'événement étant identifié par le partenaire et l'objet, un rejeu ne crée pas
  de doublon.

## Points d'attention

- **Le POST de consentement est synchrone dans la requête** (timeout 5 s) : c'est
  assumé, le contrôleur a besoin de la réponse pour afficher soit la
  confirmation, soit un message d'erreur avec le bouton conservé. Pas de bascule
  optimiste : mieux vaut avouer l'échec que confirmer un suivi inexistant.
- `Ami::Client#handle_bodyless_result` requalifie en succès un 2xx au corps
  illisible. Le contrat promet un corps aux deux endpoints de consentement —
  **ce filet est à retirer une fois le comportement réel confirmé avec l'équipe
  AMI**, et c'est la principale raison du statut draft.
- `Ami::APP_NAME` et `Ami::APP_URL` sont encore des valeurs provisoires, à figer
  avec l'équipe AMI (l'URL doit devenir l'universal link de téléchargement).
- Les credentials AMI sont neutralisés dans `.env.test`, donc aucun appel réel
  n'est possible depuis la suite.