### PR TITLE
Fix référentiel: autoriser l'autocomplétion du référentiel sur la révision du dossier

### DIFF
--- a/app/controllers/data_sources/referentiel_controller.rb
+++ b/app/controllers/data_sources/referentiel_controller.rb
@@ -72,7 +72,7 @@ class DataSources::ReferentielController < DataSources::BaseController
     candidate = Referentiel.find_by(id: params[:referentiel_id])
     return nil if candidate.nil?
 
-    @type_de_champ = @dossier.procedure.active_revision.type_de_champs.find { it.referentiel_id == candidate.id }
+    @type_de_champ = @dossier.revision.type_de_champs.find { it.referentiel_id == candidate.id }
     candidate if @type_de_champ.present?
   end
 

--- a/spec/controllers/data_sources/referentiel_controller_spec.rb
+++ b/spec/controllers/data_sources/referentiel_controller_spec.rb
@@ -177,6 +177,26 @@ describe DataSources::ReferentielController, type: :controller do
         end
       end
 
+      context 'when the dossier is a preview of the draft revision of a published procedure' do
+        let(:procedure) { create(:procedure, :published, public_type_de_champs:) }
+        let(:draft_referentiel) { referentiel.dup.tap(&:save!) }
+        let(:dossier) { procedure.draft_revision.dossier_for_preview(user) }
+
+        before do
+          stable_id = procedure.draft_revision.type_de_champs.first.stable_id
+          procedure.draft_revision
+            .find_and_ensure_exclusive_use(stable_id)
+            .update!(referentiel: draft_referentiel)
+        end
+
+        subject { post :search, params: { q: '010002699', referentiel_id: draft_referentiel.id, dossier_id: dossier.id } }
+
+        it 'returns results', vcr: 'referentiel/datagouv-finess' do
+          expect(subject).to have_http_status(:ok)
+          expect(response.parsed_body.size).to eq(1)
+        end
+      end
+
       context 'when the referentiel has no rendering template' do
         before { referentiel.update_column(:autocomplete_configuration, { 'datasource' => '$.data' }) }
 


### PR DESCRIPTION
Ticket support : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_2a423669-4ecf-4279-98cb-b768a7c3ba40/

Sur une démarche publiée, rouvrir le wizard du référentiel configurable crée un nouveau Referentiel rattaché à la révision brouillon (clonage volontaire pour ne pas toucher la révision publiée). L’endpoint d’autocomplétion n’autorisait la recherche que si `procedure.active_revision référençait l’id envoyé ce qui n’est jamais le cas pour un dossier de prévisualisation, qui vit sur la révision brouillon. Résultat : autocomplétion vide, sans qu’aucune modification n’apparaisse dans l’interface admin (le diff de révision compare les valeurs, identiques, pas les id).

Même mécanisme pour les usagers : après republication, les dossiers en cours restent sur leur ancienne révision et envoient un `referentiel_id` absent de la nouvelle révision publiée.

On autorise désormais sur la révision du dossier, qui est par construction celle dont le champ a été rendu. Le contrôle d’appartenance du dossier à `current_user` est inchangé.

Régression introduite par #13128 .