### PR TITLE
ETQ usager, le badge « Partagé avec moi » ne s'affiche plus sur une proposition de transfert

### DIFF
--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -111,6 +111,11 @@ module DossierHelper
     )
   end
 
+  # relies on the preloaded invites association to avoid an N+1 on the dossiers list
+  def shared_with_me?(dossier)
+    dossier.invites.any? { it.user_id == current_user.id }
+  end
+
   def partage_badge(html_class: nil)
     tag.span(
       Dossier.human_attribute_name("partage.for_user"),

--- a/app/views/users/dossiers/_dossier_card_content.html.erb
+++ b/app/views/users/dossiers/_dossier_card_content.html.erb
@@ -38,7 +38,7 @@
 
         <%= expiration_badge(dossier) %>
 
-        <%= partage_badge unless current_user.owns?(dossier) %>
+        <%= partage_badge if shared_with_me?(dossier) %>
       </div>
     </div>
 
@@ -112,7 +112,7 @@
 
       <%= expiration_badge(dossier) %>
 
-      <%= partage_badge unless current_user.owns?(dossier) %>
+      <%= partage_badge if shared_with_me?(dossier) %>
     </div>
   </div>
 </div>

--- a/spec/system/users/transfer_dossier_spec.rb
+++ b/spec/system/users/transfer_dossier_spec.rb
@@ -60,6 +60,13 @@ describe 'Transfer dossier flow', js: true do
       expect(page).to have_content('1 dossier en attente de transfert')
     end
 
+    it 'does not show the "Partagé avec moi" badge on a transfer proposal' do
+      visit transferts_path
+
+      expect(page).to have_content('1 dossier en attente de transfert')
+      expect(page).not_to have_css('.fr-badge--blue-cumulus', text: 'Partagé avec moi')
+    end
+
     it 'accepts a transfer' do
       visit transferts_path
       find_link('Accepter').click


### PR DESCRIPTION
Signalé par Marlène : côté destinataire, la page « Propositions de transfert » affichait le badge
« Partagé avec moi » sur chaque dossier proposé au transfert.

Le badge était rendu dès que l'usager n'était **pas propriétaire** du dossier. Sur la liste des
dossiers les deux notions coïncident, mais la page des transferts réutilise la même carte pour
des dossiers dont le destinataire n'est ni propriétaire ni invité.

- le badge teste maintenant l'invitation réelle (`shared_with_me?`), via l'association `invites`
  déjà préchargée dans `USER_LIST_PRELOADS` — pas de N+1 sur la liste
- test système ajouté sur la page des propositions de transfert

### Avant / après (page « Propositions de transfert »)

| Avant | Après |
|---|---|
| ![avant](https://gist.githubusercontent.com/mmagn/b39cd638c93ab724364d0492b8bc0622/raw/before.png) | ![après](https://gist.githubusercontent.com/mmagn/b39cd638c93ab724364d0492b8bc0622/raw/after.png) |

Non-régression — le badge reste affiché sur un dossier réellement partagé :

![partagé](https://gist.githubusercontent.com/mmagn/b39cd638c93ab724364d0492b8bc0622/raw/shared.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

