### PR TITLE
ETQ usager, la liste des modifications apportées à mon dossier est fiable

### DIFF
--- a/app/components/dossiers/changes_component.rb
+++ b/app/components/dossiers/changes_component.rb
@@ -38,10 +38,8 @@ class Dossiers::ChangesComponent < ApplicationComponent
     when :enum
       column.label_for_value(value)
     when :date
-      value = Date.parse(value) if value.is_a?(String)
       I18n.l(value, format: :short)
     when :datetime
-      value = Time.zone.parse(value) if value.is_a?(String)
       I18n.l(value, format: :short_with_time)
     else
       value.to_s

--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -29,7 +29,7 @@ class API::V2::Schema < GraphQL::Schema
       object.is_a?(DeletedDossier) ? object.to_typed_id : GraphQL::Schema::UniqueWithinType.encode('DeletedDossier', object.id)
     elsif object.is_a?(Hash)
       object[:id]
-    elsif object.is_a?(Column)
+    elsif object.is_a?(Column) || object.is_a?(ChangedColumn)
       GraphQL::Schema::UniqueWithinType.encode('Column', object.h_id.fetch(:column_id))
     else
       object.to_typed_id

--- a/app/models/changed_column.rb
+++ b/app/models/changed_column.rb
@@ -36,13 +36,13 @@ class ChangedColumn
           row_ids.flat_map do |row_id|
             type_de_champs.filter_map do |type_de_champ|
               public_id = type_de_champ.public_id(row_id)
-              column = type_de_champ.canonical_column(procedure_id: revision.procedure_id, prefix:)
+              column = type_de_champ.change_column(procedure_id: revision.procedure_id, prefix:)
               diff_column(column, champs[public_id], reference_champs[public_id], row_id:)
             end
           end
         else
           public_id = type_de_champ.public_id(nil)
-          column = type_de_champ.canonical_column(procedure_id: revision.procedure_id)
+          column = type_de_champ.change_column(procedure_id: revision.procedure_id)
           [diff_column(column, champs[public_id], reference_champs[public_id])].compact
         end
       end

--- a/app/models/changed_column.rb
+++ b/app/models/changed_column.rb
@@ -55,9 +55,17 @@ class ChangedColumn
 
       value = column.value(champ)
       previous_value = column.value(reference_champ)
-      return nil if value == previous_value
+      return nil if comparable(column, value) == comparable(column, previous_value)
 
       new(column, value, previous_value, row_id:)
+    end
+
+    # Attachments are cloned (new attachment rows) when a champ is copied to a
+    # buffer stream, so compare the files themselves rather than the records.
+    def comparable(column, value)
+      return value if column.type != :attachments
+
+      Array(value).map { it.blob.checksum }.sort
     end
   end
 end

--- a/app/models/changed_column.rb
+++ b/app/models/changed_column.rb
@@ -13,7 +13,9 @@ class ChangedColumn
     @row_id = row_id
   end
 
-  def value(_ = nil) = @value
+  # The GraphQL column types call `column.value(parent)` for both a Column
+  # (parent is the champ) and a ChangedColumn (value already computed).
+  def value(_parent = nil) = @value
 
   # A Column identifies a type de champ; a change inside a repetition is
   # identified by the row too, otherwise every corrected row shares one id.
@@ -26,30 +28,32 @@ class ChangedColumn
   def id = h_id.to_json
 
   class << self
-    # `champs` are the champs carrying the change (a buffer stream, or the
-    # champs merged at a checkpoint), `reference_champs` the champs they
-    # replace. A reference champ without counterpart, or whose row `champs`
-    # discards, is reported as removed.
-    def columns(revision, champs, reference_champs)
-      discarded_row_ids = champs.values.filter { it.row? && it.discarded? }.map(&:row_id).to_set
-      champs = champs.reject { |_, champ| champ.row_id.in?(discarded_row_ids) }
-      row_ids = (champs.values + reference_champs.values).map(&:row_id).compact.uniq.sort
+    # `champs_by_public_id` are the champs carrying the change (a buffer stream,
+    # or the champs merged at a checkpoint), `reference_champs_by_public_id` the
+    # champs they replace. A reference champ without counterpart, or whose row
+    # the change discards, is reported as removed.
+    def columns(revision, champs_by_public_id, reference_champs_by_public_id)
+      discarded_row_ids = champs_by_public_id.values.filter { it.row? && it.discarded? }.map(&:row_id).to_set
+      champs_by_public_id = champs_by_public_id.reject { |_, champ| champ.row_id.in?(discarded_row_ids) }
+      all_champs = champs_by_public_id.values + reference_champs_by_public_id.values
 
       revision.public_root_type_de_champs.flat_map do |type_de_champ|
         if type_de_champ.repetition?
           prefix = type_de_champ.libelle
           type_de_champs = revision.children_of(type_de_champ)
