### PR TITLE
Tech : précharge la révision et la démarche des dossiers liés dans l’API GraphQL

### DIFF
--- a/app/graphql/types/champs/dossier_link_champ_type.rb
+++ b/app/graphql/types/champs/dossier_link_champ_type.rb
@@ -8,7 +8,7 @@ module Types::Champs
 
     def dossier
       if object.value.present?
-        dataloader.with(Sources::RecordById, Dossier.visible_by_administration).load(object.value)
+        dataloader.with(Sources::RecordById, Dossier.visible_by_administration.includes(revision: :procedure)).load(object.value)
       end
     end
   end

--- a/spec/graphql/connections/dossiers_connection_spec.rb
+++ b/spec/graphql/connections/dossiers_connection_spec.rb
@@ -44,6 +44,55 @@ RSpec.describe Connections::DossiersConnection, type: :graphql do
     it_behaves_like 'a shape preloading champs'
   end
 
+  context 'when linked dossiers are selected' do
+    let_it_be(:procedure_with_link) { create(:procedure, :published, :for_individual, administrateurs: [admin], public_type_de_champs: [{ type: :dossier_link }]) }
+    let(:query) { LINKED_DOSSIERS_QUERY }
+
+    def execute(query)
+      API::V2::Schema.execute(query, variables: { number: procedure_with_link.id }, context: { administrateur_id: admin.id, procedure_ids: admin.reload.procedure_ids })
+    end
+
+    # Each linked dossier lives on its own procedure, so its revision and
+    # procedure are not shared with the dossiers of the connection.
+    def create_dossier_with_link
+      linked_procedure = create(:procedure, :published, :for_individual, administrateurs: [admin])
+      linked_dossier = create(:dossier, :en_construction, :with_individual, procedure: linked_procedure)
+      dossier = create(:dossier, :en_construction, :with_individual, :with_populated_champs, procedure: procedure_with_link)
+      dossier.root_champs_public.first.update(value: linked_dossier.id)
+    end
+
+    it 'does not run one query per linked dossier' do
+      create_dossier_with_link
+      count_for_one_dossier = count_queries(query)
+
+      3.times { create_dossier_with_link }
+
+      expect(count_queries(query)).to eq(count_for_one_dossier)
+    end
+  end
+
+  LINKED_DOSSIERS_QUERY = <<-GRAPHQL
+  query getDemarche($number: Int!) {
+    demarche(number: $number) {
+      dossiers {
+        nodes {
+          id
+          champs {
+            id
+            ... on DossierLinkChamp {
+              dossier {
+                id
+                state
+                demandeur { id }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  GRAPHQL
+
   NODES_CHAMPS_QUERY = <<-GRAPHQL
   query getDemarche($number: Int!) {
     demarche(number: $number) {


### PR DESCRIPTION
## Contexte

Skylight signale sur `graphql:custom` une boucle de requêtes `SELECT procedure_revisions WHERE id = ?` (jusqu’à 28 répétitions par requête) suivie d’autant de `SELECT procedures`.

Les dossiers atteints via un champ « lien vers un dossier » (`DossierLinkChamp`) sont chargés par lot par `Sources::RecordById`, mais sans `includes` : `DossierType.authorized?` et `demandeur` chargent ensuite la révision puis la démarche dossier lié par dossier lié.

## Changement

- `Types::Champs::DossierLinkChampType#dossier` précharge `revision: :procedure` sur les dossiers liés.
- Un spec sur `Connections::DossiersConnection` vérifie que le nombre de requêtes reste constant quand on ajoute des dossiers liés vivant sur d’autres démarches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)