### PR TITLE
ETQ admin, je ne veux pas pouvoir saisir un jeton API Particulier invalide

### DIFF
--- a/app/components/procedure/api_entreprise_token_expiration_alert_component.rb
+++ b/app/components/procedure/api_entreprise_token_expiration_alert_component.rb
@@ -6,7 +6,7 @@ class Procedure::APIEntrepriseTokenExpirationAlertComponent < ApplicationCompone
   end
 
   def render?
-    @procedure.api_entreprise_token.expired_or_expires_soon?
+    @procedure.api_entreprise_token_needs_renewal?
   end
 
   private

--- a/app/components/procedure/card/api_token_component.rb
+++ b/app/components/procedure/card/api_token_component.rb
@@ -13,7 +13,15 @@ class Procedure::Card::APITokenComponent < ApplicationComponent
   def api_tokens_count
     [
       @procedure.specific_api_entreprise_token? || nil,
-      @procedure.api_particulier_token.presence,
+      @procedure.api_particulier_token? || nil,
     ].compact.size
+  end
+
+  def any_token_configured?
+    api_tokens_count.positive?
+  end
+
+  def any_token_needs_renewal?
+    @procedure.api_entreprise_token_needs_renewal? || @procedure.api_particulier_token.needs_renewal?
   end
 end

--- a/app/components/procedure/card/api_token_component/api_token_component.html.haml
+++ b/app/components/procedure/card/api_token_component/api_token_component.html.haml
@@ -1,8 +1,8 @@
 .fr-col-6.fr-col-md-4.fr-col-lg-3
   = link_to admin_procedure_jetons_path(@procedure), class: 'fr-tile fr-enlarge-link', id: "api_token" do
     .fr-tile__body.flex.column.align-center.justify-between
-      - if @procedure.specific_api_entreprise_token? || @procedure.api_particulier_token.present?
-        - if @procedure.api_entreprise_token_needs_renewal?
+      - if any_token_configured?
+        - if any_token_needs_renewal?
           %p.fr-badge.fr-badge--error À renouveler
         - else
           %p.fr-badge.fr-badge--success Configuré

--- a/app/components/procedure/card/api_token_component/api_token_component.html.haml
+++ b/app/components/procedure/card/api_token_component/api_token_component.html.haml
@@ -2,7 +2,7 @@
   = link_to admin_procedure_jetons_path(@procedure), class: 'fr-tile fr-enlarge-link', id: "api_token" do
     .fr-tile__body.flex.column.align-center.justify-between
       - if @procedure.specific_api_entreprise_token? || @procedure.api_particulier_token.present?
-        - if @procedure.api_entreprise_token&.expired_or_expires_soon?
+        - if @procedure.api_entreprise_token_needs_renewal?
           %p.fr-badge.fr-badge--error À renouveler
         - else
           %p.fr-badge.fr-badge--success Configuré

--- a/app/components/types_de_champ_editor/france_connect_component/france_connect_component.html.erb
+++ b/app/components/types_de_champ_editor/france_connect_component/france_connect_component.html.erb
@@ -1,5 +1,5 @@
 <div class="fr-px-2w">
-  <% if @procedure.api_particulier_token.blank? %>
+  <% if !@procedure.api_particulier_token? %>
     <%= render Dsfr::AlertComponent.new(
       state: '',
       extra_class_names: 'fr-mb-3w fr-icon-lock-fill'
@@ -20,7 +20,7 @@
     <% end %>
   <% end %>
 
-  <div class="<%= class_names(inactive: @procedure.api_particulier_token.blank?) %>">
+  <div class="<%= class_names(inactive: !@procedure.api_particulier_token?) %>">
     <hr class="fr-hr">
 
     <div class="fr-mb-1w cell">

--- a/app/controllers/administrateurs/jetons_controller.rb
+++ b/app/controllers/administrateurs/jetons_controller.rb
@@ -11,10 +11,15 @@ module Administrateurs
     end
 
     def update_particulier
-      string_token = params[:procedure][:api_particulier_token]
-      @procedure.api_particulier_token = string_token
+      # Un jeton collé traîne des espaces ; un champ vidé arrive en chaîne vide,
+      # qui serait chiffrée puis stockée comme une valeur.
+      @procedure.api_particulier_token = params[:procedure][:api_particulier_token].to_s.strip.presence
+      alert = unusable_token_alert
 
-      if @procedure.save
+      if alert.present?
+        flash.now.alert = alert
+        render :edit_particulier
+      elsif @procedure.save
         flash.notice = 'Le jeton a bien été mis à jour'
         redirect_to admin_procedure_jetons_path(id: @procedure.id)
       else
@@ -51,6 +56,21 @@ module Administrateurs
       @procedure.update!(api_entreprise_token: nil)
       flash.notice = 'Le jeton API Entreprise a bien été supprimé'
       redirect_to admin_procedure_jetons_path(@procedure)
+    end
+
+    private
+
+    # Un jeton expiré, ou dont la charge utile n'est pas un objet, se décode :
+    # rien ne le refuserait, et les appels seraient coupés dès l'enregistrement.
+    def unusable_token_alert
+      token = @procedure.api_particulier_token
+      return if token.jwt_token.blank? || !token.unusable?
+
+      if token.expires_at.present?
+        "Mise à jour impossible : ce jeton a expiré"
+      else
+        "Mise à jour impossible : le jeton n’est pas valide"
+      end
     end
   end
 end

--- a/app/jobs/cron/send_api_entreprise_token_expiration_notice_job.rb
+++ b/app/jobs/cron/send_api_entreprise_token_expiration_notice_job.rb
@@ -3,34 +3,37 @@
 class Cron::SendAPIEntrepriseTokenExpirationNoticeJob < Cron::CronJob
   self.schedule_expression = "every day at 08:00"
 
-  WINDOWS = [1.day, 1.week, 1.month]
-
   def perform
-    procedures_with_expiring_token.each do |procedure|
-      expires_at = procedure.api_entreprise_token.expires_at
-      current_window = matching_window(expires_at)
-      next if current_window.nil?
-
-      last_sent_at = procedure.api_entreprise_token_expiration_notice_sent_at
-      next if last_sent_at.present? && matching_window(expires_at, reference_time: last_sent_at) == current_window
-
-      procedure.administrateurs.includes(:user).find_each do |admin|
-        AdministrateurMailer.api_entreprise_token_expiration(admin, procedure).deliver_later
-      end
-
-      procedure.update!(api_entreprise_token_expiration_notice_sent_at: Time.current)
+    procedures_with_specific_token.find_each do |procedure|
+      # Une démarche au jeton biscornu ne doit pas priver les suivantes de leur
+      # notification.
+      notify(procedure)
+    rescue StandardError => e
+      Sentry.capture_exception(e, extra: { procedure_id: procedure.id })
     end
   end
 
   private
 
-  def procedures_with_expiring_token
-    Procedure.kept
-      .where.not(api_entreprise_token: [nil, ''])
-      .filter { it.api_entreprise_token.expired_or_expires_soon? }
+  def notify(procedure)
+    token = procedure.api_entreprise_token
+    # Une démarche qui ne reçoit plus de dossiers est signalée une fois : sans
+    # cela, un jeton illisible — désormais couvert par needs_renewal? — vaudrait
+    # un rappel mensuel perpétuel sur un brouillon abandonné ou une démarche close.
+    return if !token.notification_due?(procedure.api_entreprise_token_expiration_notice_sent_at, remind: procedure.publiee?)
+
+    procedure.administrateurs.includes(:user).find_each do |admin|
+      AdministrateurMailer.api_entreprise_token_expiration(admin, procedure).deliver_later
+    end
+
+    # update_column : une démarche dont le jeton est illisible ne passe plus la
+    # validation, et c'est justement celle qu'on vient de notifier.
+    procedure.update_column(:api_entreprise_token_expiration_notice_sent_at, Time.current)
   end
 
-  def matching_window(expires_at, reference_time: Time.current)
-    WINDOWS.find { |window| expires_at <= reference_time + window }
+  # Tous les états, comme avant : un administrateur qui prépare une démarche doit
+  # être prévenu que son jeton expire avant de la publier.
+  def procedures_with_specific_token
+    Procedure.kept.where.not(api_entreprise_token: [nil, ''])
   end
 end

--- a/app/jobs/cron/send_api_particulier_token_expiration_notice_job.rb
+++ b/app/jobs/cron/send_api_particulier_token_expiration_notice_job.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class Cron::SendAPIParticulierTokenExpirationNoticeJob < Cron::CronJob
+  self.schedule_expression = "every day at 08:15"
+
+  def perform
+    procedures_with_token.find_each do |procedure|
+      notify(procedure)
+    rescue StandardError => e
+      Sentry.capture_exception(e, extra: { procedure_id: procedure.id })
+    end
+  end
+
+  private
+
+  def notify(procedure)
+    return if !uses_api_particulier?(procedure)
+
+    token = procedure.api_particulier_token
+    # Pas de rappel mensuel perpétuel sur un brouillon abandonné ou une démarche
+    # close, qui ne reçoivent plus de dossiers.
+    return if !token.notification_due?(procedure.api_particulier_token_expiration_notice_sent_at, remind: procedure.publiee?)
+
+    procedure.administrateurs.includes(:user).find_each do |admin|
+      AdministrateurMailer.api_particulier_token_expiration(admin, procedure).deliver_later
+    end
+
+    # update_column : une démarche dont le jeton est illisible ne passe plus la
+    # validation, et c'est justement celle qu'on vient de notifier.
+    procedure.update_column(:api_particulier_token_expiration_notice_sent_at, Time.current)
+  end
+
+  # Tous les états : sans quoi une démarche que le jeton empêche justement de
+  # publier ne serait jamais signalée.
+  def procedures_with_token
+    Procedure.kept.where.not(api_particulier_token: nil)
+  end
+
+  # La colonne charrie des jetons v1/v2 abandonnés depuis 2021, sur des démarches
+  # dont les champs ont depuis été convertis en texte
+  # (T20260817ConvertLegacyAPIParticulierChampsToTextTask) : leurs administrateurs
+  # n'ont rien à renouveler.
+  #
+  # Le tri part des rares démarches qui portent un jeton : passer d'abord par les
+  # champs ferait balayer types_de_champ, qui n'a pas d'index sur `type_champ`.
+  def uses_api_particulier?(procedure)
+    revisions = [procedure.published_revision_id, procedure.draft_revision_id].compact
+
+    ProcedureRevisionTypeDeChamp
+      .unscope(:eager_load)
+      .joins(:type_de_champ)
+      .where(revision_id: revisions)
+      .exists?(types_de_champ: { type_champ: TypesDeChamp::FranceConnectTypeDeChamp::REGISTRY.keys.map(&:to_s) })
+  end
+end

--- a/app/lib/api_particulier/api.rb
+++ b/app/lib/api_particulier/api.rb
@@ -12,6 +12,11 @@ class APIParticulier::API
   end
 
   def call_with_fci(fci)
+    # Un jeton absent, illisible ou expiré sera refusé par API Particulier : on
+    # s'épargne l'appel, et la construction des paramètres. L'administrateur est
+    # prévenu par Cron::SendAPIParticulierTokenExpirationNoticeJob.
+    return Failure(retryable: false, error: StandardError.new("API Particulier: token_unusable"), code: :token_unusable) if @token.unusable?
+
     url = [API_PARTICULIER_URL, resource].join("/")
 
     params = build_params(fci)
@@ -55,7 +60,7 @@ class APIParticulier::API
 
   def call(url, params)
     response = Typhoeus.get(url,
-      headers: { Authorization: "Bearer #{@token}" },
+      headers: { Authorization: "Bearer #{@token.jwt_token}" },
       params: params,
       params_encoding: :multi,
       timeout: TIMEOUT)
@@ -68,19 +73,28 @@ class APIParticulier::API
           "Invalid API schema response",
           extra: {
             url: url,
-            response: body,
+            response_keys: body.is_a?(Hash) ? body.keys : body.class.name,
             schema_errors: schema.validate(body).map { |e| e["error"] }.join("\n"),
           }
         )
 
