### PR TITLE
ETQ instructeur, les retours à la ligne saisis dans un champ reviennent dans l'attestation

### DIFF
--- a/app/models/champ_presentations/multiline_text_presentation.rb
+++ b/app/models/champ_presentations/multiline_text_presentation.rb
@@ -10,10 +10,15 @@ class ChampPresentations::MultilineTextPresentation < ChampPresentations::BasePr
     @text = text.to_s.gsub("\r\n", "\n").strip
   end
 
+  # A newline, or the `<br>` an instructeur types in a motivation: both reach
+  # the tree as raw text, and both mean a line. The break comes first so that a
+  # newline touching it is swallowed with it, rather than counted twice.
+  SEPARATOR = Regexp.union(TiptapService::LINE_BREAK, "\n")
+
   def to_s = text
 
   def to_tiptap_nodes
-    text.split("\n").flat_map.with_index do |line, index|
+    text.split(SEPARATOR, -1).flat_map.with_index do |line, index|
       [({ type: 'hardBreak' } if index > 0), ({ type: 'text', text: line } unless line.empty?)].compact
     end
   end

--- a/app/models/champ_presentations/repetition_presentation.rb
+++ b/app/models/champ_presentations/repetition_presentation.rb
@@ -41,12 +41,7 @@ class ChampPresentations::RepetitionPresentation < ChampPresentations::BasePrese
                   }.compact,
                   {
                     type: 'descriptionDetails',
-                    content: [
-                      {
-                        type: 'text',
-                        text: champ.to_s,
-                      },
-                    ],
+                    content: TiptapService.line_nodes(champ.to_s),
                   },
                 ]
               end.flatten,

--- a/app/services/tiptap_service.rb
+++ b/app/services/tiptap_service.rb
@@ -10,6 +10,15 @@ class TiptapService
   # Inline nodes of the tiptap schema, every other node is a block.
   INLINE_TYPES = ['text', 'hardBreak'].freeze
 
+  # The line breaks a champ value carries. Instructeurs and admins write `<br>`
+  # in them - in a private annotation, mostly - because substitutions used to be
+  # spliced raw into the page, so they have to become nodes now that the tree is
+  # resolved before rendering. A run of them is one break: the attestation
+  # renders a hard break as a blank line, and `<br><br>` means one blank line.
+  # Nothing else in a value is read as markup: it is free text, where an HTML
+  # parser would swallow `Cher <Prénom>` and stray `<` along the way.
+  LINE_BREAK = %r{[[:space:]]*(?:<br[[:space:]]*/?>[[:space:]]*)+}i
+
   # NOTE: node must be deep symbolized keys
   def self.used_tags_and_libelle_for(node, tags = Set.new)
     case node
@@ -27,9 +36,10 @@ class TiptapService
   # Replaces every mention by its substitution and returns a document that
   # follows the tiptap schema, so that renderers (HTML, Typst) never have to
   # know about mentions:
-  # - a text substitution becomes a text node carrying the mention marks
-  #   (the string keeps its `html_safe?` flag, so an HTML renderer escapes
-  #   exactly what the substitution layer did not);
+  # - a text substitution becomes text nodes separated by the hard breaks its
+  #   `<br>` stand for, carrying the mention marks; the string keeps its
+  #   `html_safe?` flag when it holds no break, so an HTML renderer escapes
+  #   exactly what the substitution layer did not;
   # - a presentation becomes its tiptap nodes: inline ones (multiline text)
   #   stay in the paragraph, their text nodes carrying the mention marks;
   #   block ones (the lists of a repetition, a multiple drop down or a carte)
@@ -71,12 +81,23 @@ class TiptapService
       nodes = if value.respond_to?(:to_tiptap_nodes) && !text_only
         value.to_tiptap_nodes
       else
-        [{ type: 'text', text: value.to_s }]
+        line_nodes(value, text_only:)
       end
       marks = rest[:marks]
       marks.present? ? nodes.map { it[:type] == 'text' ? it.merge(marks:) : it } : nodes
     else
       [node]
+    end
+  end
+
+  # A title and a heading read as one line, so their breaks become spaces.
+  def self.line_nodes(value, text_only: false)
+    text = value.to_s
+    return [{ type: 'text', text: }] if !text.match?(LINE_BREAK)
+    return [{ type: 'text', text: text.gsub(LINE_BREAK, ' ') }] if text_only
+
+    text.split(LINE_BREAK, -1).flat_map.with_index do |line, index|
+      [({ type: 'hardBreak' } if index > 0), ({ type: 'text', text: line } unless line.empty?)].compact
     end
   end
 

--- a/spec/models/champ_presentations/multiline_text_presentation_spec.rb
+++ b/spec/models/champ_presentations/multiline_text_presentation_spec.rb
@@ -24,6 +24,14 @@ describe ChampPresentations::MultilineTextPresentation do
       ])
     end
 
