### PR TITLE
Tech: répare le spec des stats qui casse le 1er du mois

### DIFF
--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -86,6 +86,9 @@ describe Stat, type: :model do
   end
 
   describe '.cumulative_hash' do
+    # the metric is a global aggregate: run it against an empty dossiers table
+    empty_seeds Dossier
+
     it 'works count and cumulate counters by month for both dossier and deleted dossiers' do
       2.downto(1).map do |i|
         create(:dossier, state: :en_construction, depose_at: i.months.ago)


### PR DESCRIPTION
`Stat.cumulative_hash` est testé en passant le scope global non paramétré
`Dossier.state_not_brouillon` à `cumulative_month_serie` : les dossiers des seeds
sont donc comptés dans l'assertion.

Leur `depose_at` vaut `1.day.ago`, et `group_by_month` est appelé avec
`current: false`. Tous les jours du mois sauf le 1er, ces seeds tombent dans le
mois courant et sont exclus — le test est vert. Le 1er, `1.day.ago` bascule dans
le mois précédent, qui est justement asserté : on obtient 10 au lieu de 4.

Résultat : la suite est rouge chaque 1er du mois et bloque la merge queue de tout
le monde (c'est le cas aujourd'hui, cf. #13745 et #13754 éjectées ce matin).

On applique le même correctif que celui déjà reçu par le bloc voisin
`.dossiers_states` dans 1cde9ce684 : `empty_seeds Dossier`.