### PR TITLE
Tech: extraire les textes en dur de GroupeInstructeurMenuComponent vers i18n

### DIFF
--- a/app/components/procedure/groupe_instructeur_menu_component.en.yml
+++ b/app/components/procedure/groupe_instructeur_menu_component.en.yml
@@ -1,0 +1,7 @@
+en:
+  back_to_list: "Back to the list"
+  group_params: "Group settings"
+  assigned_dossiers: "Assigned dossiers"
+  routing_rules: "Routing rule(s)"
+  contact_information: "Contact information"
+  attestation_stamp: "Attestation stamp"

--- a/app/components/procedure/groupe_instructeur_menu_component.fr.yml
+++ b/app/components/procedure/groupe_instructeur_menu_component.fr.yml
@@ -1,0 +1,7 @@
+fr:
+  back_to_list: "Revenir à la liste"
+  group_params: "Paramètres du groupe"
+  assigned_dossiers: "Dossiers affectés"
+  routing_rules: "Règle(s) de routage"
+  contact_information: "Informations de contact"
+  attestation_stamp: "Tampon de l’attestation"

--- a/app/components/procedure/groupe_instructeur_menu_component.rb
+++ b/app/components/procedure/groupe_instructeur_menu_component.rb
@@ -9,13 +9,13 @@ class Procedure::GroupeInstructeurMenuComponent < ApplicationComponent
 
   def links
     links = [
-      { name: 'Paramètres du groupe', url: '#parametres-groupe' },
-      { name: 'Dossiers affectés', url: '#dossiers-affectes' },
-      { name: 'Règle(s) de routage', url: '#regles-routage' },
-      { name: 'Affectation des instructeurs', url: '#affectation-instructeurs' },
-      { name: 'Informations de contact', url: '#informations-contact' },
+      { name: t(".group_params"), url: '#parametres-groupe' },
+      { name: t(".assigned_dossiers"), url: '#dossiers-affectes' },
+      { name: t(".routing_rules"), url: '#regles-routage' },
+      { name: t("views.shared.groupe_instructeurs.instructeur_assignation"), url: '#affectation-instructeurs' },
+      { name: t(".contact_information"), url: '#informations-contact' },
     ]
-    links.push({ name: 'Tampon de l’attestation', url: '#tampon-attestation' }) if @procedure.attestation_acceptation_template&.activated?
+    links.push({ name: t(".attestation_stamp"), url: '#tampon-attestation' }) if @procedure.attestation_acceptation_template&.activated?
     links
   end
 end

--- a/app/components/procedure/groupe_instructeur_menu_component/groupe_instructeur_menu_component.html.haml
+++ b/app/components/procedure/groupe_instructeur_menu_component/groupe_instructeur_menu_component.html.haml
@@ -3,7 +3,7 @@
     .fr-col.fr-col-12.fr-col-md-3
       .fr-mb-2w.fr-ml-2w
         = link_to admin_procedure_groupe_instructeurs_path, class: 'fr-link fr-icon-arrow-left-line fr-link--icon-left' do
-          Revenir à la liste
+          = t(".back_to_list")
       = render(Dsfr::SidemenuComponent.new) do |component|
         - component.with_links(links)
     .fr-col= content

--- a/app/components/procedure/procedure_administrateurs/administrateur_component.en.yml
+++ b/app/components/procedure/procedure_administrateurs/administrateur_component.en.yml
@@ -1,0 +1,4 @@
+en:
+  remove: Remove
+  its_you: "(It's you!)"
+  confirm_remove: "Remove « %{email} » from the administrators of « %{libelle} » ?"

--- a/app/components/procedure/procedure_administrateurs/administrateur_component.fr.yml
+++ b/app/components/procedure/procedure_administrateurs/administrateur_component.fr.yml
@@ -1,0 +1,4 @@
+fr:
+  remove: Retirer
+  its_you: "(C’est vous !)"
+  confirm_remove: "Retirer « %{email} » des administrateurs de « %{libelle} » ?"

--- a/app/components/procedure/procedure_administrateurs/administrateur_component.rb
+++ b/app/components/procedure/procedure_administrateurs/administrateur_component.rb
@@ -10,7 +10,7 @@ class Procedure::ProcedureAdministrateurs::AdministrateurComponent < Application
 
   def email
     if @administrateur == current_administrateur
-      "#{@administrateur.email} (C’est vous !)"
+      "#{@administrateur.email} #{t('.its_you')}"
     else
       @administrateur.email
     end
@@ -26,11 +26,11 @@ class Procedure::ProcedureAdministrateurs::AdministrateurComponent < Application
 
   def remove_button
     if is_there_at_least_another_active_admin?
