### PR TITLE
[wip] Tech : état dégradé pour les champs à données externes

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -215,7 +215,7 @@ module Users
       end
 
       case APIEntrepriseService.create_etablissement_with_fallback(@dossier, sanitized_siret, current_user.id)
-      in Success
+      in Success | Failure(degraded: true, **)
         current_user.update!(siret: sanitized_siret)
         @dossier.update!(autorisation_donnees: true, last_champ_updated_at: Time.zone.now)
         redirect_to etablissement_dossier_path

--- a/app/jobs/api_entreprise/etablissement_job.rb
+++ b/app/jobs/api_entreprise/etablissement_job.rb
@@ -3,6 +3,12 @@
 class APIEntreprise::EtablissementJob < APIEntreprise::Job
   def perform(etablissement_id, procedure_id)
     find_etablissement(etablissement_id)
-    APIEntrepriseService.update_etablissement_from_degraded_mode(etablissement, procedure_id)
+
+    case APIEntrepriseService.update_etablissement_from_degraded_mode(etablissement, procedure_id)
+    in Failure(type:, **)
+      raise RetryableError, "#{self.class.name}: #{type}, retrying later"
+    else
+      nil
+    end
   end
 end

--- a/app/jobs/champ_fetch_external_data_job.rb
+++ b/app/jobs/champ_fetch_external_data_job.rb
@@ -5,8 +5,7 @@ class ChampFetchExternalDataJob < ApplicationJob
   queue_as :critical # ui feedback, asap
 
   retry_on RetryableFetchError, attempts: 3, wait: :polynomially_longer do |job, err|
-    champ = job.arguments.first
-    champ.external_data_error!
+    job.settle_exhausted_champ
 
     # Don't raise, otherwise it will pop forever as "working" queue without doing anything
     Sentry.capture_exception(err.cause)
@@ -20,5 +19,16 @@ class ChampFetchExternalDataJob < ApplicationJob
     Sentry.set_extras(external_id:)
 
     champ.fetch!
+  end
+
+  def settle_exhausted_champ
+    champ, external_id = arguments
+    return if champ.external_id != external_id
+    return if !champ.waiting_for_job?
+
+    champ.handle_exhausted_external_data_retries!
+  rescue StandardError => e
+    Sentry.capture_exception(e)
+    champ.external_data_error! if champ&.may_external_data_error?
   end
 end

--- a/app/jobs/cron/backfill_siret_degraded_mode_job.rb
+++ b/app/jobs/cron/backfill_siret_degraded_mode_job.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# TODO: remove this job in a few days once all failed etablissements are queued as separate jobs
 class Cron::BackfillSiretDegradedModeJob < Cron::CronJob
   self.schedule_expression = "every 2 hour"
 

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -33,11 +33,11 @@ class Champs::SiretChamp < ChampData
   end
 
   def fetch_external_data
-    case APIEntrepriseService.create_etablissement_with_fallback(self, external_id.delete(" "), dossier.user&.id)
-    in Success(etablissement) if etablissement.as_degraded_mode?
-      Failure(retryable: true, error: StandardError.new("API Entreprise: degraded mode"), code: 503)
+    case APIEntrepriseService.create_etablissement_with_fallback(self, external_id, dossier.user&.id)
     in Success(etablissement)
       Success(etablissement:, value: external_id)
+    in Failure(degraded: true, etablissement:, type:, code:)
+      degraded_failure(etablissement:, type:, code:)
     in Failure(type: :not_found, **)
       Failure(retryable: false, error: StandardError.new('NotFound'), code: 404)
     in Failure(type:, code:, retryable:, **)
@@ -56,6 +56,11 @@ class Champs::SiretChamp < ChampData
   end
 
   private
+
+  def degraded_failure(etablissement:, type:, code:)
+    Failure(degraded: true, etablissement:, value: external_id,
+      error: StandardError.new("API Entreprise: #{type}"), code:)
+  end
 
   # We want to validate if SIRET really exists
   # It's valid when an etablissement have been created in turbo with SIRET controller

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -45,6 +45,12 @@ class Champs::SiretChamp < ChampData
     end
   end
 
+  def handle_exhausted_external_data_retries!
+    etablissement = APIEntrepriseService.create_etablissement_as_degraded_mode(self, external_id, dossier.user&.id)
+
+    handle_result(degraded_failure(etablissement:, type: :retries_exhausted, code: 504))
+  end
+
   def search_terms
     etablissement.present? ? etablissement.search_terms : [value]
   end

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -51,6 +51,14 @@ class Champs::SiretChamp < ChampData
     handle_result(degraded_failure(etablissement:, type: :retries_exhausted, code: 504))
   end
 