-        return Failure(retryable: false, error: StandardError.new("Not retryable: invalid schema"), code: :invalid_schema)
+        return Failure(retryable: false, error: StandardError.new("API Particulier: invalid_schema"), code: :invalid_schema)
       end
 
       Success(body[:data])
     else
-      error_message = body&.dig(:errors) || response.body.presence || "HTTP #{response.code}"
-      Failure(retryable: false, error: StandardError.new("Not retryable: #{error_message}"), code: response.code)
+      # Le corps entier donnait autant de groupes Sentry distincts que de
+      # dossiers, et porte des données personnelles. Le code d'erreur métier
+      # suffit à identifier la cause.
+      Failure(retryable: false, error: StandardError.new(error_message(response, body)), code: response.code)
     end
+  end
+
+  def error_message(response, body)
+    errors = body[:errors] if body.is_a?(Hash)
+    business_code = errors.first[:code] if errors.is_a?(Array) && errors.first.is_a?(Hash)
+
+    ["API Particulier: #{response.code}", business_code].compact.join(' ')
   end
 
   def parse_response_body(body)

--- a/app/mailers/administrateur_mailer.rb
+++ b/app/mailers/administrateur_mailer.rb
@@ -37,14 +37,27 @@ class AdministrateurMailer < ApplicationMailer
   def api_entreprise_token_expiration(administrateur, procedure)
     @procedure = procedure
     @expires_at = procedure.api_entreprise_token.expires_at
-    subject = "[Action requise] Votre jeton API Entreprise expire bientôt (démarche nº#{procedure.id})"
 
     mail(to: administrateur.user.email,
-      subject:,
+      subject: token_renewal_subject("API Entreprise", procedure, @expires_at),
       reply_to: CONTACT_EMAIL)
   end
 
   def self.critical_email?(action_name)
     action_name == "activate_before_expiration"
+  end
+
+  private
+
+  def token_renewal_subject(api_name, procedure, expires_at)
+    state = if expires_at.blank? # un jeton illisible n'a pas d'échéance à annoncer
+      "n’est pas valide"
+    elsif expires_at.past?
+      "a expiré"
+    else
+      "expire bientôt"
+    end
+
+    "[Action requise] Votre jeton #{api_name} #{state} (démarche nº#{procedure.id})"
   end
 end

--- a/app/mailers/administrateur_mailer.rb
+++ b/app/mailers/administrateur_mailer.rb
@@ -43,6 +43,15 @@ class AdministrateurMailer < ApplicationMailer
       reply_to: CONTACT_EMAIL)
   end
 
+  def api_particulier_token_expiration(administrateur, procedure)
+    @procedure = procedure
+    @expires_at = procedure.api_particulier_token.expires_at
+
+    mail(to: administrateur.user.email,
+      subject: token_renewal_subject("API Particulier", procedure, @expires_at),
+      reply_to: CONTACT_EMAIL)
+  end
+
   def self.critical_email?(action_name)
     action_name == "activate_before_expiration"
   end

--- a/app/models/api_entreprise_token.rb
+++ b/app/models/api_entreprise_token.rb
@@ -1,38 +1,9 @@
 # frozen_string_literal: true
 
 class APIEntrepriseToken
-  include ActiveModel::Validations
-
-  validates :jwt_token, jwt_token: true, allow_blank: true
+  include ExpiringJwtTokenConcern
 
   TokenError = Class.new(StandardError)
-
-  SOON_TO_EXPIRE_DELAY = 1.month
-
-  attr_reader :jwt_token
-
-  def initialize(jwt_token)
-    @jwt_token = jwt_token
-  end
-
-  def expired?
-    return true if decoded_token.blank?
-
-    # we have a decoded token but no exp claim, consider it as non-expiring
-    return false if expires_at.nil?
-
-    expires_at <= Time.zone.now
-  end
-
-  def expires_at
-    exp = decoded_token["exp"]
-
-    Time.zone.at(exp) if exp.present?
-  end
-
-  def expired_or_expires_soon?
-    expires_at && expires_at <= SOON_TO_EXPIRE_DELAY.from_now
-  end
 
   def can_fetch_attestation_sociale?
     # https://github.com/etalab/admin_api_entreprise/blob/6f5c7ecbe94af8d5403dbff320af56e8797f3fc6/app/policies/download_attestations_policy.rb#L16
@@ -54,14 +25,5 @@ class APIEntrepriseToken
 
   def roles
     Array(decoded_token["roles"] || decoded_token["scopes"])
-  end
-
-  def decoded_token
-    return {} if @jwt_token.blank?
-
-    @decoded_token ||= JWT.decode(@jwt_token, nil, false)[0]
-  rescue JWT::DecodeError => e
-    Rails.logger.error e.message
-    {}
   end
 end

--- a/app/models/api_particulier_token.rb
+++ b/app/models/api_particulier_token.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class APIParticulierToken
+  include ExpiringJwtTokenConcern
+end

--- a/app/models/concerns/api_entreprise_token_concern.rb
+++ b/app/models/concerns/api_entreprise_token_concern.rb
@@ -16,4 +16,10 @@ module APIEntrepriseTokenConcern
   def specific_api_entreprise_token?
     self[:api_entreprise_token].present?
   end
+
+  # Le jeton global de l'instance n'est pas à la main de l'administrateur : il n'a
+  # rien à renouveler, et rien ne doit l'alerter à son sujet.
+  def api_entreprise_token_needs_renewal?
+    specific_api_entreprise_token? && api_entreprise_token.needs_renewal?
+  end
 end

