### PR TITLE
Tech : dependent_conditions oubliait les annotations privées conditionnées par un champ public

### DIFF
--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -212,7 +212,8 @@ class ProcedureRevision < ApplicationRecord
   def dependent_conditions(tdc)
     stable_id = tdc.stable_id
 
-    (tdc.public? ? public_root_type_de_champs : private_root_type_de_champs).filter do |other_tdc|
+    tdcs = tdc.public? ? public_root_type_de_champs + private_root_type_de_champs : private_root_type_de_champs
+    tdcs.filter do |other_tdc|
       next if !other_tdc.condition?
 
       other_tdc.condition.sources.include?(stable_id)

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -1397,6 +1397,25 @@ describe ProcedureRevision do
       expect(draft.dependent_conditions(first_champ)).to eq([second_champ])
       expect(draft.dependent_conditions(second_champ)).to eq([])
     end
+
+    context 'when a private annotation has a condition on a public champ' do
+      let(:procedure) do
+        create(:procedure, public_type_de_champs: [{ type: :integer_number, libelle: 'public' }]).tap do |p|
+          public_tdc = p.draft_revision.public_root_type_de_champs.first
+          p.draft_revision.add_type_de_champ(type_champ: :text,
+                                             libelle: 'annotation',
+                                             private: true,
+                                             condition: ds_eq(champ_value(public_tdc.stable_id), constant(1)))
+        end
+      end
+
+      def public_champ = procedure.draft_revision.public_root_type_de_champs.first
+      def private_annotation = procedure.draft_revision.private_root_type_de_champs.first
+
+      it 'finds the private annotation as dependent' do
+        expect(draft.dependent_conditions(public_champ)).to include(private_annotation)
+      end
+    end
   end
 
   describe 'only_present_on_draft?' do


### PR DESCRIPTION
`ProcedureRevision#dependent_conditions(tdc)` ne cherchait les conditions que dans le même périmètre que le champ passé en argument. Pour un champ public, les annotations privées qui dépendent de lui étaient donc ignorées.

Conséquence : le champ ne portait pas l'attribut `data-dependent-conditions`, et sa modification ne déclenchait pas la ré-évaluation de la condition côté annotation.

Correction de mfo, extraite de #13435 pour alléger la revue.