### PR TITLE
Correctif: ETQ usager, faire fonctionner les conditions sur une case à cocher décochée

### DIFF
--- a/app/components/dossiers/edit_footer_component.rb
+++ b/app/components/dossiers/edit_footer_component.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Dossiers::EditFooterComponent < ApplicationComponent
-  delegate :can_passer_en_construction?, :can_transition_to_en_construction?, :user_buffer_changes?, to: :@dossier
+  delegate :can_passer_en_construction?, :can_submit_modifications?,
+           :can_transition_to_en_construction?, :user_buffer_changes?, to: :@dossier
 
   def initialize(dossier:, annotation:)
     @dossier = dossier
@@ -36,6 +37,12 @@ class Dossiers::EditFooterComponent < ApplicationComponent
     @dossier.en_construction?
   end
 
+  # Reads the rule the button below applies, so the link shows exactly when it is
+  # the ineligibilite that disables it.
+  def ineligibilite_blocks_submit?
+    can_submit_draft? ? !can_passer_en_construction? : !can_submit_modifications?
+  end
+
   def submit_button_label
     if can_submit_draft?
       t('.submit')
@@ -60,10 +67,12 @@ class Dossiers::EditFooterComponent < ApplicationComponent
     end
   end
 
+  # fr-opened must stay present for the click to work, "true" would open the modal
+  # as soon as DSFR initializes.
   def disabled_submit_button_options
     {
       class: 'fr-text--sm fr-mb-0 fr-mr-2w',
-      data: { 'fr-opened': "true" },
+      data: { 'fr-opened': "false" },
       aria: { controls: 'modal-eligibilite-rules-dialog', haspopup: 'dialog' },
       role: :button,
     }
@@ -79,7 +88,7 @@ class Dossiers::EditFooterComponent < ApplicationComponent
   end
 
   def submit_en_construction_button_options
