### PR TITLE
ETQ admin, la condition « est dans la région » reconnaît l'Etranger pour un département étranger

### DIFF
--- a/app/services/api_geo_service.rb
+++ b/app/services/api_geo_service.rb
@@ -92,7 +92,7 @@ class APIGeoService
 
     def departements
       memoize(:departements) do
-        ([{ code: '99', name: 'Etranger' }] + get_from_api_geo(:departements)).sort_by { _1[:code] }.freeze
+        ([{ code: '99', name: 'Etranger', region_code: '99' }] + get_from_api_geo(:departements)).sort_by { _1[:code] }.freeze
       end
     end
 

--- a/spec/models/logic/in_region_operator_spec.rb
+++ b/spec/models/logic/in_region_operator_spec.rb
@@ -37,5 +37,14 @@ describe Logic::InRegionOperator do
     context 'departement' do
       it { expect(ds_in_region(champ_value(champ_departement.stable_id), constant('84')).compute([champ_departement])).to be(true) }
     end
+
+    context 'departement Etranger' do
+      let(:champ_departement) { Champs::DepartementChamp.new(value: '99', stable_id: tdc_departement.stable_id, dossier:) }
+
+      it 'is in the region Etranger' do
+        expect(ds_in_region(champ_value(champ_departement.stable_id), constant('99')).compute([champ_departement])).to be(true)
+        expect(ds_in_region(champ_value(champ_departement.stable_id), constant('84')).compute([champ_departement])).to be(false)
+      end
+    end
   end
 end

--- a/spec/services/api_geo_service_spec.rb
+++ b/spec/services/api_geo_service_spec.rb
@@ -33,7 +33,7 @@ describe APIGeoService do
     it 'return sorted results' do
       expect(APIGeoService.departements.size).to eq(110)
       expect(APIGeoService.departements.first).to eq(code: '01', name: 'Ain', region_code: "84")
-      expect(APIGeoService.departements.last).to eq(code: '99', name: 'Etranger')
+      expect(APIGeoService.departements.last).to eq(code: '99', name: 'Etranger', region_code: '99')
     end
   end
 


### PR DESCRIPTION
## Contexte

Le département « Etranger » (code `99`) n'avait pas de `region_code`, alors que la région « Etranger » (code `99`) existe bien dans la liste des régions. Une condition « département est dans la région Etranger » ne pouvait donc jamais être vraie pour une adresse à l'étranger.

## Changement

- `APIGeoService.departements` rattache le département `99` à la région `99`.
- Spec de `Logic::InRegionOperator` couvrant un département étranger (vrai pour la région Etranger, faux pour une autre région).

🤖 Generated with [Claude Code](https://claude.com/claude-code)