### PR TITLE
Tech: répondre 400 ou 422 aux entrées malformées qui provoquaient des 500

### DIFF
--- a/app/controllers/carte_controller.rb
+++ b/app/controllers/carte_controller.rb
@@ -2,7 +2,7 @@
 
 class CarteController < ApplicationController
   def show
-    @map_filter = MapFilter.new(params.fetch(:map_filter, {}).permit(:kind, :year))
+    @map_filter = MapFilter.new(map_filter_params)
     @map_filter.validate
 
     # Reset to default params in case of invalid params injection
@@ -14,6 +14,14 @@ class CarteController < ApplicationController
   end
 
   private
+
+  def map_filter_params
+    return {} if !params.key?(:map_filter)
+
+    # A scalar where a hash is expected (`?map_filter=x`) is a bad request,
+    # not a NoMethodError on String.
+    params.expect(map_filter: [:kind, :year])
+  end
 
   def stats
     departements_sql = "select departement, count(procedures.id) as nb_demarches, sum(procedures.estimated_dossiers_count) as nb_dossiers from services inner join procedures on services.id = procedures.service_id where procedures.hidden_at is null and procedures.aasm_state in ('publiee', 'close', 'depubliee')"

--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -79,7 +79,9 @@ class ContactController < ApplicationController
     keys << :email if !user_signed_in? # Email autorisé UNIQUEMENT si non connecté
 
     if params.key?(:contact_form) # submitting form
-      params.require(:contact_form).permit(*keys)
+      # expect rather than require: a scalar (`?contact_form=x`) is a bad
+      # request, not a NoMethodError on String
+      params.expect(contact_form: keys)
     else
       params.permit(:dossier_id, :origin, :error_id) # prefilling form
     end

--- a/app/middleware/reject_null_byte_params.rb
+++ b/app/middleware/reject_null_byte_params.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# PostgreSQL refuses strings containing a null byte, and so does bcrypt, so a
+# request carrying one in a parameter can only end in a 500 once the value
+# reaches them. Nothing legitimate sends null bytes: answer 400 up front, the
+# way Rails already does for parameters with an invalid encoding.
+class RejectNullByteParams
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    request = ActionDispatch::Request.new(env)
+
+    if null_byte?(request.query_parameters) || null_byte?(request.request_parameters)
+      raise ActionController::BadRequest, "Invalid request parameters: null byte"
+    end
+
+    @app.call(env)
+  end
+
+  private
+
+  def null_byte?(value)
+    case value
+    when String then value.include?("\0")
+    when Array then value.any? { null_byte?(it) }
+    when Hash then value.any? { |key, item| null_byte?(key) || null_byte?(item) }
+    else false
+    end
+  end
+end

--- a/app/services/attachment/piece_justificative_service.rb
+++ b/app/services/attachment/piece_justificative_service.rb
@@ -18,16 +18,32 @@ class Attachment::PieceJustificativeService
       # be computed on the stream being edited
       champ.association(:dossier).target = dossier
       champ.updated_by = updated_by
-      # Assign rather than #attach: attach saves immediately unless the record
-      # happens to be dirty, which would commit the attachment without running
-      # the :champ_value validations (size, content type, empty file).
-      champ.piece_justificative_file = champ.piece_justificative_file.blobs + [blob_signed_id]
 
-      # fetch_later should be called inside the transaction to avoid
-      # race condition with processor_job
-      champ.fetch_later if champ.has_async_external_data? && champ.may_fetch_later?
+      if assign_attachment(champ, blob_signed_id)
+        # fetch_later should be called inside the transaction to avoid
+        # race condition with processor_job
+        champ.fetch_later if champ.has_async_external_data? && champ.may_fetch_later?
 
-      champ.save(context: :champ_value)
+        champ.save(context: :champ_value)
+      else
+        false
+      end
     end
+  end
+
+  # Assign rather than #attach: attach saves immediately unless the record
+  # happens to be dirty, which would commit the attachment without running
+  # the :champ_value validations (size, content type, empty file).
+  #
+  # Returns false when the signed id sent by the direct upload is no longer
+  # valid: BlobSignedIdConcern gives it a one hour lifetime, so the form stayed
+  # open too long (or the id was tampered with) and the file has to be
+  # selected again.
+  def self.assign_attachment(champ, attachable)
+    champ.piece_justificative_file = champ.piece_justificative_file.blobs + [attachable]
+    true
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    champ.errors.add(:piece_justificative_file, :attachment_expired)
+    false
   end
 end

