### PR TITLE
Tech : ne recharge plus les révisions déjà préchargées dans DossierPreloader

### DIFF
--- a/app/models/dossier_preloader.rb
+++ b/app/models/dossier_preloader.rb
@@ -61,13 +61,42 @@ class DossierPreloader
 
   private
 
-  def revisions(pj_template: false)
-    @revisions ||= ProcedureRevision.where(id: @dossiers.pluck(:revision_id, :submitted_revision_id).flatten.compact.uniq)
-      .includes(procedure: [], revision_type_de_champs: { type_de_champ: pj_template ? { piece_justificative_template_attachment: :blob, notice_explicative_attachment: :blob } : [] })
-      .index_by(&:id)
+  # Révisions indexées par id pour un batch de dossiers, mémorisées d'un batch
+  # à l'autre. Les révisions déjà chargées avec leurs `revision_type_de_champs`
+  # (ex: `Dossier.for_api_v2`) sont réutilisées : recharger les types de champ
+  # d'une révision est la requête la plus coûteuse du préchargement.
+  def revisions_for(dossiers, pj_template: false)
+    @revisions ||= {}
+    @revisions.merge!(preloaded_revisions(dossiers)) unless pj_template
+
+    missing_ids = dossiers.flat_map { [it.revision_id, it.submitted_revision_id] }.compact.uniq - @revisions.keys
+    if missing_ids.any?
+      @revisions.merge!(
+        ProcedureRevision.where(id: missing_ids)
+          .includes(procedure: [], revision_type_de_champs: { type_de_champ: pj_template ? { piece_justificative_template_attachment: :blob, notice_explicative_attachment: :blob } : [] })
+          .index_by(&:id)
+      )
+    end
+
+    @revisions
+  end
+
+  def preloaded_revisions(dossiers)
+    revisions = dossiers.filter_map do |dossier|
+      association = dossier.association(:revision)
+      revision = association.target if association.loaded?
+      revision if revision&.association(:revision_type_de_champs)&.loaded?
+    end.index_by(&:id)
+
+    if revisions.any?
+      ::ActiveRecord::Associations::Preloader.new(records: revisions.values, associations: :procedure).call
+    end
+
+    revisions
   end
 
   def load_dossiers(dossiers, pj_template: false)
+    revisions = revisions_for(dossiers, pj_template:)
     to_include = @includes_for_champ.dup
 
     blob_include = if pj_template
@@ -97,7 +126,7 @@ class DossierPreloader
     champs_by_dossier = all_champs.group_by(&:dossier_id)
 
     dossiers.each do |dossier|
-      load_dossier(dossier, champs_by_dossier[dossier.id] || [], pj_template:)
+      load_dossier(dossier, champs_by_dossier[dossier.id] || [], revisions)
     end
 
     load_etablissements(all_champs)
@@ -117,8 +146,8 @@ class DossierPreloader
     end
   end
 
-  def load_dossier(dossier, champs, pj_template: false)
-    revision = revisions(pj_template:)[dossier.revision_id]
+  def load_dossier(dossier, champs, revisions)
+    revision = revisions[dossier.revision_id]
     if revision.present?
       dossier.association(:revision).target = revision
     end

--- a/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
@@ -45,6 +45,22 @@ describe API::V2::GraphqlController do
       expect(query_count).to be <= MAX_QUERY_COUNT
     end
 
+    # `Procedure.for_api_v2` loads the types de champ of the démarche's active
+    # revisions, then the dossiers of the connection carry their own revision:
+    # DossierPreloader must reuse it rather than load its types de champ again.
+    it "loads the types de champ of the dossiers' revision once" do
+      variables = { demarcheNumber: procedure.id, includeDossiers: true, includeChamps: true, includeTraitements: false }
+      dossier
+      revision_queries = []
+      callback = lambda { |*args| revision_queries << args.last[:sql] if args.last[:sql].include?('"procedure_revision_types_de_champ"') }
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        post :execute, params: { queryId: query_id, variables:, operationName: operation_name }, as: :json
+      end
+
+      expect(gql_errors).to be_nil
+      expect(revision_queries.size).to eq(2)
+    end
+
     context "with 3 dossiers per state" do
       let(:dossiers_per_state) { 3 }
 