--- a/app/models/concerns/api_particulier_token_concern.rb
+++ b/app/models/concerns/api_particulier_token_concern.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module APIParticulierTokenConcern
+  extend ActiveSupport::Concern
+
+  included do
+    # Uniquement à la saisie : des jetons illisibles sont déjà en base, et une
+    # validation inconditionnelle rendrait ces démarches insauvegardables.
+    validates_associated :api_particulier_token, if: :will_save_change_to_api_particulier_token?
+  end
+
+  def api_particulier_token
+    APIParticulierToken.new(self[:api_particulier_token])
+  end
+
+  def api_particulier_token?
+    self[:api_particulier_token].present?
+  end
+end

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -5,6 +5,11 @@ module ChampExternalDataConcern
 
   include Dry::Monads[:result]
 
+  # La donnée n'existe pas (404), ou le jeton est déjà connu comme hors service :
+  # l'administrateur est prévenu par mail, il n'y a rien à corriger côté code. Un
+  # 401 malgré un jeton lisible et non expiré continue, lui, de remonter.
+  SILENT_CODES = [404, :token_unusable].freeze
+
   # A champ is updated, a reset and fetch later event is triggered
   # from the controller
   # idle -> waiting_for_job
@@ -101,7 +106,7 @@ module ChampExternalDataConcern
         raise RetryableFetchError.new(error)
       in Failure(retryable: false, error:, code:)
         save_external_error(error, code)
-        Sentry.capture_exception(error) if code != 404
+        Sentry.capture_exception(error) if !code.in?(SILENT_CODES)
         external_data_error!
       end
     elsif result.present?

--- a/app/models/concerns/expiring_jwt_token_concern.rb
+++ b/app/models/concerns/expiring_jwt_token_concern.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Jetons d'API configurés par un administrateur sur une démarche : des JWT dont
+# on lit l'expiration localement.
+#
+# `unusable?` coupe les appels, `needs_renewal?` prévient l'administrateur. Le
+# second est faux sans jeton du tout : la démarche est « à configurer », pas « à
+# renouveler ».
+module ExpiringJwtTokenConcern
+  extend ActiveSupport::Concern
+
+  SOON_TO_EXPIRE_DELAY = 1.month
+
+  included do
+    include ActiveModel::Validations
+
+    validates :jwt_token, jwt_token: true, allow_blank: true
+
+    attr_reader :jwt_token
+  end
+
+  def initialize(jwt_token)
+    @jwt_token = jwt_token
+  end
+
+  # `JWT.decode` ne contrôle pas le type des claims : un `exp` textuel ferait
+  # lever Time.zone.at, dans une page d'administration ou un mail que rien ne
+  # rattrape.
+  def expires_at
+    exp = decoded_token["exp"]
+
+    Time.zone.at(exp) if exp.is_a?(Numeric)
+  end
+
+  def expired?
+    return true if decoded_token.blank?
+
+    # we have a decoded token but no exp claim, consider it as non-expiring
+    return false if expires_at.nil?
+
+    expires_at <= Time.zone.now
+  end
+
+  def expires_soon?
+    expires_at.present? && !expired? && expires_at <= SOON_TO_EXPIRE_DELAY.from_now
+  end
+
+  def unusable?
+    jwt_token.blank? || expired?
+  end
+
+  def needs_renewal?
+    jwt_token.present? && (unusable? || expires_soon?)
+  end
+
+  private
+
+  def decoded_token
+    return {} if jwt_token.blank?
+
+    # Un JWT décodable n'a pas forcément un objet pour charge utile. Mémoïsé
+    # aussi en échec : une liste de démarches évalue ces prédicats par centaines.
+    @decoded_token ||= JWT.decode(jwt_token, nil, false)[0].then { it.is_a?(Hash) ? it : {} }
+  rescue JWT::DecodeError => e
+    Rails.logger.error e.message
+    @decoded_token = {}
+  end
+end

--- a/app/models/concerns/expiring_jwt_token_concern.rb
+++ b/app/models/concerns/expiring_jwt_token_concern.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Jetons d'API configurés par un administrateur sur une démarche : des JWT dont
-# on lit l'expiration localement.
+# Jetons d'API configurés par un administrateur sur une démarche (API Entreprise,
+# API Particulier) : des JWT dont on lit l'expiration localement.
 #
 # `unusable?` coupe les appels, `needs_renewal?` prévient l'administrateur. Le
 # second est faux sans jeton du tout : la démarche est « à configurer », pas « à
@@ -10,6 +10,11 @@ module ExpiringJwtTokenConcern
   extend ActiveSupport::Concern
 
   SOON_TO_EXPIRE_DELAY = 1.month
+
+  # Un jeton illisible n'a pas d'échéance sur laquelle caler des relances.
+  UNUSABLE_REMINDER_DELAY = 1.month
+
+  NOTIFICATION_WINDOWS = [1.day, 1.week, 1.month].freeze
 
   included do
     include ActiveModel::Validations
@@ -53,7 +58,31 @@ module ExpiringJwtTokenConcern
     jwt_token.present? && (unusable? || expires_soon?)
   end
 
+  # Avant l'échéance, les relances se resserrent en suivant NOTIFICATION_WINDOWS.
+  # Après, rien ne se répare tout seul : on relance à cadence fixe jusqu'au
+  # renouvellement, sans quoi la panne s'installerait en silence — et c'est ce
+  # silence qui nous autorise à ne plus remonter ses erreurs à Sentry.
+  # `remind: false` pour une démarche qui ne reçoit plus de dossiers.
+  def notification_due?(last_sent_at, remind: true)
+    return false if !needs_renewal?
+    return last_sent_at.blank? || just_expired?(last_sent_at) || (remind && last_sent_at <= UNUSABLE_REMINDER_DELAY.ago) if unusable?
+
+    window = matching_window(expires_at)
+
+    last_sent_at.blank? || matching_window(expires_at, reference_time: last_sent_at) != window
+  end
+
   private
+
+  # Le dernier courrier annonçait une échéance à venir : il en faut un autre
+  # maintenant qu'elle est passée.
+  def just_expired?(last_sent_at)
+    expires_at.present? && last_sent_at < expires_at
+  end
+
+  def matching_window(expires_at, reference_time: Time.current)
+    NOTIFICATION_WINDOWS.find { |window| expires_at <= reference_time + window }
+  end
 
   def decoded_token
     return {} if jwt_token.blank?

--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -86,6 +86,7 @@ module ProcedureCloneConcern
     'admin_default_procedure_presentation_active',
     'admin_default_procedure_presentation_id',
     'api_entreprise_token_expiration_notice_sent_at',
+    'api_particulier_token_expiration_notice_sent_at',
   ]
 
   NEW_MAX_DUREE_CONSERVATION = Expired::DEFAULT_DOSSIER_RENTENTION_IN_MONTH
@@ -193,6 +194,7 @@ module ProcedureCloneConcern
     procedure.admin_default_procedure_presentation_active = false
     procedure.admin_default_procedure_presentation_id = nil
     procedure.api_entreprise_token_expiration_notice_sent_at = nil
+    procedure.api_particulier_token_expiration_notice_sent_at = nil
     procedure
   end
 

--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -253,6 +253,13 @@ module ProcedureCloneConcern
       procedure.opendata = true
     end
 
+    # Un jeton hors service ne se recopie pas : expiré, il n'apporterait rien au
+    # clone ; illisible, il le ferait échouer — le clone est un nouvel
+    # enregistrement, donc l'attribut y compte comme modifié et la validation
+    # s'applique.
+    procedure.api_particulier_token = nil if procedure.api_particulier_token.unusable?
+    procedure.api_entreprise_token = nil if procedure.specific_api_entreprise_token? && procedure.api_entreprise_token.unusable?
+
     procedure
   end
 

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -2,6 +2,7 @@
 
 class Procedure < ApplicationRecord
   include APIEntrepriseTokenConcern
+  include APIParticulierTokenConcern
   include ProcedureStatsConcern
   include InitiationProcedureConcern
   include ProcedureGroupeInstructeurAPIHackConcern
@@ -341,7 +342,6 @@ class Procedure < ApplicationRecord
     empty_file: true,
     if: -> { new_record? || created_at > Date.new(2020, 11, 13) }
 
-  validates :api_particulier_token, format: { with: /\A[A-Za-z0-9\-_=.]{15,}\z/ }, allow_blank: true
   validate :validate_auto_archive_on_in_the_future, if: :will_save_change_to_auto_archive_on?
 
   before_save :update_juridique_required

--- a/app/validators/type_de_champs/api_particulier_validator.rb
+++ b/app/validators/type_de_champs/api_particulier_validator.rb
@@ -3,14 +3,14 @@
 class TypeDeChamps::APIParticulierValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, types_de_champ)
     types_de_champ.filter(&:api_particulier?).each do |api_part_tdc|