-      button_to 'Retirer',
+      button_to t(".remove"),
        admin_procedure_administrateur_path(@procedure, @administrateur),
        method: :delete,
        class: 'fr-btn fr-btn--tertiary fr-btn--sm',
-       form: { data: { turbo: true, turbo_confirm: "Retirer « #{@administrateur.email} » des administrateurs de « #{@procedure.libelle} » ?" } }
+       form: { data: { turbo: true, turbo_confirm: t(".confirm_remove", email: @administrateur.email, libelle: @procedure.libelle) } }
     end
   end
 

--- a/app/components/referentiels/stepper_component.en.yml
+++ b/app/components/referentiels/stepper_component.en.yml
@@ -1,0 +1,7 @@
+en:
+  configuration_champ: "Configuration of field « %{libelle} »"
+  configuration_annotation: "Configuration of private annotation « %{libelle} »"
+  step_title_query: "Request"
+  step_title_response_mapping: "Response and mapping"
+  step_title_prefill: "Pre-filling of fields and/or display of retrieved data"
+  step_title_autocomplete_configuration: "Autocomplete configuration"

--- a/app/components/referentiels/stepper_component.fr.yml
+++ b/app/components/referentiels/stepper_component.fr.yml
@@ -1,0 +1,7 @@
+fr:
+  configuration_champ: "Configuration du champ « %{libelle} »"
+  configuration_annotation: "Configuration de l’annotation privée « %{libelle} »"
+  step_title_query: "Requête"
+  step_title_response_mapping: "Réponse et mapping"
+  step_title_prefill: "Pré remplissage des champs et/ou affichage des données récupérées"
+  step_title_autocomplete_configuration: "Configuration de l’autocomplétion"

--- a/app/components/referentiels/stepper_component.rb
+++ b/app/components/referentiels/stepper_component.rb
@@ -13,31 +13,31 @@ class Referentiels::StepperComponent < StepperBaseComponent
 
   def title
     if type_de_champ.public?
-      "Configuration du champ « #{type_de_champ.libelle} »"
+      t(".configuration_champ", libelle: type_de_champ.libelle)
     else
-      "Configuration de l’annotation privée « #{type_de_champ.libelle} »"
+      t(".configuration_annotation", libelle: type_de_champ.libelle)
     end
   end
 
   def step_title
     if step_component_class == Referentiels::NewFormComponent || (step_component_class == Referentiels::ConfigurationErrorComponent && referentiel.exact_match?)
-      "Requête"
+      t(".step_title_query")
     elsif step_component_class == Referentiels::MappingFormComponent
-      "Réponse et mapping"
+      t(".step_title_response_mapping")
     elsif step_component_class == Referentiels::PrefillAndDisplayComponent
-      "Pré remplissage des champs et/ou affichage des données récupérées"
+      t(".step_title_prefill")
     elsif step_component_class == Referentiels::AutocompleteConfigurationComponent || (step_component == Referentiels::ConfigurationErrorComponent && referentiel.autocomplete?)
-      "Configuration de l’autocomplétion"
+      t(".step_title_autocomplete_configuration")
     end
   end
 
   def next_step_title
     if step_component_class == Referentiels::NewFormComponent && referentiel.mode == 'autocomplete'
-      "Configuration de l’autocomplétion"
+      t(".step_title_autocomplete_configuration")
     elsif step_component_class == Referentiels::NewFormComponent && referentiel.mode == 'exact_match' || step_component_class == Referentiels::AutocompleteConfigurationComponent
-      "Réponse et mapping"
+      t(".step_title_response_mapping")
     elsif step_component_class == Referentiels::MappingFormComponent
-      "Pré remplissage des champs et/ou affichage des données récupérées"
+      t(".step_title_prefill")
     end
   end
 
@@ -65,7 +65,11 @@ class Referentiels::StepperComponent < StepperBaseComponent
   private
 
   def back_link_label
-    type_de_champ.public? ? 'Champs du formulaire' : 'Annotations privées'
+    if type_de_champ.public?
+      t("administrateurs.procedures.clone.types_de_champ_public")
+    else
+      t("administrateurs.procedures.clone.types_de_champ_private")
+    end
   end
 
   def back_path


### PR DESCRIPTION
# Problème

