### PR TITLE
ETQ admin, je ne peux pas placer une balise de répétition, choix multiples ou carte dans un titre de l’attestation

### DIFF
--- a/app/components/tags_button_list_component/tags_button_list_component.html.erb
+++ b/app/components/tags_button_list_component/tags_button_list_component.html.erb
@@ -62,6 +62,7 @@
             data-tag-label="<%= label %>"
             data-tag-mandatory="<%= tag[:mandatory].to_s %>"
             data-tag-conditional="<%= tag[:conditional].to_s %>"
+            data-tag-block="<%= tag[:block].to_s %>"
           >
             <%= label %>
 

--- a/app/javascript/controllers/lazy/tiptap_controller.ts
+++ b/app/javascript/controllers/lazy/tiptap_controller.ts
@@ -3,6 +3,7 @@ import { isButtonElement, isHTMLElement } from 'coldwired/utils';
 import * as s from 'superstruct';
 
 import { getAction } from '../../shared/tiptap/actions';
+import { blockTagsAllowed } from '../../shared/tiptap/block_tags';
 import { createEditor } from '../../shared/tiptap/editor';
 import { tagSchema, type TagSchema } from '../../shared/tiptap/tags';
 import { httpRequest } from '../../shared/utils';
@@ -82,6 +83,14 @@ export class TiptapController extends ApplicationController {
             button.disabled = empty && !hasExistingLink;
           } else {
             button.disabled = action.isDisabled();
+          }
+        }
+
+        // Tags rendered as a list cannot be inserted in a title or a heading.
+        const blockTagsEnabled = blockTagsAllowed(editor.state);
+        for (const tag of this.tagTargets) {
+          if (tag.dataset.tagBlock === 'true' && isButtonElement(tag)) {
+            tag.disabled = !blockTagsEnabled;
           }
         }
 

--- a/app/javascript/shared/tiptap/actions.ts
+++ b/app/javascript/shared/tiptap/actions.ts
@@ -1,6 +1,8 @@
 import { Editor } from '@tiptap/core';
 import * as s from 'superstruct';
 
