### PR TITLE
Correctif: ETQ usager, le champ référentiel d'une répétition interroge l'API avec les valeurs de sa ligne

### DIFF
--- a/app/components/editable_champ/referentiel_component.rb
+++ b/app/components/editable_champ/referentiel_component.rb
@@ -17,7 +17,7 @@ class EditableChamp::ReferentielComponent < EditableChamp::EditableChampBaseComp
       selected_key: @champ.selected_key,
       items: @champ.selected_items,
       limit: ReferentielAutocompleteRenderService::MAX_RENDERED_OBJECTS,
-      loader: data_sources_data_source_referentiel_path(referentiel_id: referentiel.id, dossier_id: @champ.dossier_id),
+      loader: data_sources_data_source_referentiel_path(referentiel_id: referentiel.id, dossier_id: @champ.dossier_id, row_id: @champ.row_id),
       minimum_input_length: DataSources::ReferentielController::MIN_QUERY_LENGTH,
       use_post: true,
       is_disabled: false,

--- a/app/controllers/data_sources/referentiel_controller.rb
+++ b/app/controllers/data_sources/referentiel_controller.rb
@@ -10,7 +10,7 @@ class DataSources::ReferentielController < DataSources::BaseController
       return render json: [] if !referentiel&.autocomplete_ready?
 
       begin
-        result = referentiel_service.call(query, dossier: @dossier)
+        result = referentiel_service.call(query, dossier: dossier_on_edit_stream, row_id: params[:row_id].presence)
 
         case result
         in Dry::Monads::Success
@@ -72,7 +72,17 @@ class DataSources::ReferentielController < DataSources::BaseController
     candidate = Referentiel.find_by(id: params[:referentiel_id])
     return nil if candidate.nil?
 
-    candidate if @dossier.procedure.active_revision.type_de_champs.any? { it.referentiel_id == candidate.id }
+    @type_de_champ = @dossier.procedure.active_revision.type_de_champs.find { it.referentiel_id == candidate.id }
+    candidate if @type_de_champ.present?
+  end
+
+  # L'usager remplit le formulaire sur un stream de brouillon : les tags de l'URL doivent
+  # être résolus sur les valeurs qu'il vient de saisir, pas sur celles du stream principal.
+  def dossier_on_edit_stream
+    return nil if @dossier.nil?
+
+    @dossier.with_update_stream(current_user) if @type_de_champ&.public?
+    @dossier
   end
 
   def set_dossier

--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -11,7 +11,11 @@ class Champs::ReferentielChamp < ChampData
   before_save :clear_previous_result, if: -> { external_id_changed? }
 
   def fetch_external_data