-    disabled = !can_passer_en_construction? || !user_buffer_changes?
+    disabled = !can_submit_modifications? || !user_buffer_changes?
 
     {
       class: 'fr-btn',

--- a/app/components/dossiers/edit_footer_component/edit_footer_component.html.haml
+++ b/app/components/dossiers/edit_footer_component/edit_footer_component.html.haml
@@ -8,7 +8,7 @@
 
           - if show_for_user?
             - if show_submit?
-              - if !can_passer_en_construction?
+              - if ineligibilite_blocks_submit?
                 %li.dossier-edit-footer--ineligibilite-link.fr-mt-1w.fr-mb-2w= link_to t('.submit_disabled'), "#", disabled_submit_button_options
 
               %li= button_to submit_button_label, submit_button_path, submit_button_options

--- a/app/components/dossiers/invalid_ineligibilite_rules_component.rb
+++ b/app/components/dossiers/invalid_ineligibilite_rules_component.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 class Dossiers::InvalidIneligibiliteRulesComponent < ApplicationComponent
-  delegate :can_passer_en_construction?, to: :dossier
-
   def initialize(dossier:, wrapped: true)
     @dossier = dossier
     @revision = dossier.revision
-
-    @opened = !dossier.can_passer_en_construction?
     @wrapped = wrapped
   end
 
@@ -23,6 +19,8 @@ class Dossiers::InvalidIneligibiliteRulesComponent < ApplicationComponent
     dossier.revision.ineligibilite_message
   end
 
-  def opened? = @opened
+  # The alert only speaks about champs the usager wrote.
+  def opened? = !dossier.can_submit_modifications?
+
   def wrapped? = @wrapped
 end

--- a/app/components/dossiers/invalid_ineligibilite_rules_component.rb
+++ b/app/components/dossiers/invalid_ineligibilite_rules_component.rb
@@ -3,7 +3,6 @@
 class Dossiers::InvalidIneligibiliteRulesComponent < ApplicationComponent
   def initialize(dossier:, wrapped: true)
     @dossier = dossier
-    @revision = dossier.revision
     @wrapped = wrapped
   end
 
@@ -19,8 +18,13 @@ class Dossiers::InvalidIneligibiliteRulesComponent < ApplicationComponent
     dossier.revision.ineligibilite_message
   end
 
-  # The alert only speaks about champs the usager wrote.
-  def opened? = !dossier.can_submit_modifications?
+  # The alert only speaks about champs the usager wrote. Each read walks the
+  # whole rule tree; ||= would not memoize a false.
+  def opened?
+    return @opened if defined?(@opened)
+
+    @opened = !dossier.can_submit_modifications?
+  end
 
   def wrapped? = @wrapped
 end

--- a/app/controllers/instructeurs/edit_controller.rb
+++ b/app/controllers/instructeurs/edit_controller.rb
@@ -31,7 +31,7 @@ module Instructeurs
       dossier.champs_public_valid?
 
       @demande_seen_at = current_instructeur.follows.find_by(dossier:)&.demande_seen_at
-      @can_confirm = dossier.errors.blank? && dossier.can_passer_en_construction?
+      @can_confirm = dossier.errors.blank? && dossier.can_submit_modifications?
 
       respond_to do |format|
         format.turbo_stream do
@@ -43,7 +43,7 @@ module Instructeurs
     def submit
       dossier.champs_public_valid?
 
-      if dossier.errors.blank? && dossier.can_passer_en_construction?
+      if dossier.errors.blank? && dossier.can_submit_modifications?
         dossier.instructeur_submit_en_construction!(instructeur: current_instructeur, motivation: submit_params[:motivation])
 
         redirect_to instructeur_dossier_path(dossier.procedure, dossier, statut: params[:statut])

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -294,7 +294,7 @@ module Users
 
       dossier.champs_public_valid?
 
-      if dossier.errors.blank? && dossier.can_passer_en_construction?
+      if dossier.errors.blank? && dossier.can_submit_modifications?
         dossier.submitted_with_france_connect = current_user.loged_in_with_france_connect.present?
         dossier.submitted_with_pro_connect = logged_in_with_pro_connect?
         dossier.usager_submit_en_construction!
@@ -308,8 +308,9 @@ module Users
     def check_completude
       @dossier = dossier_with_champs
       dossier.champs_public_valid?
+      submittable = dossier.brouillon? ? dossier.can_passer_en_construction? : dossier.can_submit_modifications?
 
-      if @dossier.errors.blank? && @dossier.can_passer_en_construction?
+      if @dossier.errors.blank? && submittable
         flash.notice = t('.success')
         if dossier.brouillon?
           redirect_to brouillon_dossier_path(@dossier)

--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -226,6 +226,9 @@ class ChampData < ApplicationRecord
 
   def blank_for_condition? = blank?
 
+  # True when the value comes from the type rather than from the usager.
+  def implicit_value? = false
+
   def last_write_type_champ
     TypeDeChamp::CHAMP_TYPE_TO_TYPE_CHAMP.fetch(type)
   end

--- a/app/models/champs/checkbox_champ.rb
+++ b/app/models/champs/checkbox_champ.rb
@@ -5,6 +5,11 @@ class Champs::CheckboxChamp < Champs::BooleanChamp
   # condition on it reads « Non » rather than « pas de reponse ».
   def blank_for_condition? = false
 
+  # Untouched, the row holds nil: unchecking posts 'false' through the hidden
+  # field. value_updated_at, set on user writes only, covers a write normalized
+  # back to nil. A prefilled value is real data, not implicit.
+  def implicit_value? = value.nil? && self[:value_updated_at].nil?
+
   def legend_label?
     false
   end

--- a/app/models/champs/checkbox_champ.rb
+++ b/app/models/champs/checkbox_champ.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Champs::CheckboxChamp < Champs::BooleanChamp
+  # A checkbox has no empty state: untouched, it displays unchecked, so a
+  # condition on it reads « Non » rather than « pas de reponse ».
+  def blank_for_condition? = false
+
   def legend_label?
     false
   end

--- a/app/models/champs/multiple_drop_down_list_champ.rb
+++ b/app/models/champs/multiple_drop_down_list_champ.rb
@@ -11,9 +11,8 @@ class Champs::MultipleDropDownListChamp < ChampData
     selected_options
   end
 
-  def selected_options
-    value.blank? ? [] : JSON.parse(value)
-  end
+  # One reading for both paths: champ_blank? goes through the type de champ.
+  def selected_options = TypesDeChamp::MultipleDropDownListTypeDeChamp.parse_selected_options(self)
 
   def render_as_checkboxes?
     drop_down_options.size <= THRESHOLD_NB_OPTIONS_AS_CHECKBOX

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -419,8 +419,9 @@ module DossierChampsConcern
     if data.class != type_de_champ.champ_class
       data = data.becomes!(type_de_champ.champ_class)
       # external_state must be reset too: a champ left "fetched" with nil data
-      # crashes the components rendering the fetched external data
-      data.assign_attributes(value: nil, value_json: nil, external_id: nil, data: nil, external_state: nil, fetch_external_data_exceptions: [])
+      # crashes the components rendering the fetched external data. So must
+      # value_updated_at, which would date a write made under the previous type.
+      data.assign_attributes(value: nil, value_json: nil, external_id: nil, data: nil, external_state: nil, fetch_external_data_exceptions: [], value_updated_at: nil)
     elsif !main_stream? && data.previously_new_record?
       main_stream_data = champ_data.find_by(stable_id: type_de_champ.stable_id, row_id:, stream: Dossier::MAIN_STREAM)
       data.clone_value_from(main_stream_data) if main_stream_data.present?

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -588,10 +588,17 @@ class Dossier < ApplicationRecord
     procedure.publiee? && procedure.feature_enabled?(:blocking_pending_correction) && pending_correction?
   end
 
+  # Guards the brouillon deposit and the AASM transition: the rule applies whole,
+  # implicit answers included.
   def can_passer_en_construction?
-    return true if !revision.ineligibilite_enabled || !revision.ineligibilite_rules
+    !ineligibilite_triggered?(filled_champs_public)
+  end
 
-    !revision.ineligibilite_rules.compute(filled_champs_public)
+  # Guards the other doors: the usager editing a deposited dossier, the
+  # instructeur correcting one. They were deposited under a rule blind to an
+  # implicit answer, so it must not close them now.
+  def can_submit_modifications?
+    !ineligibilite_triggered?(filled_champs_public.reject(&:implicit_value?))
   end
 
   def can_passer_en_instruction?
@@ -1156,6 +1163,12 @@ class Dossier < ApplicationRecord
       # commit un état partiel (champs deja batch-destroy, dossier intact).
       raise ActiveRecord::Rollback
     end
+  end
+
+  def ineligibilite_triggered?(champs)
+    return false if !revision.ineligibilite_enabled || !revision.ineligibilite_rules
+
+    revision.ineligibilite_rules.compute(champs)
   end
 
   def build_default_champs

--- a/app/models/logic/champ_column_value.rb
+++ b/app/models/logic/champ_column_value.rb
@@ -22,6 +22,9 @@ class Logic::ChampColumnValue < Logic::Term
     # and the dropdown is other, return other
     if targeted_champ.is_type?(column.tdc_type) && targeted_champ.drop_down_list? && targeted_champ.other?
       Champs::DropDownListChamp::OTHER
+    # the column reads the raw value, nil on a checkbox nobody touched
+    elsif targeted_champ.is_type?(column.tdc_type) && targeted_champ.checkbox?
+      targeted_champ.condition_value
     else
       column.value(targeted_champ)
     end

--- a/app/models/logic/champ_column_value.rb
+++ b/app/models/logic/champ_column_value.rb
@@ -18,6 +18,9 @@ class Logic::ChampColumnValue < Logic::Term
 
     column = targeted_column([targeted_champ.type_de_champ])
 
+    # the rule outlived the column it targets, #errors reports it as :not_available
+    return nil if column.nil?
+
     # if it s a dropdown champ and a dropdown tdc (no cast)
     # and the dropdown is other, return other
     if targeted_champ.is_type?(column.tdc_type) && targeted_champ.drop_down_list? && targeted_champ.other?

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -416,6 +416,9 @@ class TypeDeChamp < ApplicationRecord
     end
   end
 
+  # Not condition predicates: these drive ChampData#blank?, the :missing error,
+  # "Non renseigné" and the export/API/tag defaults. Conditions go through
+  # ChampData#blank_for_condition? — do not specialize these to fix one.
   def typed_champ_blank?(champ) = champ.value.blank?
   def typed_champ_blank_or_invalid?(champ) = typed_champ_blank?(champ)
 

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -55,13 +55,16 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypesDeChamp::DropDownBase
 
   def typed_champ_blank?(champ) = selected_options(champ).blank?
 
+  # JSON.parse('42') returns an Integer rather than raising: a champ last written
+  # under another type holds a scalar, which is no selection.
   def self.parse_selected_options(champ)
     return [] if champ.value.blank?
 
     if champ.is_type?(TypeDeChamp.type_champs.fetch(:drop_down_list))
       [champ.value]
     else
-      JSON.parse(champ.value)
+      parsed = JSON.parse(champ.value)
+      parsed.is_a?(Array) ? parsed : []
     end
   rescue JSON::ParserError
     []

--- a/spec/components/dossiers/edit_footer_component_spec.rb
+++ b/spec/components/dossiers/edit_footer_component_spec.rb
@@ -41,12 +41,14 @@ RSpec.describe Dossiers::EditFooterComponent, type: :component do
     end
   end
 
+  # A deposited dossier is guarded by can_submit_modifications?, not by
+  # can_passer_en_construction?: the deposit already happened.
   context 'when en construction' do
     let(:dossier) { create(:dossier, :en_construction) }
     before { allow(dossier).to receive(:user_buffer_changes?).and_return(true) }
 
     context 'when dossier can be submitted' do
-      before { allow(component).to receive(:can_passer_en_construction?).and_return(true) }
+      before { allow(component).to receive(:can_submit_modifications?).and_return(true) }
 
       it 'renders submit button without disabled' do
         expect(subject).to have_selector('button', text: 'Déposer les modifications')
@@ -54,7 +56,7 @@ RSpec.describe Dossiers::EditFooterComponent, type: :component do
     end
 
     context 'when dossier can not be submitted' do
-      before { allow(component).to receive(:can_passer_en_construction?).and_return(false) }
+      before { allow(component).to receive(:can_submit_modifications?).and_return(false) }
 
       it 'renders submit button with disabled' do
         expect(subject).to have_selector('a', text: 'Pourquoi je ne peux pas déposer mon dossier ?')

--- a/spec/models/champs/drop_down_list_champ_spec.rb
+++ b/spec/models/champs/drop_down_list_champ_spec.rb
@@ -58,6 +58,35 @@ describe Champs::DropDownListChamp do
         end
       end
     end
+
+    describe 'completeness' do
+      let(:public_type_de_champs) { [{ type: :drop_down_list, mandatory: true, drop_down_other: true, referentiel:, drop_down_mode: }] }
+
+      subject { champ.validate(:champ_completeness) }
+
+      context 'when nothing is selected' do
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when an option is selected' do
+        let(:value) { 'val1' }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'when « Autre » is selected but no text is typed' do
+        let(:other) { true }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when « Autre » is selected and a text is typed' do
+        let(:other) { true }
+        let(:value) { 'something else' }
+
+        it { is_expected.to be_truthy }
+      end
+    end
   end
 
   describe 'value' do

--- a/spec/models/concerns/champ_conditional_concern_spec.rb
+++ b/spec/models/concerns/champ_conditional_concern_spec.rb
@@ -77,6 +77,53 @@ describe ChampConditionalConcern do
         end
       end
     end
+
+    context 'when the condition targets a single checkbox' do
+      let(:procedure) do
+        create(:procedure, public_type_de_champs: [
+          { type: :checkbox, stable_id: 1 },
+          { type: :text, stable_id: 2, condition: },
+        ])
+      end
+      let(:dossier) { create(:dossier, procedure:) }
+      let(:checkbox) { dossier.champ_data.find { it.stable_id == 1 } }
+      let(:conditional_champ) { dossier.reload.root_champs_public.find { it.stable_id == 2 } }
+
+      context 'on « Non »' do
+        let(:condition) { ds_eq(champ_value(1), constant(false)) }
+
+        it 'is visible while the checkbox is untouched' do
+          expect(conditional_champ.visible?).to be true
+        end
+
+        it 'is visible once the checkbox has been checked then unchecked' do
+          checkbox.update!(value: 'true')
+          checkbox.update!(value: 'false')
+
+          expect(conditional_champ.visible?).to be true
+        end
+
+        it 'is hidden while the checkbox is checked' do
+          checkbox.update!(value: 'true')
+
+          expect(conditional_champ.visible?).to be false
+        end
+      end
+
+      context 'on « Oui »' do
+        let(:condition) { ds_eq(champ_value(1), constant(true)) }
+
+        it 'is hidden while the checkbox is untouched' do
+          expect(conditional_champ.visible?).to be false
+        end
+
+        it 'is visible once the checkbox is checked' do
+          checkbox.update!(value: 'true')
+
+          expect(conditional_champ.visible?).to be true
+        end
+      end
+    end
   end
 
   describe '#submitted_filled?' do

--- a/spec/models/dossier_ineligibilite_spec.rb
+++ b/spec/models/dossier_ineligibilite_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+describe 'Dossier#can_submit_modifications?' do
+  include Logic
+
+  let(:procedure) do
+    create(:procedure, :published, public_type_de_champs: [
+      { type: :checkbox, libelle: 'certifie', stable_id: 1 },
+      { type: :text, libelle: 'texte', stable_id: 2 },
+    ])
+  end
+  let(:dossier) { create(:dossier, procedure:) }
+  let(:checkbox) { dossier.champ_data.find { it.stable_id == 1 } }
+  let(:texte) { dossier.champ_data.find { it.stable_id == 2 } }
+
+  before do
+    procedure.published_revision.update!(
+      ineligibilite_enabled: true,
+      ineligibilite_message: 'non éligible',
+      ineligibilite_rules: ds_eq(champ_value(1), constant(false))
+    )
+  end
+
+  context 'when the dossier is untouched, its champ rows existing since creation' do
+    it 'stays modifiable, but the deposit of the brouillon stays closed' do
+      expect(dossier.reload.can_submit_modifications?).to be true
+      expect(dossier.can_passer_en_construction?).to be false
+    end
+  end
+
+  context 'when the usager filled another champ' do
+    before { texte.update!(value: 'coucou') && texte.update_timestamps }
+
+    it 'stays modifiable' do
+      expect(dossier.reload.can_submit_modifications?).to be true
+    end
+  end
+
+  context 'when the usager checked then unchecked the box, leaving only a write trace' do
+    before do
+      checkbox.update!(value: 'true')
+      checkbox.update_timestamps
+      checkbox.update!(value: 'false')
+    end
+
+    it 'is closed' do
+      expect(dossier.reload.can_submit_modifications?).to be false
+      expect(dossier.can_passer_en_construction?).to be false
+    end
+  end
+
+  context 'when the box was prefilled to the ineligible value' do
+    before { checkbox.update!(value: 'false', prefilled: true) }
+
+    it 'is closed, prefilled data being real data' do
+      expect(dossier.reload.can_submit_modifications?).to be false
+    end
+  end
+
+  context 'when the usager checked the box' do
+    before do
+      checkbox.update!(value: 'true')
+      checkbox.update_timestamps
+    end
+
+    it 'stays modifiable and opens the deposit' do
+      expect(dossier.reload.can_submit_modifications?).to be true
+      expect(dossier.can_passer_en_construction?).to be true
+    end
+  end
+
+  context 'when the dossier has already been submitted, its checkbox never touched' do
+    let(:dossier) { create(:dossier, :en_construction, procedure:) }
+
+    it 'leaves the usager and the instructeur free to modify it' do
+      expect(dossier.reload.can_submit_modifications?).to be true
+    end
+  end
+
+  context 'with a drop_down_list on « Autre », blank? yet answered, in the undated user buffer' do
+    let(:procedure) do
+      create(:procedure, :published, public_type_de_champs: [
+        { type: :drop_down_list, stable_id: 1, drop_down_options: ['a', 'b'], drop_down_other: true },
+      ])
+    end
+    let(:dossier) { create(:dossier, :en_construction, procedure:) }
+
+    before do
+      procedure.published_revision.update!(ineligibilite_rules: ds_eq(champ_value(1), constant(Champs::DropDownListChamp::OTHER)))
+
+      dossier.with_update_stream(dossier.user) do
+        champ = dossier.champ_for_update(dossier.revision.type_de_champs.first, updated_by: dossier.user.email)
+        champ.assign_attributes(value: Champs::DropDownListChamp::OTHER)
+        Dossier.no_touching { champ.save }
+        champ.update_timestamps
+      end
+      dossier.reload
+    end
+
+    it 'is closed' do
+      dossier.with_update_stream(dossier.user) do
+        expect(dossier.can_submit_modifications?).to be false
+      end
+    end
+  end
+
+  context 'with a yes_no rule instead, which yields no value until answered' do
+    let(:procedure) do
+      create(:procedure, :published, public_type_de_champs: [{ type: :yes_no, libelle: 'majeur', stable_id: 1 }])
+    end
+
+    before do
+      procedure.published_revision.update!(ineligibilite_rules: ds_eq(champ_value(1), constant(true)))
+    end
+
+    context 'when the dossier is untouched' do
+      it 'stays modifiable and leaves the deposit open' do
+        expect(dossier.reload.can_submit_modifications?).to be true
+        expect(dossier.can_passer_en_construction?).to be true
+      end
+    end
+
+    context 'when the usager answered Oui' do
+      before { dossier.champ_data.find { it.stable_id == 1 }.update!(value: 'true') }
+
+      it 'is closed and blocks the deposit' do
+        expect(dossier.reload.can_submit_modifications?).to be false
+        expect(dossier.can_passer_en_construction?).to be false
+      end
+    end
+  end
+
+  context 'when ineligibilite is disabled' do
+    before { procedure.published_revision.update!(ineligibilite_enabled: false) }
+
+    it { expect(dossier.reload.can_submit_modifications?).to be true }
+  end
+end

--- a/spec/models/logic/champ_column_value_spec.rb
+++ b/spec/models/logic/champ_column_value_spec.rb
@@ -67,6 +67,26 @@ describe Logic::ChampColumnValue do
     end
   end
 
+  describe '#compute with a checkbox, which has no empty state unlike a yes_no' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :checkbox, libelle: 'case' }]) }
+    let(:column) { procedure.find_column(label: 'case') }
+    let(:champ_column_value) { Logic::ChampColumnValue.new(column.stable_id, column.column_id) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+
+    context 'when the checkbox is checked' do
+      before { champ.update!(value: 'true') }
+
+      it { expect(champ_column_value.compute([champ])).to be(true) }
+    end
+
+    context 'when the checkbox is explicitly unchecked' do
+      before { champ.update!(value: 'false') }
+
+      it { expect(champ_column_value.compute([champ])).to be(false) }
+    end
+  end
+
   describe '#sources' do
     it { expect(champ_column_value.sources).to eq([column.stable_id]) }
   end

--- a/spec/models/logic/champ_value_spec.rb
+++ b/spec/models/logic/champ_value_spec.rb
@@ -92,6 +92,13 @@ describe Logic::ChampValue do
 
           it { is_expected.to eq(Champs::DropDownListChamp::OTHER) }
         end
+
+        context 'with other selected but no text, which is still an answer' do
+          let(:other) { true }
+          let(:value) { nil }
+
+          it { is_expected.to eq(Champs::DropDownListChamp::OTHER) }
+        end
       end
     end
 
@@ -133,6 +140,12 @@ describe Logic::ChampValue do
       it do
         expect(champ_value(champ.stable_id).type([champ.type_de_champ])).to eq(:boolean)
         is_expected.to eq(true)
+      end
+
+      context 'with false value' do
+        let(:value) { 'false' }
+
+        it { is_expected.to be(false) }
       end
     end
 

--- a/spec/models/logic/unanswered_champ_spec.rb
+++ b/spec/models/logic/unanswered_champ_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+conditionable_types = [
+  :checkbox,
+  :yes_no,
+  :integer_number,
+  :decimal_number,
+  :drop_down_list,
+  :multiple_drop_down_list,
+  :pre_rempli,
+  :communes,
+  :epci,
+  :departements,
+  :regions,
+  :pays,
+  :address,
+]
+
+describe 'an unanswered champ triggers no operator' do
+  include Logic
+
+  def computed_on_every_column(champ, procedure)
+    champ.type_de_champ.columns(procedure_id: procedure.id).to_h do |column|
+      [column.column_id, Logic::ChampColumnValue.new(column.stable_id, column.column_id).compute([champ])]
+    end
+  end
+
+  conditionable_types.each do |type_champ|
+    context "on a blank #{type_champ}" do
+      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: type_champ }]) }
+      let(:dossier) { create(:dossier, procedure:) }
+      let(:champ) { dossier.champ_data.first }
+      # A checkbox has no empty state: untouched, it answers « Non ».
+      let(:expected) { type_champ == :checkbox ? false : nil }
+
+      it 'computes nothing, on either term and on any of its columns' do
+        expect(champ_value(champ.stable_id).compute([champ])).to eq(expected)
+
+        computed_on_every_column(champ, procedure).each do |column_id, computed|
+          expect(computed).to(eq(expected), "#{column_id} computed #{computed.inspect}")
+        end
+      end
+    end
+  end
+
+  context 'on a blank multiple_drop_down_list in advanced mode, whose columns read value_json' do
+    let(:referentiel) { create(:csv_referentiel, :with_items) }
+    let(:procedure) do
+      create(:procedure, public_type_de_champs: [{ type: :multiple_drop_down_list, referentiel:, drop_down_mode: 'advanced' }])
+    end
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+
+    it 'computes nil rather than the empty join of its JSON path' do
+      expect(computed_on_every_column(champ, procedure).values).to all(be_nil)
+    end
+  end
+
+  context 'on a half-filled champ the type still reports as unanswered' do
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+    let(:column) { champ.type_de_champ.canonical_column(procedure_id: procedure.id) }
+
+    subject do
+      [
+        champ_value(champ.stable_id).compute([champ]),
+        Logic::ChampColumnValue.new(column.stable_id, column.column_id).compute([champ]),
+      ]
+    end
+
+    context 'an address typed in free text, never resolved against the BAN' do
+      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :address }]) }
+
+      before { champ.update_column(:value, '12 rue de la Paix') }
+
+      it { is_expected.to eq([nil, nil]) }
+    end
+
+    context 'a multiple_drop_down_list holding an empty JSON array' do
+      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :multiple_drop_down_list }]) }
+
+      before { champ.update_column(:value, '[]') }
+
+      it { is_expected.to eq([nil, nil]) }
+    end
+
+    context 'a region holding a code no name resolved against, blank? yet not nil' do
+      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :regions }]) }
+
+      before { champ.update_columns(value: nil, external_id: 'XX') }
+
+      it { is_expected.to eq([nil, nil]) }
+    end
+
+    context 'a yes_no left as an empty string' do
+      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :yes_no }]) }
+
+      before { champ.update_column(:value, '') }
+
+      it { is_expected.to eq([nil, nil]) }
+    end
+  end
+
+  context 'on a rule that outlived the column it targets' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :checkbox }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+
+    it 'computes nil rather than raising on the missing column' do
+      expect(Logic::ChampColumnValue.new(champ.stable_id, 'gone').compute([champ])).to be_nil
+    end
+  end
+
+  context 'on an answered champ whose type defines no condition_value' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :siret }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+    let(:column) do
+      champ.type_de_champ.columns(procedure_id: procedure.id).find { it.try(:jsonpath) == '$.department_code' }
+    end
+
+    before { champ.update_columns(value: '13001650200018', value_json: { 'department_code' => '13' }) }
+
+    it 'still computes its column, which a routing rule can target' do
+      expect(Logic::ChampColumnValue.new(column.stable_id, column.column_id).compute([champ.reload])).to eq('13')
+    end
+  end
+
+  context 'on a multiple_drop_down_list holding a value written under another type' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :multiple_drop_down_list }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+
+    let(:column) { champ.type_de_champ.canonical_column(procedure_id: procedure.id) }
+
+    ['plain text, not JSON', '42', '"une chaine"', 'true'].each do |raw|
+      context "when it holds #{raw}" do
+        before { champ.update_column(:value, raw) }
+
+        it 'computes nil on both terms, not a scalar the operators cannot handle' do
+          expect(champ_value(champ.reload.stable_id).compute([champ.reload])).to be_nil
+          expect(Logic::ChampColumnValue.new(column.stable_id, column.column_id).compute([champ.reload])).to be_nil
+        end
+      end
+    end
+  end
+
+  context 'on a drop_down_list set to « Autre » with no text, which is an answer' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :drop_down_list, drop_down_other: true }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+    let(:column) { champ.type_de_champ.canonical_column(procedure_id: procedure.id) }
+
+    before { champ.update!(value: Champs::DropDownListChamp::OTHER) }
+
+    it 'computes OTHER on both terms' do
+      expect(champ_value(champ.stable_id).compute([champ])).to eq(Champs::DropDownListChamp::OTHER)
+      expect(Logic::ChampColumnValue.new(column.stable_id, column.column_id).compute([champ]))
+        .to eq(Champs::DropDownListChamp::OTHER)
+    end
+  end
+end

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -523,6 +523,32 @@ describe 'The user', js: true do
       end
     end
 
