### PR TITLE
ETQ admin, les balises de répétition, choix multiples et carte ne cassent plus le HTML de l’attestation

### DIFF
--- a/app/models/champ_presentations/base_presentation.rb
+++ b/app/models/champ_presentations/base_presentation.rb
@@ -2,5 +2,8 @@
 
 module ChampPresentations
   class BasePresentation
+    # Nodes of the tiptap schema standing for the value where it is mentioned:
+    # block nodes replace the enclosing paragraph, inline nodes stay in it.
+    def to_tiptap_nodes = [to_tiptap_node]
   end
 end

--- a/app/models/champ_presentations/base_presentation.rb
+++ b/app/models/champ_presentations/base_presentation.rb
@@ -2,8 +2,5 @@
 
 module ChampPresentations
   class BasePresentation
-    def block_level?
-      true
-    end
   end
 end

--- a/app/models/champ_presentations/multiline_text_presentation.rb
+++ b/app/models/champ_presentations/multiline_text_presentation.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Free text spanning several lines (the motivation of a decision): a text
+# node per line separated by hard breaks, so the value stays inside the
+# paragraph that mentions it.
+class ChampPresentations::MultilineTextPresentation < ChampPresentations::BasePresentation
+  attr_reader :text
+
+  def initialize(text)
+    @text = text.to_s.gsub("\r\n", "\n").strip
+  end
+
+  def to_s = text
+
+  def to_tiptap_nodes
+    text.split("\n").flat_map.with_index do |line, index|
+      [({ type: 'hardBreak' } if index > 0), ({ type: 'text', text: line } unless line.empty?)].compact
+    end
+  end
+end

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -78,7 +78,8 @@ module TagsSubstitutionConcern
       libelle: 'motivation',
       description: 'Motivation facultative associée à la décision finale d’acceptation, refus ou classement sans suite',
       lambda: -> (d) { simple_format(d.motivation) },
