### PR TITLE
Tech: remplace des validations maison par les validateurs Rails intégrés

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,13 @@ Controllers are organized by user role:
   - `Tech: [description]` for purely technical changes
 - **PR description**: Short summary with essential points for reviewers, avoid excessive technical detail
 
+**Validations:**
+- Prefer a built-in validator (`comparison`, `numericality`, `inclusion`, `length`, `format`, `presence`, `uniqueness`) over a hand-written `validate :method`. Keep the custom method when it carries business logic the built-in cannot express, or when it produces several distinct errors that matter to the user.
+- Pick the cheapest form the bound allows: a frozen constant for a static list (`in: NAMES`), a symbol when the bound is read off the record (`other_than: :id`), a lambda **only** when the bound genuinely varies over time (`greater_than: -> (_) { Date.current }`, which a constant would freeze at class load). A lambda on a static list is re-evaluated at every validation for nothing.
+- `presence` and `comparison` belong in **two separate `validates` calls**, with `allow_nil: true` on the `comparison` one only. Sharing a call breaks both ways: `comparison` reports a nil value as `:blank` too, so the message shows twice; and `allow_nil` applies to the whole call, so adding it silently disables the presence check.
+- Override the default messages in i18n under `activerecord.errors.models.<model>.attributes.<attr>.<kind>` (fr **and** en) — the built-in ones quote the raw bound ("doit être supérieur à 2026-09-02").
+- Specs must assert the attribute **and** the error kind (`expect(record.errors).to be_of_kind(:attr, :kind)`), never a bare `be_invalid`. Beware: with `inclusion: { message: :custom_symbol }` the kind stays `:inclusion` — the symbol only drives the translation lookup.
+
 **Code Cleanliness:**
 - Remove dead code and commented code
 - Separate refactoring commits from feature commits

--- a/app/models/champs/departement_champ.rb
+++ b/app/models/champs/departement_champ.rb
@@ -3,8 +3,17 @@
 class Champs::DepartementChamp < Champs::TextChamp
   store_accessor :value_json,  :code_region
 
-  validate :value_in_departement_names, if: -> { !value.nil? && should_validate_in_current_context? }
-  validate :external_id_in_departement_codes, if: -> { !external_id.nil? && should_validate_in_current_context? }
+  NAMES = APIGeoService.departements.pluck(:name).freeze
+  CODES = APIGeoService.departements.pluck(:code).freeze
+
+  validates :value,
+            inclusion: { in: NAMES, message: :not_in_departement_names },
+            allow_nil: true,
+            if: :should_validate_in_current_context?
+  validates :external_id,
+            inclusion: { in: CODES, message: :not_in_departement_codes },
+            allow_nil: true,
+            if: :should_validate_in_current_context?
   before_save :store_code_region
 
   def code_region=(v)
@@ -42,18 +51,6 @@ class Champs::DepartementChamp < Champs::TextChamp
   def condition_value = { value: code, region_code: code_region }
 
   private
-
-  def value_in_departement_names
-    return if value.in?(APIGeoService.departements.pluck(:name))
-
-    errors.add(:value, :not_in_departement_names)
-  end
-
-  def external_id_in_departement_codes
-    return if external_id.in?(APIGeoService.departements.pluck(:code))
-
-    errors.add(:external_id, :not_in_departement_codes)
-  end
 
   def store_code_region
     self.code_region = code_region

--- a/app/models/champs/region_champ.rb
+++ b/app/models/champs/region_champ.rb
@@ -4,8 +4,17 @@ class Champs::RegionChamp < Champs::TextChamp
   store_accessor :value_json, :region_code
   before_save :store_region_code
 