-      validate_api_particulier_token_presence(procedure, attribute, api_part_tdc)
+      validate_api_particulier_token_usable(procedure, attribute, api_part_tdc)
     end
   end
 
   private
 
-  def validate_api_particulier_token_presence(procedure, attribute, api_part_tdc)
-    if procedure.api_particulier_token.blank?
+  def validate_api_particulier_token_usable(procedure, attribute, api_part_tdc)
+    if procedure.api_particulier_token.unusable?
       procedure.errors.add(
         attribute,
         :missing_api_particulier_token,

--- a/app/views/administrateur_mailer/_token_status.html.erb
+++ b/app/views/administrateur_mailer/_token_status.html.erb
@@ -1,0 +1,23 @@
+<% if expires_at.blank? %>
+  <p>
+    <strong>
+      Le jeton <%= api_name %> associé à cette démarche n’est pas un jeton
+      valide. Les appels à <%= api_name %> échouent.
+    </strong>
+  </p>
+<% elsif expires_at.past? %>
+  <p>
+    <strong>
+      Le jeton <%= api_name %> associé à cette démarche a expiré le
+      <%= I18n.l(expires_at, format: :long_with_time) %>. Les appels à
+      <%= api_name %> échouent.
+    </strong>
+  </p>
+<% else %>
+  <p>
+    <strong>
+      Le jeton <%= api_name %> associé à cette démarche expirera le
+      <%= I18n.l(expires_at, format: :long_with_time) %>.
+    </strong>
+  </p>
+<% end %>

--- a/app/views/administrateur_mailer/api_entreprise_token_expiration.html.erb
+++ b/app/views/administrateur_mailer/api_entreprise_token_expiration.html.erb
@@ -7,24 +7,19 @@
   <%= link_to "« #{@procedure.libelle} »", admin_procedure_url(@procedure) %>.
 </p>
 
-<p>
-  <strong>
-    Le jeton API Entreprise associé à cette démarche expirera le
-    <%= I18n.l(@expires_at, format: :long_with_time) %>.
-  </strong>
-</p>
+<%= render "token_status", api_name: "API Entreprise", expires_at: @expires_at %>
 
 <p>
-  <strong>Attention :</strong> si votre jeton expire sans être renouvelé, selon
-  la structure de votre démarche, cela pourrait empêcher la création ou le dépôt
-  de dossiers.
+  <strong>Attention&nbsp;:</strong> si votre jeton n’est pas renouvelé, selon la
+  structure de votre démarche, cela peut empêcher la création ou le dépôt de
+  dossiers.
 </p>
 
 <p>
   Pour renouveler votre jeton, rapprochez-vous de
   <%= link_to 'Datapass', 'https://datapass.api.gouv.fr' %>, puis copiez-collez
   le nouveau jeton sur <%= APPLICATION_NAME %> depuis la page de configuration
-  de votre démarche :
+  de votre démarche&nbsp;:
   <br>
   <%= link_to api_entreprise_admin_procedure_jetons_url(@procedure), api_entreprise_admin_procedure_jetons_url(@procedure) %>
 </p>

--- a/app/views/administrateur_mailer/api_particulier_token_expiration.html.erb
+++ b/app/views/administrateur_mailer/api_particulier_token_expiration.html.erb
@@ -1,0 +1,27 @@
+<%- content_for(:title, "Renouvelez votre jeton API Particulier") %>
+
+<p>Bonjour,</p>
+
+<p>
+  Vous êtes administrateur de la démarche
+  <%= link_to "« #{@procedure.libelle} »", admin_procedure_url(@procedure) %>.
+</p>
+
+<%= render "token_status", api_name: "API Particulier", expires_at: @expires_at %>
+
+<p>
+  <strong>Attention&nbsp;:</strong> tant que le jeton n’est pas valide, les
+  données des usagers ne sont pas récupérées automatiquement, et chaque usager
+  doit déposer lui-même la pièce justificative correspondante.
+</p>
+
+<p>
+  Pour renouveler votre jeton, rapprochez-vous de
+  <%= link_to 'Datapass', 'https://datapass.api.gouv.fr' %>, puis copiez-collez
+  le nouveau jeton sur <%= APPLICATION_NAME %> depuis la page de configuration
+  de votre démarche&nbsp;:
+  <br>
+  <%= link_to api_particulier_admin_procedure_jetons_url(@procedure), api_particulier_admin_procedure_jetons_url(@procedure) %>
+</p>
+
+<%= render partial: "layouts/mailers/signature" %>

--- a/app/views/administrateurs/jetons/_token_expiration.html.erb
+++ b/app/views/administrateurs/jetons/_token_expiration.html.erb
@@ -1,0 +1,10 @@
+<% if token.expires_at.present? %>
+  <div class="fr-badge <%= token.needs_renewal? ? 'fr-badge--error' : 'fr-badge--success' %>">
+    <%= token.expired? ? "Expiré le" : "Expire le" %>
+    <%= l(token.expires_at.to_date, format: :long) %>
+  </div>
+<% elsif token.needs_renewal? %>
+  <div class="fr-badge fr-badge--error">Jeton invalide</div>
+<% else %>
+  <div class="fr-badge fr-badge--success">Sans expiration</div>
+<% end %>

--- a/app/views/administrateurs/jetons/index.html.haml
+++ b/app/views/administrateurs/jetons/index.html.haml
@@ -60,7 +60,7 @@
   %p
     = t('.api_particulier_description_html', app_name: Current.application_name)
 
-  - if @procedure.api_particulier_token.present?
+  - if @procedure.api_particulier_token?
     .fr-table.fr-table--lg
       .fr-table__wrapper
         .fr-table__container
@@ -70,6 +70,8 @@
                 %tr
                   %th{ scope: "col" }
                     Jeton
+                  %th{ scope: "col" }
+                    Expiration
                   %th.change.fr-col-2{ scope: "col" }
                     Actions
 
@@ -78,6 +80,8 @@
                   %td
                     .fr-badge
                       API particulier
+                  %td
+                    = render 'token_expiration', token: @procedure.api_particulier_token
                   %td.change
 
                     = link_to 'Modifier',

--- a/app/views/administrateurs/jetons/index.html.haml
+++ b/app/views/administrateurs/jetons/index.html.haml
@@ -37,12 +37,7 @@
                     .fr-badge
                       API entreprise
                   %td
-                    - if @procedure.api_entreprise_token&.expired_or_expires_soon?
-                      .fr-badge.fr-badge--error
-                        = l(@procedure.api_entreprise_token.expires_at.to_date, format: :long)
-                    - else
-                      .fr-badge.fr-badge--success
-                        = l(@procedure.api_entreprise_token.expires_at.to_date, format: :long)
+                    = render 'token_expiration', token: @procedure.api_entreprise_token
                   %td.change
 
                     = link_to 'Modifier',

--- a/app/views/administrateurs/procedures/_api_entreprise_token_expiration_alert.html.haml
+++ b/app/views/administrateurs/procedures/_api_entreprise_token_expiration_alert.html.haml
@@ -1,11 +1,17 @@
-- if procedure.api_entreprise_token.valid? && procedure.api_entreprise_token.expires_at.present?
-  - if procedure.api_entreprise_token.expired?
+- if procedure.api_entreprise_token_needs_renewal?
+  - if procedure.api_entreprise_token.expires_at.nil?
+    = render Dsfr::AlertComponent.new(state: :error, size: :sm, extra_class_names: 'fr-mb-2w') do |c|
+      - c.with_body do
+        %p
+          Votre jeton API Entreprise n’est pas valide.
+          Merci de le renouveler.
+  - elsif procedure.api_entreprise_token.expired?
     = render Dsfr::AlertComponent.new(state: :error, size: :sm, extra_class_names: 'fr-mb-2w') do |c|
       - c.with_body do
         %p
           Votre jeton API Entreprise est expiré.
           Merci de le renouveler.
-  - elsif procedure.api_entreprise_token.expired_or_expires_soon?
+  - else
     = render Dsfr::AlertComponent.new(state: :warning, size: :sm, extra_class_names: 'fr-mb-2w') do |c|
       - c.with_body do
         %p

--- a/app/views/administrateurs/procedures/_procedures_list.html.haml
+++ b/app/views/administrateurs/procedures/_procedures_list.html.haml
@@ -57,7 +57,7 @@
             = t('closed', scope: [:layouts, :breadcrumb])
 
         - elsif procedure.publiee?
-          - if procedure.api_entreprise_token.expired_or_expires_soon?
+          - if procedure.api_entreprise_token_needs_renewal?
             %span.fr-badge.fr-badge--sm.fr-badge--error
               = t('to_modify', scope: [:layouts, :breadcrumb])
           %span.fr-badge.fr-badge--sm.fr-badge--success

--- a/app/views/shared/_breadcrumbs_section.html.erb
+++ b/app/views/shared/_breadcrumbs_section.html.erb
@@ -23,7 +23,7 @@
             <%= link_to commencer_url(@procedure.path), commencer_url(@procedure.path), class: "fr-link" %>
             <%= link_to "", admin_procedure_path_path(@procedure), class: "fr-btn fr-icon-pencil-line fr-btn--sm fr-btn--tertiary-no-outline", "aria-label": t('edit_path', scope: [:layouts, :breadcrumb]), title: t('edit_path', scope: [:layouts, :breadcrumb]) %>
             <div class="flex fr-mt-1w">
-              <% if @procedure.api_entreprise_token.expired_or_expires_soon? %>
+              <% if @procedure.api_entreprise_token_needs_renewal? %>
                 <span class="fr-badge fr-badge--error fr-mr-1w">
                   <%= t('to_modify', scope: [:layouts, :breadcrumb]) %>
                 </span>

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -8,6 +8,7 @@ en:
       procedure:
         hints:
           api_entreprise_token: 'For example: eyJhbGciOiJIUzI1NiJ9.eyJ1...'
+          api_particulier_token: 'For example: eyJhbGciOiJIUzI1NiJ9.eyJ1...'
           description: Describe in a few lines the context, the aim etc.
           description_target_audience: Describe in a few lines the final recipients of the process, the eligibility criteria if there are any, the prerequisites, etc.
           description_pj: Describe the required attachments list if there is any
@@ -85,7 +86,7 @@ en:
         procedure:
           attributes:
             api_particulier_token:
-              invalid: 'invalid format'
+              invalid: 'is not a valid token'
             public_draft_type_de_champs:
               format: 'Public field %{message}'
               invalid_condition: "have an invalid logic"
@@ -97,7 +98,7 @@ en:
               missing_libelle_in_repetition: "field label in position %{position}, within the repetition in position %{parent_position}, must be filled"
               expression_reguliere_invalid: "is invalid"
               referentiel_not_ready: "is not configured"
-              missing_api_particulier_token: "does not work without a API Particulier token"
+              missing_api_particulier_token: "does not work without a valid API Particulier token"
             private_draft_type_de_champs:
               format: 'Private field %{message}'
               invalid_condition: "have an invalid logic"

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -8,7 +8,7 @@ fr:
       procedure:
         hints:
           api_entreprise_token: 'Exemple : eyJhbGciOiJIUzI1NiJ9.eyJ1...'
-          api_particulier_token: "Il doit contenir au minimum 15 caractères."
+          api_particulier_token: 'Exemple : eyJhbGciOiJIUzI1NiJ9.eyJ1...'
           description: Décrivez en quelques lignes le contexte, la finalité, etc.
           description_target_audience: Décrivez en quelques lignes les destinataires finaux de la démarche, les conditions d’éligibilité s’il y en a, les pré-requis, etc.
           description_pj: Décrivez la liste des pièces jointes à fournir s’il y en a
@@ -92,7 +92,7 @@ fr:
         procedure:
           attributes:
             api_particulier_token:
-              invalid: 'n’a pas le bon format'
+              invalid: 'n’est pas un jeton valide'
             public_draft_type_de_champs:
               format: 'Le champ %{message}'
               invalid_condition: "a une logique conditionnelle invalide"
@@ -104,7 +104,7 @@ fr:
               missing_libelle_in_repetition: "Le libellé du champ en position %{position}, dans le bloc répétable en position %{parent_position}, doit être rempli"
               expression_reguliere_invalid: "est invalide, veuillez la corriger"
               referentiel_not_ready: "n’est pas configuré"
-              missing_api_particulier_token: "n’est pas fonctionnel en l’absence d’un jeton API Particulier"
+              missing_api_particulier_token: "n’est pas fonctionnel sans un jeton API Particulier valide"
             private_draft_type_de_champs:
               format: 'L’annotation privée %{message}'
               invalid_condition: "a une logique conditionnelle invalide"

--- a/db/migrate/20260831100000_add_api_particulier_token_expiration_notice_sent_at_to_procedures.rb
+++ b/db/migrate/20260831100000_add_api_particulier_token_expiration_notice_sent_at_to_procedures.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAPIParticulierTokenExpirationNoticeSentAtToProcedures < ActiveRecord::Migration[8.1]
+  def change
+    add_column :procedures, :api_particulier_token_expiration_notice_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_27_093000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_31_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_catalog.plpgsql"
@@ -1099,6 +1099,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_27_093000) do
     t.string "api_entreprise_token"
     t.datetime "api_entreprise_token_expiration_notice_sent_at"
     t.string "api_particulier_token"
