### PR TITLE
ETQ admin, je m'authentifie obligatoirement via ProConnect

### DIFF
--- a/app/controllers/concerns/pro_connect_session_concern.rb
+++ b/app/controllers/concerns/pro_connect_session_concern.rb
@@ -42,6 +42,10 @@ module ProConnectSessionConcern
     cookies.delete SESSION_INFO_COOKIE_NAME
   end
 
+  def redirect_to_pro_connect_required
+    redirect_to pro_connect_path(force_pro_connect: true), alert: t('errors.messages.pro_connect.required')
+  end
+
   private
 
   def pro_connect_session

--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -251,10 +251,13 @@ module Experts
         redirect_to expert_avis_url(avis.procedure, avis)
       elsif avis.expert&.email == params[:email] &&
             avis.expert.user.confirmation_token.present? &&
-            avis.expert.user.confirmation_token == submitted_token &&
-            avis.expert.user.active?
-        # The expert already used the sign-in page to change their password: ask them to sign-in instead.
-        redirect_to new_user_session_url
+            avis.expert.user.confirmation_token == submitted_token
+        if avis.expert.user.administrateur&.pro_connect_required?
+          redirect_to_pro_connect_required
+        elsif avis.expert.user.active?
+          # The expert already used the sign-in page to change their password: ask them to sign-in instead.
+          redirect_to new_user_session_url
+        end
       end
     end
 

--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -51,7 +51,11 @@ module Manager
     def resend_reset_password_instructions
       user = User.find(params[:id])
       user.send_reset_password_instructions
-      flash[:notice] = "L’email de réinitialisation du mot de passe a été renvoyé."
+      flash[:notice] = if user.administrateur&.pro_connect_required?
+        "L’email d’invitation à se connecter avec ProConnect a été envoyé."
+      else
+        "L’email de réinitialisation du mot de passe a été renvoyé."
+      end
       redirect_to manager_user_path(user)
     end
 

--- a/app/controllers/users/activate_controller.rb
+++ b/app/controllers/users/activate_controller.rb
@@ -6,10 +6,12 @@ class Users::ActivateController < ApplicationController
   def new
     @user = User.with_reset_password_token(params[:token])
 
-    return if @user
-
-    flash.alert = t('.expired_link_html', contact_link: helpers.contact_link('contactez-nous'))
-    redirect_to root_path
+    if @user.nil?
+      flash.alert = t('.expired_link_html', contact_link: helpers.contact_link('contactez-nous'))
+      redirect_to root_path
+    elsif @user.administrateur&.pro_connect_required?
+      redirect_to_pro_connect_required
+    end
   end
 
   def create

--- a/app/controllers/users/activate_controller.rb
+++ b/app/controllers/users/activate_controller.rb
@@ -13,6 +13,9 @@ class Users::ActivateController < ApplicationController
   end
 
   def create
+    user = User.with_reset_password_token(user_params[:reset_password_token])
+    return redirect_to_pro_connect_required if user&.administrateur&.pro_connect_required?
+
     password = user_params[:password]
 
     user = User.reset_password_by_token({

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -18,9 +18,12 @@ class Users::PasswordsController < Devise::PasswordsController
   # end
 
   # GET /resource/password/edit?reset_password_token=abcdef
-  # def edit
-  #   super
-  # end
+  def edit
+    user = User.with_reset_password_token(params[:reset_password_token])
+    return redirect_to_pro_connect_required if user&.administrateur&.pro_connect_required?
+
+    super
+  end
 
   # PUT /resource/password
   def update

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -23,10 +23,13 @@ class Users::PasswordsController < Devise::PasswordsController
   # end
 
   # PUT /resource/password
-  # def update
-  #   # params[:user][:password_confirmation] = params[:user][:password]
-  #   super
-  # end
+  def update
+    user = User.with_reset_password_token(resource_params[:reset_password_token])
+
+    return redirect_to_pro_connect_required if user&.administrateur&.pro_connect_required?
+
+    super
+  end
 
   def reset_link_sent
     @email = message_encryptor_service.decrypt_and_verify(params[:email], purpose: :reset_password) rescue nil

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -17,7 +17,18 @@ class Users::SessionsController < Devise::SessionsController
     # `super`. Devise's paranoid mode normalises the bcrypt timing for unknown
     # emails inside `warden.authenticate!`; a manual pre-check would only run
     # bcrypt for existing accounts and reintroduce a timing-based enumeration.
+    # Devise tracks the sign in as soon as the password is verified; we track
+    # it ourselves once we know the session is kept.
+    request.env['devise.skip_trackable'] = true
+
     super do |resource|
+      if resource.administrateur&.pro_connect_required?
+        sign_out(resource)
+        flash.discard(:notice)
+        return redirect_to_pro_connect_required
+      end
+
+      resource.update_tracked_fields!(request)
       delete_france_connect_cookies
       delete_pro_connect_session_info_cookie
       resource.update(loged_in_with_france_connect: nil)

--- a/app/mailers/administration_mailer.rb
+++ b/app/mailers/administration_mailer.rb
@@ -17,6 +17,17 @@ class AdministrationMailer < ApplicationMailer
       reply_to: CONTACT_EMAIL)
   end
 
+  def invite_admin_via_pro_connect(user)
+    @user = user
+    @author_name = "Équipe de #{APPLICATION_NAME}"
+
+    bypass_unverified_mail_protection!
+
+    mail(to: user.email,
+      subject: "Activez votre compte administrateur",
+      reply_to: CONTACT_EMAIL)
+  end
+
   def refuse_admin(admin_email)
     subject = "Votre demande de compte a été refusée"
 
@@ -28,6 +39,6 @@ class AdministrationMailer < ApplicationMailer
   end
 
   def self.critical_email?(action_name)
-    action_name == "invite_admin"
+    action_name.in?(["invite_admin", "invite_admin_via_pro_connect"])
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -91,6 +91,16 @@ class UserMailer < ApplicationMailer
       reply_to: CONTACT_EMAIL)
   end
 