+import { selectionHoldsBlockTag } from './block_tags';
+
 type EditorAction = {
   run(): void;
   isActive(): boolean;
@@ -26,7 +28,8 @@ const EDITOR_ACTIONS: Record<string, (editor: Editor) => EditorAction> = {
     isDisabled: () =>
       editor.isActive('title') ||
       editor.isActive('header') ||
-      editor.isActive('footer')
+      editor.isActive('footer') ||
+      selectionHoldsBlockTag(editor)
   }),
   heading3: (editor) => ({
     run: () => editor.chain().focus().toggleHeading({ level: 3 }).run(),
@@ -34,7 +37,8 @@ const EDITOR_ACTIONS: Record<string, (editor: Editor) => EditorAction> = {
     isDisabled: () =>
       editor.isActive('title') ||
       editor.isActive('header') ||
-      editor.isActive('footer')
+      editor.isActive('footer') ||
+      selectionHoldsBlockTag(editor)
   }),
   bold: (editor) => ({
     run: () => editor.chain().focus().toggleBold().run(),

--- a/app/javascript/shared/tiptap/block_tags.test.ts
+++ b/app/javascript/shared/tiptap/block_tags.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import type { Editor, JSONContent } from '@tiptap/core';
+
+import { getAction } from './actions';
+import { blockTagsAllowed } from './block_tags';
+import { createEditor } from './editor';
+import { createSuggestionMenu, type TagSchema } from './tags';
+
+const tags: TagSchema[] = [
+  { id: 'dossier_number', label: 'numéro du dossier' },
+  { id: 'tdc1', label: 'Langages', block: true }
+];
+
+const mention = (id: string, label: string) => ({
+  type: 'mention',
+  attrs: { id, label }
+});
+const text = (text: string) => ({ type: 'text', text });
+
+function setup(content: JSONContent[]) {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+
+  const editor = createEditor({
+    editorElement: element,
+    content: { type: 'doc', content },
+    tags,
+    buttons: ['bold', 'heading2'],
+    onChange: () => {}
+  });
+
+  return {
+    editor,
+    element,
+    teardown: () => {
+      editor.destroy();
+      element.remove();
+    }
+  };
+}
+
+function suggestions(editor: Editor, element: Element) {
+  const { items } = createSuggestionMenu(tags, element);
+  return (items?.({ query: '', editor }) as TagSchema[])
+    .map((t) => t.label)
+    .sort();
+}
+
+describe('block tags guard', () => {
+  it('does not offer block tags inside a heading', () => {
+    const { editor, element, teardown } = setup([
+      { type: 'heading', attrs: { level: 2 }, content: [text('Titre')] },
+      { type: 'paragraph', content: [text('Texte')] }
+    ]);
+
+    editor.commands.setTextSelection(2);
+    expect(blockTagsAllowed(editor.state)).toBe(false);
+    expect(suggestions(editor, element)).toEqual(['numéro du dossier']);
+
+    editor.commands.setTextSelection(9);
+    expect(blockTagsAllowed(editor.state)).toBe(true);
+    expect(suggestions(editor, element)).toEqual([
+      'Langages',
+      'numéro du dossier'
+    ]);
+
+    teardown();
+  });
+
+  it('rejects turning a paragraph holding a block tag into a heading', () => {
+    const { editor, teardown } = setup([
+      {
+        type: 'paragraph',
+        content: [text('Avant '), mention('tdc1', 'Langages')]
+      }
+    ]);
+
+    editor.commands.setTextSelection(2);
+    editor.commands.toggleHeading({ level: 2 });
+
+    expect(editor.getJSON().content?.[0].type).toBe('paragraph');
+
+    teardown();
+  });
+
+  it('still turns a paragraph holding an inline tag into a heading', () => {
+    const { editor, teardown } = setup([
+      {
+        type: 'paragraph',
+        content: [text('N° '), mention('dossier_number', 'numéro du dossier')]
+      }
+    ]);
+
+    editor.commands.setTextSelection(2);
+    editor.commands.toggleHeading({ level: 2 });
+
+    expect(editor.getJSON().content?.[0].type).toBe('heading');
+
+    teardown();
+  });
+
+  it('disables the heading button on a paragraph holding a block tag', () => {
+    const { editor, teardown } = setup([
+      {
+        type: 'paragraph',
+        content: [text('Avant '), mention('tdc1', 'Langages')]
+      },
+      { type: 'paragraph', content: [text('Texte')] }
+    ]);
+    const button = document.createElement('button');
+    button.dataset.tiptapAction = 'heading2';
+
+    editor.commands.setTextSelection(2);
+    expect(getAction(editor, button).isDisabled()).toBe(true);
+
+    editor.commands.setTextSelection(12);
+    expect(getAction(editor, button).isDisabled()).toBe(false);
+
+    teardown();
+  });
+
+  it('strips marks applied to a block tag', () => {
+    const { editor, teardown } = setup([
+      {
+        type: 'paragraph',
+        content: [text('Avant '), mention('tdc1', 'Langages')]
+      }
+    ]);
+
+    editor.commands.selectAll();
+    editor.commands.toggleBold();
+
+    expect(editor.getJSON().content?.[0].content).toEqual([
+      { type: 'text', text: 'Avant ', marks: [{ type: 'bold' }] },
+      mention('tdc1', 'Langages')
+    ]);
+
+    teardown();
+  });
+});

--- a/app/javascript/shared/tiptap/block_tags.ts
+++ b/app/javascript/shared/tiptap/block_tags.ts
@@ -1,0 +1,130 @@
+import { Extension, type Editor } from '@tiptap/core';
+import type { Node as PMNode, ResolvedPos } from '@tiptap/pm/model';
+import { Plugin, PluginKey, type EditorState } from '@tiptap/pm/state';
+
+// Some tags (repetition, multiple drop down, carte) render as a list. A list
+// cannot live inside a title or a heading, so the server degrades such a tag to
+// plain text there (TiptapService#to_html) and rejects it (TagsValidator). This
+// module enforces the same rule in the editor.
+const INLINE_ONLY_NODE_TYPES = ['title', 'heading'];
+
+export function blockTagsAllowedAt($pos: ResolvedPos): boolean {
+  for (let depth = $pos.depth; depth > 0; depth--) {
+    if (INLINE_ONLY_NODE_TYPES.includes($pos.node(depth).type.name)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function blockTagsAllowed(state: EditorState): boolean {
+  return blockTagsAllowedAt(state.selection.$from);
+}
+
+// true when one of the text blocks covered by the selection holds a block tag
+// (used to disable the heading buttons on such a paragraph).
+export function selectionHoldsBlockTag(editor: Editor): boolean {
+  const ids = blockTagIds(editor);
+  if (ids.size == 0) {
+    return false;
+  }
+
+  const { doc, selection } = editor.state;
+  const { from, to, $from } = selection;
+  const blocks: PMNode[] = [];
+
+  if (from == to) {
+    blocks.push($from.parent);
+  } else {
+    doc.nodesBetween(from, to, (node) => {
+      if (node.isTextblock) {
+        blocks.push(node);
+        return false;
+      }
+      return true;
+    });
+  }
+
+  return blocks.some((block) => {
+    let found = false;
+    block.forEach((child) => {
+      if (isBlockTag(child, ids)) {
+        found = true;
+      }
+    });
+    return found;
+  });
+}
+
+function blockTagIds(editor: Editor): Set<string> {
+  return editor.storage.blockTagGuard?.ids ?? new Set<string>();
+}
+
+function isBlockTag(node: PMNode, ids: Set<string>): boolean {
+  return node.type.name == 'mention' && ids.has(node.attrs.id);
+}
+
+export const BlockTagGuard = Extension.create<
+  { blockTagIds: string[] },
+  { ids: Set<string> }
+>({
+  name: 'blockTagGuard',
+
+  addOptions() {
+    return { blockTagIds: [] };
+  },
+
+  addStorage() {
+    return { ids: new Set<string>() };
+  },
+
+  onBeforeCreate() {
+    this.storage.ids = new Set(this.options.blockTagIds);
+  },
+
+  addProseMirrorPlugins() {
+    const ids = this.storage.ids;
+
+    return [
+      new Plugin({
+        key: new PluginKey('blockTagGuard'),
+
+        // Reject any change that would leave a block tag inside a title or a
+        // heading: turning the paragraph into a heading (button, shortcut or
+        // "## " input rule), pasting, dropping…
+        filterTransaction(tr) {
+          if (!tr.docChanged) {
+            return true;
+          }
+
+          let allowed = true;
+          tr.doc.descendants((node, pos) => {
+            if (allowed && isBlockTag(node, ids)) {
+              allowed = blockTagsAllowedAt(tr.doc.resolve(pos));
+            }
+            return allowed;
+          });
+          return allowed;
+        },
+
+        // The renderer ignores marks on a block tag; strip them so the editor
+        // does not pretend the list will be bold or italic.
+        appendTransaction(transactions, _oldState, newState) {
+          if (!transactions.some((tr) => tr.docChanged)) {
+            return null;
+          }
+
+          const tr = newState.tr;
+          newState.doc.descendants((node, pos) => {
+            if (isBlockTag(node, ids)) {
+              for (const mark of node.marks) {
+                tr.removeMark(pos, pos + node.nodeSize, mark);
+              }
+            }
+          });
+          return tr.steps.length > 0 ? tr : null;
+        }
+      })
+    ];
+  }
+});

--- a/app/javascript/shared/tiptap/editor.ts
+++ b/app/javascript/shared/tiptap/editor.ts
@@ -28,6 +28,7 @@ import {
   type Extensions
 } from '@tiptap/core';
 
+import { BlockTagGuard } from './block_tags';
 import {
   DocumentWithHeader,
   Title,
@@ -189,6 +190,9 @@ function getEditorOptions(
           return node.attrs.label;
         },
         suggestion: createSuggestionMenu(tags, element)
+      }),
+      BlockTagGuard.configure({
+        blockTagIds: tags.filter((t) => t.block).map((t) => t.id)
       })
     );
   }

--- a/app/javascript/shared/tiptap/tags.ts
+++ b/app/javascript/shared/tiptap/tags.ts
@@ -3,24 +3,30 @@ import * as s from 'superstruct';
 import tippy, { type Instance as TippyInstance } from 'tippy.js';
 import { matchSorter } from 'match-sorter';
 
+import { blockTagsAllowed } from './block_tags';
+
 export const tagSchema = s.coerce(
   s.object({
     label: s.string(),
     id: s.string(),
     mandatory: s.optional(s.boolean()),
-    conditional: s.optional(s.boolean())
+    conditional: s.optional(s.boolean()),
+    // the tag renders as a list (repetition, multiple drop down, carte)
+    block: s.optional(s.boolean())
   }),
   s.type({
     tagLabel: s.string(),
     tagId: s.string(),
     tagMandatory: s.optional(s.string()),
-    tagConditional: s.optional(s.string())
+    tagConditional: s.optional(s.string()),
+    tagBlock: s.optional(s.string())
   }),
-  ({ tagId, tagLabel, tagMandatory, tagConditional }) => ({
+  ({ tagId, tagLabel, tagMandatory, tagConditional, tagBlock }) => ({
     label: tagLabel,
     id: tagId,
     mandatory: tagMandatory === 'true',
-    conditional: tagConditional === 'true'
+    conditional: tagConditional === 'true',
+    block: tagBlock === 'true'
   })
 );
 export type TagSchema = s.Infer<typeof tagSchema>;
@@ -222,8 +228,12 @@ export function createSuggestionMenu(
     char: '@',
     allowedPrefixes: null,
     allowSpaces: true,
-    items: ({ query }) => {
-      return matchSorter(tags, query, { keys: ['label'] }).slice(0, 6);
+    items: ({ query, editor }) => {
+      // Block tags are not offered inside a title or a heading.
+      const candidates = blockTagsAllowed(editor.state)
+        ? tags
+        : tags.filter((tag) => !tag.block);
+      return matchSorter(candidates, query, { keys: ['label'] }).slice(0, 6);
     },
     render: () => {
       let menu: SuggestionMenu;

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -305,6 +305,10 @@ module TagsSubstitutionConcern
     end
   end
 
+  def block_level_tag_ids
+    procedure_type_de_champs_tags.filter { _1[:block] }.map { _1[:id] }
+  end
+
   def used_tags_for(text)
     used_tags_and_libelle_for(text).map { _1.first.nil? ? _1.second : _1.first }
   end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -356,6 +356,10 @@ class TypeDeChamp < ApplicationRecord
   def typed_champ_blank?(champ) = champ.value.blank?
   def typed_champ_blank_or_invalid?(champ) = typed_champ_blank?(champ)
 
+  # true when `champ_value_for_tag` returns a block presentation (a list)
+  # rather than inline text: such a tag cannot live inside a title or heading.
+  def block_level_tag? = false
+
   def tags_for_template
     type_de_champ = self
     conditional = type_de_champ.condition.present?
@@ -365,6 +369,7 @@ class TypeDeChamp < ApplicationRecord
         id: path[:path] == :value ? "tdc#{stable_id}" : "tdc#{stable_id}/#{path[:path]}",
         conditional:,
         mandatory: mandatory?,
+        block: block_level_tag?,
         lambda: -> (dossier) { dossier.champ_value_for_tag(type_de_champ, path[:path]) }
       )
     end

--- a/app/models/types_de_champ/carte_type_de_champ.rb
+++ b/app/models/types_de_champ/carte_type_de_champ.rb
@@ -79,6 +79,7 @@ class TypesDeChamp::CarteTypeDeChamp < TypeDeChamp
   end
 
   def typed_champ_blank?(champ) = champ.geo_areas.blank?
+  def block_level_tag? = true
 
   def canonical_column(procedure_id:, displayable: true, prefix: nil)
     Columns::GeoJSONColumn.new(

--- a/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/multiple_drop_down_list_type_de_champ.rb
@@ -55,6 +55,7 @@ class TypesDeChamp::MultipleDropDownListTypeDeChamp < TypesDeChamp::DropDownBase
   end
 
   def typed_champ_blank?(champ) = selected_options(champ).blank?
+  def block_level_tag? = true
 
   def self.parse_selected_options(champ)
     return [] if champ.value.blank?

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -49,6 +49,7 @@ class TypesDeChamp::RepetitionTypeDeChamp < TypeDeChamp
   end
 
   def typed_champ_blank?(champ) = champ.dossier.repetition_row_ids(self).blank?
+  def block_level_tag? = true
 
   private
 

--- a/app/services/tiptap_service.rb
+++ b/app/services/tiptap_service.rb
@@ -88,6 +88,21 @@ class TiptapService
 
   private_class_method :resolve_blocks, :resolve_block, :resolve_inline, :block?, :empty_text?
 
+  # [id, label] pairs of the mentions nested, at any depth, inside a node whose
+  # type is one of `types`.
+  def self.mentions_within(node, types, inside: false, mentions: [])
+    case node
+    in type: 'mention', attrs: { id:, label: }
+      mentions << [id, label] if inside
+    in { type:, content: } if content.is_a?(Array)
+      content.each { mentions_within(_1, types, inside: inside || type.in?(types), mentions:) }
+    else
+      # leaf node
+    end
+
+    mentions
+  end
+
   def to_html(node, substitutions = {})
     return '' if node.nil?
 

--- a/app/validators/tags_validator.rb
+++ b/app/validators/tags_validator.rb
@@ -40,9 +40,26 @@ class TagsValidator < ActiveModel::EachValidator
 
     # unknown champ
     add_errors(record, attribute, :champ_missing, invalid_tags)
+
+    # champ rendered as a list, placed where a list cannot be rendered
+    add_errors(record, attribute, :block_tag_in_heading, block_tags_in_headings(record, value))
   end
 
   private
+
+  # Tiptap node types whose HTML element cannot contain a list; the editor
+  # enforces the same rule (see app/javascript/shared/tiptap/block_tags.ts).
+  INLINE_ONLY_NODE_TYPES = ['title', 'heading'].freeze
+
+  def block_tags_in_headings(record, value)
+    return [] unless value.respond_to?(:deconstruct_keys)
+
+    mentions = TiptapService.mentions_within(value.deep_symbolize_keys, INLINE_ONLY_NODE_TYPES)
+    return [] if mentions.empty?
+
+    block_tag_ids = record.block_level_tag_ids
+    mentions.filter_map { |(id, label)| label if id.in?(block_tag_ids) }.uniq
+  end
 
   def add_errors(record, attribute, message, tags)
     if tags.present?

--- a/config/locales/models/tags_validator/fr.yml
+++ b/config/locales/models/tags_validator/fr.yml
@@ -19,3 +19,6 @@ fr:
         champ_missing_in_previous_revision:
           one: contient la balise "%{tags}" qui n’existe pas sur un des dossiers en cours de traitement. Supprimer la balise
           other: contient %{count} balises (%{tags}) qui n’existent pas sur un des dossiers en cours de traitement. Supprimer les balises
+        block_tag_in_heading:
+          one: contient la balise "%{tags}" dans un titre. Cette balise affiche une liste, la placer dans un paragraphe
+          other: contient %{count} balises (%{tags}) dans un titre. Ces balises affichent une liste, les placer dans un paragraphe

--- a/spec/components/tags_button_list_component_spec.rb
+++ b/spec/components/tags_button_list_component_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe TagsButtonListComponent, type: :component do
           mandatory: true,
           conditional: true,
         },
+        {
+          id: 'tdc16',
+          libelle: 'Une répétition',
+          description: '',
+          mandatory: true,
+          conditional: false,
+          block: true,
+        },
       ],
 
       champ_private: [
@@ -57,6 +65,11 @@ RSpec.describe TagsButtonListComponent, type: :component do
     expect(subject).to have_text("civilité")
     expect(subject).to have_text("Votre avis")
     expect(subject).to have_text("Montant accordé")
+  end
+
+  it 'flags the tags rendered as a list for the editor' do
+    expect(subject).to have_css("button[data-tag-id='tdc16'][data-tag-block='true']")
+    expect(subject).to have_css("button[data-tag-id='dossier_number'][data-tag-block='']")
   end
 
   it "hides optional and conditional tags by default" do

--- a/spec/models/attestation_template_spec.rb
+++ b/spec/models/attestation_template_spec.rb
@@ -16,6 +16,48 @@ describe AttestationTemplate, type: :model do
     end
   end
 
+  describe 'validates block tags placement (v2)' do
+    let(:procedure) do
+      create(:procedure, public_type_de_champs: [
+        { type: :repetition, libelle: 'Langages', children: [{ type: :text, libelle: 'nom' }] },
+        { type: :text, libelle: 'Nom' },
+      ])
+    end
+    let(:repetition_tag) { "tdc#{procedure.draft_revision.public_root_type_de_champs.find(&:repetition?).stable_id}" }
+    let(:text_tag) { "tdc#{procedure.draft_revision.public_root_type_de_champs.find { !_1.repetition? }.stable_id}" }
+    let(:attestation_template) { build(:attestation_template, :v2, procedure:, json_body:) }
+
+    def mention(id, label) = { 'type' => 'mention', 'attrs' => { 'id' => id, 'label' => label } }
+    def doc(*content) = { 'type' => 'doc', 'content' => content }
+
+    context 'with a repetition tag in a paragraph' do
+      let(:json_body) { doc({ 'type' => 'paragraph', 'content' => [mention(repetition_tag, 'Langages')] }) }
+
+      it { expect(attestation_template).to be_valid }
+    end
+
+    context 'with a text tag in a heading' do
+      let(:json_body) { doc({ 'type' => 'heading', 'attrs' => { 'level' => 2 }, 'content' => [mention(text_tag, 'Nom')] }) }
+
+      it { expect(attestation_template).to be_valid }
+    end
+
+    context 'with a repetition tag in a heading' do
+      let(:json_body) { doc({ 'type' => 'heading', 'attrs' => { 'level' => 2 }, 'content' => [mention(repetition_tag, 'Langages')] }) }
+
+      it 'is invalid' do
+        expect(attestation_template).not_to be_valid
+        expect(attestation_template.errors.full_messages).to include(/contient la balise "Langages" dans un titre/)
+      end
+    end
+
+    context 'with a repetition tag in the title' do
+      let(:json_body) { doc({ 'type' => 'title', 'content' => [mention(repetition_tag, 'Langages')] }) }
+
+      it { expect(attestation_template).not_to be_valid }
+    end
+  end
+
   describe 'dup' do
     let(:attestation_template) { create(:attestation_template, attributes) }
     subject { attestation_template.dup }

--- a/spec/models/type_de_champ_spec.rb
+++ b/spec/models/type_de_champ_spec.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 describe TypeDeChamp do
+  describe '#tags_for_template' do
+    it 'flags the types rendered as a list in templates' do
+      expect(build(:type_de_champ_text).tags_for_template.map { _1[:block] }).to eq([false])
+      expect(build(:type_de_champ_repetition).tags_for_template.map { _1[:block] }).to eq([true])
+      expect(build(:type_de_champ_multiple_drop_down_list).tags_for_template.map { _1[:block] }).to eq([true])
+      expect(build(:type_de_champ_carte).tags_for_template.map { _1[:block] }).to eq([true])
+    end
+  end
+
   describe 'validation' do
     context 'type' do
       before_all { seed "cases/champs" }

--- a/spec/services/tiptap_service_spec.rb
+++ b/spec/services/tiptap_service_spec.rb
@@ -544,6 +544,21 @@ RSpec.describe TiptapService do
     end
   end
 
+  describe '.mentions_within' do
+    it 'lists the mentions nested inside the given node types' do
+      json = {
+        type: 'doc',
+        content: [
+          { type: 'title', content: [{ type: 'mention', attrs: { id: 'tdc1', label: 'A' } }] },
+          { type: 'paragraph', content: [{ type: 'mention', attrs: { id: 'tdc2', label: 'B' } }] },
+          { type: 'bulletList', content: [{ type: 'listItem', content: [{ type: 'heading', attrs: { level: 2 }, content: [{ type: 'mention', attrs: { id: 'tdc3', label: 'C' } }] }] }] },
+        ],
+      }
+
+      expect(described_class.mentions_within(json, ['title', 'heading'])).to eq([['tdc1', 'A'], ['tdc3', 'C']])
+    end
+  end
+
   describe '#used_tags' do
     it 'returns used tags' do
       expect(described_class.used_tags_and_libelle_for(json)).to eq(Set.new([['name', 'Nom'], ['languages', 'Langages']]))


### PR DESCRIPTION
## Contexte

Suite de #13796. Les balises rendues sous forme de liste (répétition, choix multiples, carte) ne peuvent pas être affichées dans un titre (h1/h2/h3) : le rendu retombe sur une forme texte. Plutôt que de laisser l’administrateur le découvrir sur le PDF, on interdit ce placement.

## Changements

**Côté serveur**
- Les balises de champ portent un indicateur `block` (`TypeDeChamp#block_level_tag?`, vrai pour répétition, choix multiples et carte), transmis à l’éditeur via `data-tag-block` sur les boutons de balises.
- `TagsValidator` refuse une balise bloc imbriquée dans un `title` ou un `heading` (message : « contient la balise "…" dans un titre. Cette balise affiche une liste, la placer dans un paragraphe »). Couvre l’API et les corps déjà enregistrés.

**Côté éditeur** (`app/javascript/shared/tiptap/block_tags.ts`)
- Les balises bloc ne sont pas proposées par la suggestion `@` dans un titre, et leurs boutons y sont désactivés.
- Les boutons Titre / Sous-titre sont désactivés sur un paragraphe qui contient une balise bloc.
- Un plugin ProseMirror rejette toute transaction qui laisserait une balise bloc dans un titre (raccourci clavier, règle `## `, collage) et retire les marques (gras, italique) posées sur une balise bloc, puisque le rendu les ignore.

Les colonnes d’en-tête ne sont pas concernées : une liste y est rendue correctement.

## Tests

- Vitest : `block_tags.test.ts` (suggestions filtrées, transaction rejetée, bouton titre désactivé, marques retirées).
- RSpec : validation sur `AttestationTemplate` v2, `TiptapService.mentions_within`, indicateur `block` dans `tags_for_template`, attribut `data-tag-block` du composant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)