-    ReferentielService.new(referentiel:).call(external_id, dossier:).fmap do |data|
+    # Les tags de l'URL sont résolus sur le stream du champ : sur un buffer, la ligne
+    # de répétition en cours de saisie n'existe pas encore sur le stream principal.
+    dossier.with_champ_stream(self) do
+      ReferentielService.new(referentiel:).call(external_id, dossier:, row_id:)
+    end.fmap do |data|
       {
         data:, # keep raw API response
         value: external_id, # now that we have the data, we can set the value

--- a/app/models/concerns/champ_conditional_concern.rb
+++ b/app/models/concerns/champ_conditional_concern.rb
@@ -39,15 +39,7 @@ module ChampConditionalConcern
   private
 
   def champs_for_condition
-    if row_id.nil?
-      Array(filled_champs_by_row_id[nil])
-    else
-      Array(filled_champs_by_row_id[row_id]) + Array(filled_champs_by_row_id[nil])
-    end
-  end
-
-  def filled_champs_by_row_id
-    @filled_champs_by_row_id ||= dossier.filled_champs.group_by(&:row_id)
+    dossier.filled_champs_for_row(row_id)
   end
 
   def parent_hidden?

--- a/app/models/concerns/dossier_champs_concern.rb
+++ b/app/models/concerns/dossier_champs_concern.rb
@@ -72,6 +72,15 @@ module DossierChampsConcern
     filled_champs_public + filled_champs_private
   end
 
+  # Les champs qu'un champ situé sur `row_id` peut référencer : ceux de sa propre
+  # ligne de répétition, plus ceux qui sont hors répétition. Un champ hors
+  # répétition (row_id nil) ne voit que ces derniers.
+  def filled_champs_for_row(row_id)
+    return Array(filled_champs_by_row_id[nil]) if row_id.nil?
+
+    Array(filled_champs_by_row_id[row_id]) + Array(filled_champs_by_row_id[nil])
+  end
+
   def flat_champs_public
     @flat_champs_public ||= revision.public_root_type_de_champs.flat_map do |type_de_champ|
       champ = project_champ(type_de_champ)
@@ -494,11 +503,16 @@ module DossierChampsConcern
     end
   end
 
+  def filled_champs_by_row_id
+    @filled_champs_by_row_id ||= filled_champs.group_by(&:row_id)
+  end
+
   def reset_champs_cache
     @champ_data_by_public_id = nil
     @discarded_champ_data_by_public_id = nil
     @filled_champs_public = nil
     @filled_champs_private = nil
+    @filled_champs_by_row_id = nil
     @root_champs_public = nil
     @root_champs_private = nil
     @flat_champs_public = nil

--- a/app/services/referentiel_service.rb
+++ b/app/services/referentiel_service.rb
@@ -18,8 +18,8 @@ class ReferentielService
     @timeout = timeout
   end
 
-  def call(query_params, dossier: nil)
-    resolved_url = url(query_params, dossier:)
+  def call(query_params, dossier: nil, row_id: nil)
+    resolved_url = url(query_params, dossier:, row_id:)
     return Failure(retryable: false, error: StandardError.new("URL could not be resolved"), code: nil) if resolved_url.nil?
 
     result = API::Client.new.call(
@@ -31,8 +31,8 @@ class ReferentielService
     handle_api_result(result)
   end
 
-  def url(query_params, dossier: nil)
-    resolve_tiptap_url(query_params, dossier || referentiel.test_data_tiptap)
+  def url(query_params, dossier: nil, row_id: nil)
+    resolve_tiptap_url(query_params, dossier || referentiel.test_data_tiptap, row_id)
   end
 
   def test_url
@@ -84,8 +84,8 @@ class ReferentielService
     end
   end
 
-  def resolve_tiptap_url(query_params, values_source)
-    substitutions = build_substitutions(query_params, values_source)
+  def resolve_tiptap_url(query_params, values_source, row_id = nil)
+    substitutions = build_substitutions(query_params, values_source, row_id)
     return nil if substitutions.nil?
 
     return nil if referentiel.url_tiptap.blank?
@@ -96,19 +96,19 @@ class ReferentielService
     )
   end
 
-  def build_substitutions(query_params, values_source)
+  def build_substitutions(query_params, values_source, row_id = nil)
     referentiel.tiptap_mention_ids.each_with_object({}) do |id, hash|
       value = if id == "{query}"
         query_params.presence&.to_s
       else
-        extract_value(values_source, id)
+        extract_value(values_source, id, row_id)
       end
       return nil if value.blank?
       hash[id] = URI.encode_www_form_component(value)
     end
   end
 
-  def extract_value(values_source, tag_id)
+  def extract_value(values_source, tag_id, row_id = nil)
     case values_source
     when NilClass
       nil
@@ -116,8 +116,20 @@ class ReferentielService
       values_source[tag_id]
     else
       stable_id = tag_id.delete_prefix("tdc").to_i
-      champ = values_source.filled_champs.find { _1.stable_id == stable_id }
-      champ&.value
+      champ_for_tag(values_source, stable_id, row_id)&.value
     end
+  end
+
+  # Le tag est résolu sur les champs que le champ référentiel appelant peut référencer :
+  # ceux de sa propre ligne de répétition, et ceux hors répétition. Jamais ceux d'une
+  # autre ligne : mieux vaut ne pas résoudre l'URL que d'appeler l'API avec la donnée
+  # d'une ligne voisine.
+  # Sans contexte de ligne (référentiel hors répétition), un tag visant une répétition
+  # n'a pas de ligne de référence : on garde alors le premier champ trouvé.
+  def champ_for_tag(dossier, stable_id, row_id)
+    champ = dossier.filled_champs_for_row(row_id).find { it.stable_id == stable_id }
+    return champ if champ.present? || row_id.present?
+
+    dossier.filled_champs.find { it.stable_id == stable_id }
   end
 end

--- a/spec/components/editable_champ/referentiel_component_spec.rb
+++ b/spec/components/editable_champ/referentiel_component_spec.rb
@@ -33,8 +33,24 @@ describe EditableChamp::ReferentielComponent, type: :component do
       expect(subject).to have_selector('react-fragment')
     end
 
-    it 'includes dossier_id in loader URL' do
+    it 'includes dossier_id but no row_id in loader URL' do
       expect(subject.to_html).to include("dossier_id=#{dossier.id}")
+      expect(subject.to_html).not_to include("row_id")
+    end
+
+    context 'when the champ is inside a repetition' do
+      let(:public_type_de_champs) do
+        [{ type: :repetition, stable_id: 100, children: [{ type: :referentiel, stable_id: 101, referentiel:, referentiel_mapping: {} }] }]
+      end
+      let(:dossier) { create(:dossier, procedure:) }
+      let(:row_id) { dossier.repetition_add_row(dossier.find_type_de_champ_by_stable_id(100), updated_by: 'test') }
+      let(:champ) do
+        dossier.champ_for_update(dossier.find_type_de_champ_by_stable_id(101), row_id:, updated_by: 'test')
+      end
+
+      it 'includes the row_id in loader URL, so the API call resolves the champs of this row' do
+        expect(subject.to_html).to include("row_id=#{row_id}")
+      end
     end
   end
 end

--- a/spec/controllers/data_sources/referentiel_controller_spec.rb
+++ b/spec/controllers/data_sources/referentiel_controller_spec.rb
@@ -187,6 +187,33 @@ describe DataSources::ReferentielController, type: :controller do
         end
       end
 
+      context 'when a row_id is provided (referentiel champ inside a repetition)' do
+        let(:referentiel_service) { instance_double(ReferentielService) }
+        subject { post :search, params: { q: '010002699', referentiel_id: referentiel.id, dossier_id: dossier.id, row_id: 'ROW-1' } }
+
+        before { allow(ReferentielService).to receive(:new).and_return(referentiel_service) }
+
+        it 'forwards the row_id, so tags resolve the champs of this row' do
+          expect(referentiel_service).to receive(:call).with('010002699', dossier:, row_id: 'ROW-1').and_return(Success({ 'data' => [] }))
+
+          expect(subject).to have_http_status(:ok)
+        end
+
+        context 'when the usager is editing a dossier en construction' do
+          let(:dossier) { create(:dossier, :en_construction, procedure:, user:) }
+
+          it 'resolves the tags on the stream being edited, where the row being filled lives' do
+            expect(referentiel_service).to receive(:call) do |_query, dossier:, row_id:|
+              expect(dossier).to be_user_buffer_stream
+              expect(row_id).to eq('ROW-1')
+              Success({ 'data' => [] })
+            end
+
+            expect(subject).to have_http_status(:ok)
+          end
+        end
+      end
+
       context 'when failure' do
         let(:referentiel_service) { double(call: service_respone) }
 

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -321,16 +321,18 @@ FactoryBot.define do
 end
 
 def build_type_de_champs(type_de_champs, revision:, scope: :public, parent: nil)
-  type_de_champs.map do |type_de_champ_attributes|
-    referentiel = type_de_champ_attributes.delete(:referentiel)
-    if referentiel.present?
-      type_de_champ_attributes[:referentiel_id] = referentiel.id
-    end
-    type_de_champ_attributes
-  end.deep_dup.flat_map.with_index do |type_de_champ_attributes, i|
+  type_de_champs.flat_map.with_index do |source_attributes, i|
+    # `referentiel` et `children` sont lus sur la source, jamais sur la copie :
+    # deep_dup duplique l'enregistrement ActiveRecord et la copie a un id nil.
+    # Les children sont dupliqués par l'appel récursif, à leur tour.
+    referentiel = source_attributes[:referentiel]
+    children = source_attributes[:children]
+
+    type_de_champ_attributes = source_attributes.except(:referentiel, :children).deep_dup
+    type_de_champ_attributes[:referentiel_id] = referentiel.id if referentiel.present?
+
     type = TypeDeChamp.type_champs.fetch(type_de_champ_attributes.delete(:type) || :text).to_sym
     position = type_de_champ_attributes.delete(:position) || i
-    children = type_de_champ_attributes.delete(:children)
     options = type_de_champ_attributes.delete(:options)
     layers = type_de_champ_attributes.delete(:layers)
 

--- a/spec/models/champs/referentiel_champ_spec.rb
+++ b/spec/models/champs/referentiel_champ_spec.rb
@@ -53,6 +53,46 @@ describe Champs::ReferentielChamp, type: :model do
     end
   end
 
+  describe '#fetch_external_data when the champ is inside a repetition' do
+    include Dry::Monads[:result]
+
+    let(:public_type_de_champs) do
+      [{ type: :repetition, stable_id: 100, children: [{ type: :referentiel, stable_id: 101, referentiel: }] }]
+    end
+    let(:row_id) { dossier.repetition_add_row(dossier.find_type_de_champ_by_stable_id(100), updated_by: 'test') }
+    let(:champ_in_row) { dossier.champ_for_update(dossier.find_type_de_champ_by_stable_id(101), row_id:, updated_by: 'test') }
+
+    it 'passes its row_id, so the url tags resolve the champs of this row' do
+      champ_in_row.update!(external_id: 'ext-1')
+
+      expect_any_instance_of(ReferentielService).to receive(:call).with('ext-1', dossier:, row_id:).and_return(Success({}))
+
+      champ_in_row.fetch_external_data
+    end
+
+    context 'when the champ is on a buffer stream' do
+      let(:dossier) { create(:dossier, :en_construction, procedure:) }
+      let(:champ_on_buffer) do
+        dossier.with_update_stream(dossier.user) do
+          row_id = dossier.repetition_add_row(dossier.find_type_de_champ_by_stable_id(100), updated_by: 'test')
+          dossier.champ_for_update(dossier.find_type_de_champ_by_stable_id(101), row_id:, updated_by: 'test')
+        end
+      end
+
+      it 'resolves the url tags on the stream of the champ, where the row being filled lives' do
+        champ_on_buffer.update!(external_id: 'ext-1')
+
+        expect_any_instance_of(ReferentielService).to receive(:call) do |_service, _external_id, dossier:, row_id:|
+          expect(dossier.stream).to eq(champ_on_buffer.stream)
+          expect(row_id).to eq(champ_on_buffer.row_id)
+          Success({})
+        end
+
+        champ_on_buffer.fetch_external_data
+      end
+    end
+  end
+
   describe '#fetch_external_data' do
     subject { referentiel_champ.update_external_data!(data:) }
 

--- a/spec/services/referentiel_service_spec.rb
+++ b/spec/services/referentiel_service_spec.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe ReferentielService, type: :service do
+  def url_tiptap_for(tag_id, separator = "/dep/")
+    {
+      "type" => "doc", "content" => [
+        {
+          "type" => "paragraph", "content" => [
+            { "type" => "text", "text" => "https://api.gouv.fr/" },
+            { "type" => "mention", "attrs" => { "id" => "{query}", "label" => "Query" } },
+            { "type" => "text", "text" => separator },
+            { "type" => "mention", "attrs" => { "id" => tag_id, "label" => "Tag" } },
+          ],
+        },
+      ],
+    }
+  end
+
   let(:api_referentiel) { create(:api_referentiel, :exact_match) }
   let(:query_params) { api_referentiel.effective_test_data }
   let(:resolved_url) { described_class.new(referentiel: api_referentiel).url(query_params) }
@@ -151,20 +166,7 @@ RSpec.describe ReferentielService, type: :service do
     let(:api_referentiel) { build(:api_referentiel, :exact_match, url_tiptap:) }
     let(:service) { described_class.new(referentiel: api_referentiel) }
 
-    let(:url_tiptap) do
-      {
-        "type" => "doc", "content" => [
-          {
-            "type" => "paragraph", "content" => [
-              { "type" => "text", "text" => "https://api.gouv.fr/" },
-              { "type" => "mention", "attrs" => { "id" => "{query}", "label" => "Query" } },
-              { "type" => "text", "text" => "/dep/" },
-              { "type" => "mention", "attrs" => { "id" => "tdc42", "label" => "Dep" } },
-            ],
-          },
-        ],
-      }
-    end
+    let(:url_tiptap) { url_tiptap_for("tdc42") }
 
     context 'with Hash values_source and all values present' do
       let(:values_source) { { "{query}" => "search term", "tdc42" => "75" } }
@@ -197,20 +199,7 @@ RSpec.describe ReferentielService, type: :service do
       let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :text }]) }
       let(:dossier) { create(:dossier, procedure:) }
       let(:type_de_champ) { procedure.draft_revision.public_root_type_de_champs.first }
