### PR TITLE
Tech: optimiser les tests de champ_column_spec

### DIFF
--- a/spec/models/columns/champ_column_spec.rb
+++ b/spec/models/columns/champ_column_spec.rb
@@ -2,7 +2,7 @@
 
 describe Columns::ChampColumn do
   describe '#value' do
-    let(:procedure) { create(:procedure, :with_all_champs_mandatory) }
+    let_it_be(:procedure) { create(:procedure, :with_all_champs_mandatory) }
 
     context 'without any cast' do
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
@@ -176,7 +176,7 @@ describe Columns::ChampColumn do
     subject { column.filtered_ids(dossiers, { operator: 'match', value: search_terms }) }
 
     context "with a text champ" do
-      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :text, mandatory: false, libelle: "text" }]) }
+      let_it_be(:procedure) { create(:procedure, public_type_de_champs: [{ type: :text, mandatory: false, libelle: "text" }]) }
       let(:dossier_with_value) { create(:dossier, :en_instruction, procedure:) }
 
       let(:column) { procedure.find_column(label: "text") }
@@ -205,7 +205,7 @@ describe Columns::ChampColumn do
     end
 
     context "with a multiple_drop_down_list champ" do
-      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :multiple_drop_down_list, mandatory: false, libelle: "multiple_drop_down_list", options: ["Fromage", 'Fromage "blanc"'] }]) }
+      let_it_be(:procedure) { create(:procedure, public_type_de_champs: [{ type: :multiple_drop_down_list, mandatory: false, libelle: "multiple_drop_down_list", options: ["Fromage", 'Fromage "blanc"'] }]) }
       let(:dossier_with_value) { create(:dossier, :en_instruction, procedure:) }
 
       let(:column) { procedure.find_column(label: "multiple_drop_down_list") }
@@ -235,7 +235,7 @@ describe Columns::ChampColumn do
     end
 
     context "with a yes no champ not mandatory" do
-      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :yes_no, mandatory: false, libelle: "oui/non" }]) }
+      let_it_be(:procedure) { create(:procedure, public_type_de_champs: [{ type: :yes_no, mandatory: false, libelle: "oui/non" }]) }
       let(:dossier_with_yes) { create(:dossier, :en_instruction, procedure:) }
       let(:dossier_with_no) { create(:dossier, :en_instruction, procedure:) }
       let(:dossier_not_filled) { create(:dossier, :en_instruction, procedure:) }
@@ -275,7 +275,7 @@ describe Columns::ChampColumn do
     end
 
     context "with a checkbox champ not mandatory" do
-      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :checkbox, mandatory: false, libelle: "checkbox" }]) }
+      let_it_be(:procedure) { create(:procedure, public_type_de_champs: [{ type: :checkbox, mandatory: false, libelle: "checkbox" }]) }
       let(:dossier_with_checked) { create(:dossier, :en_instruction, procedure:) }
       let(:dossier_not_checked) { create(:dossier, :en_instruction, procedure:) }
 
@@ -305,7 +305,7 @@ describe Columns::ChampColumn do
     end
 
     context "with a checkbox champ not mandatory" do
-      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :checkbox, mandatory: false, libelle: "checkbox" }]) }
+      let_it_be(:procedure) { create(:procedure, public_type_de_champs: [{ type: :checkbox, mandatory: false, libelle: "checkbox" }]) }
       let(:dossier_with_checked) { create(:dossier, :en_instruction, procedure:) }
       let(:dossier_not_checked) { create(:dossier, :en_instruction, procedure:) }
 
@@ -335,7 +335,7 @@ describe Columns::ChampColumn do
     end
 
     context "with a drop_down_list champ" do
-      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :drop_down_list, libelle: "drop_down_list", options: ["Fromage", "Dessert", "Chocolat"] }]) }
+      let_it_be(:procedure) { create(:procedure, public_type_de_champs: [{ type: :drop_down_list, libelle: "drop_down_list", options: ["Fromage", "Dessert", "Chocolat"] }]) }
       let(:dossier_with_fromage) { create(:dossier, :en_instruction, procedure:) }
       let(:dossier_with_dessert) { create(:dossier, :en_instruction, procedure:) }
       let(:dossier_with_chocolat) { create(:dossier, :en_instruction, procedure:) }