+  def reset_password_via_pro_connect(user)
+    @user = user
+
+    bypass_unverified_mail_protection!
+
+    mail(to: user.email,
+      subject: default_i18n_subject,
+      reply_to: CONTACT_EMAIL)
+  end
+
   def send_archive(administrateur_or_instructeur, procedure, archive)
     @archive = archive
     @procedure = procedure
@@ -139,6 +149,7 @@ class UserMailer < ApplicationMailer
       "invite_tiers",
       "resend_confirmation_email",
       "custom_confirmation_instructions",
+      "reset_password_via_pro_connect",
     ].include?(action_name)
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -80,6 +80,17 @@ class UserMailer < ApplicationMailer
       reply_to: CONTACT_EMAIL)
   end
 
+  def invite_gestionnaire_via_pro_connect(user, groupe_gestionnaire)
+    @user = user
+    @groupe_gestionnaire = groupe_gestionnaire
+
+    bypass_unverified_mail_protection!
+
+    mail(to: user.email,
+      subject: default_i18n_subject,
+      reply_to: CONTACT_EMAIL)
+  end
+
   def send_archive(administrateur_or_instructeur, procedure, archive)
     @archive = archive
     @procedure = procedure

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -59,6 +59,12 @@ class Administrateur < ApplicationRecord
     !user.active? && !user.reset_password_period_valid?
   end
 
+  def pro_connect_required?
+    return false if !ProConnectService.enabled?
+
+    pro_connect_required_at? || Flipper.enabled?(:pro_connect_required_for_all_administrateurs, user)
+  end
+
   def owns?(procedure)
     procedure.administrateurs.include?(self)
   end

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -48,15 +48,16 @@ class Administrateur < ApplicationRecord
   def registration_state
     if user.active?
       'Actif'
-    elsif user.reset_password_period_valid?
+    elsif pro_connect_required? || user.reset_password_period_valid?
       'En attente'
     else
       'Expiré'
     end
   end
 
+  # A ProConnect invitation carries no token, so it never expires
   def invitation_expired?
-    !user.active? && !user.reset_password_period_valid?
+    !user.active? && !pro_connect_required? && !user.reset_password_period_valid?
   end
 
   def pro_connect_required?

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -55,11 +55,6 @@ class Administrateur < ApplicationRecord
     end
   end
 
-  # A ProConnect invitation carries no token, so it never expires
-  def invitation_expired?
-    !user.active? && !pro_connect_required? && !user.reset_password_period_valid?
-  end
-
   def pro_connect_required?
     return false if !ProConnectService.enabled?
 

--- a/app/models/gestionnaire.rb
+++ b/app/models/gestionnaire.rb
@@ -26,7 +26,7 @@ class Gestionnaire < ApplicationRecord
   def registration_state
     if user.active?
       'Actif'
-    elsif user.reset_password_period_valid?
+    elsif user.administrateur&.pro_connect_required? || user.reset_password_period_valid?
       'En attente'
     else
       'Expiré'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,6 +63,15 @@ class User < ApplicationRecord
     send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
   end
 
+  # Override of Devise::Models::Recoverable#send_reset_password_instructions
+  def send_reset_password_instructions
+    if administrateur&.pro_connect_required?
+      UserMailer.reset_password_via_pro_connect(self).deliver_later
+    else
+      super
+    end
+  end
+
   # Callback provided by Devise
   def after_confirmation
     update!(email_verified_at: Time.zone.now)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,9 +122,11 @@ class User < ApplicationRecord
   end
 
   def remind_invitation!
-    reset_password_token = set_reset_password_token
-
-    AdministrateurMailer.activate_before_expiration(self, reset_password_token).deliver_later
+    if administrateur.pro_connect_required?
+      invite_administrateur!
+    else
+      AdministrateurMailer.activate_before_expiration(self, set_reset_password_token).deliver_later
+    end
   end
 
   def self.create_or_promote_to_instructeur(email, password, administrateurs: [], pro_connect: false)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,7 +110,11 @@ class User < ApplicationRecord
   end
 
   def invite_gestionnaire!(groupe_gestionnaire)
-    UserMailer.invite_gestionnaire(self, set_reset_password_token, groupe_gestionnaire).deliver_later
+    if administrateur.pro_connect_required?
+      UserMailer.invite_gestionnaire_via_pro_connect(self, groupe_gestionnaire).deliver_later
+    else
+      UserMailer.invite_gestionnaire(self, set_reset_password_token, groupe_gestionnaire).deliver_later
+    end
   end
 
   def invite_administrateur!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -174,7 +174,8 @@ class User < ApplicationRecord
     user = User.create_or_promote_to_instructeur(email, password)
 
     if user.valid? && user.administrateur.nil?
-      user.create_administrateur!
+      pro_connect_required_at = Time.zone.now if ProConnectService.enabled?
+      user.create_administrateur!(pro_connect_required_at:)
       user.france_connect_informations.delete_all
       AdminUpdateDefaultZonesJob.perform_later(user.administrateur)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,7 +114,11 @@ class User < ApplicationRecord
   end
 
   def invite_administrateur!
-    AdministrationMailer.invite_admin(self, set_reset_password_token).deliver_later
+    if administrateur.pro_connect_required?
+      AdministrationMailer.invite_admin_via_pro_connect(self).deliver_later
+    else
+      AdministrationMailer.invite_admin(self, set_reset_password_token).deliver_later
+    end
   end
 
   def remind_invitation!

--- a/app/views/administration_mailer/invite_admin_via_pro_connect.html.erb
+++ b/app/views/administration_mailer/invite_admin_via_pro_connect.html.erb
@@ -1,0 +1,25 @@
+<% content_for(:title, 'Activation du compte administrateur') %>
+
+<p>Bonjour,</p>
+
+<p>
+  Je vous remercie de l’intérêt que vous portez à notre outil de
+  dématérialisation de démarches.
+</p>
+
+<p>
+  Votre compte administrateur a été créé pour l’adresse électronique
+  <%= @user.email %>.
+</p>
+
+<p>
+  <b>
+    Pour l’activer, connectez-vous avec ProConnect en utilisant cette même
+    adresse électronique&nbsp;:
+    <%= link_to pro_connect_url(force_pro_connect: true), pro_connect_url(force_pro_connect: true) %>
+  </b>
+</p>
+
+<p>
+  <%= render partial: "layouts/mailers/bizdev_signature", locals: { author_name: @author_name } %>
+</p>

