### PR TITLE
Tech: lire la claim acr de ProConnect et préparer l'exigence MFA

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,8 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception, store: :cookie # define same store in config/initializers/active_storage.rb
 
+  around_action :switch_locale
+
   before_action :set_sentry_user
   before_action :redirect_if_untrusted
   before_action :reject, if: -> { ENV.fetch("MAINTENANCE_MODE", 'false') == 'true' }
@@ -27,8 +29,6 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
   rescue_from DossierChampsConcern::ChampNotInRevisionError, with: :champ_not_in_revision
-
-  around_action :switch_locale
 
   helper_method :multiple_devise_profile_connect?, :instructeur_signed_in?, :current_instructeur, :current_expert, :expert_signed_in?,
     :administrateur_signed_in?, :current_administrateur, :current_account, :localization_enabled?, :set_locale, :current_expert_not_instructeur?,

--- a/app/controllers/concerns/pro_connect_session_concern.rb
+++ b/app/controllers/concerns/pro_connect_session_concern.rb
@@ -4,11 +4,6 @@ module ProConnectSessionConcern
   extend ActiveSupport::Concern
 
   SESSION_INFO_COOKIE_NAME = :pro_connect_session_info
-  # Cookies set before mfa_at was introduced have no client-side expiry and
-  # could otherwise persist indefinitely. Refuse them past this date (~1 month
-  # after deploy, aligned with TRUSTED_DEVICE_PERIOD) so any remaining ones
-  # are forced to renew their MFA assertion via ProConnect.
-  LEGACY_COOKIE_DEADLINE = Time.zone.local(2026, 6, 13).freeze
 
   included do
     helper_method :logged_in_with_pro_connect?
@@ -30,12 +25,9 @@ module ProConnectSessionConcern
 
   def pro_connect_mfa?
     info = pro_connect_session
-    return false if info['mfa'] != true
-    return Time.current < LEGACY_COOKIE_DEADLINE if info['mfa_at'].blank?
+    return false if info['mfa'] != true || info['mfa_at'].blank?
 
     Time.iso8601(info['mfa_at']) > TrustedDeviceConcern::TRUSTED_DEVICE_PERIOD.ago
-  rescue ArgumentError
-    false
   end
 
   def delete_pro_connect_session_info_cookie

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -27,7 +27,7 @@ class ProConnectController < ApplicationController
   end
 
   def callback
-    user_info, id_token, amr = ProConnectService.user_info(params[:code], cookies.encrypted[NONCE_COOKIE_NAME])
+    user_info, id_token, amr, acr = ProConnectService.user_info(params[:code], cookies.encrypted[NONCE_COOKIE_NAME])
     cookies.delete NONCE_COOKIE_NAME
 
     email = santized_email(user_info)
@@ -48,7 +48,7 @@ class ProConnectController < ApplicationController
     pro_connect_info = ProConnectInformation.find_or_initialize_by(user:, sub: user_info['sub'])
     pro_connect_info.update!(
       user_info.slice('given_name', 'usual_name', 'email', 'sub', 'siret', 'organizational_unit', 'belonging_population', 'phone')
-      .merge(amr:)
+      .merge(amr:, acr:)
     )
 
     mfa = amr.include?('mfa')

--- a/app/services/pro_connect_service.rb
+++ b/app/services/pro_connect_service.rb
@@ -35,9 +35,6 @@ class ProConnectService
           "eidas1-mfa", # Identité : Faible, Auth: MFA (auto-géré), Orga: Modération ou plus
           "eidas2",     # Identité : Substantielle, Auth: MFA (géré par l'organisation), Orga: Lien certifié par une source officielle
           "eidas3",     # Identité : Élevée, Auth: MFA matérielle (géré par l'organisation), Orga: Lien certifié par une source officielle
-          # deprecated claims to be removed after 18/06/2026
-          "https://proconnect.gouv.fr/assurance/self-asserted-2fa", # declarative identity + 2FA
-          "https://proconnect.gouv.fr/assurance/consistency-checked-2fa", # verified identity + 2FA
         ],
       }
     end

--- a/app/services/pro_connect_service.rb
+++ b/app/services/pro_connect_service.rb
@@ -60,7 +60,7 @@ class ProConnectService
 
     amr = id_token.amr.present? ? JSON.parse(id_token.amr) : []
 
