### PR TITLE
ETQ admin, l’aperçu d’une démarche ne plante plus avec une expression régulière invalide

### DIFF
--- a/app/validators/expression_reguliere_validator.rb
+++ b/app/validators/expression_reguliere_validator.rb
@@ -16,5 +16,7 @@ class ExpressionReguliereValidator < ActiveModel::Validator
     end
   rescue Regexp::TimeoutError
     record.errors.add(:expression_reguliere, :evil_regexp)
+  rescue RegexpError
+    record.errors.add(:expression_reguliere, :syntax_error_regexp)
   end
 end

--- a/spec/models/champs/formatted_champ_spec.rb
+++ b/spec/models/champs/formatted_champ_spec.rb
@@ -51,6 +51,23 @@ describe Champs::FormattedChamp do
     end
 
     context 'with advanced mode' do
+      context 'with an invalid expression reguliere' do
+        let(:value) { "AB-123-CD" }
+        let(:tdc_definition) {
+          {
+            type: :formatted,
+            formatted_mode: "advanced",
+            expression_reguliere: "[AA-000-ZZ]",
+          }
+        }
+
+        it 'adds an error instead of raising' do
+          expect { subject }.not_to raise_error
+          expect(subject).to be_falsey
+          expect(champ.errors[:expression_reguliere]).to be_present
+        end
+      end
+
       context 'with invalid value' do
         let(:value) { "blop" }
         context 'with expression reguliere error message defined' do


### PR DESCRIPTION
Une expression régulière invalide peut être enregistrée sur un champ formaté (la vérification côté admin n’est qu’un helper d’UI). La validation du champ levait alors `RegexpError` (500), notamment sur l’aperçu de la démarche.

`ExpressionReguliereValidator` rescue désormais `RegexpError` et ajoute une erreur de validation (clé i18n existante `syntax_error_regexp`), comme pour `Regexp::TimeoutError`.

Fixes RAILS-MH9 (Sentry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)