### PR TITLE
Tech : corrige un test instable de l’export des démarches publiques

### DIFF
--- a/spec/services/demarches_publiques_export_service_spec.rb
+++ b/spec/services/demarches_publiques_export_service_spec.rb
@@ -41,7 +41,7 @@ describe DemarchesPubliquesExportService do
         dossiersCount: 4,
         revision: {
           id: procedure.active_revision.to_typed_id,
-          datePublication: procedure.published_at.iso8601,
+          datePublication: procedure.active_revision.published_at.iso8601,
           champDescriptors: [
             {
               id: procedure.active_revision.public_root_type_de_champs.first.to_typed_id,


### PR DESCRIPTION
## Contexte

Le test `DemarchesPubliquesExportService#call` échoue par intermittence sur CI (run 33806094232, sur #13796) : `revision.datePublication` attendu à 23:07:14, obtenu à 23:07:15.

## Cause

La spec comparait la date de publication de la révision à `procedure.published_at`. La factory fixe celle-ci avec `Time.zone.now`, puis la révision reçoit sa propre `published_at` d’un second `Time.zone.now` lors de la publication du brouillon. Quand l’horloge change de seconde entre les deux, les deux dates diffèrent.

## Changement

L’attendu lit l’horodatage de la révision elle-même, comme le fait l’export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)