+  def handle_definitive_external_data_failure!(error, code)
+    old_etablissement = etablissement
+    update_columns(etablissement_id: nil)
+    old_etablissement&.destroy
+
+    super
+  end
+
   def search_terms
     etablissement.present? ? etablissement.search_terms : [value]
   end

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -83,6 +83,10 @@ module ChampExternalDataConcern
 
   def external_data_needed_for_validation? = has_async_external_data?
 
+  def handle_exhausted_external_data_retries!
+    external_data_error!
+  end
+
   private
 
   def ready_for_external_call? = external_id.present?

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -16,6 +16,11 @@ module ChampExternalDataConcern
   # fetching -> external_error
   # if the data is fetched successfully, the external_data_fetched event is triggered
   # fetching -> fetched
+  # if the data is unavailable but a usable fallback was built, the
+  # external_data_degraded event is triggered
+  # fetching -> degraded
+  # the champ leaves degraded once a backfill job completes the data
+  # degraded -> fetched
 
   included do
     include AASM
@@ -28,6 +33,7 @@ module ChampExternalDataConcern
       waiting_for_job: 'waiting_for_job',
       fetching: 'fetching',
       fetched: 'fetched',
+      degraded: 'degraded',
       external_error: 'external_error',
     }
 
@@ -36,6 +42,7 @@ module ChampExternalDataConcern
       state :waiting_for_job
       state :fetching
       state :fetched
+      state :degraded
       state :external_error
 
       event :fetch_later, after_commit: :fetch_external_data_later do
@@ -47,7 +54,11 @@ module ChampExternalDataConcern
       end
 
       event :external_data_fetched do
-        transitions from: [:fetching], to: :fetched
+        transitions from: [:fetching, :degraded], to: :fetched
+      end
+
+      event :external_data_degraded do
+        transitions from: [:fetching, :waiting_for_job], to: :degraded
       end
 
       event :external_data_error do
@@ -59,13 +70,13 @@ module ChampExternalDataConcern
       end
 
       event :reset_external_data, after: :after_reset_external_data do
-        transitions from: [:idle, :waiting_for_job, :fetching, :fetched, :external_error], to: :idle
+        transitions from: [:idle, :waiting_for_job, :fetching, :fetched, :degraded, :external_error], to: :idle
       end
     end
   end
 
   def pending? = waiting_for_job? || fetching?
-  def done? = fetched? || external_error?
+  def done? = fetched? || degraded? || external_error?
   def external_data_not_found? = external_error? && fetch_external_data_exceptions&.last&.not_found?
 
   def has_async_external_data? = false

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -105,6 +105,10 @@ module ChampExternalDataConcern
     in Success(hash)
       update_external_data!(hash)
       external_data_fetched!
+    in Failure(degraded: true, error:, code:, **data)
+      update_external_data!(data)
+      save_external_error(error, code)
+      external_data_degraded!
     in Failure(retryable: true, error:, code:)
       save_external_error(error, code)
       retry!

--- a/app/models/concerns/champ_external_data_concern.rb
+++ b/app/models/concerns/champ_external_data_concern.rb
@@ -62,7 +62,7 @@ module ChampExternalDataConcern
       end
 
       event :external_data_error do
-        transitions from: [:waiting_for_job, :fetching], to: :external_error
+        transitions from: [:waiting_for_job, :fetching, :degraded], to: :external_error
       end
 
       event :retry do
@@ -85,6 +85,10 @@ module ChampExternalDataConcern
 
   def handle_exhausted_external_data_retries!
     external_data_error!
+  end
+
+  def handle_definitive_external_data_failure!(error, code)
+    handle_result(Failure(retryable: false, error:, code:))
   end
 
   private

--- a/app/models/external_data_exception.rb
+++ b/app/models/external_data_exception.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ExternalDataException
+  DEFINITIVE_CODES = [404, 422, 451].freeze
+
   attr_accessor :error, :code
 
   def initialize(error:, code:)
@@ -10,5 +12,9 @@ class ExternalDataException
 
   def not_found?
     code == 404
+  end
+
+  def definitive?
+    code.in?(DEFINITIVE_CODES)
   end
 end

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class APIEntrepriseService
+  CREDENTIALS_CODES = [401, 403].freeze
+  CREDENTIALS_ALERT_TTL = 1.hour
+
   class << self
     include Dry::Monads[:result]
 
@@ -74,6 +77,10 @@ class APIEntrepriseService
         give_up_degraded_mode(etablissement, 'not_found', 404)
       in Failure(type:, code:, **) if code.in?(ExternalDataException::DEFINITIVE_CODES)
         give_up_degraded_mode(etablissement, type, code)
