### PR TITLE
ETQ usager, je peux changer mon mot de passe en restant connecté

### DIFF
--- a/app/controllers/concerns/profil_context_concern.rb
+++ b/app/controllers/concerns/profil_context_concern.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Les pages du profil sont atteignables depuis tous les espaces. Le paramètre
+# `context` préserve la barre de navigation de l'espace d'origine.
+#
+# Surcharge le `nav_bar_profile` vide de NavBarProfileConcern, qui fournit par
+# ailleurs le repli utilisé ici (`fallback_nav_bar_profile`).
+module ProfilContextConcern
+  extend ActiveSupport::Concern
+
+  ALLOWED_NAV_BAR_PROFILES = [:user, :instructeur, :administrateur, :expert, :gestionnaire].freeze
+
+  # Doit rester publique : _header.haml et _breadcrumbs.html.erb l'appellent
+  # via controller.try(:nav_bar_profile).
+  def nav_bar_profile
+    context = params[:context]&.to_sym
+    return context if ALLOWED_NAV_BAR_PROFILES.include?(context)
+    fallback_nav_bar_profile.presence || :user
+  end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -6,6 +6,7 @@ class Users::PasswordsController < Devise::PasswordsController
   after_action :try_to_authenticate_instructeur, only: [:update]
   after_action :try_to_authenticate_administrateur, only: [:update]
   after_action :update_email_verified_at, only: [:update]
+  after_action :notify_password_change, only: [:update]
 
   # GET /resource/password/new
   # def new
@@ -68,5 +69,13 @@ class Users::PasswordsController < Devise::PasswordsController
     if user_signed_in?
       current_user.update!(email_verified_at: Time.zone.now)
     end
+  end
+
+  # L'after_action s'execute aussi quand la reinitialisation echoue : Devise
+  # rend alors la vue avec des erreurs sur resource.
+  def notify_password_change
+    return if resource.blank? || resource.errors.any?
+
+    UserMailer.password_changed(resource).deliver_later
   end
 end

--- a/app/controllers/users/profil_controller.rb
+++ b/app/controllers/users/profil_controller.rb
@@ -3,17 +3,10 @@
 module Users
   class ProfilController < UserController
     include FranceConnectConcern
-
-    ALLOWED_NAV_BAR_PROFILES = [:user, :instructeur, :administrateur, :expert, :gestionnaire].freeze
+    include ProfilContextConcern
 
     before_action :ensure_update_email_is_authorized, only: :update_email
     before_action :find_transfers, only: [:show]
-
-    def nav_bar_profile
-      context = params[:context]&.to_sym
-      return context if ALLOWED_NAV_BAR_PROFILES.include?(context)
-      fallback_nav_bar_profile.presence || :user
-    end
 
     def show
       @france_connect_informations = FranceConnectInformation.where(user: current_user)

--- a/app/controllers/users/profil_passwords_controller.rb
+++ b/app/controllers/users/profil_passwords_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Users
+  # Namespace volontairement plat. Un contrôleur à trois niveaux
+  # (Users::Profil::PasswordsController) casse la résolution relative de
+  # contrôleur de `current_page?` dans les partials de navigation partagés :
+  # Rails ne remonte que d'un segment et cherche
+  # `users/administrateurs/procedures`.
+  class ProfilPasswordsController < UserController
+    include ProfilContextConcern
+
+    def edit
+    end
+
+    def update
+      return render_blank_password if password_params[:password].blank?
+
+      if current_user.update_with_password(password_params)
+        bypass_sign_in(current_user)
+        UserMailer.password_changed(current_user).deliver_later
+        flash.notice = t('.success')
+        redirect_to profil_path(context: params[:context])
+      else
+        render :edit, status: :unprocessable_content
+      end
+    end
+
+    # Devise interdit tout le parcours « mot de passe oublié » a un utilisateur
+    # connecté (require_no_authentication sur new, create, edit et update), y
+    # compris le lien reçu par mail. On le déconnecte donc explicitement plutôt
+    # que de lever ce garde-fou pour toute l'application.
+    def forgot
+      sign_out(current_user)
+
+      flash.notice = t('.signed_out')
+      # 303 : Turbo transforme le lien en soumission de formulaire, et ne suit
+      # la redirection d'un POST que sur un See Other.
+      redirect_to new_user_password_path, status: :see_other
+    end
+
+    private
+
+    # Devise retire password et password_confirmation des params quand le
+    # nouveau mot de passe est vide, et update({}) renvoie alors true.
+    def render_blank_password
+      current_user.errors.add(:password, :blank)
+      render :edit, status: :unprocessable_content
+    end
+
+    def password_params
+      params.require(:user).permit(:current_password, :password, :password_confirmation)
+    end
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -119,6 +119,13 @@ class UserMailer < ApplicationMailer
     mail(to: user.email, subject: @subject)
   end
 
