### PR TITLE
ETQ admin, je ne peux plus créer de jeton d'API sans date d'expiration

### DIFF
--- a/app/controllers/administrateurs/api_tokens_controller.rb
+++ b/app/controllers/administrateurs/api_tokens_controller.rb
@@ -23,11 +23,17 @@ module Administrateurs
         return redirect_to securite_admin_api_tokens_path(all_params.merge(invalidNetwork: true))
       end
 
-      @api_token, @packed_token = APIToken.generate(current_administrateur)
+      expires_at = requested_expires_at
+
+      if expires_at.nil?
+        return redirect_to securite_admin_api_tokens_path(all_params.merge(invalidLifetime: true))
+      end
+
+      @api_token, @packed_token = APIToken.generate(current_administrateur, expires_at:)
 
       @api_token.update!(name:, write_access:,
                          allowed_procedure_ids:, authorized_networks:,
-                         expires_at:, requires_ip_filtering: true)
+                         requires_ip_filtering: true)
 
       @curl_command = curl_command(@packed_token, @api_token.procedure_ids.first)
     end
@@ -168,20 +174,24 @@ module Administrateurs
       end
     end
 
-    def expires_at
-      case params[:lifetime]
-      in 'oneWeek'
-        1.week.from_now.to_date
-      in 'custom'
-        [
-          Date.parse(params[:customLifetime]),
-          1.year.from_now,
-        ].min
-      in 'infinite'
-        nil
-      else
-        1.week.from_now.to_date
-      end
+    # Returns nil when the requested lifetime is missing, unknown or out of
+    # bounds, so that create can send the admin back to the security step.
+    def requested_expires_at
+      expires_at =
+        if params[:lifetime] == 'custom'
+          begin
+            Date.parse(params[:customLifetime].to_s)
+          rescue Date::Error
+            nil
+          end
+        else
+          APIToken.selectable_lifetimes[params[:lifetime]&.to_sym]&.from_now&.to_date
+        end
+
+      return if expires_at.nil?
+      return unless expires_at.between?(Date.tomorrow, APIToken.max_expires_at)
+
+      expires_at
     end
   end
 end

--- a/app/javascript/controllers/api_token_securite_controller.ts
+++ b/app/javascript/controllers/api_token_securite_controller.ts
@@ -48,30 +48,19 @@ export class ApiTokenSecuriteController extends ApplicationController {
   }
 
   lifetimeDefined() {
-    if (
-      this.element.querySelectorAll(
-        "[name='lifetime'][value='oneWeek']:checked"
-      ).length > 0
-    ) {
+    const checked = this.element.querySelector<HTMLInputElement>(
+      "[name='lifetime']:checked"
+    );
+
+    if (!checked) {
+      return false;
+    }
+
+    // A preset lifetime is enough on its own; a custom one needs a date.
+    if (checked.value != 'custom') {
       return true;
     }
 
-    if (
-      this.element.querySelectorAll(
-        "[name='lifetime'][value='infinite']:checked"
-      ).length > 0
-    ) {
-      return true;
-    }
-
-    if (
-      this.element.querySelectorAll("[name='lifetime'][value='custom']:checked")
-        .length > 0 &&
-      this.customLifetimeInputTarget.value.trim() != ''
-    ) {
-      return true;
-    }
-
-    return false;
+    return this.customLifetimeInputTarget.value.trim() != '';
   }
 }

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -3,7 +3,27 @@
 class APIToken < ApplicationRecord
   include ActiveRecord::SecureToken
 
+  # A leaked token stays usable until it expires: cap how long that window can be.
+  MAX_LIFETIME = ENV.fetch('API_TOKEN_MAX_LIFETIME_IN_DAYS') { 365 }.to_i.days
+
+  # Expressed in days so that they compare exactly with MAX_LIFETIME, and so
+  # that a preset never lands past the cap on a leap year.
+  LIFETIMES = { oneWeek: 7.days, oneMonth: 30.days, sixMonths: 182.days, oneYear: 365.days }.freeze
+
   belongs_to :administrateur, inverse_of: :api_tokens