+      in Failure(type:, code:, **) => result if code.in?(CREDENTIALS_CODES)
+        Rails.logger.error("API Entreprise backfill blocked: etablissement=#{etablissement.id} type=#{type} code=#{code}")
+        report_credentials_error(result.failure, etablissement, procedure_id)
+        nil
       in Failure(retryable: true, **) => result
         result
       else
@@ -109,6 +116,13 @@ class APIEntrepriseService
     def degraded_failure(dossier_or_champ, siret, user_id, type:, code:)
       Failure(degraded: true, type:, code:,
         etablissement: create_etablissement_as_degraded_mode(dossier_or_champ, siret, user_id))
+    end
+
+    def report_credentials_error(failure, etablissement, procedure_id)
+      key = "api_entreprise:credentials_alert:#{procedure_id}:#{failure[:type]}"
+      return if !Rails.cache.write(key, true, expires_in: CREDENTIALS_ALERT_TTL, unless_exist: true)
+
+      report_error(failure, siret: etablissement.siret, etablissement_id: etablissement.id, procedure_id:)
     end
 
     def report_error(failure, extra = {})

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -42,15 +42,19 @@ class APIEntrepriseService
 
     # Tries to create an etablissement; falls back to degraded mode if API is unavailable.
     #
-    # Returns Success(etablissement) on success or degraded fallback
-    # Returns Failure(type: :not_found, ...) if SIRET not found
-    # Returns Failure(type:, code:, retryable:, raw_response:) on non-recoverable errors
+    # Returns Success(etablissement) when the data is complete
+    # Returns Failure(degraded: true, etablissement:, type:, code:) when only a
+    #   stub could be built: the caller can carry on, a backfill completes it later
+    # Returns Failure(type:, code:, retryable:, raw_response:) on a plain failure
     def create_etablissement_with_fallback(dossier_or_champ, siret, user_id = nil)
       case create_etablissement(dossier_or_champ, siret, user_id)
-      in Failure(type: :rate_limited, **)
-        Success(create_etablissement_as_degraded_mode(dossier_or_champ, siret, user_id))
-      in Failure(retryable: true, **) if !APIEntreprise::HealthChecker.provider_up?(:insee_sirene)
-        Success(create_etablissement_as_degraded_mode(dossier_or_champ, siret, user_id))
+      in Success(etablissement)
+        Success(etablissement)
+      in Failure(type: :rate_limited => type, code:, **)
+        degraded_failure(dossier_or_champ, siret, user_id, type:, code:)
+      # the API is down, no need to retry, go to degraded mode
+      in Failure(type:, code:, retryable: true, **) if !APIEntreprise::HealthChecker.provider_up?(:insee_sirene)
+        degraded_failure(dossier_or_champ, siret, user_id, type:, code:)
       in result
         result
       end
@@ -82,6 +86,11 @@ class APIEntrepriseService
       end
 
       APIEntreprise::AttestationFiscaleJob.set(wait:).perform_later(etablissement.id, procedure_id, user_id)
+    end
+
+    def degraded_failure(dossier_or_champ, siret, user_id, type:, code:)
+      Failure(degraded: true, type:, code:,
+        etablissement: create_etablissement_as_degraded_mode(dossier_or_champ, siret, user_id))
     end
 
     def report_error(failure, extra = {})

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -65,10 +65,28 @@ class APIEntrepriseService
       in Success(etablissement_params) if etablissement_params.present?
         etablissement.update!(etablissement_params)
         etablissement.update_champ_value_json!
+        champ = etablissement.champ_data
+        champ.external_data_fetched! if champ&.may_external_data_fetched?
+        champ&.dossier&.index_search_terms_later
         etablissement
+      in Success(_)
+        # The adapter maps a not_found to an empty Success.
+        give_up_degraded_mode(etablissement, 'not_found', 404)
+      in Failure(type:, code:, **) if code.in?(ExternalDataException::DEFINITIVE_CODES)
+        give_up_degraded_mode(etablissement, type, code)
+      in Failure(retryable: true, **) => result
+        result
       else
         nil
       end
+    end
+
+    def give_up_degraded_mode(etablissement, type, code)
+      champ = etablissement.champ_data
+      return nil if champ.nil?
+
+      champ.handle_definitive_external_data_failure!(StandardError.new("API Entreprise: #{type}"), code)
+      nil
     end
 
     def perform_later_fetch_jobs(etablissement, procedure_id, user_id, wait: nil)

