### PR TITLE
Tech: corpus HTML des documents PDF et profil d’impression linté

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,34 @@ jobs:
         # - poppler-utils for pdf previews
         run: sudo apt-get update && sudo apt-get install -y libvips-dev gsfonts rustc poppler-utils
 
+      - name: Install typst and veraPDF
+        # PDF generation (typst) and PDF/UA validation (veraPDF) for the
+        # pdf_profile specs (spec/lint, spec/lib/pdf_profile)
+        run: |
+          curl -fsSL "https://github.com/typst/typst/releases/download/v0.15.0/typst-x86_64-unknown-linux-musl.tar.xz" \
+            | sudo tar -xJ --strip-components=1 -C /usr/local/bin typst-x86_64-unknown-linux-musl/typst
+          curl -fsSL "https://software.verapdf.org/rel/verapdf-installer.zip" -o /tmp/verapdf-installer.zip
+          unzip -q /tmp/verapdf-installer.zip -d /tmp/verapdf-installer
+          cat > /tmp/verapdf-auto-install.xml <<EOF
+          <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+          <AutomatedInstallation langpack="eng">
+            <com.izforge.izpack.panels.htmlhello.HTMLHelloPanel id="welcome"/>
+            <com.izforge.izpack.panels.target.TargetPanel id="install_dir">
+              <installpath>$HOME/verapdf</installpath>
+            </com.izforge.izpack.panels.target.TargetPanel>
+            <com.izforge.izpack.panels.packs.PacksPanel id="sdk_pack_select">
+              <pack index="0" name="veraPDF Mac and *nix Scripts" selected="true"/>
+              <pack index="1" name="veraPDF Validation model" selected="false"/>
+              <pack index="2" name="veraPDF Documentation" selected="false"/>
+              <pack index="3" name="veraPDF Sample Plugins" selected="false"/>
+            </com.izforge.izpack.panels.packs.PacksPanel>
+            <com.izforge.izpack.panels.install.InstallPanel id="install"/>
+            <com.izforge.izpack.panels.finish.FinishPanel id="finish"/>
+          </AutomatedInstallation>
+          EOF
+          /tmp/verapdf-installer/verapdf-greenfield-*/verapdf-install /tmp/verapdf-auto-install.xml
+          echo "$HOME/verapdf" >> "$GITHUB_PATH"
+
       - name: Run tests
         run: |
           bin/rspec --tag slow --tag external_deps --tag ~llm_eval --format progress --format RspecJunitFormatter

--- a/app/lib/pdf_profile.rb
+++ b/app/lib/pdf_profile.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# The HTML print profile (config/pdf_profile.yml): the whitelist of what our
+# document templates may send to the PDF renderer. Enforced on rendered output
+# by spec/lint/pdf_profile_spec.rb, and at runtime by the scrubber applied to
+# admin-authored attestation bodies (attestation_template_v2s/show).
+module PdfProfile
+  def self.profile
+    @profile ||= YAML.safe_load_file(Rails.root.join('config/pdf_profile.yml'))
+  end
+
+  def self.admin_content_tags = profile.fetch('admin_content').fetch('elements')
+
+  def self.admin_content_attributes = profile.fetch('admin_content').fetch('attributes')
+
+  def self.inline_styles = profile.fetch('inline_styles')
+
+  # Fresh instance per render: scrubbers carry per-document state.
+  def self.admin_content_scrubber = AdminContentScrubber.new
+
+  # PermitScrubber restricted to the profile's admin_content whitelist, with
+  # two extras: <script>/<style> are pruned with their content (a bare
+  # PermitScrubber would inline it as text), and style="" declarations are
+  # filtered against the profile's inline_styles whitelist (Loofah's own CSS
+  # safelist is much broader - it lets color, width etc. through).
+  class AdminContentScrubber < Rails::HTML::PermitScrubber
+    PRUNE = %w[script style].freeze
+
+    def initialize
+      super
+      self.tags = PdfProfile.admin_content_tags
+      self.attributes = PdfProfile.admin_content_attributes
+    end
+
+    def scrub_node(node)
+      PRUNE.include?(node.name) ? node.remove : super
+    end
+
+    def scrub_attributes(node)
+      super
+      scrub_style(node) if node['style']
+    end
+
+    private
+
+    def scrub_style(node)
+      kept = node['style'].split(';').filter_map do |declaration|
+        property, value = declaration.split(':', 2).map(&:strip)
+        next if property.blank? || value.blank?
+
+        "#{property}: #{value}" if PdfProfile.inline_styles[property]&.include?(value)
+      end
+
+      if kept.empty?
+        node.remove_attribute('style')
+      else
+        node['style'] = kept.join('; ')
+      end
+    end
+  end
+end