--- a/app/views/manager/administrateurs/show.html.erb
+++ b/app/views/manager/administrateurs/show.html.erb
@@ -32,7 +32,7 @@
   </div>
 
   <div>
-    <% if page.resource.invitation_expired? %>
+    <% if !page.resource.user.active? %>
       <%= button_to "renvoyer l’invitation", reinvite_manager_administrateur_path(page.resource), method: :post, class: "button" %>
     <% end %>
 

--- a/app/views/user_mailer/invite_gestionnaire_via_pro_connect.html.erb
+++ b/app/views/user_mailer/invite_gestionnaire_via_pro_connect.html.erb
@@ -1,0 +1,17 @@
+<% content_for(:title, 'Activation de votre compte gestionnaire') %>
+
+<p>Bonjour,</p>
+
+<p>
+  Vous venez d’être nommé gestionnaire du groupe gestionnaire
+  <%= @groupe_gestionnaire.name %> sur <%= APPLICATION_NAME %>.
+</p>
+
+<p>
+  Votre compte a été créé pour l’adresse électronique <%= @user.email %>. Pour
+  l’activer, connectez-vous avec ProConnect en utilisant cette même adresse
+  électronique&nbsp;:
+  <%= link_to pro_connect_url(force_pro_connect: true), pro_connect_url(force_pro_connect: true) %>
+</p>
+
+<%= render partial: "layouts/mailers/signature" %>

--- a/app/views/user_mailer/reset_password_via_pro_connect.html.erb
+++ b/app/views/user_mailer/reset_password_via_pro_connect.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:title, 'Connexion avec ProConnect') %>
+
+<p>Bonjour,</p>
+
+<p>
+  Vous avez demandé la réinitialisation du mot de passe du compte
+  <%= @user.email %>. Ce compte se connecte avec ProConnect et n’a pas besoin de
+  mot de passe.
+</p>
+
+<p>
+  Pour vous connecter&nbsp;:
+  <%= link_to pro_connect_url(force_pro_connect: true), pro_connect_url(force_pro_connect: true) %>
+</p>
+
+<p>
+  Si vous n’êtes pas à l’origine de cette demande, vous pouvez ignorer ce
+  message.
+</p>
+
+<%= render partial: "layouts/mailers/signature" %>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -28,6 +28,7 @@ features = [
   :export_order_by_revision,
   :groupe_instructeur_api_hack,
   :pro_connect_restricted,
+  :pro_connect_required_for_all_administrateurs,
   :pre_rempli_type_de_champ,
   :rdv,
   :sva,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -871,6 +871,7 @@ en:
         unavailable_for_legal_reasons: 'Information for this establishment is not available (non-diffusable entity).'
       pro_connect:
         connexion: "Error trying to connect to ProConnect. Please try again."
+        required: "You must use ProConnect to sign in."
       france_connect:
         connexion: "Error trying to connect to FranceConnect."
         forbidden_html: "Only citizen can use FranceConnect. As an instructor or administrator, please identify yourself with ProConnect or log in with your %{app_name} account."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -878,6 +878,7 @@ fr:
       procedure_not_found: "La démarche n’existe pas"
       pro_connect:
         connexion: "Une erreur est survenue lors de la connexion avec ProConnect. Veuillez réessayer."
+        required: "Vous devez utiliser ProConnect pour vous connecter."
       france_connect:
         connexion: "Une erreur est survenue lors de la connexion avec FranceConnect. Veuillez réessayer."
         forbidden_html: "Seul-e-s les usagers peuvent se connecter via FranceConnect. En tant qu’instructeur ou administrateur, veuillez vous identifier avec ProConnect ou vous connecter avec votre compte %{app_name}."

--- a/config/locales/views/user_mailer/en.yml
+++ b/config/locales/views/user_mailer/en.yml
@@ -18,6 +18,8 @@ en:
       subject: Activate your manager account
     invite_gestionnaire_via_pro_connect:
       subject: Activate your manager account
+    reset_password_via_pro_connect:
+      subject: Sign in with ProConnect
     send_archive:
       subject: Your archive is available
     notify_inactive_close_to_deletion:

--- a/config/locales/views/user_mailer/en.yml
+++ b/config/locales/views/user_mailer/en.yml
@@ -16,6 +16,8 @@ en:
       subject: Verify your email address
     invite_gestionnaire:
       subject: Activate your manager account
+    invite_gestionnaire_via_pro_connect:
+      subject: Activate your manager account
     send_archive:
       subject: Your archive is available
     notify_inactive_close_to_deletion:

--- a/config/locales/views/user_mailer/fr.yml
+++ b/config/locales/views/user_mailer/fr.yml
@@ -18,6 +18,8 @@ fr:
       subject: Activez votre compte gestionnaire
     invite_gestionnaire_via_pro_connect:
       subject: Activez votre compte gestionnaire
+    reset_password_via_pro_connect:
+      subject: Connectez-vous avec ProConnect
     send_archive:
       subject: Votre archive est disponible
     notify_inactive_close_to_deletion:

--- a/config/locales/views/user_mailer/fr.yml
+++ b/config/locales/views/user_mailer/fr.yml
@@ -16,6 +16,8 @@ fr:
       subject: Vérification de votre adresse électronique
     invite_gestionnaire:
       subject: Activez votre compte gestionnaire
+    invite_gestionnaire_via_pro_connect:
+      subject: Activez votre compte gestionnaire
     send_archive:
       subject: Votre archive est disponible
     notify_inactive_close_to_deletion:

--- a/db/migrate/20260902100000_add_pro_connect_required_at_to_administrateurs.rb
+++ b/db/migrate/20260902100000_add_pro_connect_required_at_to_administrateurs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProConnectRequiredAtToAdministrateurs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :administrateurs, :pro_connect_required_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_27_093000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_02_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_catalog.plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_27_093000) do
     t.datetime "commentaire_seen_at"
     t.datetime "created_at", precision: nil
     t.bigint "groupe_gestionnaire_id"