-      let(:url_tiptap) do
-        {
-          "type" => "doc", "content" => [
-            {
-              "type" => "paragraph", "content" => [
-                { "type" => "text", "text" => "https://api.gouv.fr/" },
-                { "type" => "mention", "attrs" => { "id" => "{query}", "label" => "Query" } },
-                { "type" => "text", "text" => "/dep/" },
-                { "type" => "mention", "attrs" => { "id" => "tdc#{type_de_champ.stable_id}", "label" => "Dep" } },
-              ],
-            },
-          ],
-        }
-      end
+      let(:url_tiptap) { url_tiptap_for("tdc#{type_de_champ.stable_id}") }
 
       before do
         dossier.champ_data.find { _1.stable_id == type_de_champ.stable_id }.update!(value: "75")
@@ -234,20 +223,7 @@ RSpec.describe ReferentielService, type: :service do
       let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :yes_no }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
       let(:type_de_champ) { procedure.draft_revision.public_root_type_de_champs.first }
-      let(:url_tiptap) do
-        {
-          "type" => "doc", "content" => [
-            {
-              "type" => "paragraph", "content" => [
-                { "type" => "text", "text" => "https://api.gouv.fr/" },
-                { "type" => "mention", "attrs" => { "id" => "{query}", "label" => "Query" } },
-                { "type" => "text", "text" => "?flag=" },
-                { "type" => "mention", "attrs" => { "id" => "tdc#{type_de_champ.stable_id}", "label" => "Flag" } },
-              ],
-            },
-          ],
-        }
-      end
+      let(:url_tiptap) { url_tiptap_for("tdc#{type_de_champ.stable_id}", "?flag=") }
 
       context 'when value is true' do
         it 'resolves boolean true value' do