+          child_stable_ids = type_de_champs.map(&:stable_id).to_set
+          row_ids = all_champs.filter { child_stable_ids.include?(it.stable_id) }.map(&:row_id).uniq.sort
           row_ids.flat_map do |row_id|
             type_de_champs.filter_map do |type_de_champ|
               public_id = type_de_champ.public_id(row_id)
               column = type_de_champ.change_column(procedure_id: revision.procedure_id, prefix:)
-              diff_column(column, champs[public_id], reference_champs[public_id], row_id:)
+              diff_column(column, champs_by_public_id[public_id], reference_champs_by_public_id[public_id], row_id:)
             end
           end
         else
           public_id = type_de_champ.public_id(nil)
           column = type_de_champ.change_column(procedure_id: revision.procedure_id)
-          [diff_column(column, champs[public_id], reference_champs[public_id])].compact
+          [diff_column(column, champs_by_public_id[public_id], reference_champs_by_public_id[public_id])].compact
         end
       end
     end

--- a/app/models/changed_column.rb
+++ b/app/models/changed_column.rb
@@ -1,16 +1,29 @@
 # frozen_string_literal: true
 
+# A Column narrowed to one change: the value the correction set and the one it
+# replaced, scoped to one repetition row when the champ lives in one.
 class ChangedColumn
-  delegate :label, :type, :id, :stable_id, :label_for_value, to: :@column
-  attr_reader :previous_value
+  delegate_missing_to :@column
+  attr_reader :row_id, :previous_value
 
-  def initialize(column, value, previous_value)
+  def initialize(column, value, previous_value, row_id: nil)
     @column = column
     @value = value
     @previous_value = previous_value
+    @row_id = row_id
   end
 
   def value(_ = nil) = @value
+
+  # A Column identifies a type de champ; a change inside a repetition is
+  # identified by the row too, otherwise every corrected row shares one id.
+  def h_id
+    return @column.h_id if row_id.nil?
+
+    @column.h_id.merge(column_id: "#{@column.h_id.fetch(:column_id)}-#{row_id}")
+  end
+
+  def id = h_id.to_json
 
   class << self
     def columns(revision, champs, reference_champs)
@@ -24,7 +37,7 @@ class ChangedColumn
             type_de_champs.filter_map do |type_de_champ|
               public_id = type_de_champ.public_id(row_id)
               column = type_de_champ.canonical_column(procedure_id: revision.procedure_id, prefix:)
-              diff_column(column, champs[public_id], reference_champs[public_id])
+              diff_column(column, champs[public_id], reference_champs[public_id], row_id:)
             end
           end
         else
@@ -37,14 +50,14 @@ class ChangedColumn
 
     private
 
-    def diff_column(column, champ, reference_champ)
+    def diff_column(column, champ, reference_champ, row_id: nil)
       return nil if column.nil? || champ.nil?
 
       value = column.value(champ)
       previous_value = column.value(reference_champ)
       return nil if value == previous_value
 
-      new(column, value, previous_value)
+      new(column, value, previous_value, row_id:)
     end
   end
 end

--- a/app/models/changed_column.rb
+++ b/app/models/changed_column.rb
@@ -26,8 +26,14 @@ class ChangedColumn
   def id = h_id.to_json
 
   class << self
+    # `champs` are the champs carrying the change (a buffer stream, or the
+    # champs merged at a checkpoint), `reference_champs` the champs they
+    # replace. A reference champ without counterpart, or whose row `champs`
+    # discards, is reported as removed.
     def columns(revision, champs, reference_champs)
-      row_ids = champs.values.map(&:row_id).compact.uniq.sort
+      discarded_row_ids = champs.values.filter { it.row? && it.discarded? }.map(&:row_id).to_set
+      champs = champs.reject { |_, champ| champ.row_id.in?(discarded_row_ids) }
+      row_ids = (champs.values + reference_champs.values).map(&:row_id).compact.uniq.sort
 
       revision.public_root_type_de_champs.flat_map do |type_de_champ|
         if type_de_champ.repetition?
@@ -51,7 +57,7 @@ class ChangedColumn
     private
 
     def diff_column(column, champ, reference_champ, row_id: nil)