+
+  # Tokens created before we made it mandatory have no expiration date. They are
+  # still valid, so the validations only run on create.
+  validates :expires_at, presence: true, on: :create
+  # allow_nil keeps the blank case to the presence validation above, instead of
+  # reporting it twice.
+  validates :expires_at,
+            comparison: {
+              greater_than: -> (_) { Date.current },
+              less_than_or_equal_to: -> (_) { max_expires_at },
+            },
+            allow_nil: true,
+            on: :create
 
   scope :expiring_within, -> (duration) { where(expires_at: Date.today..duration.from_now) }
 
@@ -101,15 +121,24 @@ class APIToken < ApplicationRecord
     expires_at&.past?
   end
 
+  # Only describes the tokens created before an expiration date was mandatory.
   def eternal?
     expires_at.nil?
   end
 
   class << self
-    def generate(administrateur)
+    def selectable_lifetimes
+      LIFETIMES.filter { |_, lifetime| lifetime <= MAX_LIFETIME }
+    end
+
+    def max_expires_at
+      MAX_LIFETIME.from_now.to_date
+    end
+
+    def generate(administrateur, expires_at: max_expires_at)
       plain_token = generate_unique_secure_token
       encrypted_token = BCrypt::Password.create(plain_token)
-      api_token = create!(administrateur:, encrypted_token:, name: Date.today.strftime('Jeton d’API généré le %d/%m/%Y'))
+      api_token = create!(administrateur:, encrypted_token:, expires_at:, name: Date.today.strftime('Jeton d’API généré le %d/%m/%Y'))
       bearer = BearerToken.new(api_token.id, plain_token)
       [api_token, bearer.to_string]
     end

--- a/app/views/administrateurs/api_tokens/create.html.erb
+++ b/app/views/administrateurs/api_tokens/create.html.erb
@@ -99,11 +99,7 @@
     <li>
       <strong><%= t('.expiration') %></strong>
 
-      <%- if @api_token.expires_at.present? -%>
-        <span><%= l(@api_token.expires_at, format: :long) %></span>
-      <%- else -%>
-        <span><%= t('.no_expiration') %></span>
-      <%- end -%>
+      <span><%= l(@api_token.expires_at, format: :long) %></span>
     </li>
   </ul>
 

--- a/app/views/administrateurs/api_tokens/securite.html.erb
+++ b/app/views/administrateurs/api_tokens/securite.html.erb
@@ -50,7 +50,7 @@
     <% end %>
 
     <div
-      class="fr-input-group fr-mb-4w <%= class_names('hidden': params[:networkFiltering] == 'none' || params[:networkFiltering].blank?, 'fr-input-group--error': params[:invalidNetwork].present?) %>"
+      class="fr-input-group fr-mb-4w <%= class_names('hidden': params[:networkFiltering] != 'customNetworks', 'fr-input-group--error': params[:invalidNetwork].present?) %>"
       data-api-token-securite-target="networkFiltering"
     >
       <%= f.label :name, class: 'fr-label' do %>
@@ -75,23 +75,21 @@
 
     <%= render Dsfr::RadioButtonListComponent.new(form: f,
       target: :lifetime,
-      buttons: [ { label: t('.one_week'),
-        value: :oneWeek,
-        checked: params[:lifetime] == 'oneWeek',
-        'data-action': 'click->api-token-securite#hideCustomLifetime' },
-        { label: t('.custom_lifetime_label'),
+      error: params[:invalidLifetime].present? ? t('.invalid_lifetime') : nil,
+      buttons: APIToken.selectable_lifetimes.keys.map { |lifetime|
+        { label: t(".lifetime.#{lifetime.to_s.underscore}"),
+          value: lifetime,
+          checked: params[:lifetime].to_s == lifetime.to_s,
+          'data-action': 'click->api-token-securite#hideCustomLifetime' }
+      } + [{ label: t('.custom_lifetime_label', count: APIToken::MAX_LIFETIME.in_days.to_i),
         value: :custom,
         checked: params[:lifetime] == 'custom',
-        'data-action': 'click->api-token-securite#showCustomLifetime'},
-        { label: t('.infinite'),
-        value: :infinite,
-        checked: params[:lifetime] == 'infinite',
-        'data-action': 'click->api-token-securite#hideCustomLifetime' }]) do %>
+        'data-action': 'click->api-token-securite#showCustomLifetime' }]) do %>
       <%= t('.lifetime_label') %>
     <% end %>
 
     <div