+    t.datetime "api_particulier_token_expiration_notice_sent_at"
     t.boolean "ask_birthday", default: false, null: false
     t.date "auto_archive_on"
     t.string "cadre_juridique"

--- a/spec/components/procedure/api_entreprise_token_expiration_alert_component_spec.rb
+++ b/spec/components/procedure/api_entreprise_token_expiration_alert_component_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe Procedure::APIEntrepriseTokenExpirationAlertComponent, type: :com
     end
   end
 
+  context "when the token cannot be decoded" do
+    let(:api_entreprise_token) { 'azertyuiopqsdfgh' }
+    let(:procedure) do
+      create(:procedure).tap do
+        it.api_entreprise_token = api_entreprise_token
+        it.save(validate: false)
+      end
+    end
+
+    it "renders the alert" do
+      expect(subject).to have_text('est expiré ou va expirer prochainement')
+    end
+  end
+
   context "when token expires in a long time" do
     let(:api_entreprise_token) { JWT.encode({ exp: 2.months.from_now.to_i }, nil, "none") }
 
@@ -31,11 +45,14 @@ RSpec.describe Procedure::APIEntrepriseTokenExpirationAlertComponent, type: :com
     end
   end
 
-  context "when there is no token" do
+  # Le jeton global de l'instance n'est pas à la main de l'administrateur : il n'a
+  # rien à renouveler, rien ne doit l'alerter à son sujet.
+  context "when only the instance-wide token is set" do
     let(:api_entreprise_token) { nil }
 
     before do
-      allow_any_instance_of(APIEntrepriseToken).to receive(:expired_or_expires_soon?).and_return(false)
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('API_ENTREPRISE_KEY').and_return(JWT.encode({ exp: 2.days.from_now.to_i }, nil, "none"))
     end
 
     it "does not render" do

--- a/spec/components/procedure/card/api_token_component_spec.rb
+++ b/spec/components/procedure/card/api_token_component_spec.rb
@@ -37,10 +37,22 @@ RSpec.describe Procedure::Card::APITokenComponent, type: :component do
 
   context "API entreprise token and API particulier token are both configured" do
     let(:api_entreprise_token) { JWT.encode({ exp: 2.months.from_now.to_i }, nil, "none") }
-    let(:api_particulier_token) { 'api_particulier_token' }
+    let(:api_particulier_token) { JWT.encode({ exp: 2.months.from_now.to_i }, nil, 'none') }
     it do
       is_expected.to have_css('p.fr-badge.fr-badge--success', text: "Configuré")
       is_expected.to have_css('p.fr-tag', text: "2 / 2")
     end
+  end
+
+  context "API particulier token cannot be decoded" do
+    # Le cas de RAILS-MGX, tel que l'administrateur le verra sur sa tuile Jetons.
+    let(:procedure) do
+      create(:procedure).tap do
+        it.api_particulier_token = 'azertyuiopqsdfgh'
+        it.save(validate: false)
+      end
+    end
+
+    it { is_expected.to have_css('p.fr-badge.fr-badge--error', text: "À renouveler") }
   end
 end

--- a/spec/controllers/administrateurs/jetons_controller_spec.rb
+++ b/spec/controllers/administrateurs/jetons_controller_spec.rb
@@ -113,6 +113,22 @@ describe Administrateurs::JetonsController, type: :controller do
       sign_in(admin.user)
     end
 
+    # La page qui liste les jetons de la démarche et leur état.
+    describe "GET #index" do
+      render_views
+
+      let(:procedure) do
+        create(:procedure, administrateur: admin).tap do
+          it.api_particulier_token = 'azertyuiopqsdfgh'
+          it.save(validate: false)
+        end
+      end
+
+      subject { get :index, params: { procedure_id: procedure.id } }
+
+      it { expect(subject.body).to have_content('Jeton invalide') }
+    end
+
     describe "GET #edit_particulier" do
       render_views
 
@@ -127,8 +143,8 @@ describe Administrateurs::JetonsController, type: :controller do
     describe "PATCH #update_particulier" do
       subject { patch :update_particulier, params: { procedure_id: procedure.id, procedure: { api_particulier_token: token } } }
 
-      context "when jeton has a valid shape" do
-        let(:token) { "d7e9c9f4c3ca00caadde31f50fd4521a" }
+      context "when jeton is a valid JWT" do
+        let(:token) { JWT.encode({ exp: 2.months.from_now.to_i }, nil, 'none') }
 
         it 'saves the jeton' do
           subject