+    t.datetime "pro_connect_required_at"
     t.datetime "updated_at", precision: nil
     t.bigint "user_id", null: false
     t.index ["groupe_gestionnaire_id"], name: "index_administrateurs_on_groupe_gestionnaire_id"

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -637,6 +637,23 @@ describe Experts::AvisController, type: :controller do
         it { is_expected.to have_http_status(:success) }
       end
 
+      context 'when the expert is an administrateur who must use ProConnect' do
+        before do
+          allow(ProConnectService).to receive(:enabled?).and_return(true)
+          avis.expert.user.create_administrateur!(pro_connect_required_at: Time.zone.now)
+        end
+
+        it { is_expected.to redirect_to(pro_connect_path(force_pro_connect: true)) }
+
+        # Sécurité: sans confirmation_token valide, l’obligation ProConnect ne
+        # doit pas être observable par un attaquant.
+        context 'and no confirmation_token is provided' do
+          let(:confirmation_token) { nil }
+
+          it { is_expected.to have_http_status(:success) }
+        end
+      end
+
       context 'when the expert has already signed up' do
         before { expert.user.update(last_sign_in_at: Time.zone.now) }
 
@@ -695,6 +712,24 @@ describe Experts::AvisController, type: :controller do
         let(:confirmation_token) { "kthxbye" }
 
         it { is_expected.to redirect_to(root_path) }
+      end
+
+      context 'when the expert is an administrateur who must use ProConnect' do
+        let(:confirmation_token) { valid_confirmation_token }
+        let(:password) { '{Another-$3cure-p4ssWord}' }
+
+        before do
+          allow(ProConnectService).to receive(:enabled?).and_return(true)
+          avis.expert.user.create_administrateur!(pro_connect_required_at: Time.zone.now)
+        end
+
+        it 'keeps the password and sends to ProConnect without opening a session' do
+          subject
+
+          expect(controller.current_user).to be_nil
+          expect(avis.expert.user.reload.valid_password?(password)).to be false
+          expect(response).to redirect_to(pro_connect_path(force_pro_connect: true))
+        end
       end
 
       # Sécurité: un confirmation_token absent ou vide ne doit jamais matcher,

--- a/spec/controllers/manager/administrateurs_controller_spec.rb
+++ b/spec/controllers/manager/administrateurs_controller_spec.rb
@@ -24,7 +24,16 @@ describe Manager::AdministrateursController, type: :controller do
         subject
       end
 
-      it { expect(response.body).to include(administrateur.email) }
+      it 'offers to send the invitation again while the administrateur has not signed in' do
+        expect(response.body).to include(administrateur.email)
+        expect(response.body).to include("renvoyer l’invitation")
+      end
+
+      context 'when the administrateur has already signed in' do
+        let(:administrateur) { administrateurs.blank.tap { it.user.update!(last_sign_in_at: Time.zone.now) } }
+
+        it { expect(response.body).not_to include("renvoyer l’invitation") }
+      end
     end
   end
 

--- a/spec/controllers/manager/administrateurs_controller_spec.rb
+++ b/spec/controllers/manager/administrateurs_controller_spec.rb
@@ -48,7 +48,15 @@ describe Manager::AdministrateursController, type: :controller do
       end
 
       it 'alert new mail are send' do
+        allow(ProConnectService).to receive(:enabled?).and_return(false)
         expect(AdministrationMailer).to receive(:invite_admin).and_return(AdministrationMailer)
+        expect(AdministrationMailer).to receive(:deliver_later)
+        subject
+      end
+
+      it 'invites through ProConnect when the instance has it' do
+        allow(ProConnectService).to receive(:enabled?).and_return(true)
+        expect(AdministrationMailer).to receive(:invite_admin_via_pro_connect).and_return(AdministrationMailer)
         expect(AdministrationMailer).to receive(:deliver_later)
         subject
       end

--- a/spec/controllers/manager/users_controller_spec.rb
+++ b/spec/controllers/manager/users_controller_spec.rb
@@ -26,6 +26,30 @@ describe Manager::UsersController, type: :controller do
     end
   end
 
+  describe '#resend_reset_password_instructions' do
+    let(:super_admin) { create(:super_admin, :with_otp) }
+    let(:user) { administrateurs.default.user }
+
+    subject { post :resend_reset_password_instructions, params: { id: user.id } }
+
+    it 'sends the Devise instructions' do
+      expect { subject }.to have_enqueued_mail(DeviseUserMailer, :reset_password_instructions)
+      expect(flash[:notice]).to eq("L’email de réinitialisation du mot de passe a été renvoyé.")
+    end
+
+    context 'when the administrateur must use ProConnect' do
+      before do
+        allow(ProConnectService).to receive(:enabled?).and_return(true)
+        user.administrateur.update!(pro_connect_required_at: Time.zone.now)
+      end
+
+      it 'sends the ProConnect invitation' do
+        expect { subject }.to have_enqueued_mail(UserMailer, :reset_password_via_pro_connect)
+        expect(flash[:notice]).to eq("L’email d’invitation à se connecter avec ProConnect a été envoyé.")
+      end
+    end
+  end
+
   describe '#update' do
     let(:super_admin) { create(:super_admin, :with_otp) }
     let(:user) { create(:user, email: 'ancien.email@domaine.fr', password: '{My-$3cure-p4ssWord}') }

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -172,6 +172,23 @@ describe ProConnectController, type: :controller do
             end
           end
         end
+
+        context 'and the user is an administrateur who must use ProConnect' do
+          let(:administrateur) { administrateurs.default }
+          let(:email) { administrateur.user.email }
+
+          before do
+            allow(ProConnectService).to receive(:enabled?).and_return(true)
+            Flipper.enable(:pro_connect_required_for_all_administrateurs)
+          end
+
+          it 'signs in the administrateur' do
+            subject
+
+            expect(controller.current_user).to eq(administrateur.user)
+            expect(response).to redirect_to(root_path)
+          end
+        end
       end
 
       context 'when connecting multiple times' do

--- a/spec/controllers/users/activate_controller_spec.rb
+++ b/spec/controllers/users/activate_controller_spec.rb
@@ -48,6 +48,18 @@ describe Users::ActivateController, type: :controller do
       it { expect(controller).not_to have_received(:trust_device) }
     end
 