+    context 'with a condition on a single checkbox being unchecked' do
+      let(:stable_id) { 999 }
+      let(:condition) { ds_eq(champ_value(stable_id), constant(false)) }
+      let(:procedure) do
+        create(:procedure, :published, :for_individual,
+          public_type_de_champs: [
+            { type: :checkbox, libelle: 'champ_a', mandatory: false, stable_id: },
+            { type: :text, libelle: 'champ_b', mandatory: false, condition: },
+          ])
+      end
+
+      scenario 'the conditional champ shows from the start, the untouched box already reading « Non »' do
+        log_in_fast(user, procedure)
+
+        expect(page).to have_css('label', text: 'champ_b', visible: true)
+
+        find('label', text: 'champ_a').click # check
+        wait_for_autosave
+        expect(page).to have_no_css('label', text: 'champ_b', visible: true)
+
+        find('label', text: 'champ_a').click # uncheck
+        wait_for_autosave
+        expect(page).to have_css('label', text: 'champ_b', visible: true)
+      end
+    end
+
     context 'with a required conditionnal champ' do
       let(:stable_id) { 999 }
       let(:condition) { greater_than_eq(champ_value(stable_id), constant(18)) }

--- a/spec/system/users/dossier_ineligibilite_spec.rb
+++ b/spec/system/users/dossier_ineligibilite_spec.rb
@@ -183,6 +183,39 @@ describe 'Dossier Inéligibilité', js: true do
     end
   end
 
