### PR TITLE
ETQ instructeur, je peux accepter un dossier dont un titre d'identité a changé de type

### DIFF
--- a/app/models/concerns/dossier_state_concern.rb
+++ b/app/models/concerns/dossier_state_concern.rb
@@ -450,7 +450,9 @@ module DossierStateConcern
       next false unless champ.is_a?(Champs::PieceJustificativeChamp)
 
       begin
-        champ.titre_identite?
+        # because of revisions, champ.type can differ from champ.type_de_champ.type_champ
+        # (e.g. piece_justificative → iban): the type_de_champ then has no titre_identite?
+        champ.is_type?(champ.type_de_champ.type_champ) && champ.titre_identite?
       rescue RuntimeError
         # Champ has no type_de_champ in current revision (orphaned), skip it
         false

--- a/spec/models/concerns/dossier_state_concern_spec.rb
+++ b/spec/models/concerns/dossier_state_concern_spec.rb
@@ -341,6 +341,30 @@ RSpec.describe DossierStateConcern do
       end
     end
 
+    # After a revision changed the type of the champ, the champ_data row keeps
+    # its piece_justificative STI type while type_de_champ is now an IBAN,
+    # which has no titre_identite? (RAILS-MH0).
+    context 'when the revision changed the type of a titre_identite champ' do
+      let(:procedure) { create(:procedure, :published, :for_individual, public_type_de_champs: [{ type: :piece_justificative, nature: 'titre_identite', stable_id: 99 }]) }
+      let(:dossier) { create(:dossier, :en_instruction, :followed, :with_individual, procedure:) }
+      let(:instructeur) { dossier.followers_instructeurs.first }
+
+      before do
+        dossier
+        tdc = procedure.draft_revision.find_and_ensure_exclusive_use(99).becomes_type(:iban)
+        tdc.update!(type_champ: TypeDeChamp.type_champs.fetch(:iban))
+        procedure.publish_revision!(procedure.administrateurs.first)
+        perform_enqueued_jobs
+        dossier.reload
+        expect(dossier.champ_data.find_by(stable_id: 99)).to be_a(Champs::PieceJustificativeChamp)
+      end
+
+      it 'accepts the dossier without clearing the champ' do
+        expect { dossier.accepter!(instructeur: instructeur, motivation: 'ok') }.not_to raise_error
+        expect(dossier.reload).to be_accepte
+      end
+    end
+
     context 'when pj_auto_purge is enabled' do
       let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :piece_justificative, pj_auto_purge: '1' }]) }
       let(:dossier) { create(:dossier, :en_instruction, :followed, procedure:) }


### PR DESCRIPTION
## Contexte

Un instructeur obtient une erreur 500 en acceptant un dossier lorsqu'une révision a changé le type d'un champ « titre d'identité » (en IBAN en production) : `undefined method 'titre_identite?' for TypesDeChamp::IbanTypeDeChamp`.

## Cause

Après le changement de type, la ligne `champ_data` garde son type STI `PieceJustificativeChamp` alors que le `type_de_champ` est devenu un IBAN. `clear_titres_identite!` ne protégeait que le cas du champ orphelin (`RuntimeError`), pas celui du type discordant.

## Correctif

Même garde que #13788 pour le clonage : on ignore les champs dont le type STI ne correspond plus à celui du `type_de_champ`. Spec de reproduction ajoutée.

Fixes RAILS-MH0

🤖 Generated with [Claude Code](https://claude.com/claude-code)