### PR TITLE
Tech : charge les descripteurs de champs d’une révision à la demande dans l’API GraphQL

### DIFF
--- a/app/graphql/types/demarche_type.rb
+++ b/app/graphql/types/demarche_type.rb
@@ -88,7 +88,7 @@ module Types
     end
 
     def revisions
-      dataloader.with(Sources::Association, revisions: :revision_type_de_champs).load(object)
+      dataloader.with(Sources::Association, :revisions).load(object)
     end
 
     def dossiers(updated_since: nil, created_since: nil, state: nil, archived: nil, revision: nil, max_revision: nil, min_revision: nil, order:, lookahead:)

--- a/app/graphql/types/revision_type.rb
+++ b/app/graphql/types/revision_type.rb
@@ -6,12 +6,23 @@ module Types
     field :date_creation, GraphQL::Types::ISO8601DateTime, "Date de la création.", null: false, method: :created_at
     field :date_publication, GraphQL::Types::ISO8601DateTime, "Date de la publication.", null: true, method: :published_at
 
-    field :champ_descriptors, [Types::ChampDescriptorType], null: false, method: :public_revision_type_de_champs
+    field :champ_descriptors, [Types::ChampDescriptorType], null: false
     field :annotation_descriptors, [Types::ChampDescriptorType], null: false
+
+    # Loading the types de champ of a revision is expensive, so callers hand
+    # over bare revisions and the descriptors are loaded on demand, batched
+    # across every revision of the response.
+    def champ_descriptors
+      dataloader.with(Sources::Association, :revision_type_de_champs).load(object).then do
+        object.public_revision_type_de_champs
+      end
+    end
 
     def annotation_descriptors
       if context.authorized_demarche?(object.procedure)
-        object.private_revision_type_de_champs
+        dataloader.with(Sources::Association, :revision_type_de_champs).load(object).then do
+          object.private_revision_type_de_champs
+        end
       else
         []
       end

--- a/app/graphql/types/traitement_type.rb
+++ b/app/graphql/types/traitement_type.rb
@@ -18,7 +18,7 @@ module Types
     field :changed_columns, [Types::ColumnType], "Liste des changements par colonne", null: false
 
     def revision
-      dataloader.with(Sources::Association, revision: :revision_type_de_champs).load(object)
+      dataloader.with(Sources::Association, revision: :procedure).load(object)
     end
   end
 end

--- a/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_n+1_spec.rb
@@ -61,6 +61,23 @@ describe API::V2::GraphqlController do
       expect(revision_queries.size).to eq(2)
     end
 
+    # The stored query only reads `traitements { revision { id datePublication } }`:
+    # the types de champ of those revisions must not be loaded. The two expected
+    # queries load the démarche's active revisions and the dossiers' revision.
+    it "does not load the types de champ of the traitements' revision" do
+      variables = { demarcheNumber: procedure.id, includeDossiers: true, includeTraitements: true, includeChamps: false, includeAnnotations: false }
+      dossier
+      revision_queries = []
+      callback = lambda { |*args| revision_queries << args.last[:sql] if args.last[:sql].include?('"procedure_revision_types_de_champ"') }
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        post :execute, params: { queryId: query_id, variables:, operationName: operation_name }, as: :json
+      end
+
+      expect(gql_errors).to be_nil
+      expect(gql_data[:demarche][:dossiers][:nodes].first[:traitements].first[:revision][:id]).to eq(dossier.revision.to_typed_id)
+      expect(revision_queries.size).to eq(2)
+    end
+
     context "with 3 dossiers per state" do
       let(:dossiers_per_state) { 3 }
 

--- a/spec/graphql/dossier_spec.rb
+++ b/spec/graphql/dossier_spec.rb
@@ -610,6 +610,19 @@ RSpec.describe Types::DossierType, type: :graphql do
   }
   GRAPHQL
 
+  describe 'dossier with traitement revision descriptors' do
+    let(:dossier) { create(:dossier, :accepte) }
+    let(:query) { DOSSIER_WITH_TRAITEMENT_REVISION_QUERY }
+    let(:variables) { { number: dossier.id } }
+
+    it 'loads the descriptors of the revision on demand' do
+      traitement = data[:dossier][:traitements].first
+      expect(traitement[:revision][:id]).to eq(dossier.revision.to_typed_id)
+      expect(traitement[:revision][:champDescriptors].map { _1[:id] }).to eq(dossier.revision.public_revision_type_de_champs.map(&:to_typed_id))
+      expect(traitement[:revision][:annotationDescriptors].map { _1[:id] }).to eq(dossier.revision.private_revision_type_de_champs.map(&:to_typed_id))
+    end
+  end
+
   describe 'dossier with traitement changed columns' do
     let(:procedure) { create(:procedure, :published, public_type_de_champs:) }
     let(:public_type_de_champs) do
@@ -894,6 +907,20 @@ RSpec.describe Types::DossierType, type: :graphql do
         state
       }
       dateExpiration
+    }
+  }
+  GRAPHQL
+
+  DOSSIER_WITH_TRAITEMENT_REVISION_QUERY = <<-GRAPHQL
+  query($number: Int!) {
+    dossier(number: $number) {
+      traitements {
+        revision {
+          id
+          champDescriptors { id }
+          annotationDescriptors { id }
+        }
+      }
     }
   }
   GRAPHQL


### PR DESCRIPTION
## Contexte

Sur `graphql:custom`, le chargement des `procedure_revision_types_de_champ` d’une révision (jointure `types_de_champ`, ~96 ms) est la requête SQL la plus coûteuse de l’API.

`TraitementType#revision` et `DemarcheType#revisions` préchargeaient ces types de champ pour chaque révision renvoyée, alors que la requête stockée `getDemarche` ne lit que `traitements { revision { id datePublication } }`.

## Changement

- `RevisionType` charge `revision_type_de_champs` via le dataloader uniquement quand `champDescriptors` ou `annotationDescriptors` sont sélectionnés, en une seule requête pour toutes les révisions de la réponse.
- `TraitementType#revision` précharge seulement la démarche de la révision (nécessaire à l’autorisation) ; `DemarcheType#revisions` renvoie les révisions nues.
- Specs : la requête stockée avec traitements ne charge plus les types de champ des révisions des traitements ; les descripteurs d’une révision de traitement restent disponibles à la demande.

Suite de #13806 et #13807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)