--- a/spec/jobs/api_entreprise/etablissement_job_spec.rb
+++ b/spec/jobs/api_entreprise/etablissement_job_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe APIEntreprise::EtablissementJob, type: :job do
+  include Dry::Monads[:result]
+
+  let(:procedure) { create(:procedure, :published, public_type_de_champs: [{ type: :siret }]) }
+  let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+  let(:champ) { dossier.champ_data.first }
+  let(:etablissement) { create(:etablissement, adresse: nil, siret: '01234567891011') }
+
+  subject { described_class.new.perform(etablissement.id, procedure.id) }
+
+  before { champ.update_columns(etablissement_id: etablissement.id, external_state: 'degraded') }
+
+  context 'when the backfill succeeds' do
+    before do
+      allow(APIEntrepriseService).to receive(:update_etablissement_from_degraded_mode).and_return(etablissement)
+    end
+
+    it { expect { subject }.not_to raise_error }
+  end
+
+  context 'when the backfill hits a transient failure' do
+    before do
+      allow(APIEntrepriseService).to receive(:update_etablissement_from_degraded_mode)
+        .and_return(Failure(type: :server_error, code: 503, retryable: true, raw_response: nil))
+    end
+
+    it 'raises so the job retries instead of waiting for the cron' do
+      expect { subject }.to raise_error(APIEntreprise::Job::RetryableError, /server_error/)
+    end
+  end
+
+  context 'when the backfill cannot converge' do
+    before do
+      allow(APIEntrepriseService).to receive(:update_etablissement_from_degraded_mode).and_return(nil)
+    end
+
+    it 'does not retry: no attempt would converge' do
+      expect { subject }.not_to raise_error
+    end
+  end
+end

--- a/spec/jobs/champ_fetch_external_data_job_spec.rb
+++ b/spec/jobs/champ_fetch_external_data_job_spec.rb
@@ -66,5 +66,87 @@ RSpec.describe ChampFetchExternalDataJob, type: :job do
         expect(champ.fetch_external_data_exceptions.size).to eq(3)
       end
     end
+
+    context 'when retries are exhausted on a siret champ' do
+      let(:procedure) { create(:procedure, :published, public_type_de_champs: [{ type: :siret }]) }
+      let(:dossier) { create(:dossier, procedure:) }
+      let(:external_id) { '41816609600051' }
+
+      before do
+        champ.update_columns(external_id:, external_state: 'waiting_for_job')
+        allow_any_instance_of(Champs::SiretChamp).to receive(:fetch_external_data).and_return(failure)
+      end
+
+      it 'converges to the degraded state instead of external_error' do
+        described_class.perform_later(champ, external_id)
+
+        3.times do
+          perform_enqueued_jobs(only: ChampFetchExternalDataJob)
+        rescue StandardError
+        end
+
+        champ.reload
+
+        expect(champ).to be_degraded
+        expect(champ.etablissement).to be_as_degraded_mode
+        expect(champ.fetch_external_data_exceptions.last.code).to eq(504)
+      end
+
+      context 'and the user replaced the SIRET during the last attempt' do
+        before do
+          attempt = 0
+          allow_any_instance_of(Champs::SiretChamp).to receive(:fetch_external_data) do |c|
+            attempt += 1
+            c.update_columns(external_id: '41816609600069') if attempt == 3
+            failure
+          end
+        end
+
+        it 'does not build a stub for the identifier the user left behind' do
+          described_class.perform_later(champ, external_id)
+
+          3.times do
+            perform_enqueued_jobs(only: ChampFetchExternalDataJob)
+          rescue StandardError
+          end
+
+          champ.reload
+
+          expect(champ).not_to be_degraded
+          expect(champ.etablissement).to be_nil
+        end
+      end
+
+      context 'and the exhaustion handler itself raises' do
+        let(:boom) { StandardError.new('champ was reset meanwhile') }
+
+        before do
+          allow_any_instance_of(Champs::SiretChamp)
+            .to receive(:handle_exhausted_external_data_retries!).and_raise(boom)
+        end
+
+        it 'reports it to Sentry instead of letting the exception escape' do
+          expect(Sentry).to receive(:capture_exception).with(boom)
+          expect(Sentry).to receive(:capture_exception).with(error)
+
+          described_class.perform_later(champ, external_id)
+
+          expect { 3.times { perform_enqueued_jobs(only: ChampFetchExternalDataJob) } }.not_to raise_error
+        end
+
+        it 'settles the champ instead of leaving it pending forever' do
+          allow(Sentry).to receive(:capture_exception)
+
+          described_class.perform_later(champ, external_id)
+
+          3.times do
+            perform_enqueued_jobs(only: ChampFetchExternalDataJob)
+          rescue StandardError
+          end
+
+          expect(champ.reload).to be_external_error
+        end
+      end
+    end
   end
 end

--- a/spec/jobs/cron/backfill_siret_degraded_mode_job_spec.rb
+++ b/spec/jobs/cron/backfill_siret_degraded_mode_job_spec.rb
@@ -24,11 +24,16 @@ RSpec.describe Cron::BackfillSiretDegradedModeJob, type: :job do
 
       before do
         champ_siret
