### PR TITLE
Tech: TypstService sait embarquer des fichiers Active Storage dans un PDF

### DIFF
--- a/app/services/typst_service.rb
+++ b/app/services/typst_service.rb
@@ -47,6 +47,35 @@ class TypstService
     }
   end
 
+  # Files a template embeds beyond its payload (a champ's static map...):
+  # Typst only reads files under the compilation root, so Active Storage
+  # attachments are downloaded into a temporary directory under tmp/ for the
+  # duration of the block, and the payload references them through the
+  # { path:, alt: } descriptors Assets#image returns (theme.typ illustration).
+  def self.with_assets
+    Dir.mktmpdir('typst-assets', Rails.root.join('tmp')) { |dir| yield Assets.new(dir) }
+  end
+
+  class Assets
+    def initialize(dir)
+      @dir = Pathname(dir)
+      @count = 0
+    end
+
+    # Image descriptor of an attachment (or blob), nil when nothing is
+    # attached. A download failure propagates: the caller knows whether the
+    # document can do without the image.
+    def image(attachment, alt:)
+      return if attachment.blank?
+
+      blob = attachment.respond_to?(:blob) ? attachment.blob : attachment
+      file = @dir.join("#{@count += 1}#{blob.filename.extension_with_delimiter}")
+      File.binwrite(file, blob.download)
+
+      { path: "/#{file.relative_path_from(Rails.root)}", alt: }
+    end
+  end
+
   # Root-relative path of an image, resolved across the asset load paths like
   # the web layouts do; nil when the file is missing or outside the
   # compilation root (the Rails root), in which case the theme renders the

--- a/lib/typst/introspection.typ
+++ b/lib/typst/introspection.typ
@@ -34,3 +34,6 @@
 
 // Paragraph texts, in document order.
 #let paragraphs() = query(par).map(plain)
+
+// Images as their alt texts, in document order.
+#let images() = query(image).map(i => (alt: i.alt))

--- a/lib/typst/theme.typ
+++ b/lib/typst/theme.typ
@@ -37,10 +37,10 @@
 #let logotype-max-width = 53mm
 #let footer-height = 12mm
 