+    context 'when the administrateur must use ProConnect' do
+      let(:user) { administrateurs.default.user }
+
+      before do
+        allow(ProConnectService).to receive(:enabled?).and_return(true)
+        Flipper.enable(:pro_connect_required_for_all_administrateurs)
+        get :new, params: { token: token }
+      end
+
+      it { expect(response).to redirect_to(pro_connect_path(force_pro_connect: true)) }
+    end
+
     context 'when the user is an instructeur and the token is valid (GET request)' do
       let!(:user) { create(:instructeur).user }
       let(:token) { user.send(:set_reset_password_token) }

--- a/spec/controllers/users/activate_controller_spec.rb
+++ b/spec/controllers/users/activate_controller_spec.rb
@@ -141,6 +141,24 @@ describe Users::ActivateController, type: :controller do
     end
   end
 
+  describe '#create when the administrateur must use ProConnect' do
+    let(:user) { administrateurs.default.user }
+    let(:token) { user.send(:set_reset_password_token) }
+
+    before do
+      allow(ProConnectService).to receive(:enabled?).and_return(true)
+      Flipper.enable(:pro_connect_required_for_all_administrateurs)
+
+      post :create, params: { user: { reset_password_token: token, password: '{another-password-ok?}' } }
+    end
+
+    it 'keeps the password, refuses to sign in and sends to ProConnect' do
+      expect(user.reload.valid_password?(users.default_password)).to be true
+      expect(controller.current_user).to be_nil
+      expect(response).to redirect_to(pro_connect_path(force_pro_connect: true))
+    end
+  end
+
   describe '#confirm_email' do
     let(:user) { create(:user) }
     let(:dossier) { create(:dossier, user: user) }

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -52,6 +52,29 @@ describe Users::PasswordsController, type: :controller do
           .from(nil).to(anything)
       end
     end
+
+    context "when the administrateur must use ProConnect" do
+      let(:user) { administrateurs.default.user }
+
+      before do
+        allow(ProConnectService).to receive(:enabled?).and_return(true)
+        Flipper.enable(:pro_connect_required_for_all_administrateurs)
+
+        put :update, params: {
+          user: {
+            reset_password_token: user.send(:set_reset_password_token),
+            password: "mot de passe super secret",
+            password_confirmation: "mot de passe super secret",
+          },
+        }
+      end
+
+      it "keeps the password, does not sign in and sends to ProConnect" do
+        expect(user.reload.valid_password?(users.default_password)).to be true
+        expect(controller.current_user).to be_nil
+        expect(response).to redirect_to(pro_connect_path(force_pro_connect: true))
+      end
+    end
   end
 
   describe '#reset_link_sent' do

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -77,6 +77,24 @@ describe Users::PasswordsController, type: :controller do
     end
   end
 
+  describe '#edit' do
+    let(:user) { administrateurs.default.user }
+    let(:token) { user.send(:set_reset_password_token) }
+
+    before do
+      allow(ProConnectService).to receive(:enabled?).and_return(true)
+      get :edit, params: { reset_password_token: token }
+    end
+
+    it { expect(response).to have_http_status(:ok) }
+
+    context 'when the administrateur must use ProConnect' do
+      let(:user) { administrateurs.default.user.tap { it.administrateur.update!(pro_connect_required_at: Time.zone.now) } }
+
+      it { expect(response).to redirect_to(pro_connect_path(force_pro_connect: true)) }
+    end
+  end
+
   describe '#reset_link_sent' do
     let(:email) { 'test@example.com' }
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -116,6 +116,40 @@ describe Users::SessionsController, type: :controller do
       end
     end
 
+    context 'when the user is an administrateur who must use ProConnect' do
+      let(:user) { administrateurs.default.user }
+      let(:email) { user.email }
+      let(:password) { users.default_password }
+
+      before do
+        allow(ProConnectService).to receive(:enabled?).and_return(true)
+        Flipper.enable(:pro_connect_required_for_all_administrateurs)
+        freeze_time
+        user.update!(last_sign_in_at: 2.days.ago, sign_in_count: 3)
+      end
+
+      it 'signs out and sends to ProConnect without tracking a sign in' do
+        subject
+
+        expect(response).to redirect_to(pro_connect_path(force_pro_connect: true))
+        expect(flash.alert).to eq('Vous devez utiliser ProConnect pour vous connecter.')
+        expect(controller.current_user).to be_nil
+        expect(user.reload.last_sign_in_at).to eq(2.days.ago)
+        expect(user.sign_in_count).to eq(3)
+      end
+
+      context 'with a wrong password' do
+        let(:send_password) { 'wrong_password' }
+
+        it 'does not reveal the ProConnect requirement' do
+          subject
+
+          expect(response).to render_template(:new)
+          expect(flash.alert).to eq('Adresse électronique ou mot de passe incorrect.')
+        end
+      end
+    end
+
     xcontext 'when email domain is in mandatory list' do
       let(:email) { 'user@beta.gouv.fr' }
       it 'redirects to pro connect with force parameter and is not logged in' do

--- a/spec/jobs/cron/administrateur_activate_before_expiration_job_spec.rb
+++ b/spec/jobs/cron/administrateur_activate_before_expiration_job_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe Cron::AdministrateurActivateBeforeExpirationJob, type: :job do
 
         it { expect(AdministrateurMailer).to have_received(:activate_before_expiration).with(administrateur.user, kind_of(String)) }
       end
+
+      context "created 3 days ago and invited through ProConnect" do
+        before do
+          allow(ProConnectService).to receive(:enabled?).and_return(true)
+          allow(AdministrationMailer).to receive(:invite_admin_via_pro_connect).and_return(mailer_double)
+          administrateur.update_columns(created_at: Time.zone.local(2018, 03, 17, 20, 00), pro_connect_required_at: Time.zone.now)
+          subject
+        end
+
+        it 'sends the ProConnect invitation again' do
+          expect(AdministrationMailer).to have_received(:invite_admin_via_pro_connect).with(administrateur.user)
+          expect(AdministrateurMailer).not_to have_received(:activate_before_expiration)
+        end
+      end
     end
 
     context "with an active administrateur" do