@@ -137,28 +153,39 @@ describe Administrateurs::JetonsController, type: :controller do
         end
       end
 
-      context "when jeton is invalid" do
-        let(:token) { "jet0n 1nvalide" }
+      context "when jeton has expired" do
+        let(:token) { JWT.encode({ exp: 2.days.ago.to_i }, nil, 'none') }
+
+        it 'rejects the jeton' do
+          subject
+          expect(flash.alert).to eq("Mise à jour impossible : ce jeton a expiré")
+          expect(procedure.reload.api_particulier_token?).to be(false)
+        end
+      end
+
+      context "when jeton is not a JWT" do
+        # Le cas de RAILS-MGX : un administrateur avait saisi n'importe quoi.
+        let(:token) { "azertyuiopqsdfgh" }
 
         it 'rejects the jeton' do
           subject
           expect(flash.alert).to eq("Mise à jour impossible : le jeton n’est pas valide")
           expect(flash.notice).to be_nil
-          expect(procedure.reload.api_particulier_token).not_to eql(token)
+          expect(procedure.reload.api_particulier_token?).to be(false)
         end
       end
     end
 
     describe 'DELETE #destroy_particulier' do
       let(:procedure) { create(:procedure, administrateur: admin, api_particulier_token:) }
-      let(:api_particulier_token) { "d7e9c9f4c3ca00caadde31f50fd4521a" }
+      let(:api_particulier_token) { JWT.encode({ exp: 2.months.from_now.to_i }, nil, 'none') }
 
       subject { delete :destroy_particulier, params: { procedure_id: procedure.id } }
 
       it do
         subject
         expect(flash.notice).to eq("Le jeton API Particulier a bien été supprimé")
-        expect(procedure.reload.api_particulier_token).to eq(nil)
+        expect(procedure.reload.api_particulier_token?).to eq(false)
       end
     end
   end

--- a/spec/controllers/administrateurs/jetons_controller_spec.rb
+++ b/spec/controllers/administrateurs/jetons_controller_spec.rb
@@ -14,6 +14,33 @@ describe Administrateurs::JetonsController, type: :controller do
       subject { get :edit_entreprise, params: { procedure_id: procedure.id } }
 
       it { is_expected.to have_http_status(:success) }
+
+      # Le jeton global de l'instance n'est pas à la main de l'administrateur : lui
+      # annoncer qu'il doit le renouveler n'a pas de sens.
+      context 'when only the instance-wide token is set, and expired' do
+        render_views
+
+        before do
+          allow(ENV).to receive(:[]).and_call_original
+          allow(ENV).to receive(:[]).with('API_ENTREPRISE_KEY').and_return(JWT.encode({ exp: 2.days.ago.to_i }, nil, 'none'))
+        end
+
+        it { expect(subject.body).not_to include('Merci de le renouveler') }
+      end
+
+      # La page où atterrit l'administrateur depuis le mail « n’est pas valide ».
+      context 'when the procedure token cannot be decoded' do
+        render_views
+
+        let(:procedure) do
+          create(:procedure, administrateur: admin).tap do
+            it.api_entreprise_token = 'azertyuiopqsdfgh'
+            it.save(validate: false)
+          end
+        end
+
+        it { expect(subject.body).to include('n’est pas valide') }
+      end
     end
 
     describe 'PATCH #update_entreprise' do

--- a/spec/jobs/cron/send_api_entreprise_token_expiration_notice_job_spec.rb
+++ b/spec/jobs/cron/send_api_entreprise_token_expiration_notice_job_spec.rb
@@ -44,6 +44,21 @@ RSpec.describe Cron::SendAPIEntrepriseTokenExpirationNoticeJob, type: :job do
       end
     end
 
+    context 'when the token cannot be decoded' do
+      # Un tel jeton coupait déjà les appels (api_entreprise/api.rb:113) mais
+      # n'alertait personne : le filtre ne portait que sur l'expiration annoncée.
+      let!(:procedure) do
+        create(:procedure, administrateurs: [administrateur]).tap do
+          it.api_entreprise_token = 'azertyuiopqsdfgh'
+          it.save(validate: false)
+        end
+      end
+
+      before { perform_now }
+
+      it { expect(mailer_double).to have_received(:deliver_later).once }
+    end
+
     context 'when already notified for the same window' do
       let(:expires_at) { 3.days.from_now }
 
@@ -53,6 +68,26 @@ RSpec.describe Cron::SendAPIEntrepriseTokenExpirationNoticeJob, type: :job do
       end
 
       it { expect(mailer_double).not_to have_received(:deliver_later) }
+    end
+
+    # Un jeton illisible relève désormais de needs_renewal? : sur une démarche qui
+    # ne reçoit plus de dossiers, on le signale une fois, sans relance perpétuelle.
+    context 'when the procedure is closed and its token cannot be decoded' do
+      let!(:procedure) do
+        create(:procedure, :closed, administrateurs: [administrateur]).tap do
+          it.api_entreprise_token = 'azertyuiopqsdfgh'
+          it.save(validate: false)
+        end
+      end
+
+      it 'notifies once and never reminds' do
+        perform_now
+        expect(mailer_double).to have_received(:deliver_later).once
+
+        travel_to(2.months.from_now)
+        perform_now
+        expect(mailer_double).to have_received(:deliver_later).once
+      end
     end
 
     context 'when notified for previous window but now in a smaller window' do

--- a/spec/jobs/cron/send_api_particulier_token_expiration_notice_job_spec.rb
+++ b/spec/jobs/cron/send_api_particulier_token_expiration_notice_job_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+RSpec.describe Cron::SendAPIParticulierTokenExpirationNoticeJob, type: :job do
+  describe 'perform' do
+    let(:administrateur) { administrateurs.default }
+    let(:expires_at) { 6.months.from_now }
+    let(:token) { JWT.encode({ exp: expires_at.to_i }, nil, 'none') }
+    let(:garbage_token) { 'azertyuiopqsdfgh' }
+    let(:mailer_double) { double('mailer', deliver_later: true) }
+
+    def published_procedure(token)
+      create(:procedure, :published, :with_service,
+        administrateurs: [administrateur],
+        for_individual: true,
+        public_type_de_champs: [{ type: :quotient_familial }],
+        api_particulier_token: token)
+    end
+
+    let!(:procedure) { published_procedure(token) }
+
+    def perform_now
+      Cron::SendAPIParticulierTokenExpirationNoticeJob.perform_now
+    end
+
+    before do
+      allow(AdministrateurMailer).to receive(:api_particulier_token_expiration).and_return(mailer_double)
+    end
+
+    context 'when the token expires in more than a month' do
+      let(:expires_at) { 2.months.from_now }
+
+      before { perform_now }
+
+      it { expect(mailer_double).not_to have_received(:deliver_later) }
+    end
+
+    context 'when the procedure has no token' do
+      let!(:procedure) { published_procedure(nil) }
+
+      before { perform_now }
+
+      it { expect(mailer_double).not_to have_received(:deliver_later) }
+    end
+
+    context 'when the token expires within a month' do
+      let(:expires_at) { 3.weeks.from_now }
+
+      before { perform_now }
+
+      it 'sends a notification, saves notification date' do
+        expect(AdministrateurMailer).to have_received(:api_particulier_token_expiration).with(administrateur, procedure)
+        expect(mailer_double).to have_received(:deliver_later).once
+        expect(procedure.reload.api_particulier_token_expiration_notice_sent_at).to be_within(1.second).of(Time.current)
+      end
+    end
+
+    # La colonne charrie des clés API Particulier v1/v2 abandonnées, sur des
+    # démarches dont les champs ont été convertis en texte : leurs administrateurs
+    # n'ont rien à renouveler et ne doivent pas être dérangés.
+    context 'when the procedure no longer has an API Particulier champ' do
+      let!(:procedure) do
+        create(:procedure, :published, administrateurs: [administrateur]).tap do
+          it.api_particulier_token = garbage_token
+          it.save(validate: false)
+        end
+      end
+
+      before { perform_now }
+
+      it { expect(mailer_double).not_to have_received(:deliver_later) }
+    end
+
+    # Le cas de RAILS-MGX : l'administrateur avait saisi n'importe quoi, l'appel
+    # échouait pour chaque usager et personne n'était prévenu.
+    context 'when the token cannot be decoded' do
+      let!(:procedure) do
+        published_procedure(nil).tap do
+          it.api_particulier_token = garbage_token
+          it.save(validate: false)
+        end
+      end
+
+      it 'notifies, then reminds a month later' do
+        perform_now
+        expect(mailer_double).to have_received(:deliver_later).once
+
+        travel_to(2.days.from_now)
+        perform_now
+        expect(mailer_double).to have_received(:deliver_later).once
+
+        travel_to(2.months.from_now)
+        perform_now
+        expect(mailer_double).to have_received(:deliver_later).twice
+      end
+    end
+
+    # Le validateur empêche de publier une démarche dont le jeton est hors service :
+    # son administrateur doit savoir pourquoi, avant même la publication.
+    context 'when the procedure is still a draft' do
+      let!(:procedure) do
+        create(:procedure, :with_service,
+          administrateurs: [administrateur],
+          for_individual: true,
+          public_type_de_champs: [{ type: :quotient_familial }],
+          api_particulier_token: nil).tap do
+          it.api_particulier_token = garbage_token
+          it.save(validate: false)
+        end
+      end
+
+      it 'notifies, then stops reminding' do
+        perform_now
+        expect(mailer_double).to have_received(:deliver_later).once
+
+        travel_to(2.months.from_now)
+        perform_now
+        expect(mailer_double).to have_received(:deliver_later).once
+      end
+    end
+
+    # Un jeton expiré ne se répare pas tout seul : tant qu'il n'est pas renouvelé,
+    # les appels sont coupés, donc les relances continuent.
+    context 'when the token is expired' do
+      let(:expires_at) { 1.day.ago }
+
+      it 'keeps reminding every month' do
+        perform_now
+        expect(mailer_double).to have_received(:deliver_later).once
+
+        travel_to(2.months.from_now)
+        perform_now
+        expect(mailer_double).to have_received(:deliver_later).twice
+      end
+    end
+  end
+end

