### PR TITLE
Tech: corrige un crash quand un champ FranceConnect est en erreur sans exception enregistrée

### DIFF
--- a/app/models/champs/france_connect_champ.rb
+++ b/app/models/champs/france_connect_champ.rb
@@ -16,7 +16,7 @@ class Champs::FranceConnectChamp < ChampData
   end
 
   def fc_data_not_found?
-    external_error? && self.fetch_external_data_exceptions.first&.code == 404
+    external_error? && self.fetch_external_data_exceptions&.first&.code == 404
   end
 
   def ready_for_external_call?

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -66,7 +66,7 @@ module ChampExternalDataConcern
 
   def pending? = waiting_for_job? || fetching?
   def done? = fetched? || external_error?
-  def external_data_not_found? = external_error? && fetch_external_data_exceptions.last.not_found?
+  def external_data_not_found? = external_error? && fetch_external_data_exceptions&.last&.not_found?
 
   def has_async_external_data? = false
 

--- a/spec/models/champs/france_connect_champ_spec.rb
+++ b/spec/models/champs/france_connect_champ_spec.rb
@@ -52,6 +52,28 @@ describe Champs::FranceConnectChamp, type: :model do
     end
   end
 
+  describe '#fc_data_not_found?' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :aah }], for_individual: true) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+
+    subject { champ.fc_data_not_found? }
+
+    before { champ.external_state = 'external_error' }
+
+    context 'with a 404 exception' do
+      before { champ.fetch_external_data_exceptions = [ExternalDataException.new(error: 'NotFound', code: 404)] }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'without recorded exceptions' do
+      before { champ.fetch_external_data_exceptions = nil }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
   describe '#libelle' do
     let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :aah }], for_individual: true) }
     let(:dossier) { create(:dossier, procedure:) }

--- a/spec/models/concerns/champ_external_data_concern_spec.rb
+++ b/spec/models/concerns/champ_external_data_concern_spec.rb
@@ -39,6 +39,13 @@ RSpec.describe ChampExternalDataConcern do
       it { expect(champ).not_to be_external_data_not_found }
     end
 
+    context 'in external_error without recorded exceptions' do
+      let(:external_state) { 'external_error' }
+      let(:exceptions) { nil }
+
+      it { expect(champ).not_to be_external_data_not_found }
+    end
+
     context 'when not in error' do
       let(:external_state) { 'fetched' }
       let(:exceptions) { [] }


### PR DESCRIPTION
Un champ FranceConnect peut être en état `external_error` sans `fetch_external_data_exceptions` enregistrées ; `fc_data_not_found?` (et `external_data_not_found?` dans le concern) plantaient alors en `NoMethodError` au rendu du dossier (vue instructeur, dépôt usager, suppression de pièce jointe).

Corrige avec une navigation sûre + specs de régression.

Fixes RAILS-MHN, RAILS-MHK, RAILS-MHJ (Sentry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)