### PR TITLE
ETQ expert, une réponse d’avis vide est refusée

### DIFF
--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -24,11 +24,18 @@ class Avis < ApplicationRecord
     empty_file: true
 
   validates :question_answer, inclusion: { in: [true, false] }, on: :update, if: -> { question_label.present? }
+  # The expert's answer is the only validated update path (revocation only
+  # touches answered avis, reminders and merges bypass validations).
+  validates :answer, presence: true, on: :update
   validates :piece_justificative_file, size: { less_than: FILE_MAX_SIZE }
   validates :introduction_file, size: { less_than: FILE_MAX_SIZE }
 
   normalizes :question_label, with: -> (value) { value.strip.presence }
-  normalizes :answer, with: NORMALIZES_NON_PRINTABLE_PROC
+  # `.presence` keeps blank collapsed to nil: the with_answer/without_answer
+  # scopes are nil-based while revoke_by!/remind_by! are presence-based — an
+  # empty string would count as answered for the former and unanswered for
+  # the latter.
+  normalizes :answer, with: -> (value) { NORMALIZES_NON_PRINTABLE_PROC.call(value).presence }
 
   default_scope { joins(:dossier) }
   scope :with_answer, -> { where.not(answer: nil) }

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -86,7 +86,7 @@ describe AttachmentsController, type: :controller do
       let(:expert) { create(:expert) }
       let(:procedure) { create(:procedure) }
       let(:experts_procedure) { create(:experts_procedure, procedure:, expert:) }
-      let(:avis) { create(:avis, dossier:, experts_procedure:) }
+      let(:avis) { create(:avis, :with_answer, dossier:, experts_procedure:) }
       let(:attachment) { avis.piece_justificative_file.attachments.first }
       let(:signed_id) { attachment.blob.signed_id }
 
@@ -103,7 +103,7 @@ describe AttachmentsController, type: :controller do
       let(:other_expert) { experts.second }
       let(:procedure) { create(:procedure) }
       let(:experts_procedure) { create(:experts_procedure, procedure:, expert:) }
-      let(:avis) { create(:avis, dossier:, experts_procedure:) }
+      let(:avis) { create(:avis, :with_answer, dossier:, experts_procedure:) }
       let(:attachment) { avis.piece_justificative_file.attachments.first }
       let(:signed_id) { attachment.blob.signed_id }
 
@@ -307,7 +307,7 @@ describe AttachmentsController, type: :controller do
       let(:expert) { create(:expert) }
       let(:procedure) { create(:procedure) }
       let(:experts_procedure) { create(:experts_procedure, procedure:, expert:) }
-      let(:avis) { create(:avis, dossier:, experts_procedure:) }
+      let(:avis) { create(:avis, :with_answer, dossier:, experts_procedure:) }
       let(:attachment) { avis.piece_justificative_file.attachments.first }
       let(:signed_id) { attachment.blob.signed_id }
       let(:view_as) { 'link' }

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -289,6 +289,22 @@ describe Experts::AvisController, type: :controller do
         end
       end
 
+      context 'with a blank answer' do
+        subject do
+          post :update, params: { id: avis.id, procedure_id:, avis: { answer: ' ' } }
+          avis.reload
+        end
+
+        it 'refuses the answer and leaves the dossier untouched' do
+          expect(DossierMailer).not_to receive(:notify_new_avis_to_instructeur)
+          expect(subject).to render_template(:instruction)
+          expect(avis.answer).to be_nil
+          expect(dossier.reload.last_avis_updated_at).to be_nil
+          expect(assigns(:avis).errors.of_kind?(:answer, :blank)).to be(true)
+          expect(flash.alert).to eq(assigns(:avis).errors.full_messages)
+        end
+      end
+
       context 'when an instructeur wants to be notified by email' do
         let!(:ip) { create(:instructeurs_procedure, instructeur: instructeur_with_instant_avis_notification, procedure:, instant_email_new_expert_avis: true) }
 
@@ -626,7 +642,7 @@ describe Experts::AvisController, type: :controller do
       # Sécurité: l’état de révocation d’un avis ne doit pas être observable
       # par un attaquant non authentifié (IDOR / information disclosure).
       context 'when the avis is revoked' do
-        before { avis.update(revoked_at: Time.zone.now) }
+        before { avis.update_column(:revoked_at, Time.zone.now) }
 
         it { is_expected.to have_http_status(:success) }
       end
@@ -775,7 +791,7 @@ describe Experts::AvisController, type: :controller do
         # Sécurité: l’état de révocation d’un avis ne doit pas être observable
         # par un attaquant non authentifié (IDOR / information disclosure).
         context 'when the avis is revoked' do
-          before { avis.update(revoked_at: Time.zone.now) }
+          before { avis.update_column(:revoked_at, Time.zone.now) }
 
           it { is_expected.to redirect_to(expert_all_avis_path) }
         end

--- a/spec/controllers/recherche_controller_spec.rb
+++ b/spec/controllers/recherche_controller_spec.rb
@@ -46,7 +46,7 @@ describe RechercheController, type: :controller do
         let(:user) { avis.experts_procedure.expert.user }
         let(:query) { dossier_with_expert.id }
 
-        before { avis.update!(revoked_at: 1.day.ago) }
+        before { avis.update_column(:revoked_at, 1.day.ago) }
 
         it 'does not return the dossier' do
           is_expected.to have_http_status(200)