-// Image resolved by the caller. When no file is available the alt text is
-// rendered in a placeholder frame, so the document still compiles and the
-// information stays available.
-#let logo-image(path: none, alt: "", height: auto, width: auto) = if path != none {
+// Image resolved by the caller (a repo file or a TypstService asset). When no
+// file is available the alt text is rendered in a placeholder frame, so the
+// document still compiles and the information stays available.
+#let asset-image(path: none, alt: "", height: auto, width: auto) = if path != none {
   image(path, alt: alt, height: height, width: width, fit: "contain")
 } else {
   rect(stroke: 0.5pt + luma(120), inset: 2mm, height: height, text(size: 7pt, fill: luma(120))[#alt])
@@ -49,9 +49,9 @@
 // The operator logotype: as tall as the bloc-marque, unless that would make
 // it wider than its zone.
 #let logotype(logo) = context {
-  let tall = logo-image(path: logo.path, alt: logo.alt, height: bloc-marque-height)
+  let tall = asset-image(path: logo.path, alt: logo.alt, height: bloc-marque-height)
   if logo.path != none and measure(tall).width > logotype-max-width {
-    logo-image(path: logo.path, alt: logo.alt, width: logotype-max-width)
+    asset-image(path: logo.path, alt: logo.alt, width: logotype-max-width)
   } else {
     tall
   }
@@ -70,7 +70,7 @@
   grid(
     columns: (1fr, auto),
     align: (left + top, right + top),
-    if marianne != none { logo-image(path: marianne.path, alt: marianne.alt, height: bloc-marque-height) } else { logotype(logo) },
+    if marianne != none { asset-image(path: marianne.path, alt: marianne.alt, height: bloc-marque-height) } else { logotype(logo) },
     if marianne != none { logotype(logo) },
   ),
 )
@@ -105,6 +105,12 @@
   letterhead-header(marianne: marianne, logo: logo)
   doc
 }
+
+// Illustration downloaded for the rendering (TypstService assets, a
+// { path, alt } descriptor), centred on the text column: the alt text enters
+// the PDF/UA tag tree, and a file that could not be resolved leaves the alt
+// text in a placeholder frame, like the logos.
+#let illustration(asset, width: 100%) = block(width: 100%, below: 3mm, align(center, asset-image(path: asset.path, alt: asset.alt, width: width)))
 
 // Head of a letter-like document, after the charte's press release: the
 // document type in Marianne Light 12pt capitals, then the subject in Bold

--- a/spec/services/typst_service_spec.rb
+++ b/spec/services/typst_service_spec.rb
@@ -181,6 +181,73 @@ describe TypstService do
     end
   end
 
+  describe '.with_assets' do
+    let(:blob) do
+      ActiveStorage::Blob.create_and_upload!(io: Rails.root.join('spec/fixtures/files/image-no-exif.jpg').open, filename: 'carte.jpg', content_type: 'image/jpeg')
+    end
+
+    it 'downloads a blob under the compilation root for the duration of the block' do
+      asset = nil
+
+      described_class.with_assets do |assets|
+        asset = assets.image(blob, alt: 'Carte de la zone')
+
+        expect(asset).to match(path: start_with('/tmp/typst-assets'), alt: 'Carte de la zone')
+        expect(asset[:path]).to end_with('.jpg')
+        expect(Rails.root.join(asset[:path].delete_prefix('/')).binread).to eq(blob.download)
+      end
+
+      expect(Rails.root.join(asset[:path].delete_prefix('/'))).not_to be_exist
+    end
+
+    it 'reads an attachment through its blob and returns nil for an empty one' do
+      procedure = Procedure.new
+      procedure.logo.attach(blob)
+
+      described_class.with_assets do |assets|
+        expect(assets.image(procedure.logo, alt: 'Logo')).to include(alt: 'Logo')
+        expect(assets.image(Procedure.new.logo, alt: 'Logo')).to be_nil
+        expect(assets.image(nil, alt: 'Logo')).to be_nil
+      end
+    end
+
+    it 'embeds the image with its alt text in a PDF/UA-1 document', :external_deps do
+      require_tool!('typst')
+
+      Dir.mktmpdir('typst-templates', Rails.root.join('tmp')) do |dir|
+        File.write(File.join(dir, 'illustration.typ'), <<~TYPST)
+          #import "/lib/typst/theme.typ": *
+          #let data = json(sys.inputs.data)
+          #show: letterhead.with(title: "Illustration", marianne: data.marianne, logo: data.logo, sender: data.sender)
+          #heading(level: 1)[Carte]
+          #illustration(data.map)
+        TYPST
+        stub_const('TypstService::TEMPLATES_DIR', Pathname(dir))
+
+        described_class.with_assets do |assets|
+          data = { **described_class.letterhead, map: assets.image(blob, alt: 'Carte de la zone') }
+
+          expect(described_class.query('illustration', data, 'images()')).to include('alt' => 'Carte de la zone')
+
+          pdf = described_class.generate_pdf('illustration', data)
+          expect(pdf[0, 5]).to eq('%PDF-')
+
+          require_tool!('verapdf')
+
+          Tempfile.create(['illustration', '.pdf']) do |file|
+            file.binmode
+            file.write(pdf)
+            file.flush
+
+            report, warnings, = Open3.capture3('verapdf', '--format', 'text', '--flavour', 'ua1', file.path)
+
+            expect(report).to start_with('PASS'), -> { "veraPDF PDF/UA-1 validation failed:\n#{report}\n#{warnings}" }
+          end
+        end
+      end
+    end
+  end
+
   describe '.query' do
     let(:success) { instance_double(Process::Status, success?: true) }
 


### PR DESCRIPTION
## Contexte

Empilé sur #13770. Typst ne lit que les fichiers sous la racine de compilation : un template ne peut pas embarquer directement une pièce Active Storage (la carte statique d'un champ carte, pour le PDF de dossier à venir).

## Changement

- `TypstService.with_assets { |assets| ... }` : un répertoire temporaire sous `tmp/` le temps du rendu ; `assets.image(blob_ou_attachment, alt:)` y télécharge le fichier et renvoie le descripteur `{ path:, alt: }` que le thème consomme.
- Thème : `logo-image` devient `asset-image` (il sert désormais à tout fichier résolu) et un bloc `illustration` centre une image avec son texte alternatif, qui entre dans l'arbre de balises PDF/UA comme les logos de l'en-tête.
- `introspection.typ` gagne `images()` pour que les specs vérifient les images embarquées.

La spec `:external_deps` compile un template avec une image et le fait valider PDF/UA-1 par veraPDF.

Préparatif du port du PDF de dossier vers Typst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)