@@ -272,20 +248,7 @@ RSpec.describe ReferentielService, type: :service do
       let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :address }]) }
       let(:dossier) { create(:dossier, :with_populated_champs, procedure:) }
       let(:type_de_champ) { procedure.draft_revision.public_root_type_de_champs.first }
-      let(:url_tiptap) do
-        {
-          "type" => "doc", "content" => [
-            {
-              "type" => "paragraph", "content" => [
-                { "type" => "text", "text" => "https://api.gouv.fr/" },
-                { "type" => "mention", "attrs" => { "id" => "{query}", "label" => "Query" } },
-                { "type" => "text", "text" => "?address=" },
-                { "type" => "mention", "attrs" => { "id" => "tdc#{type_de_champ.stable_id}", "label" => "Adresse" } },
-              ],
-            },
-          ],
-        }
-      end
+      let(:url_tiptap) { url_tiptap_for("tdc#{type_de_champ.stable_id}", "?address=") }
 
       it 'resolves address label with encoding' do
         result = service.send(:resolve_tiptap_url, "search", dossier)
@@ -300,6 +263,69 @@ RSpec.describe ReferentielService, type: :service do
 
     context 'when values_source is nil' do
       it { expect(service.send(:resolve_tiptap_url, "search", nil)).to be_nil }