--- a/app/services/commentaire_service.rb
+++ b/app/services/commentaire_service.rb
@@ -52,5 +52,15 @@ class CommentaireService
       message.save
       message
     end
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    # Assigning piece_jointe verifies the signed ids sent by the direct upload,
+    # which BlobSignedIdConcern makes valid for one hour: the form stayed open
+    # too long, or an id was tampered with. Either way the file has to be
+    # selected again; the message is kept so the user does not lose it.
+    message = dossier.commentaires.build(params.except(:piece_jointe))
+    message.errors.add(:piece_jointe, :attachment_expired)
+    raise ActiveRecord::RecordInvalid, message if raise_exception
+
+    message
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,6 +5,7 @@ require_relative "boot"
 require "rails/all"
 require_relative "../app/middleware/cookie_overflow_handler"
 require_relative "../app/middleware/direct_upload_406_logger"
+require_relative "../app/middleware/reject_null_byte_params"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -83,6 +84,7 @@ module TPS
     config.middleware.use Rack::Attack
     config.middleware.insert_before ActionDispatch::Cookies, CookieOverflowHandler
     config.middleware.insert_before Rack::Head, DirectUpload406Logger
+    config.middleware.use RejectNullByteParams
 
     config.ds_env = ENV.fetch('DS_ENV', Rails.env)
 

--- a/config/locales/models/champs/champs.en.yml
+++ b/config/locales/models/champs/champs.en.yml
@@ -4,6 +4,8 @@ en:
       models:
         champ:
           attributes:
+            piece_justificative_file:
+              attachment_expired: "is no longer valid, the file was selected too long ago: please pick it again"
             value:
               format: '%{message}'
               missing: must be filled

--- a/config/locales/models/champs/champs.fr.yml
+++ b/config/locales/models/champs/champs.fr.yml
@@ -4,6 +4,8 @@ fr:
       models:
         champ:
           attributes:
+            piece_justificative_file:
+              attachment_expired: "n’est plus valide, le fichier a été sélectionné il y a trop longtemps : veuillez le choisir à nouveau"
             value:
               format: '%{message}'
               missing: doit être rempli

--- a/config/locales/models/commentaire/en.yml
+++ b/config/locales/models/commentaire/en.yml
@@ -4,3 +4,9 @@ en:
       commentaire:
         body: 'Your message'
         piece_jointe: "Attachment"
+    errors:
+      models:
+        commentaire:
+          attributes:
+            piece_jointe:
+              attachment_expired: "is no longer valid, the file was selected too long ago: please pick it again"

--- a/config/locales/models/commentaire/fr.yml
+++ b/config/locales/models/commentaire/fr.yml
@@ -4,3 +4,9 @@ fr:
       commentaire:
         body: 'Votre message'
         piece_jointe: "Pièce jointe"
+    errors:
+      models:
+        commentaire:
+          attributes:
+            piece_jointe:
+              attachment_expired: "n’est plus valide, le fichier a été sélectionné il y a trop longtemps : veuillez le choisir à nouveau"

--- a/spec/controllers/carte_controller_spec.rb
+++ b/spec/controllers/carte_controller_spec.rb
@@ -28,5 +28,9 @@ describe CarteController do
       get :show, params: { map_filter: { kind: "nimp" } }
       expect(subject.stats['75']).to eq({ nb_demarches: 2, nb_dossiers: 50 })
     end
+
+    it 'rejects a scalar map_filter as a bad request' do
+      expect { get :show, params: { map_filter: 'nimp' } }.to raise_error(ActionController::ParameterMissing)
+    end
   end
 end

--- a/spec/controllers/contact_controller_spec.rb
+++ b/spec/controllers/contact_controller_spec.rb
@@ -274,4 +274,10 @@ describe ContactController, question_type: :controller do
       end
     end
   end
+
+  context 'with a scalar contact_form' do
+    it 'rejects the request as a bad request' do
+      expect { get :index, params: { contact_form: 'nimp' } }.to raise_error(ActionController::ParameterMissing)
+    end
+  end
 end

--- a/spec/requests/reject_null_byte_params_spec.rb
+++ b/spec/requests/reject_null_byte_params_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe RejectNullByteParams, type: :request do
+  it 'rejects a form value containing a null byte' do
+    post '/users/sign_in', params: { user: { email: 'usager@example.com', password: "x\0y" } }
+
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it 'rejects a JSON body containing a null byte' do
+    blob = { filename: "x\0.pdf", byte_size: 1, checksum: 'a', content_type: 'text/plain' }
+    post '/rails/active_storage/direct_uploads', params: { blob: }.to_json, headers: { 'CONTENT_TYPE' => 'application/json' }
+
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it 'rejects a query parameter containing a null byte' do
+    get '/contact', params: { origin: "x\0y" }
+
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it 'lets other requests through' do
+    get '/contact', params: { origin: 'autosave' }
+
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/services/attachment/piece_justificative_service_spec.rb
+++ b/spec/services/attachment/piece_justificative_service_spec.rb
@@ -77,5 +77,15 @@ RSpec.describe Attachment::PieceJustificativeService do
         expect(pj_champ.errors[:piece_justificative_file]).to be_present
       end
     end
