### PR TITLE
Tech: trace tous les appels HTTP sortants en développement

### DIFF
--- a/app/lib/typhoeus/trace.rb
+++ b/app/lib/typhoeus/trace.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Typhoeus
+  # Exchanges with our external providers are invisible from the application. In
+  # development, trace one greppable line per outgoing call, whatever the call
+  # site — direct Typhoeus.get/post, API::Client, or a Hydra:
+  #
+  #   tail -f log/development.log | grep '\[HTTP\]'
+  #
+  # Deliberately limited to verb, host, path and status: no query string, no
+  # headers, no body. The query string alone carries pre-signed storage
+  # signatures (DownloadManager::ParallelDownloadQueue), API Particulier's civil
+  # status params, and administrator webhook tokens (WebHookJob); headers and
+  # userpwd carry every bearer token we hold.
+  #
+  # Development only, on purpose: Sentry turns every Rails.logger write into a
+  # breadcrumb (breadcrumbs_logger = [:active_support_logger]) while
+  # send_default_pii is false.
+  #
+  # Known reserve: a Mattermost webhook URL *is* its secret (.../hooks/<token>),
+  # so its path lands in the log. Acceptable on a developer's own .env.
+  module Trace
+    TAG = "[HTTP]"
+
+    class << self
+      # Returns the response: registered as a Typhoeus.on_complete callback, the
+      # return value becomes response.handled_response, and the response is what
+      # it already defaults to.
+      def log(response)
+        request = response.request
+
+        Rails.logger.info("#{TAG} #{verb(request)} #{endpoint(request)} → #{response.code} (#{detail(response)})")
+
+        response
+      rescue => e
+        # A comfort trace must never break the call it observes.
+        Rails.logger.debug { "#{TAG} untraceable call (#{e.class})" }
+
+        response
+      end
+
+      private
+
+      def verb(request) = (request.options[:method] || :get).to_s.upcase
+
+      def endpoint(request)
+        url = request.base_url.to_s
+        uri = URI.parse(url)
+
+        "#{uri.host}#{uri.path}"
+      rescue URI::InvalidURIError
+        url.split("?", 2).first
+      end
+
+      def detail(response)
+        if response.cached?
+          "cache"
+        elsif response.code.zero?
+          response.return_code.presence || "no response"
+        else
+          "#{(response.total_time.to_f * 1000).round}ms"
+        end
+      end
+    end
+  end
+end

--- a/app/services/ami/client.rb
+++ b/app/services/ami/client.rb
@@ -9,7 +9,7 @@ module Ami
     # PUT et non POST : l'événement est identifié par le partenaire et l'objet
     # associé, donc un rejeu ne crée pas de doublon (200 s'il existait, 201 sinon).
     def send_notification(payload)
-      handle_result(call_api(url: build_url(EVENT_PATH), json: payload, method: :put))
+      handle_result(API::Client.new.call(url: build_url(EVENT_PATH), json: payload, method: :put, userpwd: credentials))
     end
 
     def configured?
@@ -17,34 +17,6 @@ module Ami
     end
 
     private
-
-    def call_api(**options)
-      result = API::Client.new.call(userpwd: credentials, **options)
-      log_api_call(options, result)
-      result
-    end
-
-    # Les échanges avec AMI sont invisibles depuis l'application : en
-    # développement, on trace une ligne par appel, suivable avec un simple
-    # `tail -f log/development.log | grep '\[AMI\]'`. Volontairement limitée à
-    # l'URL, la méthode et le code : ni payload ni réponse, donc aucune donnée
-    # métier dans les logs.
-    def log_api_call(options, result)
-      return if !Rails.env.development?
-
-      verb = options.fetch(:method, :get).to_s.upcase
-      Rails.logger.info("[AMI] #{verb} #{options.fetch(:url).path} → #{response_code_for(result)}")
-    end
-
-    # Une trace de confort ne doit jamais casser l'appel qu'elle observe : on ne
-    # suppose pas la forme du résultat.
-    def response_code_for(result)
-      case result
-      in Success(API::Client::OK => ok) then ok.response.code
-      in Failure(API::Client::Error => error) then error.code
-      else "?"
-      end
-    end
 
     def api_url = ENV.fetch("AMI_API_URL", nil)
     def api_user = ENV.fetch("AMI_API_USER", nil)