Textes français en dur dans `app/components/procedure/groupe_instructeur_menu_component.rb` et son template HAML — bloque l'internationalisation et l'accessibilité (les lecteurs d'écran dépendent des traductions structurées).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 7 clés i18n vers `app/components/procedure/groupe_instructeur_menu_component.fr.yml` et `app/components/procedure/groupe_instructeur_menu_component.en.yml`.

### Clés extraites

| Cle | FR | EN |
|-----|----|----|
| `groupe_instructeur_menu.back_to_list` | "Revenir à la liste" | "Back to the list" |
| `groupe_instructeur_menu.group_params` | "Paramètres du groupe" | "Group settings" |
| `groupe_instructeur_menu.assigned_dossiers` | "Dossiers affectés" | "Assigned dossiers" |
| `groupe_instructeur_menu.routing_rules` | "Règle(s) de routage" | "Routing rule(s)" |
| `groupe_instructeur_menu.contact_information` | "Informations de contact" | "Contact information" |
| `groupe_instructeur_menu.attestation_stamp` | "Tampon de l'attestation" | "Attestation stamp" |

### Clé réutilisée

| Cle | Source | FR | EN |
|-----|--------|----|----|
| `views.shared.groupe_instructeurs.instructeur_assignation` | `config/locales/views/shared/fr.yml` | "Affectation des instructeurs" | "Instructors assignment" |

### Validation visuelle

⚠️ Serveur local non accessible — les captures d'écran n'ont pas pu être réalisées. Le rendu visuel reste inchangé car les valeurs FR dans les YAML sont identiques aux chaînes originales.

### Validation technique

- [x] Chaque `t()` a sa clé YAML correspondante (FR + EN)
- [x] Apostrophes typographiques vérifiées
- [x] Tests non exécutés (DB non accessible via tunnel SSH — problème connu)
- [x] Rubocop OK (hors cop DS/I18nOutputSafety manquant — problème préexistant)
- [x] Valeurs FR inchangées — aucune régression visuelle attendue

Generated with [Claude Code](https://claude.com/claude-code)

---

# Probleme

Textes francais en dur dans `app/components/procedure/procedure_administrateurs/administrateur_component.rb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 3 cles i18n vers `app/components/procedure/procedure_administrateurs/administrateur_component.fr.yml` et `administrateur_component.en.yml`.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `remove` | "Retirer" | "Remove" |
| `its_you` | "(C'est vous !)" | "(It's you!)" |
| `confirm_remove` | "Retirer « %{email} » des administrateurs de « %{libelle} » ?" | "Remove « %{email} » from the administrators of « %{libelle} » ?" |

### Validation visuelle — RESULTAT

Screenshots non disponibles — le serveur de developpement n'etait pas en cours d'execution au moment du traitement.

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante
- [x] Apostrophes typographiques verifiees
- [x] Rubocop OK
- [ ] Screenshots avant/apres — indisponible (serveur eteint)

---

# Probleme

Textes francais en dur dans `app/components/referentiels/stepper_component.rb` — bloque l'internationalisation et l'accessibilite (les lecteurs d'ecran dependent des traductions structurees).

# Solution

Skill [`/i18n-hardcoded`](https://github.com/mfo/night-shift/blob/main/.claude/skills/i18n-hardcoded/SKILL.md)

Extraction de 6 cles i18n vers `app/components/referentiels/stepper_component.fr.yml` et `app/components/referentiels/stepper_component.en.yml`, et reuse de 2 cles existantes depuis `config/locales/views/administrateurs/procedures/fr.yml`.

### Cles extraites

| Cle | FR | EN |
|-----|----|----|
| `configuration_champ` | "Configuration du champ « %{libelle} »" | "Configuration of field « %{libelle} »" |
| `configuration_annotation` | "Configuration de l'annotation privée « %{libelle} »" | "Configuration of private annotation « %{libelle} »" |
| `step_title_query` | "Requête" | "Request" |
| `step_title_response_mapping` | "Réponse et mapping" | "Response and mapping" |
| `step_title_prefill` | "Pré remplissage des champs et/ou affichage des données récupérées" | "Pre-filling of fields and/or display of retrieved data" |
| `step_title_autocomplete_configuration` | "Configuration de l'autocomplétion" | "Autocomplete configuration" |

### Cles reutilisees

| Cle existante | FR | EN |
|-----|----|----|
| `administrateurs.procedures.clone.types_de_champ_public` | "Champs du formulaire" | "Form fields" |
| `administrateurs.procedures.clone.types_de_champ_private` | "Annotations privées" | "Private annotations" |

### Validation visuelle

Screenshots non disponibles — le serveur de dev n'est pas accessible.

### Validation technique

- [x] Chaque `t()` a sa cle YAML correspondante
- [x] Apostrophes typographiques verifiees
- [x] Rubocop OK
- [ ] Tests — base de données de test inaccessible (port 15432)
- [ ] Screenshots avant/après — serveur non accessible