-      class="fr-input-group fr-mb-4w hidden"
+      class="fr-input-group fr-mb-4w <%= class_names('hidden': params[:lifetime] != 'custom') %>"
       data-api-token-securite-target="customLifetime"
     >
       <%= f.label :name, class: 'fr-label' do %>
@@ -103,10 +101,11 @@
         type="date"
         class="fr-input width-33 fr-mb-4w"
         name="customLifetime"
+        value="<%= params[:customLifetime] %>"
         data-action="input->api-token-securite#setContinueButtonState"
         data-api-token-securite-target="customLifetimeInput"
         min="<%= Date.tomorrow.iso8601 %>"
-        max="<%= 1.year.from_now.to_date.iso8601 %>"
+        max="<%= APIToken.max_expires_at.iso8601 %>"
       >
     </div>
 

--- a/config/env.example
+++ b/config/env.example
@@ -111,3 +111,8 @@ WEASYPRINT_URL="http://127.0.0.1:5000/pdf"
 # to 0 to lift the limit entirely. See app/graphql/api/v2/schema.rb for how the
 # default was measured.
 # GRAPHQL_MAX_COMPLEXITY="60000"
+
+# Maximum lifetime, in days, of an API token created by an administrateur
+# (defaults to 365). Presets longer than this cap disappear from the creation
+# form, and a custom date beyond it is rejected. See app/models/api_token.rb.
+# API_TOKEN_MAX_LIFETIME_IN_DAYS="365"

--- a/config/locales/models/api_token/en.yml
+++ b/config/locales/models/api_token/en.yml
@@ -1,0 +1,10 @@
+en:
+  activerecord:
+    errors:
+      models:
+        api_token:
+          attributes:
+            expires_at:
+              blank: "must be set"
+              greater_than: "must be later than today"
+              less_than_or_equal_to: "cannot exceed the maximum allowed duration"

--- a/config/locales/models/api_token/fr.yml
+++ b/config/locales/models/api_token/fr.yml
@@ -1,0 +1,10 @@
+fr:
+  activerecord:
+    errors:
+      models:
+        api_token:
+          attributes:
+            expires_at:
+              blank: "doit être renseignée"
+              greater_than: "doit être postérieure à aujourd’hui"
+              less_than_or_equal_to: "ne peut pas dépasser la durée maximale autorisée"

--- a/config/locales/views/administrateurs/api_tokens/create.en.yml
+++ b/config/locales/views/administrateurs/api_tokens/create.en.yml
@@ -24,5 +24,4 @@ en:
         read_only: read only
         all_procedures: all
         all_networks: all internet
-        no_expiration: none
         back_to_profile: Back to profile

--- a/config/locales/views/administrateurs/api_tokens/create.fr.yml
+++ b/config/locales/views/administrateurs/api_tokens/create.fr.yml
@@ -24,5 +24,4 @@ fr:
         read_only: lecture
         all_procedures: toutes
         all_networks: tout internet
-        no_expiration: aucune
         back_to_profile: Retour au profil

--- a/config/locales/views/api_tokens.en.yml
+++ b/config/locales/views/api_tokens.en.yml
@@ -58,9 +58,13 @@ en:
         network_hint: 'network addresses separated by spaces. e.g. 176.31.79.200 192.168.33.0/24 2001:41d0:304:400::52f/128'
         invalid_network: You must enter valid IPv4 or IPv6 addresses
         lifetime_label: 'Token lifetime:'
-        one_week: 1 week
-        custom_lifetime_label: custom duration less than 1 year
-        infinite: Infinite
+        lifetime:
+          one_week: 1 week
+          one_month: 1 month
+          six_months: 6 months
+          one_year: 1 year
+        custom_lifetime_label: 'custom duration, at most %{count} days'
+        invalid_lifetime: You must choose a lifetime between tomorrow and the maximum allowed duration
         enter_expiry: Enter the token expiry date
         create_token: Create the token
         back: Back

--- a/config/locales/views/api_tokens.fr.yml
+++ b/config/locales/views/api_tokens.fr.yml
@@ -58,9 +58,13 @@ fr:
         network_hint: 'adresses réseaux séparées par des espaces. Ex: 176.31.79.200 192.168.33.0/24 2001:41d0:304:400::52f/128'
         invalid_network: Vous devez entrer des adresses IPv4 ou IPv6 valides
         lifetime_label: 'Durée de vie du jeton :'
