### PR TITLE
Tech: la purge des démarches supprimées ne plante plus quand une présentation par défaut est définie

### DIFF
--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -122,7 +122,11 @@ class ProcedurePresentation < ApplicationRecord
   end
 
   def unset_admin_default_on_procedure
+    # with_discarded: the purge of a discarded procedure destroys its
+    # presentations through the groupe_instructeur cascade, and the default
+    # scope would hide that procedure from the nullify (FK violation).
     Procedure
+      .with_discarded
       .where(admin_default_procedure_presentation_id: id)
       .update_all(
         admin_default_procedure_presentation_active: false,

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -119,4 +119,32 @@ describe ProcedurePresentation do
       ])
     end
   end
+
+  describe '#unset_admin_default_on_procedure' do
+    let(:procedure_presentation) { create(:procedure_presentation, assign_to:) }
+
+    before do
+      procedure.update!(admin_default_procedure_presentation_id: procedure_presentation.id, admin_default_procedure_presentation_active: true)
+    end
+
+    it 'unsets the admin default before the presentation is destroyed' do
+      procedure_presentation.destroy!
+
+      expect(procedure.reload.admin_default_procedure_presentation_id).to be_nil
+      expect(procedure.admin_default_procedure_presentation_active).to be(false)
+    end
+
+    # Cron::DiscardedProceduresDeletionJob destroys presentations through the
+    # groupe_instructeur cascade of a discarded procedure: the default scope
+    # must not hide that procedure from the nullify, or the FK blocks the delete.
+    context 'when the procedure is discarded' do
+      before { procedure.discard! }
+
+      it 'still unsets the admin default' do
+        expect { procedure_presentation.destroy! }.not_to raise_error
+
+        expect(Procedure.with_discarded.find(procedure.id).admin_default_procedure_presentation_id).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Contexte

`Cron::DiscardedProceduresDeletionJob` échoue chaque nuit sur la démarche 149526 avec une violation de clé étrangère (`procedures.admin_default_procedure_presentation_id` → `procedure_presentations`), et arrête donc la purge des démarches suivantes.

## Cause

Le `before_destroy` de `ProcedurePresentation` remet à `nil` la présentation par défaut via `Procedure.where(...)`, donc sous le `default_scope kept`. La démarche en cours de purge est `discarded` : elle n'est jamais mise à jour et la FK bloque la suppression.

## Correctif

Requête en `with_discarded` pour que la remise à `nil` atteigne aussi la démarche purgée. Spec de reproduction ajoutée (elle levait `ActiveRecord::InvalidForeignKey` sans le correctif).

Fixes RAILS-MJ8

🤖 Generated with [Claude Code](https://claude.com/claude-code)