-        champ_siret.update_column(:etablissement_id, etablissement.id)
+        champ_siret.update_columns(etablissement_id: etablissement.id, external_state: 'degraded')
       end
       it 'works' do
         allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params).and_return(Dry::Monads::Success({ adresse: new_adresse }))
         expect { Cron::BackfillSiretDegradedModeJob.perform_now }.to change { etablissement.reload.adresse }.from(nil).to(new_adresse)
+      end
+
+      it 'gets the champ out of the degraded state' do
+        allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params).and_return(Dry::Monads::Success({ adresse: new_adresse }))
+        expect { Cron::BackfillSiretDegradedModeJob.perform_now }.to change { champ_siret.reload.external_state }.from('degraded').to('fetched')
       end
     end
   end

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -116,9 +116,18 @@ describe Champs::SiretChamp do
 
       it { expect { fetch_external_data }.to change { Etablissement.count }.by(1) }
 
-      it 'returns a retryable failure to trigger job retry' do
-        expect(fetch_external_data).to be_failure
-        expect(fetch_external_data.failure[:retryable]).to be true
+      it 'returns a degraded failure carrying the stub (no retry loop, backfill jobs are scheduled)' do
+        result = fetch_external_data
+        expect(result).to be_failure
+        expect(result.failure[:degraded]).to be true
+        expect(result.failure[:etablissement]).to be_as_degraded_mode
+      end
+
+      it 'puts the champ in the degraded state' do
+        champ.update_columns(external_state: 'fetching')
+        champ.send(:handle_result, fetch_external_data)
+
+        expect(champ.reload).to be_degraded
       end
     end
 
@@ -145,6 +154,53 @@ describe Champs::SiretChamp do
       it "fetches the entreprise raison sociale" do
         fetch_external_data
         expect(champ.reload.etablissement.entreprise_raison_sociale).to eq("DIRECTION INTERMINISTERIELLE DU NUMERIQUE")
+      end
+    end
+  end
+
+  describe '#fetch_external_data (result mapping)' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :siret }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+    before { champ.update_column(:external_id, '12345678901234') }
+
+    context 'when API returns not_found' do
+      before do
+        allow(APIEntrepriseService).to receive(:create_etablissement_with_fallback)
+          .and_return(Dry::Monads::Failure(type: :not_found, code: 404, retryable: false))
+      end
+
+      it 'wraps as a non-retryable 404 failure' do
+        result = champ.fetch_external_data
+        expect(result).to be_failure
+        expect(result.failure[:code]).to eq(404)
+        expect(result.failure[:retryable]).to be_falsey
+      end
+    end
+
+    context 'when API returns a generic technical failure' do
+      before do
+        allow(APIEntrepriseService).to receive(:create_etablissement_with_fallback)
+          .and_return(Dry::Monads::Failure(type: :network, code: 503, retryable: true))
+      end
+
+      it 'keeps the failure code' do
+        expect(champ.fetch_external_data.failure[:code]).to eq(503)
+      end
+    end
+
+    context 'when the service falls back to degraded mode' do
+      let(:etablissement) { instance_double(Etablissement) }
+      before do
+        allow(APIEntrepriseService).to receive(:create_etablissement_with_fallback)
+          .and_return(Dry::Monads::Failure(degraded: true, etablissement:, type: :service_unavailable, code: 503))
+      end
+
+      it 'forwards the stub as a degraded failure (data will be backfilled later)' do
+        result = champ.fetch_external_data
+        expect(result).to be_failure
+        expect(result.failure[:degraded]).to be true
+        expect(result.failure[:etablissement]).to eq(etablissement)
       end
     end
   end

--- a/spec/models/champs/siret_champ_spec.rb
+++ b/spec/models/champs/siret_champ_spec.rb
@@ -205,6 +205,29 @@ describe Champs::SiretChamp do
     end
   end
 
+  describe '#handle_exhausted_external_data_retries!' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :siret }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+
+    before do
+      champ.update_columns(
+        external_id: '41816609600051',
+        external_state: 'waiting_for_job',
+        fetch_external_data_exceptions: [ExternalDataException.new(error: 'boom', code: 503)]
+      )
+    end
+
+    it 'converges to the degraded state instead of external_error' do
+      expect { champ.handle_exhausted_external_data_retries! }
+        .to have_enqueued_job(APIEntreprise::EtablissementJob)
+
+      champ.reload
+      expect(champ).to be_degraded
+      expect(champ.etablissement).to be_as_degraded_mode
+    end
+  end
+
   describe '#reset_external_data!' do
     let(:external_id) { "12345678901245" }
     let(:etablissement) { create(:etablissement, siret: external_id) }