-        one_week: 1 semaine
-        custom_lifetime_label: durée personnalisée inférieure à 1 an
-        infinite: Infini
+        lifetime:
+          one_week: 1 semaine
+          one_month: 1 mois
+          six_months: 6 mois
+          one_year: 1 an
+        custom_lifetime_label: 'durée personnalisée, au maximum %{count} jours'
+        invalid_lifetime: Vous devez choisir une durée de vie comprise entre demain et la durée maximale autorisée
         enter_expiry: Entrez la date de fin de validité du jeton
         create_token: Créer le jeton
         back: Retour

--- a/spec/controllers/administrateurs/api_tokens_controller_spec.rb
+++ b/spec/controllers/administrateurs/api_tokens_controller_spec.rb
@@ -8,6 +8,9 @@ describe Administrateurs::APITokensController, type: :controller do
 
   before { travel_to(Time.zone.local(2020, 1, 1, 12, 0, 0)) }
 
+  # Pin the cap so the suite does not depend on the local configuration.
+  before { stub_const('APIToken::MAX_LIFETIME', 365.days) }
+
   describe 'create' do
     let(:default_params) do
       {
@@ -42,13 +45,59 @@ describe Administrateurs::APITokensController, type: :controller do
       it { expect(token.write_access?).to be false }
     end
 
-    context 'with infinite lifetime' do
-      let(:params) { default_params.merge(lifetime: 'infinite') }
+    APIToken.selectable_lifetimes.each do |lifetime, duration|
+      context "with the #{lifetime} lifetime" do
+        let(:params) { default_params.merge(lifetime:) }
 
-      it { expect(token.expires_at).to be_nil }
+        it { expect(token.expires_at).to eq(duration.from_now.to_date) }
+      end
     end
 
-    context 'with bad network and infinite lifetime' do
+    context 'with a custom lifetime' do
+      let(:params) { default_params.merge(lifetime: 'custom', customLifetime: 3.months.from_now.to_date.iso8601) }
+
+      it { expect(token.expires_at).to eq(3.months.from_now.to_date) }
+    end
+
+    shared_examples 'a rejected lifetime' do
+      it 'does not create a token and sends the admin back to the security step' do
+        expect(token).to be_nil
+        expect(response.location).to include(securite_admin_api_tokens_path)
+        expect(response.location).to include('invalidLifetime=true')
+      end
+    end
+
+    context 'with an infinite lifetime' do
+      let(:params) { default_params.merge(lifetime: 'infinite') }
+
+      it_behaves_like 'a rejected lifetime'
+    end
+
+    context 'with an unknown lifetime' do
+      let(:params) { default_params.merge(lifetime: 'whatever') }
+
+      it_behaves_like 'a rejected lifetime'
+    end
+
+    context 'with a custom lifetime in the past' do
+      let(:params) { default_params.merge(lifetime: 'custom', customLifetime: 1.day.ago.to_date.iso8601) }
+
+      it_behaves_like 'a rejected lifetime'
+    end
+
+    context 'with a custom lifetime beyond the cap' do
+      let(:params) { default_params.merge(lifetime: 'custom', customLifetime: (APIToken.max_expires_at + 1.day).iso8601) }
+
+      it_behaves_like 'a rejected lifetime'
+    end
+
+    context 'with an unparsable custom lifetime' do
+      let(:params) { default_params.merge(lifetime: 'custom', customLifetime: 'not a date') }
+
+      it_behaves_like 'a rejected lifetime'
+    end
+
+    context 'with bad network' do
       let(:networks) { 'bad' }
       let(:params) { default_params.merge(networkFiltering: 'customNetworks', networks:) }
 
@@ -69,11 +118,11 @@ describe Administrateurs::APITokensController, type: :controller do
 }
     end
 
-    context 'with network filtering and infinite lifetime' do
+    context 'with network filtering and a one year lifetime' do
       let(:networks) { '192.168.1.23/32 2001:41d0:304:400::52f/128' }
