### PR TITLE
Tech: un lien automatique Markdown suivi d'un caractère accentué ou d'une espace insécable ne fait plus planter le rendu sur macOS

### DIFF
--- a/app/lib/redcarpet/bare_renderer.rb
+++ b/app/lib/redcarpet/bare_renderer.rb
@@ -30,8 +30,16 @@ module Redcarpet
       content_tag(:a, content, { href:, title: new_tab_suffix(title), **external_link_attributes }, false)
     end
 
+    # Redcarpet's C scanner ends an autolink on isalnum(), which on macOS in a
+    # UTF-8 locale accepts the lead byte of the character following the address
+    # (a no-break space before a colon, an accented letter, a « ») and hands us
+    # a link with a stray byte that Rails then rejects as invalid UTF-8. glibc
+    # does not classify those bytes, so production is unaffected. Link the valid
+    # prefix and put the stray bytes back after it, where Redcarpet emits the
+    # rest of the character: the output bytes are the intended ones.
     def autolink(link, link_type)
-      case link_type
+      link, stray = split_invalid_tail(link)
+      html = case link_type
       when :url
         link(link, nil, link)
       when :email
@@ -40,6 +48,17 @@ module Redcarpet
       else
         link
       end
+      stray ? html.to_str + stray : html
+    end
+
+    private
+
+    def split_invalid_tail(text)
+      return [text, nil] if text.valid_encoding?
+
+      valid = text.dup
+      valid = valid.byteslice(0, valid.bytesize - 1) until valid.valid_encoding?
+      [valid, text.byteslice(valid.bytesize..)]
     end
   end
 end

--- a/spec/components/simple_format_component_spec.rb
+++ b/spec/components/simple_format_component_spec.rb
@@ -141,6 +141,20 @@ TEXT
         expect(link[:rel]).to be_nil
       end
 
+      context "followed by a multibyte character (no-break space before a colon, accented letter)" do
+        # On macOS Redcarpet swallows the lead byte of the next character into the link
+        let(:text) { "Contact : ds@rspec.io\u00A0: écrire à ds@rspec.frécrivez, voir https://ds.io/aide\u00A0!" }
+
+        it "links the address alone and keeps the following character" do
+          expect(page.find_link("ds@rspec.io").native[:href]).to eq("mailto:ds@rspec.io")
+          expect(page.find_link("ds@rspec.fr").native[:href]).to eq("mailto:ds@rspec.fr")
+          # Redcarpet's URL scanner stops on ASCII whitespace only, so with glibc
+          # the no-break space stays inside the link: check the link, not its href
+          expect(page).to have_link("https://ds.io/aide")
+          expect(page.text).to include("ds@rspec.io\u00A0: écrire à ds@rspec.frécrivez, voir https://ds.io/aide\u00A0!")
+        end
+      end
+
       it "convert www only" do
         link = page.find_link("www.ds.io").native
         expect(link[:href]).to eq("http://www.ds.io")


### PR DESCRIPTION
Le scanner C de Redcarpet termine un lien automatique sur `isalnum()`. Sur macOS en locale UTF-8, `isalnum()` accepte le premier octet du caractère qui suit une adresse ou une URL (espace insécable avant un deux-points, lettre accentuée, guillemet fermant) : `BareRenderer#autolink` recevait un lien terminé par un octet parasite et `content_tag` levait `invalid byte sequence in UTF-8` pour toute la description. Exemple : `contact@exemple.fr : merci` avec l'espace insécable du français.

**Production n'est pas concernée** : glibc ne classe pas ces octets, le scanner s'arrête au bon endroit (vérifié en locale `C`, et aucun événement Sentry). En revanche le rendu local échoue sur 108 démarches du snapshot dev (27 publiées), ce qui faussait le harnais de rendu du dossier vide (#13810).

Correctif : le lien est posé sur le préfixe valide, et les octets parasites sont remis après lui, là où Redcarpet émet la suite du caractère ; la sortie est octet pour octet celle attendue. Sous glibc le correctif ne fait rien. Spec ajoutée sur le composant (elle passe trivialement sur Linux, elle reproduisait le crash sur macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