--- a/spec/lib/recovery/revision_life_cycle_spec.rb
+++ b/spec/lib/recovery/revision_life_cycle_spec.rb
@@ -32,8 +32,11 @@ describe 'Recovery::Revision::LifeCycle' do
         expect(dossier.root_champs_public.size).to eq(1)
         expect(dossier.champ_data.size).to eq(2)
         importer.load
-        expect { DossierPreloader.load_one(dossier) }.not_to raise_error
-        expect(dossier.root_champs_public.size).to eq(2)
+        # DossierPreloader reuses a revision already loaded with its types de
+        # champ, so the imported one is only visible on a fresh dossier.
+        imported_dossier = Dossier.find(dossier.id)
+        expect { DossierPreloader.load_one(imported_dossier) }.not_to raise_error
+        expect(imported_dossier.root_champs_public.size).to eq(2)
       end
     end
 

--- a/spec/models/dossier_preloader_spec.rb
+++ b/spec/models/dossier_preloader_spec.rb
@@ -48,6 +48,36 @@ describe DossierPreloader do
     end
   end
 
+  describe 'all with revisions already loaded' do
+    let!(:dossiers) { [create(:dossier, procedure:)] }
+
+    def sql_touching(table, &block)
+      queries = []
+      callback = lambda { |*args| queries << args.last[:sql] if args.last[:sql].include?(table) }
+      ActiveSupport::Notifications.subscribed(callback, 'sql.active_record', &block)
+      queries
+    end
+
+    it 'reuses revisions loaded with their types de champ instead of loading them again' do
+      loaded_dossiers = Dossier.where(id: dossiers).for_api_v2.to_a
+
+      expect(sql_touching('procedure_revision') { DossierPreloader.new(loaded_dossiers).all }).to be_empty
+
+      loaded_dossier = loaded_dossiers.first
+      expect(loaded_dossier.revision.association(:procedure)).to be_loaded
+      expect(sql_touching('') { loaded_dossier.root_champs_public.map(&:type_de_champ) }).to be_empty
+    end
+
+    it 'loads revisions that are missing or loaded without their types de champ' do
+      loaded_dossiers = Dossier.where(id: dossiers).includes(:revision).to_a
+
+      queries = sql_touching('"procedure_revision_types_de_champ"') { DossierPreloader.new(loaded_dossiers).all }
+
+      expect(queries.size).to eq(1)
+      expect(sql_touching('') { loaded_dossiers.first.root_champs_public.map(&:type_de_champ) }).to be_empty
+    end
+  end
+
   describe '#in_batches (preloading for PDF/zip export)' do
     let(:instructeur) { create(:instructeur) }
     let(:expert) { experts.default }


### PR DESCRIPTION
## Contexte

Sur `graphql:custom`, Skylight montre que le chargement des `procedure_revision_types_de_champ` d’une révision (jointure `types_de_champ`, ~96 ms par requête) est la requête SQL la plus coûteuse de l’API, et qu’elle s’exécute deux fois par requête dès que les champs sont demandés.

`Dossier.for_api_v2` précharge la révision de chaque dossier avec ses `revision_type_de_champs`, puis `DossierPreloader#revisions` rechargeait les mêmes révisions pour les attacher aux dossiers.

## Changement

- `DossierPreloader` réutilise les révisions déjà chargées avec leurs `revision_type_de_champs` (il précharge seulement leur démarche si besoin) et ne charge que les révisions manquantes, par batch, au lieu d’un `pluck` sur toute la relation.
- Le chemin `pj_template: true` (exports, pages usager) continue de charger les révisions lui-même, car il a besoin des pièces jointes des types de champ.
- Specs : `DossierPreloader` réutilise ou charge selon ce qui est déjà en mémoire ; `demarche.dossiers` ne charge les types de champ de la révision des dossiers qu’une fois.

Suite de #13806.

🤖 Generated with [Claude Code](https://claude.com/claude-code)