### PR TITLE
Tech: bascule les événements AMI sur PUT /api/v2/event

### DIFF
--- a/app/lib/api/client.rb
+++ b/app/lib/api/client.rb
@@ -19,6 +19,12 @@ class API::Client
         body: json.nil? ? body : json.to_json,
         timeout:,
         **typhoeus_options)
+    when :put
+      Typhoeus.put(url,
+        headers: headers_with_authorization(headers, json, authorization_token:),
+        body: json.nil? ? body : json.to_json,
+        timeout:,
+        **typhoeus_options)
     when :patch
       Typhoeus.patch(url,
         headers: headers_with_authorization(headers, json, authorization_token:),

--- a/app/services/ami/client.rb
+++ b/app/services/ami/client.rb
@@ -4,13 +4,15 @@ module Ami
   class Client
     include Dry::Monads[:result]
 
-    def send_notification(payload)
-      path = "/api/v1/notifications"
+    EVENT_PATH = "/api/v2/event"
 
+    # PUT et non POST : l'événement est identifié par le partenaire et l'objet
+    # associé, donc un rejeu ne crée pas de doublon (200 s'il existait, 201 sinon).
+    def send_notification(payload)
       result = API::Client.new.call(
-        url: build_url(path),
+        url: build_url(EVENT_PATH),
         json: payload,
-        method: :post,
+        method: :put,
         userpwd: "#{api_user}:#{api_password}"
       )
       handle_result(result)

--- a/app/services/ami/client.rb
+++ b/app/services/ami/client.rb
@@ -9,13 +9,7 @@ module Ami
     # PUT et non POST : l'événement est identifié par le partenaire et l'objet
     # associé, donc un rejeu ne crée pas de doublon (200 s'il existait, 201 sinon).
     def send_notification(payload)
-      result = API::Client.new.call(
-        url: build_url(EVENT_PATH),
-        json: payload,
-        method: :put,
-        userpwd: "#{api_user}:#{api_password}"
-      )
-      handle_result(result)
+      handle_result(call_api(url: build_url(EVENT_PATH), json: payload, method: :put))
     end
 
     def configured?
@@ -24,9 +18,38 @@ module Ami
 
     private
 
+    def call_api(**options)
+      result = API::Client.new.call(userpwd: credentials, **options)
+      log_api_call(options, result)
+      result
+    end
+
+    # Les échanges avec AMI sont invisibles depuis l'application : en
+    # développement, on trace une ligne par appel, suivable avec un simple
+    # `tail -f log/development.log | grep '\[AMI\]'`. Volontairement limitée à
+    # l'URL, la méthode et le code : ni payload ni réponse, donc aucune donnée
+    # métier dans les logs.
+    def log_api_call(options, result)
+      return if !Rails.env.development?
+
+      verb = options.fetch(:method, :get).to_s.upcase
+      Rails.logger.info("[AMI] #{verb} #{options.fetch(:url).path} → #{response_code_for(result)}")
+    end
+
+    # Une trace de confort ne doit jamais casser l'appel qu'elle observe : on ne
+    # suppose pas la forme du résultat.
+    def response_code_for(result)
+      case result
+      in Success(API::Client::OK => ok) then ok.response.code
+      in Failure(API::Client::Error => error) then error.code
+      else "?"
+      end
+    end
+
     def api_url = ENV.fetch("AMI_API_URL", nil)
     def api_user = ENV.fetch("AMI_API_USER", nil)
     def api_password = ENV.fetch("AMI_API_PASSWORD", nil)
+    def credentials = "#{api_user}:#{api_password}"
 
     def build_url(path)
       uri = URI(api_url)

--- a/app/services/ami/client.rb
+++ b/app/services/ami/client.rb
@@ -36,8 +36,8 @@ module Ami
       case result
       in Success(body:)
         Success(body)
-      in Failure(code:, reason:, retryable:)
-        Failure(API::Client::Error[:api_error, code, retryable, reason])
+      in Failure(API::Client::Error => error)
+        Failure(error)
       end
     end
   end

--- a/app/services/ami/create_notification_service.rb
+++ b/app/services/ami/create_notification_service.rb
@@ -34,24 +34,26 @@ module Ami
 
       Rails.logger.debug { "AMI notification eligible for dossier #{dossier.id} (state: #{state})" }
 
-      payload = create_notification_payload(send_date: Time.zone.now.iso8601)
+      payload = create_notification_payload(event_date: Time.zone.now.iso8601)
       return if payload[:recipient_fc_hash].blank?
 
       Ami::SendNotificationJob.perform_later(payload, context)
     end
 
-    def create_notification_payload(send_date:)
+    # Contrat de PUT /api/v2/event : event_date remplace send_date et
+    # content_link remplace item_external_url.
+    def create_notification_payload(event_date:)
       {
         recipient_fc_hash: RecipientFcHash.call(dossier.user),
         content_title:,
         content_body:,
+        content_link: item_external_url,
         item_type: dossier.procedure.id.to_s,
         item_id: dossier.id.to_s,
         item_status_label:,
         item_generic_status:,
-        item_external_url:,
         item_canal: ApplicationHelper::APP_HOST,
-        send_date:,
+        event_date:,
       }
     end
 

--- a/spec/lib/api/client_spec.rb
+++ b/spec/lib/api/client_spec.rb
@@ -3,6 +3,18 @@
 require 'rails_helper'
 
 describe API::Client do
+  describe '#call' do
+    let(:response) { instance_double(Typhoeus::Response, success?: true, body: '{}', code: 200, headers: { 'content-type' => 'application/json' }) }
+
+    it 'sends a body on a PUT' do
+      allow(Typhoeus).to receive(:put).and_return(response)
+
+      described_class.new.call(url: URI("https://example.org/thing"), json: { a: 1 }, method: :put)
+
+      expect(Typhoeus).to have_received(:put).with(URI("https://example.org/thing"), hash_including(body: '{"a":1}'))
+    end
+  end
+
   describe '#handle_response' do
     let(:client) { described_class.new }
     let(:response) { instance_double(Typhoeus::Response, success?: success, body: body, code: code, headers: headers) }

--- a/spec/services/ami/client_spec.rb
+++ b/spec/services/ami/client_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe Ami::Client do
     result = service.send_notification(payload)
 
     expect(api_client).to have_received(:call).with(
-      url: URI("https://ami.example.org/api/v1/notifications"),
+      url: URI("https://ami.example.org#{described_class::EVENT_PATH}"),
       json: payload,
-      method: :post,
+      method: :put,
       userpwd: "ami-user:ami-password"
     )
     expect(result).to be_success

--- a/spec/services/ami/client_spec.rb
+++ b/spec/services/ami/client_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Ami::Client do
   let(:service) { described_class.new }
   let(:payload) { { event: { state: "accepte" } } }
   let(:api_client) { instance_double(API::Client) }
+  let(:response) { double(code: 200, body: '{"ok":true}') }
 
   before do
     allow(ENV).to receive(:fetch).and_call_original
@@ -17,7 +18,7 @@ RSpec.describe Ami::Client do
 
   it 'returns success when API call succeeds' do
     allow(api_client).to receive(:call).and_return(
-      Dry::Monads::Success({ body: { ok: true } })
+      Dry::Monads::Success(API::Client::OK[{ ok: true }, response])
     )
 
     result = service.send_notification(payload)
@@ -29,16 +30,19 @@ RSpec.describe Ami::Client do
       userpwd: "ami-user:ami-password"
     )
     expect(result).to be_success