--- a/spec/models/concerns/champ_external_data_concern_spec.rb
+++ b/spec/models/concerns/champ_external_data_concern_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe ChampExternalDataConcern do
 
       it { expect(champ).not_to be_external_data_not_found }
     end
+
+    context 'in external_error without any recorded exception' do
+      let(:external_state) { 'external_error' }
+      let(:exceptions) { [] }
+
+      it { expect(champ).not_to be_external_data_not_found }
+    end
   end
 
   describe 'the state machine' do
@@ -197,6 +204,64 @@ RSpec.describe ChampExternalDataConcern do
           expect(champ).to have_received(:after_reset_external_data)
         end
       end
+
+      context 'from degraded' do
+        before do
+          champ.update_column(:external_state, 'degraded')
+
+          allow(champ).to receive(:after_reset_external_data)
+          champ.reset_external_data!
+        end
+
+        it do
+          expect(champ).to be_idle
+          expect(champ).to have_received(:after_reset_external_data)
+        end
+      end
+    end
+
+    describe 'external_data_degraded' do
+      context 'from fetching' do
+        before do
+          allow(champ).to receive(:ready_for_external_call?).and_return(true)
+          champ.fetch_later!
+          champ.update_column(:external_state, 'fetching')
+          champ.external_data_degraded!
+        end
+
+        it { expect(champ.reload).to be_degraded }
+      end
+
+      # retry! has already moved the champ back to waiting_for_job.
+      context 'from waiting_for_job' do
+        before do
+          allow(champ).to receive(:ready_for_external_call?).and_return(true)
+          champ.fetch_later!
+          champ.external_data_degraded!
+        end
+
+        it { expect(champ.reload).to be_degraded }
+      end
+    end
+
+    describe 'external_data_fetched from degraded' do
+      before do
+        champ.update_column(:external_state, 'degraded')
+        champ.external_data_fetched!
+      end
+
+      it { expect(champ.reload).to be_fetched }
+    end
+  end
+
+  describe '#done?' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :rnf }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+
+    it 'is true in degraded' do
+      champ.external_state = 'degraded'
+      expect(champ).to be_done
     end
   end
 end

--- a/spec/models/external_data_exception_spec.rb
+++ b/spec/models/external_data_exception_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe ExternalDataException do
+  describe '#definitive?' do
+    [404, 422, 451].each do |code|
+      it "is true for #{code}" do
+        expect(described_class.new(error: 'boom', code:)).to be_definitive
+      end
+    end
+
+    [429, 500, 503, nil].each do |code|
+      it "is false for #{code.inspect}" do
+        expect(described_class.new(error: 'boom', code:)).not_to be_definitive
+      end
+    end
+  end
+end

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -188,6 +188,126 @@ describe APIEntrepriseService do
     end
   end
 
