### PR TITLE
ETQ admin, les conditions contradictoires ou jamais vraies sont signalées et bloquent la publication

### DIFF
--- a/app/components/conditions/champs_conditions_component/champs_conditions_component.html.haml
+++ b/app/components/conditions/champs_conditions_component/champs_conditions_component.html.haml
@@ -6,7 +6,7 @@
           Logique conditionnelle
           = logic_conditionnel_button
 
-      = render Conditions::ConditionsErrorsComponent.new(conditions: condition_per_row, source_tdcs: @source_tdcs)
+      = render Conditions::ConditionsErrorsComponent.new(condition: @condition, source_tdcs: @source_tdcs)
 
       - if @condition.present?
         %table.condition-table.fr-mt-4v

--- a/app/components/conditions/conditions_errors_component.rb
+++ b/app/components/conditions/conditions_errors_component.rb
@@ -66,6 +66,12 @@ class Conditions::ConditionsErrorsComponent < ApplicationComponent
       targeted_champ = @source_tdcs.find { |tdc| tdc.stable_id == stable_id }
       t('empty_options', scope: '.errors',
         libelle: targeted_champ.libelle)
+    in { type: :contradiction, stable_id: stable_id, comparisons: comparisons, limits: limits }
+      targeted_champ = @source_tdcs.find { |tdc| tdc.stable_id == stable_id }
+      t('limited', scope: '.errors',
+        libelle: targeted_champ.libelle,
+        comparisons: comparisons.map { humanize_comparison(it) }.to_sentence,
+        limits: humanize_limits(limits))
     in { type: :contradiction, stable_id: stable_id, comparisons: comparisons }
       targeted_champ = @source_tdcs.find { |tdc| tdc.stable_id == stable_id }
       t('contradiction', scope: '.errors',
@@ -79,6 +85,20 @@ class Conditions::ConditionsErrorsComponent < ApplicationComponent
       nil
     end
   end
+
+  def humanize_limits(limits)
+    case limits
+    in { min: Numeric => min, max: Numeric => max }
+      t('limits.between', scope: '.errors', min: humanize_number(min), max: humanize_number(max))
+    in { min: Numeric => min }
+      t('limits.min', scope: '.errors', min: humanize_number(min))
+    in { max: Numeric => max }
+      t('limits.max', scope: '.errors', max: humanize_number(max))
+    end
+  end
+
+  # A decimal bound typed as a whole number reads as one
+  def humanize_number(number) = (number.is_a?(Float) && number == number.to_i ? number.to_i : number).to_s
 
   def humanize_comparison(comparison)
     "#{t(comparison.class.name, scope: 'logic.operators').downcase} « #{humanize_value(comparison)} »"

--- a/app/components/conditions/conditions_errors_component.rb
+++ b/app/components/conditions/conditions_errors_component.rb
@@ -78,6 +78,9 @@ class Conditions::ConditionsErrorsComponent < ApplicationComponent
         count: comparisons.size,
         libelle: targeted_champ.libelle,
         comparisons: comparisons.map { humanize_comparison(it) }.to_sentence)
+    in { type: :unreachable, stable_id: stable_id, branch: true }
+      targeted_champ = @source_tdcs.find { |tdc| tdc.stable_id == stable_id }
+      t('unreachable_branch', scope: '.errors', libelle: targeted_champ.libelle)
     in { type: :unreachable, stable_id: stable_id }
       targeted_champ = @source_tdcs.find { |tdc| tdc.stable_id == stable_id }
       t('unreachable', scope: '.errors', libelle: targeted_champ.libelle)

--- a/app/components/conditions/conditions_errors_component.rb
+++ b/app/components/conditions/conditions_errors_component.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
 class Conditions::ConditionsErrorsComponent < ApplicationComponent
-  def initialize(conditions:, source_tdcs:)
-    @conditions, @source_tdcs = conditions, source_tdcs
+  def initialize(condition:, source_tdcs:)
+    @condition, @source_tdcs = condition, source_tdcs
   end
 
   private
 
-  def errors
-    errors = @conditions
-      .flat_map { |condition| condition.errors(@source_tdcs) }
-      .uniq
+  def errors = to_html_list(messages)
 
-    # if a tdc is not available (has been removed for example)
-    # it causes a lot of errors (incompatible type for example)
-    # only the root cause is displayed
-    messages = if errors.include?({ type: :not_available })
-      [t('not_available', scope: '.errors')]
-    else
-      errors.map { |error| humanize(error) }
+  def messages
+    @messages ||= begin
+      errors = @condition ? Logic.errors(@condition, @source_tdcs).uniq : []
+
+      # if a tdc is not available (has been removed for example)
+      # it causes a lot of errors (incompatible type for example)
+      # only the root cause is displayed
+      if errors.include?({ type: :not_available })
+        [t('not_available', scope: '.errors')]
+      else
+        errors.filter_map { |error| humanize(error) }
+      end
     end
-
-    to_html_list(messages)
   end
 
   def to_html_list(messages)
@@ -66,14 +66,31 @@ class Conditions::ConditionsErrorsComponent < ApplicationComponent
       targeted_champ = @source_tdcs.find { |tdc| tdc.stable_id == stable_id }
       t('empty_options', scope: '.errors',
         libelle: targeted_champ.libelle)
+    in { type: :contradiction, stable_id: stable_id, comparisons: comparisons }
+      targeted_champ = @source_tdcs.find { |tdc| tdc.stable_id == stable_id }
+      t('contradiction', scope: '.errors',
+        count: comparisons.size,
+        libelle: targeted_champ.libelle,
+        comparisons: comparisons.map { humanize_comparison(it) }.to_sentence)
+    in { type: :unreachable, stable_id: stable_id }
+      targeted_champ = @source_tdcs.find { |tdc| tdc.stable_id == stable_id }
+      t('unreachable', scope: '.errors', libelle: targeted_champ.libelle)
     else
       nil
     end
   end
 
-  def render?
-    @conditions
-      .filter { |condition| condition.errors(@source_tdcs).present? }
-      .present?
+  def humanize_comparison(comparison)
+    "#{t(comparison.class.name, scope: 'logic.operators').downcase} « #{humanize_value(comparison)} »"
   end
+
+  # The label the admin picked (a region name, a departement, a choice) rather
+  # than the value stored behind it
+  def humanize_value(comparison)
+    label, _value = comparison.left.options(@source_tdcs, comparison.class.name)&.find { |_label, value| value == comparison.right.value }
+
+    label || comparison.right.to_s.downcase
+  end
+
+  def render? = messages.present?
 end

--- a/app/components/conditions/conditions_errors_component/conditions_errors_component.en.yml
+++ b/app/components/conditions/conditions_errors_component/conditions_errors_component.en.yml
@@ -14,4 +14,9 @@ en:
     contradiction:
       one: "The field « %{libelle} » can never be %{comparisons}."
       other: "The field « %{libelle} » cannot be both %{comparisons}."
+    limited: "The field « %{libelle} » cannot be %{comparisons}: its values are limited %{limits}."
+    limits:
+      between: "between « %{min} » and « %{max} »"
+      min: "to « %{min} » at least"
+      max: "to « %{max} » at most"
     unreachable: "This condition can never be true: the field « %{libelle} » is not displayed in that case."

--- a/app/components/conditions/conditions_errors_component/conditions_errors_component.en.yml
+++ b/app/components/conditions/conditions_errors_component/conditions_errors_component.en.yml
@@ -20,3 +20,4 @@ en:
       min: "to « %{min} » at least"
       max: "to « %{max} » at most"
     unreachable: "This condition can never be true: the field « %{libelle} » is not displayed in that case."
+    unreachable_branch: "One « Or » branch of this condition can never be true: the field « %{libelle} » is not displayed in that case."

--- a/app/components/conditions/conditions_errors_component/conditions_errors_component.en.yml
+++ b/app/components/conditions/conditions_errors_component/conditions_errors_component.en.yml
@@ -11,3 +11,7 @@ en:
       not_eq: "The « is not » operator does not apply to multiple dropdown list."
     not_included: "« %{right} » is not included in « %{libelle} »."
     empty_options: "The field « %{libelle} » has no options to select from."
+    contradiction:
+      one: "The field « %{libelle} » can never be %{comparisons}."
+      other: "The field « %{libelle} » cannot be both %{comparisons}."
+    unreachable: "This condition can never be true: the field « %{libelle} » is not displayed in that case."

--- a/app/components/conditions/conditions_errors_component/conditions_errors_component.fr.yml
+++ b/app/components/conditions/conditions_errors_component/conditions_errors_component.fr.yml
@@ -20,3 +20,4 @@ fr:
       min: "à « %{min} » au minimum"
       max: "à « %{max} » au maximum"
     unreachable: "Cette condition ne peut jamais être vraie : le champ « %{libelle} » n’est pas affiché dans ce cas."
+    unreachable_branch: "Une des branches « Ou » de cette condition ne peut jamais être vraie : le champ « %{libelle} » n’est pas affiché dans ce cas."

--- a/app/components/conditions/conditions_errors_component/conditions_errors_component.fr.yml
+++ b/app/components/conditions/conditions_errors_component/conditions_errors_component.fr.yml
@@ -14,4 +14,9 @@ fr:
     contradiction:
       one: "Le champ « %{libelle} » ne peut jamais être %{comparisons}."
       other: "Le champ « %{libelle} » ne peut pas être à la fois %{comparisons}."
+    limited: "Le champ « %{libelle} » ne peut pas être %{comparisons} : ses valeurs sont limitées %{limits}."
+    limits:
+      between: "entre « %{min} » et « %{max} »"
+      min: "à « %{min} » au minimum"
+      max: "à « %{max} » au maximum"
     unreachable: "Cette condition ne peut jamais être vraie : le champ « %{libelle} » n’est pas affiché dans ce cas."

--- a/app/components/conditions/conditions_errors_component/conditions_errors_component.fr.yml
+++ b/app/components/conditions/conditions_errors_component/conditions_errors_component.fr.yml
@@ -11,3 +11,7 @@ fr:
       not_eq: "Lʼopérateur « n’est pas » ne s’applique pas au choix multiple."
     not_included: "« %{right} » ne fait pas partie de « %{libelle} »."
     empty_options: "Le champ « %{libelle} » n’a aucune option parmi lesquelles choisir."
+    contradiction:
+      one: "Le champ « %{libelle} » ne peut jamais être %{comparisons}."
+      other: "Le champ « %{libelle} » ne peut pas être à la fois %{comparisons}."
+    unreachable: "Cette condition ne peut jamais être vraie : le champ « %{libelle} » n’est pas affiché dans ce cas."

--- a/app/components/conditions/ineligibilite_rules_component/ineligibilite_rules_component.html.erb
+++ b/app/components/conditions/ineligibilite_rules_component/ineligibilite_rules_component.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id(@draft_revision, :ineligibilite_rules) %>">
   <%= render Procedure::PendingRepublishComponent.new(procedure: @draft_revision.procedure, render_if: pending_changes?) %>
-  <%= render Conditions::ConditionsErrorsComponent.new(conditions: condition_per_row, source_tdcs: @source_tdcs) %>
+  <%= render Conditions::ConditionsErrorsComponent.new(condition: @condition, source_tdcs: @source_tdcs) %>
 
   <div class="fr-fieldset">
     <%= form_for(@draft_revision, url: change_admin_procedure_ineligibilite_rules_path(@draft_revision.procedure_id), html: { id: 'ineligibilite_form', class: 'width-100', novalidate: true }) do |f| %>

--- a/app/components/conditions/routing_rules_component/routing_rules_component.html.haml
+++ b/app/components/conditions/routing_rules_component/routing_rules_component.html.haml
@@ -12,7 +12,7 @@
         - elsif @groupe_instructeur.non_unique_rule?
           %p.fr-mb-1w.fr-badge.fr-badge--warning.fr-badge--sm règle déjà attribuée à #{@groupe_instructeur.groups_with_same_rule}
 
-      = render Conditions::ConditionsErrorsComponent.new(conditions: condition_per_row, source_tdcs: @source_tdcs)
+      = render Conditions::ConditionsErrorsComponent.new(condition: @condition, source_tdcs: @source_tdcs)
 
       %table.condition-table
         %thead

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -112,17 +112,12 @@ class GroupeInstructeur < ApplicationRecord
     !valid_rule?
   end
 
+  # A rule is valid when it is well formed on the champs of the active
+  # revision and can actually match a dossier (no contradictory rows).
   def valid_rule?
-    return false if routing_rule.nil?
-    if [And, Or].include?(routing_rule.class)
-      routing_rule.operands.all? { |rule_line| valid_rule_line?(rule_line) }
-    else
-      valid_rule_line?(routing_rule)
-    end
-  end
+    return false if routing_rule.nil? || routing_rule.is_a?(EmptyOperator)
 
-  def valid_rule_line?(rule)
-    !rule.is_a?(EmptyOperator) && routing_rule_matches_tdc?(rule)
+    Logic.errors(routing_rule, procedure.active_revision.public_root_type_de_champs).blank?
   end
 
   def non_unique_rule?
@@ -145,13 +140,6 @@ class GroupeInstructeur < ApplicationRecord
 
   def humanized_routing_rule
     routing_rule&.to_s(procedure.active_revision.type_de_champs)
-  end
-
-  private
-
-  def routing_rule_matches_tdc?(rule)
-    tdcs = procedure.active_revision.public_root_type_de_champs
-    rule.errors(tdcs).blank?
   end
 
   serialize :routing_rule, coder: LogicSerializer

--- a/app/models/logic.rb
+++ b/app/models/logic.rb
@@ -9,6 +9,14 @@ module Logic
     from_h(JSON.parse(s))
   end
 