-      let(:params) { default_params.merge(networkFiltering: 'customNetworks', networks:, lifetime: 'infinite') }
+      let(:params) { default_params.merge(networkFiltering: 'customNetworks', networks:, lifetime: 'oneYear') }
 
-      it { expect(token.expires_at).to eq(nil) }
+      it { expect(token.expires_at).to eq(APIToken::LIFETIMES[:oneYear].from_now.to_date) }
     end
 
     context 'with procedure filtering' do

--- a/spec/controllers/administrateurs/api_tokens_controller_spec.rb
+++ b/spec/controllers/administrateurs/api_tokens_controller_spec.rb
@@ -125,9 +125,12 @@ describe Administrateurs::APITokensController, type: :controller do
       end
     end
 
-    context 'with no network and infinite lifetime' do
+    # Eternal tokens can no longer be created, but the existing ones keep their
+    # own rule: they must always be restricted to at least one network.
+    context 'with no network on a legacy eternal token' do
       before do
         token.update!(authorized_networks: [IPAddr.new('118.218.200.200')])
+        token.update_column(:expires_at, nil)
         subject
         token.reload
       end

--- a/spec/jobs/cron/send_api_token_expiration_notice_job_spec.rb
+++ b/spec/jobs/cron/send_api_token_expiration_notice_job_spec.rb
@@ -17,8 +17,13 @@ RSpec.describe Cron::SendAPITokenExpirationNoticeJob, type: :job do
       allow(APITokenMailer).to receive(:expiration).and_return(mailer_double)
     end
 
+    # Eternal tokens can no longer be created, but the existing ones must keep
+    # falling outside of every notice window.
     context 'when the token does not expire' do
-      before { perform_now }
+      before do
+        token.update_column(:expires_at, nil)
+        perform_now
+      end
 
       it { expect(mailer_double).not_to have_received(:deliver_later) }
     end

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -5,6 +5,153 @@ describe APIToken, type: :model do
   # administrateur, who is guaranteed to own nothing.
   let(:administrateur) { administrateurs.blank }
 