+    expect(result.value!).to eq({ ok: true })
   end
 
   it 'returns failure when API returns 4xx' do
     allow(api_client).to receive(:call).and_return(
-      Dry::Monads::Failure({ code: 400, reason: "Bad request", retryable: false })
+      Dry::Monads::Failure(API::Client::Error[:http, 400, false, "Bad request"])
     )
 
     result = service.send_notification(payload)
 
     expect(result).to be_failure
+    expect(result.failure.type).to eq(:http)
+    expect(result.failure.code).to eq(400)
     expect(result.failure.retryable).to be(false)
   end
 
@@ -55,12 +59,13 @@ RSpec.describe Ami::Client do
       )
     )
     allow(api_client).to receive(:call).and_return(
-      Dry::Monads::Failure({ code: 0, reason: timeout_error, retryable: true })
+      Dry::Monads::Failure(API::Client::Error[:timeout, 0, true, timeout_error])
     )
 
     result = service.send_notification(payload)
 
     expect(result).to be_failure
+    expect(result.failure.type).to eq(:timeout)
     expect(result.failure.retryable).to be(true)
   end
 end

--- a/spec/services/ami/client_spec.rb
+++ b/spec/services/ami/client_spec.rb
@@ -46,6 +46,38 @@ RSpec.describe Ami::Client do
     expect(result.failure.retryable).to be(false)
   end
 