+  # The errors of a whole condition: the structural ones of its terms (unknown
+  # champ, incompatible types…), or, when it is well formed, the reason it can
+  # never be true (see Logic::Solver). Checked on the root only: a
+  # branch of an `or` may well be dead while the condition is not.
+  def self.errors(condition, type_de_champs)
+    condition.errors(type_de_champs).presence || Solver.new(type_de_champs).errors(condition)
+  end
+
   def self.class_from_name(name)
     [
       ChampValue,

--- a/app/models/logic.rb
+++ b/app/models/logic.rb
@@ -11,8 +11,8 @@ module Logic
 
   # The errors of a whole condition: the structural ones of its terms (unknown
   # champ, incompatible types…), or, when it is well formed, the reason it can
-  # never be true (see Logic::Solver). Checked on the root only: a
-  # branch of an `or` may well be dead while the condition is not.
+  # never be true (see Logic::Solver), or the branch of an `or` that never
+  # can.
   def self.errors(condition, type_de_champs)
     condition.errors(type_de_champs).presence || Solver.new(type_de_champs).errors(condition)
   end

--- a/app/models/logic/champ_column_value.rb
+++ b/app/models/logic/champ_column_value.rb
@@ -48,6 +48,11 @@ class Logic::ChampColumnValue < Logic::Term
     targeted_column(type_de_champs).options_for_select
   end
 
+  def possible_values(type_de_champs)
+    column = targeted_column(type_de_champs)
+    Logic::PossibleValues.for_column(column) if column
+  end
+
   def errors(type_de_champs)
     # the targeted tdc is below current tdc or has been removed
     if targeted_column(type_de_champs).nil?

--- a/app/models/logic/champ_column_value.rb
+++ b/app/models/logic/champ_column_value.rb
@@ -50,7 +50,7 @@ class Logic::ChampColumnValue < Logic::Term
 
   def possible_values(type_de_champs)
     column = targeted_column(type_de_champs)
-    Logic::PossibleValues.for_column(column) if column
+    Logic::PossibleValues.for_column(column, targeted_tdc(type_de_champs)) if column
   end
 
   def errors(type_de_champs)

--- a/app/models/logic/champ_value.rb
+++ b/app/models/logic/champ_value.rb
@@ -40,6 +40,11 @@ class Logic::ChampValue < Logic::Term
     type_de_champ(type_de_champs)&.condition_value_type || CHAMP_VALUE_TYPE.fetch(:unmanaged)
   end
 
+  def possible_values(type_de_champs)
+    tdc = type_de_champ(type_de_champs)
+    Logic::PossibleValues.for(tdc) if tdc
+  end
+
   def errors(type_de_champs)
     if !type_de_champs.map(&:stable_id).include?(stable_id)
       [{ type: :not_available }]

--- a/app/models/logic/display_conditions.rb
+++ b/app/models/logic/display_conditions.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# A blank or hidden champ makes every comparison on it false (see
+# Logic::BinaryOperator#compute), so a comparison on a conditional champ is
+# only ever true when that champ is displayed. This rewrites a condition to
+# say so: every comparison on one of the given champs is joined with the
+# condition under which the champ is displayed — its own, rewritten the same
+# way for the champs it depends on, and so on.
+#
+#   b == 'x' and a < 5           with b displayed when a > 10
+#   (b == 'x' and a > 10) and a < 5
+#
+# Logic::Solver checks the rewritten condition to tell a condition that can
+# never be true because of the form around it from one contradicting itself.
+class Logic::DisplayConditions
+  def initialize(type_de_champs)
+    @type_de_champs = type_de_champs
+    @conditions = {}
+  end
+
+  # The champs the condition targets that are displayed under a condition of
+  # their own
+  def conditional_sources(condition)
+    condition.sources.uniq.filter_map { |stable_id| @type_de_champs.find { it.stable_id == stable_id } }.filter(&:condition?)
+  end
+
+  # The condition with every comparison on one of the sources holding only
+  # while that champ is displayed. Adding the display condition to the
+  # comparisons rather than to the whole condition keeps an `or` alive
+  # through the branches that do not need the champ.
+  def apply(condition, sources)
+    and_with(*hoist_shared(condition, sources))
+  end
+
+  private
+
+  # [term, conditions]: the term with the display conditions added to its
+  # comparisons, except for the ones every operand shares, returned to be
+  # added once above. Lifting them out is `(a and g) or (b and g)` rewritten
+  # as `(a or b) and g`, and it is what keeps a chain of display conditions
+  # flat instead of copied into every branch.
+  #
+  # This lifting is what stands in for clause learning in Logic::Solver: a
+  # chain of champs each displayed under an `or` on the previous one folds
+  # into one flat `and` of `or`s, which the search prunes from the top. It
+  # stops at an `or` whose branches target different champs — the display
+  # condition is then copied into the branches that need it, and a dead
+  # condition on such a chain is searched once per branch at every level.
+  def hoist_shared(term, sources)
+    case term
+    when Logic::And, Logic::Or
+      parts = term.operands.map { hoist_shared(it, sources) }
+      shared = parts.map(&:last).reduce(:&) || []
+
+      [term.class.new(parts.map { |operand, conditions| and_with(operand, conditions - shared) }), shared]
+    else
+      [term, sources.filter { term.sources.include?(it.stable_id) }.filter_map { of(it) }]
+    end
+  end
+
+  def and_with(term, conditions) = conditions.empty? ? term : Logic::And.new([term, *conditions])
+
+  # The condition under which a champ is displayed, its own with every
+  # comparison held in turn by the champs it depends on. A champ met again
+  # while its display condition is being computed (conditions that depend on
+  # each other) is left out: such a form is broken in its own way, and the
+  # rewrite has to end.
+  def of(source)
+    return @conditions[source.stable_id] if @conditions.key?(source.stable_id)
+
+    @conditions[source.stable_id] = nil
+    @conditions[source.stable_id] = apply(source.condition, conditional_sources(source.condition))
+  end
+end

--- a/app/models/logic/possible_values.rb
+++ b/app/models/logic/possible_values.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# What a champ can still hold once the comparisons of a condition have been
+# applied to it: `age` starts out unbounded, `age >= 18` leaves [18, +inf[,
+# and a further `age < 10` leaves nothing — nothing left is how a
+# contradiction shows up. It starts full (`PossibleValues.for(type_de_champ)`,
+# `PossibleValues.for_column(column)`), narrows through
+# `#restrict(operator_class, value)` and can be asked whether it is `#empty?`.
+#
+# Restricting only ever removes values, never adds any, so the comparisons can
+# be folded in in any order and the fold stopped as soon as nothing is left.
+#
+# The four implementations hold their values however suits them — a set of
+# options, a pair of requirements, intervals, departement codes — and
+# Logic::Solver only ever calls `restrict` and `empty?`, so a new kind of
+# champ is a new class plus a line in `.for`. This is the part an SMT solver
+# calls a *theory solver*: the boolean search asks "can these comparisons hold
+# together?" and the champ they constrain answers. The set itself is a
+# *domain*, in the sense constraint solvers give the word.
+#
+# This models the value of a *filled* champ. A blank or hidden champ makes
+# every comparison false (see Logic::BinaryOperator#compute), which is handled
+# by Logic::Solver, not here.
+module Logic::PossibleValues
+  def self.for(type_de_champ)
+    case type_de_champ.condition_value_type
+    when :number
+      Number.new(integer: type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:integer_number))
+    when :departement_enum, :commune_enum, :epci_enum, :address
+      Geo.new
+    else
+      choices(type_de_champ.condition_value_type, type_de_champ.condition_options)
+    end
+  end
+
+  def self.for_column(column)
+    case column.type
+    when :integer
+      Number.new(integer: true)
+    when :decimal
+      Number.new(integer: false)
+    else
+      choices(column.type, column.options_for_select)
+    end
+  end
+
+  # Picked among options: yes/no, one of them, several of them.
+  def self.choices(type, options)
+    case type
+    when :boolean
+      Enum.new([true, false])
+    when :enum
+      Enum.new(options.map(&:second))
+    when :enums
+      Enums.new(options.map(&:second))
+    end
+  end
+  private_class_method :choices
+end

--- a/app/models/logic/possible_values.rb
+++ b/app/models/logic/possible_values.rb
@@ -6,17 +6,19 @@
 # contradiction shows up. It starts full (`PossibleValues.for(type_de_champ)`,
 # `PossibleValues.for_column(column)`), narrows through
 # `#restrict(operator_class, value)` and can be asked whether it is `#empty?`.
+# `#limits` are the bounds the champ's own validation put on it, if any, for
+# the error to name.
 #
 # Restricting only ever removes values, never adds any, so the comparisons can
 # be folded in in any order and the fold stopped as soon as nothing is left.
 #
 # The four implementations hold their values however suits them — a set of
 # options, a pair of requirements, intervals, departement codes — and
-# Logic::Solver only ever calls `restrict` and `empty?`, so a new kind of
-# champ is a new class plus a line in `.for`. This is the part an SMT solver
-# calls a *theory solver*: the boolean search asks "can these comparisons hold
-# together?" and the champ they constrain answers. The set itself is a
-# *domain*, in the sense constraint solvers give the word.
+# Logic::Solver only ever calls `restrict`, `empty?` and `limits`, so a new
+# kind of champ is a new class plus a line in `.for`. This is the part an
+# SMT solver calls a *theory solver*: the boolean search asks "can these
+# comparisons hold together?" and the champ they constrain answers. The set
+# itself is a *domain*, in the sense constraint solvers give the word.
 #
 # This models the value of a *filled* champ. A blank or hidden champ makes
 # every comparison false (see Logic::BinaryOperator#compute), which is handled
@@ -25,7 +27,7 @@ module Logic::PossibleValues
   def self.for(type_de_champ)
     case type_de_champ.condition_value_type
     when :number
-      Number.new(integer: type_de_champ.type_champ == TypeDeChamp.type_champs.fetch(:integer_number))
+      Number.for(type_de_champ)
     when :departement_enum, :commune_enum, :epci_enum, :address
       Geo.new
     else
@@ -33,12 +35,13 @@ module Logic::PossibleValues
     end
   end
 
-  def self.for_column(column)
+  # A numeric column is the champ's own value only on a numeric champ, whose
+  # validation limits then apply; on any other champ it is a facet with no
+  # limits of its own.
+  def self.for_column(column, type_de_champ)
     case column.type
-    when :integer
-      Number.new(integer: true)
-    when :decimal
-      Number.new(integer: false)
+    when :integer, :decimal
+      type_de_champ.condition_value_type == :number ? Number.for(type_de_champ) : Number.new(integer: column.type == :integer)
     else
       choices(column.type, column.options_for_select)
     end

--- a/app/models/logic/possible_values/enum.rb
+++ b/app/models/logic/possible_values/enum.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# The set of options a single-choice champ (drop down, pays, region, yes/no,
+# checkbox…) can still hold. `est` keeps only the option asked for, `n’est
+# pas` drops it, so two different `est` on the same champ leave nothing.
+class Logic::PossibleValues::Enum < Data.define(:values)
+  def initialize(values:) = super(values: values.to_set)
+
+  def empty? = values.empty?
+
+  def restrict(operator_class, value)
+    case operator_class.name
+    when Logic::Eq.name then self.class.new(values & [value])
+    when Logic::NotEq.name then self.class.new(values - [value])
+    else self
+    end
+  end
+end

--- a/app/models/logic/possible_values/enum.rb
+++ b/app/models/logic/possible_values/enum.rb
@@ -8,6 +8,8 @@ class Logic::PossibleValues::Enum < Data.define(:values)
 
   def empty? = values.empty?
 
+  def limits = nil
+
   def restrict(operator_class, value)
     case operator_class.name
     when Logic::Eq.name then self.class.new(values & [value])

