### PR TITLE
Tech: le hash d'une condition est calculé en temps linéaire

### DIFF
--- a/app/models/logic.rb
+++ b/app/models/logic.rb
@@ -93,7 +93,7 @@ module Logic
     if condition.nil?
       empty_condition
     elsif [And, Or].include?(condition.class)
-      condition.tap { |c| c.operands << empty_condition }
+      condition.class.new([*condition.operands, empty_condition])
     else
       Logic::And.new([condition, empty_condition])
     end

--- a/app/models/logic/eq.rb
+++ b/app/models/logic/eq.rb
@@ -45,9 +45,11 @@ class Logic::Eq < Logic::BinaryOperator
       [@left, @right].permutation.any? { |p| p == [other.left, other.right] }
   end
 
-  def hash
+  private
+
+  def hash_value
     term = self.class.name
-    sorted_operands = [@left, @right].sort_by(&:hash)
-    [term, *sorted_operands].hash
+    sorted_hashes = [@left, @right].map(&:hash).sort
+    [term, *sorted_hashes].hash
   end
 end

--- a/app/models/logic/n_ary_operator.rb
+++ b/app/models/logic/n_ary_operator.rb
@@ -49,9 +49,12 @@ class Logic::NAryOperator < Logic::Term
       end
   end
 
-  def hash
+  private
+
+  # The same whatever the order of the operands, each one hashed once
+  def hash_value
     term = self.class.name
-    sorted_operands = operands.sort_by(&:hash)
-    [term, *sorted_operands].hash
+    sorted_hashes = @operands.map(&:hash).sort
+    [term, *sorted_hashes].hash
   end
 end

--- a/app/models/logic/term.rb
+++ b/app/models/logic/term.rb
@@ -5,13 +5,18 @@ class Logic::Term
     to_h.to_json
   end
 
-  def hash
-    to_json.hash
-  end
+  # A term is never changed once built, so its hash is computed once. Hashing
+  # is what Array#&, Array#-, #uniq and #in? run on the terms, and a term
+  # nested twenty levels deep is hashed as many times as it has ancestors.
+  def hash = @hash ||= hash_value
 
   def eql?(other)
     hash == other.hash
   end
 
   def terms = [self]
+
+  private
+
+  def hash_value = to_h.hash
 end

--- a/spec/models/logic/n_ary_operator_spec.rb
+++ b/spec/models/logic/n_ary_operator_spec.rb
@@ -46,5 +46,13 @@ describe Logic::NAryOperator do
       expect(or_from([false, true]).hash).to eq(or_from([true, false]).hash)
       expect(and_from([false, true]).hash).not_to eq(or_from([true, false]).hash)
     end
+
+    it 'hashes each operand once, however deep the term' do
+      leaf = constant(true)
+      term = 30.times.reduce(ds_and([leaf, constant(false)])) { |inner, _| ds_and([inner, constant(false)]) }
+
+      expect(leaf).to receive(:hash).once.and_call_original
+      expect(term.hash).to eq(term.hash)
+    end
   end
 end


### PR DESCRIPTION
## Le problème

`Logic::Term#hash` sérialisait tout le terme en JSON à chaque appel, et `NAryOperator#hash` / `Eq#hash` hashaient chaque opérande deux fois : une fois pour les trier (`sort_by(&:hash)`), une deuxième fois via `Array#hash` sur le tableau trié. Le coût du hash d'un terme doublait donc à chaque niveau d'imbrication : 2^profondeur sérialisations JSON.

`Array#&`, `Array#-`, `#uniq` et `#in?` hashent leurs éléments. Aujourd'hui les termes hashés sont petits et ça ne se voit pas. #13756 réécrit chaque condition avec les conditions d'affichage des champs qu'elle cible, et sur certaines démarches publiées (ex. « Demande de retournement de prairies », 75 champs conditionnels, chaîne de conditions d'affichage imbriquée sur 20 niveaux) une seule condition prenait **90 s**, entièrement dans le hash : 115 millions d'appels à `hash`, 106 millions d'encodages JSON, 80 % du temps en GC.

## Le correctif

- Un terme n'est jamais modifié après sa construction : le hash est mémoïsé par instance (`Term#hash`), les sous-classes redéfinissent `hash_value`.
- `NAryOperator` et `Eq` hashent chaque opérande une fois puis trient les entiers, ce qui reste indépendant de l'ordre des opérandes.
- `Logic.add_empty_condition_to` était le seul endroit qui mutait un terme (`operands <<`) ; il construit maintenant une nouvelle condition, sinon le hash mémoïsé serait périmé.

## Mesures

Sur la condition ci-dessus :

| | avant | après |
|---|---|---|
| Appels à `hash` | 115 millions | 116 |
| Encodages JSON | 106 millions | 0 |
| `Logic::Solver#errors` | 90 s | 30 ms |

Sur la validation de #13756 rejouée contre les 66 000 révisions publiées du snapshot de dev (1,9 million de conditions, harnais local non versionné) :

| | avant | après |
|---|---|---|
| Durée totale | 304 s | 114 s |
| Conditions en timeout (> 10 s) | 24 | 0 |
| Condition la plus lente | > 90 s | 33 ms |
| p99 sur les conditions valides | 1,6 ms | 0,8 ms |

Les conditions rejetées sont exactement les mêmes avant et après : le changement n'affecte que la vitesse.

Ref #13756

🤖 Generated with [Claude Code](https://claude.com/claude-code)