--- a/app/lib/pdf_profile/typst_compiler.rb
+++ b/app/lib/pdf_profile/typst_compiler.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+module PdfProfile
+  # Compiles profile-conformant HTML (config/pdf_profile.yml) to Typst markup
+  # built on lib/typst/theme.typ. Deliberately strict: any element, class or
+  # structure outside the implemented subset raises, so a template change
+  # either compiles everywhere or fails loudly - never silently drops styling.
+  #
+  # Skeleton scope: the attestation de depot family, plus the profile's shared
+  # inline grammar (strong/em/u/mark/a/br). Extend handler by handler as
+  # document families are migrated.
+  class TypstCompiler
+    class Error < StandardError; end
+
+    # Characters with markup meaning in Typst prose. (# and $ are
+    # backslash-escaped so Ruby does not read #$... as interpolation.)
+    TYPST_SPECIALS = /[\\\#\$&@*_`<>~\[\]]/
+
+    def self.compile(html, assets: {}) = new(assets:).compile(html)
+
+    def initialize(assets: {})
+      @assets = assets
+    end
+
+    def compile(html)
+      doc = Nokogiri::HTML5(html)
+      body = doc.at_css('body') || raise(Error, 'document has no <body>')
+      title = doc.at_css('head > title')&.text&.strip
+      lang = doc.at_css('html')&.attr('lang') || 'fr'
+
+      preamble = <<~TYP
+        #import "theme.typ": *
+        #show: conf.with(title: #{string(title)}, lang: #{string(lang)})
+      TYP
+
+      "#{preamble}\n#{blocks(body)}\n"
+    end
+
+    private
+
+    def blocks(node)
+      node.element_children.map { block(it) }.join("\n\n")
+    end
+
+    def block(node)
+      raise Error, "style attribute not implemented for <#{node.name}>" if node['style']
+
+      case [node.name, node.classes.sort]
+      in ['div', ['a4-container', *]] | ['div', ['content']] | ['div', ['main']]
+        blocks(node)
+      in ['header', [*, 'first-header', *]]
+        first_header(node)
+      in ['div', ['bloc-marque']]
+        "#bloc-marque[#{blocks(node)}]"
+      in ['div', ['logo-site']]
+        "#logo-site[#{blocks(node)}]"
+      in ['div', ['direction-block']]
+        "#direction-block[\n#{blocks(node)}\n]"
+      in ['p', ['direction-label']]
+        "#direction-label[#{inline_content(node)}]"
+      in ['p', ['direction-site']]
+        "#direction-site[#{inline_content(node)}]"
+      in ['h1', ['attestation-depot-title']]
+        "#depot-title[#{inline_content(node)}]"
+      in ['h2', []]
+        "#heading(level: 2)[#{inline_content(node)}]"
+      in ['p', ['attestation-depot-procedure']]
+        "#depot-procedure[#{inline_content(node)}]"
+      in ['p', ['attestation-depot-description']]
+        "#depot-description[#{inline_content(node)}]"
+      in ['p', []]
+        "#par[#{inline_content(node)}]"
+      in ['section', ['attestation-depot-section']]
+        "#depot-section[\n#{blocks(node)}\n]"
+      in ['dl', []]
+        key_value(node)
+      in ['div', ['signature']]
+        "#signature[\n#{blocks(node)}\n]"
+      in ['img', classes]
+        image(node, classes)
+      else
+        raise Error, "unsupported element <#{node.name} class=\"#{node.classes.join(' ')}\"> - extend the compiler or fix the template"
+      end
+    end
+
+    def first_header(node)
+      left = child_by_class(node, 'left')
+      right = child_by_class(node, 'right')
+
+      "#first-header(\n[\n#{blocks(left)}\n],\n[\n#{blocks(right)}\n],\n)"
+    end
+
+    IMAGE_HEIGHTS = {
+      'marianne-with-devise' => '20mm', # attestation.scss .marianne-with-devise
+      nil => '15mm', # .logo-site img
+    }.freeze
+
+    def image(node, classes)
+      alt = node['alt'].to_s
+      raise Error, "<img> without alt text (#{node['src']})" if alt.blank?
+
+      height = IMAGE_HEIGHTS.fetch(classes.first) do
+        raise Error, "<img class=\"#{classes.join(' ')}\"> has no height mapping"
+      end
+
+      path = @assets[node['src']]
+      arguments = [("path: #{string(path)}" if path), "alt: #{string(alt)}", "height: #{height}"].compact
+
+      "#profile-image(#{arguments.join(', ')})"
+    end
+
+    def key_value(node)
+      pairs = []
+
+      node.element_children.each do |child|
+        case child.name
+        when 'dt'
+          pairs << [inline_content(child), nil]
+        when 'dd'
+          raise Error, '<dd> without a preceding <dt>' if pairs.empty? || !pairs.last[1].nil?
+
+          pairs.last[1] = inline_content(child)
+        else
+          raise Error, "unexpected <#{child.name}> in <dl>"
+        end
+      end
+
+      raise Error, '<dt> without a <dd>' if pairs.any? { it[1].nil? }
+
+      arguments = pairs.map { |term, description| "  ([#{term}], [#{description}])," }.join("\n")
+      "#key-value(\n#{arguments}\n)"
+    end
+
+    def inline_content(node)
+      node.children.map { inline(it) }.join.strip
+    end
+
+    def inline(node)
+      return escape(node.text) if node.text?
+      raise Error, "unexpected #{node.name} node in inline content" unless node.element?
+
+      case [node.name, node.classes]
+      in ['strong', []] then "#strong[#{inline_content(node)}]"
+      in ['em', []] then "#emph[#{inline_content(node)}]"
+      in ['u', []] then "#underline[#{inline_content(node)}]"
+      in ['mark', []] then "#highlight[#{inline_content(node)}]"
+      in ['a', []] then "#link(#{string(node['href'])})[#{inline_content(node)}]"
+      in ['br', []] then "#linebreak()"
+      else
+        raise Error, "unsupported inline element <#{node.name} class=\"#{node.classes.join(' ')}\">"
+      end
+    end
+
+    def child_by_class(node, css_class)
+      node.element_children.find { it.classes.include?(css_class) } ||
+        raise(Error, "expected a .#{css_class} child in <#{node.name} class=\"#{node.classes.join(' ')}\">")
+    end
+
+    # Text with Typst markup characters escaped, whitespace collapsed.
+    def escape(text)
+      text.gsub(/\s+/, ' ').gsub(TYPST_SPECIALS) { "\\#{it}" }
+    end
+
+    # A Typst string literal (backslashes and quotes escaped in one pass).
+    def string(text)
+      escaped = text.to_s.gsub(/["\\]/) { "\\#{it}" }
+      "\"#{escaped}\""
+    end
+  end
+end

--- a/app/lib/pdf_profile/typst_compiler.rb
+++ b/app/lib/pdf_profile/typst_compiler.rb
@@ -18,6 +18,22 @@ module PdfProfile
 
     def self.compile(html, assets: {}) = new(assets:).compile(html)
 
+    ASSET_DIGEST = /-[0-9a-f]{32,64}(?=\.\w+\z)/
+
+    # Resolves the <img> sources of a profile document to files on disk:
+    # { src => { name:, path: } }, where name is the digest-less basename to
+    # copy next to the .typ file and path the source under app/assets/images.
+    def self.image_assets(html)
+      Nokogiri::HTML5(html).css('img').to_h do |img|
+        src = img['src'].to_s
+        name = File.basename(URI.parse(src).path).sub(ASSET_DIGEST, '')
+        path = Rails.root.glob("app/assets/images/**/#{name}").first ||
+          raise(Error, "cannot resolve image asset #{src}")
+
+        [src, { name:, path: }]
+      end
+    end
+
     def initialize(assets: {})
       @assets = assets
     end
@@ -90,21 +106,25 @@ module PdfProfile
       "#first-header(\n[\n#{blocks(left)}\n],\n[\n#{blocks(right)}\n],\n)"
     end
 
-    IMAGE_HEIGHTS = {
-      'marianne-with-devise' => '20mm', # attestation.scss .marianne-with-devise
-      nil => '15mm', # .logo-site img
+    IMAGE_SIZES = {
+      'marianne-with-devise' => { height: '20mm' }, # attestation.scss .marianne-with-devise
+      nil => { height: '15mm', width: '30mm' }, # .logo-site img (max-height/max-width)
     }.freeze
 
     def image(node, classes)
       alt = node['alt'].to_s
       raise Error, "<img> without alt text (#{node['src']})" if alt.blank?
 
-      height = IMAGE_HEIGHTS.fetch(classes.first) do
-        raise Error, "<img class=\"#{classes.join(' ')}\"> has no height mapping"
+      sizes = IMAGE_SIZES.fetch(classes.first) do
+        raise Error, "<img class=\"#{classes.join(' ')}\"> has no size mapping"
       end
 
       path = @assets[node['src']]
-      arguments = [("path: #{string(path)}" if path), "alt: #{string(alt)}", "height: #{height}"].compact
+      arguments = [
+        ("path: #{string(path)}" if path),
+        "alt: #{string(alt)}",
+        *sizes.map { |dimension, value| "#{dimension}: #{value}" },
+      ].compact
 
       "#profile-image(#{arguments.join(', ')})"
     end

--- a/app/views/administrateurs/attestation_template_v2s/show.html.erb
+++ b/app/views/administrateurs/attestation_template_v2s/show.html.erb
@@ -33,7 +33,7 @@
     <%- end -%>
 
     <div class="main">
-      <%= sanitize(@body, attributes: %w[class style], tags: Rails.configuration.action_view.sanitized_allowed_tags + %w[header]) %>
+      <%= sanitize(@body, scrubber: PdfProfile.admin_content_scrubber) %>
 
       <%- if @signature&.attached? -%>
         <div class="signature">

--- a/config/pdf_profile.yml
+++ b/config/pdf_profile.yml
@@ -131,6 +131,15 @@ classes:
 inline_styles:
   text-align: [left, center, right, justify]
 
+# Subset of `elements` allowed in admin-authored (TipTap) bodies - the runtime
+# sanitizer in attestation_template_v2s/show enforces exactly this list (via
+# PdfProfile). TipTap can also emit <a> and <footer>, which the sanitizer
+# deliberately strips (see Findings above); style declarations are filtered
+# down to the `inline_styles` whitelist by PdfProfile::AdminContentScrubber.
+admin_content:
+  elements: [header, div, p, h1, h2, h3, h4, h5, h6, ul, ol, li, dl, dt, dd, br, strong, em, u, mark]
+  attributes: [class, style]
+
 # ---------------------------------------------------------------------------
 # CSS stylesheet profile - DRAFT, not yet enforced by the lint spec.
 # Derived from attestation.scss and dossier_vide_pdf.scss.

--- a/config/pdf_profile.yml
+++ b/config/pdf_profile.yml
@@ -1,0 +1,185 @@
+# HTML print profile - the contract between our document templates and the
+# PDF renderer (WeasyPrint today; a future HTML -> Typst compiler).
+#
+# Scope: the *rendered* HTML sent to the PDF service, i.e. after ERB,
+# TiptapService#to_html and the sanitizer have run. Three document families:
+#   - attestation v2       (admin-authored TipTap content)
+#   - attestation de depot (static template)
+#   - dossier vide         (generated empty form)
+#
+# spec/lint/pdf_profile_spec.rb renders a representative corpus of each family
+# and fails when the output uses an element, attribute, class or inline style
+# not listed here. Extending a template therefore starts by extending this
+# profile. This is deliberate: the profile is exactly what an HTML -> Typst
+# compiler will have to implement, and anything outside it must be a compile
+# error rather than silently-dropped styling.
+#
+# Findings recorded by the harvest (spec/fixtures/pdf_profile/):
+#   - The sanitizer applied to admin bodies (attestation_template_v2s/show +
+#     config/application.rb) keeps <mark> but strips <a> and <footer>,
+#     keeping their text content. TipTap links and footers therefore never
+#     reach the renderer today; re-allowing them is a separate decision.
+#   - Block-level mention presentations are spliced out of their enclosing
+#     paragraph as raw "</p><ul>...</ul><p>" (TiptapService
+#     #handle_presentation_node); HTML5 parsing normalizes this into sibling
+#     elements, and a compiler must parse (not regex) the input to see it.
+
+version: 1
+
+# element => allowed attributes
+elements:
+  # Document shell - metadata for the PDF compiler (title, lang), not content.
+  html: [lang]
+  head: []
+  meta: [name, content]
+  title: []
+  link: [rel, href, media]
+  body: [id]
+
+  # Structure
+  div: [class, style, aria-hidden]
+  section: [class]
+  header: [class]
+  footer: [class]
+  h1: [class, style]
+  h2: [class, style]
+  h3: [class, style]
+  h4: [class, style]
+  h5: [class, style]
+  h6: [class, style]
+  p: [class, style]
+  dl: [class]
+  dt: [class]
+  dd: [class]
+  ul: [class]
+  ol: [class]
+  li: [class]
+
+  # Inline
+  a: [href, target, rel, title] # target/rel come from SimpleFormatComponent auto-links; meaningless in PDF
+  span: [class, aria-hidden]
+  strong: []
+  em: []
+  u: []
+  mark: []
+  br: []
+
+  # Media
+  img: [src, alt, class, width]
+
+# Every class carries meaning for the print stylesheet / future Typst theme.
+classes:
+  # attestation shell (layouts/attestation + attestation_template_v2s/show)
+  - a4-container
+  - official-layout
+  - content
+  - first-header
+  - left
+  - right
+  - bloc-marque
+  - marianne
+  - marianne-with-devise
+  - intitule
+  - devise
+  - logo-co-emetteur
+  - logo-free-layout
+  - direction
+  - direction-block
+  - direction-label
+  - direction-site
+  - logo-site
+  - main
+  - signature
+  # TipTap output (TiptapService#to_html + ChampPresentations)
+  - body-start
+  - page-break
+  - tdc-repetition
+  - invisible
+  # attestation de depot
+  - attestation-depot
+  - attestation-depot-header
+  - attestation-depot-title
+  - attestation-depot-procedure
+  - attestation-depot-description
+  - attestation-depot-section
+  # dossier vide (DossierVidePdfComponent)
+  - logo
+  - header
+  - identity
+  - field-pair
+  - champ
+  - champ--conditional
+  - label
+  - description
+  - explication
+  - explanation
+  - condition
+  - mailing
+  - presentation
+  - annexes
+  - annex
+  - annex-options
+  - box
+  - box--line
+  - box--block
+  - options
+  - option
+  - secondary
+  - checkbox
+
+# style="..." - the only inline styling in the corpus is TipTap's textAlign.
+inline_styles:
+  text-align: [left, center, right, justify]
+
+# ---------------------------------------------------------------------------
+# CSS stylesheet profile - DRAFT, not yet enforced by the lint spec.
+# Derived from attestation.scss and dossier_vide_pdf.scss.
+#   direct: properties a Typst compiler maps one-to-one
+#   idioms: patterns recognized as a whole, not general CSS support
+#   reject: forbidden (mostly WeasyPrint-era layout workarounds)
+css:
+  selectors:
+    - element
+    - .class
+    - element.class
+    - 'ancestor descendant (one level)'
+  properties:
+    direct:
+      - font-family
+      - font-size
+      - font-weight
+      - font-style
+      - line-height
+      - color
+      - background-color
+      - text-align
+      - text-decoration
+      - white-space
+      - margin (+ margin-*)
+      - padding (+ padding-*)
+      - width
+      - height
+      - max-width
+      - max-height
+      - border
+      - break-before
+      - break-after
+      - page-break-before
+      - column-count
+      - column-gap
+      - gap
+      - visibility
+      - list-style
+    idioms:
+      - '@font-face (Marianne)'
+      - '@page + margin boxes (A4, margins, page counter, running footer)'
+      - 'display: grid + grid-template-columns on dl (key/value table)'
+      - 'display: inline-block (logo rows)'
+      - 'display: block / none'
+    reject:
+      - 'display: flex / inline-flex (and justify-content, align-items, flex-direction, flex)'
+      - 'position: absolute / relative / running()'
+      - float
+      - z-index
+      - vertical-align
+      - box-shadow

--- a/lib/typst/theme.typ
+++ b/lib/typst/theme.typ
@@ -28,7 +28,7 @@
 // alt text is rendered in a placeholder frame, so the document still compiles
 // and the information stays available.
 #let profile-image(path: none, alt: "", height: auto, width: auto) = if path != none {
-  image(path, alt: alt, height: height, width: width)
+  image(path, alt: alt, height: height, width: width, fit: "contain")
 } else {
   rect(stroke: 0.5pt + luma(120), inset: 2mm, height: height, text(size: 7pt, fill: luma(120))[#alt])
 }

--- a/lib/typst/theme.typ
+++ b/lib/typst/theme.typ
@@ -1,0 +1,76 @@
+// Print theme for the PDF HTML profile (config/pdf_profile.yml).
+//
+// Hand-written Typst counterpart of attestation.scss: the HTML -> Typst
+// compiler (PdfProfile::TypstCompiler) maps profile classes onto these
+// functions. Layout decisions live here, never in the compiler.
+//
+// Compile with: typst compile --pdf-standard ua-1 --font-path lib/prawn/fonts
+
+#let ink = rgb("161616")
+
+// Document shell: A4, Marianne, page counter in the footer.
+#let conf(title: none, lang: "fr", doc) = {
+  set document(title: title)
+  set page(
+    paper: "a4",
+    margin: (x: 17mm, top: 17mm, bottom: 34mm),
+    footer: align(center, text(size: 8pt)[
+      #context counter(page).display("1 / 1", both: true)
+    ]),
+  )
+  set text(font: "Marianne", size: 10pt, lang: lang, fill: ink)
+  show heading.where(level: 2): set text(size: 12pt)
+  show heading.where(level: 2): set block(above: 0mm, below: 3mm)
+  doc
+}
+
+// Compiler-resolved image. When the source file is not available locally the
+// alt text is rendered in a placeholder frame, so the document still compiles
+// and the information stays available.
+#let profile-image(path: none, alt: "", height: auto, width: auto) = if path != none {
+  image(path, alt: alt, height: height, width: width)
+} else {
+  rect(stroke: 0.5pt + luma(120), inset: 2mm, height: height, text(size: 7pt, fill: luma(120))[#alt])
+}
+
+// Two-column document header: marque block left, direction block right.
+#let first-header(left-content, right-content) = grid(
+  columns: (1fr, auto),
+  align: (left, right),
+  left-content,
+  right-content,
+)
+
+#let bloc-marque(body) = box(inset: (right: 5mm), body)
+
+#let logo-site(body) = box(inset: (left: 2mm), body)
+
+#let direction-block(body) = align(right, body)
+
+#let direction-label(body) = par(text(size: 8pt, body))
+
+#let direction-site(body) = par(text(size: 10pt, weight: "bold", body))
+
+// Attestation de depot
+#let depot-title(body) = block(above: 10mm, below: 5mm, align(center, {
+  show heading: set text(size: 16pt)
+  heading(level: 1, body)
+}))
+
+#let depot-procedure(body) = align(center, block(below: 12mm, text(size: 12pt, weight: "bold", body)))
+
+#let depot-description(body) = block(below: 10mm, body)
+
+#let depot-section(body) = block(below: 8mm, body)
+
+// Key/value list (HTML <dl>): a borderless two-column table keeps the
+// pairing in the PDF tag tree.
+#let key-value(..pairs) = table(
+  columns: (40mm, 1fr),
+  stroke: none,
+  inset: (x: 0mm, y: 0.75mm),
+  column-gutter: 5mm,
+  ..pairs.pos().map(((term, desc)) => (strong(term), desc)).flatten(),
+)
+
+#let signature(body) = align(right, block(above: 14mm, inset: (right: 25mm), body))