--- a/spec/mailers/administration_mailer_spec.rb
+++ b/spec/mailers/administration_mailer_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe AdministrationMailer, type: :mailer do
     end
   end
 
+  describe '#invite_admin_via_pro_connect' do
+    let(:admin_user) { create(:user) }
+
+    subject { described_class.invite_admin_via_pro_connect(admin_user) }
+
+    it do
+      expect(subject.subject).to eq("Activez votre compte administrateur")
+      expect(subject.body).to include(pro_connect_url(force_pro_connect: true))
+      expect(subject.body).not_to include('token=')
+      expect(subject['BYPASS_UNVERIFIED_MAIL_PROTECTION']).to be_present
+    end
+  end
+
   describe '#refuse_admin' do
     let(:mail) { "l33t-4dm1n@h4x0r.com" }
 

--- a/spec/mailers/previews/administration_mailer_preview.rb
+++ b/spec/mailers/previews/administration_mailer_preview.rb
@@ -9,6 +9,10 @@ class AdministrationMailerPreview < ActionMailer::Preview
     AdministrationMailer.invite_admin(administrateur, nil)
   end
 
+  def invite_admin_via_pro_connect
+    AdministrationMailer.invite_admin_via_pro_connect(administrateur)
+  end
+
   def refuse_admin
     AdministrationMailer.refuse_admin('bad_admin@pipo.com')
   end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -40,6 +40,10 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.invite_gestionnaire_via_pro_connect(user, groupe_gestionnaire)
   end
 
+  def reset_password_via_pro_connect
+    UserMailer.reset_password_via_pro_connect(user)
+  end
+
   def notify_inactive_close_to_deletion
     UserMailer.notify_inactive_close_to_deletion(user)
   end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -35,6 +35,11 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.invite_gestionnaire(user, 'aedfa0d0', groupe_gestionnaire)
   end
 
+  def invite_gestionnaire_via_pro_connect
+    groupe_gestionnaire = GroupeGestionnaire.new(name: 'Root admins group')
+    UserMailer.invite_gestionnaire_via_pro_connect(user, groupe_gestionnaire)
+  end
+
   def notify_inactive_close_to_deletion
     UserMailer.notify_inactive_close_to_deletion(user)
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -209,6 +209,17 @@ RSpec.describe UserMailer, type: :mailer do
     end
   end
 
+  describe '.reset_password_via_pro_connect' do
+    subject { described_class.reset_password_via_pro_connect(user) }
+
+    it do
+      expect(subject.to).to eq([user.email])
+      expect(subject.body).to include(pro_connect_url(force_pro_connect: true))
+      expect(subject.body).not_to include('reset_password_token=')
+      expect(subject['BYPASS_UNVERIFIED_MAIL_PROTECTION']).to be_present
+    end
+  end
+
   describe '.account_reactivated' do
     subject { described_class.account_reactivated(user) }
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -197,6 +197,18 @@ RSpec.describe UserMailer, type: :mailer do
     it { expect(subject['BYPASS_UNVERIFIED_MAIL_PROTECTION']).to be_present }
   end
 
+  describe '.invite_gestionnaire_via_pro_connect' do
+    let(:groupe_gestionnaire) { create(:groupe_gestionnaire) }
+    subject { described_class.invite_gestionnaire_via_pro_connect(user, groupe_gestionnaire) }
+
+    it do
+      expect(subject.body).to include(groupe_gestionnaire.name)
+      expect(subject.body).to include(pro_connect_url(force_pro_connect: true))
+      expect(subject.body).not_to include('token=')
+      expect(subject['BYPASS_UNVERIFIED_MAIL_PROTECTION']).to be_present
+    end
+  end
+
   describe '.account_reactivated' do
     subject { described_class.account_reactivated(user) }
 

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -316,6 +316,47 @@ describe Administrateur, type: :model do
     end
   end
 
+  describe '#registration_state and #invitation_expired?' do
+    let(:administrateur) { administrateurs.blank }
+    let(:user) { administrateur.user }
+
+    before { allow(ProConnectService).to receive(:enabled?).and_return(true) }
+
+    context 'when the administrateur has already signed in' do
+      before { user.update!(last_sign_in_at: Time.zone.now) }
+
+      it do
+        expect(administrateur.registration_state).to eq('Actif')
+        expect(administrateur.invitation_expired?).to be false
+      end
+    end
+
+    context 'when the password invitation is still valid' do
+      before { user.send(:set_reset_password_token) }
+
+      it do
+        expect(administrateur.registration_state).to eq('En attente')
+        expect(administrateur.invitation_expired?).to be false
+      end
+    end
+
+    context 'when the password invitation has expired' do
+      it do
+        expect(administrateur.registration_state).to eq('Expiré')
+        expect(administrateur.invitation_expired?).to be true
+      end
+    end
+
+    context 'when the administrateur was invited through ProConnect' do
+      before { administrateur.update!(pro_connect_required_at: Time.zone.now) }
+
+      it 'never expires' do
+        expect(administrateur.registration_state).to eq('En attente')
+        expect(administrateur.invitation_expired?).to be false
+      end
+    end
+  end
+
   describe '#pro_connect_required?' do
     let(:administrateur) { administrateurs.blank }
 

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -316,44 +316,34 @@ describe Administrateur, type: :model do
     end
   end
 
-  describe '#registration_state and #invitation_expired?' do
+  describe '#registration_state' do
     let(:administrateur) { administrateurs.blank }
     let(:user) { administrateur.user }
 
     before { allow(ProConnectService).to receive(:enabled?).and_return(true) }
 
+    subject { administrateur.registration_state }
+
     context 'when the administrateur has already signed in' do
       before { user.update!(last_sign_in_at: Time.zone.now) }
 
-      it do
-        expect(administrateur.registration_state).to eq('Actif')
-        expect(administrateur.invitation_expired?).to be false
-      end
+      it { is_expected.to eq('Actif') }
     end
 
     context 'when the password invitation is still valid' do
       before { user.send(:set_reset_password_token) }
 
-      it do
-        expect(administrateur.registration_state).to eq('En attente')
-        expect(administrateur.invitation_expired?).to be false
-      end
+      it { is_expected.to eq('En attente') }
     end
 
     context 'when the password invitation has expired' do
