### PR TITLE
Tech: ColumnValueFormatter sait produire du texte brut

### DIFF
--- a/app/services/column_value_formatter.rb
+++ b/app/services/column_value_formatter.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+# Human-readable rendering of a column value (Column#value): the dossier
+# tables and cards, and any plain-text medium (PDF payloads) with html: false,
+# where nothing is escaped and lists are joined as plain strings.
 module ColumnValueFormatter
   module_function
 
-  def format(column:, raw_value:)
+  def format(column:, raw_value:, html: true)
     return if raw_value.nil?
 
     case column.type
@@ -18,7 +21,7 @@ module ColumnValueFormatter
     when :enum
       format_enum(column:, raw_value:)
     when :enums
-      format_enums(column:, raw_values: raw_value)
+      format_enums(column:, raw_values: raw_value, html:)
     when :date
       raw_value = Date.parse(raw_value) if raw_value.is_a?(String)
       I18n.l(raw_value, format: :short)
@@ -26,15 +29,20 @@ module ColumnValueFormatter
       raw_value = DateTime.parse(raw_value) if raw_value.is_a?(String)
       I18n.l(raw_value, format: :short_with_time)
     else
-      raw_value.html_safe? ? raw_value : ERB::Util.html_escape(raw_value.to_s)
+      format_text(raw_value:, html:)
     end
   end
 
-  def format_enums(column:, raw_values:)
-    ActionController::Base.helpers.safe_join(
-      raw_values.map { |v| format_enum(column:, raw_value: v) },
-      ', '
-    )
+  def format_text(raw_value:, html:)
+    return raw_value.to_s if !html
+
+    raw_value.html_safe? ? raw_value : ERB::Util.html_escape(raw_value.to_s)
+  end
+
+  def format_enums(column:, raw_values:, html: true)
+    labels = raw_values.map { format_enum(column:, raw_value: it) }
+
+    html ? ActionController::Base.helpers.safe_join(labels, ', ') : labels.join(', ')
   end
 
   def format_enum(column:, raw_value:)

--- a/spec/services/column_value_formatter_spec.rb
+++ b/spec/services/column_value_formatter_spec.rb
@@ -22,15 +22,41 @@ RSpec.describe ColumnValueFormatter do
   describe 'format_enums' do
     let(:enums_column) { double('column', type: :enums) }
 
-    it 'returns an html_safe SafeBuffer and escapes HTML chars in labels' do
+    before do
       allow(enums_column).to receive(:label_for_value).with('a').and_return('A & B')
       allow(enums_column).to receive(:label_for_value).with('b').and_return('C')
+    end
 
+    it 'returns an html_safe SafeBuffer and escapes HTML chars in labels' do
       result = described_class.format(column: enums_column, raw_value: ['a', 'b'])
 
       expect(result).to be_html_safe
       expect(result).to include('A &amp; B')
       expect(result).to include('C')
+    end
+
+    it 'joins the labels as plain text with html: false' do
+      result = described_class.format(column: enums_column, raw_value: ['a', 'b'], html: false)
+
+      expect(result).to eq('A & B, C')
+      expect(result).not_to be_html_safe
+    end
+  end
+
+  describe 'plain text (html: false)' do
+    it 'returns text values unescaped' do
+      result = described_class.format(column: text_column, raw_value: 'Presse <Océan> & Cie', html: false)
+
+      expect(result).to eq('Presse <Océan> & Cie')
+      expect(result).not_to be_html_safe
+    end
+
+    it 'stringifies non-string values' do
+      expect(described_class.format(column: text_column, raw_value: 42, html: false)).to eq('42')
+    end
+
+    it 'keeps the localized rendering of dates' do
+      expect(described_class.format(column: date_column, raw_value: Date.new(2026, 3, 18), html: false)).to eq(I18n.l(Date.new(2026, 3, 18), format: :short))
     end
   end
 end


### PR DESCRIPTION
## Contexte

`ColumnValueFormatter` est le formatage d'affichage des valeurs de colonnes (`Column#value`) dans les tableaux et cartes de dossiers. Il est orienté HTML : les textes sont échappés et les listes d'énumérations passent par `safe_join`.

Les payloads des PDF Typst à venir (port du PDF de dossier, cf. #13770) rendent chaque chaîne littéralement : les entités HTML apparaîtraient sur le papier.

## Changement

- `ColumnValueFormatter.format(column:, raw_value:, html: false)` renvoie le même rendu sans échappement, les listes jointes en texte brut.
- Le mode HTML par défaut est inchangé pour les composants existants.

Préparatif du port du PDF de dossier vers Typst via `canonical_column` / `columns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)