+  def password_changed(user)
+    @user = user
+    @subject = default_i18n_subject
+
+    mail(to: user.email, subject: @subject)
+  end
+
   def self.critical_email?(action_name)
     [
       'france_connect_merge_confirmation',
@@ -128,6 +135,7 @@ class UserMailer < ApplicationMailer
       "invite_tiers",
       "resend_confirmation_email",
       "custom_confirmation_instructions",
+      "password_changed",
     ].include?(action_name)
   end
 end

--- a/app/views/user_mailer/password_changed.html.haml
+++ b/app/views/user_mailer/password_changed.html.haml
@@ -1,0 +1,22 @@
+- content_for(:title, @subject)
+
+%p
+  Bonjour,
+
+%p
+  Le mot de passe du compte #{APPLICATION_NAME} associé à l’adresse
+  %strong= @user.email
+  vient d’être modifié. Par sécurité, toutes les autres sessions ouvertes sur ce
+  compte ont été déconnectées.
+
+%p
+  Si vous êtes à l’origine de ce changement, vous n’avez rien à faire.
+
+%p
+  Dans le cas contraire, votre compte est peut-être compromis : demandez
+  immédiatement un nouveau mot de passe, puis contactez le support.
+
+= dsfr_button('Demander un nouveau mot de passe', new_user_password_url, :primary)
+= vertical_margin(6)
+
+= render partial: "layouts/mailers/signature"

--- a/app/views/users/profil/show.html.haml
+++ b/app/views/users/profil/show.html.haml
@@ -45,6 +45,11 @@
       = render Dsfr::InputComponent.new(form: f, attribute: :email, input_type: :email_field, opts: { value: nil, placeholder: t('.new_email_address') })
       = f.submit t('.change_address'), class: 'fr-btn fr-btn--secondary'
 
+  .card
+    .card-title= t('.password_title')
+    %p= t('.password_explication')
+    = link_to t('.change_password'), edit_profil_password_path(context: params[:context]), class: 'fr-btn fr-btn--secondary'
+
   - if !instructeur_signed_in?
     .card
       .card-title= t('.transfer_title')

--- a/app/views/users/profil_passwords/edit.html.haml
+++ b/app/views/users/profil_passwords/edit.html.haml
@@ -1,0 +1,44 @@
+- content_for(:title, t('.title'))
+
+= render partial: 'shared/breadcrumbs_section',
+  locals: { steps: [[t('users.profil.show.profile'), profil_path(context: params[:context])], [t('.title')]] }
+
+.fr-container.fr-my-5w
+  .fr-grid-row
+    .fr-col-lg-6
+      %h1= t('.title')
+
+      - if current_user.france_connect_informations.any?
+        = render Dsfr::AlertComponent.new(title: t('.france_connect_title'), state: :info, heading_level: 'h2', extra_class_names: 'fr-mb-4w') do |c|
+          - c.with_body do
+            %p= t('.france_connect_body')
+
+      = form_for current_user, as: :user, url: profil_password_path(context: params[:context]), method: :patch do |f|
+        %fieldset.fr-mb-0.fr-fieldset
+          .fr-fieldset__element
+            %p.fr-text--sm= t('utils.asterisk_html')
+
+          .fr-fieldset__element
+            = render Dsfr::InputComponent.new(form: f, attribute: :current_password, input_type: :password_field,
+              opts: { autocomplete: 'current-password' })
+
+          .fr-fieldset__element
+            = render Dsfr::InputComponent.new(form: f, attribute: :password, input_type: :password_field,
+              opts: { autocomplete: 'new-password',
+                data: { controller: 'turbo-input', turbo_input_url_value: show_password_complexity_path },
+                aria: { describedby: 'password_hint' } })
+
+            #password_complexity
+              = render PasswordComplexityComponent.new
+
+          .fr-fieldset__element
+            = render Dsfr::InputComponent.new(form: f, attribute: :password_confirmation, input_type: :password_field)
+
+        = f.submit t('.submit'), id: 'submit-password', disabled: :disabled, class: 'fr-btn fr-btn--lg fr-mt-2w', data: { disable_with: t('.submit_loading') }
+
+      -# Hors du formulaire : button_to genere son propre <form>, et les
+      -# formulaires imbriques sont interdits en HTML.
+      .fr-mt-4w
+        %h2.fr-h6= t('.forgot_title')
+        %p.fr-hint-text= t('.forgot_hint')
+        = button_to t('.forgot_current_password'), forgot_profil_password_path, class: 'fr-btn fr-btn--secondary'

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -27,6 +27,14 @@ class Rack::Attack
     end
   end
 