-    [access_token.userinfo!.raw_attributes, access_token.id_token, amr]
+    [access_token.userinfo!.raw_attributes, access_token.id_token, amr, id_token.acr]
   end
 
   def self.logout_url(id_token, host_with_port:)

--- a/app/services/pro_connect_service.rb
+++ b/app/services/pro_connect_service.rb
@@ -3,8 +3,15 @@
 class ProConnectService
   include OpenIDConnect
 
+  # https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/double_authentification
+  MFA_ACR_VALUES = ["eidas0-mfa", "eidas1-mfa", "eidas2", "eidas3"].freeze
+
   def self.enabled?
     ENV['PRO_CONNECT_BASE_URL'].present?
+  end
+
+  def self.mfa?(amr:, acr:)
+    amr.include?('mfa') || MFA_ACR_VALUES.include?(acr)
   end
 
   def self.authorization_uri(force_mfa: false, login_hint: nil)
@@ -27,16 +34,7 @@ class ProConnectService
 
     if force_mfa
       # acr (Authentication Context Class Reference) force the level of security
-      # https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/double_authentification
-      claims[:id_token][:acr] = {
-        essential: true,
-        values: [
-          "eidas0-mfa", # Identité : Faible ou déclarative, Auth: MFA (auto-géré), Orga: Modération ou déclaratif
-          "eidas1-mfa", # Identité : Faible, Auth: MFA (auto-géré), Orga: Modération ou plus
-          "eidas2",     # Identité : Substantielle, Auth: MFA (géré par l'organisation), Orga: Lien certifié par une source officielle
-          "eidas3",     # Identité : Élevée, Auth: MFA matérielle (géré par l'organisation), Orga: Lien certifié par une source officielle
-        ],
-      }
+      claims[:id_token][:acr] = { essential: true, values: MFA_ACR_VALUES }
     end
 
     uri = client.authorization_uri(

--- a/app/views/instructeur_mailer/send_login_token.html.haml
+++ b/app/views/instructeur_mailer/send_login_token.html.haml
@@ -3,24 +3,21 @@
 - ds_link = sign_in_by_link_url(@instructeur.id, jeton: @login_token, host: 'www.demarches-simplifiees.fr')
 
 %p
-  Bonjour,
+  = t(:hello, scope: [:views, :shared, :greetings])
 
 %p
-  Veuillez cliquer sur le lien sécurisé suivant pour vous connecter à  #{APPLICATION_NAME} : 
+  = t('.login_link', application_name: APPLICATION_NAME)
   - if ENV['APP_HOST'] == 'demarche.numerique.gouv.fr'
     = link_to(demarche_link, demarche_link)
 
     %p
-      En cas de difficulté, essayez l’ancienne adresse : 
+      = t('.legacy_address')
       = link_to(ds_link, ds_link)
   - else
     = link_to(sign_in_by_link_url(@instructeur.id, jeton: @login_token), sign_in_by_link_url(@instructeur.id, jeton: @login_token))
 
 %p
-  Ce lien est
-  %b valide une semaine
-  et peut être réutilisé
-  %b plusieurs fois.
+  = t('.link_validity_html')
 
 = render partial: "layouts/mailers/signature"
 -# haml-lint:enable ApplicationNameLinter

--- a/config/locales/views/instructeur_mailer/send_login_token/en.yml
+++ b/config/locales/views/instructeur_mailer/send_login_token/en.yml
@@ -2,3 +2,6 @@ en:
   instructeur_mailer:
     send_login_token:
       subject: "Secure login to %{application_name}"
+      login_link: "Please click the following secure link to sign in to %{application_name}:"
+      legacy_address: "If you have any trouble, try the former address:"
+      link_validity_html: This link is <b>valid for one week</b> and can be reused <b>several times.</b>

--- a/config/locales/views/instructeur_mailer/send_login_token/fr.yml
+++ b/config/locales/views/instructeur_mailer/send_login_token/fr.yml
@@ -2,3 +2,6 @@ fr:
   instructeur_mailer:
     send_login_token:
       subject: "Connexion sécurisée à %{application_name}"
+      login_link: "Veuillez cliquer sur le lien sécurisé suivant pour vous connecter à %{application_name} :"
+      legacy_address: "En cas de difficulté, essayez l’ancienne adresse :"
+      link_validity_html: Ce lien est <b>valide une semaine</b> et peut être réutilisé <b>plusieurs fois.</b>

--- a/db/migrate/20260907192353_add_acr_to_agent_connect_informations.rb
+++ b/db/migrate/20260907192353_add_acr_to_agent_connect_informations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAcrToAgentConnectInformations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :agent_connect_informations, :acr, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_02_100000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_07_192353) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_catalog.plpgsql"
@@ -98,6 +98,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_02_100000) do
   end
 
   create_table "agent_connect_informations", force: :cascade do |t|