-  validate :value_in_region_names, if: -> { !value.nil? && should_validate_in_current_context? }
-  validate :external_id_in_region_codes, if: -> { !external_id.nil? && should_validate_in_current_context? }
+  NAMES = APIGeoService.regions.pluck(:name).freeze
+  CODES = APIGeoService.regions.pluck(:code).freeze
+
+  validates :value,
+            inclusion: { in: NAMES, message: :not_in_region_names },
+            allow_nil: true,
+            if: :should_validate_in_current_context?
+  validates :external_id,
+            inclusion: { in: CODES, message: :not_in_region_codes },
+            allow_nil: true,
+            if: :should_validate_in_current_context?
 
   def selected
     code
@@ -28,18 +37,6 @@ class Champs::RegionChamp < Champs::TextChamp
   def condition_value = code
 
   private
-
-  def value_in_region_names
-    return if value.in?(APIGeoService.regions.pluck(:name))
-
-    errors.add(:value, :not_in_region_names)
-  end
-
-  def external_id_in_region_codes
-    return if external_id.in?(APIGeoService.regions.pluck(:code))
-
-    errors.add(:external_id, :not_in_region_codes)
-  end
 
   def store_region_code
     self.region_code = code

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -344,7 +344,10 @@ class Procedure < ApplicationRecord
     if: -> { new_record? || created_at > Date.new(2020, 11, 13) }
 
   validates :api_particulier_token, format: { with: /\A[A-Za-z0-9\-_=.]{15,}\z/ }, allow_blank: true
-  validate :validate_auto_archive_on_in_the_future, if: :will_save_change_to_auto_archive_on?
+  validates :auto_archive_on,
+            comparison: { greater_than: -> (_) { Date.current } },
+            allow_nil: true,
+            if: :will_save_change_to_auto_archive_on?
 
   before_save :update_juridique_required
   after_save :extend_conservation_for_dossiers
@@ -922,12 +925,5 @@ class Procedure < ApplicationRecord
     return if draft_revision.validate(validation_context)
 
     draft_revision.errors.map { errors.import(_1) }
-  end
-
-  def validate_auto_archive_on_in_the_future
-    return if auto_archive_on.nil?
-    return if auto_archive_on.future?
-
-    errors.add(:auto_archive_on, 'doit être dans le futur')
   end
 end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -286,7 +286,14 @@ class Procedure < ApplicationRecord
   validate :check_juridique, on: [:create, :publication]
 
   validates :replaced_by_procedure_id, presence: true, if: :closing_reason_internal_procedure?