+  # Devise `lockable` n'incremente `failed_attempts` que lors d'une
+  # authentification : `update_with_password` echappe au verrouillage.
+  throttle('profil/mot-de-passe/ip', limit: 5, period: 60.seconds) do |req|
+    if req.path == '/profil/mot-de-passe' && req.patch? && rack_attack_enabled?
+      req.remote_ip
+    end
+  end
+
   # API prefill
   throttle('/api/public/v1/dossiers/ip', limit: 15, period: 15.seconds) do |req|
     if req.path == '/api/public/v1/dossiers' && req.post? && rack_attack_enabled?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -728,6 +728,7 @@ en:
       default_attributes: &default_attributes
         email: Email
         password: 'Password'
+        current_password: 'Current password'
         requested_merge_into: 'new email address'
         hints:
           email: 'Example: address@mail.com'
@@ -794,7 +795,11 @@ en:
               blank: 'is empty. Fill in the email'
               invalid: 'is invalid. Fill in a valid email address, example: address@mail.com'
               taken: 'already in use. Fill in another email'
+            current_password:
+              blank: 'is empty. Fill in your current password'
+              invalid: 'is incorrect. Fill in your current password'
             password:
+              blank: 'is empty. Fill in a new password'
               too_short: "is too short. Fill in a password with at least 12 characters"
               not_strong: "not strong enough. Fill in a stronger password"
             password_confirmation:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -738,6 +738,7 @@ fr:
       default_attributes: &default_attributes
         email: Adresse électronique
         password: 'Mot de passe'
+        current_password: 'Mot de passe actuel'
         requested_merge_into: 'La nouvelle adresse électronique'
         hints:
           email: 'Exemple : adresse@mail.com'
@@ -805,7 +806,11 @@ fr:
               blank: 'est vide. Saisissez une adresse électronique'
               invalid: 'est invalide. Saisissez une adresse électronique valide. Exemple : adresse@mail.com'
               taken: 'déjà utilisé. Saisir une autre adresse électronique.'
+            current_password:
+              blank: 'est vide. Saisir votre mot de passe actuel'
+              invalid: 'est incorrect. Saisir votre mot de passe actuel'
             password:
+              blank: 'est vide. Saisir un nouveau mot de passe'
               too_short: "est trop court. Saisir un mot de passe avec au moins 12 caractères"
               not_strong: "n’est pas assez complexe. Saisir un mot de passe plus complexe"
             password_confirmation:

--- a/config/locales/views/user_mailer/en.yml
+++ b/config/locales/views/user_mailer/en.yml
@@ -22,5 +22,7 @@ en:
       subject: "Your account will be deleted in %{remaining_weeks} weeks"
     notify_after_closing:
       subject: "Closing of a procedure on %{application_name}"
+    password_changed:
+      subject: Your account password has been changed
     account_reactivated:
       subject: Your account has been reactivated

--- a/config/locales/views/user_mailer/fr.yml
+++ b/config/locales/views/user_mailer/fr.yml
@@ -22,5 +22,7 @@ fr:
       subject: "Votre compte sera supprimé dans %{remaining_weeks} semaines"
     notify_after_closing:
       subject: "Clôture d’une démarche sur %{application_name}"
+    password_changed:
+      subject: Le mot de passe de votre compte a été modifié
     account_reactivated:
       subject: Votre compte a été réactivé

--- a/config/locales/views/users/profil/en.yml
+++ b/config/locales/views/users/profil/en.yml
@@ -1,5 +1,19 @@
 en:
   users:
+    profil_passwords:
+      edit:
+        title: Change my password
+        forgot_title: You do not know your current password?
+        forgot_current_password: Reset my password
+        forgot_hint: You will be signed out, then you will receive an email link to choose a new password.
+        france_connect_title: Your FranceConnect login is not affected
+        france_connect_body: This change only applies to your account password. Logging in through FranceConnect will keep working exactly as before.
+        submit: Change the password
+        submit_loading: Changing…
+      forgot:
+        signed_out: You have been signed out. Fill in your email address to receive a reset link.
+      update:
+        success: Your password has been changed. Any other session opened on your account has been signed out.
     profil:
       show:
         profile: Profile
@@ -7,6 +21,9 @@ en:
         your_email: Your current email is
         new_email_address: New email address
         change_address: Change my address
+        password_title: Password
+        password_explication: You can change your account password at any time. Any other open session will then be signed out.
+        change_password: Change my password
         transfer_title: Transfer all your files
         transfer_explication_html: "<p>This feature allows you to change the owner of all your files. This is usually useful when changing jobs or if you want to merge several accounts.</p>"
         transfer_next_owner_label: "Email of the next owner of your files"

--- a/config/locales/views/users/profil/fr.yml
+++ b/config/locales/views/users/profil/fr.yml
@@ -1,5 +1,19 @@
 fr:
   users:
+    profil_passwords:
+      edit:
+        title: Modifier mon mot de passe
+        forgot_title: Vous ne connaissez pas votre mot de passe actuel ?
+        forgot_current_password: Réinitialiser mon mot de passe
+        forgot_hint: Vous serez déconnecté, puis vous recevrez un lien par e-mail pour choisir un nouveau mot de passe.
+        france_connect_title: Votre connexion FranceConnect n’est pas concernée
+        france_connect_body: Ce changement ne porte que sur le mot de passe de votre compte. Votre connexion via FranceConnect continuera de fonctionner à l’identique.
+        submit: Changer le mot de passe
+        submit_loading: Modification en cours…
+      forgot:
+        signed_out: Vous avez été déconnecté. Saisissez votre adresse électronique pour recevoir un lien de réinitialisation.
+      update:
+        success: Votre mot de passe a bien été modifié. Toute autre session ouverte sur votre compte a été déconnectée.
     profil:
       show:
         profile: Profil
@@ -7,6 +21,9 @@ fr:
         new_email_address: Nouvelle adresse électronique
         your_email: Votre adresse électronique actuelle
         change_address: Changer mon adresse
+        password_title: Mot de passe
+        password_explication: Vous pouvez modifier à tout moment le mot de passe de votre compte. Toute autre session ouverte sera alors déconnectée.
+        change_password: Modifier mon mot de passe
         transfer_title: Transférer tous vos dossiers
         transfer_explication_html: "<p>Cette fonctionnalité vous permet de changer le propriétaire de tous vos dossiers. C’est généralement utile lors d’un changement de poste ou si vous souhaitez fusionner plusieurs comptes.</p>"
         transfer_next_owner_label: "Adresse électronique du prochain propriétaire de tous vos dossiers"

--- a/config/routes/usager.rb
+++ b/config/routes/usager.rb
@@ -94,6 +94,9 @@ scope module: 'users', defaults: { nav_bar_profile: :user } do
   patch 'personnalisation', to: 'dossiers#update_personnalisation'
 
   get 'profil' => 'profil#show'
+  get 'profil/mot-de-passe' => 'profil_passwords#edit', as: :edit_profil_password
+  patch 'profil/mot-de-passe' => 'profil_passwords#update', as: :profil_password
+  post 'profil/mot-de-passe/oubli' => 'profil_passwords#forgot', as: :forgot_profil_password
   patch 'update_email' => 'profil#update_email'
   post 'transfer_all_dossiers' => 'profil#transfer_all_dossiers'
   post 'accept_merge' => 'profil#accept_merge'

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -87,4 +87,26 @@ describe Users::PasswordsController, type: :controller do
       end
     end
   end
