### PR TITLE
Tech : clone d'un champ, external_state n'était pas copié

### DIFF
--- a/app/models/champ_data.rb
+++ b/app/models/champ_data.rb
@@ -305,7 +305,7 @@ class ChampData < ApplicationRecord
 
   def clone
     champ_attributes = [:private, :row_id, :type, :stable_id, :stream]
-    value_attributes = !private? ? [:value, :value_json, :data, :external_id, :prefilled, :prefilled_original_value] : []
+    value_attributes = !private? ? [:value, :value_json, :data, :external_id, :external_state, :prefilled, :prefilled_original_value] : []
     relationships = !private? ? [:etablissement, :geo_areas] : []
 
     deep_clone(only: champ_attributes + value_attributes, include: relationships, validate: true) do |original, kopy|

--- a/spec/models/champ_data_spec.rb
+++ b/spec/models/champ_data_spec.rb
@@ -614,6 +614,28 @@ describe ChampData do
 
       it { expect(subject.piece_justificative_file).not_to be_attached }
     end
+
+    context 'when champ siret has already been fetched' do
+      let(:public_type_de_champs) { [{ type: :siret }] }
+      let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+
+      before { champ.update_columns(external_state: 'fetched') }
+
+      it 'carries the external_state over' do
+        expect(subject).to be_fetched
+      end
+    end
+
+    context 'when champ siret is in error' do
+      let(:public_type_de_champs) { [{ type: :siret }] }
+      let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+
+      before { champ.update_columns(external_state: 'external_error') }
+
+      it 'carries the external_state over' do
+        expect(subject).to be_external_error
+      end
+    end
   end
 
   describe "#parent" do


### PR DESCRIPTION
`ChampData#clone` ne copie pas `external_state`. Un dossier dupliqué revient donc avec un champ marqué `idle` alors qu'il porte toujours son établissement — un état incohérent que `Champs::SiretChamp#external_id` contourne déjà par un `idle? && etablissement_id.present?`.

`clone_value_from`, l'autre chemin de duplication, copiait bien l'attribut : les deux avaient divergé.

Repéré en préparant #13435, mais indépendant : le bug existe sur `main` aujourd'hui.