-  validate :check_replaced_by_procedure_not_self, if: :closing_reason_internal_procedure?
+  # `presence` and `comparison` must stay in two separate `validates` calls:
+  # `comparison` reports a nil value as `:blank` too, and `allow_nil` applies to
+  # the whole call — sharing one would either duplicate the blank error or
+  # disable the presence check entirely.
+  validates :replaced_by_procedure_id,
+            comparison: { other_than: :id },
+            allow_nil: true,
+            if: :closing_reason_internal_procedure?
 
   validates :duree_conservation_dossiers_dans_ds, allow_nil: false,
                                                   numericality: {
@@ -728,12 +735,6 @@ class Procedure < ApplicationRecord
   def check_juridique
     if juridique_required? && (cadre_juridique.blank? && !deliberation.attached?)
       errors.add(:cadre_juridique, " : veuillez remplir le texte de loi ou la délibération")
-    end
-  end
-
-  def check_replaced_by_procedure_not_self
-    if replaced_by_procedure_id == id
-      errors.add(:replaced_by_procedure_id, "ne peut pas être la procédure elle-même")
     end
   end
 

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -129,6 +129,8 @@ en:
               invalid_uri_or_email: "Fill in with an email or a link"
             auto_archive_on:
               greater_than: must be in the future
+            replaced_by_procedure_id:
+              other_than: can not be the procedure itself
             sva_svr:
               immutable: "SVA/SVR configuration can no longer be modified"
               declarative_incompatible: "SVA/SVR is incompatible with a declarative procedure"

--- a/config/locales/models/procedure/en.yml
+++ b/config/locales/models/procedure/en.yml
@@ -127,6 +127,8 @@ en:
               format: "%{attribute} %{message}"
             lien_dpo:
               invalid_uri_or_email: "Fill in with an email or a link"
+            auto_archive_on:
+              greater_than: must be in the future
             sva_svr:
               immutable: "SVA/SVR configuration can no longer be modified"
               declarative_incompatible: "SVA/SVR is incompatible with a declarative procedure"

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -135,7 +135,7 @@ fr:
             lien_dpo:
               invalid_uri_or_email: "Veuillez saisir une adresse électronique ou un lien"
             auto_archive_on:
-              future: doit être dans le futur
+              greater_than: doit être dans le futur
             sva_svr:
               immutable: "La configuration SVA/SVR ne peut plus être modifiée"
               declarative_incompatible: "Le SVA/SVR est incompatible avec une démarche déclarative"

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -136,6 +136,8 @@ fr:
               invalid_uri_or_email: "Veuillez saisir une adresse électronique ou un lien"
             auto_archive_on:
               greater_than: doit être dans le futur
+            replaced_by_procedure_id:
+              other_than: ne peut pas être la procédure elle-même
             sva_svr:
               immutable: "La configuration SVA/SVR ne peut plus être modifiée"
               declarative_incompatible: "Le SVA/SVR est incompatible avec une démarche déclarative"

--- a/spec/models/champs/departement_champ_spec.rb
+++ b/spec/models/champs/departement_champ_spec.rb
@@ -32,7 +32,11 @@ describe Champs::DepartementChamp, type: :model do
       context 'when not included in the departement codes' do
         let(:external_id) { "totoro" }
 
-        it { is_expected.to be_falsey }
+        it 'reports an inclusion error on external_id' do
+          is_expected.to be_falsey
+          expect(champ.errors).to be_of_kind(:external_id, :inclusion)
+          expect(champ.errors.messages_for(:external_id)).to eq(["doit être un code de département valide"])
+        end
       end
     end
 
@@ -58,7 +62,11 @@ describe Champs::DepartementChamp, type: :model do
       context 'when not included in the departement names' do
         let(:value) { "totoro" }
 
-        it { is_expected.to be_falsey }
+        it 'reports an inclusion error on value' do
+          is_expected.to be_falsey
+          expect(champ.errors).to be_of_kind(:value, :inclusion)
+          expect(champ.errors.messages_for(:value)).to eq(["doit être un nom de département valide"])
+        end
       end
     end
   end

--- a/spec/models/champs/region_champ_spec.rb
+++ b/spec/models/champs/region_champ_spec.rb
@@ -32,7 +32,11 @@ describe Champs::RegionChamp, type: :model do
       context 'when not included in the region codes' do
         let(:external_id) { "totoro" }
 
-        it { is_expected.to be_falsey }
+        it 'reports an inclusion error on external_id' do
+          is_expected.to be_falsey
+          expect(champ.errors).to be_of_kind(:external_id, :inclusion)
+          expect(champ.errors.messages_for(:external_id)).to eq(["doit être un code de région valide"])
+        end
       end
     end
 
@@ -59,7 +63,11 @@ describe Champs::RegionChamp, type: :model do
       context 'when not included in the region names' do
         let(:value) { "totoro" }
 
-        it { is_expected.to be_falsey }
+        it 'reports an inclusion error on value' do
+          is_expected.to be_falsey
+          expect(champ.errors).to be_of_kind(:value, :inclusion)
+          expect(champ.errors.messages_for(:value)).to eq(["doit être un nom de région valide"])
+        end
       end
     end
   end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -835,8 +835,24 @@ describe Procedure do
         it 'validates only when attribute is changed' do
           procedure.auto_archive_on = 1.day.ago
           expect(procedure).not_to be_valid
+          expect(procedure.errors).to be_of_kind(:auto_archive_on, :greater_than)
 
           procedure.save!(validate: false)
+          expect(procedure).to be_valid
+        end
+      end
+
+      context 'when auto_archive_on is today' do
+        it 'is invalid' do
+          procedure.auto_archive_on = Date.current
+          expect(procedure).not_to be_valid
+          expect(procedure.errors).to be_of_kind(:auto_archive_on, :greater_than)
+        end
+      end
+
+      context 'when auto_archive_on is removed' do
+        it 'is valid' do
+          procedure.auto_archive_on = nil
           expect(procedure).to be_valid
         end
       end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -326,6 +326,38 @@ describe Procedure do
           it { expect(procedure).to be_valid }
         end
       end
+
+      context 'replaced by another procedure in DS' do
+        let(:procedure) { procedures.brouillon }
+
+        before { procedure.closing_reason = Procedure.closing_reasons.fetch(:internal_procedure) }
+
+        context 'when the replacing procedure is missing' do
+          it 'reports a single blank error' do
+            procedure.replaced_by_procedure_id = nil
+
+            expect(procedure).not_to be_valid
+            expect(procedure.errors.where(:replaced_by_procedure_id).map(&:type)).to eq([:blank])
+          end
+        end
+
+        context 'when the replacing procedure is the procedure itself' do
+          it 'is invalid' do
+            procedure.replaced_by_procedure_id = procedure.id
+
+            expect(procedure).not_to be_valid
+            expect(procedure.errors).to be_of_kind(:replaced_by_procedure_id, :other_than)
+          end
+        end
+
+        context 'when the replacing procedure is another one' do
+          it 'is valid' do
+            procedure.replaced_by_procedure_id = procedures.individual.id
+
+            expect(procedure).to be_valid
+          end
+        end
+      end
     end
 
     context 'description' do


### PR DESCRIPTION
Quatre validations écrites à la main refaisaient le travail d'un validateur intégré. Elles passent sur `comparison` et `inclusion`, avec les messages surchargés en i18n (fr et en) pour ne rien changer côté usager.

## Changements

- `Procedure#auto_archive_on` → `comparison: { greater_than: -> (_) { Date.current } }`
- `Procedure#replaced_by_procedure_id` → `comparison: { other_than: :id }`
- `Champs::RegionChamp` et `Champs::DepartementChamp` (`value` et `external_id`) → `inclusion`
- Règle correspondante ajoutée dans `AGENTS.md`

Chaque borne prend la forme la moins coûteuse qu'elle autorise : constante gelée pour les listes statiques de régions/départements, symbole `:id` pour une borne lue sur l'enregistrement, et lambda pour le seul cas réellement dynamique (`Date.current`, qu'une constante figerait au chargement de la classe).

## Points d'attention

`presence` et `comparison` sont dans **deux appels `validates` distincts**, avec `allow_nil` sur le seul `comparison`. Partager un appel casse dans les deux sens, vérifié en console :
- sans `allow_nil`, `comparison` signale aussi une valeur nulle comme `:blank` → le message s'affiche deux fois ;
- avec `allow_nil`, l'option s'applique à tout l'appel et **désactive la présence** → la valeur nulle ne lève plus aucune erreur.

Pour `inclusion`, le kind d'erreur devient `:inclusion` : `message: :mon_symbole` ne pilote que le lookup i18n. Aucun code ni spec ne dépendait des anciens kinds. Les messages rendus sont identiques en fr ; les traductions en manquantes ont été ajoutées.

Chaque spec assertionne l'attribut **et** le kind, et a été prouvée par mutation (borne relâchée → spec rouge → restaurée).

## Non converti

EPCI (gardes composées), `DropDownListChamp` (options déléguées au type de champ), `User#does_not_merge_on_self` (l'erreur changerait d'attribut), `Individual#email_different_from_mandataire` (comparaison casse-insensible que `comparison` ne sait pas faire), et tout ce qui porte de la logique métier ou des erreurs différenciées.