### PR TITLE
Tech: corriger le plantage DSFR HeaderLinks quand Turbo affiche une page d'erreur statique

### DIFF
--- a/public/400.html
+++ b/public/400.html
@@ -2086,6 +2086,13 @@
           </div>
         </div>
       </div>
+      <!--
+        DSFR's HeaderLinks copies .fr-header__tools-links into this element for
+        the mobile menu, and throws when it is missing. It matters even without
+        the burger button: Turbo renders this page in place after a failed
+        request, while the DSFR script of the previous page is still running.
+      -->
+      <div class="fr-header__menu-links" hidden></div>
     </header>
 
     <main id="content" role="main">

--- a/public/403.html
+++ b/public/403.html
@@ -2110,6 +2110,13 @@
           </div>
         </div>
       </div>
+      <!--
+        DSFR's HeaderLinks copies .fr-header__tools-links into this element for
+        the mobile menu, and throws when it is missing. It matters even without
+        the burger button: Turbo renders this page in place after a failed
+        request, while the DSFR script of the previous page is still running.
+      -->
+      <div class="fr-header__menu-links" hidden></div>
     </header>
 
     <main id="content" role="main">

--- a/public/404.html
+++ b/public/404.html
@@ -2091,6 +2091,13 @@
           </div>
         </div>
       </div>
+      <!--
+        DSFR's HeaderLinks copies .fr-header__tools-links into this element for
+        the mobile menu, and throws when it is missing. It matters even without
+        the burger button: Turbo renders this page in place after a failed
+        request, while the DSFR script of the previous page is still running.
+      -->
+      <div class="fr-header__menu-links" hidden></div>
     </header>
 
     <main id="content" role="main">

--- a/public/406-unsupported-browser.html
+++ b/public/406-unsupported-browser.html
@@ -2086,6 +2086,13 @@
           </div>
         </div>
       </div>
+      <!--
+        DSFR's HeaderLinks copies .fr-header__tools-links into this element for
+        the mobile menu, and throws when it is missing. It matters even without
+        the burger button: Turbo renders this page in place after a failed
+        request, while the DSFR script of the previous page is still running.
+      -->
+      <div class="fr-header__menu-links" hidden></div>
     </header>
 
     <main id="content" role="main">

--- a/public/422.html
+++ b/public/422.html
@@ -2086,6 +2086,13 @@
           </div>
         </div>
       </div>
+      <!--
+        DSFR's HeaderLinks copies .fr-header__tools-links into this element for
+        the mobile menu, and throws when it is missing. It matters even without
+        the burger button: Turbo renders this page in place after a failed
+        request, while the DSFR script of the previous page is still running.
+      -->
+      <div class="fr-header__menu-links" hidden></div>
     </header>
 
     <main id="content" role="main">

--- a/public/500.html
+++ b/public/500.html
@@ -2086,6 +2086,13 @@
           </div>
         </div>
       </div>
+      <!--
+        DSFR's HeaderLinks copies .fr-header__tools-links into this element for
+        the mobile menu, and throws when it is missing. It matters even without
+        the burger button: Turbo renders this page in place after a failed
+        request, while the DSFR script of the previous page is still running.
+      -->
+      <div class="fr-header__menu-links" hidden></div>
     </header>
 
     <main id="content" role="main">

--- a/public/502.html
+++ b/public/502.html
@@ -2086,6 +2086,13 @@
           </div>
         </div>
       </div>
+      <!--
+        DSFR's HeaderLinks copies .fr-header__tools-links into this element for
+        the mobile menu, and throws when it is missing. It matters even without
+        the burger button: Turbo renders this page in place after a failed
+        request, while the DSFR script of the previous page is still running.
+      -->
+      <div class="fr-header__menu-links" hidden></div>
     </header>
 
     <main id="content" role="main">

--- a/public/503.html
+++ b/public/503.html
@@ -2088,6 +2088,13 @@
           </div>
         </div>
       </div>
+      <!--
+        DSFR's HeaderLinks copies .fr-header__tools-links into this element for
+        the mobile menu, and throws when it is missing. It matters even without
+        the burger button: Turbo renders this page in place after a failed
+        request, while the DSFR script of the previous page is still running.
+      -->
+      <div class="fr-header__menu-links" hidden></div>
     </header>
 
     <main id="content" role="main">

--- a/public/504.html
+++ b/public/504.html
@@ -2094,6 +2094,13 @@
           </div>
         </div>
       </div>
+      <!--
+        DSFR's HeaderLinks copies .fr-header__tools-links into this element for
+        the mobile menu, and throws when it is missing. It matters even without
+        the burger button: Turbo renders this page in place after a failed
+        request, while the DSFR script of the previous page is still running.
+      -->
+      <div class="fr-header__menu-links" hidden></div>
     </header>
 
     <main id="content" role="main">

--- a/spec/public/static_error_pages_spec.rb
+++ b/spec/public/static_error_pages_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'nokogiri'
+
+# The static pages in public/ are served by the reverse proxy or as a last
+# resort by ErrorsController. When Turbo receives one of them as the response
+# to a visit or a form submission, it swaps it into the current document, where
+# the DSFR script of the previous page is still running and initialises the
+# header components it finds. This checks the markup they rely on.
+RSpec.describe 'static error pages' do
+  pages = Dir[File.expand_path('../../public/*.html', __dir__)]
+
+  pages.each do |path|
+    describe File.basename(path) do
+      subject(:header) { Nokogiri::HTML(File.read(path)).at_css('header.fr-header') }
+
+      it 'gives DSFR HeaderLinks the menu container it copies the tools links into' do
+        skip 'no DSFR header' if header.nil?
+
+        if header.at_css('.fr-header__tools-links')
+          expect(header.at_css('.fr-header__menu-links')).to be_present
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Sept issues Sentry (`JAVASCRIPT-DRR`, `DRN`, `EDT`, `EFZ`, `EP1`, `F12`, `EY6`), ≈15 000 événements et plus de 5 000 usagers sur 90 jours, avec la même erreur : `Cannot read properties of null (reading 'innerHTML')` dans `HeaderLinks.init` du DSFR, déclenchée par le `MutationObserver` du DSFR.

## Cause

Les pages statiques de `public/` (400, 403, 404, 406, 422, 500, 502, 503, 504) contiennent un `.fr-header__tools-links` mais pas de `.fr-header__menu-links`. Servies seules par le reverse proxy, elles ne chargent aucun script et ça ne pose pas de problème. Mais quand Turbo reçoit une de ces pages en réponse à une visite ou à une soumission de formulaire, il remplace le `body` de la page courante : l'observer du DSFR voit arriver le nouveau header, instancie `HeaderLinks` sur `.fr-header__tools-links` (le DSFR ne saute pas les nœuds déjà marqués `data-fr-js-header-links`) et lit le conteneur absent.

## Correction

- Ajout d'un `<div class="fr-header__menu-links" hidden>` dans le header des neuf pages, avec un commentaire expliquant pourquoi il est là sans bouton menu.
- Spec `spec/public/static_error_pages_spec.rb` qui vérifie le contrat de markup (tout `.fr-header__tools-links` a son `.fr-header__menu-links`).

Vérifié dans un navigateur (vitest, Chromium) en injectant le header de `public/500.html` dans un document où tournent nos modules DSFR : l'ancien markup lève exactement l'erreur remontée par Sentry via `Stage.mutate`, le nouveau s'initialise et remplit le conteneur avec le lien d'aide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)