-      escapable: false, # sanitized by simple_format
+      tiptap_lambda: -> (d) { ChampPresentations::MultilineTextPresentation.new(d.motivation) },
+      escapable: false, # legacy: sanitized by simple_format; tiptap: the renderer escapes the text nodes
       available_for_states: Dossier::TERMINE,
     },
     {
@@ -329,7 +330,7 @@ module TagsSubstitutionConcern
 
     tags_and_libelles.each_with_object({}) do |(tag_id, libelle), substitutions|
       substitutions[tag_id] = if flat_tags[tag_id].present?
-        replace_tag(flat_tags[tag_id], dossier)
+        replace_tag(flat_tags[tag_id], dossier, tiptap: true)
       else # champ not in dossier, for example during preview on draft revision
         libelle
       end
@@ -453,8 +454,10 @@ module TagsSubstitutionConcern
     end.join('')
   end
 
-  def replace_tag(tag, dossier)
-    value = instance_exec(dossier, &tag[:lambda])
+  # `tiptap_lambda` gives a tag a structured value (a presentation) for tiptap
+  # templates, where `lambda` keeps the HTML the legacy text templates expect.
+  def replace_tag(tag, dossier, tiptap: false)
+    value = instance_exec(dossier, &(tiptap && tag[:tiptap_lambda] || tag[:lambda]))
 
     if escape_unsafe_tags? && tag.fetch(:escapable, true)
       escape_once(value)

--- a/app/services/tiptap_service.rb
+++ b/app/services/tiptap_service.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 class TiptapService
+  BODY_START_CLASS = 'body-start'
+  BODY_START_MARK = " class=\"#{BODY_START_CLASS}\"".freeze
+
+  # Level-0 nodes that can open the body of an attestation (everything after
+  # the header and the title).
+  BODY_BLOCK_TYPES = ['paragraph', 'heading', 'bulletList', 'orderedList', 'descriptionList'].freeze
+
+  # Inline nodes of the tiptap schema, every other node is a block.
+  INLINE_TYPES = ['text', 'hardBreak'].freeze
+
   # NOTE: node must be deep symbolized keys
   def self.used_tags_and_libelle_for(node, tags = Set.new)
     case node
@@ -15,10 +25,71 @@ class TiptapService
     tags
   end
 
+  # Replaces every mention by its substitution and returns a document that
+  # follows the tiptap schema, so that renderers (HTML, Typst) never have to
+  # know about mentions:
+  # - a text substitution becomes a text node carrying the mention marks
+  #   (the string keeps its `html_safe?` flag, so an HTML renderer escapes
+  #   exactly what the substitution layer did not);
+  # - a champ presentation (repetition, multiple drop down, carte) becomes its
+  #   tiptap node, a list: the enclosing paragraph is split around it, every
+  #   inline run keeping the paragraph attributes and empty runs being
+  #   dropped; inside a title or a heading, which cannot hold a block, it
+  #   degrades to its text;
+  # - a missing substitution becomes the "--id--" placeholder.
+  def self.resolve(node, substitutions = {})
+    return nil if node.nil?
+
+    node.merge(content: resolve_blocks(node[:content], substitutions))
+  end
+
+  def self.resolve_blocks(content, substitutions)
+    content.flat_map { resolve_block(it, substitutions) }
+  end
+
+  def self.resolve_block(node, substitutions)
+    case node
+    in type: 'paragraph', content:
+      content
+        .map { resolve_inline(it, substitutions) }
+        .reject { empty_text?(it) }
+        .slice_when { |a, b| block?(a) || block?(b) }
+        .map { block?(it.first) ? it.first : node.merge(content: it) }
+    in type: 'title' | 'heading', content:
+      [node.merge(content: content.map { resolve_inline(it, substitutions, text_only: true) })]
+    in { content: } if content.is_a?(Array)
+      [node.merge(content: resolve_blocks(content, substitutions))]
+    else
+      [node]
+    end
+  end
+
+  def self.resolve_inline(node, substitutions, text_only: false)
+    case node
+    in type: 'mention', attrs: { id: }, **rest
+      value = substitutions.fetch(id) { "--#{id}--" }
+      if value.respond_to?(:to_tiptap_node) && !text_only
+        value.to_tiptap_node
+      else
+        { type: 'text', text: value.to_s, marks: rest[:marks] }.compact
+      end
+    else
+      node
+    end
+  end
+
+  def self.block?(node) = !node[:type].in?(INLINE_TYPES)
+
+  def self.empty_text?(node)
+    node in { type: 'text', text: '' }
+  end
+
+  private_class_method :resolve_blocks, :resolve_block, :resolve_inline, :block?, :empty_text?
+
   def to_html(node, substitutions = {})
     return '' if node.nil?
 
-    children(node[:content], substitutions, 0).gsub('<p></p>', '')
+    children(self.class.resolve(node, substitutions)[:content], 0)
   end
 
   def to_texts_and_tags(node, substitutions = {}, strip: true)
@@ -60,54 +131,55 @@ class TiptapService
     end
   end
 
-  def children(content, substitutions, level)
-    content.map { node_to_html(_1, substitutions, level) }.join
+  def children(content, level)
+    content.map { node_to_html(_1, level) }.join
   end
 
-  def list_item_body(content, substitutions, level)
+  # List items are rendered without their inner paragraph (PDF/UA).
+  def list_item_body(content, level)
     content.map do |node|
       case node
       in type: 'paragraph', content: paragraph_content
-        children(paragraph_content, substitutions, level + 1)
+        children(paragraph_content, level + 1)
       in type: 'paragraph' # empty paragraph
         ''
       else
-        node_to_html(node, substitutions, level)
+        node_to_html(node, level)
       end
     end.join
   end
 
-  def node_to_html(node, substitutions, level)
-    if level == 0 && !@body_started && node[:type].in?(['paragraph', 'heading']) && node.key?(:content)
+  def node_to_html(node, level)
+    if level == 0 && !@body_started && node[:type].in?(BODY_BLOCK_TYPES) && node.key?(:content)
       @body_started = true
-      body_start_mark = " class=\"body-start\""
+      body_start_mark = BODY_START_MARK
     end
 
     case node
     in type: 'header', content:
-      "<header>#{children(content, substitutions, level + 1)}</header>"
+      "<header>#{children(content, level + 1)}</header>"
     in type: 'footer', content:, **rest
-      "<footer#{text_align(rest[:attrs])}>#{children(content, substitutions, level + 1)}</footer>"
+      "<footer#{text_align(rest[:attrs])}>#{children(content, level + 1)}</footer>"
     in type: 'headerColumn', content:, **rest
-      "<div#{text_align(rest[:attrs])}>#{children(content, substitutions, level + 1)}</div>"
+      "<div#{text_align(rest[:attrs])}>#{children(content, level + 1)}</div>"
     in type: 'paragraph', content:, **rest
-      "<p#{body_start_mark}#{text_align(rest[:attrs])}>#{children(content, substitutions, level + 1)}</p>"
+      "<p#{body_start_mark}#{text_align(rest[:attrs])}>#{children(content, level + 1)}</p>"
     in type: 'title', content:, **rest
-      "<h1#{text_align(rest[:attrs])}>#{children(content, substitutions, level + 1)}</h1>"
+      "<h1#{text_align(rest[:attrs])}>#{children(content, level + 1)}</h1>"
     in type: 'heading', attrs: { level: hlevel, **attrs }, content:
-      "<h#{hlevel}#{body_start_mark}#{text_align(attrs)}>#{children(content, substitutions, level + 1)}</h#{hlevel}>"
-    in type: 'bulletList', content:
-      "<ul>#{children(content, substitutions, level + 1)}</ul>"
+      "<h#{hlevel}#{body_start_mark}#{text_align(attrs)}>#{children(content, level + 1)}</h#{hlevel}>"
+    in type: 'bulletList', content:, **rest
+      "<ul#{class_list(rest[:attrs], body_start_mark)}>#{children(content, level + 1)}</ul>"
     in type: 'orderedList', content:, **rest
-      "<ol#{class_list(rest[:attrs])}>#{children(content, substitutions, level + 1)}</ol>"
+      "<ol#{class_list(rest[:attrs], body_start_mark)}>#{children(content, level + 1)}</ol>"
     in type: 'listItem', content:
-      "<li>#{list_item_body(content, substitutions, level + 1)}</li>"
+      "<li>#{list_item_body(content, level + 1)}</li>"
     in type: 'descriptionList', content:
-      "<dl>#{children(content, substitutions, level + 1)}</dl>"
+      "<dl#{body_start_mark}>#{children(content, level + 1)}</dl>"
     in type: 'descriptionTerm', content:, **rest
-      "<dt#{class_list(rest[:attrs])}>#{children(content, substitutions, level + 1)}</dt>"
+      "<dt#{class_list(rest[:attrs])}>#{children(content, level + 1)}</dt>"
     in type: 'descriptionDetails', content:
-      "<dd>#{children(content, substitutions, level + 1)}</dd>"
+      "<dd>#{children(content, level + 1)}</dd>"
     in type: 'hardBreak'
       @hard_break
     in type: 'text', text:, **rest
@@ -117,36 +189,13 @@ class TiptapService
       else
         escaped
       end
-    in type: 'mention', attrs: { id: }, **rest
-      text_or_presentation = substitutions.fetch(id) { "--#{id}--" }
-      text = if text_or_presentation.respond_to?(:to_tiptap_node)
-        handle_presentation_node(text_or_presentation, substitutions, level + 1)
-      else
-        text_or_presentation
-      end
-
-      if rest[:marks].present?
-        apply_marks(text, rest[:marks])
-      else
-        text
-      end
     in type: 'pageBreak'
       level == 0 && !@body_started ? '' : '<div class="page-break"></div>'
     in { type: type } if ["paragraph", "title", "heading"].include?(type) && !node.key?(:content)
-      # noop
+      '' # empty block
     else
       # ignore unknown node types
       ''
-    end
-  end
-
-  def handle_presentation_node(presentation, substitutions, level)
-    node = presentation.to_tiptap_node
-    content = node_to_html(node, substitutions, level)
-    if presentation.block_level?
-      "</p>#{content}<p>"
-    else
-      content
     end
   end
 
@@ -158,10 +207,9 @@ class TiptapService
     end
   end
 
-  def class_list(attrs)
-    if attrs.present? && attrs[:class].present?
-      " class=\"#{attrs[:class]}\""
-    end
+  def class_list(attrs, body_start_mark = nil)
+    classes = [attrs&.dig(:class).presence, body_start_mark && BODY_START_CLASS].compact
+    " class=\"#{classes.join(' ')}\"" if classes.any?
   end
 
   def apply_marks(text, marks)

--- a/app/services/tiptap_service.rb
+++ b/app/services/tiptap_service.rb
@@ -2,7 +2,6 @@
 
 class TiptapService
   BODY_START_CLASS = 'body-start'
-  BODY_START_MARK = " class=\"#{BODY_START_CLASS}\"".freeze
 
   # Level-0 nodes that can open the body of an attestation (everything after
   # the header and the title).
@@ -150,10 +149,8 @@ class TiptapService
   end
 
   def node_to_html(node, level)
-    if level == 0 && !@body_started && node[:type].in?(BODY_BLOCK_TYPES) && node.key?(:content)
-      @body_started = true
-      body_start_mark = BODY_START_MARK
-    end
+    body_start = level == 0 && !@body_started && node[:type].in?(BODY_BLOCK_TYPES) && node.key?(:content)
+    @body_started = true if body_start
 
     case node
     in type: 'header', content:
@@ -163,19 +160,19 @@ class TiptapService
     in type: 'headerColumn', content:, **rest
       "<div#{text_align(rest[:attrs])}>#{children(content, level + 1)}</div>"
     in type: 'paragraph', content:, **rest
-      "<p#{body_start_mark}#{text_align(rest[:attrs])}>#{children(content, level + 1)}</p>"
+      "<p#{class_list(nil, body_start)}#{text_align(rest[:attrs])}>#{children(content, level + 1)}</p>"
     in type: 'title', content:, **rest
       "<h1#{text_align(rest[:attrs])}>#{children(content, level + 1)}</h1>"
     in type: 'heading', attrs: { level: hlevel, **attrs }, content:
-      "<h#{hlevel}#{body_start_mark}#{text_align(attrs)}>#{children(content, level + 1)}</h#{hlevel}>"
+      "<h#{hlevel}#{class_list(nil, body_start)}#{text_align(attrs)}>#{children(content, level + 1)}</h#{hlevel}>"
     in type: 'bulletList', content:, **rest
-      "<ul#{class_list(rest[:attrs], body_start_mark)}>#{children(content, level + 1)}</ul>"
+      "<ul#{class_list(rest[:attrs], body_start)}>#{children(content, level + 1)}</ul>"
     in type: 'orderedList', content:, **rest
-      "<ol#{class_list(rest[:attrs], body_start_mark)}>#{children(content, level + 1)}</ol>"
+      "<ol#{class_list(rest[:attrs], body_start)}>#{children(content, level + 1)}</ol>"
     in type: 'listItem', content:
       "<li>#{list_item_body(content, level + 1)}</li>"
     in type: 'descriptionList', content:
-      "<dl#{body_start_mark}>#{children(content, level + 1)}</dl>"
+      "<dl#{class_list(nil, body_start)}>#{children(content, level + 1)}</dl>"
     in type: 'descriptionTerm', content:, **rest
       "<dt#{class_list(rest[:attrs])}>#{children(content, level + 1)}</dt>"
     in type: 'descriptionDetails', content:
@@ -191,10 +188,8 @@ class TiptapService
       end
     in type: 'pageBreak'
       level == 0 && !@body_started ? '' : '<div class="page-break"></div>'
-    in { type: type } if ["paragraph", "title", "heading"].include?(type) && !node.key?(:content)
-      '' # empty block
     else
-      # ignore unknown node types
+      # empty blocks and unknown node types
       ''
     end
   end
@@ -207,8 +202,8 @@ class TiptapService
     end
   end
 
-  def class_list(attrs, body_start_mark = nil)
-    classes = [attrs&.dig(:class).presence, body_start_mark && BODY_START_CLASS].compact
+  def class_list(attrs, body_start = false)
+    classes = [attrs&.dig(:class).presence, (BODY_START_CLASS if body_start)].compact
     " class=\"#{classes.join(' ')}\"" if classes.any?
   end
 

--- a/app/services/tiptap_service.rb
+++ b/app/services/tiptap_service.rb
@@ -30,11 +30,12 @@ class TiptapService
   # - a text substitution becomes a text node carrying the mention marks
   #   (the string keeps its `html_safe?` flag, so an HTML renderer escapes
   #   exactly what the substitution layer did not);
-  # - a champ presentation (repetition, multiple drop down, carte) becomes its
-  #   tiptap node, a list: the enclosing paragraph is split around it, every
-  #   inline run keeping the paragraph attributes and empty runs being
-  #   dropped; inside a title or a heading, which cannot hold a block, it
-  #   degrades to its text;
+  # - a presentation becomes its tiptap nodes: inline ones (multiline text)
+  #   stay in the paragraph, their text nodes carrying the mention marks;
+  #   block ones (the lists of a repetition, a multiple drop down or a carte)
+  #   split the enclosing paragraph, every inline run keeping the paragraph
+  #   attributes and empty runs being dropped; inside a title or a heading,
+  #   which cannot hold a block, a presentation degrades to its text;
   # - a missing substitution becomes the "--id--" placeholder.
   def self.resolve(node, substitutions = {})
     return nil if node.nil?
@@ -50,12 +51,12 @@ class TiptapService
     case node
     in type: 'paragraph', content:
       content
-        .map { resolve_inline(it, substitutions) }
+        .flat_map { resolve_inline(it, substitutions) }
         .reject { empty_text?(it) }
         .slice_when { |a, b| block?(a) || block?(b) }
         .map { block?(it.first) ? it.first : node.merge(content: it) }
     in type: 'title' | 'heading', content:
-      [node.merge(content: content.map { resolve_inline(it, substitutions, text_only: true) })]
+      [node.merge(content: content.flat_map { resolve_inline(it, substitutions, text_only: true) })]
     in { content: } if content.is_a?(Array)
       [node.merge(content: resolve_blocks(content, substitutions))]
     else
@@ -67,13 +68,15 @@ class TiptapService
     case node
     in type: 'mention', attrs: { id: }, **rest
       value = substitutions.fetch(id) { "--#{id}--" }
-      if value.respond_to?(:to_tiptap_node) && !text_only
-        value.to_tiptap_node
+      nodes = if value.respond_to?(:to_tiptap_nodes) && !text_only
+        value.to_tiptap_nodes
       else
-        { type: 'text', text: value.to_s, marks: rest[:marks] }.compact
+        [{ type: 'text', text: value.to_s }]
       end
+      marks = rest[:marks]
+      marks.present? ? nodes.map { it[:type] == 'text' ? it.merge(marks:) : it } : nodes
     else
-      node
+      [node]
     end
   end
 

--- a/spec/models/champ_presentations/carte_presentation_spec.rb
+++ b/spec/models/champ_presentations/carte_presentation_spec.rb
@@ -43,8 +43,4 @@ describe ChampPresentations::CartePresentation do
       expect(presentation.to_tiptap_node).to eq(expected)
     end
   end
-
-  describe '#block_level?' do
-    it { expect(presentation.block_level?).to be true }
-  end
 end

--- a/spec/models/champ_presentations/multiline_text_presentation_spec.rb
+++ b/spec/models/champ_presentations/multiline_text_presentation_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe ChampPresentations::MultilineTextPresentation do
+  let(:text) { "Première ligne\r\nDeuxième ligne\n\nAprès un saut\n" }
+  let(:presentation) { described_class.new(text) }
+
+  describe '#to_s' do
+    it 'returns the text with normalized line breaks' do
+      expect(presentation.to_s).to eq("Première ligne\nDeuxième ligne\n\nAprès un saut")
+    end
+
+    it { expect(described_class.new(nil).to_s).to eq('') }
+  end
+
+  describe '#to_tiptap_nodes' do
+    it 'returns a text node per line separated by hard breaks' do
+      expect(presentation.to_tiptap_nodes).to eq([
+        { type: 'text', text: 'Première ligne' },
+        { type: 'hardBreak' },
+        { type: 'text', text: 'Deuxième ligne' },
+        { type: 'hardBreak' },
+        { type: 'hardBreak' },
+        { type: 'text', text: 'Après un saut' },
+      ])
+    end
+
+    it { expect(described_class.new(nil).to_tiptap_nodes).to eq([]) }
+  end
+end

--- a/spec/models/concerns/tags_substitution_concern_spec.rb
+++ b/spec/models/concerns/tags_substitution_concern_spec.rb
@@ -64,6 +64,18 @@ describe TagsSubstitutionConcern, type: :model do
       end
     end
 
+    context 'when the dossier has a motivation' do
+      let(:dossier) { create(:dossier, :accepte, procedure:, motivation: "Première ligne\nDeuxième ligne") }
+      let(:tags) { Set.new([["dossier_motivation", "motivation"]]) }
+
+      it 'substitutes a multiline text presentation instead of the legacy HTML' do
+        presentation = subject.fetch('dossier_motivation')
+
+        expect(presentation).to be_a(ChampPresentations::MultilineTextPresentation)
+        expect(presentation.to_s).to eq("Première ligne\nDeuxième ligne")
+      end
+    end
+
     context 'when the dossier and the procedure has an individual' do
       let(:for_individual) { true }
       let(:individual) { Individual.create(nom: 'Adama', prenom: 'William', gender: 'M') }

--- a/spec/services/tiptap_service_spec.rb
+++ b/spec/services/tiptap_service_spec.rb
@@ -431,6 +431,16 @@ RSpec.describe TiptapService do
 
         expect(described_class.new.to_html(json, substitutions)).to eq("<p class=\"body-start\">Avant </p>#{list}")
       end
+
+      it 'keeps an inline presentation inside the paragraph, with the mention marks and the hard break' do
+        motivation = { type: 'mention', attrs: { id: 'motivation', label: 'Motivation' }, marks: [{ type: 'italic' }] }
+        json = doc({ type: 'paragraph', content: [text('Motivation : '), motivation, text('.')] })
+        substitutions = { 'motivation' => ChampPresentations::MultilineTextPresentation.new("<b>ok</b>\nsuite") }
+
+        expect(described_class.new(hard_break: '<br><br>').to_html(json, substitutions)).to eq(
+          '<p class="body-start">Motivation : <em>&lt;b&gt;ok&lt;/b&gt;</em><br><br><em>suite</em>.</p>'
+        )
+      end
     end
   end
 
@@ -508,6 +518,23 @@ RSpec.describe TiptapService do
       expect(described_class.resolve(json, substitutions)).to eq(
         doc({ type: 'title', content: [text('ruby, rust')] }, { type: 'heading', attrs: { level: 2 }, content: [text('Titre '), text('ruby, rust')] })
       )
+    end
+
+    it 'keeps an inline presentation in the paragraph and marks its text nodes' do
+      motivation = { type: 'mention', attrs: { id: 'motivation', label: 'Motivation' }, marks: [{ type: 'bold' }] }
+      json = doc({ type: 'paragraph', content: [text('Avant '), motivation, text(' après')] })
+      resolved = described_class.resolve(json, { 'motivation' => ChampPresentations::MultilineTextPresentation.new("a\nb") })
+
+      expect(resolved).to eq(
+        doc({ type: 'paragraph', content: [text('Avant '), text('a', marks: [{ type: 'bold' }]), { type: 'hardBreak' }, text('b', marks: [{ type: 'bold' }]), text(' après')] })
+      )
+    end
+
+    it 'degrades an inline presentation to its text inside a heading' do
+      json = doc({ type: 'heading', attrs: { level: 2 }, content: [{ type: 'mention', attrs: { id: 'motivation', label: 'Motivation' } }] })
+      resolved = described_class.resolve(json, { 'motivation' => ChampPresentations::MultilineTextPresentation.new("a\nb") })
+
+      expect(resolved).to eq(doc({ type: 'heading', attrs: { level: 2 }, content: [text("a\nb")] }))
     end
 
     it 'leaves empty blocks and unknown nodes untouched' do

--- a/spec/services/tiptap_service_spec.rb
+++ b/spec/services/tiptap_service_spec.rb
@@ -360,8 +360,160 @@ RSpec.describe TiptapService do
       end
 
       it "set class attribute" do
-        expect(described_class.new.to_html(json, substitutions)).to eq('<ol class="my-class"><li>Item 1</li></ol>')
+        expect(described_class.new.to_html(json, substitutions)).to eq('<ol class="my-class body-start"><li>Item 1</li></ol>')
       end
+    end
+    context 'block presentation (list rendered for a champ tag)' do
+      let(:presentation) { ChampPresentations::MultipleDropDownListPresentation.new(['ruby', 'rust']) }
+      let(:substitutions) { { 'languages' => presentation } }
+      let(:mention) { { type: 'mention', attrs: { id: 'languages', label: 'Langages' } } }
+      let(:list) { '<ul><li>ruby</li><li>rust</li></ul>' }
+
+      def doc(*content) = { type: 'doc', content: }
+      def text(text) = { type: 'text', text: }
+
+      it 'splits the paragraph around the list and keeps the paragraph attributes on both halves' do
+        json = doc({ type: 'paragraph', attrs: { textAlign: 'center' }, content: [text('Avant '), mention, text(' après')] })
+
+        expect(described_class.new.to_html(json, substitutions)).to eq(
+          "<p class=\"body-start\" style=\"text-align: center\">Avant </p>#{list}<p style=\"text-align: center\"> après</p>"
+        )
+      end
+
+      it 'does not emit empty paragraphs around a mention at the start or the end' do
+        json = doc({ type: 'paragraph', content: [text('Intro')] }, { type: 'paragraph', content: [mention] })
+
+        expect(described_class.new.to_html(json, substitutions)).to eq("<p class=\"body-start\">Intro</p>#{list}")
+      end
+
+      it 'moves the body-start mark to the list when the body starts with a mention' do
+        json = doc({ type: 'paragraph', content: [mention, text(' après')] })
+
+        expect(described_class.new.to_html(json, substitutions)).to eq(
+          "<ul class=\"body-start\"><li>ruby</li><li>rust</li></ul><p> après</p>"
+        )
+      end
+
+      it 'keeps the presentation class when adding the body-start mark' do
+        repetition = ChampPresentations::RepetitionPresentation.new('Rows', [])
+        json = doc({ type: 'paragraph', content: [{ type: 'mention', attrs: { id: 'rows', label: 'Rows' } }] })
+
+        expect(described_class.new.to_html(json, { 'rows' => repetition })).to eq('<ol class="tdc-repetition body-start"></ol>')
+      end
+
+      it 'nests the list inside a list item' do
+        json = doc({ type: 'bulletList', content: [{ type: 'listItem', content: [{ type: 'paragraph', content: [text('Item '), mention] }] }] })
+
+        expect(described_class.new.to_html(json, substitutions)).to eq("<ul class=\"body-start\"><li>Item #{list}</li></ul>")
+      end
+
+      it 'falls back to the text form inside a heading' do
+        json = doc({ type: 'heading', attrs: { level: 2 }, content: [text('Titre '), mention] })
+
+        expect(described_class.new.to_html(json, substitutions)).to eq('<h2 class="body-start">Titre ruby, rust</h2>')
+      end
+
+      it 'falls back to the escaped text form inside the title' do
+        json = doc({ type: 'title', content: [mention] })
+        substitutions = { 'languages' => ChampPresentations::MultipleDropDownListPresentation.new(['<b>']) }
+
+        expect(described_class.new.to_html(json, substitutions)).to eq('<h1>&lt;b&gt;</h1>')
+      end
+
+      it 'stringifies non-string substitutions in the inline runs' do
+        json = doc({ type: 'paragraph', content: [text('N° '), { type: 'mention', attrs: { id: 'number', label: 'N°' } }, mention] })
+
+        expect(described_class.new.to_html(json, substitutions.merge('number' => 42))).to eq("<p class=\"body-start\">N° 42</p>#{list}")
+      end
+
+      it 'ignores marks on the mention' do
+        json = doc({ type: 'paragraph', content: [text('Avant '), mention.merge(marks: [{ type: 'bold' }])] })
+
+        expect(described_class.new.to_html(json, substitutions)).to eq("<p class=\"body-start\">Avant </p>#{list}")
+      end
+    end
+  end
+
+  describe '.resolve' do
+    let(:presentation) { ChampPresentations::MultipleDropDownListPresentation.new(['ruby', 'rust']) }
+    let(:substitutions) { { 'name' => 'Paul', 'languages' => presentation } }
+    let(:mention) { { type: 'mention', attrs: { id: 'languages', label: 'Langages' } } }
+    let(:name) { { type: 'mention', attrs: { id: 'name', label: 'Nom' }, marks: [{ type: 'bold' }] } }
+
+    def doc(*content) = { type: 'doc', content: }
+    def text(text, **rest) = { type: 'text', text:, **rest }
+
+    it 'returns nil for a nil document' do
+      expect(described_class.resolve(nil, substitutions)).to be_nil
+    end
+
+    it 'replaces a text mention by a text node carrying the mention marks' do
+      json = doc({ type: 'paragraph', content: [text('Bonjour '), name] })
+
+      expect(described_class.resolve(json, substitutions)).to eq(
+        doc({ type: 'paragraph', content: [text('Bonjour '), text('Paul', marks: [{ type: 'bold' }])] })
+      )
+    end
+
+    it 'keeps the html_safe flag of a substitution' do
+      json = doc({ type: 'paragraph', content: [name] })
+      resolved = described_class.resolve(json, { 'name' => '<a>Paul</a>'.html_safe })
+
+      expect(resolved[:content].first[:content].first[:text]).to be_html_safe
+    end
+
+    it 'stringifies non-string substitutions' do
+      json = doc({ type: 'paragraph', content: [name] })
+
+      expect(described_class.resolve(json, { 'name' => 42 })[:content].first[:content]).to eq([text('42', marks: [{ type: 'bold' }])])
+    end
+
+    it 'uses the --id-- placeholder for a missing substitution' do
+      json = doc({ type: 'paragraph', content: [mention] })
+
+      expect(described_class.resolve(json)[:content].first[:content]).to eq([text('--languages--')])
+    end
+
+    it 'splits the paragraph around a block presentation and keeps the paragraph attributes on both halves' do
+      json = doc({ type: 'paragraph', attrs: { textAlign: 'center' }, content: [text('Avant '), mention, text(' après')] })
+
+      expect(described_class.resolve(json, substitutions)).to eq(
+        doc(
+          { type: 'paragraph', attrs: { textAlign: 'center' }, content: [text('Avant ')] },
+          presentation.to_tiptap_node,
+          { type: 'paragraph', attrs: { textAlign: 'center' }, content: [text(' après')] }
+        )
+      )
+    end
+
+    it 'drops the empty runs around a mention at the start or the end, and an empty substitution' do
+      json = doc({ type: 'paragraph', content: [mention, name, mention] })
+
+      expect(described_class.resolve(json, substitutions.merge('name' => ''))).to eq(
+        doc(presentation.to_tiptap_node, presentation.to_tiptap_node)
+      )
+    end
+
+    it 'nests the block presentation inside the list item' do
+      json = doc({ type: 'bulletList', content: [{ type: 'listItem', content: [{ type: 'paragraph', content: [text('Item '), mention] }] }] })
+
+      expect(described_class.resolve(json, substitutions)).to eq(
+        doc({ type: 'bulletList', content: [{ type: 'listItem', content: [{ type: 'paragraph', content: [text('Item ')] }, presentation.to_tiptap_node] }] })
+      )
+    end
+
+    it 'degrades a block presentation to its text inside a title or a heading' do
+      json = doc({ type: 'title', content: [mention] }, { type: 'heading', attrs: { level: 2 }, content: [text('Titre '), mention] })
+
+      expect(described_class.resolve(json, substitutions)).to eq(
+        doc({ type: 'title', content: [text('ruby, rust')] }, { type: 'heading', attrs: { level: 2 }, content: [text('Titre '), text('ruby, rust')] })
+      )
+    end
+
+    it 'leaves empty blocks and unknown nodes untouched' do
+      json = doc({ type: 'paragraph' }, { type: 'pageBreak' }, { type: 'heading', attrs: { level: 3 } })
+
+      expect(described_class.resolve(json, substitutions)).to eq(json)
     end
   end
 


### PR DESCRIPTION
## Contexte

Les balises de champs rendues sous forme de liste (répétition, choix multiples, carte) étaient insérées dans le paragraphe courant en émettant `</p>…<p>` puis en supprimant les `<p></p>` résiduels. Ça ne fonctionne que si la balise est directement dans un paragraphe simple. Dans un titre (h2/h3), dans un élément de liste ou avec une mise en forme (gras/italique), le HTML produit était invalide :

- `<h2>Titre </p><ul>…</ul><p></h2>` → le sanitizer imbrique la liste dans le titre
- `<li>item </p><ul>…</ul><p></li>` → un `<p></p>` vide réapparaît dans le `<li>` (problème PDF/UA)
- `<strong></p><ul>…</ul><p></strong>`

Le paragraphe rouvert perdait aussi son alignement (`text-align`).

## Changements

La substitution des balises se fait désormais sur l’arbre tiptap, avant tout rendu, via `TiptapService.resolve` qui renvoie un document conforme au schéma tiptap :

- une substitution texte devient un nœud `text` portant les marques de la balise (le flag `html_safe` de la chaîne est conservé : le rendu HTML échappe ce que la couche de substitution n’a pas échappé) ;
- une présentation (répétition, choix multiples, carte) devient son nœud tiptap, une liste, et découpe le paragraphe qui la contient : chaque segment inline garde les attributs du paragraphe, les segments vides sont supprimés, dans un élément de liste la liste est imbriquée ;
- dans un titre ou le `title`, qui ne peuvent pas contenir de bloc, la présentation retombe sur sa forme texte (`ruby, rust`) ;
- une balise sans substitution devient `--id--`.

Le découpage se fait sur le type des nœuds (`INLINE_TYPES`) : `block_level?` disparaît des présentations. Le rendu HTML redevient un simple parcours d’arbre, sans rien savoir des balises. Le futur rendu Typst (#13770) recevra le même arbre bien formé au lieu de devoir réimplémenter le découpage.

Deux effets de bord assumés : les substitutions sont échappées par le rendu HTML sauf si `html_safe` (elles étaient insérées brutes), et une liste qui ouvre le corps de l’attestation reçoit la classe `body-start` comme un paragraphe.

Aucune donnée stockée ne change. Un second PR empêchera, côté éditeur et validation, de placer ces balises dans un titre.

Un second commit, purement technique, fait passer l’attribut `class` de tous les éléments par le même helper et supprime une branche morte du rendu HTML.

Un troisième commit retire le dernier HTML qui atteignait l’arbre résolu : la balise `motivation` (sortie de `simple_format`) devient une `MultilineTextPresentation`, un nœud texte par ligne séparé par des `hardBreak`, qui reste dans le paragraphe et porte les marques de la balise. Les présentations répondent désormais à `to_tiptap_nodes` (un tableau). Les gabarits texte historiques (attestations v1, mails non migrés) gardent le HTML de `simple_format` via `lambda` ; `tiptap_lambda` n’est lu que par `tags_substitutions`. Visible côté attestation : la motivation suit directement son libellé au lieu d’ouvrir un nouveau paragraphe, et un retour à la ligne se rend comme un `hardBreak` de l’éditeur (`<br><br>`).

## Tests

`spec/services/tiptap_service_spec.rb` : nouveaux cas sur `.resolve` (marques, `html_safe`, substitution vide ou absente, découpage, imbrication dans un `<li>`, titre) et sur le rendu HTML (paragraphe centré, `body-start` sur la liste, `<li>`, titre).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