--- a/spec/lib/api_particulier/api_spec.rb
+++ b/spec/lib/api_particulier/api_spec.rb
@@ -6,6 +6,9 @@ describe APIParticulier::API do
   let(:fci) { create(:france_connect_information) }
   let(:subject) { api.call_with_fci(fci) }
 
+  # Le .env local peut pointer sur staging, que le stub WebMock ne reconnaît pas.
+  before { stub_const("API_PARTICULIER_URL", "https://particulier.api.gouv.fr") }
+
   context ' when type_champ is quotient_familial' do
     let(:type_champ) { 'quotient_familial' }
 
@@ -107,9 +110,43 @@ describe APIParticulier::API do
       let(:status) { 400 }
       let(:body) { { errors: "dossier allocataire non trouvé" }.to_json }
 
-      it 'returns a Failure with an invalid_schema code' do
+      it 'returns a Failure carrying the http code, without the response body' do
         expect(subject).to be_failure
-        expect(subject.failure[:error].message).to include("dossier allocataire non trouvé")
+        expect(subject.failure).to include(code: 400)
+        expect(subject.failure[:error].message).to eq("API Particulier: 400")
+      end
+    end
+
+    context "when responds with a business error code" do
+      let(:status) { 403 }
+      # La réponse de RAILS-MGX.
+      let(:body) do
+        { errors: [{ code: "00101", title: "Interdit", detail: "Votre token n'est pas valide ou n'est pas renseigné" }] }.to_json
+      end
+
+      it 'keeps the business code, not the whole response body' do
+        expect(subject.failure[:error].message).to eq("API Particulier: 403 00101")
+      end
+    end
+  end
+
+  describe 'unusable token' do
+    let(:type_champ) { 'quotient_familial' }
+
+    context "when the procedure token cannot be decoded" do
+      # Le cas de RAILS-MGX : l'administrateur avait saisi n'importe quoi. La
+      # validation l'interdit désormais, mais de tels jetons sont déjà en base.
+      let(:procedure) do
+        create(:procedure, :with_service).tap do
+          it.api_particulier_token = 'azertyuiopqsdfgh'
+          it.save(validate: false)
+        end
+      end
+
+      it 'fails without calling API Particulier' do
+        expect(subject).to be_failure
+        expect(subject.failure).to include(code: :token_unusable)
+        expect(WebMock).not_to have_requested(:get, /particulier.api.gouv.fr/)
       end
     end
   end

--- a/spec/mailers/administrateur_mailer_spec.rb
+++ b/spec/mailers/administrateur_mailer_spec.rb
@@ -59,6 +59,45 @@ end
     end
   end
 
+  describe '.api_particulier_token_expiration' do
+    let(:administrateur) { create(:administrateur) }
+    let(:token) { JWT.encode({ exp: 2.weeks.from_now.to_i }, nil, 'none') }
+    let(:procedure) { create(:procedure, administrateurs: [administrateur], api_particulier_token: token) }
+
+    subject { described_class.api_particulier_token_expiration(administrateur, procedure) }
+
+    it do
+      expect(subject.to).to eq([administrateur.user.email])
+      expect(subject.subject).to include("[Action requise]")
+      expect(subject.subject).to include("nº#{procedure.id}")
+      expect(subject.body).to include(procedure.libelle)
+      expect(subject.body).to include("expirera le")
+    end
+
+    context 'when the token cannot be decoded' do
+      let(:procedure) do
+        create(:procedure, administrateurs: [administrateur]).tap do
+          it.api_particulier_token = 'azertyuiopqsdfgh'
+          it.save(validate: false)
+        end
+      end
+
+      it 'announces an invalid token rather than an expiry date' do
+        expect(subject.subject).to include("n’est pas valide")
+        expect(subject.body.to_s.gsub(/\s+/, " ")).to include("n’est pas un jeton valide")
+      end
+    end
+
+    context 'when the token has already expired' do
+      let(:token) { JWT.encode({ exp: 2.weeks.ago.to_i }, nil, 'none') }
+
+      it 'speaks of the expiry in the past' do
+        expect(subject.subject).to include("a expiré")
+        expect(subject.body.to_s.gsub(/\s+/, " ")).to include("a expiré le")
+      end
+    end
+  end
+
   describe '.notify_service_without_siret' do
     subject { described_class.notify_service_without_siret(admin_email) }
 

--- a/spec/mailers/administrateur_mailer_spec.rb
+++ b/spec/mailers/administrateur_mailer_spec.rb
@@ -43,6 +43,20 @@ end
       expect(subject.body).to include(procedure.libelle)
       expect(subject.body).to include("empêcher la création")
     end
+
+    context 'when the token cannot be decoded' do
+      let(:procedure) do
+        create(:procedure, administrateurs: [administrateur]).tap do
+          it.api_entreprise_token = 'azertyuiopqsdfgh'
+          it.save(validate: false)
+        end
+      end
+
+      it 'announces an invalid token rather than an expiry date' do
+        expect(subject.subject).to include("n’est pas valide")
+        expect(subject.body.to_s.gsub(/\s+/, " ")).to include("n’est pas un jeton valide")
+      end
+    end
   end
 
   describe '.notify_service_without_siret' do

--- a/spec/mailers/previews/administrateur_mailer_preview.rb
+++ b/spec/mailers/previews/administrateur_mailer_preview.rb
@@ -13,6 +13,12 @@ class AdministrateurMailerPreview < ActionMailer::Preview
     AdministrateurMailer.api_entreprise_token_expiration(administrateur, procedure)
   end
 
+  def api_particulier_token_expiration
+    administrateur = Administrateur.first
+    procedure = Procedure.kept.where.not(api_particulier_token: nil).first || Procedure.first
+    AdministrateurMailer.api_particulier_token_expiration(administrateur, procedure)
+  end
+
   def api_token_expiration
     user = User.last
     tokens = [APIToken.last, APIToken.last]

--- a/spec/models/api_entreprise_token_spec.rb
+++ b/spec/models/api_entreprise_token_spec.rb
@@ -113,8 +113,8 @@ describe APIEntrepriseToken, type: :model do
     end
   end
 
-  describe "#api_entreprise_token_expired_or_expires_soon?" do
-    subject { api_entreprise_token.expired_or_expires_soon? }
+  describe "#needs_renewal?" do
+    subject { api_entreprise_token.needs_renewal? }
 
     context "when there is no token" do
       let(:token) { nil }
@@ -136,6 +136,12 @@ describe APIEntrepriseToken, type: :model do
 
     context "when the token is expired" do
       let(:token) { JWT.encode({ exp: 1.day.ago.to_i }, nil, "none") }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when the token cannot be decoded" do
+      let(:token) { "azertyuiopqsdfgh" }
 
       it { is_expected.to be_truthy }
     end