-      return nil if column.nil? || champ.nil?
+      return nil if column.nil? || (champ.nil? && reference_champ.nil?)
 
       value = column.value(champ)
       previous_value = column.value(reference_champ)

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -270,22 +270,26 @@ module DossierChampsConcern
   end
 
   def user_changed_columns
-    if user_buffer_changes?
-      ChangedColumn.columns(revision, champ_data_on_user_buffer_stream.index_by(&:public_id), champ_data_on_main_stream.index_by(&:public_id))
-    else
-      []
-    end
+    changed_columns_for(champ_data_on_user_buffer_stream)
   end
 
   def instructeur_changed_columns
-    if instructeur_buffer_changes?
-      ChangedColumn.columns(revision, champ_data_on_instructeur_buffer_stream.index_by(&:public_id), champ_data_on_main_stream.index_by(&:public_id))
-    else
-      []
-    end
+    changed_columns_for(champ_data_on_instructeur_buffer_stream)
   end
 
   private
+
+  # The reference champs are the main stream counterparts of the buffer champs,
+  # plus the champs of the rows the buffer removes (they only exist on main).
+  def changed_columns_for(buffer_champs)
+    return [] if buffer_champs.blank?
+
+    public_ids = buffer_champs.map(&:public_id).to_set
+    discarded_row_ids = buffer_champs.filter { _1.row? && _1.discarded? }.map(&:row_id).to_set
+    reference_champs = champ_data_on_main_stream.filter { _1.public_id.in?(public_ids) || _1.row_id.in?(discarded_row_ids) }
+
+    ChangedColumn.columns(revision, buffer_champs.index_by(&:public_id), reference_champs.index_by(&:public_id))
+  end
 
   def changed_champ_data_ids_for_merge(stream)
     stream_h = champ_data.where(stream:, stable_id: revision_stable_ids)

--- a/app/models/traitement.rb
+++ b/app/models/traitement.rb
@@ -96,21 +96,31 @@ class Traitement < ApplicationRecord
 
   private
 
+  # The champs replaced by this correction: they were moved to the checkpoint
+  # history stream by the merge. Rows removed by the correction only exist here.
   def reference_champs
-    if checkpoint.present?
-      changed_keys = changed_champs.keys
-      dossier.champ_data.filter { _1.stream == checkpoint && _1.public_id.in?(changed_keys) }
-    else
-      []
-    end.index_by(&:public_id)
+    return {} if checkpoint.blank?
+
+    changed_public_ids = changed_champs.keys
+    dossier.champ_data
+      .filter { _1.stream == checkpoint && (_1.public_id.in?(changed_public_ids) || removed_row_champ?(_1)) }
+      .index_by(&:public_id)
   end
 
+  # A correction only ever removes repetition rows. A root champ, or a champ
+  # whose type de champ left the dossier's revision, lost its main stream
+  # counterpart to a later revision, not to this correction. (A repetition
+  # hidden by a condition after the correction still reads as removed rows.)
+  def removed_row_champ?(champ)
+    champ.row_id.present? && dossier.stable_id_in_revision?(champ.stable_id)
+  end
+
+  # The champs merged by this correction. A later correction on the same champ
+  # moves them to a newer history stream but keeps their checkpoint.
   def changed_champs
-    if checkpoint.present?
-      dossier.champ_data.filter { _1.checkpoint == checkpoint && !_1.row? }
-    else
-      []
-    end.index_by(&:public_id)
+    return {} if checkpoint.blank?
+
+    dossier.champ_data.filter { _1.checkpoint == checkpoint }.index_by(&:public_id)
   end
 
   def previous_state

--- a/app/models/traitement.rb
+++ b/app/models/traitement.rb
@@ -29,7 +29,6 @@ class Traitement < ApplicationRecord
   end
 
   def termine? = state.in?(Dossier::TERMINE)
-  def has_changes? = revision_id.present? && event.in?([:depose_correction_usager, :depose_correction_instructeur])
 
   EVENT = [
     :depose,
@@ -80,12 +79,11 @@ class Traitement < ApplicationRecord
     end
   end
 
+  # Only corrections (usager or instructeur) record a checkpoint.
   def changed_columns
-    if has_changes?
-      ChangedColumn.columns(revision, changed_champs, reference_champs)
-    else
-      []
-    end
+    return [] if checkpoint.blank?
+
+    ChangedColumn.columns(revision, changed_champs, reference_champs)
   end
 
   def instructeur
@@ -99,8 +97,6 @@ class Traitement < ApplicationRecord
   # The champs replaced by this correction: they were moved to the checkpoint
   # history stream by the merge. Rows removed by the correction only exist here.
   def reference_champs
-    return {} if checkpoint.blank?
-
     changed_public_ids = changed_champs.keys
     dossier.champ_data
       .filter { _1.stream == checkpoint && (_1.public_id.in?(changed_public_ids) || removed_row_champ?(_1)) }
@@ -118,8 +114,6 @@ class Traitement < ApplicationRecord
   # The champs merged by this correction. A later correction on the same champ
   # moves them to a newer history stream but keeps their checkpoint.
   def changed_champs
-    return {} if checkpoint.blank?
-
     dossier.champ_data.filter { _1.checkpoint == checkpoint }.index_by(&:public_id)
   end
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -389,6 +389,12 @@ class TypeDeChamp < ApplicationRecord
     )
   end
 