--- a/config/initializers/typhoeus.rb
+++ b/config/initializers/typhoeus.rb
@@ -5,3 +5,11 @@ Typhoeus::Config.user_agent = APPLICATION_NAME
 Rails.application.config.after_initialize do
   Typhoeus::Config.cache = Typhoeus::Cache::SuccessfulRequestsRailsCache.new
 end
+
+# The only hook that sees every outgoing call: the ~20 direct Typhoeus.get/post
+# call sites, the API::Client consumers, and the Hydras. Typhoeus::Trace is
+# resolved inside the block rather than here, so the constant is autoloaded on
+# first call rather than during initialization, and code reloading picks it up.
+if Rails.env.development?
+  Typhoeus.on_complete { |response| Typhoeus::Trace.log(response) }
+end

--- a/spec/lib/typhoeus/trace_spec.rb
+++ b/spec/lib/typhoeus/trace_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe Typhoeus::Trace do
+  before { allow(Rails.logger).to receive(:info) }
+
+  def response_for(url, method: nil, **options)
+    Typhoeus::Response.new(**options).tap do |response|
+      response.request = Typhoeus::Request.new(url, **{ method: }.compact)
+    end
+  end
+
+  describe '.log' do
+    it 'traces the verb, the endpoint and the status' do
+      described_class.log(response_for("https://ami.example.org/api/v2/event", method: :put, code: 201, total_time: 0.1181))
+
+      expect(Rails.logger).to have_received(:info).with("[HTTP] PUT ami.example.org/api/v2/event → 201 (118ms)")
+    end
+
+    it 'assumes GET when the request carries no method' do
+      described_class.log(response_for("https://geo.api.gouv.fr/communes", code: 200, total_time: 0.041))
+
+      expect(Rails.logger).to have_received(:info).with("[HTTP] GET geo.api.gouv.fr/communes → 200 (41ms)")
+    end
+
+    it 'never logs the query string, which carries signatures and civil status' do
+      described_class.log(response_for("https://storage.example.org/blob/xyz?temp_url_sig=s3cr3t&temp_url_expires=1", code: 200, total_time: 0.02))
+
+      expect(Rails.logger).to have_received(:info).with("[HTTP] GET storage.example.org/blob/xyz → 200 (20ms)")
+    end
+
+    it 'marks cache hits instead of a duration' do
+      response = response_for("https://geo.api.gouv.fr/communes", code: 200, total_time: 0.0)
+      response.cached = true
+
+      described_class.log(response)
+
+      expect(Rails.logger).to have_received(:info).with("[HTTP] GET geo.api.gouv.fr/communes → 200 (cache)")
+    end
+
+    it 'reports the curl return code when no response came back' do
+      described_class.log(response_for("https://hooks.example.org/webhook", method: :post, code: 0, return_code: :couldnt_connect))
+
+      expect(Rails.logger).to have_received(:info).with("[HTTP] POST hooks.example.org/webhook → 0 (couldnt_connect)")
+    end
+
+    it 'returns the response, so the callback chain is left untouched' do
+      response = response_for("https://example.org/ping", code: 200, total_time: 0.0)
+
+      expect(described_class.log(response)).to eq(response)
+    end
+
+    it 'never breaks the call it observes' do
+      allow(Rails.logger).to receive(:debug)
+      response = Typhoeus::Response.new(code: 200)
+
+      expect { described_class.log(response) }.not_to raise_error
+      expect(response).to eq(described_class.log(response))
+      expect(Rails.logger).not_to have_received(:info)
+    end
+  end
+
+  describe 'wired as a global Typhoeus callback' do
+    around do |example|
+      hook = -> (response) { described_class.log(response) } # mirrors config/initializers/typhoeus.rb
+      Typhoeus.on_complete << hook
+      example.run
+    ensure
+      # never `Typhoeus.on_complete.clear`: it would drop WebMock's own callback
+      Typhoeus.on_complete.delete(hook)
+    end
+
+    it 'traces a request whatever the call site, without altering the handled response' do
+      stub_request(:get, "https://example.org/ping").to_return(status: 200, body: "{}")
+
+      response = Typhoeus.get("https://example.org/ping")
+
+      expect(Rails.logger).to have_received(:info).with("[HTTP] GET example.org/ping → 200 (0ms)")
+      expect(response.handled_response).to eq(response)
+    end
+  end
+end