+    it 'reads the <br> an instructeur types as a line too' do
+      expect(described_class.new("Refus.<br><br>Motif : incomplet").to_tiptap_nodes).to eq([
+        { type: 'text', text: 'Refus.' },
+        { type: 'hardBreak' },
+        { type: 'text', text: 'Motif : incomplet' },
+      ])
+    end
+
     it { expect(described_class.new(nil).to_tiptap_nodes).to eq([]) }
   end
 end

--- a/spec/models/champ_presentations/repetition_presentation_spec.rb
+++ b/spec/models/champ_presentations/repetition_presentation_spec.rb
@@ -108,5 +108,15 @@ describe ChampPresentations::RepetitionPresentation do
 
       expect(representation.to_tiptap_node).to eq(expected_node)
     end
+
+    it 'reads the <br> a champ value carries as a line' do
+      champ = double(libelle: 'Adresse', to_s: '12 rue X<br>75001 Paris', blank?: false)
+      node = described_class.new(libelle, [[champ]]).to_tiptap_node
+
+      expect(node[:content].first[:content].first[:content].second).to eq({
+        type: "descriptionDetails",
+        content: [{ type: 'text', text: '12 rue X' }, { type: 'hardBreak' }, { type: 'text', text: '75001 Paris' }],
+      })
+    end
   end
 end

--- a/spec/services/tiptap_service_spec.rb
+++ b/spec/services/tiptap_service_spec.rb
@@ -441,6 +441,21 @@ RSpec.describe TiptapService do
           '<p class="body-start">Motivation : <em>&lt;b&gt;ok&lt;/b&gt;</em><br><br><em>suite</em>.</p>'
         )
       end
+
+      it 'turns the line breaks a champ value carries into hard breaks, and escapes the rest' do
+        json = doc({ type: 'paragraph', content: [text('Réponse : '), mention] })
+        substitutions = { 'languages' => 'Monsieur,<br> <br>surface < 100 m² <Réf 2026>' }
+
+        expect(described_class.new(hard_break: '<br><br>').to_html(json, substitutions)).to eq(
+          '<p class="body-start">Réponse : Monsieur,<br><br>surface &lt; 100 m² &lt;Réf 2026&gt;</p>'
+        )
+      end
+
+      it 'reads the line breaks of a champ value as spaces inside the title' do
+        json = doc({ type: 'title', content: [mention] })
+
+        expect(described_class.new.to_html(json, { 'languages' => 'Ligne 1<br>Ligne 2' })).to eq('<h1>Ligne 1 Ligne 2</h1>')
+      end
     end
   end
 


### PR DESCRIPTION
Conséquence (attendue) de #13796 : une balise de champ dont la valeur contient du HTML rend maintenant ce HTML en clair. Une réponse saisie en annotation privée comme `Monsieur,<br> <br>En réponse à votre demande…` sort sur une seule ligne, `<br>` compris.
On semble avoir plusieurs cas pas forcément isolés, ex ici https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_2198f2c4-d47a-4e71-907f-a20911c6a805/

#13796 a déplacé la substitution sur l'arbre tiptap : la valeur devient un nœud `text`, que le rendu échappe. Or les instructeurs écrivent `<br>` dans les annotations et les motivations depuis des années, quand la substitution était injectée brute.

Une suite de `<br>` devient un `hardBreak`, le reste de la valeur demeure du texte échappé. La motivation et les champs d'un bloc répétable sont couverts aussi : ils atteignent l'arbre par une présentation, pas comme une chaîne.

Surtout, la valeur n'est pas lue comme du HTML. Sur 100 024 valeurs de champs échantillonnées en production — des valeurs saisies, pas des attestations — 101 portent un `<`, et **69 ne sont pas du balisage** : `Cher <Prénom>`, `<BTS BLANC`, `100 < 200`. Un parseur HTML détruit ce texte, et l'injection brute d'avant #13796 le détruisait déjà.

| valeurs échantillonnées | avec `<` | dont non-balise | dont `<br>` | dont liste ou tableau |
|---|---|---|---|---|
| 100 024, dont 11 939 annotations | 101 | 69 | 6 | 0 |

Renoncements : un `<br>` isolé rend une ligne blanche plutôt qu'un simple retour, l'attestation rendant un `hardBreak` comme une ligne blanche depuis juillet ; et une balise réellement écrite s'imprime en clair au lieu d'être rendue, sur moins de 32 valeurs. L'échantillon ne couvre ni `dossiers.motivation` ni les enfants de répétition, qui sont hors du chemin lu par le script.

À prévoir au déploiement : les attestations sont générées une fois puis stockées, donc les dossiers acceptés depuis le 07/09 gardent leur PDF fautif. Régénération avec `Maintenance::RegenerateAttestationTask`.
