### PR TITLE
Tech : OCRService renvoie toujours une clé code: dans ses Failure

### DIFF
--- a/app/services/ocr_service.rb
+++ b/app/services/ocr_service.rb
@@ -145,7 +145,7 @@ class OCRService
   def self.document_ia_url = ENV.fetch("DOCUMENT_IA_URL", nil)
 
   def self.not_configured(message)
-    Failure(retryable: false, error: StandardError.new("#{message} not configured"))
+    Failure(retryable: false, error: StandardError.new("#{message} not configured"), code: nil)
   end
 
   def self.to_not_retryable_failure(data)
@@ -153,7 +153,7 @@ class OCRService
     in code:, error:
       Failure(retryable: false, error:, code:)
     else
-      Failure(retryable: false, error: StandardError.new('Unknown error'))
+      Failure(retryable: false, error: StandardError.new('Unknown error'), code: nil)
     end
   end
 end

--- a/spec/models/concerns/champ_external_data_concern_spec.rb
+++ b/spec/models/concerns/champ_external_data_concern_spec.rb
@@ -152,6 +152,12 @@ RSpec.describe ChampExternalDataConcern do
 
         it { expect(Sentry).to have_received(:capture_exception) }
       end
+
+      context 'when code is nil' do
+        let(:code) { nil }
+
+        it { expect(champ).to be_external_error }
+      end
     end
 
     describe 'fetch a retryable failure, now is back in waiting_for_job state' do

--- a/spec/services/ocr_service_spec.rb
+++ b/spec/services/ocr_service_spec.rb
@@ -54,6 +54,21 @@ describe OCRService do
         end
       end
     end
+
+    context 'when the service is not configured' do
+      let(:blob) { double('Blob', url: 'http://example.com/blob.pdf') }
+
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("OCR_SERVICE_URL", nil).and_return(nil)
+      end
+
+      it 'returns a failure carrying a code key' do
+        analysis = described_class.analyze(blob, nature: 'rib')
+        expect(analysis.failure?).to be true
+        expect(analysis.failure).to include(retryable: false, code: nil)
+      end
+    end
   end
 
   describe '#analyze with unknown nature' do
@@ -62,6 +77,13 @@ describe OCRService do
     it 'raises ArgumentError' do
       expect { described_class.analyze(blob, nature: 'UNKNOWN') }
         .to raise_error(ArgumentError, /unknown nature/)
+    end
+  end
+
+  describe '#to_not_retryable_failure with an unrecognized failure shape' do
+    it 'returns a failure carrying a code key' do
+      failure = described_class.to_not_retryable_failure(:boom)
+      expect(failure.failure).to include(retryable: false, code: nil)
     end
   end
 


### PR DESCRIPTION
`OCRService` est le seul producteur de `fetch_external_data` à renvoyer un `Failure` sans clé `code:`. Or `ChampExternalDataConcern#handle_result` fait un pattern matching sur cette clé : les deux cas concernés (`not_configured` et la branche `else` de `to_not_retryable_failure`) lèvent donc un `NoMatchingPatternKeyError` au lieu de faire passer le champ en `external_error`.

Correction à la source : on ajoute `code: nil`, et on couvre au passage les trois formes de `Failure` dans le spec du concern.

Extrait de #13435 pour alléger la revue.