+
+  describe 'password change notification' do
+    include ActiveJob::TestHelper
+
+    let(:user) { create(:user) }
+
+    context 'when the reset succeeds' do
+      let(:token) { user.send(:set_reset_password_token) }
+
+      it 'notifies the user' do
+        expect { put :update, params: { user: { reset_password_token: token, password: SECURE_PASSWORD, password_confirmation: SECURE_PASSWORD } } }
+          .to have_enqueued_mail(UserMailer, :password_changed)
+      end
+    end
+
+    context 'when the token is invalid' do
+      it 'does not notify anyone' do
+        expect { put :update, params: { user: { reset_password_token: 'nope', password: SECURE_PASSWORD, password_confirmation: SECURE_PASSWORD } } }
+          .not_to have_enqueued_mail(UserMailer, :password_changed)
+      end
+    end
+  end
 end

--- a/spec/controllers/users/profil_passwords_controller_spec.rb
+++ b/spec/controllers/users/profil_passwords_controller_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+describe Users::ProfilPasswordsController, type: :controller do
+  include ActiveJob::TestHelper
+
+  let(:user) { users.usager }
+  let(:current_password) { users.default_password }
+  let(:new_password) { 'un nouveau mot de passe bien long !' }
+
+  before { sign_in(user) }
+
+  # La page est rendue ici parce que l'encart FranceConnect et l'affichage des
+  # erreurs sous les champs sont des exigences de conception qu'aucune autre
+  # spec ne couvre.
+  describe '#edit' do
+    render_views
+
+    it 'renders the form' do
+      get :edit
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Mot de passe actuel')
+      expect(response.body).to include('Réinitialiser mon mot de passe')
+    end
+
+    context 'when the account is linked to FranceConnect' do
+      before { create(:france_connect_information, user: user) }
+
+      it 'reassures the user that FranceConnect is not affected' do
+        get :edit
+
+        expect(response.body).to include('Votre connexion FranceConnect n’est pas concernée')
+      end
+    end
+  end
+
+  describe '#update' do
+    subject(:update_request) do
+      patch :update, params: { user: { current_password: submitted_current, password: submitted_new, password_confirmation: submitted_confirmation } }
+    end
+
+    let(:submitted_current) { current_password }
+    let(:submitted_new) { new_password }
+    let(:submitted_confirmation) { new_password }
+
+    context 'with valid params' do
+      it 'changes the password' do
+        expect { update_request }.to change { user.reload.encrypted_password }
+        expect(response).to redirect_to(profil_path)
+      end
+
+      # `bypass_sign_in` n'appelle pas warden.set_user : il ne réécrit que le
+      # session serializer. Asserter sur controller.current_user ne prouverait
+      # donc rien, l'objet en mémoire restant le même. C'est le sel stocké en
+      # session qui doit suivre le nouveau mot de passe.
+      it 'refreshes the session so the user stays signed in' do
+        update_request
+        expect(session['warden.user.user.key'].last).to eq(user.reload.authenticatable_salt)
+      end
+
+      it 'notifies the user' do
+        expect { update_request }.to have_enqueued_mail(UserMailer, :password_changed)
+      end
+    end
+
+    shared_examples 'a rejected change' do
+      it 'does not change the password and re-renders the form' do
+        expect { update_request }.not_to change { user.reload.encrypted_password }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it 'does not notify the user' do
+        expect { update_request }.not_to have_enqueued_mail(UserMailer, :password_changed)
+      end
+    end
+
+    context 'with a wrong current password, rendering the page' do
+      render_views
+
+      let(:submitted_current) { 'ce n’est pas le bon mot de passe' }
+
+      it 'shows the error under the field' do
+        update_request
+
+        expect(response.body).to include('est incorrect')
+      end
+    end
+
+    context 'with a wrong current password' do
+      let(:submitted_current) { 'ce n’est pas le bon mot de passe' }
+
+      it_behaves_like 'a rejected change'
+    end
+
+    # Cas d'un compte créé via FranceConnect : son propriétaire n'a pas de mot
+    # de passe à saisir.
+    context 'with a blank current password' do
+      let(:submitted_current) { '' }
+
+      it_behaves_like 'a rejected change'
+    end
+
+    # Devise supprime password et password_confirmation des params quand le
+    # nouveau mot de passe est vide, puis update({}) renvoie true : sans la
+    # garde du contrôleur, ce cas produirait un faux succès et une fausse
+    # alerte de sécurité.
+    context 'with a blank new password' do
+      let(:submitted_new) { '' }
+      let(:submitted_confirmation) { '' }
+
+      it_behaves_like 'a rejected change'
+    end
+
+    context 'with a mismatched confirmation' do
+      let(:submitted_confirmation) { 'autre chose de tout aussi long' }
+
+      it_behaves_like 'a rejected change'
+    end
+
+    context 'with a weak new password' do
+      let(:submitted_new) { '000000000000' }
+      let(:submitted_confirmation) { '000000000000' }
+
+      it_behaves_like 'a rejected change'
+    end
+  end
+
+  describe '#forgot' do
+    it 'signs the user out and sends them to the reset form' do
+      post :forgot
+
+      expect(controller.current_user).to be_nil
+      expect(session['warden.user.user.key']).to be_nil
+      expect(response).to redirect_to(new_user_password_path)
+      expect(response).to have_http_status(:see_other)
+    end
+  end
+
+  describe '#nav_bar_profile' do
+    let(:user) { create(:instructeur).user }
+
+    it 'honours the context parameter' do
+      get :edit, params: { context: 'instructeur' }
+      expect(controller.nav_bar_profile).to eq(:instructeur)
+    end
+  end
+end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -47,6 +47,10 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.account_reactivated(user)
   end
 