-      it do
-        expect(administrateur.registration_state).to eq('Expiré')
-        expect(administrateur.invitation_expired?).to be true
-      end
+      it { is_expected.to eq('Expiré') }
     end
 
     context 'when the administrateur was invited through ProConnect' do
       before { administrateur.update!(pro_connect_required_at: Time.zone.now) }
 
-      it 'never expires' do
-        expect(administrateur.registration_state).to eq('En attente')
-        expect(administrateur.invitation_expired?).to be false
-      end
+      it { is_expected.to eq('En attente') }
     end
   end
 

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -315,4 +315,32 @@ describe Administrateur, type: :model do
       expect(Archive.exists?(archive.id)).to eq(false)
     end
   end
+
+  describe '#pro_connect_required?' do
+    let(:administrateur) { administrateurs.blank }
+
+    before { allow(ProConnectService).to receive(:enabled?).and_return(true) }
+
+    subject { administrateur.pro_connect_required? }
+
+    it { is_expected.to be false }
+
+    context 'when the administrateur was created with ProConnect required' do
+      before { administrateur.update!(pro_connect_required_at: Time.zone.now) }
+
+      it { is_expected.to be true }
+
+      context 'but ProConnect is not enabled on this instance' do
+        before { allow(ProConnectService).to receive(:enabled?).and_return(false) }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'when ProConnect is required for all administrateurs' do
+      before { Flipper.enable(:pro_connect_required_for_all_administrateurs) }
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/models/gestionnaire_spec.rb
+++ b/spec/models/gestionnaire_spec.rb
@@ -58,6 +58,17 @@ describe Gestionnaire, type: :model do
 
       it { is_expected.to eq 'Expiré' }
     end
+
+    context "when invited through ProConnect" do
+      let!(:gestionnaire) { create(:gestionnaire) }
+
+      before do
+        allow(ProConnectService).to receive(:enabled?).and_return(true)
+        gestionnaire.user.create_administrateur!(pro_connect_required_at: Time.zone.now)
+      end
+
+      it { is_expected.to eq 'En attente' }
+    end
   end
 
   describe "#by_email" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -341,6 +341,40 @@ describe User, type: :model do
     end
   end
 