+  describe '#update_etablissement_from_degraded_mode' do
+    let(:procedure) { create(:procedure, :published, public_type_de_champs: [{ type: :siret }]) }
+    let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
+    let(:champ) { dossier.champ_data.first }
+    let(:etablissement) { create(:etablissement, adresse: nil, siret: '01234567891011') }
+
+    before do
+      allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params)
+        .and_return(Dry::Monads::Success(adresse: '7 rue du puits, coye la foret'))
+    end
+
+    context 'when the etablissement belongs to a degraded champ' do
+      before do
+        champ.update_columns(etablissement_id: etablissement.id, external_state: 'degraded')
+      end
+
+      it 'completes the data and leaves the degraded state' do
+        described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id)
+
+        expect(etablissement.reload.adresse).to eq('7 rue du puits, coye la foret')
+        expect(champ.reload).to be_fetched
+      end
+
+      it 'reindexes the dossier search terms' do
+        expect_any_instance_of(Dossier).to receive(:index_search_terms_later)
+
+        described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id)
+      end
+    end
+
+    context 'when the etablissement belongs to a dossier (no champ)' do
+      let!(:dossier_with_etablissement) { create(:dossier, :en_construction, etablissement:) }
+
+      it 'completes the data without raising' do
+        expect { described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id) }
+          .to change { etablissement.reload.adresse }.from(nil).to('7 rue du puits, coye la foret')
+      end
+    end
+
+    context 'when the API gives a definitive answer' do
+      before { champ.update_columns(etablissement_id: etablissement.id, external_state: 'degraded') }
+
+      context 'a not_found, which the adapter maps to an empty Success' do
+        before do
+          allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params)
+            .and_return(Dry::Monads::Success({}))
+        end
+
+        it 'moves the champ to external_error and drops the stub' do
+          expect { described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id) }
+            .to change { Etablissement.exists?(etablissement.id) }.from(true).to(false)
+
+          champ.reload
+          expect(champ).to be_external_error
+          expect(champ.etablissement).to be_nil
+          expect(champ.fetch_external_data_exceptions.last.code).to eq(404)
+        end
+
+        it 'unblocks the dossier' do
+          described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id)
+
+          expect(dossier.reload.any_etablissement_as_degraded_mode?).to be false
+        end
+      end
+
+      [422, 451].each do |code|
+        context "a #{code}" do
+          before do
+            allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params)
+              .and_return(Dry::Monads::Failure(type: :unprocessable, code:, retryable: false, raw_response: nil))
+          end
+
+          it 'moves the champ to external_error and drops the stub' do
+            expect { described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id) }
+              .to change { Etablissement.exists?(etablissement.id) }.from(true).to(false)
+
+            expect(champ.reload).to be_external_error
+            expect(champ.fetch_external_data_exceptions.last.code).to eq(code)
+          end
+        end
+      end
+
+      context 'on an etablissement that belongs to a dossier' do
+        let(:dossier_etablissement) { create(:etablissement, adresse: nil, siret: '01234567891012') }
+        let!(:dossier_with_etablissement) { create(:dossier, :en_construction, etablissement: dossier_etablissement) }
+
+        before do
+          allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params)
+            .and_return(Dry::Monads::Success({}))
+        end
+
+        it 'keeps it: dropping it would take the dossier identity with it' do
+          expect(described_class.update_etablissement_from_degraded_mode(dossier_etablissement, procedure.id)).to be_nil
+          expect(Etablissement.exists?(dossier_etablissement.id)).to be true
+        end
+      end
+    end
+
+    context 'when the backfill cannot converge' do
+      before { champ.update_columns(etablissement_id: etablissement.id, external_state: 'degraded') }
+
+      context 'on any other failure' do
+        before do
+          allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params)
+            .and_return(Dry::Monads::Failure(type: :server_error, code: 503, retryable: true, raw_response: nil))
+        end
+
+        it 'hands the failure back so the job can retry, and stays silent' do
+          expect(Sentry).not_to receive(:capture_message)
+
+          result = described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id)
+
+          expect(result).to be_failure
+          expect(result.failure[:code]).to eq(503)
+          expect(champ.reload).to be_degraded
+        end
+      end
+    end
+  end
+
   describe '#report_error' do
     it 'sends a message to Sentry with context' do
       failure = { type: :server_error, code: 503, retryable: true, raw_response: nil }

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -140,10 +140,11 @@ describe APIEntrepriseService do
         allow(APIEntreprise::HealthChecker).to receive(:provider_up?).with(:insee_sirene).and_return(false)
       end
 
-      it 'returns Success with degraded etablissement' do
-        expect(subject).to be_success
-        expect(subject.value!.siret).to eq(siret)
-        expect(subject.value!).to be_as_degraded_mode
+      it 'returns an explicit degraded Failure carrying the stub' do
+        expect(subject).to be_failure
+        expect(subject.failure[:degraded]).to be true
+        expect(subject.failure[:etablissement].siret).to eq(siret)
+        expect(subject.failure[:etablissement]).to be_as_degraded_mode
       end
     end
 
@@ -168,9 +169,9 @@ describe APIEntrepriseService do
 
       it 'falls back to degraded mode without checking provider health' do
         expect(APIEntreprise::HealthChecker).not_to receive(:provider_up?)
-        expect(subject).to be_success
-        expect(subject.value!.siret).to eq(siret)
-        expect(subject.value!).to be_as_degraded_mode
+        expect(subject).to be_failure
+        expect(subject.failure[:degraded]).to be true
+        expect(subject.failure[:etablissement]).to be_as_degraded_mode
       end
     end
 

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -289,6 +289,53 @@ describe APIEntrepriseService do
     context 'when the backfill cannot converge' do
       before { champ.update_columns(etablissement_id: etablissement.id, external_state: 'degraded') }
 