--- a/spec/fixtures/pdf_profile/attestation_depot.html
+++ b/spec/fixtures/pdf_profile/attestation_depot.html
@@ -1,0 +1,106 @@
+<html lang='fr'>
+<head>
+<link rel="stylesheet" href="/assets/attestation-d0a3b9c30bacac220ea36f0e17b08d3f2564c7485587714363ebca35e4dbfce6.css" media="all" />
+<title>Attestation</title>
+
+
+
+<meta content='test.host' name='generator'>
+<meta content='2026-08-31T16:28:19+02:00' name='dcterms.created'>
+</head>
+<body id='attestation'>
+<div class="a4-container official-layout attestation-depot">
+
+  <div class="content">
+    <header class="first-header attestation-depot-header">
+      <div class="left">
+          <div class="bloc-marque">
+            <img alt="Logo Marianne, République Française" class="marianne-with-devise" src="http://test.host/assets/Marianne-Light@2x-31305575f97bb694abbf6758b506571207ea89dd3cb94144d480ad16630d1d21.png" />
+          </div>
+
+        <div class="logo-site">
+          <img alt="demarche.numerique.gouv.fr" src="http://test.host/assets/logo-demarche-numerique@2x-a4fea260a3dca9735e231f8c9160c6e0f5b089c57305a64e3a41920c7822d241.png" />
+        </div>
+      </div>
+
+      <div class="right">
+        <div class="direction-block">
+            <p class="direction-label">Direction interministérielle du numérique</p>
+
+          <p class="direction-site">demarche.numerique.gouv.fr</p>
+        </div>
+      </div>
+    </header>
+
+    <div class="main">
+      <h1 class="attestation-depot-title">Attestation de dépôt</h1>
+
+      <p class="attestation-depot-procedure">
+        Démarche de démonstration
+      </p>
+
+      <p class="attestation-depot-description">
+        Ce document atteste que Jeanne DUPONT a déposé le 30 août 2026 un dossier sur la démarche « Démarche de démonstration ».
+      </p>
+
+      <section class="attestation-depot-section">
+        <h2>Identité du demandeur</h2>
+
+          <dl>
+            <dt>Prénom</dt>
+            <dd>Jeanne</dd>
+            <dt>Nom</dt>
+            <dd>DUPONT</dd>
+            <dt>Adresse électronique</dt>
+            <dd>usager@exemple.fr</dd>
+          </dl>
+
+      </section>
+
+      <section class="attestation-depot-section">
+        <h2>Dossier</h2>
+
+        <dl>
+          <dt>Numéro de dossier</dt>
+          <dd>233</dd>
+          <dt>Dossier déposé le</dt>
+          <dd>30 août 2026</dd>
+          <dt>État du dossier</dt>
+          <dd>déposé, en attente d’examen par l’administration</dd>
+        </dl>
+      </section>
+
+
+        <section class="attestation-depot-section">
+          <h2>Service administratif</h2>
+
+          <dl>
+            <dt>Service</dt>
+
+            <dd>Service de démonstration, Organisme de démonstration</dd>
+
+            <dt>Adresse postale</dt>
+
+            <dd>20 avenue de Ségur, 75007 Paris</dd>
+
+              <dt>Adresse électronique</dt>
+              <dd>contact@exemple.fr</dd>
+
+              <dt>Téléphone</dt>
+              <dd>0102030405</dd>
+          </dl>
+        </section>
+
+      <div class="signature">
+        <p>
+          Fait le 31 août 2026,
+        </p>
+
+        <p>La direction de demarche.numerique.gouv.fr</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/spec/fixtures/pdf_profile/attestation_depot.html
+++ b/spec/fixtures/pdf_profile/attestation_depot.html
@@ -6,7 +6,7 @@
 
 
 <meta content='test.host' name='generator'>
-<meta content='2026-08-31T16:28:19+02:00' name='dcterms.created'>
+<meta content='2026-08-31T16:55:27+02:00' name='dcterms.created'>
 </head>
 <body id='attestation'>
 <div class="a4-container official-layout attestation-depot">