+  describe 'invite_gestionnaire!' do
+    let(:administrateur) { administrateurs.default }
+    let(:user) { administrateur.user }
+    let(:groupe_gestionnaire) { create(:groupe_gestionnaire) }
+    let(:mailer_double) { double('mailer', deliver_later: true) }
+
+    before do
+      allow(UserMailer).to receive(:invite_gestionnaire).and_return(mailer_double)
+      allow(UserMailer).to receive(:invite_gestionnaire_via_pro_connect).and_return(mailer_double)
+    end
+
+    subject { user.invite_gestionnaire!(groupe_gestionnaire) }
+
+    it 'receives an invitation to choose a password' do
+      subject
+
+      expect(UserMailer).to have_received(:invite_gestionnaire).with(user, kind_of(String), groupe_gestionnaire)
+    end
+
+    context 'when the administrateur must use ProConnect' do
+      before do
+        allow(ProConnectService).to receive(:enabled?).and_return(true)
+        administrateur.update!(pro_connect_required_at: Time.zone.now)
+      end
+
+      it 'receives a ProConnect invitation without any reset password token' do
+        expect { subject }.not_to change { user.reload.reset_password_token }
+
+        expect(UserMailer).to have_received(:invite_gestionnaire_via_pro_connect).with(user, groupe_gestionnaire)
+        expect(UserMailer).not_to have_received(:invite_gestionnaire)
+      end
+    end
+  end
+
   describe '#active?' do
     let!(:user) { create(:user) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -375,6 +375,29 @@ describe User, type: :model do
     end
   end
 
+  describe '#send_reset_password_instructions' do
+    let(:administrateur) { administrateurs.default }
+    let(:user) { administrateur.user }
+
+    subject { user.send_reset_password_instructions }
+
+    it 'sends the Devise instructions' do
+      expect { subject }.to have_enqueued_mail(DeviseUserMailer, :reset_password_instructions)
+    end
+
+    context 'when the administrateur must use ProConnect' do
+      before do
+        allow(ProConnectService).to receive(:enabled?).and_return(true)
+        administrateur.update!(pro_connect_required_at: Time.zone.now)
+      end
+
+      it 'sends to ProConnect without any reset password token' do
+        expect { subject }.to have_enqueued_mail(UserMailer, :reset_password_via_pro_connect)
+          .and not_change { user.reload.reset_password_token }
+      end
+    end
+  end
+
   describe '#active?' do
     let!(:user) { create(:user) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -324,6 +324,21 @@ describe User, type: :model do
         expect(AdministrationMailer).to have_received(:invite_admin).with(user, kind_of(String))
       end
     end
+
+    context 'when the administrateur must use ProConnect' do
+      before do
+        allow(ProConnectService).to receive(:enabled?).and_return(true)
+        administrateur.update!(pro_connect_required_at: Time.zone.now)
+        allow(AdministrationMailer).to receive(:invite_admin_via_pro_connect).and_return(mailer_double)
+      end
+
+      it 'receives a ProConnect invitation without any reset password token' do
+        expect { subject }.not_to change { user.reload.reset_password_token }
+
+        expect(AdministrationMailer).to have_received(:invite_admin_via_pro_connect).with(user)
+        expect(AdministrationMailer).not_to have_received(:invite_admin)
+      end
+    end
   end
 
   describe '#active?' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -275,6 +275,28 @@ describe User, type: :model do
     end
   end
 
+  describe '.create_or_promote_to_administrateur' do
+    subject { User.create_or_promote_to_administrateur('nouvel-admin@exemple.fr', SECURE_PASSWORD) }
+
+    before { freeze_time }
+
+    context 'when ProConnect is enabled on this instance' do
+      before { allow(ProConnectService).to receive(:enabled?).and_return(true) }
+
+      it 'creates an administrateur who must use ProConnect' do
+        expect(subject.administrateur.pro_connect_required_at).to eq(Time.zone.now)
+      end
+    end
+
+    context 'when ProConnect is not enabled on this instance' do
+      before { allow(ProConnectService).to receive(:enabled?).and_return(false) }
+
+      it 'creates an administrateur who may use a password' do
+        expect(subject.administrateur.pro_connect_required_at).to be_nil
+      end
+    end
+  end
+
   describe 'invite_administrateur!' do
     let(:super_admin) { create(:super_admin) }
     let(:administrateur) { administrateurs.default }

--- a/spec/system/administrateurs/admin_creation_spec.rb
+++ b/spec/system/administrateurs/admin_creation_spec.rb
@@ -12,32 +12,49 @@ describe 'As an administrateur', js: true do
     WebMock.stub_request(:get, /https:\/\/matrix.agent.tchap.gouv.fr\/_matrix\/identity\/api\/v1\/info\?address=(.*)&medium=email/)
       .to_return(body: body, status: 200)
 
+    allow(ProConnectService).to receive(:enabled?).and_return(pro_connect_enabled)
+
     perform_enqueued_jobs do
       super_admin.invite_admin(admin_email)
     end
   end
 
-  scenario 'I can register' do
-    expect(new_admin.reload.user.active?).to be(false)
+  context 'when the instance has no ProConnect' do
+    let(:pro_connect_enabled) { false }
 
-    confirmation_email = open_email(admin_email)
-    token_params = confirmation_email.body.match(/token=[^"]+/)
+    scenario 'I can register' do
+      expect(new_admin.reload.user.active?).to be(false)
 
-    visit "admin/activate?#{token_params}"
+      confirmation_email = open_email(admin_email)
+      token_params = confirmation_email.body.match(/token=[^"]+/)
 
-    fill_in :user_password, with: weak_password
+      visit "admin/activate?#{token_params}"
 
-    expect(page).to have_text('Mot de passe très vulnérable')
-    expect(page).to have_button('Créer un compte', disabled: true)
+      fill_in :user_password, with: weak_password
 
-    fill_in :user_password, with: strong_password
-    expect(page).to have_text('Mot de passe suffisamment fort et sécurisé')
-    expect(page).to have_button('Créer un compte', disabled: false)
+      expect(page).to have_text('Mot de passe très vulnérable')
+      expect(page).to have_button('Créer un compte', disabled: true)
 
-    click_button 'Créer un compte'
+      fill_in :user_password, with: strong_password
+      expect(page).to have_text('Mot de passe suffisamment fort et sécurisé')
+      expect(page).to have_button('Créer un compte', disabled: false)
 
-    expect(page).to have_content 'Mot de passe enregistré'
+      click_button 'Créer un compte'
 
-    expect(new_admin.reload.user.active?).to be(true)
+      expect(page).to have_content 'Mot de passe enregistré'
+
+      expect(new_admin.reload.user.active?).to be(true)
+    end
+  end
+
+  context 'when the instance has ProConnect' do
+    let(:pro_connect_enabled) { true }
+
+    scenario 'I am invited to sign in with ProConnect' do
+      invitation_email = open_email(admin_email)
+
+      expect(invitation_email).to have_link(href: pro_connect_url(force_pro_connect: true))
+      expect(invitation_email.body).not_to include('token=')
+    end
   end
 end

--- a/spec/system/sessions/sign_in_spec.rb
+++ b/spec/system/sessions/sign_in_spec.rb
@@ -32,6 +32,27 @@ describe 'Signin in:' do
     end
   end
 
+  context 'when the user is an administrateur who must use ProConnect' do
+    let(:admin) { administrateurs.default }
+
+    before do
+      allow(ProConnectService).to receive(:enabled?).and_return(true)
+      Flipper.enable(:pro_connect_required_for_all_administrateurs)
+    end
+
+    scenario 'the password is refused and ProConnect is offered instead' do
+      visit root_path
+      click_on 'Se connecter', match: :first
+
+      try_sign_in_with admin.email, users.default_password
+
+      expect(page).to have_current_path(pro_connect_path(force_pro_connect: true))
+      expect(page).to have_content('Vous devez utiliser ProConnect pour vous connecter.')
+      expect(page).to have_link('S’identifier avec ProConnect')
+      expect(page).not_to have_field(:user_password)
+    end
+  end
+
   scenario 'an existing user can lock its account' do
     visit root_path
     click_on 'Se connecter', match: :first


### PR DESCRIPTION
**Nouveaux comptes** (actif dès le déploiement, sur toute instance où ProConnect est configuré)
- Un administrateur créé depuis le manager, par un gestionnaire, par un co-admin (GraphQL) ou par `superadmin:create` porte `pro_connect_required_at`.
- Son invitation (et celle d’un gestionnaire, qui est aussi admin) pointe vers ProConnect, sans lien d’activation ni jeton. Le rappel à J+3 renvoie cette invitation. Dans le manager, l’état reste « En attente » et « renvoyer l’invitation » est proposé tant que le compte ne s’est pas connecté.

**Tous les comptes** (flag Flipper `pro_connect_required_for_all_administrateurs`, activable par pourcentage d’acteurs ou par `User;<id>`)

**Refus de toute connexion hors ProConnect** pour un compte soumis
- Formulaire de connexion : Devise vérifie le mot de passe, puis on déconnecte et on redirige vers la page ProConnect. Un mot de passe faux garde le message générique, lockable compte comme avant, et rien n’est enregistré côté trackable.
- Lien d’activation, lien de reset, inscription expert : redirection dès la présentation du jeton, sans écrire de mot de passe.
- « Mot de passe oublié » : le compte reçoit un mail l’orientant vers ProConnect au lieu d’un lien de reset ; la page reste neutre pour ne pas révéler l’existence du compte.

## Points d’attention

- Aucune décision n’est prise avant une preuve (mot de passe vérifié, jeton, jeton de confirmation) : pas d’énumération des comptes admin.
- Secours : retirer `PRO_CONNECT_BASE_URL` désactive toute l’obligation ; le flag couvre le palier « tous ».
- Limites assumées : un cookie « se souvenir de moi » ou une session ouverts avant l’activation restent valables jusqu’à expiration ; `superadmin:create` continue de poser un mot de passe, utile sans ProConnect.