### PR TITLE
ETQ usager, mes notifications AMI ont leurs propres libellés

### DIFF
--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -158,7 +158,9 @@ class Commentaire < ApplicationRecord
       DossierMailer.with(commentaire: self).notify_new_answer.deliver_later(job_options)
     end
 
-    Ami::CreateNotificationService.call(dossier:, trigger: :messagerie_message)
+    # Une demande de correction n'est pas un message ordinaire : elle attend une
+    # action de l'usager, et AMI la formule comme telle.
+    Ami::CreateNotificationService.call(dossier:, trigger: flagged_pending_correction? ? :pending_correction : :messagerie_message)
   end
 
   def notify_administration

--- a/app/services/ami/create_notification_service.rb
+++ b/app/services/ami/create_notification_service.rb
@@ -4,6 +4,8 @@ module Ami
   class CreateNotificationService
     SOURCE = ApplicationHelper::APP_HOST
 
+    DECISION_STATES = [:accepte, :refuse, :sans_suite].freeze
+
     ITEM_GENERIC_STATUS_BY_STATE = {
       brouillon: "new",
       en_construction: "wip",
@@ -98,7 +100,18 @@ module Ami
       end
     end
 
-    def notification_key = messagerie_message? ? :messagerie_message : state
+    def notification_key
+      return :messagerie_message if messagerie_message?
+      return :decision_rendue if hidden_decision?
+
+      state
+    end
+
+    # Avec l'accusé de lecture, la plateforme ne dévoile la décision qu'une fois
+    # que l'usager l'a affichée : la notification ne doit pas la divulguer avant.
+    def hidden_decision?
+      state.in?(DECISION_STATES) && dossier.hide_info_with_accuse_lecture?
+    end
 
     def context
       {

--- a/app/services/ami/create_notification_service.rb
+++ b/app/services/ami/create_notification_service.rb
@@ -79,21 +79,26 @@ module Ami
       return ":ami_notifications feature flag disabled" unless dossier.procedure.feature_enabled?(:ami_notifications)
     end
 
-    def content_title
-      return APPLICATION_NAME
-    end
+    # Les libellés sont figés dans l'application, et non repris des modèles
+    # d'email : AMI impose ses propres conventions de formulation, et un sujet
+    # d'email personnalisé par l'administrateur ne les respecterait pas.
+    def content_title = wording(:title)
 
-    def content_body
+    def content_body = wording(:body)
+
+    def wording(part)
       I18n.with_locale(dossier.user_locale) do
-        if messagerie_message?
-          I18n.t("dossier_mailer.notify_new_answer.subject", dossier_id: dossier.id, libelle_demarche: dossier.procedure.libelle)
-        elsif state == :brouillon
-          I18n.t("dossier_mailer.notify_new_draft.subject", libelle_demarche: dossier.procedure.libelle)
-        else
-          dossier.email_template_for(email_template_state).subject_for_dossier(dossier)
-        end
+        I18n.t(
+          part,
+          scope: [:ami, :notifications, notification_key],
+          libelle_demarche: dossier.procedure.libelle,
+          dossier_id: dossier.id,
+          app_host: ApplicationHelper::APP_HOST
+        )
       end
     end
+
+    def notification_key = messagerie_message? ? :messagerie_message : state
 
     def context
       {
@@ -114,14 +119,6 @@ module Ami
 
     def messagerie_message?
       trigger == :messagerie_message
-    end
-
-    def email_template_state
-      if state == :repasser_en_instruction
-        DossierOperationLog.operations.fetch(:repasser_en_instruction)
-      else
-        Dossier.states.fetch(state)
-      end
     end
   end
 end

--- a/app/services/ami/create_notification_service.rb
+++ b/app/services/ami/create_notification_service.rb
@@ -5,6 +5,7 @@ module Ami
     SOURCE = ApplicationHelper::APP_HOST
 
     DECISION_STATES = [:accepte, :refuse, :sans_suite].freeze
+    MESSAGE_TRIGGERS = [:messagerie_message, :pending_correction].freeze
 
     ITEM_GENERIC_STATUS_BY_STATE = {
       brouillon: "new",
@@ -65,7 +66,7 @@ module Ami
     private
 
     def item_external_url
-      if messagerie_message?
+      if message_trigger?
         Rails.application.routes.url_helpers.messagerie_dossier_url(dossier)
       else
         Rails.application.routes.url_helpers.dossier_url(dossier)
@@ -101,7 +102,7 @@ module Ami
     end
 
     def notification_key
-      return :messagerie_message if messagerie_message?
+      return trigger if message_trigger?
       return :decision_rendue if hidden_decision?
 
       state
@@ -130,8 +131,9 @@ module Ami
       ITEM_GENERIC_STATUS_BY_STATE.fetch(state.to_sym, ITEM_GENERIC_STATUS_BY_STATE.fetch(state, "wip"))
     end
 
-    def messagerie_message?
-      trigger == :messagerie_message
-    end
+    # Ces déclencheurs ne sont pas des changements d'état : ils nomment eux-mêmes
+    # le libellé, et renvoient l'usager au fil de discussion du dossier, où se
+    # trouvent aussi bien le message que la demande de correction.
+    def message_trigger? = trigger.in?(MESSAGE_TRIGGERS)
   end
 end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -114,6 +114,8 @@ ignore_unused:
   - 'attachment.gallery_item_component.{created_at,updated_at}'
   # t(@procedure.publiee? ? '.notification_alert.publiee' : '.notification_alert.non_publiee')
   - 'procedure.instructeurs_management_component.notification_alert.*'
+  # t(part, scope: [:ami, :notifications, notification_key]) in ami/create_notification_service.rb
+  - 'ami.notifications.*'
   # t(@champ.fc_data_not_found? ? '.piece_justificative_champ.data_not_found' : '...data_not_recovered')
   - 'editable_champ.france_connect_champ_base_component.piece_justificative_champ.*'
   - 'errors.format'

--- a/config/locales/ami.en.yml
+++ b/config/locales/ami.en.yml
@@ -25,6 +25,9 @@ en:
       decision_rendue:
         title: See the decision on your file
         body: Read the decision on your procedure « %{libelle_demarche} » no. %{dossier_id} now, from your %{app_host} account.
+      pending_correction:
+        title: Correct your file
+        body: Complete your procedure « %{libelle_demarche} » from the app or your %{app_host} account.
       messagerie_message:
         title: New message
         body: Read the message about your procedure « %{libelle_demarche} » no. %{dossier_id}.

--- a/config/locales/ami.en.yml
+++ b/config/locales/ami.en.yml
@@ -22,6 +22,9 @@ en:
       sans_suite:
         title: File closed with no further action
         body: Find your procedure « %{libelle_demarche} » no. %{dossier_id}.
+      decision_rendue:
+        title: See the decision on your file
+        body: Read the decision on your procedure « %{libelle_demarche} » no. %{dossier_id} now, from your %{app_host} account.
       messagerie_message:
         title: New message
         body: Read the message about your procedure « %{libelle_demarche} » no. %{dossier_id}.

--- a/config/locales/ami.en.yml
+++ b/config/locales/ami.en.yml
@@ -1,0 +1,27 @@
+en:
+  ami:
+    notifications:
+      brouillon:
+        title: Resume your draft
+        body: Complete your procedure « %{libelle_demarche} » from the app or your %{app_host} account.
+      en_construction:
+        title: File submitted
+        body: Find your procedure « %{libelle_demarche} » no. %{dossier_id}.
+      en_instruction:
+        title: File being processed
+        body: Find your procedure « %{libelle_demarche} » no. %{dossier_id}.
+      repasser_en_instruction:
+        title: File under review
+        body: Your file no. %{dossier_id} is being reviewed again (%{libelle_demarche}).
+      accepte:
+        title: File accepted
+        body: Find your procedure « %{libelle_demarche} » no. %{dossier_id}.
+      refuse:
+        title: File refused
+        body: Find your procedure « %{libelle_demarche} » no. %{dossier_id}.
+      sans_suite:
+        title: File closed with no further action
+        body: Find your procedure « %{libelle_demarche} » no. %{dossier_id}.
+      messagerie_message:
+        title: New message
+        body: Read the message about your procedure « %{libelle_demarche} » no. %{dossier_id}.

--- a/config/locales/ami.fr.yml
+++ b/config/locales/ami.fr.yml
@@ -22,6 +22,9 @@ fr:
       sans_suite:
         title: Dossier classé sans suite
         body: Retrouvez votre démarche « %{libelle_demarche} » n° %{dossier_id}.
+      decision_rendue:
+        title: Voir la décision sur votre dossier
+        body: Consultez dès maintenant la décision liée à votre démarche « %{libelle_demarche} » n° %{dossier_id} depuis votre compte %{app_host}.
       messagerie_message:
         title: Nouveau message
         body: Lire le message concernant votre démarche « %{libelle_demarche} » n° %{dossier_id}.

--- a/config/locales/ami.fr.yml
+++ b/config/locales/ami.fr.yml
@@ -1,0 +1,27 @@
+fr:
+  ami:
+    notifications:
+      brouillon:
+        title: Reprendre votre brouillon
+        body: Complétez votre démarche « %{libelle_demarche} » depuis l’application ou votre compte %{app_host}.
+      en_construction:
+        title: Dossier déposé
+        body: Retrouvez votre démarche « %{libelle_demarche} » n° %{dossier_id}.
+      en_instruction:
+        title: Dossier en cours de traitement
+        body: Retrouvez votre démarche « %{libelle_demarche} » n° %{dossier_id}.
+      repasser_en_instruction:
+        title: Dossier en cours de réexamen
+        body: Votre dossier n° %{dossier_id} est en train d’être réexaminé (%{libelle_demarche}).
+      accepte:
+        title: Dossier accepté
+        body: Retrouvez votre démarche « %{libelle_demarche} » n° %{dossier_id}.
+      refuse:
+        title: Dossier refusé
+        body: Retrouvez votre démarche « %{libelle_demarche} » n° %{dossier_id}.
+      sans_suite:
+        title: Dossier classé sans suite
+        body: Retrouvez votre démarche « %{libelle_demarche} » n° %{dossier_id}.
+      messagerie_message:
+        title: Nouveau message
+        body: Lire le message concernant votre démarche « %{libelle_demarche} » n° %{dossier_id}.

--- a/config/locales/ami.fr.yml
+++ b/config/locales/ami.fr.yml
@@ -25,6 +25,9 @@ fr:
       decision_rendue:
         title: Voir la décision sur votre dossier
         body: Consultez dès maintenant la décision liée à votre démarche « %{libelle_demarche} » n° %{dossier_id} depuis votre compte %{app_host}.
+      pending_correction:
+        title: Corriger votre dossier
+        body: Complétez votre démarche « %{libelle_demarche} » depuis l’application ou votre compte %{app_host}.
       messagerie_message:
         title: Nouveau message
         body: Lire le message concernant votre démarche « %{libelle_demarche} » n° %{dossier_id}.

--- a/spec/models/commentaire_spec.rb
+++ b/spec/models/commentaire_spec.rb
@@ -154,6 +154,16 @@ describe Commentaire do
 
       commentaire.send(:notify_user, wait: 5.minutes)
     end
+
+    context "when the commentaire carries a correction request" do
+      before { commentaire.dossier_correction = build(:dossier_correction, dossier:, commentaire:) }
+
+      it "triggers AMI notification with the correction trigger" do
+        expect(Ami::CreateNotificationService).to receive(:call).with(dossier: dossier, trigger: :pending_correction)
+
+        commentaire.send(:notify_user, wait: 5.minutes)
+      end
+    end
   end
 
   describe 'body validation' do

--- a/spec/services/ami/create_notification_service_spec.rb
+++ b/spec/services/ami/create_notification_service_spec.rb
@@ -191,5 +191,23 @@ RSpec.describe Ami::CreateNotificationService do
         )
       end
     end
+
+    context 'when triggered by a correction request' do
+      it 'asks the user to act rather than to read' do
+        payload = described_class.new(dossier:, trigger: :pending_correction, state: nil).create_notification_payload(event_date:)
+
+        expect(payload).to include(
+          content_title: "Corriger votre dossier",
+          content_body: "Complétez votre démarche « #{procedure.libelle} » depuis l’application ou votre compte #{ApplicationHelper::APP_HOST}."
+        )
+      end
+
+      # La demande de correction se lit dans la messagerie, comme un message.
+      it 'links to the messagerie' do
+        payload = described_class.new(dossier:, trigger: :pending_correction, state: nil).create_notification_payload(event_date:)
+
+        expect(payload[:content_link]).to end_with("/dossiers/#{dossier.id}/messagerie")
+      end
+    end
   end
 end

--- a/spec/services/ami/create_notification_service_spec.rb
+++ b/spec/services/ami/create_notification_service_spec.rb
@@ -96,25 +96,47 @@ RSpec.describe Ami::CreateNotificationService do
       )
     end
 
-    it 'uses the same wording as the user notification email subject' do
+    # Les libellés ne suivent plus les modèles d'email, que l'administrateur
+    # personnalise par démarche : ils sont figés dans config/locales/ami.*.yml.
+    it 'words the notification from the application, not from the email template' do
+      allow(dossier).to receive(:email_template_for).and_call_original
       payload = described_class.new(dossier:, trigger: :dossier_state_change, state: nil).create_notification_payload(event_date:)
 
       expect(payload).to include(
-        content_title: APPLICATION_NAME,
-        content_body: dossier.email_template_for(Dossier.states.fetch(:en_instruction)).subject_for_dossier(dossier)
+        content_title: "Dossier en cours de traitement",
+        content_body: "Retrouvez votre démarche « #{procedure.libelle} » n° #{dossier.id}."
       )
+      expect(dossier).not_to have_received(:email_template_for)
+    end
+
+    it 'speaks the language of the user' do
+      allow(dossier).to receive(:user_locale).and_return(:en)
+      payload = described_class.new(dossier:, trigger: :dossier_state_change, state: nil).create_notification_payload(event_date:)
+
+      expect(payload).to include(content_title: "File being processed")
     end
 
     context 'when dossier is brouillon' do
       let(:dossier) { create(:dossier, :brouillon, :with_individual, procedure:, user:) }
 
-      it 'builds a creation-oriented payload' do
+      it 'invites the user to resume it' do
         payload = described_class.new(dossier:, trigger: :dossier_state_change, state: nil).create_notification_payload(event_date:)
 
         expect(payload).to include(
-          content_title: APPLICATION_NAME,
-          content_body: I18n.t("dossier_mailer.notify_new_draft.subject", libelle_demarche: dossier.procedure.libelle),
+          content_title: "Reprendre votre brouillon",
+          content_body: "Complétez votre démarche « #{procedure.libelle} » depuis l’application ou votre compte #{ApplicationHelper::APP_HOST}.",
           item_generic_status: "new"
+        )
+      end
+    end
+
+    context 'when the dossier goes back to instruction' do
+      it 'says the decision is being reviewed again' do
+        payload = described_class.new(dossier:, trigger: :dossier_state_change, state: :repasser_en_instruction).create_notification_payload(event_date:)
+
+        expect(payload).to include(
+          content_title: "Dossier en cours de réexamen",
+          content_body: "Votre dossier n° #{dossier.id} est en train d’être réexaminé (#{procedure.libelle})."
         )
       end
     end
@@ -124,8 +146,8 @@ RSpec.describe Ami::CreateNotificationService do
         payload = described_class.new(dossier:, trigger: :messagerie_message, state: nil).create_notification_payload(event_date:)
 
         expect(payload).to include(
-          content_title: APPLICATION_NAME,
-          content_body: I18n.t("dossier_mailer.notify_new_answer.subject", dossier_id: dossier.id, libelle_demarche: dossier.procedure.libelle),
+          content_title: "Nouveau message",
+          content_body: "Lire le message concernant votre démarche « #{procedure.libelle} » n° #{dossier.id}.",
           item_generic_status: "wip"
         )
       end

--- a/spec/services/ami/create_notification_service_spec.rb
+++ b/spec/services/ami/create_notification_service_spec.rb
@@ -141,6 +141,45 @@ RSpec.describe Ami::CreateNotificationService do
       end
     end
 
+    context 'when the procedure requires a read receipt' do
+      let(:procedure) { create(:procedure, :published, :for_individual, accuse_lecture: true) }
+      let(:dossier) { create(:dossier, :accepte, :with_individual, procedure:, user:) }
+
+      # La plateforme cache la décision jusqu'à ce que l'usager l'affiche : la
+      # notification ne doit pas la divulguer à sa place.
+      it 'does not reveal the decision' do
+        payload = described_class.new(dossier:, trigger: :dossier_state_change, state: nil).create_notification_payload(event_date:)
+
+        expect(payload).to include(
+          content_title: "Voir la décision sur votre dossier",
+          content_body: "Consultez dès maintenant la décision liée à votre démarche « #{procedure.libelle} » n° #{dossier.id} depuis votre compte #{ApplicationHelper::APP_HOST}."
+        )
+      end
+
+      it 'names the decision once the user has agreed to read it' do
+        dossier.update!(accuse_lecture_agreement_at: Time.zone.now)
+        payload = described_class.new(dossier:, trigger: :dossier_state_change, state: nil).create_notification_payload(event_date:)
+
+        expect(payload).to include(content_title: "Dossier accepté")
+      end
+
+      it 'still names a state that is not a decision' do
+        payload = described_class.new(dossier:, trigger: :dossier_state_change, state: :en_instruction).create_notification_payload(event_date:)
+
+        expect(payload).to include(content_title: "Dossier en cours de traitement")
+      end
+    end
+
+    context 'when the procedure does not require a read receipt' do
+      let(:dossier) { create(:dossier, :accepte, :with_individual, procedure:, user:) }
+
+      it 'names the decision' do
+        payload = described_class.new(dossier:, trigger: :dossier_state_change, state: nil).create_notification_payload(event_date:)
+
+        expect(payload).to include(content_title: "Dossier accepté")
+      end
+    end
+
     context 'when triggered by a messagerie message' do
       it 'builds a messagerie-oriented payload' do
         payload = described_class.new(dossier:, trigger: :messagerie_message, state: nil).create_notification_payload(event_date:)


### PR DESCRIPTION


https://github.com/user-attachments/assets/af259455-27da-42ef-ac71-0bee3b162f8f


Les libellés des notifications AMI reprenaient le sujet des modèles d'email, que
l'administrateur personnalise par démarche. AMI a ses propres conventions — un
titre court, une phrase sous 200 caractères, l'action en tête quand l'usager en a
une à faire — qu'un sujet personnalisé ne respecte pas.

Ils sont désormais figés dans `config/locales/ami.*.yml`, indexés par état, avec
`messagerie_message`, `pending_correction` et `decision_rendue` comme clés
non-état. Les textes suivent le guide de wording fourni par l'équipe AMI.

## Une divulgation corrigée au passage

Quand une démarche exige un accusé de lecture, la plateforme cache la décision
jusqu'à ce que l'usager l'affiche et en accuse la lecture. La notification AMI,
elle, l'annonçait quand même : « Dossier accepté » arrivait sur le téléphone d'un
usager que l'interface gardait dans l'ignorance.

Les trois états de décision basculent maintenant sur un libellé neutre — « Voir
la décision sur votre dossier » — quand `Dossier#hide_info_with_accuse_lecture?`
est vrai.

## Une demande de correction n'est plus un message

Elle arrivait libellée « Nouveau message », qui ne dit rien de ce qu'on attend.
`Commentaire#notify_user` distinguait déjà les deux cas pour l'email ; le
déclencheur AMI suit. Les deux pointent vers la messagerie, où se trouve la
demande.

## Points d'attention

- **`repasser_en_construction` reste en suspens.** Quand un instructeur renvoie
  le dossier en construction, l'usager reçoit aujourd'hui « Dossier déposé », ce
  qui est faux. Le guide ne couvre pas ce cas, le libellé est à arbitrer.
- **Deux choix de rédaction à confirmer** : le titre du réexamen (« Dossier en
  cours de réexamen », l'une des deux variantes du guide, l'autre dépassant les
  50 caractères recommandés) et le point final ajouté à la phrase du réexamen
  pour rester cohérent avec les sept autres textes.
- **La méthode s'appelle `wording` et non `translate`** : i18n-tasks lit
  `translate()` comme un appel de traduction et signalait `title`/`body` comme
  clés manquantes. Les clés étant construites dynamiquement, `ami.notifications.*`
  est déclaré dans `ignore_unused`.
- L'hôte est interpolé plutôt qu'écrit en dur, comme l'exige
  `lib/cops/application_name.rb`.