@@ -367,7 +367,7 @@ describe Columns::ChampColumn do
     end
 
     context "with a pays champ" do
-      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :pays, libelle: "pays" }]) }
+      let_it_be(:procedure) { create(:procedure, public_type_de_champs: [{ type: :pays, libelle: "pays" }]) }
       let(:dossier_fr) { create(:dossier, :en_instruction, procedure:) }
       let(:dossier_de) { create(:dossier, :en_instruction, procedure:) }
 
@@ -389,7 +389,7 @@ describe Columns::ChampColumn do
     end
 
     context "with a date champ" do
-      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :date, libelle: "date" }]) }
+      let_it_be(:procedure) { create(:procedure, public_type_de_champs: [{ type: :date, libelle: "date" }]) }
 
       subject { column.filtered_ids(dossiers, filter) }
 
@@ -516,7 +516,7 @@ describe Columns::ChampColumn do
     end
 
     context "with a datetime champ" do
-      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :datetime, libelle: "datetime" }]) }
+      let_it_be(:procedure) { create(:procedure, public_type_de_champs: [{ type: :datetime, libelle: "datetime" }]) }
 
       subject { column.filtered_ids(dossiers, filter) }
 


### PR DESCRIPTION
# Probleme

Tests lents dans `spec/models/columns/champ_column_spec.rb` — temps baseline : 5.19s (mediane locale, 3 runs).

# Solution

Skill [`/test-optimization`](https://github.com/mfo/night-shift/blob/main/.claude/skills/test-optimization/SKILL.md)

### Techniques appliquees

| Technique | Avant | Apres | Gain |
|-----------|-------|-------|------|
| T08 (let_it_be) | 5.19s | 4.23s | -18.5% |

### Techniques tentees sans succes

| Technique | Raison |
|-----------|--------|
| T13 (create → seeds) | Procedures custom (with_all_champs_mandatory trait, public_type_de_champs specifiques) — pas de figurant generique |
| T04 (setup inutile) | `retrieve_champ` supprime (dead code) mais gain < bruit de mesure (±0.87s) |
| T06 (duplicats) | Bloc checkbox duplique supprime mais gain < bruit de mesure |
| T09 (aggregate_failures) | Setup deja lazy, gain negligeable |

**Resultat final : 5.19s → 4.23s (gain total -18.5%)**

Coverage : 46.24% → 46.24% (maintenue)

Generated with [Claude Code](https://claude.com/claude-code)

---

# Probleme

Tests lents dans `spec/system/administrateurs/procedure_cloning_spec.rb` — temps baseline : 22.4s (médiane 3 runs locales).

# Solution

Skill [`/test-optimization`](https://github.com/mfo/night-shift/blob/main/.claude/skills/test-optimization/SKILL.md)

### Techniques appliquées

| Technique | Avant | Après | Gain |
|-----------|-------|-------|------|
| — | 22.4s | — | pas de gain mesurable |

Aucune technique n'a produit un gain > bruit de mesure (±2.4 % / ±0.53 s).

### Analyse

Ce fichier est une **system spec** dominée par le temps navigateur Playwright (~20s sur 22s). Le
setup applicatif est minimal : 1 `create(:procedure)` dans un `before` partagé par 2 scenarios.
Les techniques suivantes ont été évaluées :

| Technique | Raison du skip |
|-----------|----------------|
| T08 (let_it_be) | Gain < 5 % et < amplitude du bruit (±0.53 s) sur une spec système |
| T10 (let!→let) | Aucun `let!` dans le fichier |
| T13 (create → seed) | Déjà utilise `administrateurs.blank` ; les attributs de la procédure (libellé, path) sont le sujet du test |
| T04 (réduire setup) | Setup déjà minimal : 1 création par scénario |
| T01 (create→build) | Impossible — system spec a besoin des records en base |
| S01 (sleep) | `sleep 0.1` dans une boucle de polling download avec timeout — attente légitime |

**Résultat final : 22.4s → 22.4s (aucun gain mesurable)**

Coverage : 47.29 % → 47.29 % (maintenue)

Generated with [Claude Code](https://claude.com/claude-code)