+  # The column used to describe a change of this champ to the usager and in
+  # the API (see ChangedColumn).
+  def change_column(procedure_id:, prefix: nil)
+    canonical_column(procedure_id:, prefix:)
+  end
+
   def columns(procedure_id:, displayable: true, prefix: nil)
     [canonical_column(procedure_id:, displayable:, prefix:)].compact
   end

--- a/app/models/types_de_champ/piece_justificative_type_de_champ.rb
+++ b/app/models/types_de_champ/piece_justificative_type_de_champ.rb
@@ -143,6 +143,22 @@ class TypesDeChamp::PieceJustificativeTypeDeChamp < TypeDeChamp
     end
   end
 
+  # The canonical titre d'identité column is an export column ("– filled"
+  # suffix); the files themselves stay hidden, so a change is still reported
+  # as présent/absent but under the plain libellé.
+  def change_column(procedure_id:, prefix: nil)
+    return super unless titre_identite?
+
+    Columns::TitreIdentiteColumn.new(
+      procedure_id:,
+      stable_id:,
+      tdc_type: type_champ,
+      label: libelle_with_prefix(prefix),
+      type: :text,
+      mandatory: mandatory?
+    )
+  end
+
   def columns(procedure_id:, displayable: true, prefix: nil)
     cs = []
 

--- a/spec/components/dossiers/changes_component_spec.rb
+++ b/spec/components/dossiers/changes_component_spec.rb
@@ -46,6 +46,37 @@ RSpec.describe Dossiers::ChangesComponent, type: :component do
     end
   end
 
+  context 'with a false boolean value' do
+    let(:changed_column) { build_changed_column(label: 'Accord', type: :boolean, value: false, previous_value: true) }
+
+    it 'renders "Non" rather than a removal' do
+      expect(subject).to have_selector('strong', text: 'Non')
+      expect(subject).not_to have_content('La valeur a été supprimée')
+    end
+  end
+
+  context 'with a datetime value' do
+    let(:changed_column) { build_changed_column(label: 'Rendez-vous', type: :datetime, value: Time.zone.local(2026, 6, 16, 14, 30)) }
+
+    it 'renders a formatted date and time' do
+      expect(subject).to have_selector('strong', text: I18n.l(Time.zone.local(2026, 6, 16, 14, 30), format: :short_with_time))
+    end
+  end
+
+  context 'with number values' do
+    let(:changed_columns) do
+      [
+        build_changed_column(label: 'Entier', type: :integer, value: 42),
+        build_changed_column(label: 'Décimal', type: :decimal, value: 3.14),
+      ]
+    end
+
+    it 'renders the numbers' do
+      expect(subject).to have_selector('strong', text: '42')
+      expect(subject).to have_selector('strong', text: '3.14')
+    end
+  end
+
   context 'with a date value' do
     let(:changed_column) { build_changed_column(label: 'Date', type: :date, value: Date.new(2026, 6, 16)) }
 
@@ -88,6 +119,17 @@ RSpec.describe Dossiers::ChangesComponent, type: :component do
 
     it 'does not list unchanged values' do
       expect(subject).not_to have_selector('strong', text: 'Musique')
+    end
+
+    context 'when only the order changed' do
+      let(:changed_column) do
+        build_changed_column(label: 'Choix', type: :enums, value: ['Danse', 'Musique'], previous_value: ['Musique', 'Danse'])
+      end
+
+      it 'says the value has been changed' do
+        expect(subject).to have_content('La valeur a été modifiée')
+        expect(subject).not_to have_content('Ajouté :')
+      end
     end
   end
 

--- a/spec/graphql/dossier_spec.rb
+++ b/spec/graphql/dossier_spec.rb
@@ -666,6 +666,13 @@ RSpec.describe Types::DossierType, type: :graphql do
           a_hash_including(label: "Texte", stringValue: "Nouvelle valeur")
         )
       end