+    end
+  end
+
+  describe '#url with a row_id' do
+    let(:api_referentiel) { build(:api_referentiel, :exact_match, url_tiptap:) }
+    let(:service) { described_class.new(referentiel: api_referentiel) }
+    let(:procedure) do
+      create(:procedure, public_type_de_champs: [
+        { type: :text, stable_id: 1, libelle: 'Code' },
+        {
+          type: :repetition, stable_id: 100, libelle: 'Bloc', children: [
+            { type: :text, stable_id: 102, libelle: 'Code' },
+          ],
+        },
+      ])
+    end
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:repetition) { dossier.find_type_de_champ_by_stable_id(100) }
+    let(:type_de_champ) { dossier.find_type_de_champ_by_stable_id(102) }
+    let(:row_ids) do
+      Array.new(2) { dossier.repetition_add_row(repetition, updated_by: 'test') }
+    end
+
+    before do
+      row_ids.each_with_index do |row_id, index|
+        dossier.champ_for_update(type_de_champ, row_id:, updated_by: 'test').update!(value: "LIGNE-#{index + 1}")
+      end
+      dossier.champ_data.find { _1.stable_id == 1 }.update!(value: "RACINE")
+      dossier.reload
+    end
+
+    context 'when the tag targets a champ of the repetition' do
+      let(:url_tiptap) { url_tiptap_for("tdc102", "/code/") }
+
+      it 'resolves the champ of the given row' do
+        expect(service.url("search", dossier:, row_id: row_ids.first)).to eq("https://api.gouv.fr/search/code/LIGNE-1")
+        expect(service.url("search", dossier:, row_id: row_ids.second)).to eq("https://api.gouv.fr/search/code/LIGNE-2")
+      end
+    end
+
+    context 'when the tag targets a champ outside of the repetition' do
+      let(:url_tiptap) { url_tiptap_for("tdc1", "/code/") }
+
+      it 'resolves the root champ whatever the row' do
+        expect(service.url("search", dossier:, row_id: row_ids.second)).to eq("https://api.gouv.fr/search/code/RACINE")
+      end
+    end
+
+    context 'when the champ of the given row is not filled yet' do
+      let(:url_tiptap) { url_tiptap_for("tdc102", "/code/") }
+      let(:empty_row_id) { dossier.repetition_add_row(repetition, updated_by: 'test') }
+
+      it 'does not resolve the url rather than borrowing another row' do
+        expect(service.url("search", dossier: dossier.reload, row_id: empty_row_id)).to be_nil
+      end
+    end
+
+    context 'when the referentiel champ is outside of the repetition (no row context)' do
+      let(:url_tiptap) { url_tiptap_for("tdc102", "/code/") }
+
+      it 'resolves the first row' do
+        expect(service.url("search", dossier:)).to eq("https://api.gouv.fr/search/code/LIGNE-1")
+      end
     end
   end
 end