+  def password_changed
+    UserMailer.password_changed(user)
+  end
+
   private
 
   def user

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -206,4 +206,19 @@ RSpec.describe UserMailer, type: :mailer do
       expect(subject.body).to have_link('Se connecter', href: new_user_session_url)
     end
   end
+
+  describe '.password_changed' do
+    subject { described_class.password_changed(user) }
+
+    it 'sends a security notification to the user' do
+      expect(subject.to).to eq([user.email])
+      expect(subject.subject).to eq('Le mot de passe de votre compte a été modifié')
+      expect(subject.body).to include(user.email)
+      expect(subject.body).to have_link('Demander un nouveau mot de passe')
+    end
+
+    it 'is a critical email' do
+      expect(described_class.critical_email?('password_changed')).to be true
+    end
+  end
 end

--- a/spec/requests/users/profil_passwords_spec.rb
+++ b/spec/requests/users/profil_passwords_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe 'Users::ProfilPasswords', type: :request do
+  before { login_as user, scope: :user }
+
+  # Le layout complet est rendu ici parce que la barre de navigation partagée
+  # appelle current_page?(controller: 'administrateurs/procedures'). Rails
+  # résout ce contrôleur relativement au contrôleur courant : un namespace à
+  # trois niveaux le ferait chercher users/administrateurs/procedures et lever
+  # une UrlGenerationError.
+  describe 'GET /profil/mot-de-passe' do
+    context 'as a usager' do
+      let(:user) { users.usager }
+
+      it 'renders' do
+        get edit_profil_password_path
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'in the administrateur context' do
+      let(:user) { administrateurs.default.user }
+
+      it 'renders the administrateur navigation' do
+        get edit_profil_password_path(context: 'administrateur')
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(admin_procedures_path)
+      end
+    end
+
+    context 'in the instructeur context' do
+      let(:user) { instructeurs.default.user }
+
+      it 'renders the instructeur navigation' do
+        get edit_profil_password_path(context: 'instructeur')
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/system/users/managing_password_spec.rb
+++ b/spec/system/users/managing_password_spec.rb
@@ -105,6 +105,74 @@ describe 'Managing password:', js: true do
     end
   end
 
