### PR TITLE
ETQ usager, le dossier vide d'une démarche à liste liée volumineuse se génère sans délai

### DIFF
--- a/app/components/dossiers/dossier_vide_pdf_component.rb
+++ b/app/components/dossiers/dossier_vide_pdf_component.rb
@@ -210,11 +210,14 @@ class Dossiers::DossierVidePdfComponent < ApplicationComponent
     safe_join([libelle(type_de_champ), description(type_de_champ), explanation_tag, checkboxes(options)].compact)
   end
 
+  # secondary_options parses the whole option list on every call: read it once,
+  # not once per primary (quadratic on lists of thousands of options).
   def linked_field(type_de_champ)
-    items = type_de_champ.primary_options.compact_blank.flat_map do |primary|
-      secondaries = type_de_champ.secondary_options[primary].to_a.compact_blank
+    items = type_de_champ.secondary_options.flat_map do |primary, secondaries|
+      next [] if primary.blank?
+
       [tag.li(checkbox(primary))] +
-        secondaries.map { |s| tag.li(checkbox(s), class: 'secondary') }
+        secondaries.compact_blank.map { |s| tag.li(checkbox(s), class: 'secondary') }
     end
     safe_join([libelle(type_de_champ), tag.ul(safe_join(items), class: 'options')])
   end

--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -189,9 +189,12 @@ def render_single_champ(pdf, revision, type_de_champ)
     pdf.text "\n"
   when TypeDeChamp.type_champs.fetch(:linked_drop_down_list)
     add_libelle(pdf, type_de_champ)
-    type_de_champ.primary_options.compact_blank.each do |o|
-      format_with_checkbox(pdf, o)
-      type_de_champ.secondary_options[o].compact_blank.each do |secondary_option|
+    # secondary_options parses the whole option list on every call: read it once, not once per primary
+    type_de_champ.secondary_options.each do |primary, secondary_options|
+      next if primary.blank?
+
+      format_with_checkbox(pdf, primary)
+      secondary_options.compact_blank.each do |secondary_option|
         format_with_checkbox(pdf, secondary_option, 15)
       end
     end


### PR DESCRIPTION
Les deux moteurs actuels du dossier vide (le composant HTML derrière WeasyPrint et le template Prawn) lisent `secondary_options[primaire]` pour chaque option primaire d'une liste liée, et `secondary_options` re-parse toute la liste à chaque appel : coût quadratique.

Sur une liste liée d'environ 4 300 options (démarches 16200, 14239, 17542, 17558 du snapshot dev), la construction du HTML passe d'environ 3 s à 45 ms ; sur les plus gros formulaires publiés (300 champs) le composant prenait 12 s de Ruby. Trouvé par le harnais de rendu de toutes les démarches publiées, voir #13810.

Le rendu est identique : mêmes primaires, même ordre, mêmes secondaires (`secondary_options` est déjà le Hash `primaire → secondaires` dans l'ordre des options).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