--- a/spec/models/avis_spec.rb
+++ b/spec/models/avis_spec.rb
@@ -19,10 +19,7 @@ RSpec.describe Avis, type: :model do
   end
 
   describe "an avis is linked to an experts_procedure" do
-    it do
-      expect(avis.pending.valid?).to be_truthy
-      expect(avis.pending.experts_procedure).to eq(experts_procedures.default)
-    end
+    it { expect(avis.pending.experts_procedure).to eq(experts_procedures.default) }
   end
 
   describe ".revoke_by!" do
@@ -102,6 +99,25 @@ RSpec.describe Avis, type: :model do
       built_avis = build(:avis, answer: "Valid\x17Answer", dossier: dossiers.en_construction, experts_procedure: experts_procedures.default)
       built_avis.validate
       expect(built_avis.answer).to eq("ValidAnswer")
+    end
+
+    it 'collapses a blank answer to nil' do
+      built_avis = build(:avis, answer: " \n ", dossier: dossiers.en_construction, experts_procedure: experts_procedures.default)
+      built_avis.validate
+      expect(built_avis.answer).to be_nil
+    end
+  end
+
+  describe 'answer presence' do
+    let(:unanswered_avis) { avis.pending }
+
+    it 'refuses a blank answer on update' do
+      expect(unanswered_avis.update(answer: ' ')).to be(false)
+      expect(unanswered_avis.errors.of_kind?(:answer, :blank)).to be(true)
+    end
+
+    it 'accepts an answer on update' do
+      expect(unanswered_avis.update(answer: 'Avis favorable')).to be(true)
     end
   end
 end

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -374,7 +374,7 @@ describe PiecesJustificativesService do
 
       context 'with avis.piece_justificative being confidentiel' do
         let(:procedure) { create(:procedure) }
-        let(:avis) { create(:avis, dossier: dossier, confidentiel: true) }
+        let(:avis) { create(:avis, :with_answer, dossier: dossier, confidentiel: true) }
 
         before do
           to_be_attached = {
@@ -417,7 +417,7 @@ describe PiecesJustificativesService do
 
         context 'when the expert has given the avis' do
           let(:experts_procedure) { create(:experts_procedure, expert: user_profile, procedure:) }
-          let(:avis) { create(:avis, experts_procedure:, dossier: dossier, confidentiel: true) }
+          let(:avis) { create(:avis, :with_answer, experts_procedure:, dossier: dossier, confidentiel: true) }
           let(:user_profile) { create(:expert) }
           it "return confidentiel avis.piece_justificative_file" do
             expect(subject.size).to eq(2)
@@ -428,7 +428,7 @@ describe PiecesJustificativesService do
       context 'with avis.piece_justificative being public' do
         let(:procedure) { create(:procedure) }
         let(:dossier) { create(:dossier, procedure: procedure) }
-        let(:avis) { create(:avis, dossier: dossier, confidentiel: false) }
+        let(:avis) { create(:avis, :with_answer, dossier: dossier, confidentiel: false) }
         before do
           to_be_attached = {
             io: StringIO.new("toto"),

--- a/spec/validators/empty_file_validator_spec.rb
+++ b/spec/validators/empty_file_validator_spec.rb
@@ -93,23 +93,23 @@ describe EmptyFileValidator do
   end
 
   describe "on a has_one_attached association" do
-    let(:avis) { create(:avis) }
+    let(:record) { avis.answered }
 
     it "rejects an empty file" do
-      avis.introduction_file = empty_blob
+      record.introduction_file = empty_blob
 
-      expect(avis).not_to be_valid
-      expect(avis.errors[:introduction_file].join).to include('vide')
+      expect(record).not_to be_valid
+      expect(record.errors[:introduction_file].join).to include('vide')
     end
 
     it "accepts a file with content" do
-      avis.introduction_file = { io: StringIO.new('x'), filename: 'intro.pdf', content_type: 'application/pdf' }
+      record.introduction_file = { io: StringIO.new('x'), filename: 'intro.pdf', content_type: 'application/pdf' }
 
-      expect(avis).to be_valid
+      expect(record).to be_valid
     end
 
     it "accepts a record without any attachment" do
-      expect(avis).to be_valid
+      expect(record).to be_valid
     end
 
     # #attach on a persisted record saves it right away: the validation still


### PR DESCRIPTION
## Contexte

Le formulaire de réponse marque le champ comme obligatoire, mais une requête forgée avec une réponse vide passait : l’avis était enregistré avec une chaîne vide, comptée comme « répondu » par le scope `with_answer` mais comme « sans réponse » par `revoke_by!`, `remind_by!` et le badge de l’onglet expert. Les notifications et emails aux instructeurs partaient quand même.

Extrait de #13556 (webhooks), où cette validation est nécessaire pour ne pas consommer l’émission `avis_repondu` sur une réponse vide.

## Changements

- `answer` blanc normalisé en `nil`, cohérent avec les scopes.
- Validation de présence de `answer` en mise à jour : la réponse de l’expert est le seul chemin de mise à jour validé (la révocation ne touche que les avis répondus, relances et fusions d’experts passent par `update_column` / `update_all`).
- Specs : les avis sans réponse auxquels on attachait un fichier ou qu’on révoquait via `update` deviennent des avis répondus (ou passent par `update_column`), ce qui correspond à ce que le code permet réellement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)