### PR TITLE
Tech: fetch_external_data retourne toujours une monade Result

### DIFF
--- a/app/lib/api_education/api.rb
+++ b/app/lib/api_education/api.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class APIEducation::API
-  class ResourceNotFound < StandardError
+  class RequestFailedError < StandardError
   end
 
   def self.get_annuaire_education(id)
@@ -18,7 +18,7 @@ class APIEducation::API
     else
       message = response.code == 0 ? response.return_message : response.code.to_s
       Rails.logger.error "[APIEducation] Error on #{url}: #{message}"
-      raise ResourceNotFound
+      raise RequestFailedError
     end
   end
 end

--- a/app/models/champs/annuaire_education_champ.rb
+++ b/app/models/champs/annuaire_education_champ.rb
@@ -13,7 +13,7 @@ class Champs::AnnuaireEducationChamp < Champs::TextChamp
     else
       Failure(retryable: false, error: StandardError.new('NotFound'), code: 404)
     end
-  rescue APIEducation::API::ResourceNotFound => error
+  rescue APIEducation::API::RequestFailedError => error
     Failure(retryable: true, error:, code: 503)
   rescue APIEducation::AnnuaireEducationAdapter::InvalidSchemaError => error
     Failure(retryable: false, error:, code: 422)

--- a/app/models/champs/annuaire_education_champ.rb
+++ b/app/models/champs/annuaire_education_champ.rb
@@ -13,6 +13,10 @@ class Champs::AnnuaireEducationChamp < Champs::TextChamp
     else
       Failure(retryable: false, error: StandardError.new('NotFound'), code: 404)
     end
+  rescue APIEducation::API::ResourceNotFound => error
+    Failure(retryable: true, error:, code: 503)
+  rescue APIEducation::AnnuaireEducationAdapter::InvalidSchemaError => error
+    Failure(retryable: false, error:, code: 422)
   end
 
   def selected_items

--- a/app/models/champs/annuaire_education_champ.rb
+++ b/app/models/champs/annuaire_education_champ.rb
@@ -6,7 +6,13 @@ class Champs::AnnuaireEducationChamp < Champs::TextChamp
   end
 
   def fetch_external_data
-    APIEducation::AnnuaireEducationAdapter.new(external_id).to_params
+    data = APIEducation::AnnuaireEducationAdapter.new(external_id).to_params
+
+    if data.present?
+      Success(data:)
+    else
+      Failure(retryable: false, error: StandardError.new('NotFound'), code: 404)
+    end
   end
 
   def selected_items

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -90,23 +90,18 @@ module ChampExternalDataConcern
   end
 
   def handle_result(result)
-    if result.is_a?(Dry::Monads::Result)
-      case result
-      in Success(hash)
-        update_external_data!(hash)
-        external_data_fetched!
-      in Failure(retryable: true, error:, code:)
-        save_external_error(error, code)
-        retry!
-        raise RetryableFetchError.new(error)
-      in Failure(retryable: false, error:, code:)
-        save_external_error(error, code)
-        Sentry.capture_exception(error) if code != 404
-        external_data_error!
-      end
-    elsif result.present?
-      update_external_data!(data: result)
+    case result
+    in Success(hash)
+      update_external_data!(hash)
       external_data_fetched!
+    in Failure(retryable: true, error:, code:)
+      save_external_error(error, code)
+      retry!
+      raise RetryableFetchError.new(error)
+    in Failure(retryable: false, error:, code:)
+      save_external_error(error, code)
+      Sentry.capture_exception(error) if code != 404
+      external_data_error!
     end
   end
 

--- a/spec/models/champs/annuaire_education_champ_spec.rb
+++ b/spec/models/champs/annuaire_education_champ_spec.rb
@@ -3,6 +3,37 @@
 require 'rails_helper'
 
 RSpec.describe Champs::AnnuaireEducationChamp do
+  include Dry::Monads[:result]
+
+  describe '#fetch_external_data' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :annuaire_education }]) }
+    let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+
+    subject { champ.fetch_external_data }
+
+    before do
+      allow_any_instance_of(APIEducation::AnnuaireEducationAdapter).to receive(:to_params).and_return(params)
+    end
+
+    context 'when a record is found' do
+      let(:params) { { 'nom_etablissement' => 'karrigel an ankou' } }
+
+      it { is_expected.to eq(Success(data: params)) }
+    end
+
+    context 'when no record is found' do
+      let(:params) { nil }
+
+      it 'returns a non-retryable not found failure' do
+        expect(subject).to be_failure
+        expect(subject.failure[:retryable]).to eq(false)
+        expect(subject.failure[:code]).to eq(404)
+        expect(subject.failure[:error].message).to eq('NotFound')
+      end
+    end
+  end
+
   describe '#update_external_data!' do
     let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :annuaire_education }]) }
     let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }

--- a/spec/models/champs/annuaire_education_champ_spec.rb
+++ b/spec/models/champs/annuaire_education_champ_spec.rb
@@ -12,24 +12,44 @@ RSpec.describe Champs::AnnuaireEducationChamp do
 
     subject { champ.fetch_external_data }
 
-    before do
-      allow_any_instance_of(APIEducation::AnnuaireEducationAdapter).to receive(:to_params).and_return(params)
-    end
-
     context 'when a record is found' do
       let(:params) { { 'nom_etablissement' => 'karrigel an ankou' } }
+
+      before { allow_any_instance_of(APIEducation::AnnuaireEducationAdapter).to receive(:to_params).and_return(params) }
 
       it { is_expected.to eq(Success(data: params)) }
     end
 
     context 'when no record is found' do
-      let(:params) { nil }
+      before { allow_any_instance_of(APIEducation::AnnuaireEducationAdapter).to receive(:to_params).and_return(nil) }
 
       it 'returns a non-retryable not found failure' do
         expect(subject).to be_failure
         expect(subject.failure[:retryable]).to eq(false)
         expect(subject.failure[:code]).to eq(404)
         expect(subject.failure[:error].message).to eq('NotFound')
+      end
+    end
+
+    context 'when the API call fails' do
+      before { allow_any_instance_of(APIEducation::AnnuaireEducationAdapter).to receive(:to_params).and_raise(APIEducation::API::ResourceNotFound) }
+
+      it 'returns a retryable failure' do
+        expect(subject).to be_failure
+        expect(subject.failure[:retryable]).to eq(true)
+        expect(subject.failure[:code]).to eq(503)
+        expect(subject.failure[:error]).to be_a(APIEducation::API::ResourceNotFound)
+      end
+    end
+
+    context 'when the response does not match the expected schema' do
+      before { allow_any_instance_of(APIEducation::AnnuaireEducationAdapter).to receive(:to_params).and_raise(APIEducation::AnnuaireEducationAdapter::InvalidSchemaError.new([])) }
+
+      it 'returns a non-retryable failure' do
+        expect(subject).to be_failure
+        expect(subject.failure[:retryable]).to eq(false)
+        expect(subject.failure[:code]).to eq(422)
+        expect(subject.failure[:error]).to be_a(APIEducation::AnnuaireEducationAdapter::InvalidSchemaError)
       end
     end
   end

--- a/spec/models/champs/annuaire_education_champ_spec.rb
+++ b/spec/models/champs/annuaire_education_champ_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe Champs::AnnuaireEducationChamp do
     end
 
     context 'when the API call fails' do
-      before { allow_any_instance_of(APIEducation::AnnuaireEducationAdapter).to receive(:to_params).and_raise(APIEducation::API::ResourceNotFound) }
+      before { allow_any_instance_of(APIEducation::AnnuaireEducationAdapter).to receive(:to_params).and_raise(APIEducation::API::RequestFailedError) }
 
       it 'returns a retryable failure' do
         expect(subject).to be_failure
         expect(subject.failure[:retryable]).to eq(true)
         expect(subject.failure[:code]).to eq(503)
-        expect(subject.failure[:error]).to be_a(APIEducation::API::ResourceNotFound)
+        expect(subject.failure[:error]).to be_a(APIEducation::API::RequestFailedError)
       end
     end
 


### PR DESCRIPTION
Retire le chemin non-monadique de `ChampExternalDataConcern#handle_result` (le `elsif result.present?`) : `AnnuaireEducationChamp` était le dernier champ à retourner une valeur brute.

- Établissement introuvable (réponse 200, `records` vide) → `Failure(retryable: false, code: 404)` : le champ passe en `external_error` / `external_data_not_found?` au lieu de rester bloqué en `fetching`.
- Échec HTTP (`RequestFailedError`, ex-`ResourceNotFound`, levée pour tout appel en échec) → `Failure(retryable: true, code: 503)` : 3 tentatives puis `external_error`, au lieu de faire échouer le job.
- Schéma invalide → `Failure(retryable: false, code: 422)`, capturé par Sentry via `handle_result`.

Un `fetch_external_data` qui retournerait autre chose qu'une monade lèvera désormais `NoMatchingPatternError` (fail fast).