+
+    context 'with an expired signed id' do
+      let(:expired_signed_id) { ActiveStorage.verifier.generate(blob_1.id, purpose: :blob_id, expires_at: 1.minute.ago) }
+
+      it 'refuses the attachment and reports it on the champ' do
+        expect(described_class.attach_champ_pj(champ, expired_signed_id)).to be(false)
+        expect(champ.errors[:piece_justificative_file]).to be_present
+        expect(champ.reload.piece_justificative_file).not_to be_attached
+      end
+    end
   end
 end

--- a/spec/services/commentaire_service_spec.rb
+++ b/spec/services/commentaire_service_spec.rb
@@ -45,4 +45,24 @@ describe CommentaireService do
       end
     end
   end
+
+  describe 'with an expired attachment signed id' do
+    let(:dossier) { create(:dossier, :en_construction) }
+    let(:blob) { ActiveStorage::Blob.create_and_upload!(io: StringIO.new('file'), filename: 'file.pdf', content_type: 'application/pdf') }
+    let(:expired_signed_id) { ActiveStorage.verifier.generate(blob.id, purpose: :blob_id, expires_at: 1.minute.ago) }
+    let(:params) { { body: 'Contenu du message.', piece_jointe: [expired_signed_id] } }
+
+    it 'keeps the message unsaved with an error on the attachment' do
+      commentaire = CommentaireService.create(dossier.user, dossier, params)
+
+      expect(commentaire).not_to be_persisted
+      expect(commentaire.body).to eq('Contenu du message.')
+      expect(commentaire.piece_jointe).not_to be_attached
+      expect(commentaire.errors[:piece_jointe]).to be_present
+    end
+
+    it 'raises with the bang version' do
+      expect { CommentaireService.create!(dossier.user, dossier, params) }.to raise_error(ActiveRecord::RecordInvalid, /plus valide/)
+    end
+  end
 end


### PR DESCRIPTION
## Contexte

Six issues Sentry où une entrée malformée finit en 500 alors que c'est une erreur du client. Un commit par correction, chacun avec son `Fixes RAILS-XXX`.

## Corrections

1. **`/carte` avec `?map_filter=x`** (`RAILS-K64`) : `params.expect` au lieu de `fetch(...).permit`, un scalaire là où un hash est attendu devient un 400.
2. **`/contact` avec `?contact_form=x`** (`RAILS-K55`) : même chose avec `params.expect`.
3. **Octet nul dans un paramètre** (`RAILS-KT0` mot de passe à la connexion, `RAILS-MAD` nom de fichier d'un direct upload) : PostgreSQL et bcrypt refusent les chaînes contenant `\0`, donc ça ne pouvait que finir en 500. Un middleware `RejectNullByteParams` parcourt les paramètres de requête et de corps déjà parsés par Rails et lève `ActionController::BadRequest`, comme Rails le fait pour un encodage invalide : page 400, ignoré par Sentry.
4. **Pièce jointe d'un message dont le signed id a expiré** (`RAILS-GBD`, 44 usagers) : les signed ids des direct uploads sont valables une heure (`BlobSignedIdConcern`). Le message est reconstruit sans la pièce jointe avec une erreur « n’est plus valide, le fichier a été sélectionné il y a trop longtemps », le rendu 422 existant l'affiche et le texte saisi n'est pas perdu.
5. **Pièce justificative dont le signed id a expiré** (`RAILS-KKB`) : même erreur posée sur `piece_justificative_file`, le contrôleur répond 422 avec le message.

## Déjà corrigés, résolus dans Sentry sans code ici

- `RAILS-K6P` (clé de paramètre en UTF-8 invalide) : corrigé par le passage à Rails 8.1, qui valide l'encodage des clés. Vérifié par une request spec en URL-encoded et en multipart.
- `RAILS-MF6` (guillemet dans un filtre jsonpath) : corrigé le 20 août par `to_json` dans le littéral jsonpath.

Specs : contrôleur pour 1 et 2, request spec pour 3 (formulaire, JSON, query string, et un cas qui passe), specs de service pour 4 et 5 avec un signed id expiré généré via `ActiveStorage.verifier`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)