+  context 'from the profile page' do
+    let(:user) { users.usager }
+    let(:weak_password) { '000000000000' }
+    let(:strong_password) { 'a new, long, and complicated password!' }
+
+    before { login_as user, scope: :user }
+
+    scenario 'a signed-in user changes their password' do
+      visit profil_path
+      click_on 'Modifier mon mot de passe'
+
+      fill_in 'Mot de passe actuel', with: users.default_password
+      fill_in 'user_password', with: weak_password
+      fill_in 'user_password_confirmation', with: weak_password
+      expect(page).to have_text('Mot de passe très vulnérable')
+      expect(page).to have_button('Changer le mot de passe', disabled: true)
+
+      fill_in 'user_password', with: strong_password
+      fill_in 'user_password_confirmation', with: strong_password
+      expect(page).to have_text('Mot de passe suffisamment fort et sécurisé')
+
+      perform_enqueued_jobs { click_on 'Changer le mot de passe' }
+      expect(page).to have_current_path(profil_path)
+      expect(page).to have_content('Votre mot de passe a bien été modifié')
+
+      # La session courante doit survivre au changement : sans bypass_sign_in,
+      # Devise deconnecte l'utilisateur au prochain chargement de page.
+      visit dossiers_path
+      expect(page).to have_current_path(dossiers_path)
+    end
+
+    # Devise refuse tout le parcours « mot de passe oublié » a un utilisateur
+    # connecté, lien reçu par mail compris. Ce scénario va donc jusqu'au bout
+    # pour garantir qu'aucune étape ne rebondit vers l'accueil.
+    scenario 'a user who does not know their current password resets it' do
+      visit edit_profil_password_path
+
+      click_on 'Réinitialiser mon mot de passe'
+      expect(page).to have_current_path(new_user_password_path)
+
+      fill_in 'Adresse électronique', with: user.email
+      perform_enqueued_jobs { click_on 'Demander un nouveau mot de passe' }
+      expect(page).to have_text 'nous vous avons envoyé un email'
+
+      click_reset_password_link_for user.email
+      expect(page).to have_content 'Changement de mot de passe'
+
+      fill_in 'user_password', with: strong_password
+      fill_in 'user_password_confirmation', with: strong_password
+      click_on 'Changer le mot de passe'
+
+      expect(page).to have_content('Votre mot de passe a bien été modifié.')
+      expect(user.reload.valid_password?(strong_password)).to be true
+    end
+
+    scenario 'a wrong current password is rejected' do
+      visit edit_profil_password_path
+
+      fill_in 'Mot de passe actuel', with: 'ce n’est pas le bon mot de passe'
+      fill_in 'user_password', with: strong_password
+      fill_in 'user_password_confirmation', with: strong_password
+      click_on 'Changer le mot de passe'
+
+      expect(page).to have_text('est incorrect')
+      expect(user.reload.valid_password?(strong_password)).to be false
+    end
+  end
+
   scenario 'the password reset token has expired' do
     visit edit_user_password_path(reset_password_token: 'invalid-password-token')
     expect(page).to have_content 'Changement de mot de passe'


### PR DESCRIPTION
Closes #13781

Ajoute une page `/profil/mot-de-passe`, atteignable depuis une nouvelle carte du profil, qui demande le mot de passe actuel avant d'en choisir un nouveau. La session courante est conservée, toutes les autres sont déconnectées, et un e-mail de notification part désormais depuis les deux parcours de changement — le profil et « mot de passe oublié ».

### Points d'attention pour la revue

- **`update_with_password` renvoie `true` quand le nouveau mot de passe est vide.** Devise retire alors `password` des paramètres et tombe sur `update({})`. D'où la garde en tête de l'action : sans elle, un champ vide produirait un faux succès et une fausse alerte de sécurité.
- **`bypass_sign_in` n'est pas optionnel.** Le sel d'authentification dérive du mot de passe chiffré ; sans ce rappel, l'usager serait déconnecté par son propre changement.
- **Le contrôleur reste à deux niveaux.** Un `Users::Profil::PasswordsController` casse `current_page?` dans les partials de navigation partagés, qui cherche alors `users/administrateurs/procedures`.
- **Le renvoi vers « mot de passe oublié » déconnecte explicitement.** Devise interdit ses quatre actions à un usager connecté, lien reçu par mail compris. Lever ce garde-fou aurait modifié l'authentification de toute l'application pour un besoin local à une page.

Les comptes créés via FranceConnect n'ont pas de mot de passe connu de leur propriétaire : c'est ce bouton qui les prend en charge, sans détection ni colonne supplémentaire. S'il y a une identité FranceConnect sur le compte, un encart rappelle que la connexion FranceConnect n'est pas affectée.

### Captures d'écran

<img width="1798" height="1482" alt="Capture d’écran 2026-09-02 à 16 36 32" src="https://github.com/user-attachments/assets/352f9a38-0573-447a-b385-60fc9d1c4268" />

---------------------------------------------------

<img width="1798" height="1996" alt="Capture d’écran 2026-09-02 à 16 34 05" src="https://github.com/user-attachments/assets/dd3458f7-a86e-48e2-898d-341c3bc1aab1" />
