### PR TITLE
Tech: ne plus signaler `html_safe?` comme un contournement d'échappement

### DIFF
--- a/lib/linters/output_safety_linter.rb
+++ b/lib/linters/output_safety_linter.rb
@@ -12,7 +12,7 @@ if defined?(HamlLint)
       include LinterRegistry
 
       RAW = /\braw[\s(]/
-      HTML_SAFE = /\.html_safe\b/
+      HTML_SAFE = /\.html_safe\b(?!\?)/ # `html_safe?` asks the question, it does not bypass escaping
 
       RAW_MSG = 'Avoid `raw`: it bypasses HTML escaping. Suffix the translation key with `_html`, ' \
                 'or build the markup with `tag`/`safe_join`.'

--- a/spec/lib/linters/output_safety_linter_spec.rb
+++ b/spec/lib/linters/output_safety_linter_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'haml_lint'
+require 'haml_lint/spec'
+require_relative '../../../lib/linters/output_safety_linter'
+
+RSpec.describe HamlLint::Linter::OutputSafetyLinter do
+  include_context 'linter'
+
+  context 'when the markup is tagged safe by hand' do
+    let(:haml) { '= body.html_safe' }
+
+    it { is_expected.to report_lint line: 1 }
+  end
+
+  context 'when `raw` bypasses the escaping' do
+    let(:haml) { '= raw(body)' }
+
+    it { is_expected.to report_lint line: 1 }
+  end
+
+  context 'when `html_safe?` only asks whether the string is already safe' do
+    let(:haml) do
+      <<~HAML
+        - if body.html_safe?
+          %p= body
+      HAML
+    end
+
+    it { is_expected.not_to report_lint }
+  end
+
+  context 'when nothing bypasses the escaping' do
+    let(:haml) { '%p= t(".body_html")' }
+
+    it { is_expected.not_to report_lint }
+  end
+end


### PR DESCRIPTION
# Problème

`OutputSafetyLinter` (haml-lint maison) interdit `raw` et `.html_safe` dans les vues HAML. Il travaille sur le texte des lignes, et sa regex `/\.html_safe\b/` matche aussi `html_safe?` : `\b` est une frontière de mot, et elle tombe entre le `e` et le `?`.

Résultat : un simple prédicat se fait refuser avec un message qui ne s'applique pas à lui.

```haml
- if body.html_safe?    →  [W] Avoid `.html_safe`: it bypasses HTML escaping.
```

Or `html_safe?` ne contourne rien : il *pose la question*. C'est même la moitié de l'idiome standard pour ne pas doubler l'échappement (`value.html_safe? ? value : h(value)`, cf. `ColumnValueFormatter#format_text`), donc le linter bloquait le code correct.

# Solution

Un lookahead négatif sur le `?` :

```ruby
HTML_SAFE = /\.html_safe\b(?!\?)/
```

`.html_safe` reste signalé, `html_safe?` passe. Un spec couvre les quatre cas (`.html_safe`, `raw`, `html_safe?`, ligne sans bypass) — il échoue bien sur la regex d'avant.

`bundle exec haml-lint app/views app/components` : 546 fichiers, 0 lint, donc aucune vue existante ne dépendait du faux positif.

Le cop RuboCop `DS/I18nOutputSafety` n'était pas concerné : il matche sur l'AST, où `:html_safe?` est un autre nom de méthode.

**Pas dans cette PR** : la constante voisine `RAW = /\braw[\s(]/` a le même défaut et signale le mot « raw » en contenu texte (`%p Le fichier raw (brut) est disponible`). Aucun fichier du repo ne tombe dedans aujourd'hui, et le corriger proprement demande de lire le script du nœud plutôt que la ligne source.

Generated with [Claude Code](https://claude.com/claude-code)