@@ -62,7 +62,7 @@
 
         <dl>
           <dt>Numéro de dossier</dt>
-          <dd>233</dd>
+          <dd>274</dd>
           <dt>Dossier déposé le</dt>
           <dd>30 août 2026</dd>
           <dt>État du dossier</dt>

--- a/spec/fixtures/pdf_profile/attestation_depot.typ
+++ b/spec/fixtures/pdf_profile/attestation_depot.typ
@@ -1,0 +1,60 @@
+#import "theme.typ": *
+#show: conf.with(title: "Attestation", lang: "fr")
+
+#first-header(
+[
+#bloc-marque[#profile-image(alt: "Logo Marianne, République Française", height: 20mm)]
+
+#logo-site[#profile-image(alt: "demarche.numerique.gouv.fr", height: 15mm)]
+],
+[
+#direction-block[
+#direction-label[Direction interministérielle du numérique]
+
+#direction-site[demarche.numerique.gouv.fr]
+]
+],
+)
+
+#depot-title[Attestation de dépôt]
+
+#depot-procedure[Démarche de démonstration]
+
+#depot-description[Ce document atteste que Jeanne DUPONT a déposé le 30 août 2026 un dossier sur la démarche « Démarche de démonstration ».]
+
+#depot-section[
+#heading(level: 2)[Identité du demandeur]
+
+#key-value(
+  ([Prénom], [Jeanne]),
+  ([Nom], [DUPONT]),
+  ([Adresse électronique], [usager\@exemple.fr]),
+)
+]
+
+#depot-section[
+#heading(level: 2)[Dossier]
+
+#key-value(
+  ([Numéro de dossier], [274]),
+  ([Dossier déposé le], [30 août 2026]),
+  ([État du dossier], [déposé, en attente d’examen par l’administration]),
+)
+]
+
+#depot-section[
+#heading(level: 2)[Service administratif]
+
+#key-value(
+  ([Service], [Service de démonstration, Organisme de démonstration]),
+  ([Adresse postale], [20 avenue de Ségur, 75007 Paris]),
+  ([Adresse électronique], [contact\@exemple.fr]),
+  ([Téléphone], [0102030405]),
+)
+]
+
+#signature[
+#par[Fait le 31 août 2026,]
+
+#par[La direction de demarche.numerique.gouv.fr]
+]