+  describe 'logging' do
+    before { allow(Rails.logger).to receive(:info) }
+
+    it 'traces a failed call with the status AMI answered' do
+      allow(Rails.env).to receive(:development?).and_return(true)
+      allow(api_client).to receive(:call).and_return(
+        Dry::Monads::Failure(API::Client::Error[:http, 404, false, "Not found"])
+      )
+
+      service.send_notification(payload)
+
+      expect(Rails.logger).to have_received(:info).with("[AMI] PUT /api/v2/event → 404")
+    end
+
+    it 'traces a successful call with the status AMI answered' do
+      allow(Rails.env).to receive(:development?).and_return(true)
+      allow(api_client).to receive(:call).and_return(Dry::Monads::Success(API::Client::OK[{}, response]))
+
+      service.send_notification(payload)
+
+      expect(Rails.logger).to have_received(:info).with("[AMI] PUT /api/v2/event → 200")
+    end
+
+    it 'stays quiet outside development' do
+      allow(api_client).to receive(:call).and_return(Dry::Monads::Success(API::Client::OK[{}, response]))
+
+      service.send_notification(payload)
+
+      expect(Rails.logger).not_to have_received(:info)
+    end
+  end
+
   it 'returns retryable failure when API times out' do
     timeout_error = API::Client::HTTPError.new(
       double(

--- a/spec/services/ami/create_notification_service_spec.rb
+++ b/spec/services/ami/create_notification_service_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Ami::CreateNotificationService do
     let(:procedure) { create(:procedure, :published, :for_individual) }
     let(:user) { create(:user) }
     let(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure:, user:) }
-    let(:send_date) { "2026-03-02T12:34:56+01:00" }
+    let(:event_date) { "2026-03-02T12:34:56+01:00" }
 
     before do
       create(
@@ -68,7 +68,7 @@ RSpec.describe Ami::CreateNotificationService do
     end
 
     it 'builds the expected payload contract' do
-      payload = described_class.new(dossier:, trigger: :dossier_state_change, state: nil).create_notification_payload(send_date:)
+      payload = described_class.new(dossier:, trigger: :dossier_state_change, state: nil).create_notification_payload(event_date:)
 
       expect(payload).to include(
         recipient_fc_hash: kind_of(String),
@@ -79,12 +79,13 @@ RSpec.describe Ami::CreateNotificationService do
         item_status_label: "En\u00a0instruction",
         item_generic_status: "wip",
         item_canal: described_class::SOURCE,
-        send_date:
+        content_link: kind_of(String),
+        event_date:
       )
     end
 
     it 'uses the same wording as the user notification email subject' do
-      payload = described_class.new(dossier:, trigger: :dossier_state_change, state: nil).create_notification_payload(send_date:)
+      payload = described_class.new(dossier:, trigger: :dossier_state_change, state: nil).create_notification_payload(event_date:)
 
       expect(payload).to include(
         content_title: APPLICATION_NAME,
@@ -96,7 +97,7 @@ RSpec.describe Ami::CreateNotificationService do
       let(:dossier) { create(:dossier, :brouillon, :with_individual, procedure:, user:) }
 
       it 'builds a creation-oriented payload' do
-        payload = described_class.new(dossier:, trigger: :dossier_state_change, state: nil).create_notification_payload(send_date:)
+        payload = described_class.new(dossier:, trigger: :dossier_state_change, state: nil).create_notification_payload(event_date:)
 
         expect(payload).to include(
           content_title: APPLICATION_NAME,
@@ -108,7 +109,7 @@ RSpec.describe Ami::CreateNotificationService do
 
     context 'when triggered by a messagerie message' do
       it 'builds a messagerie-oriented payload' do
-        payload = described_class.new(dossier:, trigger: :messagerie_message, state: nil).create_notification_payload(send_date:)
+        payload = described_class.new(dossier:, trigger: :messagerie_message, state: nil).create_notification_payload(event_date:)
 
         expect(payload).to include(
           content_title: APPLICATION_NAME,


### PR DESCRIPTION
Premier lot du découpage de #13753, qui fait 1250 lignes et n'est pas relisable
en l'état. Ce lot est autonome : il ne dépend d'aucun code de consentement et se
merge sans attendre le reste.

- **`fix(ami): relay API::Client error`** — bug de production. `Ami::Client#handle_result`
  filtre `in Failure(code:, reason:, retryable:)`, mais `API::Client::Error` est un
  `Data.define(:type, :code, :retryable, :error)` : il n'y a pas de `reason`. Le pattern
  ne matche donc jamais une erreur réelle, et dès qu'AMI répond en erreur c'est un
  `NoMatchingPatternError` au lieu du `Failure` attendu. Le spec masquait le bug en
  stubbant un `Hash` ; il utilise désormais les vrais types.
- **`tech(api): support PUT in API::Client`** — ajoute la branche `when :put`, identique
  à `:post`/`:patch`. Purement additif : aucun des 13 consommateurs existants ne change
  de comportement.
- **`feat(ami): send events on the v2 endpoint`** — `POST /api/v1/notifications` devient
  `PUT /api/v2/event`. PUT et non POST : l'événement étant identifié par le partenaire et
  l'objet associé, un rejeu ne crée pas de doublon (200 s'il existait, 201 sinon). Côté
  payload, `event_date` remplace `send_date` et `content_link` remplace `item_external_url`.

Le contrat de payload gagne au passage une assertion sur `content_link`, que l'assertion
`include(...)` partielle laissait sans couverture.