--- a/spec/services/ami/client_spec.rb
+++ b/spec/services/ami/client_spec.rb
@@ -46,38 +46,6 @@ RSpec.describe Ami::Client do
     expect(result.failure.retryable).to be(false)
   end
 
-  describe 'logging' do
-    before { allow(Rails.logger).to receive(:info) }
-
-    it 'traces a failed call with the status AMI answered' do
-      allow(Rails.env).to receive(:development?).and_return(true)
-      allow(api_client).to receive(:call).and_return(
-        Dry::Monads::Failure(API::Client::Error[:http, 404, false, "Not found"])
-      )
-
-      service.send_notification(payload)
-
-      expect(Rails.logger).to have_received(:info).with("[AMI] PUT /api/v2/event → 404")
-    end
-
-    it 'traces a successful call with the status AMI answered' do
-      allow(Rails.env).to receive(:development?).and_return(true)
-      allow(api_client).to receive(:call).and_return(Dry::Monads::Success(API::Client::OK[{}, response]))
-
-      service.send_notification(payload)
-
-      expect(Rails.logger).to have_received(:info).with("[AMI] PUT /api/v2/event → 200")
-    end
-
-    it 'stays quiet outside development' do
-      allow(api_client).to receive(:call).and_return(Dry::Monads::Success(API::Client::OK[{}, response]))
-
-      service.send_notification(payload)
-
-      expect(Rails.logger).not_to have_received(:info)
-    end
-  end
-
   it 'returns retryable failure when API times out' do
     timeout_error = API::Client::HTTPError.new(
       double(


### PR DESCRIPTION
Suite de la remarque de @colinux sur #13754 : généraliser à tous les appels Typhoeus
la trace dev introduite pour AMI. Empilée sur #13754 (base `feat/ami-event-v2`),
à relire après lui.

`Typhoeus.on_complete` est le seul point d'accroche qui voit *tous* les appels : les
~20 `Typhoeus.get/post` directs, les consommateurs d'`API::Client`, et les 4 `Hydra`
(`api_ign`, `brevo`, `health_checker`, `parallel_download_queue`). Les cache hits y
passent aussi, via `Request::Cacheable#run`, et sont marqués comme tels.

```
[HTTP] GET geo.api.gouv.fr/regions → 200 (57ms)
[HTTP] GET geo.api.gouv.fr/communes → 200 (473ms)
[HTTP] POST 127.0.0.1/hooks/xxx → 0 (couldnt_connect)
[HTTP] GET geo.api.gouv.fr/regions → 200 (cache)
```

Suivable avec `tail -f log/development.log | grep '\[HTTP\]'`. Le second commit
supprime la trace `[AMI]` de #13754, devenue redondante : le host AMI est sur la
ligne générique, donc `grep ami` marche toujours.

**Périmètre volontairement réduit à verbe, host, path et code.** Pas de query
string : elle transporte les signatures des URLs pré-signées du stockage
(`DownloadManager::ParallelDownloadQueue`), les paramètres d'état civil d'API
Particulier, et les tokens des webhooks administrateurs (`WebHookJob`). Pas de
headers ni de `userpwd` non plus, qui portent tous nos bearer tokens. Et
développement uniquement : en production, `breadcrumbs_logger =
[:active_support_logger]` transformerait chaque ligne en breadcrumb Sentry alors
que `send_default_pii` est à false.

Réserve assumée, documentée dans le code : une URL de webhook Mattermost *est* son
secret (`.../hooks/<token>`), donc son path apparaît dans le log. Acceptable sur le
`.env` d'un développeur.