--- a/spec/fixtures/pdf_profile/attestation_depot.typ
+++ b/spec/fixtures/pdf_profile/attestation_depot.typ
@@ -3,9 +3,9 @@
 
 #first-header(
 [
-#bloc-marque[#profile-image(alt: "Logo Marianne, République Française", height: 20mm)]
+#bloc-marque[#profile-image(path: "assets/Marianne-Light@2x.png", alt: "Logo Marianne, République Française", height: 20mm)]
 
-#logo-site[#profile-image(alt: "demarche.numerique.gouv.fr", height: 15mm)]
+#logo-site[#profile-image(path: "assets/logo-demarche-numerique@2x.png", alt: "demarche.numerique.gouv.fr", height: 15mm, width: 30mm)]
 ],
 [
 #direction-block[

--- a/spec/fixtures/pdf_profile/attestation_v2.html
+++ b/spec/fixtures/pdf_profile/attestation_v2.html
@@ -1,0 +1,39 @@
+<html lang='fr'>
+<head>
+<link rel="stylesheet" href="/assets/attestation-d0a3b9c30bacac220ea36f0e17b08d3f2564c7485587714363ebca35e4dbfce6.css" media="all" />
+<title>Attestation</title>
+
+
+
+<meta content='test.host' name='generator'>
+<meta content='2026-08-31T16:28:19+02:00' name='dcterms.created'>
+</head>
+<body id='attestation'>
+<div class="a4-container official-layout">
+  <div class="content">
+    <header class="first-header">
+      <div class="left">
+          <img alt="République française" class="marianne" src="/assets/centered_marianne-00cb9c7009adea9ffa65aa8cf028ce2f94b88b1bcdaf202c5a42fc1976f0dabd.svg" />
+          <div class="bloc-marque">
+            <p class="intitule">Ministère des devs</p>
+            <img alt="Liberté Égalité Fraternité" class="devise" src="/assets/liberte2-5ee183e5c6400eccff4b10a6a3c3beff34ec3582b77aa13ef701bb8f40c6bd19.svg" />
+          </div>
+      </div>
+
+      <div class="right">
+
+          <p class="direction">Direction des services</p>
+      </div>
+    </header>
+
+      <footer><p>Mairie de Bordeaux</p></footer>
+
+    <div class="main">
+      <header><div style="text-align:left;"><p>Colonne gauche</p></div><div style="text-align:right;"><p>Colonne droite</p></div></header><h1 style="text-align:center;">Attestation pour le dossier 42</h1><h2 class="body-start" style="text-align:left;">Sous-titre</h2><h3>Sous-sous-titre</h3><p style="text-align:justify;"><strong>gras</strong><em> italique</em><u> souligné</u><mark> surligné</mark> lien<br><br>après saut de ligne</p><ul><li>une puce</li></ul><ol><li>une entrée numérotée</li></ol><p>Choix : </p><ul><li>Premier choix</li><li>Deuxième choix</li></ul><p>Bloc répétable : </p><ol class="tdc-repetition"><li><dl><dt>Nom</dt><dd>Dupont</dd><dt class="invisible">Prénom</dt><dd></dd></dl></li></ol><div class="page-break"></div><p>Sur la page suivante.</p>Pied de page
+
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/spec/fixtures/pdf_profile/attestation_v2_co_emetteur.html
+++ b/spec/fixtures/pdf_profile/attestation_v2_co_emetteur.html
@@ -1,0 +1,44 @@
+<html lang='fr'>
+<head>
+<link rel="stylesheet" href="/assets/attestation-d0a3b9c30bacac220ea36f0e17b08d3f2564c7485587714363ebca35e4dbfce6.css" media="all" />
+<title>Attestation</title>
+
+
+
+<meta content='test.host' name='generator'>
+<meta content='2026-08-31T16:28:19+02:00' name='dcterms.created'>
+</head>
+<body id='attestation'>
+<div class="a4-container official-layout">
+  <div class="content">
+    <header class="first-header">
+      <div class="left">
+          <img alt="République française" class="marianne" src="/assets/centered_marianne-00cb9c7009adea9ffa65aa8cf028ce2f94b88b1bcdaf202c5a42fc1976f0dabd.svg" />
+          <div class="bloc-marque">
+            <p class="intitule">Ministère des devs</p>
+            <img alt="Liberté Égalité Fraternité" class="devise" src="/assets/liberte2-5ee183e5c6400eccff4b10a6a3c3beff34ec3582b77aa13ef701bb8f40c6bd19.svg" />
+          </div>
+      </div>
+
+      <div class="right">
+          <div class="logo-co-emetteur">
+            <img alt="Ministère des devs" src="http://test.host/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MjQsImV4cCI6IjIwMjYtMDgtMzFUMTU6Mjg6MTkuNDcyWiIsInB1ciI6ImJsb2JfaWQifX0=--1c4b515ea2f78a22463a8b2382c06595d69b15a3/logo_test_procedure.png" />
+          </div>
+
+      </div>
+    </header>
+
+      <footer><p>footer</p></footer>
+
+    <div class="main">
+      <header><div style="text-align:left;"><p>Colonne gauche</p></div><div style="text-align:right;"><p>Colonne droite</p></div></header><h1 style="text-align:center;">Attestation pour le dossier 42</h1><h2 class="body-start" style="text-align:left;">Sous-titre</h2><h3>Sous-sous-titre</h3><p style="text-align:justify;"><strong>gras</strong><em> italique</em><u> souligné</u><mark> surligné</mark> lien<br><br>après saut de ligne</p><ul><li>une puce</li></ul><ol><li>une entrée numérotée</li></ol><p>Choix : </p><ul><li>Premier choix</li><li>Deuxième choix</li></ul><p>Bloc répétable : </p><ol class="tdc-repetition"><li><dl><dt>Nom</dt><dd>Dupont</dd><dt class="invisible">Prénom</dt><dd></dd></dl></li></ol><div class="page-break"></div><p>Sur la page suivante.</p>Pied de page
+
+        <div class="signature">
+          <img alt="Signature" src="http://test.host/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MjUsImV4cCI6IjIwMjYtMDgtMzFUMTU6Mjg6MTkuNDc3WiIsInB1ciI6ImJsb2JfaWQifX0=--e38543f50f1526b2ffbb0dc18a53dc1e44b14679/logo_test_procedure.png" />
+        </div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/spec/fixtures/pdf_profile/attestation_v2_co_emetteur.html
+++ b/spec/fixtures/pdf_profile/attestation_v2_co_emetteur.html
@@ -6,7 +6,7 @@
 
 
 <meta content='test.host' name='generator'>
-<meta content='2026-08-31T16:28:19+02:00' name='dcterms.created'>
+<meta content='2026-08-31T16:55:27+02:00' name='dcterms.created'>
 </head>
 <body id='attestation'>
 <div class="a4-container official-layout">
@@ -22,7 +22,7 @@
 
       <div class="right">
           <div class="logo-co-emetteur">
-            <img alt="Ministère des devs" src="http://test.host/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MjQsImV4cCI6IjIwMjYtMDgtMzFUMTU6Mjg6MTkuNDcyWiIsInB1ciI6ImJsb2JfaWQifX0=--1c4b515ea2f78a22463a8b2382c06595d69b15a3/logo_test_procedure.png" />
+            <img alt="Ministère des devs" src="http://test.host/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6NjQsImV4cCI6IjIwMjYtMDgtMzFUMTU6NTU6MjcuOTY3WiIsInB1ciI6ImJsb2JfaWQifX0=--ba54a0648f79a4d31034fd58fbe159e9f1ca9796/logo_test_procedure.png" />
           </div>
 
       </div>
@@ -31,10 +31,10 @@
       <footer><p>footer</p></footer>
 
     <div class="main">
-      <header><div style="text-align:left;"><p>Colonne gauche</p></div><div style="text-align:right;"><p>Colonne droite</p></div></header><h1 style="text-align:center;">Attestation pour le dossier 42</h1><h2 class="body-start" style="text-align:left;">Sous-titre</h2><h3>Sous-sous-titre</h3><p style="text-align:justify;"><strong>gras</strong><em> italique</em><u> souligné</u><mark> surligné</mark> lien<br><br>après saut de ligne</p><ul><li>une puce</li></ul><ol><li>une entrée numérotée</li></ol><p>Choix : </p><ul><li>Premier choix</li><li>Deuxième choix</li></ul><p>Bloc répétable : </p><ol class="tdc-repetition"><li><dl><dt>Nom</dt><dd>Dupont</dd><dt class="invisible">Prénom</dt><dd></dd></dl></li></ol><div class="page-break"></div><p>Sur la page suivante.</p>Pied de page
+      <header><div style="text-align: left"><p>Colonne gauche</p></div><div style="text-align: right"><p>Colonne droite</p></div></header><h1 style="text-align: center">Attestation pour le dossier 42</h1><h2 class="body-start" style="text-align: left">Sous-titre</h2><h3>Sous-sous-titre</h3><p style="text-align: justify"><strong>gras</strong><em> italique</em><u> souligné</u><mark> surligné</mark> lien<br><br>après saut de ligne</p><ul><li>une puce</li></ul><ol><li>une entrée numérotée</li></ol><p>Choix : </p><ul><li>Premier choix</li><li>Deuxième choix</li></ul><p>Bloc répétable : </p><ol class="tdc-repetition"><li><dl><dt>Nom</dt><dd>Dupont</dd><dt class="invisible">Prénom</dt><dd></dd></dl></li></ol><div class="page-break"></div><p>Sur la page suivante.</p>Pied de page
 
         <div class="signature">
-          <img alt="Signature" src="http://test.host/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MjUsImV4cCI6IjIwMjYtMDgtMzFUMTU6Mjg6MTkuNDc3WiIsInB1ciI6ImJsb2JfaWQifX0=--e38543f50f1526b2ffbb0dc18a53dc1e44b14679/logo_test_procedure.png" />
+          <img alt="Signature" src="http://test.host/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6NjUsImV4cCI6IjIwMjYtMDgtMzFUMTU6NTU6MjcuOTcyWiIsInB1ciI6ImJsb2JfaWQifX0=--4728757b1476d88097c1701f2c473221ac6f9d8b/logo_test_procedure.png" />
         </div>
     </div>
   </div>

--- a/spec/fixtures/pdf_profile/attestation_v2_free_layout.html
+++ b/spec/fixtures/pdf_profile/attestation_v2_free_layout.html
@@ -1,0 +1,36 @@
+<html lang='fr'>
+<head>
+<link rel="stylesheet" href="/assets/attestation-d0a3b9c30bacac220ea36f0e17b08d3f2564c7485587714363ebca35e4dbfce6.css" media="all" />
+<title>Attestation</title>
+
+
+
+<meta content='test.host' name='generator'>
+<meta content='2026-08-31T16:28:19+02:00' name='dcterms.created'>
+</head>
+<body id='attestation'>
+<div class="a4-container ">
+  <div class="content">
+    <header class="first-header">
+      <div class="left">
+          <div class="bloc-marque logo-free-layout">
+            <img alt="Ministère des devs" src="http://test.host/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MjYsImV4cCI6IjIwMjYtMDgtMzFUMTU6Mjg6MTkuNjE4WiIsInB1ciI6ImJsb2JfaWQifX0=--6add503a1ec602f26e2d18503ae09c37b120dd16/logo_test_procedure.png" />
+          </div>
+      </div>
+
+      <div class="right">
+
+      </div>
+    </header>
+
+      <footer><p>footer</p></footer>
+
+    <div class="main">
+      <header><div style="text-align:left;"><p>Colonne gauche</p></div><div style="text-align:right;"><p>Colonne droite</p></div></header><h1 style="text-align:center;">Attestation pour le dossier 42</h1><h2 class="body-start" style="text-align:left;">Sous-titre</h2><h3>Sous-sous-titre</h3><p style="text-align:justify;"><strong>gras</strong><em> italique</em><u> souligné</u><mark> surligné</mark> lien<br><br>après saut de ligne</p><ul><li>une puce</li></ul><ol><li>une entrée numérotée</li></ol><p>Choix : </p><ul><li>Premier choix</li><li>Deuxième choix</li></ul><p>Bloc répétable : </p><ol class="tdc-repetition"><li><dl><dt>Nom</dt><dd>Dupont</dd><dt class="invisible">Prénom</dt><dd></dd></dl></li></ol><div class="page-break"></div><p>Sur la page suivante.</p>Pied de page
+
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/spec/fixtures/pdf_profile/attestation_v2_free_layout.html
+++ b/spec/fixtures/pdf_profile/attestation_v2_free_layout.html
@@ -6,7 +6,7 @@
 
 
 <meta content='test.host' name='generator'>
-<meta content='2026-08-31T16:28:19+02:00' name='dcterms.created'>
+<meta content='2026-08-31T16:55:28+02:00' name='dcterms.created'>
 </head>
 <body id='attestation'>
 <div class="a4-container ">
@@ -14,7 +14,7 @@
     <header class="first-header">
       <div class="left">
           <div class="bloc-marque logo-free-layout">
-            <img alt="Ministère des devs" src="http://test.host/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MjYsImV4cCI6IjIwMjYtMDgtMzFUMTU6Mjg6MTkuNjE4WiIsInB1ciI6ImJsb2JfaWQifX0=--6add503a1ec602f26e2d18503ae09c37b120dd16/logo_test_procedure.png" />
+            <img alt="Ministère des devs" src="http://test.host/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6NjYsImV4cCI6IjIwMjYtMDgtMzFUMTU6NTU6MjguMDkyWiIsInB1ciI6ImJsb2JfaWQifX0=--06227e3d85c5bf576deed61af0bc9cb7b0b96109/logo_test_procedure.png" />
           </div>
       </div>
 
@@ -26,7 +26,7 @@
       <footer><p>footer</p></footer>
 
     <div class="main">
-      <header><div style="text-align:left;"><p>Colonne gauche</p></div><div style="text-align:right;"><p>Colonne droite</p></div></header><h1 style="text-align:center;">Attestation pour le dossier 42</h1><h2 class="body-start" style="text-align:left;">Sous-titre</h2><h3>Sous-sous-titre</h3><p style="text-align:justify;"><strong>gras</strong><em> italique</em><u> souligné</u><mark> surligné</mark> lien<br><br>après saut de ligne</p><ul><li>une puce</li></ul><ol><li>une entrée numérotée</li></ol><p>Choix : </p><ul><li>Premier choix</li><li>Deuxième choix</li></ul><p>Bloc répétable : </p><ol class="tdc-repetition"><li><dl><dt>Nom</dt><dd>Dupont</dd><dt class="invisible">Prénom</dt><dd></dd></dl></li></ol><div class="page-break"></div><p>Sur la page suivante.</p>Pied de page
+      <header><div style="text-align: left"><p>Colonne gauche</p></div><div style="text-align: right"><p>Colonne droite</p></div></header><h1 style="text-align: center">Attestation pour le dossier 42</h1><h2 class="body-start" style="text-align: left">Sous-titre</h2><h3>Sous-sous-titre</h3><p style="text-align: justify"><strong>gras</strong><em> italique</em><u> souligné</u><mark> surligné</mark> lien<br><br>après saut de ligne</p><ul><li>une puce</li></ul><ol><li>une entrée numérotée</li></ol><p>Choix : </p><ul><li>Premier choix</li><li>Deuxième choix</li></ul><p>Bloc répétable : </p><ol class="tdc-repetition"><li><dl><dt>Nom</dt><dd>Dupont</dd><dt class="invisible">Prénom</dt><dd></dd></dl></li></ol><div class="page-break"></div><p>Sur la page suivante.</p>Pied de page
 
     </div>
   </div>

--- a/spec/fixtures/pdf_profile/attestation_v2_hostile.html
+++ b/spec/fixtures/pdf_profile/attestation_v2_hostile.html
@@ -22,14 +22,20 @@
 
       <div class="right">
 
-          <p class="direction">Direction des services</p>
       </div>
     </header>
 
-      <footer><p>Mairie de Bordeaux</p></footer>
+      <footer><p>footer</p></footer>
 
     <div class="main">
-      <header><div style="text-align: left"><p>Colonne gauche</p></div><div style="text-align: right"><p>Colonne droite</p></div></header><h1 style="text-align: center">Attestation pour le dossier 42</h1><h2 class="body-start" style="text-align: left">Sous-titre</h2><h3>Sous-sous-titre</h3><p style="text-align: justify"><strong>gras</strong><em> italique</em><u> souligné</u><mark> surligné</mark> lien<br><br>après saut de ligne</p><ul><li>une puce</li></ul><ol><li>une entrée numérotée</li></ol><p>Choix : </p><ul><li>Premier choix</li><li>Deuxième choix</li></ul><p>Bloc répétable : </p><ol class="tdc-repetition"><li><dl><dt>Nom</dt><dd>Dupont</dd><dt class="invisible">Prénom</dt><dd></dd></dl></li></ol><div class="page-break"></div><p>Sur la page suivante.</p>Pied de page
+      
+citation
+
+lien
+pied
+<p style="text-align: center">aligné</p>
+<mark>surligné</mark>
+
 
     </div>
   </div>

--- a/spec/fixtures/pdf_profile/dossier_vide.html
+++ b/spec/fixtures/pdf_profile/dossier_vide.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+
+<html lang="fr">
+  <head>
+    <link rel="stylesheet" href="/assets/dossier_vide_pdf-e0af6ab4b9d538fec7cd715cbb3fe2b4e103283a366847361b107a5124109dbe.css" media="all" />
+    <title>Démarche avec tous les types de champ</title>
+    <meta name="generator" content="test.host">
+    <meta name="dcterms.created" content="(harvest)">
+  </head>
+
+  <body id="dossier-vide-pdf">
+<img alt="Logo de l’administration" width="300" class="logo" src="/assets/header/logo-ds-wide-769c5a86d3240cd5535fd507117ba50979fdddf89d0de7afb94d50d422d78642.png" />
+
+<h1>Démarche avec tous les types de champ</h1>
+
+<dl class="header">
+  <div class="field-pair">
+    <dt>Organisme</dt>
+    <dd>Service de démonstration</dd>
+  </div>
+</dl>
+
+<h2>Identité du demandeur</h2>
+
+<dl class="identity">
+  <div class="field-pair"><dt>Email</dt><dd><div class="box box--line" aria-hidden="true"></div></dd></div>
+
+    <div class="field-pair"><dt>Civilité</dt><dd><div class="box box--line" aria-hidden="true"></div></dd></div>
+    <div class="field-pair"><dt>Nom</dt><dd><div class="box box--line" aria-hidden="true"></div></dd></div>
+    <div class="field-pair"><dt>Prénom</dt><dd><div class="box box--line" aria-hidden="true"></div></dd></div>
+</dl>
+
+<h2>Formulaire</h2>
+
+  <div class="presentation"><p>Une démarche de démonstration avec un champ de chaque type.</p>
+</div>
+
+  <p class="mailing">À envoyer à Service de démonstration - 20 avenue de Ségur, 75007 Paris</p>
+
+  <section class="champ">
+    <p class="label">Grande liste</p><p class="explanation">La liste complète des options figure en Annexe 1. Renseignez la mention applicable, une seule valeur possible</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">engagement_juridique</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <h3>header_section</h3>
+  </section>
+  <section class="champ">
+    <p class="label">repetition</p><section class="champ"><p class="label">sub type de champ</p><div class="box box--block" aria-hidden="true"></div></section><section class="champ"><p class="label">sub type de champ2</p><div class="box box--block" aria-hidden="true"></div></section><section class="champ"><p class="label">sub type de champ</p><div class="box box--block" aria-hidden="true"></div></section><section class="champ"><p class="label">sub type de champ2</p><div class="box box--block" aria-hidden="true"></div></section><section class="champ"><p class="label">sub type de champ</p><div class="box box--block" aria-hidden="true"></div></section><section class="champ"><p class="label">sub type de champ2</p><div class="box box--block" aria-hidden="true"></div></section>
+  </section>
+  <section class="champ">
+    <p class="label">dossier_link</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">explication</p><div class="explication">
+</div>
+  </section>
+  <section class="champ">
+    <p class="label">civilite</p><ul class="options"><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>Mme</span></span></li><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>M.</span></span></li></ul>
+  </section>
+  <section class="champ">
+    <p class="label">email</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">phone</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">address</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">communes</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">departements</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">regions</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">pays</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">iban</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">siret</p><div class="field-pair"><dt>SIRET</dt><dd><div class="box box--line" aria-hidden="true"></div></dd></div><div class="field-pair"><dt>Dénomination</dt><dd><div class="box box--line" aria-hidden="true"></div></dd></div><div class="field-pair"><dt>Forme juridique</dt><dd><div class="box box--line" aria-hidden="true"></div></dd></div>
+  </section>
+  <section class="champ champ--conditional">
+    <p class="label">text</p><p class="condition">À remplir si « simple_drop_down_list » égal à « val1 »</p><div class="description"><p>Une description du champ, avec un lien <a href="https://exemple.gouv.fr" title="Nouvel onglet" target="_blank" rel="noopener noreferrer">https://exemple.gouv.fr</a></p>
+</div><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">textarea</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">number</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">decimal_number</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">integer_number</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">formatted</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">date</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">datetime</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">Pièce justificative à joindre en complément du dossier</p><ul class="options"><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>piece_justificative</span></span></li></ul>
+  </section>
+  <section class="champ">
+    <p class="label">checkbox</p><p class="explanation">Cochez la mention applicable</p><ul class="options"><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>Oui</span></span></li><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>Non</span></span></li></ul>
+  </section>
+  <section class="champ">
+    <p class="label">simple_drop_down_list</p><p class="explanation">Cochez la mention applicable, une seule valeur possible</p><ul class="options"><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>val1</span></span></li><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>val2</span></span></li><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>val3</span></span></li></ul>
+  </section>
+  <section class="champ">
+    <p class="label">multiple_drop_down_list</p><p class="explanation">Cochez la mention applicable, plusieurs valeurs possibles</p><ul class="options"><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>val1</span></span></li><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>val2</span></span></li><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>val3</span></span></li></ul>
+  </section>
+  <section class="champ">
+    <p class="label">linked_drop_down_list</p><ul class="options"><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>primary</span></span></li><li class="secondary"><span class="option"><span class="checkbox" aria-hidden="true"></span><span>secondary</span></span></li></ul>
+  </section>
+  <section class="champ">
+    <p class="label">yes_no</p><p class="explanation">Cochez la mention applicable</p><ul class="options"><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>Oui</span></span></li><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>Non</span></span></li></ul>
+  </section>
+  <section class="champ">
+    <p class="label">annuaire_education</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">rna</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">rnf</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">carte</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">epci</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">cojo</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">referentiel</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">pre_rempli</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">quotient_familial</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">etudiant_boursier</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">aah</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">aeeh</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">ars</p><div class="box box--block" aria-hidden="true"></div>
+  </section>
+  <section class="champ">
+    <p class="label">Pièce justificative à joindre en complément du dossier</p><ul class="options"><li><span class="option"><span class="checkbox" aria-hidden="true"></span><span>titre_identité</span></span></li></ul>
+  </section>
+
+  <section class="annexes">
+    <h2>Annexes</h2>
+
+      <section class="annex">
+        <h3>Annexe 1 : Grande liste</h3><ul class="annex-options"><li>Option 1</li><li>Option 2</li><li>Option 3</li><li>Option 4</li><li>Option 5</li><li>Option 6</li><li>Option 7</li><li>Option 8</li><li>Option 9</li><li>Option 10</li><li>Option 11</li><li>Option 12</li><li>Option 13</li><li>Option 14</li><li>Option 15</li><li>Option 16</li><li>Option 17</li><li>Option 18</li><li>Option 19</li><li>Option 20</li><li>Option 21</li><li>Option 22</li><li>Option 23</li><li>Option 24</li><li>Option 25</li></ul>
+      </section>
+  </section>
+</body>
+</html>

--- a/spec/lib/pdf_profile/typst_compiler_spec.rb
+++ b/spec/lib/pdf_profile/typst_compiler_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+describe PdfProfile::TypstCompiler do
+  let(:fixture) { Rails.root.join('spec/fixtures/pdf_profile/attestation_depot.html').read }
+
+  describe '.compile' do
+    subject(:typ) { described_class.compile(fixture) }
+
+    it 'compiles the attestation de dépôt corpus to the golden Typst source' do
+      golden = Rails.root.join('spec/fixtures/pdf_profile/attestation_depot.typ')
+      golden.write(typ) if ENV['PDF_PROFILE_DUMP'] == '1'
+
+      expect(typ).to eq(golden.read)
+    end
+
+    it 'produces a document Typst accepts as PDF/UA-1' do
+      skip 'typst binary not installed' unless system('which typst', out: File::NULL, err: File::NULL)
+
+      Dir.mktmpdir do |dir|
+        FileUtils.cp(Rails.root.join('lib/typst/theme.typ'), dir)
+        File.write(File.join(dir, 'main.typ'), typ)
+
+        output, status = Open3.capture2e(
+          'typst', 'compile',
+          '--pdf-standard', 'ua-1',
+          '--font-path', Rails.root.join('lib/prawn/fonts').to_s,
+          File.join(dir, 'main.typ'),
+          File.join(dir, 'out.pdf')
+        )
+
+        expect(status).to be_success, -> { "typst compile failed:\n#{output}" }
+        expect(output).not_to include('warning'), -> { "typst emitted warnings:\n#{output}" }
+        expect(File.binread(File.join(dir, 'out.pdf'), 5)).to eq('%PDF-')
+      end
+    end
+
+    it 'raises on HTML outside the implemented profile subset' do
+      expect { described_class.compile('<body><table><tr><td>x</td></tr></table></body>') }
+        .to raise_error(described_class::Error, /unsupported element/)
+    end
+
+    it 'raises on inline styles (not implemented yet)' do
+      expect { described_class.compile('<body><p style="text-align: center">x</p></body>') }
+        .to raise_error(described_class::Error, /style attribute/)
+    end
+
+    it 'raises on images without alt text' do
+      expect { described_class.compile('<body><img class="marianne-with-devise" src="x.png"></body>') }
+        .to raise_error(described_class::Error, /alt/)
+    end
+
+    it 'escapes Typst markup characters in text' do
+      typ = described_class.compile('<body><p>#import $calc & 100_0 *gras* [x] @ref</p></body>')
+
+      expect(typ).to include('#par[\#import \$calc \& 100\_0 \*gras\* \[x\] \@ref]')
+    end
+
+    it 'escapes quotes and backslashes in Typst string literals' do
+      typ = described_class.compile(<<~HTML)
+        <html><head><title>Attestation "spéciale" \\ 2026</title></head><body></body></html>
+      HTML
+
+      expect(typ).to include('title: "Attestation \"spéciale\" \\\\ 2026"')
+    end
+  end
+end

--- a/spec/lib/pdf_profile/typst_compiler_spec.rb
+++ b/spec/lib/pdf_profile/typst_compiler_spec.rb
@@ -4,9 +4,11 @@ require 'open3'
 
 describe PdfProfile::TypstCompiler do
   let(:fixture) { Rails.root.join('spec/fixtures/pdf_profile/attestation_depot.html').read }
+  let(:image_assets) { described_class.image_assets(fixture) }
+  let(:assets) { image_assets.transform_values { "assets/#{it[:name]}" } }
 
   describe '.compile' do
-    subject(:typ) { described_class.compile(fixture) }
+    subject(:typ) { described_class.compile(fixture, assets:) }
 
     it 'compiles the attestation de dépôt corpus to the golden Typst source' do
       golden = Rails.root.join('spec/fixtures/pdf_profile/attestation_depot.typ')
@@ -15,24 +17,30 @@ describe PdfProfile::TypstCompiler do
       expect(typ).to eq(golden.read)
     end
 
-    it 'produces a document Typst accepts as PDF/UA-1' do
-      skip 'typst binary not installed' unless system('which typst', out: File::NULL, err: File::NULL)
+    it 'produces a document Typst accepts as PDF/UA-1', :external_deps do
+      skip 'typst binary not installed' unless installed?('typst')
 
       Dir.mktmpdir do |dir|
-        FileUtils.cp(Rails.root.join('lib/typst/theme.typ'), dir)
-        File.write(File.join(dir, 'main.typ'), typ)
-
-        output, status = Open3.capture2e(
-          'typst', 'compile',
-          '--pdf-standard', 'ua-1',
-          '--font-path', Rails.root.join('lib/prawn/fonts').to_s,
-          File.join(dir, 'main.typ'),
-          File.join(dir, 'out.pdf')
-        )
+        pdf, output, status = compile_pdf(dir)
 
         expect(status).to be_success, -> { "typst compile failed:\n#{output}" }
         expect(output).not_to include('warning'), -> { "typst emitted warnings:\n#{output}" }
-        expect(File.binread(File.join(dir, 'out.pdf'), 5)).to eq('%PDF-')
+        expect(File.binread(pdf, 5)).to eq('%PDF-')
+      end
+    end
+
+    it 'passes veraPDF PDF/UA-1 validation', :external_deps do
+      skip 'typst binary not installed' unless installed?('typst')
+      skip 'verapdf binary not installed' unless installed?('verapdf')
+
+      Dir.mktmpdir do |dir|
+        pdf, output, status = compile_pdf(dir)
+        expect(status).to be_success, -> { "typst compile failed:\n#{output}" }
+
+        # (stderr holds only JVM noise; the text report lands on stdout)
+        report, warnings, = Open3.capture3('verapdf', '--format', 'text', '--flavour', 'ua1', pdf)
+
+        expect(report).to start_with('PASS'), -> { "veraPDF PDF/UA-1 validation failed:\n#{report}\n#{warnings}" }
       end
     end
 
@@ -64,5 +72,47 @@ describe PdfProfile::TypstCompiler do
 
       expect(typ).to include('title: "Attestation \"spéciale\" \\\\ 2026"')
     end
+  end
+
+  describe '.image_assets' do
+    it 'resolves every corpus image to a file on disk' do
+      expect(image_assets.values).to all(satisfy { it[:path].exist? })
+      expect(image_assets.values.map { it[:name] })
+        .to contain_exactly('Marianne-Light@2x.png', 'logo-demarche-numerique@2x.png')
+    end
+
+    it 'raises on unresolvable images' do
+      expect { described_class.image_assets('<body><img src="/assets/nope-000.png" alt="x"></body>') }
+        .to raise_error(described_class::Error, /cannot resolve/)
+    end
+  end
+
+  private
+
+  def installed?(binary)
+    system("which #{binary}", out: File::NULL, err: File::NULL)
+  end
+
+  # Assembles a compilation directory (theme, resolved assets, main.typ) and
+  # compiles it with the PDF/UA-1 standard enforced.
+  def compile_pdf(dir)
+    FileUtils.cp(Rails.root.join('lib/typst/theme.typ'), dir)
+
+    assets_dir = File.join(dir, 'assets')
+    FileUtils.mkdir_p(assets_dir)
+    image_assets.each_value { FileUtils.cp(it[:path], File.join(assets_dir, it[:name])) }
+
+    File.write(File.join(dir, 'main.typ'), typ)
+    pdf = File.join(dir, 'out.pdf')
+
+    output, status = Open3.capture2e(
+      'typst', 'compile',
+      '--pdf-standard', 'ua-1',
+      '--font-path', Rails.root.join('lib/prawn/fonts').to_s,
+      File.join(dir, 'main.typ'),
+      pdf
+    )
+
+    [pdf, output, status]
   end
 end

--- a/spec/lint/pdf_profile_spec.rb
+++ b/spec/lint/pdf_profile_spec.rb
@@ -166,6 +166,43 @@ describe 'PDF HTML print profile' do
     check_profile!('attestation_v2_free_layout', render_attestation_v2(free_layout))
   end
 
+  it 'attestation v2 sanitizes hostile admin HTML down to the profile' do
+    hostile = <<~HTML
+      <script>alert("xss")</script>
+      <blockquote>citation</blockquote>
+      <img src="tracker.png" alt="pixel">
+      <a href="https://exemple.gouv.fr" target="_blank">lien</a>
+      <footer>pied</footer>
+      <p style="color: red; text-align: center">aligné</p>
+      <mark>surligné</mark>
+    HTML
+    attestation_template = FactoryBot.build(:attestation_template, :v2)
+
+    html = ApplicationController.render(
+      template: '/administrateurs/attestation_template_v2s/show',
+      formats: [:html],
+      layout: 'attestation',
+      assigns: { attestation_template:, body: hostile, signature: nil }
+    )
+
+    check_profile!('attestation_v2_hostile', html)
+
+    main = Nokogiri::HTML5(html).at_css('.main')
+    expect(main.css('script, blockquote, img, a, footer')).to be_empty
+    expect(main.text).not_to include('alert')
+    expect(main.text).to include('citation', 'lien', 'pied')
+    expect(main.at_css('mark').text).to eq('surligné')
+
+    aligned = main.css('p[style]').find { it.text == 'aligné' }
+    expect(aligned['style']).to include('text-align')
+    expect(aligned['style']).not_to include('color')
+  end
+
+  it 'admin_content stays a subset of the profile elements' do
+    expect(PdfProfile.admin_content_tags - profile['elements'].keys).to be_empty
+    expect(PdfProfile.admin_content_attributes - %w[class style]).to be_empty
+  end
+
   it 'attestation de dépôt' do
     stub_const('DIRECTION_LABEL', 'Direction interministérielle du numérique')
 

--- a/spec/lint/pdf_profile_spec.rb
+++ b/spec/lint/pdf_profile_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+# Renders a representative corpus of every document family we send to the PDF
+# renderer and checks the output against config/pdf_profile.yml (see that file
+# for the rationale). Run with PDF_PROFILE_DUMP=1 to (re)write the harvested
+# corpus into spec/fixtures/pdf_profile/.
+describe 'PDF HTML print profile' do
+  let(:profile) { YAML.safe_load_file(Rails.root.join('config/pdf_profile.yml')) }
+
+  # --- corpus ---------------------------------------------------------------
+
+  # Admin-authored TipTap body exercising every node type and mark the editor
+  # or a ChampPresentation can emit. TiptapService#to_html is the only
+  # producer of admin HTML, so this corpus is exhaustive by construction.
+  def all_nodes_json
+    {
+      type: 'doc',
+      content: [
+        {
+          type: 'header',
+          content: [
+            { type: 'headerColumn', attrs: { textAlign: 'left' }, content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Colonne gauche' }] }] },
+            { type: 'headerColumn', attrs: { textAlign: 'right' }, content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Colonne droite' }] }] },
+          ],
+        },
+        { type: 'title', attrs: { textAlign: 'center' }, content: [{ type: 'text', text: 'Attestation pour le dossier ' }, { type: 'mention', attrs: { id: 'dossier_number', label: 'numéro du dossier' } }] },
+        { type: 'heading', attrs: { level: 2, textAlign: 'left' }, content: [{ type: 'text', text: 'Sous-titre' }] },
+        { type: 'heading', attrs: { level: 3 }, content: [{ type: 'text', text: 'Sous-sous-titre' }] },
+        {
+          type: 'paragraph',
+          attrs: { textAlign: 'justify' },
+          content: [
+            { type: 'text', text: 'gras', marks: [{ type: 'bold' }] },
+            { type: 'text', text: ' italique', marks: [{ type: 'italic' }] },
+            { type: 'text', text: ' souligné', marks: [{ type: 'underline' }] },
+            { type: 'text', text: ' surligné', marks: [{ type: 'highlight' }] },
+            { type: 'text', text: ' lien', marks: [{ type: 'link', attrs: { href: 'https://exemple.gouv.fr' } }] },
+            { type: 'hardBreak' },
+            { type: 'text', text: 'après saut de ligne' },
+          ],
+        },
+        { type: 'bulletList', content: [{ type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'une puce' }] }] }] },
+        { type: 'orderedList', content: [{ type: 'listItem', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'une entrée numérotée' }] }] }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Choix : ' }, { type: 'mention', attrs: { id: 'champ_liste', label: 'liste' } }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Bloc répétable : ' }, { type: 'mention', attrs: { id: 'champ_repetition', label: 'répétition' } }] },
+        { type: 'pageBreak' },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Sur la page suivante.' }] },
+        { type: 'footer', attrs: { textAlign: 'center' }, content: [{ type: 'text', text: 'Pied de page' }] },
+      ],
+    }
+  end
+
+  def tiptap_substitutions
+    {
+      'dossier_number' => '42',
+      'champ_liste' => ChampPresentations::MultipleDropDownListPresentation.new(['Premier choix', 'Deuxième choix']),
+      'champ_repetition' => ChampPresentations::RepetitionPresentation.new(
+        'Personnes',
+        [[fake_champ('Nom', 'Dupont'), fake_champ('Prénom', nil)]]
+      ),
+    }
+  end
+
+  # Champ-like object for RepetitionPresentation (libelle / to_s / blank?).
+  def fake_champ(libelle, value)
+    double(libelle:, to_s: value.to_s, blank?: value.blank?)
+  end
+
+  def render_attestation_v2(attestation_template, signature: nil)
+    body = TiptapService.new(hard_break: '<br><br>').to_html(all_nodes_json, tiptap_substitutions)
+
+    ApplicationController.render(
+      template: '/administrateurs/attestation_template_v2s/show',
+      formats: [:html],
+      layout: 'attestation',
+      assigns: { attestation_template:, body:, signature: }
+    )
+  end
+
+  def dossier_vide_html(revision)
+    ApplicationController.render(
+      Dossiers::DossierVidePdfComponent.new(revision:),
+      layout: 'dossier_vide_pdf',
+      formats: [:html]
+    )
+  end
+
+  # --- profile check --------------------------------------------------------
+
+  def check_profile!(name, html)
+    dump_fixture(name, html) if ENV['PDF_PROFILE_DUMP'] == '1'
+
+    violations = collect_violations(Nokogiri::HTML5(html))
+
+    expect(violations).to be_empty, lambda {
+      "#{name}: rendered HTML strays outside config/pdf_profile.yml:\n  - #{violations.join("\n  - ")}"
+    }
+  end
+
+  def collect_violations(doc)
+    violations = []
+
+    doc.root.traverse do |node|
+      next unless node.element?
+
+      allowed_attributes = profile['elements'][node.name]
+
+      if allowed_attributes.nil?
+        violations << "element <#{node.name}>"
+        next
+      end
+
+      node.attribute_nodes.each do |attribute|
+        violations.concat(attribute_violations(node, attribute, allowed_attributes))
+      end
+    end
+
+    violations.uniq
+  end
+
+  def attribute_violations(node, attribute, allowed_attributes)
+    violations = []
+    violations << "attribute #{attribute.name} on <#{node.name}>" unless allowed_attributes.include?(attribute.name)
+
+    case attribute.name
+    when 'class'
+      (attribute.value.split - profile['classes']).each { violations << "class .#{it} (on <#{node.name}>)" }
+    when 'style'
+      violations.concat(style_violations(attribute.value))
+    end
+
+    violations
+  end
+
+  def style_violations(style)
+    style.split(';').map(&:strip).compact_blank.filter_map do |declaration|
+      property, value = declaration.split(':', 2).map(&:strip)
+      allowed_values = profile['inline_styles'][property]
+
+      if allowed_values.nil?
+        "inline style property #{property}"
+      elsif !allowed_values.include?(value)
+        "inline style #{property}: #{value}"
+      end
+    end
+  end
+
+  def dump_fixture(name, html)
+    normalized = html.gsub(/dcterms\.created" content="[^"]*"/, 'dcterms.created" content="(harvest)"')
+    Rails.root.join("spec/fixtures/pdf_profile/#{name}.html").write(normalized)
+  end
+
+  # --- the corpus stays within the profile ----------------------------------
+
+  it 'attestation v2 with every TipTap node type and mark' do
+    attestation_template = FactoryBot.build(:attestation_template, :v2, label_direction: 'Direction des services', footer: 'Mairie de Bordeaux')
+
+    check_profile!('attestation_v2', render_attestation_v2(attestation_template))
+  end
+
+  it 'attestation v2 layout variants (co-émetteur logo, free layout, signature)' do
+    official = FactoryBot.create(:attestation_template, :v2, :with_files)
+    check_profile!('attestation_v2_co_emetteur', render_attestation_v2(official, signature: official.signature))
+
+    free_layout = FactoryBot.create(:attestation_template, :v2, :with_files, official_layout: false)
+    check_profile!('attestation_v2_free_layout', render_attestation_v2(free_layout))
+  end
+
+  it 'attestation de dépôt' do
+    stub_const('DIRECTION_LABEL', 'Direction interministérielle du numérique')
+
+    html = ApplicationController.render(
+      template: 'users/dossiers/attestation_depot',
+      formats: [:html],
+      layout: 'attestation',
+      assigns: { dossier: dossiers.en_construction }
+    )
+
+    check_profile!('attestation_depot', html)
+  end
+
+  describe 'dossier vide' do
+    before_all { seed "cases/champs" }
+
+    it 'with every champ type, a conditional champ with description and an annex' do
+      revision = procedures.tous_champs.draft_revision
+
+      # A condition and a description, so the corpus exercises the
+      # champ--conditional and description patterns.
+      source = revision.type_de_champs.find { it.libelle == 'simple_drop_down_list' && !it.private? }
+      target = revision.type_de_champs.find { it.libelle == 'text' && !it.private? }
+      target.update!(
+        condition: Logic::Eq.new(Logic::ChampValue.new(source.stable_id), Logic::Constant.new('val1')),
+        description: 'Une description du champ, avec un lien https://exemple.gouv.fr'
+      )
+
+      # A long list, so the corpus exercises the annex pattern.
+      revision.add_type_de_champ(
+        type_champ: TypeDeChamp.type_champs.fetch(:drop_down_list),
+        libelle: 'Grande liste',
+        drop_down_options: (1..(Champs::DropDownListChamp::THRESHOLD_NB_OPTIONS_AS_AUTOCOMPLETE + 5)).map { "Option #{it}" }
+      )
+
+      check_profile!('dossier_vide', dossier_vide_html(revision.reload))
+    end
+  end
+end


### PR DESCRIPTION
Premiers pas vers un profil HTML/CSS strict pour la génération de PDF (piste WeasyPrint → Typst, garantie d’accessibilité PDF/UA). Quatre étapes sur cette branche :

**1. Corpus + profil (`config/pdf_profile.yml`)**
- liste blanche des éléments, attributs, classes et styles inline que nos documents PDF peuvent utiliser (+ ébauche non contrainte du sous-ensemble CSS) ;
- `spec/lint/pdf_profile_spec.rb` rend un corpus représentatif de chaque famille (attestation v2 avec tous les nœuds TipTap et variantes de mise en page, attestation de dépôt, dossier vide complet) et échoue si le HTML produit sort du profil ; corpus moissonné dans `spec/fixtures/pdf_profile/` (`PDF_PROFILE_DUMP=1` pour régénérer) ;
- profil et corpus coïncident exactement (aucune classe inutilisée ni manquante). Constats : le sanitizer conserve `<mark>` mais supprime `<a>` et `<footer>` du contenu admin ; aucun `<table>` dans le corpus.

**2. Le profil appliqué au runtime**
- `PdfProfile::AdminContentScrubber` remplace la liste Rails par défaut dans `attestation_template_v2s/show` : seuls les ~20 éléments que TipTap peut émettre passent, `<script>`/`<style>` sont élagués avec leur contenu, et les déclarations `style=""` sont filtrées sur la liste `inline_styles` — la safelist CSS de Loofah laissait passer `color:` etc. jusqu’ici.

**3. Thème Typst + squelette du compilateur**
- `lib/typst/theme.typ` : `attestation.scss` réécrit en fonctions Typst (A4, Marianne, grille d’en-tête, tables clé/valeur, composants dépôt) ;
- `PdfProfile::TypstCompiler` : parcours strict du HTML conforme au profil, **erreur** sur tout élément/classe/style non implémenté (périmètre : attestation de dépôt + grammaire inline commune) ;
- golden `.typ` figé pour le corpus + compilation gardée par `typst compile --pdf-standard ua-1`.

**4. Assets réels + CI**
- `TypstCompiler.image_assets` résout les `<img>` vers `app/assets/images/` (digest retiré) — logos Marianne et site réels dans le PDF ;
- le job CI `(slow, dep)` installe typst 0.15 et veraPDF (exemples taggués `:external_deps`) ;
- **l’attestation de dépôt compilée passe la validation veraPDF PDF/UA-1**.

À comparer avec l’approche alternative sans HTML (template Typst natif + payload JSON) : PR #13770. Reste à faire sur cette piste : famille attestation v2 (parcours TipTap dans le compilateur), résolution d’assets côté rendu réel, et choix Ruby vs sidecar Rust une fois le profil stabilisé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)