### PR TITLE
fix(admin): ETQ admin, je vois à nouveau les colonnes Statut/Date/Action sur “Toutes les démarches”

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -163,6 +163,10 @@ input[type='radio'] {
   font-variant-numeric: tabular-nums;
 }
 
+.fr-cell--breakable {
+  overflow-wrap: anywhere;
+}
+
 .fr-text--monospace {
   font-family: monospace;
 }

--- a/app/views/administrateurs/procedures/_detail.html.haml
+++ b/app/views/administrateurs/procedures/_detail.html.haml
@@ -5,7 +5,7 @@
     - params = show_detail ? {} : { show_detail: true }
     = button_to detail_admin_procedure_path(procedure["id"]), method: :post, params:, title:, class: [icon, "fr-icon--sm fr-mb-1w fr-text-action-high--blue-france fr-btn fr-btn--tertiary-no-outline" ] do
       = title
-  %td
+  %td.fr-cell--breakable
     - if procedure.template
       %p.fr-badge.fr-badge--info.fr-badge--sm= "Modèle"
       %abbr{ title: APPLICATION_NAME }= acronymize(APPLICATION_NAME)

--- a/spec/system/administrateurs/all_procedures_spec.rb
+++ b/spec/system/administrateurs/all_procedures_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+describe 'As an administrateur I can browse all procedures', js: true do
+  let(:administrateur) { administrateurs.blank }
+  let(:zone) { Zone.find_by!(acronym: 'MEF') }
+
+  before do
+    create(:procedure, :published,
+      zones: [zone],
+      administrateurs: [administrateur],
+      libelle: "DDAS9_JOURNEE_A_LA_MINE_ET_GRANDE_SORTIE_ANNUELLE_DU_PERSONNEL")
+    login_as administrateur.user, scope: :user
+  end
+
+  scenario 'the table keeps every column visible with a zone filter and a long unbreakable libelle' do
+    page.current_window.resize_to(1080, 900)
+    visit all_admin_procedures_path(zone_ids: [zone.id])
+
+    expect(page).to have_link('Cloner')
+
+    table_right_edge, viewport_width = page.evaluate_script(
+      "[document.querySelector('.fr-table__wrapper').getBoundingClientRect().right, document.documentElement.clientWidth]"
+    )
+    expect(table_right_edge).to be <= viewport_width
+  end
+end


### PR DESCRIPTION
Un libellé insécable (ex. DDAS93_JOURNEE_A_LA_MINE) faisait déborder le tableau `fr-table--no-scroll `hors du conteneur sans scrollbar et masquait les 3 dernières colonnes. Le filtre zone ne faisait que remonter les lignes fautives en page 1.