+
+      it 'exposes a global id for the changed column' do
+        expect(errors).to be_nil
+
+        correction = traitements.find { _1[:event] == 'depose_correction_usager' }
+        expect(correction[:changedColumns].first[:id]).to eq(GraphQL::Schema::UniqueWithinType.encode('Column', 'type_de_champ/99'))
+      end
     end
 
     context 'when the usager corrects a champ inside a repetition' do
@@ -689,6 +696,14 @@ RSpec.describe Types::DossierType, type: :graphql do
         correction = traitements.find { _1[:event] == 'depose_correction_usager' }
         expect(correction[:changedColumns].map { _1[:stringValue] })
           .to include("Valeur dans la répétition")
+      end
+
+      it 'scopes the global id to the row' do
+        expect(errors).to be_nil
+
+        correction = traitements.find { _1[:event] == 'depose_correction_usager' }
+        column = correction[:changedColumns].find { _1[:stringValue] == "Valeur dans la répétition" }
+        expect(column[:id]).to eq(GraphQL::Schema::UniqueWithinType.encode('Column', "type_de_champ/994-#{row_id}"))
       end
     end
 
@@ -848,6 +863,7 @@ RSpec.describe Types::DossierType, type: :graphql do
       traitements {
         event
         changedColumns {
+          id
           label
           stringValue
         }

--- a/spec/models/changed_column_spec.rb
+++ b/spec/models/changed_column_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe ChangedColumn do
+  let(:procedure) { create(:procedure, :published, public_type_de_champs:) }
+  let(:public_type_de_champs) do
+    [
+      { type: :text, libelle: "Texte", stable_id: 99 },
+      { type: :piece_justificative, libelle: "Pièce", stable_id: 997 },
+    ]
+  end
+  let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
+  let(:instructeur) { create(:instructeur) }
+
+  describe '.columns' do
+    subject(:columns) { dossier.instructeur_changed_columns }
+
+    context 'when a piece justificative champ is copied to the buffer without touching its files' do
+      before do
+        dossier.with_instructeur_buffer_stream do
+          dossier.public_champ_for_update('997', updated_by: instructeur.email)
+        end
+        dossier.save!
+      end
+
+      it 'does not report the cloned attachments as a change' do
+        expect(columns).to eq([])
+      end
+    end
+
+    context 'when a file is replaced by another one with the same name' do
+      before do
+        dossier.with_instructeur_buffer_stream do
+          champ = dossier.public_champ_for_update('997', updated_by: instructeur.email)
+          champ.piece_justificative_file.purge
+          champ.piece_justificative_file.attach(io: Rails.root.join('spec/fixtures/files/Contrat.pdf').open, filename: 'toto.txt')
+          champ.save!
+        end
+        dossier.save!
+      end
+
+      it 'reports the change' do
+        expect(columns.map(&:stable_id)).to eq([997])
+      end
+    end
+  end
+end

--- a/spec/models/changed_column_spec.rb
+++ b/spec/models/changed_column_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ChangedColumn do
     [
       { type: :text, libelle: "Texte", stable_id: 99 },
       { type: :piece_justificative, libelle: "Pièce", stable_id: 997 },
+      { type: :piece_justificative, libelle: "Identité", stable_id: 998, nature: 'titre_identite' },
     ]
   end
   let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
@@ -13,6 +14,28 @@ RSpec.describe ChangedColumn do
 
   describe '.columns' do
     subject(:columns) { dossier.instructeur_changed_columns }
+
+    context 'when a titre d’identité is attached' do
+      let(:dossier) { create(:dossier, :en_construction, procedure:) }
+
+      before do
+        dossier.with_instructeur_buffer_stream do
+          champ = dossier.public_champ_for_update('998', updated_by: instructeur.email)
+          champ.piece_justificative_file.attach(io: Rails.root.join('spec/fixtures/files/Contrat.pdf').open, filename: 'Contrat.pdf')
+          champ.save!
+        end
+        dossier.save!
+      end
+
+      it 'reports it under its libellé without exposing the file' do
+        column = columns.find { _1.stable_id == 998 }
+
+        expect(column.label).to eq("Identité")
+        expect(column.type).to eq(:text)
+        expect(column.value).to eq('présent')
+        expect(column.previous_value).to eq('absent')
+      end
+    end
 
     context 'when a piece justificative champ is copied to the buffer without touching its files' do
       before do

--- a/spec/models/changed_column_spec.rb
+++ b/spec/models/changed_column_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe ChangedColumn do
   let(:procedure) { create(:procedure, :published, public_type_de_champs:) }
   let(:public_type_de_champs) do
     [
+      { type: :header_section, libelle: "Titre", stable_id: 98 },
       { type: :text, libelle: "Texte", stable_id: 99 },
+      { type: :text, libelle: "Autre texte", stable_id: 991 },
+      { type: :repetition, libelle: "Répétition", stable_id: 993, children: [{ type: :text, libelle: 'Nom', stable_id: 994 }] },
       { type: :piece_justificative, libelle: "Pièce", stable_id: 997 },
       { type: :piece_justificative, libelle: "Identité", stable_id: 998, nature: 'titre_identite' },
     ]
@@ -14,6 +17,73 @@ RSpec.describe ChangedColumn do
 
   describe '.columns' do
     subject(:columns) { dossier.instructeur_changed_columns }
+
+    context 'when a text champ is changed' do
+      before do
+        dossier.with_instructeur_buffer_stream do
+          dossier.public_champ_for_update('99', updated_by: instructeur.email).assign_attributes(value: "Nouvelle valeur")
+          dossier.public_champ_for_update('991', updated_by: instructeur.email)
+        end
+        dossier.save!
+      end
+
+      it 'carries the new and the previous value' do
+        expect(columns.map(&:stable_id)).to eq([99])
+
+        column = columns.first
+        expect(column.label).to eq("Texte")
+        expect(column.value).to eq("Nouvelle valeur")
+        expect(column.previous_value).to eq(dossier.champ_data.find { _1.stable_id == 99 && _1.main_stream? }.value)
+        expect(column.previous_value).not_to eq("Nouvelle valeur")
+      end
+
+      it 'ignores champs copied to the buffer without a change, and non fillable champs' do
+        expect(columns.map(&:stable_id)).not_to include(991, 98)
+      end
+    end
+
+    context 'when a champ is emptied' do
+      before do
+        dossier.with_instructeur_buffer_stream do
+          dossier.public_champ_for_update('99', updated_by: instructeur.email).assign_attributes(value: '')
+        end
+        dossier.save!
+      end
+
+      it 'reports a nil value' do
+        expect(columns.map(&:stable_id)).to eq([99])
+        expect(columns.first.value).to be_nil
+        expect(columns.first.previous_value).to be_present
+      end
+    end
+
+    context 'when a repetition row is added' do
+      let(:type_de_champ) { dossier.find_type_de_champ_by_stable_id(993) }
+      let(:row_id) { dossier.with_instructeur_buffer_stream { dossier.repetition_add_row(type_de_champ, updated_by: instructeur.email) } }
+
+      before do
+        dossier.with_instructeur_buffer_stream do
+          dossier.public_champ_for_update("994-#{row_id}", updated_by: instructeur.email).assign_attributes(value: "Nouvelle ligne")
+        end
+        dossier.save!
+      end
+
+      it 'reports the row champs prefixed with the repetition libellé' do
+        column = columns.find { _1.value == "Nouvelle ligne" }
+
+        expect(column.stable_id).to eq(994)
+        expect(column.label).to eq("Répétition – Nom")
+        expect(column.previous_value).to be_nil
+      end
+
+      it 'identifies the change by its row, unlike the type de champ column' do
+        column = columns.find { _1.value == "Nouvelle ligne" }
+
+        expect(column.row_id).to eq(row_id)
+        expect(column.h_id).to eq(procedure_id: procedure.id, column_id: "type_de_champ/994-#{row_id}")
+        expect(columns.map(&:id)).to all(be_present).and satisfy { it.uniq.size == it.size }
+      end
+    end
 
     context 'when a titre d’identité is attached' do
       let(:dossier) { create(:dossier, :en_construction, procedure:) }

--- a/spec/models/concerns/dossier_champs_concern_spec.rb
+++ b/spec/models/concerns/dossier_champs_concern_spec.rb
@@ -1465,6 +1465,43 @@ RSpec.describe DossierChampsConcern do
         expect(column.value).to eq("Correction dans la répétition")
       end
     end
+
+    context "when the instructeur buffer stream removes a repetition row" do
+      let(:type_de_champ) { dossier.find_type_de_champ_by_stable_id(993) }
+      let(:row_id) { dossier.project_champ(type_de_champ).row_ids.first }
+
+      before do
+        dossier.with_instructeur_buffer_stream do
+          dossier.repetition_remove_row(type_de_champ, row_id, updated_by: 'instructeur@exemple.fr')
+        end
+        dossier.save!
+      end
+
+      it "reports the removed row champs with their previous value" do
+        column = dossier.instructeur_changed_columns.find { _1.stable_id == 994 }
+
+        expect(column).not_to be_nil
+        expect(column.value).to be_nil
+        expect(column.previous_value).to be_present
+      end
+
+      context "after editing a champ of the row" do
+        before do
+          dossier.with_instructeur_buffer_stream do
+            dossier.public_champ_for_update("994-#{row_id}", updated_by: 'instructeur@exemple.fr')
+              .assign_attributes(value: "Modifié puis supprimé")
+          end
+          dossier.save!
+        end
+
+        it "still reports the row champs as removed" do
+          column = dossier.instructeur_changed_columns.find { _1.stable_id == 994 }
+
+          expect(column.value).to be_nil
+          expect(column.previous_value).not_to eq("Modifié puis supprimé")
+        end
+      end
+    end
   end
 
   describe "#reload" do

--- a/spec/models/traitement_spec.rb
+++ b/spec/models/traitement_spec.rb
@@ -32,21 +32,6 @@ RSpec.describe Traitement do
     dossier.traitements.last
   end
 
-  describe "#has_changes?" do
-    it "is false for the initial depose traitement" do
-      expect(dossier.traitements.last.has_changes?).to be(false)
-    end
-
-    it "is true for a correction traitement" do
-      traitement = submit_usager_correction do
-        dossier.public_champ_for_update('99', updated_by: dossier.user.email)
-          .assign_attributes(value: "Nouvelle valeur")
-      end
-
-      expect(traitement.has_changes?).to be(true)
-    end
-  end
-
   describe "#changed_columns" do
     context "when the traitement is the initial depose" do
       subject(:traitement) { dossier.traitements.last }

--- a/spec/models/traitement_spec.rb
+++ b/spec/models/traitement_spec.rb
@@ -95,6 +95,106 @@ RSpec.describe Traitement do
       end
     end
 
+    context "when the usager correction removes a repetition row" do
+      subject(:traitement) do
+        type_de_champ = dossier.find_type_de_champ_by_stable_id(993)
+        row_id = repetition_row_id
+        submit_usager_correction do
+          dossier.repetition_remove_row(type_de_champ, row_id, updated_by: dossier.user.email)
+        end
+      end
+
+      it "reports the removed row champs with their previous value" do
+        column = traitement.changed_columns.find { _1.stable_id == 994 }
+
+        expect(column).not_to be_nil
+        expect(column.value).to be_nil
+        expect(column.previous_value).to be_present
+      end
+    end
+
+    context "when the same champ is corrected twice" do
+      let!(:first_traitement) do
+        submit_usager_correction do
+          dossier.public_champ_for_update('99', updated_by: dossier.user.email)
+            .assign_attributes(value: "Première correction")
+        end
+      end
+
+      let!(:second_traitement) do
+        # the history stream is named after the merge time, at second resolution
+        travel 1.minute
+        submit_usager_correction do
+          dossier.public_champ_for_update('99', updated_by: dossier.user.email)
+            .assign_attributes(value: "Seconde correction")
+        end
+      end
+
+      it "keeps the changes of each traitement" do
+        first_column = first_traitement.reload.changed_columns.find { _1.stable_id == 99 }
+        second_column = second_traitement.changed_columns.find { _1.stable_id == 99 }
+
+        expect(first_column.value).to eq("Première correction")
+        expect(second_column.previous_value).to eq("Première correction")
+        expect(second_column.value).to eq("Seconde correction")
+      end
+    end
+
+    # A later revision dropping a type de champ destroys its main stream champs
+    # at the next submit, while the checkpoint copies survive: the correction
+    # must not read them as values it removed.
+    context "when a later revision removes the corrected champ" do
+      let!(:traitement) do
+        submit_usager_correction do
+          dossier.public_champ_for_update('99', updated_by: dossier.user.email)
+            .assign_attributes(value: "Valeur corrigée")
+        end
+      end
+
+      before do
+        procedure.draft_revision.remove_type_de_champ(99)
+        procedure.publish_revision!(procedure.administrateurs.first)
+        dossier.reload.rebase!
+
+        travel 1.minute
+        submit_usager_correction do
+          dossier.public_champ_for_update('991', updated_by: dossier.user.email)
+            .assign_attributes(value: "Autre correction")
+        end
+      end
+
+      it "no longer lists the champ, rather than reporting it as removed" do
+        expect(dossier.champ_data.filter { _1.stable_id == 99 }.map(&:stream)).to all(start_with(Dossier::HISTORY_STREAM))
+        expect(traitement.reload.changed_columns.map(&:stable_id)).not_to include(99)
+      end
+    end
+
+    context "when a later revision removes the corrected repetition" do
+      let!(:traitement) do
+        row_id = repetition_row_id
+        submit_usager_correction do
+          dossier.public_champ_for_update("994-#{row_id}", updated_by: dossier.user.email)
+            .assign_attributes(value: "Valeur dans la répétition")
+        end
+      end
+
+      before do
+        procedure.draft_revision.remove_type_de_champ(993)
+        procedure.publish_revision!(procedure.administrateurs.first)
+        dossier.reload.rebase!
+
+        travel 1.minute
+        submit_usager_correction do
+          dossier.public_champ_for_update('99', updated_by: dossier.user.email)
+            .assign_attributes(value: "Autre correction")
+        end
+      end
+
+      it "does not report the rows as removed" do
+        expect(traitement.reload.changed_columns.map(&:stable_id)).not_to include(994)
+      end
+    end
+
     context "when the traitement is an instructeur correction" do
       let(:instructeur) { create(:instructeur) }
 
@@ -127,6 +227,23 @@ RSpec.describe Traitement do
         columns = dossier.traitements.last.changed_columns
         expect(columns.map(&:stable_id)).to contain_exactly(99)
         expect(columns.first.value).to eq("Correction sans reload")
+      end
+
+      # Unlike the usager submit, the instructeur submit does not purge the
+      # discarded row champ: it stays on main with the checkpoint.
+      it "reports a row edited then removed as removed" do
+        type_de_champ = dossier.find_type_de_champ_by_stable_id(993)
+        row_id = repetition_row_id
+        traitement = submit_instructeur_correction(instructeur) do
+          dossier.public_champ_for_update("994-#{row_id}", updated_by: instructeur.email)
+            .assign_attributes(value: "Modifié puis supprimé")
+          dossier.repetition_remove_row(type_de_champ, row_id, updated_by: instructeur.email)
+        end
+
+        column = traitement.changed_columns.find { _1.stable_id == 994 }
+        expect(column).not_to be_nil
+        expect(column.value).to be_nil
+        expect(column.previous_value).not_to eq("Modifié puis supprimé")
       end
     end
   end

--- a/spec/system/instructeurs/edit_dossier_spec.rb
+++ b/spec/system/instructeurs/edit_dossier_spec.rb
@@ -70,7 +70,8 @@ describe 'Editing a dossier as an instructeur:', js: true do
       # the usager is notified through the messagerie, with the detailed change and the motivation
       commentaire_body = dossier.commentaires.last.body
       expect(commentaire_body).to include('a apporté les modifications suivantes')
-      expect(commentaire_body).to include('Valeur corrigée par l’instructeur')
+      expect(commentaire_body).to include('<dt>Texte :</dt>')
+      expect(commentaire_body).to include('<strong>Valeur corrigée par l’instructeur</strong>')
       expect(commentaire_body).to include('J’ai corrigé une coquille.')
     end
 


### PR DESCRIPTION
## Contexte

Revue de `ChangedColumn` (liste des modifications apportées à un dossier lors d'une correction usager ou instructeur, affichée dans le message envoyé à l'usager et exposée par l'API dans `traitements.changedColumns`).

## Corrections

- **API** : `changedColumns { id }` levait une `NoMethodError` (`ChangedColumn` n'est pas une `Column`).
- **Pièces justificatives** : une PJ copiée dans le buffer sans modification apparaissait comme « La valeur a été modifiée » (les pièces jointes sont clonées, comparaison par enregistrement). Comparaison par checksum désormais.
- **Titre d'identité** : le libellé de la colonne d'export (`« Identité – filled »`) fuyait dans le message à l'usager. Nouveau hook `TypeDeChamp#change_column` ; les fichiers restent masqués (`présent`/`absent`).
- **Lignes de répétition supprimées** : la suppression d'une ligne n'apparaissait ni dans l'aperçu ni dans le traitement. Elle est maintenant listée comme valeur supprimée pour chaque champ de la ligne. L'historique d'un champ corrigé deux fois est verrouillé par un test.

## Simplifications

- `Traitement#has_changes?` supprimé : seul le `checkpoint` compte.
- `ChangedColumn` n'itère que les lignes appartenant à chaque répétition.
- Branches mortes de parsing de dates dans `Dossiers::ChangesComponent`.

## Tests

Spec unitaire `ChangedColumn` ajoutée, branches restantes du composant couvertes, assertion du libellé dans le spec système.

## À noter

Le nom du stream d'historique est horodaté à la seconde : deux fusions du même dossier dans la même seconde violent l'index unique. Non traité ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