### PR DESCRIPTION
# Problème

Un champ référentiel placé **dans une répétition** construit l'URL d'appel à l'API avec les valeurs de la **première ligne**, quelle que soit la ligne où il se trouve. Toutes les lignes appellent donc la même URL et préremplissent la même donnée.

`ReferentielService` résolvait les tags de l'URL par `stable_id` seul, dans `filled_champs` qui aplatit toutes les lignes : le `find` renvoyait toujours la première. Aucun contexte de ligne n'était transmis au service.

# Solution

Faire descendre le `row_id` du champ appelant jusqu'à la résolution des tags, pour le fetch `exact_match` comme pour la source de données de l'autocomplete.

Les tags sont alors résolus :

- sur les champs que le champ appelant peut référencer — ceux de sa ligne, plus ceux hors répétition, jamais ceux d'une autre ligne — en réutilisant la règle de portée de la visibilité conditionnelle, extraite en `Dossier#filled_champs_for_row` ;
- sur le stream où vit la ligne en cours de saisie : sur le seul stream principal, une ligne saisie dans un buffer est invisible.

Une ligne pas encore remplie laisse l'URL non résolue plutôt que d'appeler l'API avec la donnée de la voisine. Sans contexte de ligne (référentiel hors répétition), le comportement est inchangé.

Le premier commit corrige la factory de procédure, qui ne savait pas câbler un référentiel déclaré dans une répétition — sans quoi aucune de ces specs n'est écrivable.

Reste à traiter séparément : dans l'éditeur, les tags proposés pour l'URL affichent le libellé nu, donc un champ racine et un champ de la répétition portant le même libellé sont indistinguables.

Generated with [Claude Code](https://claude.com/claude-code)