+      [401, 403].each do |code|
+        context "on a credentials failure (#{code})" do
+          before do
+            allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params)
+              .and_return(Dry::Monads::Failure(type: :token_expired, code:, retryable: false, raw_response: nil))
+          end
+
+          it 'alerts and leaves the champ degraded' do
+            expect(Rails.logger).to receive(:error).with(/API Entreprise backfill blocked/)
+            expect(Sentry).to receive(:capture_message).with(
+              'API Entreprise error: token_expired',
+              level: :error,
+              extra: hash_including(code:, siret: etablissement.siret)
+            )
+
+            expect(described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id)).to be_nil
+            expect(champ.reload).to be_degraded
+          end
+        end
+      end
+
+      context 'on a credentials failure hitting several etablissements', :caching do
+        let(:other_etablissement) { create(:etablissement, adresse: nil, siret: '98765432109876') }
+        let(:other_procedure) { create(:procedure, :published) }
+
+        before do
+          allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params)
+            .and_return(Dry::Monads::Failure(type: :token_expired, code: 401, retryable: false, raw_response: nil))
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it 'alerts once per hour instead of once per etablissement' do
+          expect(Rails.logger).to receive(:error).with(/API Entreprise backfill blocked/).twice
+          expect(Sentry).to receive(:capture_message).once
+
+          described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id)
+          described_class.update_etablissement_from_degraded_mode(other_etablissement, procedure.id)
+        end
+
+        it 'alerts again for another procedure, which has its own token' do
+          expect(Sentry).to receive(:capture_message).twice
+
+          described_class.update_etablissement_from_degraded_mode(etablissement, procedure.id)
+          described_class.update_etablissement_from_degraded_mode(other_etablissement, other_procedure.id)
+        end
+      end
+
       context 'on any other failure' do
         before do
           allow_any_instance_of(APIEntreprise::EtablissementAdapter).to receive(:to_params)


### PR DESCRIPTION
Première des 4 PRs issues du découpage de #13435, qui était devenue trop grosse.

## Ce que ça fait

Quand API Entreprise ne répond pas, on crée déjà un établissement « stub » — le SIRET seul, sans adresse — qu’un rattrapage complète plus tard. Mais le champ, lui, n’a aucun état pour dire ça : il finit en `external_error`, exactement comme un SIRET inexistant.

Cette PR ajoute l’état `degraded` à la machine à états du champ, et le cycle complet : comment on y entre, et comment on en sort.

## Deux bugs de `main` que ça corrige

En instrumentant le comportement actuel, deux choses sont apparues :

**Le rattrapage ne débloque pas le champ.** `update_etablissement_from_degraded_mode` complète bien l’établissement, mais ne contient aucune transition d’état. Vérifié en console sur `main` : après un 429 puis un cron réussi, l’adresse est remplie et le champ reste en `external_error`, donc le dépôt reste bloqué alors que la donnée est disponible. La seule sortie pour l’usager est de ressaisir son SIRET à la main.

**Chaque tentative recrée un stub.** Sur trois tentatives, deux établissements se retrouvent orphelins — rattachés ni à un dossier ni à un champ, donc invisibles pour le cron qui les cherche par jointure. C’est la source que draine la tâche `t20260129destroy_orphan_etablissements_task`.

## Impact usager

**Il y en a un.** Le validateur n’est pas modifié ici : il teste `pending?` puis `external_error?`, et rien ne correspond à `degraded`. Un champ dégradé ne produit donc aucune erreur, et **l’usager peut déposer** là où il était bloqué auparavant.

C’est la direction voulue, et le garde-fou côté instruction reste en place : `any_etablissement_as_degraded_mode?` empêche toujours d’accepter un dossier dont l’établissement est incomplet. La PR suivante rendra cette décision explicite plutôt que subie, en indexant le blocage sur l’existence d’un rattrapage plutôt que sur le code d’erreur.

## À relire
Quatre endroits se lisent mal sans le contexte :

- **`Failure(degraded: true)` n’est pas une erreur.** Ça veut dire « j’ai une réponse utilisable tout de suite, incomplète, qu’un rattrapage complétera ». Le `Failure` sert à porter l’information jusqu’à l’appelant, qui décide : le contrôleur laisse passer l’usager, le champ passe en `degraded`.
- **Un `Success({})` déclenche un abandon en 404.** L’adaptateur mappe `not_found` en `Success` vide. C’est contre-intuitif, et c’était la moitié du bug : sans ça, un SIRET mal saisi pendant une panne restait dégradé à vie et le dossier devenait impossible à instruire.
- **Le 504 sur épuisement des tentatives est synthétique** — aucune API ne l’a renvoyé. Il est choisi hors de `DEFINITIVE_CODES`, pour que le rattrapage puisse encore aboutir, et hors de la famille des messages « nous réessayons pour vous », puisqu’on a justement arrêté de réessayer.
- **Sur 401/403, on ne change pas l’état du champ.** C’est le jeton de l'administration, pas le SIRET de l’usager : le champ reste `degraded`, donc dans la population que le rattrapage rebalaie, et il se répare tout seul dès que le jeton est renouvelé. On se contente d’alerter.

## Suite

Les 3 PRs suivantes portent la validation permissive, les messages par code d’erreur, puis le 409 et le bandeau usager. Elles s’enchaînent dans cet ordre : celle-ci doit passer en premier.