--- a/app/models/logic/possible_values/enums.rb
+++ b/app/models/logic/possible_values/enums.rb
@@ -11,6 +11,8 @@ class Logic::PossibleValues::Enums < Data.define(:options, :must_include, :must_
 
   def empty? = must_include.intersect?(must_exclude) || (options.any? && options.subset?(must_exclude))
 
+  def limits = nil
+
   def restrict(operator_class, value)
     case operator_class.name
     when Logic::IncludeOperator.name then with(must_include: must_include | [value], must_exclude: must_exclude)

--- a/app/models/logic/possible_values/enums.rb
+++ b/app/models/logic/possible_values/enums.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# A multiple-choice champ holds a subset of its options, so listing the values
+# it can take would mean listing every subset — 2^n of them for n options. The
+# comparisons only ever require an option to be selected or not, so it keeps
+# just the pair of those requirements, contradictory as soon as one option is
+# in both, or as soon as every option is excluded: a filled champ has at least
+# one selected.
+class Logic::PossibleValues::Enums < Data.define(:options, :must_include, :must_exclude)
+  def initialize(options:, must_include: Set.new, must_exclude: Set.new) = super(options: options.to_set, must_include:, must_exclude:)
+
+  def empty? = must_include.intersect?(must_exclude) || (options.any? && options.subset?(must_exclude))
+
+  def restrict(operator_class, value)
+    case operator_class.name
+    when Logic::IncludeOperator.name then with(must_include: must_include | [value], must_exclude: must_exclude)
+    when Logic::ExcludeOperator.name then with(must_include: must_include, must_exclude: must_exclude | [value])
+    else self
+    end
+  end
+end

--- a/app/models/logic/possible_values/geo.rb
+++ b/app/models/logic/possible_values/geo.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Every geographic champ (departement, commune, EPCI, address) resolves to a
+# departement code, and a region is a fixed set of departements, so what it
+# can hold is a set of departement codes. Expanding regions onto that
+# common alphabet is what makes `en Bretagne and à Paris` a plain empty set
+# intersection, with no knowledge of the geography left in the check.
+class Logic::PossibleValues::Geo < Data.define(:codes)
+  def initialize(codes: APIGeoService.departements.map { it[:code] }) = super(codes: codes.to_set)
+
+  def empty? = codes.empty?
+
+  def restrict(operator_class, value)
+    case operator_class.name
+    when Logic::Eq.name, Logic::InDepartementOperator.name then self.class.new(codes & [value])
+    when Logic::NotEq.name, Logic::NotInDepartementOperator.name then self.class.new(codes - [value])
+    when Logic::InRegionOperator.name then self.class.new(codes & departements_in_region(value))
+    when Logic::NotInRegionOperator.name then self.class.new(codes - departements_in_region(value))
+    else self
+    end
+  end
+
+  private
+
+  def departements_in_region(region_code)
+    APIGeoService.departements.filter { it[:region_code] == region_code }.map { it[:code] }
+  end
+end

--- a/app/models/logic/possible_values/geo.rb
+++ b/app/models/logic/possible_values/geo.rb
@@ -10,6 +10,8 @@ class Logic::PossibleValues::Geo < Data.define(:codes)
 
   def empty? = codes.empty?
 
+  def limits = nil
+
   def restrict(operator_class, value)
     case operator_class.name
     when Logic::Eq.name, Logic::InDepartementOperator.name then self.class.new(codes & [value])

--- a/app/models/logic/possible_values/number.rb
+++ b/app/models/logic/possible_values/number.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# The values a numeric champ can still take: a finite union of disjoint
+# intervals over the integers or the decimals, since they cannot be listed one
+# by one. `min_inclusive` says whether the bound itself is allowed, which is
+# what tells `> 18` from `>= 18`, and a `nil` bound stands for ±infinity.
+# Restricting intersects, so the intervals only ever shrink; `n’est pas`
+# (Logic::NotEq) is the one operator that cuts a hole in the middle, which is
+# why several intervals are kept rather than one.
+class Logic::PossibleValues::Number < Data.define(:integer, :intervals)
+  Interval = Data.define(:min, :min_inclusive, :max, :max_inclusive) do
+    def self.unbounded = new(min: nil, min_inclusive: false, max: nil, max_inclusive: false)
+
+    def self.at_least(value, inclusive:) = new(min: value, min_inclusive: inclusive, max: nil, max_inclusive: false)
+
+    def self.at_most(value, inclusive:) = new(min: nil, min_inclusive: false, max: value, max_inclusive: inclusive)
+
+    def self.point(value) = new(min: value, min_inclusive: true, max: value, max_inclusive: true)
+
+    # The tightest interval contained in both: the higher of the two lower
+    # bounds, the lower of the two upper ones. A missing bound is no
+    # constraint, so it never wins.
+    def intersect(other)
+      lower = [self, other].reject { it.min.nil? }.max_by { [it.min, it.min_inclusive ? 0 : 1] }
+      upper = [self, other].reject { it.max.nil? }.min_by { [it.max, it.max_inclusive ? 1 : 0] }
+
+      with(
+        min: lower&.min,
+        min_inclusive: lower.nil? ? false : lower.min_inclusive,
+        max: upper&.max,
+        max_inclusive: upper.nil? ? false : upper.max_inclusive
+      )
+    end
+
+    # On integers an open bound is the same as a closed bound one step
+    # further in, which lets `> 2 and < 3` collapse to nothing.
+    def snap_to_integers
+      with(
+        min: min.nil? ? nil : (min_inclusive ? min.ceil : min.floor + 1),
+        min_inclusive: !min.nil?,
+        max: max.nil? ? nil : (max_inclusive ? max.floor : max.ceil - 1),
+        max_inclusive: !max.nil?
+      )
+    end
+
+    def empty?
+      return false if min.nil? || max.nil?
+      return true if min > max
+
+      min == max && !(min_inclusive && max_inclusive)
+    end
+  end
+
+  def initialize(integer:, intervals: [Interval.unbounded])
+    super(integer:, intervals: intervals.map { integer ? it.snap_to_integers : it }.reject(&:empty?))
+  end
+
+  def empty? = intervals.empty?
+
+  def restrict(operator_class, value)
+    return self if !value.is_a?(Numeric)
+
+    intersect(
+      case operator_class.name
+      when Logic::Eq.name then [Interval.point(value)]
+      when Logic::NotEq.name then [Interval.at_most(value, inclusive: false), Interval.at_least(value, inclusive: false)]
+      when Logic::LessThan.name then [Interval.at_most(value, inclusive: false)]
+      when Logic::LessThanEq.name then [Interval.at_most(value, inclusive: true)]
+      when Logic::GreaterThan.name then [Interval.at_least(value, inclusive: false)]
+      when Logic::GreaterThanEq.name then [Interval.at_least(value, inclusive: true)]
+      else return self
+      end
+    )
+  end
+
+  private
+
+  # Every kept interval crossed with every new one: intersecting two unions of
+  # intervals means intersecting them pairwise, and the constructor drops the
+  # pairs that do not overlap.
+  def intersect(others)
+    self.class.new(integer: integer, intervals: intervals.product(others).map { |a, b| a.intersect(b) })
+  end
+end

--- a/app/models/logic/possible_values/number.rb
+++ b/app/models/logic/possible_values/number.rb
@@ -7,7 +7,11 @@
 # Restricting intersects, so the intervals only ever shrink; `n’est pas`
 # (Logic::NotEq) is the one operator that cuts a hole in the middle, which is
 # why several intervals are kept rather than one.
-class Logic::PossibleValues::Number < Data.define(:integer, :intervals)
+#
+# A champ validated within limits (`positive_number`, `min_number`,
+# `max_number`) starts out already narrowed to them, and remembers them in
+# `limits` so that an error can say which limit a comparison runs into.
+class Logic::PossibleValues::Number < Data.define(:integer, :intervals, :limits)
   Interval = Data.define(:min, :min_inclusive, :max, :max_inclusive) do
     def self.unbounded = new(min: nil, min_inclusive: false, max: nil, max_inclusive: false)
 
@@ -51,11 +55,33 @@ class Logic::PossibleValues::Number < Data.define(:integer, :intervals)
     end
   end
 
-  def initialize(integer:, intervals: [Interval.unbounded])
-    super(integer:, intervals: intervals.map { integer ? it.snap_to_integers : it }.reject(&:empty?))
+  # The values the champ's own validation leaves it (see
+  # NumberLimitValidator): non-negative when `positive_number`, within
+  # `min_number`..`max_number` when `range_number`, both ends included and
+  # either one optional. A bound is read the way the validator reads it, as
+  # an integer or a decimal depending on the champ.
+  def self.for(type_de_champ)
+    integer = type_de_champ.integer_number?
+    range = type_de_champ.range_number?
+    range_min, range_max = [type_de_champ.min_number, type_de_champ.max_number].map do |bound|
+      next if !range || bound.blank?
+
+      integer ? bound.to_i : bound.to_f
+    end
+    min = [type_de_champ.positive_number? ? 0 : nil, range_min].compact.max
+    limits = { min:, max: range_max } if min || range_max
+
+    new(integer:, limits:).restrict(Logic::GreaterThanEq, min).restrict(Logic::LessThanEq, range_max)
+  end
+
+  def initialize(integer:, intervals: [Interval.unbounded], limits: nil)
+    super(integer:, intervals: intervals.map { integer ? it.snap_to_integers : it }.reject(&:empty?), limits:)
   end
 
   def empty? = intervals.empty?
+
+  # The same champ as if it had no limits: what its comparisons alone leave.
+  def unlimited = self.class.new(integer:)
 
   def restrict(operator_class, value)
     return self if !value.is_a?(Numeric)
@@ -79,6 +105,6 @@ class Logic::PossibleValues::Number < Data.define(:integer, :intervals)
   # intervals means intersecting them pairwise, and the constructor drops the
   # pairs that do not overlap.
   def intersect(others)
-    self.class.new(integer: integer, intervals: intervals.product(others).map { |a, b| a.intersect(b) })
+    with(intervals: intervals.product(others).map { |a, b| a.intersect(b) })
   end
 end

--- a/app/models/logic/solver.rb
+++ b/app/models/logic/solver.rb
@@ -70,7 +70,7 @@ class Logic::Solver
   private
 
   def contradictions(condition)
-    conflicts([condition]).map { |source, comparisons| { type: :contradiction, stable_id: source.stable_id, comparisons: } }.uniq
+    conflicts([condition]).map { |source, comparisons, limits| { type: :contradiction, stable_id: source.stable_id, comparisons:, limits: }.compact }.uniq
   end
 
   # The search itself: the champs left without a value on every way of
@@ -122,10 +122,12 @@ class Logic::Solver
   # independent and can be looked at one at a time: take everything that champ
   # could hold, narrow it with each comparison on it, and if nothing is left
   # those comparisons cannot hold together. They are returned along with the
-  # champ, to be named in the error.
+  # champ, to be named in the error, and with the champ's validation limits
+  # when the comparisons only conflict within them: `age > 6` on a champ
+  # capped at 5 is fine on its own, and the error has to say what it runs into.
   #
-  # [[source, comparisons]] for every champ the alternative leaves with no
-  # possible value
+  # [[source, comparisons, limits]] for every champ the alternative leaves
+  # with no possible value
   def conflicting_sources(comparisons)
     comparisons
       .filter { checkable?(it) }
@@ -134,10 +136,17 @@ class Logic::Solver
         values = source.possible_values(@type_de_champs)
         next if values.nil?
 
-        narrowed = source_comparisons.reduce(values) { |v, comparison| v.restrict(comparison.class, comparison.right.value) }
-        [source, source_comparisons] if narrowed.empty?
+        next if !restrict(values, source_comparisons).empty?
+
+        [source, source_comparisons, limits_to_blame(values, source_comparisons)]
       end
   end
+
+  def limits_to_blame(values, comparisons)
+    values.limits if values.limits && !restrict(values.unlimited, comparisons).empty?
+  end
+
+  def restrict(values, comparisons) = comparisons.reduce(values) { |v, comparison| v.restrict(comparison.class, comparison.right.value) }
 
   # A comparison Logic::PossibleValues can interpret: `champ operator
   # constant`. Anything else is left out, which can only make a condition look

--- a/app/models/logic/solver.rb
+++ b/app/models/logic/solver.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+# Checks that a condition can be true for at least one way of filling the
+# form: `a == 2 and a == 3` or `a > 3 and a < 2` never are, nor is
+# `b == 'x' and a < 5` when `b` is only displayed if `a > 10`. A condition
+# that can never be true hides its champ for ever, which is a defect of the
+# form.
+#
+# ## What is checked
+#
+# A condition is read as a list of alternatives — the operands of an `or`
+# (Logic::Or) — each one a list of comparisons that must hold together, an
+# `and` (Logic::And):
+#
+#   (age >= 18 and dept == 75) or (age >= 18 and tuteur == 'oui')
+#    \_______ alternative 1 __/     \_______ alternative 2 ______/
+#
+# The condition is possible as soon as one alternative is, and an alternative
+# is possible when no champ is asked for two incompatible things at once: its
+# comparisons are grouped by champ and folded into the values that champ can
+# still take (Logic::PossibleValues). A champ left with no value at all is a
+# contradiction.
+#
+# ## How the alternatives are searched
+#
+# They are never listed up front: n two-way `or` give up to 2^n of them. They
+# are walked instead, in three moves:
+#
+#   guess       open one `or` and try one of its branches;
+#   check       after every guess, look at the comparisons accepted so far and
+#               stop at once if two of them already contradict each other —
+#               this is what kills whole families of alternatives without ever
+#               building them;
+#   backtrack   a dead branch is abandoned and the next one tried; when every
+#               branch of every `or` dies, the condition is impossible.
+#
+# ## Where this comes from
+#
+# This is a small SAT solver, and the literature has its own names for all of
+# the above, should you want to look it up: a comparison is an *atom* or a
+# *literal*, an `and` and an `or` are a *conjunction* and a *disjunction*,
+# the shape a condition is read in is *disjunctive normal form*, "possible"
+# is *satisfiable*, a conflict is an *unsat core*, and the three moves are
+# the backbone of the DPLL algorithm (Davis–Putnam–Logemann–Loveland, 1962),
+# which works on clauses and adds unit propagation on top of them.
+# Real SAT solvers add clause learning — remembering why a branch failed, so
+# as not to retry it elsewhere — and cleverer heuristics; neither is needed
+# for conditions holding tens of comparisons rather than millions.
+#
+# Plain DPLL only knows booleans that are true or false on their own, while
+# `age >= 18` and `age < 10` are two comparisons whose incompatibility is
+# invisible to it. Deciding whether a group of comparisons means anything is
+# therefore delegated to Logic::PossibleValues, one implementation per kind of
+# champ — the split SMT solvers call DPLL(T).
+#
+# A blank or hidden champ makes every comparison on it false, so a comparison
+# on a conditional champ is only ever true when the champ is displayed: the
+# condition is also checked rewritten with the display condition of each
+# champ it targets (Logic::DisplayConditions).
+class Logic::Solver
+  def initialize(type_de_champs)
+    @type_de_champs = type_de_champs
+    @display_conditions = Logic::DisplayConditions.new(type_de_champs)
+  end
+
+  def errors(condition)
+    contradictions(condition).presence || unreachable(condition)
+  end
+
+  private
+
+  def contradictions(condition)
+    conflicts([condition]).map { |source, comparisons| { type: :contradiction, stable_id: source.stable_id, comparisons: } }.uniq
+  end
+
+  # The search itself: the champs left without a value on every way of
+  # reading `terms` together with the `comparisons` already accepted — none
+  # when one way holds, and a failed search has to say why.
+  #
+  # `and` are flattened into terms and `or` opened one at a time, each
+  # branch pushed back into terms, so nesting of any depth is handled
+  # without ever building the alternatives. The `or` opened first is one
+  # on a champ the comparisons already constrain, so that a dead alternative
+  # shows up before the branches multiply.
+  def conflicts(terms, comparisons = [])
+    ors, more = flatten(terms).partition { it.is_a?(Logic::Or) }
+    comparisons += more
+
+    found = conflicting_sources(comparisons)
+    return found if found.any? || ors.empty?
+
+    constrained = comparisons.flat_map(&:sources)
+    branching = ors.delete_at(ors.index { it.sources.intersect?(constrained) } || 0)
+
+    branching.operands.each_with_object([]) do |branch, all|
+      found = conflicts([branch, *ors], comparisons)
+      return [] if found.empty?
+
+      all.concat(found)
+    end
+  end
+
+  # The operands of every nested `and`, brought up to one level
+  def flatten(terms) = terms.flat_map { it.is_a?(Logic::And) ? flatten(it.operands) : [it] }
+
+  # The champs the condition targets may only be displayed under conditions of
+  # their own: the condition is dead when no comparison on them can hold
+  # together with them. The culprits are the targeted champs whose display
+  # condition alone kills it, or all of them when only their combination does.
+  def unreachable(condition)
+    sources = @display_conditions.conditional_sources(condition)
+
+    return [] if sources.empty?
+    return [] if contradictions(@display_conditions.apply(condition, sources)).empty?
+
+    culprits = sources.filter { contradictions(@display_conditions.apply(condition, [it])).any? }.presence || sources
+
+    culprits.map { { type: :unreachable, stable_id: it.stable_id } }
+  end
+
+  # Every comparison constrains exactly one champ, so the champs are
+  # independent and can be looked at one at a time: take everything that champ
+  # could hold, narrow it with each comparison on it, and if nothing is left
+  # those comparisons cannot hold together. They are returned along with the
+  # champ, to be named in the error.
+  #
+  # [[source, comparisons]] for every champ the alternative leaves with no
+  # possible value
+  def conflicting_sources(comparisons)
+    comparisons
+      .filter { checkable?(it) }
+      .group_by(&:left)
+      .filter_map do |source, source_comparisons|
+        values = source.possible_values(@type_de_champs)
+        next if values.nil?
+
+        narrowed = source_comparisons.reduce(values) { |v, comparison| v.restrict(comparison.class, comparison.right.value) }
+        [source, source_comparisons] if narrowed.empty?
+      end
+  end
+
+  # A comparison Logic::PossibleValues can interpret: `champ operator
+  # constant`. Anything else is left out, which can only make a condition look
+  # more possible than it is — the check then misses contradictions rather
+  # than inventing them, and never blocks a publication by mistake.
+  def checkable?(comparison)
+    comparison.is_a?(Logic::BinaryOperator) &&
+      !comparison.is_a?(Logic::EmptyOperator) &&
+      comparison.left.respond_to?(:possible_values) &&
+      comparison.right.is_a?(Logic::Constant)
+  end
+end

--- a/app/models/logic/solver.rb
+++ b/app/models/logic/solver.rb
@@ -57,6 +57,14 @@
 # on a conditional champ is only ever true when the champ is displayed: the
 # condition is also checked rewritten with the display condition of each
 # champ it targets (Logic::DisplayConditions).
+#
+# Every branch of every `or` has to be able to hold as well: a group of rows
+# that never matches was written for nothing, and hides the same mistake as a
+# contradictory condition behind its siblings. A branch is dead when the
+# condition, read with that branch in place of its `or` (and, above it, with
+# the branch leading to it in place of each enclosing `or`), is impossible —
+# which also catches a branch that holds on its own but not where it stands,
+# as `a == 0` in `a > 1 and (a == 0 or a == 5)`.
 class Logic::Solver
   def initialize(type_de_champs)
     @type_de_champs = type_de_champs
@@ -64,10 +72,37 @@ class Logic::Solver
   end
 
   def errors(condition)
-    contradictions(condition).presence || unreachable(condition)
+    impossibility(condition).presence || dead_branches(condition)
   end
 
   private
+
+  # Why the condition can never be true: its own contradictions, or else the
+  # champs it targets that are never displayed when it holds.
+  def impossibility(condition)
+    contradictions(condition).presence || unreachable(condition)
+  end
+
+  # Checked once the condition itself holds: an impossible condition makes
+  # every branch dead, and saying so once is enough.
+  def dead_branches(condition)
+    branch_conditions(condition).flat_map { impossibility(it) }.map { it.merge(branch: true) }.uniq
+  end
+
+  # The condition as it reads for each branch of each `or` in it, at any
+  # depth: the `or` replaced by the branch, everything around it kept.
+  def branch_conditions(term)
+    case term
+    when Logic::Or
+      term.operands.flat_map { |branch| [branch, *branch_conditions(branch)] }
+    when Logic::And
+      term.operands.each_with_index.flat_map do |operand, index|
+        branch_conditions(operand).map { |branch| Logic::And.new(term.operands.dup.tap { it[index] = branch }) }
+      end
+    else
+      []
+    end
+  end
 
   def contradictions(condition)
     conflicts([condition]).map { |source, comparisons, limits| { type: :contradiction, stable_id: source.stable_id, comparisons:, limits: }.compact }.uniq

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -365,7 +365,7 @@ class ProcedureRevision < ApplicationRecord
   def ineligibilite_rules_are_valid?
     return unless ineligibilite_rules
 
-    rules_errors = ineligibilite_rules.errors(type_de_champs_for(scope: :public).to_a)
+    rules_errors = Logic.errors(ineligibilite_rules, type_de_champs_for(scope: :public).to_a)
 
     if rules_errors.any? || ineligibilite_rules.type == :empty
       errors.add(:ineligibilite_rules, :invalid)

--- a/app/validators/type_de_champs/condition_validator.rb
+++ b/app/validators/type_de_champs/condition_validator.rb
@@ -16,7 +16,7 @@ class TypeDeChamps::ConditionValidator < ActiveModel::EachValidator
       end
       upper_tdcs += tdcs.take(tdc_index) # we take all upper_tdcs of current tdcs
 
-      errors = tdc.condition.errors(upper_tdcs)
+      errors = Logic.errors(tdc.condition, upper_tdcs)
       next if errors.blank?
 
       procedure.errors.add(

--- a/spec/components/conditions/champs_conditions_component_spec.rb
+++ b/spec/components/conditions/champs_conditions_component_spec.rb
@@ -91,6 +91,14 @@ describe Conditions::ChampsConditionsComponent, type: :component do
           end
         end
 
+        context 'when the conditions are contradictory' do
+          let(:condition) { ds_and([greater_than(target, constant(3)), less_than(target, constant(2))]) }
+
+          it 'names the field and the conflicting rows' do
+            expect(page).to have_selector('.errors-summary', text: "Le champ « #{upper_tdc.libelle} » ne peut pas être à la fois supérieur à « 3 » et inférieur à « 2 ».")
+          end
+        end
+
         context 'when there are 3 conditions' do
           let(:condition) do
             ds_or([

--- a/spec/components/types_de_champ_editor/conditions_errors_component_spec.rb
+++ b/spec/components/types_de_champ_editor/conditions_errors_component_spec.rb
@@ -4,10 +4,10 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
   include Logic
 
   describe 'render' do
-    let(:conditions) { [] }
+    let(:condition) { nil }
     let(:source_tdcs) { [] }
 
-    before { render_inline(described_class.new(conditions: conditions, source_tdcs: source_tdcs)) }
+    before { render_inline(described_class.new(condition:, source_tdcs:)) }
 
     context 'when there are no condition' do
       it { expect(page).to have_no_css('.errors-summary') }
@@ -15,7 +15,7 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
 
     context 'when the targeted_champ is not available' do
       let(:tdc) { create(:type_de_champ_integer_number) }
-      let(:conditions) { [ds_eq(champ_value(tdc.stable_id), constant(1))] }
+      let(:condition) { ds_eq(champ_value(tdc.stable_id), constant(1)) }
 
       it do
         expect(page).to have_css('.errors-summary')
@@ -26,7 +26,7 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
     context 'when the targeted_champ is unmanaged' do
       let(:tdc) { create(:type_de_champ_email) }
       let(:source_tdcs) { [tdc] }
-      let(:conditions) { [ds_eq(champ_value(tdc.stable_id), constant(1))] }
+      let(:condition) { ds_eq(champ_value(tdc.stable_id), constant(1)) }
 
       it do
         expect(page).to have_css('.errors-summary')
@@ -37,7 +37,7 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
     context 'when the types mismatch' do
       let(:tdc) { create(:type_de_champ_integer_number) }
       let(:source_tdcs) { [tdc] }
-      let(:conditions) { [ds_eq(champ_value(tdc.stable_id), constant('a'))] }
+      let(:condition) { ds_eq(champ_value(tdc.stable_id), constant('a')) }
 
       it { expect(page).to have_content("Le champ « #{tdc.libelle} » est de type « nombre entier ». Il ne peut pas être égal à « a ».") }
     end
@@ -45,7 +45,7 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
     context 'when a number operator is applied on not a number' do
       let(:tdc) { create(:type_de_champ_multiple_drop_down_list) }
       let(:source_tdcs) { [tdc] }
-      let(:conditions) { [greater_than(champ_value(tdc.stable_id), constant('a text'))] }
+      let(:condition) { greater_than(champ_value(tdc.stable_id), constant('a text')) }
 
       it { expect(page).to have_content("« Supérieur à » ne s’applique qu’à des nombres.") }
     end
@@ -53,7 +53,7 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
     context 'when the include operator is applied on a list' do
       let(:tdc) { create(:type_de_champ_integer_number) }
       let(:source_tdcs) { [tdc] }
-      let(:conditions) { [ds_include(champ_value(tdc.stable_id), constant('a text'))] }
+      let(:condition) { ds_include(champ_value(tdc.stable_id), constant('a text')) }
 
       it { expect(page).to have_content("Lʼopérateur « inclus » ne s’applique qu’au choix simple ou multiple.") }
     end
@@ -61,7 +61,7 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
     context 'when a choice is not in a drop_down' do
       let(:tdc) { create(:type_de_champ_drop_down_list) }
       let(:source_tdcs) { [tdc] }
-      let(:conditions) { [ds_eq(champ_value(tdc.stable_id), constant('another choice'))] }
+      let(:condition) { ds_eq(champ_value(tdc.stable_id), constant('another choice')) }
 
       it { expect(page).to have_content("« another choice » ne fait pas partie de « #{tdc.libelle} ».") }
     end
@@ -69,7 +69,7 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
     context 'when a choice is not in a multiple_drop_down' do
       let(:tdc) { create(:type_de_champ_multiple_drop_down_list) }
       let(:source_tdcs) { [tdc] }
-      let(:conditions) { [ds_include(champ_value(tdc.stable_id), constant('another choice'))] }
+      let(:condition) { ds_include(champ_value(tdc.stable_id), constant('another choice')) }
 
       it { expect(page).to have_content("« another choice » ne fait pas partie de « #{tdc.libelle} ».") }
     end
@@ -77,7 +77,7 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
     context 'when an eq operator applies to a multiple_drop_down' do
       let(:tdc) { create(:type_de_champ_multiple_drop_down_list) }
       let(:source_tdcs) { [tdc] }
-      let(:conditions) { [ds_eq(champ_value(tdc.stable_id), constant(tdc.drop_down_options.first))] }
+      let(:condition) { ds_eq(champ_value(tdc.stable_id), constant(tdc.drop_down_options.first)) }
 
       it { expect(page).to have_content("« est » ne s’applique pas au choix multiple.") }
     end
@@ -85,9 +85,104 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
     context 'when an not_eq operator applies to a multiple_drop_down' do
       let(:tdc) { create(:type_de_champ_multiple_drop_down_list) }
       let(:source_tdcs) { [tdc] }
-      let(:conditions) { [ds_not_eq(champ_value(tdc.stable_id), constant(tdc.drop_down_options.first))] }
+      let(:condition) { ds_not_eq(champ_value(tdc.stable_id), constant(tdc.drop_down_options.first)) }
 
       it { expect(page).to have_content("« n’est pas » ne s’applique pas au choix multiple.") }
+    end
+
+    context 'when the rows are contradictory' do
+      let(:tdc) { create(:type_de_champ_integer_number) }
+      let(:source_tdcs) { [tdc] }
+      let(:condition) { ds_and([greater_than(champ_value(tdc.stable_id), constant(3)), less_than(champ_value(tdc.stable_id), constant(2))]) }
+
+      it { expect(page).to have_content("Le champ « #{tdc.libelle} » ne peut pas être à la fois supérieur à « 3 » et inférieur à « 2 ».") }
+    end
+
+    context 'when the rows are contradictory on a geographic champ' do
+      let(:tdc) { create(:type_de_champ_departements) }
+      let(:source_tdcs) { [tdc] }
+      let(:condition) { ds_and([ds_in_region(champ_value(tdc.stable_id), constant('84')), ds_in_departement(champ_value(tdc.stable_id), constant('75'))]) }
+
+      it 'names the region and the departement' do
+        expect(page).to have_content("Le champ « #{tdc.libelle} » ne peut pas être à la fois est dans la région « Auvergne-Rhône-Alpes » et est dans le département « 75 – Paris ».")
+      end
+    end
+
+    context 'when the rows are contradictory on a yes/no champ' do
+      let(:tdc) { create(:type_de_champ_yes_no) }
+      let(:source_tdcs) { [tdc] }
+      let(:condition) { ds_and([ds_eq(champ_value(tdc.stable_id), constant(true)), ds_eq(champ_value(tdc.stable_id), constant(false))]) }
+
+      it { expect(page).to have_content("Le champ « #{tdc.libelle} » ne peut pas être à la fois égal à « oui » et égal à « non ».") }
+    end
+
+    context 'when the rows are contradictory on the other option' do
+      let(:tdc) { create(:type_de_champ_drop_down_list, drop_down_other: true) }
+      let(:source_tdcs) { [tdc] }
+      let(:condition) { ds_and([ds_eq(champ_value(tdc.stable_id), constant(Champs::DropDownListChamp::OTHER)), ds_eq(champ_value(tdc.stable_id), constant('val1'))]) }
+
+      it { expect(page).to have_content("Le champ « #{tdc.libelle} » ne peut pas être à la fois égal à « Entrer une autre option » et égal à « val1 ».") }
+    end
+
+    context 'when the rows are contradictory on a region champ' do
+      let(:tdc) { create(:type_de_champ_regions) }
+      let(:source_tdcs) { [tdc] }
+      let(:condition) { ds_and([ds_eq(champ_value(tdc.stable_id), constant('84')), ds_eq(champ_value(tdc.stable_id), constant('11'))]) }
+
+      it { expect(page).to have_content("Le champ « #{tdc.libelle} » ne peut pas être à la fois égal à « Auvergne-Rhône-Alpes » et égal à « Île-de-France ».") }
+    end
+
+    context 'when the rows exclude every region a departement is in' do
+      let(:tdc) { create(:type_de_champ_departements) }
+      let(:source_tdcs) { [tdc] }
+      let(:condition) { ds_and([ds_not_in_region(champ_value(tdc.stable_id), constant('84')), ds_not_in_departement(champ_value(tdc.stable_id), constant('75')), ds_in_departement(champ_value(tdc.stable_id), constant('01'))]) }
+
+      it { expect(page).to have_content("ne peut pas être à la fois n’est pas dans la région « Auvergne-Rhône-Alpes », n’est pas dans le département « 75 – Paris » et est dans le département « 01 – Ain ».") }
+    end
+
+    context 'when the rows are contradictory on a column' do
+      let(:tdc) { create(:type_de_champ_drop_down_list) }
+      let(:source_tdcs) { [tdc] }
+      let(:column) { champ_column_value(tdc.columns(procedure_id: nil).find { it.type == :enum }) }
+      let(:condition) { ds_and([ds_eq(column, constant('val1')), ds_eq(column, constant('val2'))]) }
+
+      it { expect(page).to have_content("Le champ « #{tdc.libelle} » ne peut pas être à la fois égal à « val1 » et égal à « val2 ».") }
+    end
+
+    context 'when a single row can never be true' do
+      let(:tdc) { create(:type_de_champ_integer_number) }
+      let(:source_tdcs) { [tdc] }
+      let(:condition) { ds_eq(champ_value(tdc.stable_id), constant(2.5)) }
+
+      it { expect(page).to have_content("Le champ « #{tdc.libelle} » ne peut jamais être égal à « 2.5 ».") }
+    end
+
+    context 'when the targeted champ is never displayed in that case' do
+      let(:tdc) { create(:type_de_champ_integer_number) }
+      let(:hidden_tdc) { create(:type_de_champ_yes_no, condition: greater_than(champ_value(tdc.stable_id), constant(10))) }
+      let(:source_tdcs) { [tdc, hidden_tdc] }
+      let(:condition) { ds_and([ds_eq(champ_value(hidden_tdc.stable_id), constant(true)), less_than(champ_value(tdc.stable_id), constant(5))]) }
+
+      it { expect(page).to have_content("Cette condition ne peut jamais être vraie : le champ « #{hidden_tdc.libelle} » n’est pas affiché dans ce cas.") }
+    end
+
+    context 'when every targeted champ is hidden together' do
+      let(:tdc) { create(:type_de_champ_integer_number) }
+      let(:hidden_tdc) { create(:type_de_champ_yes_no, libelle: 'un', condition: greater_than(champ_value(tdc.stable_id), constant(10))) }
+      let(:other_tdc) { create(:type_de_champ_yes_no, libelle: 'deux', condition: less_than(champ_value(tdc.stable_id), constant(5))) }
+      let(:source_tdcs) { [tdc, hidden_tdc, other_tdc] }
+      let(:condition) { ds_and([ds_eq(champ_value(hidden_tdc.stable_id), constant(true)), ds_eq(champ_value(other_tdc.stable_id), constant(true))]) }
+
+      it 'lists every one of them' do
+        expect(page).to have_content('le champ « un » n’est pas affiché dans ce cas.')
+        expect(page).to have_content('le champ « deux » n’est pas affiché dans ce cas.')
+      end
+    end
+
+    context 'with a placeholder row' do
+      let(:condition) { ds_and([empty_operator(empty, empty)]) }
+
+      it { expect(page).to have_no_css('.errors-summary') }
     end
 
     context 'when target became unavailable but a right still references the value' do
@@ -95,7 +190,7 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
       # However maybe we should not have empty at left with still a constant at right
       let(:tdc) { create(:type_de_champ_integer_number) }
       let(:source_tdcs) { [tdc] }
-      let(:conditions) { [ds_eq(empty, constant('a text'))] }
+      let(:condition) { ds_eq(empty, constant('a text')) }
 
       it { expect(page).to have_content("Un champ cible n’est plus disponible") }
     end

--- a/spec/components/types_de_champ_editor/conditions_errors_component_spec.rb
+++ b/spec/components/types_de_champ_editor/conditions_errors_component_spec.rb
@@ -98,6 +98,15 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
       it { expect(page).to have_content("Le champ « #{tdc.libelle} » ne peut pas être à la fois supérieur à « 3 » et inférieur à « 2 ».") }
     end
 
+    context 'when a branch of an or targets a champ hidden in that case' do
+      let(:number) { create(:type_de_champ_integer_number) }
+      let(:tdc) { create(:type_de_champ_yes_no, condition: greater_than(champ_value(number.stable_id), constant(10))) }
+      let(:source_tdcs) { [number, tdc] }
+      let(:condition) { ds_or([ds_and([ds_eq(champ_value(tdc.stable_id), constant(true)), less_than(champ_value(number.stable_id), constant(5))]), less_than(champ_value(number.stable_id), constant(3))]) }
+
+      it { expect(page).to have_content("Une des branches « Ou » de cette condition ne peut jamais être vraie : le champ « #{tdc.libelle} » n’est pas affiché dans ce cas.") }
+    end
+
     context 'when a row runs into the validation limits of a number champ' do
       let(:tdc) { create(:type_de_champ_decimal_number, options: { range_number: '1', min_number: '0', max_number: '5' }) }
       let(:source_tdcs) { [tdc] }

--- a/spec/components/types_de_champ_editor/conditions_errors_component_spec.rb
+++ b/spec/components/types_de_champ_editor/conditions_errors_component_spec.rb
@@ -98,6 +98,14 @@ describe Conditions::ConditionsErrorsComponent, type: :component do
       it { expect(page).to have_content("Le champ « #{tdc.libelle} » ne peut pas être à la fois supérieur à « 3 » et inférieur à « 2 ».") }
     end
 
+    context 'when a row runs into the validation limits of a number champ' do
+      let(:tdc) { create(:type_de_champ_decimal_number, options: { range_number: '1', min_number: '0', max_number: '5' }) }
+      let(:source_tdcs) { [tdc] }
+      let(:condition) { greater_than(champ_value(tdc.stable_id), constant(6)) }
+
+      it { expect(page).to have_content("Le champ « #{tdc.libelle} » ne peut pas être supérieur à « 6 » : ses valeurs sont limitées entre « 0 » et « 5 ».") }
+    end
+
     context 'when the rows are contradictory on a geographic champ' do
       let(:tdc) { create(:type_de_champ_departements) }
       let(:source_tdcs) { [tdc] }

--- a/spec/models/groupe_instructeur_spec.rb
+++ b/spec/models/groupe_instructeur_spec.rb
@@ -275,6 +275,38 @@ describe GroupeInstructeur, type: :model do
         end
       end
 
+      context 'with a placeholder rule' do
+        let(:gi) { create(:groupe_instructeur, procedure: routed_procedure, routing_rule: empty_operator(empty, empty)) }
+
+        it 'returns false' do
+          expect(gi.valid_rule?).to be false
+        end
+      end
+
+      context 'with a placeholder row' do
+        let(:gi) do
+          create(:groupe_instructeur,
+                 procedure: routed_procedure,
+                 routing_rule: ds_and([ds_eq(champ_value(stable_id), constant('Paris')), empty_operator(empty, empty)]))
+        end
+
+        it 'returns false' do
+          expect(gi.valid_rule?).to be false
+        end
+      end
+
+      context 'with a contradictory routing rule' do
+        let(:gi) do
+          create(:groupe_instructeur,
+                 procedure: routed_procedure,
+                 routing_rule: ds_and([ds_eq(champ_value(stable_id), constant('Paris')), ds_eq(champ_value(stable_id), constant('Lyon'))]))
+        end
+
+        it 'returns false: the rule can never match a dossier' do
+          expect(gi.valid_rule?).to be false
+        end
+      end
+
       context 'with nil routing rule' do
         let(:gi) do
           create(:groupe_instructeur,

--- a/spec/models/logic/display_conditions_spec.rb
+++ b/spec/models/logic/display_conditions_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+describe Logic::DisplayConditions do
+  include Logic
+
+  let(:number) { build(:type_de_champ_integer_number, stable_id: 1) }
+  let(:hidden) { build(:type_de_champ_drop_down_list, stable_id: 4, drop_down_options: ['x', 'y'], condition: greater_than(n, constant(10))) }
+  let(:deeper) { build(:type_de_champ_yes_no, stable_id: 5, condition: ds_eq(h, constant('x'))) }
+  let(:type_de_champs) { [number, hidden, deeper] }
+
+  let(:n) { champ_value(1) }
+  let(:h) { champ_value(4) }
+  let(:d) { champ_value(5) }
+
+  subject(:display_conditions) { described_class.new(type_de_champs) }
+
+  def apply(condition) = display_conditions.apply(condition, display_conditions.conditional_sources(condition))
+
+  it 'joins each comparison with the display condition of its champ' do
+    expect(apply(ds_and([ds_eq(h, constant('x')), less_than(n, constant(5))])))
+      .to eq(ds_and([ds_and([ds_eq(h, constant('x')), greater_than(n, constant(10))]), less_than(n, constant(5))]))
+  end
+
+  it 'lifts a display condition shared by every branch above the or' do
+    expect(apply(ds_or([ds_eq(h, constant('x')), ds_eq(h, constant('y'))])))
+      .to eq(ds_and([ds_or([ds_eq(h, constant('x')), ds_eq(h, constant('y'))]), greater_than(n, constant(10))]))
+  end
+
+  it 'follows the display conditions transitively' do
+    expect(apply(ds_eq(d, constant(true))))
+      .to eq(ds_and([ds_eq(d, constant(true)), ds_and([ds_eq(h, constant('x')), greater_than(n, constant(10))])]))
+  end
+
+  it 'leaves a champ out of its own display condition' do
+    hidden.condition = ds_eq(d, constant(true))
+
+    expect(apply(ds_eq(d, constant(true))))
+      .to eq(ds_and([ds_eq(d, constant(true)), ds_and([ds_eq(h, constant('x')), ds_eq(d, constant(true))])]))
+  end
+end

--- a/spec/models/logic/n_ary_operator_spec.rb
+++ b/spec/models/logic/n_ary_operator_spec.rb
@@ -7,7 +7,7 @@ describe Logic::NAryOperator do
     it do
       expect(ds_and([]).errors).to eq(["opérateur 'Et' vide"])
       expect(ds_and([constant(1), constant('toto')]).errors).to eq(["'Et' ne contient pas que des booléens : 1, toto"])
-      expect(ds_and([double(type: :boolean, errors: ['from double'])]).errors).to eq(["from double"])
+      expect(ds_and([double(type: :boolean, errors: ['from double'], sources: [])]).errors).to eq(["from double"])
     end
   end
 

--- a/spec/models/logic/possible_values/enum_spec.rb
+++ b/spec/models/logic/possible_values/enum_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+describe Logic::PossibleValues::Enum do
+  let(:values) { described_class.new(['a', 'b', 'c']) }
+
+  it 'is a value: equal domains are one hash key' do
+    expect({ values => true }).to have_key(described_class.new(['c', 'b', 'a']))
+    expect(values).not_to eq(described_class.new(['a', 'b']))
+  end
+
+  it 'is empty without options' do
+    expect(values).not_to be_empty
+    expect(described_class.new([])).to be_empty
+  end
+
+  it 'narrows with equality' do
+    expect(values.restrict(Logic::Eq, 'a')).not_to be_empty
+    expect(values.restrict(Logic::Eq, 'a').restrict(Logic::Eq, 'a')).not_to be_empty
+    expect(values.restrict(Logic::Eq, 'a').restrict(Logic::Eq, 'b')).to be_empty
+    expect(values.restrict(Logic::Eq, 'unknown')).to be_empty
+  end
+
+  it 'narrows with inequality' do
+    expect(values.restrict(Logic::Eq, 'a').restrict(Logic::NotEq, 'a')).to be_empty
+    expect(values.restrict(Logic::Eq, 'a').restrict(Logic::NotEq, 'b')).not_to be_empty
+    expect(values.restrict(Logic::NotEq, 'a').restrict(Logic::NotEq, 'b')).not_to be_empty
+    expect(values.restrict(Logic::NotEq, 'a').restrict(Logic::NotEq, 'b').restrict(Logic::NotEq, 'c')).to be_empty
+  end
+
+  it 'ignores operators that do not apply' do
+    expect(values.restrict(Logic::IncludeOperator, 'a')).not_to be_empty
+  end
+
+  it 'models booleans' do
+    boolean = described_class.new([true, false])
+
+    expect(boolean.restrict(Logic::Eq, true)).not_to be_empty
+    expect(boolean.restrict(Logic::Eq, true).restrict(Logic::Eq, false)).to be_empty
+    expect(boolean.restrict(Logic::NotEq, true).restrict(Logic::Eq, false)).not_to be_empty
+  end
+end

--- a/spec/models/logic/possible_values/enums_spec.rb
+++ b/spec/models/logic/possible_values/enums_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe Logic::PossibleValues::Enums do
+  let(:values) { described_class.new(['a', 'b', 'c']) }
+
+  it 'is a value: equal domains are one hash key' do
+    expect({ values.restrict(Logic::IncludeOperator, 'a') => true }).to have_key(values.with(must_include: Set['a']))
+    expect(values.restrict(Logic::IncludeOperator, 'a')).not_to eq(values.restrict(Logic::ExcludeOperator, 'a'))
+  end
+
+  it 'is contradictory when an option must be both selected and not selected' do
+    expect(values).not_to be_empty
+    expect(values.restrict(Logic::IncludeOperator, 'a')).not_to be_empty
+    expect(values.restrict(Logic::IncludeOperator, 'a').restrict(Logic::IncludeOperator, 'b')).not_to be_empty
+    expect(values.restrict(Logic::IncludeOperator, 'a').restrict(Logic::ExcludeOperator, 'b')).not_to be_empty
+    expect(values.restrict(Logic::IncludeOperator, 'a').restrict(Logic::ExcludeOperator, 'a')).to be_empty
+    expect(values.restrict(Logic::ExcludeOperator, 'a').restrict(Logic::ExcludeOperator, 'a')).not_to be_empty
+  end
+
+  it 'is contradictory when every option is excluded' do
+    expect(values.restrict(Logic::ExcludeOperator, 'a').restrict(Logic::ExcludeOperator, 'b')).not_to be_empty
+    expect(values.restrict(Logic::ExcludeOperator, 'a').restrict(Logic::ExcludeOperator, 'b').restrict(Logic::ExcludeOperator, 'c')).to be_empty
+    expect(described_class.new([]).restrict(Logic::ExcludeOperator, 'a')).not_to be_empty
+  end
+
+  it 'stays contradictory whatever comes next' do
+    expect(values.restrict(Logic::IncludeOperator, 'a').restrict(Logic::ExcludeOperator, 'a').restrict(Logic::IncludeOperator, 'b')).to be_empty
+  end
+
+  it 'ignores operators that do not apply' do
+    expect(values.restrict(Logic::Eq, 'a').restrict(Logic::NotEq, 'a')).not_to be_empty
+  end
+end

--- a/spec/models/logic/possible_values/geo_spec.rb
+++ b/spec/models/logic/possible_values/geo_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+describe Logic::PossibleValues::Geo do
+  let(:values) { described_class.new }
+
+  it 'is a value: equal domains are one hash key' do
+    expect({ values.restrict(Logic::Eq, '75') => true }).to have_key(described_class.new(['75']))
+    expect(values.restrict(Logic::Eq, '75')).not_to eq(described_class.new(['13']))
+  end
+
+  # 01 (Ain) and 69 (Rhône) are in region 84 (Auvergne-Rhône-Alpes), 75 (Paris) in region 11 (Île-de-France)
+  it 'narrows with departements' do
+    expect(values).not_to be_empty
+    expect(values.restrict(Logic::InDepartementOperator, '01')).not_to be_empty
+    expect(values.restrict(Logic::InDepartementOperator, '01').restrict(Logic::InDepartementOperator, '69')).to be_empty
+    expect(values.restrict(Logic::InDepartementOperator, '01').restrict(Logic::NotInDepartementOperator, '01')).to be_empty
+  end
+
+  it 'narrows with regions' do
+    expect(values.restrict(Logic::InRegionOperator, '84').restrict(Logic::InRegionOperator, '11')).to be_empty
+    expect(values.restrict(Logic::InRegionOperator, '84').restrict(Logic::NotInRegionOperator, '84')).to be_empty
+    expect(values.restrict(Logic::InRegionOperator, '84').restrict(Logic::NotInDepartementOperator, '01')).not_to be_empty
+  end
+
+  it 'relates departements to their region' do
+    expect(values.restrict(Logic::InDepartementOperator, '01').restrict(Logic::InRegionOperator, '84')).not_to be_empty
+    expect(values.restrict(Logic::InDepartementOperator, '01').restrict(Logic::InRegionOperator, '11')).to be_empty
+    expect(values.restrict(Logic::InDepartementOperator, '01').restrict(Logic::NotInRegionOperator, '84')).to be_empty
+  end
+
+  it 'treats Etranger as its own region' do
+    expect(values.restrict(Logic::InRegionOperator, '99').restrict(Logic::InDepartementOperator, '99')).not_to be_empty
+    expect(values.restrict(Logic::InRegionOperator, '11').restrict(Logic::InDepartementOperator, '99')).to be_empty
+  end
+
+  it 'accepts departement equality (departement champ)' do
+    expect(values.restrict(Logic::Eq, '75').restrict(Logic::InRegionOperator, '11')).not_to be_empty
+    expect(values.restrict(Logic::Eq, '75').restrict(Logic::NotEq, '75')).to be_empty
+    expect(values.restrict(Logic::Eq, '75').restrict(Logic::InRegionOperator, '84')).to be_empty
+  end
+end

--- a/spec/models/logic/possible_values/number_spec.rb
+++ b/spec/models/logic/possible_values/number_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+describe Logic::PossibleValues::Number do
+  it 'is a value: equal domains are one hash key' do
+    integer = described_class.new(integer: true)
+
+    expect({ integer.restrict(Logic::GreaterThan, 2) => true }).to have_key(integer.restrict(Logic::GreaterThanEq, 3))
+    expect(integer.restrict(Logic::GreaterThan, 2)).not_to eq(described_class.new(integer: false).restrict(Logic::GreaterThan, 2))
+  end
+
+  def restrict(values, comparisons) = comparisons.reduce(values) { |d, (operator, value)| d.restrict(operator, value) }
+
+  shared_examples 'a numeric champ' do |integer:, cases:|
+    let(:values) { described_class.new(integer:) }
+
+    cases.each do |comparisons, empty|
+      it "#{comparisons.map { |op, v| "#{op.name.demodulize} #{v}" }.join(' and ')} is #{empty ? 'contradictory' : 'possible'}" do
+        expect(restrict(values, comparisons).empty?).to be(empty)
+      end
+    end
+  end
+
+  it { expect(described_class.new(integer: false)).not_to be_empty }
+
+  it 'ignores non numeric constants' do
+    expect(described_class.new(integer: true).restrict(Logic::Eq, 'abc')).not_to be_empty
+    expect(described_class.new(integer: true).restrict(Logic::Eq, '10').restrict(Logic::Eq, 11)).not_to be_empty
+  end
+
+  it 'ignores operators that do not apply to numbers' do
+    expect(described_class.new(integer: true).restrict(Logic::IncludeOperator, 1)).not_to be_empty
+  end
+
+  it_behaves_like 'a numeric champ', integer: false, cases: [
+    [[[Logic::Eq, 2], [Logic::Eq, 2]], false],
+    [[[Logic::Eq, 2], [Logic::Eq, 3]], true],
+    [[[Logic::Eq, 2], [Logic::NotEq, 2]], true],
+    [[[Logic::Eq, 2], [Logic::NotEq, 3]], false],
+    [[[Logic::GreaterThan, 3], [Logic::LessThan, 2]], true],
+    [[[Logic::GreaterThan, 2], [Logic::LessThan, 3]], false],
+    [[[Logic::GreaterThan, 2.5], [Logic::LessThan, 2.7]], false],
+    [[[Logic::GreaterThan, 2], [Logic::LessThan, 2]], true],
+    [[[Logic::GreaterThanEq, 2], [Logic::LessThanEq, 2]], false],
+    [[[Logic::GreaterThanEq, 2], [Logic::LessThan, 2]], true],
+    [[[Logic::GreaterThan, 2], [Logic::LessThanEq, 2]], true],
+    [[[Logic::GreaterThan, 2], [Logic::Eq, 2]], true],
+    [[[Logic::GreaterThanEq, 2], [Logic::Eq, 2]], false],
+    [[[Logic::LessThan, 2], [Logic::Eq, 2]], true],
+    [[[Logic::GreaterThan, 2], [Logic::GreaterThan, 3]], false],
+    [[[Logic::NotEq, 2], [Logic::NotEq, 3]], false],
+    [[[Logic::GreaterThan, 1], [Logic::LessThan, 3], [Logic::NotEq, 2]], false],
+    [[[Logic::GreaterThanEq, 2], [Logic::LessThanEq, 2], [Logic::NotEq, 2]], true],
+    [[[Logic::LessThanEq, -1], [Logic::GreaterThanEq, 0]], true],
+    [[[Logic::LessThanEq, -1], [Logic::GreaterThanEq, -1.5]], false],
+  ]
+
+  it_behaves_like 'a numeric champ', integer: true, cases: [
+    [[[Logic::GreaterThan, 2], [Logic::LessThan, 3]], true],
+    [[[Logic::GreaterThan, 2], [Logic::LessThan, 4]], false],
+    [[[Logic::GreaterThan, 1], [Logic::LessThan, 3], [Logic::NotEq, 2]], true],
+    [[[Logic::GreaterThan, 1], [Logic::LessThan, 4], [Logic::NotEq, 2]], false],
+    [[[Logic::GreaterThanEq, 2], [Logic::LessThanEq, 2]], false],
+    [[[Logic::GreaterThan, 2.5], [Logic::LessThan, 3.5]], false],
+    [[[Logic::GreaterThan, 2.5], [Logic::LessThan, 2.9]], true],
+    [[[Logic::GreaterThanEq, 2.5], [Logic::LessThanEq, 2.9]], true],
+    [[[Logic::GreaterThanEq, 3.0], [Logic::LessThanEq, 3.0]], false],
+    [[[Logic::Eq, 2], [Logic::NotEq, 2.5]], false],
+    [[[Logic::Eq, 2.5]], true],
+    [[[Logic::GreaterThan, 2], [Logic::NotEq, 3], [Logic::LessThan, 4]], true],
+    [[[Logic::GreaterThan, 2], [Logic::NotEq, 3], [Logic::LessThan, 5]], false],
+  ]
+end

--- a/spec/models/logic/possible_values/number_spec.rb
+++ b/spec/models/logic/possible_values/number_spec.rb
@@ -31,6 +31,57 @@ describe Logic::PossibleValues::Number do
     expect(described_class.new(integer: true).restrict(Logic::IncludeOperator, 1)).not_to be_empty
   end
 
+  describe '.for' do
+    def tdc(type, **options) = build(:"type_de_champ_#{type}", options:)
+
+    it 'starts unlimited on a champ without validation' do
+      values = described_class.for(tdc(:integer_number))
+
+      expect(values.limits).to be_nil
+      expect(values.restrict(Logic::GreaterThan, 10**9)).not_to be_empty
+    end
+
+    it 'starts at zero on a positive champ' do
+      values = described_class.for(tdc(:integer_number, positive_number: '1'))
+
+      expect(values.limits).to eq(min: 0, max: nil)
+      expect(values.restrict(Logic::LessThan, 0)).to be_empty
+      expect(values.restrict(Logic::Eq, 0)).not_to be_empty
+    end
+
+    it 'starts within the range, both ends included' do
+      values = described_class.for(tdc(:decimal_number, range_number: '1', min_number: '2.5', max_number: '18'))
+
+      expect(values.limits).to eq(min: 2.5, max: 18.0)
+      expect(values.restrict(Logic::Eq, 18)).not_to be_empty
+      expect(values.restrict(Logic::GreaterThan, 18)).to be_empty
+      expect(values.restrict(Logic::LessThan, 2.5)).to be_empty
+    end
+
+    it 'keeps the tighter of positive and range' do
+      expect(described_class.for(tdc(:integer_number, positive_number: '1', range_number: '1', min_number: '3')).limits).to eq(min: 3, max: nil)
+      expect(described_class.for(tdc(:integer_number, positive_number: '1', range_number: '1', min_number: '-3')).limits).to eq(min: 0, max: nil)
+    end
+
+    it 'ignores the range when it is switched off' do
+      expect(described_class.for(tdc(:integer_number, range_number: '0', min_number: '2', max_number: '18')).limits).to be_nil
+    end
+
+    it 'reads a bound the way the validator does' do
+      values = described_class.for(tdc(:integer_number, range_number: '1', min_number: '', max_number: '4.9'))
+
+      expect(values.limits).to eq(min: nil, max: 4)
+      expect(values.restrict(Logic::GreaterThan, 4)).to be_empty
+    end
+
+    it 'can forget its limits' do
+      values = described_class.for(tdc(:integer_number, range_number: '1', max_number: '5'))
+
+      expect(values.unlimited.limits).to be_nil
+      expect(values.unlimited.restrict(Logic::GreaterThan, 5)).not_to be_empty
+    end
+  end
+
   it_behaves_like 'a numeric champ', integer: false, cases: [
     [[[Logic::Eq, 2], [Logic::Eq, 2]], false],
     [[[Logic::Eq, 2], [Logic::Eq, 3]], true],

--- a/spec/models/logic/possible_values_spec.rb
+++ b/spec/models/logic/possible_values_spec.rb
@@ -47,18 +47,25 @@ describe Logic::PossibleValues do
   end
 
   describe '.for_column' do
-    def column(tdc) = tdc.columns(procedure_id: nil).first
+    def for_column(tdc) = described_class.for_column(tdc.columns(procedure_id: nil).first, tdc)
 
     it 'builds a values for every conditionable column type' do
-      expect(described_class.for_column(column(build(:type_de_champ_integer_number))).restrict(Logic::GreaterThan, 2).restrict(Logic::LessThan, 3)).to be_empty
-      expect(described_class.for_column(column(build(:type_de_champ_decimal_number))).restrict(Logic::GreaterThan, 2).restrict(Logic::LessThan, 3)).not_to be_empty
-      expect(described_class.for_column(column(build(:type_de_champ_yes_no))).restrict(Logic::Eq, true).restrict(Logic::Eq, false)).to be_empty
-      expect(described_class.for_column(column(build(:type_de_champ_drop_down_list, drop_down_options: ['a', 'b']))).restrict(Logic::NotEq, 'a').restrict(Logic::NotEq, 'b')).to be_empty
-      expect(described_class.for_column(column(build(:type_de_champ_multiple_drop_down_list, drop_down_options: ['a', 'b']))).restrict(Logic::ExcludeOperator, 'a').restrict(Logic::ExcludeOperator, 'b')).to be_empty
+      expect(for_column(build(:type_de_champ_integer_number)).restrict(Logic::GreaterThan, 2).restrict(Logic::LessThan, 3)).to be_empty
+      expect(for_column(build(:type_de_champ_decimal_number)).restrict(Logic::GreaterThan, 2).restrict(Logic::LessThan, 3)).not_to be_empty
+      expect(for_column(build(:type_de_champ_yes_no)).restrict(Logic::Eq, true).restrict(Logic::Eq, false)).to be_empty
+      expect(for_column(build(:type_de_champ_drop_down_list, drop_down_options: ['a', 'b'])).restrict(Logic::NotEq, 'a').restrict(Logic::NotEq, 'b')).to be_empty
+      expect(for_column(build(:type_de_champ_multiple_drop_down_list, drop_down_options: ['a', 'b'])).restrict(Logic::ExcludeOperator, 'a').restrict(Logic::ExcludeOperator, 'b')).to be_empty
+    end
+
+    it 'applies the validation limits of a numeric champ' do
+      values = for_column(build(:type_de_champ_integer_number, options: { range_number: '1', max_number: '5' }))
+
+      expect(values.limits).to eq(min: nil, max: 5)
+      expect(values.restrict(Logic::GreaterThan, 5)).to be_empty
     end
 
     it 'returns nil for other column types' do
-      expect(described_class.for_column(column(build(:type_de_champ_text)))).to be_nil
+      expect(for_column(build(:type_de_champ_text))).to be_nil
     end
   end
 end

--- a/spec/models/logic/possible_values_spec.rb
+++ b/spec/models/logic/possible_values_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+describe Logic::PossibleValues do
+  describe '.for' do
+    it 'builds a values for every conditionable type' do
+      expect(described_class.for(build(:type_de_champ_yes_no))).to be_a(Logic::PossibleValues::Enum)
+      expect(described_class.for(build(:type_de_champ_checkbox))).to be_a(Logic::PossibleValues::Enum)
+      expect(described_class.for(build(:type_de_champ_integer_number))).to be_a(Logic::PossibleValues::Number)
+      expect(described_class.for(build(:type_de_champ_decimal_number))).to be_a(Logic::PossibleValues::Number)
+      expect(described_class.for(build(:type_de_champ_drop_down_list))).to be_a(Logic::PossibleValues::Enum)
+      expect(described_class.for(build(:type_de_champ_pays))).to be_a(Logic::PossibleValues::Enum)
+      expect(described_class.for(build(:type_de_champ_regions))).to be_a(Logic::PossibleValues::Enum)
+      expect(described_class.for(build(:type_de_champ_multiple_drop_down_list))).to be_a(Logic::PossibleValues::Enums)
+      expect(described_class.for(build(:type_de_champ_departements))).to be_a(Logic::PossibleValues::Geo)
+      expect(described_class.for(build(:type_de_champ_communes))).to be_a(Logic::PossibleValues::Geo)
+      expect(described_class.for(build(:type_de_champ_epci))).to be_a(Logic::PossibleValues::Geo)
+      expect(described_class.for(build(:type_de_champ_address))).to be_a(Logic::PossibleValues::Geo)
+    end
+
+    it 'returns nil for unmanaged types' do
+      expect(described_class.for(build(:type_de_champ_text))).to be_nil
+    end
+
+    it 'distinguishes integers from decimals' do
+      expect(described_class.for(build(:type_de_champ_integer_number)).restrict(Logic::GreaterThan, 2).restrict(Logic::LessThan, 3)).to be_empty
+      expect(described_class.for(build(:type_de_champ_decimal_number)).restrict(Logic::GreaterThan, 2).restrict(Logic::LessThan, 3)).not_to be_empty
+    end
+
+    it 'uses the drop down options' do
+      tdc = build(:type_de_champ_drop_down_list, drop_down_options: ['a', 'b'])
+
+      expect(described_class.for(tdc).restrict(Logic::NotEq, 'a').restrict(Logic::NotEq, 'b')).to be_empty
+    end
+
+    it 'counts the other option in' do
+      tdc = build(:type_de_champ_drop_down_list, drop_down_options: ['a'], drop_down_other: true)
+
+      expect(described_class.for(tdc).restrict(Logic::Eq, Champs::DropDownListChamp::OTHER)).not_to be_empty
+    end
+
+    it 'holds the values behind the labels' do
+      values = described_class.for(build(:type_de_champ_regions))
+
+      expect(values.restrict(Logic::Eq, '84')).not_to be_empty
+      expect(values.restrict(Logic::Eq, 'Auvergne-Rhône-Alpes')).to be_empty
+    end
+  end
+
+  describe '.for_column' do
+    def column(tdc) = tdc.columns(procedure_id: nil).first
+
+    it 'builds a values for every conditionable column type' do
+      expect(described_class.for_column(column(build(:type_de_champ_integer_number))).restrict(Logic::GreaterThan, 2).restrict(Logic::LessThan, 3)).to be_empty
+      expect(described_class.for_column(column(build(:type_de_champ_decimal_number))).restrict(Logic::GreaterThan, 2).restrict(Logic::LessThan, 3)).not_to be_empty
+      expect(described_class.for_column(column(build(:type_de_champ_yes_no))).restrict(Logic::Eq, true).restrict(Logic::Eq, false)).to be_empty
+      expect(described_class.for_column(column(build(:type_de_champ_drop_down_list, drop_down_options: ['a', 'b']))).restrict(Logic::NotEq, 'a').restrict(Logic::NotEq, 'b')).to be_empty
+      expect(described_class.for_column(column(build(:type_de_champ_multiple_drop_down_list, drop_down_options: ['a', 'b']))).restrict(Logic::ExcludeOperator, 'a').restrict(Logic::ExcludeOperator, 'b')).to be_empty
+    end
+
+    it 'returns nil for other column types' do
+      expect(described_class.for_column(column(build(:type_de_champ_text)))).to be_nil
+    end
+  end
+end

--- a/spec/models/logic/solver_spec.rb
+++ b/spec/models/logic/solver_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+describe Logic::Solver do
+  include Logic
+
+  let(:number) { build(:type_de_champ_integer_number, stable_id: 1) }
+  let(:choice) { build(:type_de_champ_drop_down_list, stable_id: 2, drop_down_options: ['a', 'b']) }
+  let(:yes_no) { build(:type_de_champ_yes_no, stable_id: 3) }
+  let(:type_de_champs) { [number, choice, yes_no] }
+
+  let(:n) { champ_value(number.stable_id) }
+  let(:c) { champ_value(choice.stable_id) }
+  let(:y) { champ_value(yes_no.stable_id) }
+
+  subject(:errors) { described_class.new(type_de_champs).errors(condition) }
+
+  def contradiction(term, comparisons) = { type: :contradiction, stable_id: term.stable_id, comparisons: }
+
+  context 'with a single comparison' do
+    let(:condition) { greater_than(n, constant(3)) }
+
+    it { is_expected.to be_empty }
+  end
+
+  context 'with an and that holds' do
+    let(:condition) { ds_and([greater_than(n, constant(2)), less_than(n, constant(5)), ds_eq(c, constant('a'))]) }
+
+    it { is_expected.to be_empty }
+  end
+
+  context 'with a contradictory and' do
+    let(:condition) { ds_and([greater_than(n, constant(3)), less_than(n, constant(2)), ds_eq(c, constant('a'))]) }
+
+    it { is_expected.to eq([contradiction(n, [greater_than(n, constant(3)), less_than(n, constant(2))])]) }
+  end
+
+  context 'with several contradictory variables' do
+    let(:condition) { ds_and([ds_eq(n, constant(2)), ds_eq(n, constant(3)), ds_eq(y, constant(true)), ds_eq(y, constant(false))]) }
+
+    it 'reports each of them' do
+      expect(errors).to eq([
+        contradiction(n, [ds_eq(n, constant(2)), ds_eq(n, constant(3))]),
+        contradiction(y, [ds_eq(y, constant(true)), ds_eq(y, constant(false))]),
+      ])
+    end
+  end
+
+  context 'with an or' do
+    let(:condition) { ds_or([ds_and([ds_eq(n, constant(2)), ds_eq(n, constant(3))]), ds_eq(c, constant('a'))]) }
+
+    it 'is possible when one branch is' do
+      expect(errors).to be_empty
+    end
+  end
+
+  context 'with an or of contradictions' do
+    let(:condition) { ds_or([ds_and([ds_eq(n, constant(2)), ds_eq(n, constant(3))]), ds_and([ds_eq(c, constant('a')), ds_eq(c, constant('b'))])]) }
+
+    it 'reports every branch' do
+      expect(errors).to eq([
+        contradiction(n, [ds_eq(n, constant(2)), ds_eq(n, constant(3))]),
+        contradiction(c, [ds_eq(c, constant('a')), ds_eq(c, constant('b'))]),
+      ])
+    end
+  end
+
+  context 'with an or nested in an and' do
+    let(:condition) { ds_and([ds_eq(n, constant(2)), ds_or([ds_eq(n, constant(3)), ds_eq(n, constant(4))])]) }
+
+    it 'distributes' do
+      expect(errors).to eq([
+        contradiction(n, [ds_eq(n, constant(2)), ds_eq(n, constant(3))]),
+        contradiction(n, [ds_eq(n, constant(2)), ds_eq(n, constant(4))]),
+      ])
+    end
+  end
+
+  context 'with terms the domains do not cover' do
+    let(:condition) { ds_and([empty_operator(empty, empty), ds_eq(constant(1), constant(2)), ds_eq(champ_value(42), constant(1)), ds_eq(n, constant(2)), ds_eq(n, constant(2))]) }
+
+    it { is_expected.to be_empty }
+  end
+
+  context 'with a column value' do
+    let(:condition) { ds_and([ds_eq(column, constant('a')), ds_eq(column, constant('b'))]) }
+    let(:column) { champ_column_value(choice.columns(procedure_id: nil).find { it.type == :enum }) }
+
+    it { is_expected.to eq([contradiction(column, [ds_eq(column, constant('a')), ds_eq(column, constant('b'))])]) }
+  end
+
+  describe 'reachability' do
+    let(:hidden) { build(:type_de_champ_drop_down_list, stable_id: 4, drop_down_options: ['x', 'y'], condition: greater_than(n, constant(10))) }
+    let(:deeper) { build(:type_de_champ_yes_no, stable_id: 5, condition: ds_eq(champ_value(4), constant('x'))) }
+    let(:type_de_champs) { [number, choice, yes_no, hidden, deeper] }
+    let(:h) { champ_value(hidden.stable_id) }
+    let(:d) { champ_value(deeper.stable_id) }
+
+    context 'when the targeted champ can be displayed' do
+      let(:condition) { ds_and([ds_eq(h, constant('x')), greater_than(n, constant(20))]) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the targeted champ is never displayed in that case' do
+      let(:condition) { ds_and([ds_eq(h, constant('x')), less_than(n, constant(5))]) }
+
+      it { is_expected.to eq([{ type: :unreachable, stable_id: hidden.stable_id }]) }
+    end
+
+    context 'when the display condition is transitive' do
+      let(:condition) { ds_and([ds_eq(d, constant(true)), less_than(n, constant(5))]) }
+
+      it { is_expected.to eq([{ type: :unreachable, stable_id: deeper.stable_id }]) }
+    end
+
+    context 'when one of the targeted champs kills the condition on its own' do
+      let(:other) { build(:type_de_champ_yes_no, stable_id: 6, condition: less_than(n, constant(5))) }
+      let(:type_de_champs) { super() + [other] }
+      let(:condition) { ds_and([ds_eq(h, constant('x')), ds_eq(champ_value(6), constant(true)), less_than(n, constant(5))]) }
+
+      it 'blames that champ only' do
+        expect(errors).to eq([{ type: :unreachable, stable_id: hidden.stable_id }])
+      end
+    end
+
+    context 'when the targeted champ is read as a column' do
+      let(:column) { champ_column_value(hidden.columns(procedure_id: nil).find { it.type == :enum }) }
+      let(:condition) { ds_and([ds_eq(column, constant('x')), less_than(n, constant(5))]) }
+
+      it { is_expected.to eq([{ type: :unreachable, stable_id: hidden.stable_id }]) }
+    end
+
+    context 'when only the combination of targeted champs is impossible' do
+      let(:other) { build(:type_de_champ_yes_no, stable_id: 6, condition: less_than(n, constant(5))) }
+      let(:type_de_champs) { super() + [other] }
+      let(:condition) { ds_and([ds_eq(h, constant('x')), ds_eq(champ_value(6), constant(true))]) }
+
+      it 'blames every targeted champ' do
+        expect(errors).to eq([{ type: :unreachable, stable_id: hidden.stable_id }, { type: :unreachable, stable_id: other.stable_id }])
+      end
+    end
+
+    context 'when the condition is itself contradictory' do
+      let(:condition) { ds_and([ds_eq(h, constant('x')), ds_eq(h, constant('y')), less_than(n, constant(5))]) }
+
+      it 'reports the contradiction only' do
+        expect(errors).to eq([contradiction(h, [ds_eq(h, constant('x')), ds_eq(h, constant('y'))])])
+      end
+    end
+
+    context 'when the display conditions depend on each other' do
+      let(:hidden) { build(:type_de_champ_drop_down_list, stable_id: 4, drop_down_options: ['x', 'y'], condition: ds_eq(champ_value(5), constant(true))) }
+      let(:condition) { ds_and([ds_eq(d, constant(true)), less_than(n, constant(5))]) }
+
+      it 'ends' do
+        expect(errors).to be_empty
+      end
+    end
+
+    context 'with a long chain of alternatives' do
+      let(:type_de_champs) do
+        [number] + (1..12).map do |i|
+          previous = champ_value(i == 1 ? number.stable_id : 100 + i - 1)
+          build(:type_de_champ_integer_number, stable_id: 100 + i, condition: ds_or([ds_eq(previous, constant(1)), ds_eq(previous, constant(2)), ds_eq(previous, constant(3))]))
+        end
+      end
+      let(:condition) { ds_and([ds_eq(champ_value(112), constant(1)), greater_than(n, constant(0))]) }
+      let(:checker) { described_class.new(type_de_champs) }
+
+      # 3**12 alternatives in all: the search must not visit them
+      before { allow(checker).to receive(:conflicting_sources).and_call_original }
+
+      it 'stops at the first combination that holds' do
+        expect(checker.errors(condition)).to be_empty
+        expect(checker).to have_received(:conflicting_sources).at_most(20).times
+      end
+
+      context 'when it is dead' do
+        let(:condition) { ds_and([ds_eq(champ_value(112), constant(1)), greater_than(n, constant(10))]) }
+
+        it 'prunes the dead branches' do
+          expect(checker.errors(condition)).to eq([{ type: :unreachable, stable_id: 112 }])
+          expect(checker).to have_received(:conflicting_sources).at_most(20).times
+        end
+      end
+    end
+
+    context 'with an or over champs displayed in exclusive cases' do
+      let(:other) { build(:type_de_champ_yes_no, stable_id: 6, condition: less_than(n, constant(5))) }
+      let(:type_de_champs) { super() + [other] }
+      let(:condition) { ds_or([ds_eq(h, constant('x')), ds_eq(champ_value(6), constant(true))]) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'with an or whose branch on the targeted champ is dead' do
+      let(:condition) { ds_or([ds_and([ds_eq(h, constant('x')), less_than(n, constant(5))]), less_than(n, constant(3))]) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'with an or on the targeted champ under a dead and' do
+      let(:condition) { ds_and([ds_or([ds_eq(h, constant('x')), ds_eq(h, constant('y'))]), less_than(n, constant(5))]) }
+
+      it { is_expected.to eq([{ type: :unreachable, stable_id: hidden.stable_id }]) }
+    end
+
+    context 'with an or that keeps a reachable branch' do
+      let(:condition) { ds_or([ds_and([ds_eq(h, constant('x')), less_than(n, constant(5))]), ds_eq(c, constant('a'))]) }
+
+      it { is_expected.to be_empty }
+    end
+  end
+end

--- a/spec/models/logic/solver_spec.rb
+++ b/spec/models/logic/solver_spec.rb
@@ -15,6 +15,7 @@ describe Logic::Solver do
   subject(:errors) { described_class.new(type_de_champs).errors(condition) }
 
   def contradiction(term, comparisons) = { type: :contradiction, stable_id: term.stable_id, comparisons: }
+  def dead_branch(error) = error.merge(branch: true)
 
   context 'with a single comparison' do
     let(:condition) { greater_than(n, constant(3)) }
@@ -48,9 +49,27 @@ describe Logic::Solver do
   context 'with an or' do
     let(:condition) { ds_or([ds_and([ds_eq(n, constant(2)), ds_eq(n, constant(3))]), ds_eq(c, constant('a'))]) }
 
-    it 'is possible when one branch is' do
-      expect(errors).to be_empty
+    it 'reports the dead branch even though the other holds' do
+      expect(errors).to eq([dead_branch(contradiction(n, [ds_eq(n, constant(2)), ds_eq(n, constant(3))]))])
     end
+  end
+
+  context 'with an or whose branches all hold' do
+    let(:condition) { ds_or([ds_and([greater_than(n, constant(2)), less_than(n, constant(5))]), ds_eq(c, constant('a'))]) }
+
+    it { is_expected.to be_empty }
+  end
+
+  context 'with a branch dead only where it stands' do
+    let(:condition) { ds_and([greater_than(n, constant(1)), ds_or([ds_eq(n, constant(0)), ds_eq(n, constant(5))])]) }
+
+    it { is_expected.to eq([dead_branch(contradiction(n, [greater_than(n, constant(1)), ds_eq(n, constant(0))]))]) }
+  end
+
+  context 'with a nested dead branch under a live sibling' do
+    let(:condition) { ds_or([ds_and([greater_than(n, constant(2)), ds_or([greater_than(n, constant(1)), less_than(n, constant(1))])]), ds_eq(c, constant('a'))]) }
+
+    it { is_expected.to eq([dead_branch(contradiction(n, [greater_than(n, constant(2)), less_than(n, constant(1))]))]) }
   end
 
   context 'with an or of contradictions' do
@@ -229,7 +248,7 @@ describe Logic::Solver do
     context 'with an or whose branch on the targeted champ is dead' do
       let(:condition) { ds_or([ds_and([ds_eq(h, constant('x')), less_than(n, constant(5))]), less_than(n, constant(3))]) }
 
-      it { is_expected.to be_empty }
+      it { is_expected.to eq([dead_branch({ type: :unreachable, stable_id: hidden.stable_id })]) }
     end
 
     context 'with an or on the targeted champ under a dead and' do
@@ -238,8 +257,8 @@ describe Logic::Solver do
       it { is_expected.to eq([{ type: :unreachable, stable_id: hidden.stable_id }]) }
     end
 
-    context 'with an or that keeps a reachable branch' do
-      let(:condition) { ds_or([ds_and([ds_eq(h, constant('x')), less_than(n, constant(5))]), ds_eq(c, constant('a'))]) }
+    context 'with an or whose branches are all reachable' do
+      let(:condition) { ds_or([ds_and([ds_eq(h, constant('x')), greater_than(n, constant(20))]), ds_eq(c, constant('a'))]) }
 
       it { is_expected.to be_empty }
     end

--- a/spec/models/logic/solver_spec.rb
+++ b/spec/models/logic/solver_spec.rb
@@ -88,6 +88,39 @@ describe Logic::Solver do
     it { is_expected.to eq([contradiction(column, [ds_eq(column, constant('a')), ds_eq(column, constant('b'))])]) }
   end
 
+  context 'with a champ validated within limits' do
+    let(:number) { build(:type_de_champ_integer_number, stable_id: 1, options: { range_number: '1', min_number: '0', max_number: '5' }) }
+
+    def limited(term, comparisons, limits) = contradiction(term, comparisons).merge(limits:)
+
+    context 'when a comparison runs into a limit' do
+      let(:condition) { greater_than(n, constant(6)) }
+
+      it { is_expected.to eq([limited(n, [greater_than(n, constant(6))], { min: 0, max: 5 })]) }
+    end
+
+    context 'when the comparisons contradict each other on their own' do
+      let(:condition) { ds_and([greater_than_eq(n, constant(2)), less_than(n, constant(1))]) }
+
+      it 'does not blame the limits' do
+        expect(errors).to eq([contradiction(n, [greater_than_eq(n, constant(2)), less_than(n, constant(1))])])
+      end
+    end
+
+    context 'when the comparison stays within the limits' do
+      let(:condition) { greater_than_eq(n, constant(5)) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the champ is read as a column' do
+      let(:column) { champ_column_value(number.columns(procedure_id: nil).first) }
+      let(:condition) { greater_than(column, constant(6)) }
+
+      it { is_expected.to eq([limited(column, [greater_than(column, constant(6))], { min: 0, max: 5 })]) }
+    end
+  end
+
   describe 'reachability' do
     let(:hidden) { build(:type_de_champ_drop_down_list, stable_id: 4, drop_down_options: ['x', 'y'], condition: greater_than(n, constant(10))) }
     let(:deeper) { build(:type_de_champ_yes_no, stable_id: 5, condition: ds_eq(champ_value(4), constant('x'))) }

--- a/spec/models/logic_spec.rb
+++ b/spec/models/logic_spec.rb
@@ -17,6 +17,27 @@ describe Logic do
       .to eq(ds_and([constant(true), constant(true), constant(false)]))
   end
 
+  describe '.errors' do
+    let(:number) { build(:type_de_champ_integer_number, stable_id: 1) }
+    let(:too_big) { greater_than(champ_value(1), constant(3)) }
+    let(:too_small) { less_than(champ_value(1), constant(2)) }
+
+    it 'reports the structural errors first' do
+      expect(Logic.errors(ds_and([too_big, ds_eq(champ_value(1), constant('a')), too_small]), [number]).map { it[:type] }).to eq([:incompatible])
+    end
+
+    it 'then the contradictions, on the root only' do
+      expect(Logic.errors(ds_or([too_big, too_small]), [number])).to be_empty
+      expect(Logic.errors(ds_or([ds_and([too_big, too_small]), too_big]), [number])).to be_empty
+      expect(Logic.errors(ds_and([too_big, too_small]), [number])).to eq([{ type: :contradiction, stable_id: 1, comparisons: [too_big, too_small] }])
+    end
+
+    it 'checks a single comparison as well' do
+      expect(Logic.errors(too_big, [number])).to be_empty
+      expect(Logic.errors(ds_eq(champ_value(1), constant(2.5)), [number])).to eq([{ type: :contradiction, stable_id: 1, comparisons: [ds_eq(champ_value(1), constant(2.5))] }])
+    end
+  end
+
   describe '.ensure_compatibility_from_left' do
     let(:type_de_champs) { [] }
     subject { Logic.ensure_compatibility_from_left(condition, type_de_champs) }

--- a/spec/models/logic_spec.rb
+++ b/spec/models/logic_spec.rb
@@ -28,7 +28,7 @@ describe Logic do
 
     it 'then the contradictions, on the root only' do
       expect(Logic.errors(ds_or([too_big, too_small]), [number])).to be_empty
-      expect(Logic.errors(ds_or([ds_and([too_big, too_small]), too_big]), [number])).to be_empty
+      expect(Logic.errors(ds_or([ds_and([too_big, too_small]), too_big]), [number])).to eq([{ type: :contradiction, stable_id: 1, comparisons: [too_big, too_small], branch: true }])
       expect(Logic.errors(ds_and([too_big, too_small]), [number])).to eq([{ type: :contradiction, stable_id: 1, comparisons: [too_big, too_small] }])
     end
 

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -388,6 +388,17 @@ describe ProcedureRevision do
       end
     end
 
+    context 'when ineligibilite_rules can never be true' do
+      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :integer_number }]) }
+      let(:tdc_number) { draft_revision.type_de_champs_for(scope: :public).first }
+      let(:ineligibilite_rules) { ds_and([greater_than(champ_value(tdc_number.stable_id), constant(3)), less_than(champ_value(tdc_number.stable_id), constant(2))]) }
+
+      it 'is invalid' do
+        expect(draft_revision.validate(:publication)).to be_falsey
+        expect(draft_revision.validate(:ineligibilite_rules_editor)).to be_falsey
+      end
+    end
+
     context 'when ineligibilite_rules are invalid on repetition champ' do
       let(:ineligibilite_rules) { ds_eq(constant(true), constant(1)) }
       let(:procedure) { create(:procedure, public_type_de_champs:) }

--- a/spec/system/administrateurs/condition_spec.rb
+++ b/spec/system/administrateurs/condition_spec.rb
@@ -98,6 +98,28 @@ describe 'As an administrateur I can edit types de champ condition', js: true do
         end
       end
 
+      scenario "adding a contradictory row" do
+        expect(page).to have_no_selector('.errors-summary')
+
+        within '.type-de-champ:nth-child(2)' do
+          click_on 'Ajouter une condition'
+
+          within '.condition-table tbody tr:nth-child(2)' do
+            within('.target') { select('age') }
+            within('.operator') { select('Inférieur à') }
+            within('.value') { fill_in with: 10 }
+          end
+
+          expect(page).to have_selector('.errors-summary', text: 'Le champ « age » ne peut pas être à la fois supérieur ou égal à « 18 » et inférieur à « 10 ».')
+
+          within '.condition-table tbody tr:nth-child(2)' do
+            within('.value') { fill_in with: 65 }
+          end
+
+          expect(page).to have_no_selector('.errors-summary')
+        end
+      end
+
       scenario "changing target champ to a not managed type" do
         expect(page).to have_no_selector('.errors-summary')
 

--- a/spec/validators/type_de_champs/condition_validator_spec.rb
+++ b/spec/validators/type_de_champs/condition_validator_spec.rb
@@ -47,4 +47,31 @@ RSpec.describe TypeDeChamps::ConditionValidator do
       expect(subject).to include(invalid_condition_message)
     end
   end
+
+  context 'when a condition is contradictory' do
+    let(:public_type_de_champs) do
+      [
+        { type: :integer_number, libelle: 'Nombre', stable_id: 1 },
+        { type: :text, libelle: 'Conditionnel', stable_id: 2, condition: ds_and([greater_than(champ_value(1), constant(3)), less_than(champ_value(1), constant(2))]) },
+      ]
+    end
+
+    it 'adds an error on the condition' do
+      expect(subject).to include(invalid_condition_message)
+    end
+  end
+
+  context 'when a condition targets a champ that is never displayed in that case' do
+    let(:public_type_de_champs) do
+      [
+        { type: :integer_number, libelle: 'Nombre', stable_id: 1 },
+        { type: :yes_no, libelle: 'Caché', stable_id: 2, condition: greater_than(champ_value(1), constant(10)) },
+        { type: :text, libelle: 'Conditionnel', stable_id: 3, condition: ds_and([ds_eq(champ_value(2), constant(true)), less_than(champ_value(1), constant(5))]) },
+      ]
+    end
+
+    it 'adds an error on the condition' do
+      expect(subject).to include(invalid_condition_message)
+    end
+  end
 end


### PR DESCRIPTION
## Contexte

Une condition d’affichage peut être écrite de façon à ne jamais être vraie (`âge > 3 et âge < 2`, `choix = a et choix = b`, `département = 75 et région = Bretagne`…), ou cibler un champ qui n’est jamais affiché dans les cas où elle l’exige (« B » n’est affiché que si `A > 10`, et la condition demande `B = x et A < 5`). Le champ concerné n’apparaît alors jamais, sans que rien ne le signale.

## Ce que fait la PR

- Ajoute un petit solveur (`Logic::Solver` + `Logic::PossibleValues`) : la condition est lue comme une liste d’alternatives (les branches d’un « ou »), chacune étant une liste de comparaisons qui doivent tenir ensemble (un « et »). Chaque comparaison réduit l’ensemble des valeurs que le champ ciblé peut encore prendre (intervalles pour les nombres, entiers ou décimaux ; options pour les choix simples et booléens ; inclusions/exclusions pour les choix multiples ; codes de département pour les champs géographiques, une région étant un ensemble de départements). Plus aucune valeur possible = contradiction.
- Les alternatives ne sont jamais énumérées (il peut y en avoir 2^n) : la recherche ouvre un « ou » à la fois, vérifie après chaque choix que les comparaisons retenues ne se contredisent pas, et revient en arrière sinon. L’en-tête de `Logic::Solver` explique tout cela, avec un lexique pour qui veut retrouver la théorie (SAT, DPLL).
- Tient compte des limites de validation des champs nombre (positif, minimum, maximum) : `âge > 6` sur un champ limité à 5 est signalé, et le message nomme la limite en cause (« ses valeurs sont limitées entre « 0 » et « 5 » »). Les limites sont lues sur le type de champ, que la condition passe par `ChampValue` ou par `ChampColumnValue`.
- Vérifie aussi la condition conjointement avec les conditions d’affichage (récursives) des champs qu’elle cible.
- Chaque branche d’un « ou » doit elle aussi pouvoir être vraie : `(a > 1 et a > 2) ou (a > 1 et a = 0)` est refusée même si la première branche tient, car la seconde ne sert à rien et cache la même erreur qu’une condition contradictoire. Une branche est jugée là où elle se trouve (`a = 0` dans `a > 1 et (a = 0 ou a = 5)` est morte).
- Les ensembles de valeurs possibles sont des valeurs (`Data`) : immuables, à égalité structurelle, utilisables comme clés.
- Ces erreurs passent par `Logic::And#errors` / `Logic::Or#errors`, donc elles bloquent la publication comme les erreurs existantes, pour les conditions de champs, les règles d’inéligibilité et les règles de routage.
- Le composant d’erreurs reçoit désormais la condition entière (et non ses lignes) et nomme le champ et les lignes en conflit :
  - « Le champ « âge » ne peut pas être à la fois supérieur ou égal à « 18 » et inférieur à « 10 ». »
  - « Cette condition ne peut jamais être vraie : le champ « caché » n’est pas affiché dans ce cas. »

## Points d’attention pour la relecture

- Les retours de @mfo (suppression du code mort, renommage hors du jargon SAT, documentation du solveur) sont intégrés dans les deux premiers commits, dont il est co-auteur. L’historique est découpé en cinq commits : valeurs possibles, solveur, blocage à la publication, limites de validation, branches mortes.
- Les conditions déjà publiées qui sont contradictoires deviendront bloquantes à la prochaine publication (choix assumé : c’est un défaut du formulaire).
- Une démarche déjà publiée avec une branche « ou » morte deviendra elle aussi bloquante à la prochaine publication.
- Un champ masqué rend toutes ses comparaisons fausses (y compris « n’est pas »), c’est ce que modélise la vérification d’affichage.
- Ce solveur servira ensuite à énumérer les parcours possibles d’un formulaire.
