### PR TITLE
Correctif: ETQ usager, le prefill d'un référentiel reste dans sa propre répétition

### DIFF
--- a/app/models/champs/referentiel_champ.rb
+++ b/app/models/champs/referentiel_champ.rb
@@ -191,10 +191,12 @@ class Champs::ReferentielChamp < ChampData
   end
 
   def determine_row_id(repetition_type_de_champ)
-    # When referentiel champ is inside a repetition, use current row_id to keep related data together.
-    # When outside, create new rows for each array element from external data.
-    # Note: Limited to updating current row only when inside repetition.
-    if type_de_champ.child?(dossier.revision)
+    # When the referentiel champ belongs to the very repetition being prefilled, keep the data
+    # on its own row. Note: limited to updating that row only.
+    # Otherwise (root champ, or a champ of another repetition), create a new row for each array
+    # element: reusing our own row_id would write a row of our repetition into another one, where
+    # no row marker carries it — the data would be persisted but invisible to the whole app.
+    if dossier.revision.parent_of(type_de_champ) == repetition_type_de_champ
       self.row_id
     else
       dossier.repetition_add_row(repetition_type_de_champ, updated_by:)

--- a/spec/models/champs/referentiel_champ_spec.rb
+++ b/spec/models/champs/referentiel_champ_spec.rb
@@ -110,6 +110,28 @@ describe Champs::ReferentielChamp, type: :model do
       reloaded.repetition_row_ids(reloaded.find_type_de_champ_by_stable_id(stable_id))
     end
 
+    context 'when the prefill targets its own repetition' do
+      let(:prefilled_stable_id) { 102 }
+      let(:public_type_de_champs) do
+        [
+          {
+            type: :repetition, stable_id: 100, children: [
+              { type: :referentiel, stable_id: 101, referentiel:, referentiel_mapping: mapping },
+              { type: :text, stable_id: 102 },
+            ],
+          },
+        ]
+      end
+
+      it 'keeps the data on its own row, without adding one' do
+        rows_before = row_ids_of(100)
+
+        expect(prefilled.value).to eq('ACME')
+        expect(prefilled.row_id).to eq(own_row_id)
+        expect(row_ids_of(100)).to eq(rows_before)
+      end
+    end
+
     # Réutiliser son propre row_id écrirait une ligne de sa répétition dans une autre :
     # aucun marqueur de ligne ne la porterait, la donnée serait persistée mais invisible.
     context 'when a public prefill targets a private repetition' do

--- a/spec/models/champs/referentiel_champ_spec.rb
+++ b/spec/models/champs/referentiel_champ_spec.rb
@@ -93,6 +93,51 @@ describe Champs::ReferentielChamp, type: :model do
     end
   end
 
+  describe '#update_external_data! when the referentiel champ is inside a repetition' do
+    let(:mapping) { { "$.societes[0].nom" => { prefill: "1", prefill_stable_id: prefilled_stable_id } } }
+    let(:own_row_id) { dossier.repetition_add_row(dossier.find_type_de_champ_by_stable_id(100), updated_by: 'test') }
+    let(:champ_in_row) { dossier.champ_for_update(dossier.find_type_de_champ_by_stable_id(101), row_id: own_row_id, updated_by: 'test') }
+
+    before { champ_in_row }
+
+    subject(:prefilled) do
+      champ_in_row.update_external_data!(data: { societes: [{ nom: 'ACME' }] })
+      Dossier.find(dossier.id).champ_data.find { it.stable_id == prefilled_stable_id }
+    end
+
+    def row_ids_of(stable_id)
+      reloaded = Dossier.find(dossier.id)
+      reloaded.repetition_row_ids(reloaded.find_type_de_champ_by_stable_id(stable_id))
+    end
+
+    # Réutiliser son propre row_id écrirait une ligne de sa répétition dans une autre :
+    # aucun marqueur de ligne ne la porterait, la donnée serait persistée mais invisible.
+    context 'when a public prefill targets a private repetition' do
+      let(:prefilled_stable_id) { 201 }
+      let(:public_type_de_champs) do
+        [
+          {
+            type: :repetition, stable_id: 100, children: [
+              { type: :referentiel, stable_id: 101, referentiel:, referentiel_mapping: mapping },
+            ],
+          },
+        ]
+      end
+      let(:private_type_de_champs) do
+        [{ type: :repetition, stable_id: 200, children: [{ type: :text, stable_id: 201 }] }]
+      end
+      let(:procedure) { create(:procedure, public_type_de_champs:, private_type_de_champs:) }
+
+      it 'adds a row to the targeted repetition rather than reusing its own row_id' do
+        rows_before = row_ids_of(200)
+
+        expect(prefilled.value).to eq('ACME')
+        expect(prefilled.row_id).not_to eq(own_row_id)
+        expect(row_ids_of(200) - rows_before).to eq([prefilled.row_id])
+      end
+    end
+  end
+
   describe '#fetch_external_data' do
     subject { referentiel_champ.update_external_data!(data:) }
 


### PR DESCRIPTION
# Problème

Trouvé en relisant #13819 (« le champ référentiel d'une répétition interroge l'API avec les valeurs de sa ligne ») : `determine_row_id` réutilisait le `row_id` du champ référentiel dès qu'il était enfant d'une répétition, sans vérifier que la répétition préremplie était bien la sienne.

Un référentiel de la répétition A qui préremplit un champ de la répétition B écrit donc la valeur avec le `row_id` de A. Aucun marqueur de ligne ne la porte dans B : la donnée est en base, mais invisible dans le formulaire, absente de `filled_champs`, jamais validée ni exportée, et elle survit aux rebases.

**C'est défensif** : aucun cas observé en production. Mais le montage est proposé par l'éditeur — `collect_private_coordinates` ne filtre pas les cibles privées offertes à une source publique — et #13819 est ce qui rend « référentiel dans une répétition » réellement utilisable, donc ce qui promeut ce chemin latent en chemin vivant.

# Solution

Comparer le parent réel du champ à la répétition ciblée, au lieu de « suis-je enfant d'une répétition ? ». Généralisation stricte : un champ racine continue de créer une ligne par élément du tableau (`parent_of` vaut `nil`), et un champ qui préremplit sa propre répétition écrit toujours sur sa ligne.

Deux commits : le premier est la spec de reproduction, **rouge exprès** ; le second corrige et ajoute le garde-fou sur la branche conservée.

Generated with [Claude Code](https://claude.com/claude-code)