--- a/spec/models/api_particulier_token_spec.rb
+++ b/spec/models/api_particulier_token_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+describe APIParticulierToken, type: :model do
+  let(:api_particulier_token) { APIParticulierToken.new(token) }
+
+  # Le jeton saisi par un administrateur qui a mis n'importe quoi : il passait
+  # l'ancienne validation de format, et faisait échouer tous les appels (RAILS-MGX).
+  let(:garbage_token) { "azertyuiopqsdfgh" }
+
+  describe "#unusable?" do
+    subject { api_particulier_token.unusable? }
+
+    context "without token" do
+      let(:token) { nil }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a garbage token" do
+      let(:token) { garbage_token }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "with an expired token" do
+      let(:token) { JWT.encode({ exp: 1.day.ago.to_i }, nil, 'none') }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a token expiring soon" do
+      let(:token) { JWT.encode({ exp: 3.weeks.from_now.to_i }, nil, 'none') }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "with a token without expiration claim" do
+      let(:token) { JWT.encode({ sub: 'demarche' }, nil, 'none') }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  describe "#needs_renewal?" do
+    subject { api_particulier_token.needs_renewal? }
+
+    context "without token" do
+      let(:token) { nil }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "with a garbage token" do
+      let(:token) { garbage_token }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a token expiring in 2 months" do
+      let(:token) { JWT.encode({ exp: 2.months.from_now.to_i }, nil, 'none') }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "with a token expiring in 3 weeks" do
+      let(:token) { JWT.encode({ exp: 3.weeks.from_now.to_i }, nil, 'none') }
+
+      it { is_expected.to eq(true) }
+    end
+  end
+end

--- a/spec/models/api_particulier_token_spec.rb
+++ b/spec/models/api_particulier_token_spec.rb
@@ -68,4 +68,71 @@ describe APIParticulierToken, type: :model do
       it { is_expected.to eq(true) }
     end
   end
+
+  describe "#notification_due?" do
+    subject { api_particulier_token.notification_due?(last_sent_at) }
+
+    context "with a healthy token" do
+      let(:token) { JWT.encode({ exp: 2.months.from_now.to_i }, nil, 'none') }
+      let(:last_sent_at) { nil }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "with a token expiring in 3 weeks" do
+      let(:token) { JWT.encode({ exp: 3.weeks.from_now.to_i }, nil, 'none') }
+
+      context "never notified" do
+        let(:last_sent_at) { nil }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "already notified within the same window" do
+        let(:last_sent_at) { 1.day.ago }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    # Sans cela, le mail annonçant la coupure n'arriverait qu'un délai de relance
+    # après l'expiration, alors que les appels sont déjà coupés.
+    context "with a token that has just expired" do
+      let(:token) { JWT.encode({ exp: 1.day.ago.to_i }, nil, 'none') }
+
+      context "last notified before the expiry" do
+        let(:last_sent_at) { 2.days.ago }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "already notified since the expiry" do
+        let(:last_sent_at) { 1.hour.ago }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    context "with a garbage token" do
+      let(:token) { garbage_token }
+
+      context "never notified" do
+        let(:last_sent_at) { nil }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "notified recently" do
+        let(:last_sent_at) { 2.days.ago }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "notified more than a month ago" do
+        let(:last_sent_at) { 2.months.ago }
+
+        it { is_expected.to eq(true) }
+      end
+    end
+  end
 end

--- a/spec/models/concerns/champ_external_data_concern_spec.rb
+++ b/spec/models/concerns/champ_external_data_concern_spec.rb
@@ -140,6 +140,17 @@ RSpec.describe ChampExternalDataConcern do
         end
       end
 
+      # L'administrateur est prévenu par mail et son badge est au rouge : il n'y a
+      # rien à corriger côté code.
+      context 'when code is :token_unusable' do
+        let(:code) { :token_unusable }
+
+        it do
+          expect(champ).to be_external_error
+          expect(Sentry).not_to have_received(:capture_exception)
+        end
+      end
+
       context 'when code is 500' do
         let(:code) { 500 }
 

--- a/spec/models/concerns/procedure_clone_concern_spec.rb
+++ b/spec/models/concerns/procedure_clone_concern_spec.rb
@@ -69,6 +69,22 @@ describe ProcedureCloneConcern, type: :model do
 
     it { expect(subject.parent_procedure).to eq(procedure) }
 
+    # Le clone est un nouvel enregistrement : recopier un jeton hors service ferait
+    # échouer sa validation, et donc le clone entier.
+    it 'drops an unusable token instead of failing, even for the same admin' do
+      procedure.api_particulier_token = 'azertyuiopqsdfgh'
+      procedure.save(validate: false)
+
+      expect(subject).to be_persisted
+      expect(subject.api_particulier_token?).to be(false)
+    end
+
+    it 'drops an expired API Entreprise token' do
+      procedure.update!(api_entreprise_token: JWT.encode({ exp: 2.days.ago.to_i }, nil, 'none'))
+
+      expect(subject.specific_api_entreprise_token?).to be(false)
+    end
+
     it 'keeps the old pj information when cloning for the same admin' do
       tag_source_pj_with_old_pj
       pj_tdc = subject.draft_revision.public_root_type_de_champs.find(&:piece_justificative?)

--- a/spec/models/concerns/procedure_clone_concern_spec.rb
+++ b/spec/models/concerns/procedure_clone_concern_spec.rb
@@ -16,7 +16,7 @@ describe ProcedureCloneConcern, type: :model do
         attestation_refus_template: build(:attestation_template, kind: 'refus'),
         public_type_de_champs:,
         private_type_de_champs:,
-        api_particulier_token: '123456789012345',
+        api_particulier_token: JWT.encode({ exp: 2.months.from_now.to_i }, nil, 'none'),
         estimated_dossiers_count: 4,
         template: true)
     end
@@ -281,7 +281,7 @@ describe ProcedureCloneConcern, type: :model do
       end
 
       it "should discard the existing token" do
-        expect(subject.api_particulier_token).to be_nil
+        expect(subject.api_particulier_token?).to be(false)
       end
 
       it 'should not route the procedure' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -394,11 +394,23 @@ describe Procedure do
     end
 
     context 'api_particulier_token' do
-      let(:valid_token) { "3841b13fa8032ed3c31d160d3437a76a" }
-      let(:invalid_token) { 'jet0n 1nvalide' }
+      let(:valid_token) { JWT.encode({ exp: 2.months.from_now.to_i }, nil, 'none') }
+      # Le jeton de RAILS-MGX : un administrateur avait saisi n'importe quoi.
+      let(:garbage_token) { 'azertyuiopqsdfgh' }
       it do
         is_expected.to allow_value(valid_token).for(:api_particulier_token)
-        is_expected.not_to allow_value(invalid_token).for(:api_particulier_token)
+        is_expected.not_to allow_value(garbage_token).for(:api_particulier_token)
+      end
+
+      # De tels jetons sont déjà en base : les démarches concernées doivent
+      # rester modifiables, sans quoi routage, groupes instructeurs et tâches de
+      # maintenance échoueraient sur elles.
+      it 'still saves a procedure whose stored token is already unusable' do
+        unusable = create(:procedure)
+        unusable.api_particulier_token = garbage_token
+        unusable.save(validate: false)
+
+        expect(unusable.reload.update(routing_alert: true)).to be(true)
       end
     end
 

--- a/spec/validators/type_de_champs/api_particulier_validator_spec.rb
+++ b/spec/validators/type_de_champs/api_particulier_validator_spec.rb
@@ -23,4 +23,22 @@ RSpec.describe TypeDeChamps::APIParticulierValidator do
         .to include(hash_including(error: :missing_api_particulier_token))
     end
   end
+
+  context 'when procedure has a API Particulier champ and an unusable token' do
+    # Une démarche déjà publiée avec un jeton illisible ne peut plus être republiée
+    # sans le corriger.
+    let(:procedure) do
+      create(:procedure, public_type_de_champs:).tap do
+        it.api_particulier_token = 'azertyuiopqsdfgh'
+        it.save(validate: false)
+      end
+    end
+    let(:public_type_de_champs) { [{ type: :quotient_familial }] }
+
+    it 'adds errors to the procedure' do
+      subject
+      expect(procedure.errors.details[:public_draft_type_de_champs])
+        .to include(hash_including(error: :missing_api_particulier_token))
+    end
+  end
 end


### PR DESCRIPTION
Un jeton API Particulier illisible fait échouer chaque appel usager, sans que l’administrateur le sache (cas RAILS-MGX). La démarche ne contrôlait qu’un format lâche, qui laissait passer une clé v1/v2 ou n’importe quelle chaîne.

- Le jeton est désormais validé comme un JWT à la saisie, comme celui d’API Entreprise : la lecture du JWT est mutualisée dans `JwtTokenConcern`. Un jeton déjà expiré est refusé aussi. Les messages vus par l’administrateur parlent de « format API Particulier v3 », jamais de JWT. La validation ne joue qu’à la saisie, pour que les quelques démarches au jeton hérité restent modifiables.
- L’état du jeton API Particulier apparaît dans l’interface, comme pour API Entreprise : « Jeton invalide » ou date d’expiration sur la page « Jetons API », badge « À renouveler » sur la tuile, alerte sur la page de saisie (avec le rappel du format v3 quand il est invalide).

Pas de mail aux administrateurs, ni de rappel à l’approche de l’échéance, dans cette PR.

Les commits se lisent dans l’ordre : deux refactors préparatoires, la validation, puis l’interface.