+    t.string "acr"
     t.string "amr", default: [], array: true
     t.string "belonging_population"
     t.datetime "created_at", null: false

--- a/spec/controllers/concerns/pro_connect_session_concern_spec.rb
+++ b/spec/controllers/concerns/pro_connect_session_concern_spec.rb
@@ -46,25 +46,14 @@ RSpec.describe ProConnectSessionConcern, type: :controller do
       end
     end
 
-    describe 'with a legacy cookie (no mfa_at)' do
+    describe 'with a cookie without mfa_at' do
       let(:user_id) { 42 }
 
       before do
-        legacy = { user_id: 42, mfa: true }.to_json
-        controller.send(:cookies).encrypted[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME] = legacy
+        controller.send(:cookies).encrypted[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME] = { user_id: 42, mfa: true }.to_json
       end
 
-      it 'is accepted before the deadline' do
-        travel_to(ProConnectSessionConcern::LEGACY_COOKIE_DEADLINE - 1.day) do
-          expect(controller.pro_connect_mfa?).to be true
-        end
-      end
-
-      it 'is refused on or after the deadline' do
-        travel_to(ProConnectSessionConcern::LEGACY_COOKIE_DEADLINE) do
-          expect(controller.pro_connect_mfa?).to be false
-        end
-      end
+      it { expect(controller.pro_connect_mfa?).to be false }
     end
   end
 end

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -43,6 +43,7 @@ describe ProConnectController, type: :controller do
       }
     end
     let(:amr) { [] }
+    let(:acr) { nil }
     let(:idp_id) { 'an_id' }
     subject { get :callback, params: { code: code, state: state } }
 
@@ -57,7 +58,7 @@ describe ProConnectController, type: :controller do
 
       context 'and user_info returns some info' do
         before do
-          expect(ProConnectService).to receive(:user_info).with(code, nonce).and_return([user_info, id_token, amr])
+          expect(ProConnectService).to receive(:user_info).with(code, nonce).and_return([user_info, id_token, amr, acr])
         end
 
         context 'and the user does not have an account yet' do
@@ -159,6 +160,7 @@ describe ProConnectController, type: :controller do
 
           context 'and the user uses Mon Compte Pro with MFA' do
             let(:amr) { ['pwd', 'totp', 'mfa'] }
+            let(:acr) { 'eidas1-mfa' }
             let(:idp_id) { ProConnectController::MON_COMPTE_PRO_IDP_ID }
 
             it 'logs in the user' do
@@ -169,6 +171,14 @@ describe ProConnectController, type: :controller do
               cookie = JSON.parse(cookies.encrypted[ProConnectSessionConcern::SESSION_INFO_COOKIE_NAME])
               expect(cookie).to include('user_id' => instructeur.user.id, 'mfa' => true)
               expect(cookie['mfa_at']).to be_present
+            end
+
+            it 'stores the acr claim' do
+              expect(controller).to receive(:sign_in)
+
+              subject
+
+              expect(instructeur.user.pro_connect_informations.first.acr).to eq('eidas1-mfa')
             end
           end
         end
@@ -199,7 +209,7 @@ describe ProConnectController, type: :controller do
           let(:initial_instructeur_count) { Instructeur.count }
 
           before do
-            expect(ProConnectService).to receive(:user_info).with(code, nonce).and_return([user_info, id_token, amr]).twice
+            expect(ProConnectService).to receive(:user_info).with(code, nonce).and_return([user_info, id_token, amr, acr]).twice
             expect(controller).to receive(:sign_in).twice
           end
 
@@ -222,10 +232,10 @@ describe ProConnectController, type: :controller do
           end
 
           it 'does not create an instructeur' do