+  describe 'ineligibilite_rules on a single checkbox, which has no empty state' do
+    let(:public_type_de_champs) { [{ type: :checkbox, libelle: 'certifie', stable_id: 1 }] }
+    let(:ineligibilite_rules) { ds_eq(champ_value(1), constant(false)) }
+
+    scenario "n'alerte pas à l'arrivée, alerte une fois la case décochée" do
+      visit brouillon_dossier_path(dossier)
+      expect(page).to have_selector('label', text: 'certifie')
+      expect(page).to have_no_selector('#modal-eligibilite-rules-dialog', visible: true)
+      expect(page).to have_selector(:button, text: "Déposer le dossier", disabled: true)
+
+      find('label', text: 'certifie').click # coche
+      wait_for_autosave
+      expect(page).to have_no_selector('#modal-eligibilite-rules-dialog', visible: true)
+      expect(page).to have_selector(:button, text: "Déposer le dossier", disabled: false)
+
+      find('label', text: 'certifie').click # décoche
+      wait_for_autosave
+      expect(page).to have_selector('#modal-eligibilite-rules-dialog', visible: true)
+      expect(page).to have_content(ineligibilite_message)
+      expect(page).to have_selector(:button, text: "Déposer le dossier", disabled: true)
+    end
+
+    scenario "laisse ouvrir l'explication à la demande, et garde le dépôt bloqué" do
+      visit brouillon_dossier_path(dossier)
+      expect(page).to have_no_selector('#modal-eligibilite-rules-dialog', visible: true)
+
+      click_on "Pourquoi je ne peux pas déposer mon dossier ?"
+      expect(page).to have_selector('#modal-eligibilite-rules-dialog', visible: true)
+
+      expect(dossier.reload.can_passer_en_construction?).to be false
+    end
+  end
+
   describe 'ineligibilite_rules does not mess with champs.visible' do
     let(:public_type_de_champs) do
       [

--- a/spec/views/shared/dossiers/_edit.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_edit.html.haml_spec.rb
@@ -168,17 +168,39 @@ describe 'shared/dossiers/edit', type: :view do
     end
   end
 
-  context 'when dossier transitions rules are computable and passer_en_construction is false' do
-    let(:public_type_de_champs) { [] }
+  context 'when the ineligibilite rules are met' do
+    include Logic
+
+    let(:public_type_de_champs) { [{ type: :checkbox, stable_id: 1 }] }
     let(:dossier) { create(:dossier, procedure:) }
 
     before do
-      allow(dossier).to receive(:can_passer_en_construction?).and_return(false)
-      allow(dossier.revision).to receive(:ineligibilite_enabled?).and_return(true)
+      dossier.revision.update!(
+        ineligibilite_enabled: true,
+        ineligibilite_message: 'non éligible',
+        ineligibilite_rules: ds_eq(champ_value(1), constant(false))
+      )
     end
 
-    it 'renders broken transitions rules dialog' do
-      expect(subject).to have_selector("#ineligibilite_rules_modal [data-fr-opened='true']")
+    context 'thanks to a champ the usager answered, here a box checked then unchecked' do
+      before do
+        champ = dossier.champ_data.first
+        champ.update!(value: 'true')
+        champ.update_timestamps
+        champ.update!(value: 'false')
+        dossier.reload
+      end
+
+      it 'renders broken transitions rules dialog' do
+        expect(subject).to have_selector("#ineligibilite_rules_modal [data-fr-opened='true']")
+      end
+    end
+
+    context 'on an untouched dossier, where only the implicit « Non » makes them met' do
+      it 'closes the deposit without opening the dialog' do
+        expect(dossier.can_passer_en_construction?).to be false
+        expect(subject).to have_no_selector("#ineligibilite_rules_modal [data-fr-opened='true']")
+      end
     end
   end
 end


### PR DESCRIPTION
# Problème

Remonté par un usager : *« conditionner l'affichage d'un champ à la valeur "Non" d'une "Case à cocher seule" ne fonctionne pas, le champ n'est jamais affiché. »*

Une case à cocher a deux états visibles mais trois états stockés. `nil` est écarté comme vide : le terme logique calcule `nil`, et `BinaryOperator#compute` (`l&.send(operation, r) || false`) renvoie `false` quel que soit l'opérateur.

| état stocké | condition « Non » avant | après |
|---|---|---|
| jamais touchée (`nil`) | **fausse** | vraie |
| décochée après avoir été cochée (`'false'`, posté par le hidden field) | vraie | vraie |
| cochée (`'true'`) | fausse | fausse |

Une condition « Non » est donc fausse tant que la case n'a pas été touchée — l'état d'arrivée sur le formulaire — et ne devient vraie qu'après un aller-retour coché/décoché que personne ne fait : d'où « jamais affiché ». Vaut pour l'affichage conditionnel, l'inéligibilité et le routage, sans contournement admin. Un `yes_no` a un vrai état vide, il n'est pas concerné.

# Solution

**Une case décochée répond « Non »**, là où la question se pose déjà — `blank_for_condition? = false` sur `Champs::CheckboxChamp`, et la même branche sur le chemin colonne qu'emprunte le routage.

**Une réponse implicite n'alerte personne et ne ferme aucune modification.** Corollaire du premier commit : la règle « case décochée » étant vraie dès l'ouverture, l'usager était accueilli par la modale « vous ne pouvez pas déposer votre dossier » avant d'avoir rien rempli. Un champ portant une réponse jamais donnée le dit (`implicit_value?`) et `can_submit_modifications?` lit la règle sans ces champs.

Le dépôt d'un brouillon lit toujours la règle entière : c'est ce que l'administrateur a configuré. Mais `can_passer_en_construction?` gardait quatre autres portes — l'usager modifiant un dossier déposé, l'instructeur le corrigeant — que la réponse implicite aurait fermées **rétroactivement**, sur des dossiers déposés sous une règle qui ne la voyait pas. Chaque appelant nomme désormais sa porte, l'alerte et le footer compris. Le lien du footer portait par ailleurs un `fr-opened: "true"` en dur qui ouvrait la modale dès l'init de DSFR ; il redevient un déclencheur au clic.

Trois commits annexes, détaillés dans leurs messages : deux bugs sortis en balayant les 13 types conditionnables sur chacune de leurs colonnes (une règle survivant à la colonne qu'elle cible, un scalaire rendu par `JSON.parse` atteignant `exclude?`) ; `value_updated_at` remis à zéro quand une révision change le type d'un champ ; la mémoïsation de l'alerte.

# Impact en production

Mesuré sur un réplica : 687 comparaisons portant sur une case à cocher, sur **92 démarches publiées**, sont aujourd'hui fausses tant que la case n'a pas été touchée et vont se mettre à répondre juste dès l'ouverture. Aucune condition qui fonctionne aujourd'hui ne change de résultat.

| nature | démarches | rétroactif ? |
|---|---|---|
| règle d'inéligibilité | 78 | non — le dépôt d'un brouillon reste gardé, un dossier déjà déposé reste modifiable |
| affichage conditionnel | 9 | **oui** — `visible?` est calculé au rendu |
| règle de routage | 5 | **oui pour les brouillons en cours** |

Aucun dossier déposé n'est re-routé (`groupe_instructeur_id` est stocké), mais `RoutingEngine.compute` tourne au dépôt et à chaque autosave d'un champ de routage sur un brouillon : les brouillons de ces 5 démarches seront routés selon la nouvelle lecture. C'est le correctif qui s'applique, mais ce n'est pas un no-op.

Sur les 78 démarches à inéligibilité, le bouton de dépôt sera fermé dès l'arrivée avec le lien « Pourquoi je ne peux pas déposer mon dossier ? » — ce que l'administrateur a configuré, même si **rendre la case obligatoire** serait le bon outil pour ce motif (« je certifie sur l'honneur »).

**Limite connue** — la nouvelle lecture suppose une ligne `champ_data`. Un dossier rebasé n'en a pas pour un type de champ ajouté par la révision : le terme y vaut `nil` et la règle reste muette, là où un dossier créé après la publication la déclenche. Antérieur à cette PR, et toujours dans ce sens — une règle qui ne s'applique pas, jamais un dossier bloqué. Décrit dans #13837, hors périmètre ici.

**À valider en relecture** — le bouton est désactivé dès le premier rendu alors que la modale ne s'ouvre plus toute seule : plus d'explication automatique, seul le lien du footer y mène, mais il est rendu dès que le dépôt est fermé et un clic suffit. Idem sur un `Et` dont un opérande est une case jamais touchée : règle vraie, bouton grisé, modale silencieuse même après que l'usager a répondu au reste.

Generated with [Claude Code](https://claude.com/claude-code)