+  describe 'expires_at validations' do
+    # A new record validates in the :create context, which is where the
+    # expiration rules live.
+    subject(:api_token) { APIToken.new(administrateur:, expires_at:) }
+
+    context 'when expires_at is missing' do
+      let(:expires_at) { nil }
+
+      it 'is rejected as blank' do
+        expect(api_token).to be_invalid
+        expect(api_token.errors).to be_of_kind(:expires_at, :blank)
+      end
+    end
+
+    context 'when expires_at is in the past' do
+      let(:expires_at) { 1.day.ago.to_date }
+
+      it 'is rejected as too soon' do
+        expect(api_token).to be_invalid
+        expect(api_token.errors).to be_of_kind(:expires_at, :greater_than)
+      end
+    end
+
+    context 'when expires_at is today' do
+      let(:expires_at) { Date.current }
+
+      it 'is rejected as too soon' do
+        expect(api_token).to be_invalid
+        expect(api_token.errors).to be_of_kind(:expires_at, :greater_than)
+      end
+    end
+
+    context 'when expires_at is tomorrow' do
+      let(:expires_at) { Date.tomorrow }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'when expires_at is exactly the configured cap' do
+      let(:expires_at) { APIToken.max_expires_at }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'when expires_at is beyond the configured cap' do
+      let(:expires_at) { APIToken.max_expires_at + 1.day }
+
+      it 'is rejected as too late' do
+        expect(api_token).to be_invalid
+        expect(api_token.errors).to be_of_kind(:expires_at, :less_than_or_equal_to)
+      end
+    end
+
+    context 'when the cap is lowered by configuration' do
+      before { stub_const('APIToken::MAX_LIFETIME', 90.days) }
+
+      let(:expires_at) { 91.days.from_now.to_date }
+
+      it 'is rejected as too late' do
+        expect(api_token).to be_invalid
+        expect(api_token.errors).to be_of_kind(:expires_at, :less_than_or_equal_to)
+      end
+    end
+
+    describe '.generate' do
+      it 'refuses to create a token without an expiration date' do
+        expect {
+          expect { APIToken.generate(administrateur, expires_at: nil) }
+            .to raise_error(ActiveRecord::RecordInvalid) { |error|
+              expect(error.record.errors).to be_of_kind(:expires_at, :blank)
+            }
+        }.not_to change { administrateur.api_tokens.count }
+      end
+    end
+
+    # The existing stock of eternal tokens is out of scope for now: it must stay
+    # valid and editable, so the validation only runs on create.
+    context 'with a legacy eternal token' do
+      let(:expires_at) { 1.week.from_now.to_date }
+
+      it 'stays editable' do
+        persisted = APIToken.generate(administrateur, expires_at:).first
+        persisted.update_column(:expires_at, nil)
+
+        expect(persisted.reload).to be_eternal
+        expect { persisted.update!(name: 'renamed') }.not_to raise_error
+      end
+    end
+  end
+
+  describe '.selectable_lifetimes' do
+    it 'exposes every preset under the default cap' do
+      stub_const('APIToken::MAX_LIFETIME', 365.days)
+
+      expect(APIToken.selectable_lifetimes.keys).to eq([:oneWeek, :oneMonth, :sixMonths, :oneYear])
+    end
+
+    it 'drops the presets longer than the configured cap' do
+      stub_const('APIToken::MAX_LIFETIME', 90.days)
+
+      expect(APIToken.selectable_lifetimes.keys).to eq([:oneWeek, :oneMonth])
+    end
+  end
+
+  # Every token is now created with an expiration date, so check the existing
+  # expiration notices actually reach each of the lifetimes we offer.
+  describe 'expiration notices coverage' do
+    # Pin the cap so every preset stays creatable whatever the configuration.
+    before { stub_const('APIToken::MAX_LIFETIME', 365.days) }
+
+    let(:api_token) { APIToken.generate(administrateur, expires_at: duration.from_now.to_date).first }
+
+    def notified_windows(token)
+      [1.month, 1.week, 1.day].filter do |window|
+        travel_to(token.expires_at - window) do
+          APIToken.with_expiration_notice_to_send_for(window).exists?(id: token.id)
+        end
+      end
+    end
+
+    context 'with the shortest lifetime' do
+      let(:duration) { APIToken::LIFETIMES[:oneWeek] }
+
+      it 'only warns the day before' do
+        expect(notified_windows(api_token)).to eq([1.day])
+      end
+    end
+
+    context 'with the longest lifetime' do
+      let(:duration) { APIToken::LIFETIMES[:oneYear] }
+
+      it 'warns a month, a week and a day before' do
+        expect(notified_windows(api_token)).to eq([1.month, 1.week, 1.day])
+      end
+    end
+
+    it 'always warns at least the day before' do
+      APIToken.selectable_lifetimes.each_value do |lifetime|
+        token = APIToken.generate(administrateur, expires_at: lifetime.from_now.to_date).first
+
+        travel_to(token.expires_at - 1.day) do
+          expect(APIToken.with_expiration_notice_to_send_for(1.day)).to include(token)
+        end
+      end
+    end
+  end
+
   describe '#generate' do
     let(:api_token_and_packed_token) { APIToken.generate(administrateur) }
     let(:api_token) { api_token_and_packed_token.first }
@@ -264,6 +411,8 @@ describe APIToken, type: :model do
     subject { APIToken.expiring_within(7.days) }
 
     context 'when the token is not expiring' do
+      before { api_token.update_column(:expires_at, nil) }
+
       it { is_expected.to be_empty }
     end
 

--- a/spec/system/administrateurs/api_token_spec.rb
+++ b/spec/system/administrateurs/api_token_spec.rb
@@ -6,6 +6,8 @@ describe 'As an administrateur I create an API token', js: true do
   let(:procedure) { create(:procedure) }
 
   before do
+    # Pin the cap so the suite does not depend on the local configuration.
+    stub_const('APIToken::MAX_LIFETIME', 365.days)
     login_as administrateur.user, scope: :user
   end
   scenario 'procedure libelle with HTML is escaped when added to authorized list (XSS prevention)' do
@@ -71,5 +73,47 @@ describe 'As an administrateur I create an API token', js: true do
     token = APIToken.last
     expect(token.requires_ip_filtering).to be true
     expect(token.authorized_networks).to eq([IPAddr.new('192.168.1.0/24')])
