### PR TITLE
ETQ usager, je peux dupliquer un dossier dont un champ a changé de type

### DIFF
--- a/app/models/concerns/dossier_clone_concern.rb
+++ b/app/models/concerns/dossier_clone_concern.rb
@@ -15,8 +15,18 @@ module DossierCloneConcern
     discarded_row_ids = champ_data_on_main_stream
       .filter { _1.row? && _1.discarded? }
       .to_set(&:row_id)
-    champs_to_clone = champ_data_on_main_stream
+    champs_on_main_stream = champ_data_on_main_stream
       .reject { discarded_row_ids.member?(_1.row_id) }
+
+    #  each type_de_champ lookup needs the dossier
+    champs_on_main_stream.each { _1.association(:dossier).target = self }
+
+    champs_to_clone = champs_on_main_stream
+      # because of revisions, champ.type can differ from champ.type_de_champ.type_champ
+      # some champ before_save callbacks then call type_de_champ methods that don't exist
+      # solution: exclude champs where there is a type mismatch
+      .filter { _1.is_type?(_1.type_de_champ.type_champ) }
+
     ActiveRecord::Associations::Preloader.new(records: champs_to_clone, associations: [:geo_areas, :etablissement]).call
     cloned_champs = champs_to_clone.map(&:clone)
 

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -137,7 +137,7 @@ class PiecesJustificativesService
 
   def pjs_for_champs(dossiers)
     champs = liste_documents_allows?(:with_champs_private) ? dossiers.flat_map(&:filled_champs) : dossiers.flat_map(&:filled_champs_public)
-    champs = champs.filter { it.piece_justificative? && it.is_type?(it.type_de_champ.type_champ) && !it.titre_identite? }
+    champs = champs.filter { it.piece_justificative? && !it.titre_identite? }
 
     champs_id_row_index = compute_champ_id_row_index(champs)
 

--- a/spec/models/concerns/dossier_clone_concern_spec.rb
+++ b/spec/models/concerns/dossier_clone_concern_spec.rb
@@ -193,6 +193,23 @@ RSpec.describe DossierCloneConcern do
           expect(new_dossier.root_champs_private.first.value).to eq(nil)
         end
       end
+
+      context 'when the revision changed the type of a champ' do
+        let(:public_type_de_champs) { [{ type: :drop_down_list, libelle: 'Un champ drop down', stable_id: 99, options: ['a', 'b'] }] }
+
+        before do
+          tdc = dossier.procedure.draft_revision.find_and_ensure_exclusive_use(99).becomes_type(:dossier_link)
+          tdc.update!(type_champ: TypeDeChamp.type_champs.fetch(:dossier_link))
+          procedure.publish_revision!(procedure.administrateurs.first)
+          perform_enqueued_jobs
+          dossier.reload
+          expect(dossier.champ_data.find_by(stable_id: 99).last_write_type_champ).to eq('drop_down_list')
+        end
+
+        it 'does not clone the champ' do
+          expect(new_dossier.champ_data.find_by(stable_id: 99)).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Le clone d'un dossier recopiait les lignes de champ telles quelles. Quand une révision publiée avait changé le type d'un champ déjà rempli, la ligne conservait l'ancien type : à la sauvegarde du dossier cloné, les callbacks de l'ancien type s'exécutaient contre le nouveau type de champ (`store_referentiel if: :drop_down_advanced?` d'un drop_down_list, sur un tdc dossier_link) → NoMethodError, duplication impossible.

Ces lignes sont maintenant exclues du clone : le dossier dupliqué repart avec un champ vide sur le type courant.

Le premier commit supprime un garde équivalent devenu mort dans l'export des pièces justificatives : ses champs viennent de `filled_champs`, donc projetés, donc toujours accordés à leur type de champ.

Fixes RAILS-MHQ