-            expect(ProConnectService).to receive(:user_info).with(code, nonce).and_return([user_info, id_token, amr])
+            expect(ProConnectService).to receive(:user_info).with(code, nonce).and_return([user_info, id_token, amr, acr])
             get :callback, params: { code: code, state: state }
 
-            expect(ProConnectService).to receive(:user_info).with(code, nonce).and_return([user_info.merge('sub' => 'sub2'), id_token, amr])
+            expect(ProConnectService).to receive(:user_info).with(code, nonce).and_return([user_info.merge('sub' => 'sub2'), id_token, amr, acr])
             get :callback, params: { code: code, state: state }
 
             expect(Instructeur.count).to eq(initial_instructeur_count)

--- a/spec/mailers/instructeur_mailer_spec.rb
+++ b/spec/mailers/instructeur_mailer_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe InstructeurMailer, type: :mailer do
 
     it { expect(subject[BalancerDeliveryMethod::BYPASS_UNVERIFIED_MAIL_PROTECTION]).to be_present }
 
+    it 'renders the body in the current locale' do
+      I18n.with_locale(:en) { expect(subject.body).to include('valid for one week') }
+    end
+
     context 'without SafeMailer configured' do
       it { expect(subject[BalancerDeliveryMethod::FORCE_DELIVERY_METHOD_HEADER]&.value).to eq(nil) }
     end

--- a/spec/services/pro_connect_service_spec.rb
+++ b/spec/services/pro_connect_service_spec.rb
@@ -62,4 +62,15 @@ describe ProConnectService do
       end
     end
   end
+
+  describe '.mfa?' do
+    it 'is true when amr or acr asserts a multi factor authentication' do
+      expect(described_class.mfa?(amr: ['pwd', 'mail', 'mfa'], acr: nil)).to be true
+      expect(described_class.mfa?(amr: ['pwd'], acr: 'eidas1-mfa')).to be true
+    end
+
+    it 'is false otherwise' do
+      expect(described_class.mfa?(amr: ['pwd'], acr: 'eidas1')).to be false
+    end
+  end
 end

--- a/spec/services/pro_connect_service_spec.rb
+++ b/spec/services/pro_connect_service_spec.rb
@@ -50,8 +50,6 @@ describe ProConnectService do
         expect(uri).to include('eidas1-mfa')
         expect(uri).to include('eidas2')
         expect(uri).to include('eidas3')
-        expect(uri).to include('self-asserted-2fa')
-        expect(uri).to include('consistency-checked-2fa')
       end
     end
 


### PR DESCRIPTION
Première étape du chantier « MFA ProConnect pour les administrateurs » : lire la preuve de double authentification que renvoie ProConnect, sans encore rien en faire. Deux commits i18n s'y ajoutent, nécessaires pour préparer la suite.

## ProConnect

- Retrait des deux valeurs `acr` dépréciées (`self-asserted-2fa`, `consistency-checked-2fa`), que le code donnait lui-même à supprimer après le 18/06/2026. Cela change une requête sortante réelle : les valeurs `acr` essentielles du second passage `force_mfa`, aujourd'hui emprunté par les instructeurs Mon Compte Pro sans MFA. 
- Retrait de la branche du cookie ProConnect antérieur à `mfa_at`, dont l'échéance est passée depuis le 13/06/2026. 
- `MFA_ACR_VALUES` et `ProConnectService.mfa?` centralisent la règle « cette connexion atteste-t-elle une double authentification ? ». La méthode n'a pas encore d'appelant : le callback l'utilisera dans la PR suivante
- Le callback lit la claim `acr` de l'`id_token` et la stocke sur `ProConnectInformation` (colonne ajoutée). Les valeurs réellement renvoyées par ProConnect deviennent ainsi observables avant qu'on ne s'en serve pour autoriser.

## Corrections i18n

- le mail « connexion sécurisée » de l'instructeur est désormais enfilé dans la langue du destinataire quand il vient de la redirection « appareil non fiable ». Seul son sujet était traduit, son corps était en français en dur
- et un autre fix préparatoire pour `around_action switch locale` mal placé qui créait des alertes pas dans la bonne locale

Migration : `add_column :agent_connect_informations, :acr, :string`.