+  end
+  scenario 'token creation with a preset lifetime, no eternal option offered' do
+    visit profil_path
+
+    click_on 'Créer un nouveau jeton'
+    fill_in 'Nom du jeton', with: 'jeton semestriel'
+    click_on 'Continuer'
+
+    custom_check 'access_read_write'
+    custom_check 'target_all'
+    click_on 'Continuer'
+    expect(page).to have_content("Sécurité")
+
+    expect(page).to have_no_content('Infini')
+
+    custom_check 'networkFiltering_autoassign'
+    custom_check 'lifetime_sixmonths'
+    click_on('Créer le jeton')
+    expect(page).to have_content("Votre jeton est prêt")
+
+    expect(APIToken.last.expires_at).to eq(APIToken::LIFETIMES[:sixMonths].from_now.to_date)
+  end
+
+  scenario 'token creation with a custom lifetime' do
+    visit profil_path
+
+    click_on 'Créer un nouveau jeton'
+    fill_in 'Nom du jeton', with: 'jeton daté'
+    click_on 'Continuer'
+
+    custom_check 'access_read_write'
+    custom_check 'target_all'
+    click_on 'Continuer'
+    expect(page).to have_content("Sécurité")
+
+    custom_check 'networkFiltering_autoassign'
+    custom_check 'lifetime_custom'
+    fill_in 'customLifetime', with: 3.months.from_now.to_date.iso8601
+    click_on('Créer le jeton')
+    expect(page).to have_content("Votre jeton est prêt")
+
+    expect(APIToken.last.expires_at).to eq(3.months.from_now.to_date)
   end
 end


### PR DESCRIPTION
`APIToken#expires_at` était nullable et l'étape « Sécurité » proposait
explicitement une option « Infini ». Un jeton créé ainsi restait valable
indéfiniment une fois fuité, et échappait aux relances d'expiration — leurs
scopes SQL retombent tous sur `NULL`.

## Ce qui change

- `expires_at` devient obligatoire, entre demain et un plafond configurable
  `API_TOKEN_MAX_LIFETIME_IN_DAYS` (365 par défaut).
- L'étape « Sécurité » propose 1 semaine / 1 mois / 6 mois / 1 an, plus une
  date personnalisée. « Infini » disparaît.
- Une durée absente, inconnue ou hors bornes renvoie sur l'étape avec une
  erreur, sans créer de jeton — même mécanique que le filtrage réseau.

## Points d'attention pour la relecture

- **La validation est posée `on: :create` uniquement.** Le stock de jetons
  éternels existants doit rester valide et éditable : il est traité à part.
  Rien n'est modifié en base ici, ni migration `NOT NULL`, ni backfill.
- **`APIToken.generate` prend désormais la date.** Sans ça la validation ne
  s'appliquerait jamais à la valeur saisie, puisque le contrôleur créait le
  jeton puis faisait un `update!`.
- **Les paliers sont exprimés en jours** (`oneYear: 365.days`). `1.year` vaut
  365,25 jours en ActiveSupport et passait donc au-dessus d'un plafond exprimé
  en jours — le palier « 1 an » disparaissait de sa propre UI.

## Corrections annexes

Dans le code réécrit : 500 sur une date illisible, date passée acceptée en POST
direct (le `min` HTML était la seule borne), rabattement silencieux sur 1
semaine. Et deux bugs d'affichage au retour d'erreur : la date personnalisée
était perdue avec son champ masqué, et le champ IP s'affichait alors que la
détection automatique était cochée.

## Captures

| Durées prédéfinies | Durée personnalisée |
|---|---|
| ![](https://gist.githubusercontent.com/mmagn/fbded329b478ff1471a34ed5c5fb33c8/raw/01-durees-predefinies.png) | ![](https://gist.githubusercontent.com/mmagn/fbded329b478ff1471a34ed5c5fb33c8/raw/02-duree-personnalisee.png) |

| Durée invalide rejetée | Confirmation |
|---|---|
| ![](https://gist.githubusercontent.com/mmagn/fbded329b478ff1471a34ed5c5fb33c8/raw/03-erreur-duree-invalide.png) | ![](https://gist.githubusercontent.com/mmagn/fbded329b478ff1471a34ed5c5fb33c8/raw/04-confirmation-date-expiration.png) |

## Suites

Inventaire du stock de jetons éternels, notification des intégrateurs, backfill
puis migration `NOT NULL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
