### PR TITLE
ETQ instructeur, la section « Avis » du PDF de dossier n'apparaît plus en double

### DIFF
--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -497,23 +497,11 @@ prawn_document(page_size: "A4") do |pdf|
     add_champs(pdf, @dossier.root_champs_private)
   end
 
-  if @acls[:include_infos_administration] && @dossier.avis.present?
+  if (@acls[:include_infos_administration] || @acls[:include_avis_for_expert]) && @dossier.avis.present?
     add_title(pdf, "Avis")
-    @dossier.avis.each do |avis|
+    avis_to_print = @acls[:only_for_expert] ? @dossier.avis_for_expert(@acls[:only_for_expert]) : @dossier.avis
+    avis_to_print.each do |avis|
       add_avis(pdf, avis)
-    end
-  end
-
-  if @acls[:include_avis_for_expert] && @dossier.avis.present?
-    add_title(pdf, "Avis")
-    if @acls[:only_for_expert]
-      @dossier.avis_for_expert(@acls[:only_for_expert]).each do |avis|
-        add_avis(pdf, avis)
-      end
-    else
-      @dossier.avis.each do |avis|
-        add_avis(pdf, avis)
-      end
     end
   end
 

--- a/spec/views/dossiers/show.pdf.prawn_spec.rb
+++ b/spec/views/dossiers/show.pdf.prawn_spec.rb
@@ -176,6 +176,45 @@ describe 'dossiers/show.pdf', :external_deps, type: :view do
     end
   end
 
+  describe 'avis' do
+    let(:procedure) { create(:procedure, :published, public_type_de_champs: [{ type: :text, libelle: 'Nom' }]) }
+    let(:dossier) { create(:dossier, :en_instruction, procedure:) }
+    let(:instructeur) { create(:instructeur) }
+    let(:expert) { create(:expert) }
+    let(:experts_procedure) { create(:experts_procedure, expert:, procedure:) }
+    let!(:avis) { create(:avis, dossier:, experts_procedure:, introduction: 'Que pensez-vous de ce dossier ?') }
+    let!(:other_avis) { create(:avis, :confidentiel, dossier:, introduction: 'Un autre avis') }
+
+    def render_for(profile)
+      assign(:dossier, dossier)
+      assign(:acls, PiecesJustificativesService.new(user_profile: profile, export_template: nil).acl_for_dossier_export(procedure))
+      render template: 'dossiers/show', formats: [:pdf]
+
+      pdf_path = Rails.root.join("tmp/test_show_avis_#{profile.class.name.downcase}.pdf")
+      File.binwrite(pdf_path, rendered)
+      `pdftotext -layout #{pdf_path} - 2>/dev/null`
+    end
+
+    it 'prints the Avis section once for an instructeur, with every avis', if: PDFTOTEXT_AVAILABLE do
+      text = render_for(instructeur)
+
+      expect(text.scan(/^Avis$/).size).to eq(1)
+      expect(text).to include('Que pensez-vous de ce dossier ?', 'Un autre avis')
+    end
+
+    it 'hides confidential avis of other experts from an expert', if: PDFTOTEXT_AVAILABLE do
+      text = render_for(expert)
+
+      expect(text.scan(/^Avis$/).size).to eq(1)
+      expect(text).to include('Que pensez-vous de ce dossier ?')
+      expect(text).not_to include('Un autre avis')
+    end
+
+    it 'prints no avis to the usager', if: PDFTOTEXT_AVAILABLE do
+      expect(render_for(dossier.user)).not_to include('Que pensez-vous de ce dossier ?')
+    end
+  end
+
   describe 'carte champ' do
     let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :carte, libelle: 'Emprise' }]) }
     let(:dossier) { create(:dossier, :en_construction, procedure:) }


### PR DESCRIPTION
## Problème

Le PDF de dossier contenait deux blocs « Avis », l'un conditionné par `include_infos_administration`, l'autre par `include_avis_for_expert`. Les ACL d'un instructeur (ou d'un administrateur) activent les deux : chaque avis était imprimé deux fois, sous deux titres « Avis ».

## Correction

Un seul bloc choisit la liste à imprimer : la vue de l'expert quand `only_for_expert` est renseigné, tous les avis sinon. Le comportement pour l'expert (avis non confidentiels + les siens) et pour l'usager (aucun avis) est inchangé et couvert par la spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)