### PR TITLE
Tech : lier le cookie trust device à l'instructeur et le déposer que s'il est connecté

### DIFF
--- a/app/controllers/users/activate_controller.rb
+++ b/app/controllers/users/activate_controller.rb
@@ -29,7 +29,7 @@ class Users::ActivateController < ApplicationController
     if user.valid?
       sign_in(user, scope: :user)
 
-      trust_device(Time.zone.now) if user.instructeur.present?
+      trust_device(Time.zone.now, user.instructeur) if user.instructeur.present?
       user.update!(email_verified_at: Time.zone.now) if user.email_verified_at.nil?
 
       flash.notice = t('.password_registered')

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -39,11 +39,9 @@ class Users::SessionsController < Devise::SessionsController
       flash[:notice] = t("devise.sessions.signed_in_multiple_profile", roles: current_account.keys.map { |role| t("layouts.#{role}") }.to_sentence)
     end
 
-    # Display the trusted device renewal confirmation that was deferred when the
-    # user followed the renewal link without being signed in (see #sign_in_by_link).
-    if current_user && session[:trusted_device_renewal_notice].present?
-      flash[:notice] = session.delete(:trusted_device_renewal_notice)
-    end
+    # Complete the trusted device renewal that was deferred when the user followed
+    # the renewal link without being signed in (see #sign_in_by_link).
+    finish_pending_trusted_device_renewal
   end
 
   def reset_link_sent
@@ -117,26 +115,21 @@ class Users::SessionsController < Devise::SessionsController
 
       redirect_to root_path
     elsif trusted_device_token.token_valid?
-      trust_device(trusted_device_token.created_at, trusted_device_token)
-
-      period = ((trusted_device_token.created_at + TRUSTED_DEVICE_PERIOD) - Time.zone.now).to_i / ActiveSupport::Duration::SECONDS_PER_DAY
-
-      notice = "Votre connexion sécurisée a bien été renouvelée. Votre navigateur est authentifié pour #{period} jours."
-
       # redirect to procedure'url if stored by store_location_for(:user) in dossiers_controller
       # redirect to root_path otherwise
 
       if instructeur_signed_in?
+        trust_device(trusted_device_token.created_at, current_instructeur, trusted_device_token)
         current_user.update!(email_verified_at: Time.zone.now)
 
-        flash.notice = notice
+        flash.notice = trusted_device_renewal_notice(trusted_device_token)
         redirect_to after_sign_in_path_for(:user)
       else
-        # The renewal is already done; the user only needs to authenticate.
-        # Persist the confirmation so it is shown once signed in instead of
-        # being lost on the login page.
-        session[:trusted_device_renewal_notice] = notice
-        flash.notice = "#{notice} Connectez-vous pour accéder à vos dossiers."
+        # Never trust the browser before somebody has authenticated: only remember
+        # the validated token, and finish the renewal once the instructeur it
+        # belongs to signs in (see #finish_pending_trusted_device_renewal).
+        session[:trusted_device_token_id] = trusted_device_token.id
+        flash.notice = "Connectez-vous pour finaliser le renouvellement de votre connexion sécurisée."
         redirect_to new_user_session_path
       end
     else
@@ -161,6 +154,21 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   private
+
+  def finish_pending_trusted_device_renewal
+    token_id = session.delete(:trusted_device_token_id)
+
+    return if token_id.nil? || current_instructeur.nil?
+
+    trusted_device_token = TrustedDeviceToken.find_by(id: token_id, instructeur_id: current_instructeur.id)
+
+    return if trusted_device_token.nil? || !trusted_device_token.token_valid?
+
+    trust_device(trusted_device_token.created_at, current_instructeur, trusted_device_token)
+    current_user.update!(email_verified_at: Time.zone.now)
+
+    flash[:notice] = trusted_device_renewal_notice(trusted_device_token)
+  end
 
   def signed_email_for_instructeur(instructeur)
     message_encryptor_service.encrypt_and_sign(instructeur.email, purpose: :reset_link, expires_in: 1.hour)

--- a/app/models/concerns/trusted_device_concern.rb
+++ b/app/models/concerns/trusted_device_concern.rb
@@ -6,9 +6,9 @@ module TrustedDeviceConcern
   TRUSTED_DEVICE_COOKIE_NAME = :trusted_device
   TRUSTED_DEVICE_PERIOD = 1.month
 
-  def trust_device(start_at, trusted_device_token = nil)
+  def trust_device(start_at, instructeur, trusted_device_token = nil)
     cookies.encrypted[TRUSTED_DEVICE_COOKIE_NAME] = {
-      value: JSON.generate({ created_at: start_at }),
+      value: JSON.generate({ created_at: start_at, instructeur_id: instructeur.id }),
       expires: start_at + TRUSTED_DEVICE_PERIOD,
       httponly: true,
       secure: Rails.env.production?,
@@ -18,9 +18,28 @@ module TrustedDeviceConcern
     end
   end
 
+  # The cookie only vouches for the instructeur it was issued to: a browser trusted
+  # for one account must still go through the email link for any other account.
   def trusted_device?
-    trusted_device_cookie.present? &&
-      (Time.zone.now - TRUSTED_DEVICE_PERIOD) < trusted_device_cookie_created_at
+    payload = trusted_device_cookie_payload
+
+    return false if payload.nil? || current_instructeur.nil?
+
+    created_at = Time.zone.parse(payload['created_at'].to_s)
+
+    return false if created_at.blank? || created_at <= TRUSTED_DEVICE_PERIOD.ago
+
+    if payload['instructeur_id'].present?
+      payload['instructeur_id'] == current_instructeur.id
+    else
+      adopt_legacy_trusted_device_cookie(created_at)
+    end
+  end
+
+  def trusted_device_renewal_notice(trusted_device_token)
+    period = ((trusted_device_token.created_at + TRUSTED_DEVICE_PERIOD) - Time.zone.now).to_i / ActiveSupport::Duration::SECONDS_PER_DAY
+
+    "Votre connexion sécurisée a bien été renouvelée. Votre navigateur est authentifié pour #{period} jours."
   end
 
   def send_login_token_or_bufferize(instructeur)
@@ -35,11 +54,36 @@ module TrustedDeviceConcern
 
   private
 
-  def trusted_device_cookie_created_at
-    Time.zone.parse(JSON.parse(trusted_device_cookie)['created_at'])
+  # Cookies issued before the instructeur id was stored carry no owner, but the token
+  # activated when the cookie was written does: trust_device stamps activated_at with the
+  # very timestamp it puts in the cookie. So a legacy cookie is adopted only for the
+  # instructeur we can prove it was issued to — another instructeur signing in from the
+  # same browser finds no token of its own and still goes through the email link.
+  #
+  # Rewriting the cookie with its original created_at leaves the expiry untouched: no
+  # browser gains a fresh period, and the last legacy cookie dies one TRUSTED_DEVICE_PERIOD
+  # after this ships. The branch can be deleted then.
+  def adopt_legacy_trusted_device_cookie(created_at)
+    # The cookie only keeps whole seconds (JSON.generate serializes the time through to_s)
+    # while activated_at keeps microseconds.
+    return false if !current_instructeur.trusted_device_tokens
+      .exists?(activated_at: created_at...(created_at + 1.second))
+
+    # No token passed on purpose: activated_at is already set, and stamping it again would
+    # move the token inside TrustedDeviceToken.expiring_in_one_week and delay the renewal
+    # email sent by Cron::TrustedDeviceTokenRenewalJob.
+    trust_device(created_at, current_instructeur)
+
+    true
   end
 
-  def trusted_device_cookie
-    cookies.encrypted[TRUSTED_DEVICE_COOKIE_NAME]
+  def trusted_device_cookie_payload
+    cookie = cookies.encrypted[TRUSTED_DEVICE_COOKIE_NAME]
+
+    return if cookie.blank?
+
+    JSON.parse(cookie)
+  rescue JSON::ParserError
+    nil
   end
 end

--- a/app/models/concerns/trusted_device_concern.rb
+++ b/app/models/concerns/trusted_device_concern.rb
@@ -39,7 +39,7 @@ module TrustedDeviceConcern
   def trusted_device_renewal_notice(trusted_device_token)
     period = ((trusted_device_token.created_at + TRUSTED_DEVICE_PERIOD) - Time.zone.now).to_i / ActiveSupport::Duration::SECONDS_PER_DAY
 
-    "Votre connexion sécurisée a bien été renouvelée. Votre navigateur est authentifié pour #{period} jours."
+    t('views.users.sessions.trusted_device_renewal_notice', count: period)
   end
 
   def send_login_token_or_bufferize(instructeur)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -700,6 +700,9 @@ en:
         link_sent:
           consult_help_page_html: If you're seeing this page too often, <a target="_blank" rel="noopener noreferrer" href="%{href}">please consult our help page</a>.
           email_cta_html: "We have to validate your email address <strong>%{email}</strong>."
+        trusted_device_renewal_notice:
+          one: "Your secure connection has been renewed. Your browser is authenticated for %{count} day."
+          other: "Your secure connection has been renewed. Your browser is authenticated for %{count} days."
       passwords:
         edit:
           subtitle: Change password

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -709,6 +709,9 @@ fr:
         link_sent:
           consult_help_page_html: Si vous voyez cette page trop souvent, <a target="_blank" rel="noopener noreferrer" href="%{href}">consultez notre aide</a>.
           email_cta_html: "Nous avons besoin de vérifier votre adresse électronique <strong>%{email}</strong>."
+        trusted_device_renewal_notice:
+          one: "Votre connexion sécurisée a bien été renouvelée. Votre navigateur est authentifié pour %{count} jour."
+          other: "Votre connexion sécurisée a bien été renouvelée. Votre navigateur est authentifié pour %{count} jours."
       passwords:
         edit:
           subtitle: Changement de mot de passe

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -58,14 +58,32 @@ describe Users::SessionsController, type: :controller do
         end
       end
 
-      context 'when a trusted device renewal confirmation is pending' do
-        before { session[:trusted_device_renewal_notice] = 'Votre connexion sécurisée a bien été renouvelée.' }
+      context 'when a trusted device renewal is pending' do
+        let(:instructeur) { create(:instructeur, email: email, password: password) }
+        let(:user) { instructeur.user }
+        let(:pending_token) { instructeur.trusted_device_tokens.create }
 
-        it 'displays it after sign-in and clears it from the session' do
+        before { session[:trusted_device_token_id] = pending_token.id }
+
+        it 'completes the renewal after sign-in and clears it from the session' do
           subject
 
-          expect(flash[:notice]).to eq('Votre connexion sécurisée a bien été renouvelée.')
-          expect(session[:trusted_device_renewal_notice]).to be_nil
+          expect(controller.trusted_device?).to be true
+          expect(flash[:notice]).to include('renouvelée')
+          expect(pending_token.reload.activated_at).to be_present
+          expect(session[:trusted_device_token_id]).to be_nil
+        end
+
+        context 'when the pending token belongs to another instructeur' do
+          let(:pending_token) { create(:trusted_device_token) }
+
+          it 'does not trust the device' do
+            subject
+
+            expect(controller.trusted_device?).to be false
+            expect(pending_token.reload.activated_at).to be_nil
+            expect(session[:trusted_device_token_id]).to be_nil
+          end
         end
       end
 
@@ -274,16 +292,16 @@ describe Users::SessionsController, type: :controller do
 
       context 'when the instructeur is not logged in' do
         context 'when the token is valid' do
-          it do
+          it 'does not trust the browser before anybody authenticates' do
             is_expected.to redirect_to new_user_session_path
             expect(controller.current_instructeur).to be_nil
-            expect(controller).to have_received(:trust_device)
-            expect(TrustedDeviceToken.find_by(token: jeton).activated_at).to be_present
+            expect(controller).not_to have_received(:trust_device)
+            expect(TrustedDeviceToken.find_by(token: jeton).activated_at).to be_nil
           end
 
-          it 'persists a renewal confirmation to display after sign-in' do
-            expect(session[:trusted_device_renewal_notice]).to be_present
-            expect(flash.notice).to include('renouvelée')
+          it 'defers the renewal until the instructeur signs in' do
+            expect(session[:trusted_device_token_id]).to eq(TrustedDeviceToken.find_by(token: jeton).id)
+            expect(flash.notice).to include('Connectez-vous')
           end
         end
 
@@ -363,7 +381,11 @@ describe Users::SessionsController, type: :controller do
   end
 
   describe '#trust_device and #trusted_device?' do
+    let(:instructeur) { create(:instructeur) }
+
     subject { controller.trusted_device? }
+
+    before { sign_in(instructeur.user) }
 
     context 'when the trusted cookie is not present' do
       it { is_expected.to be false }
@@ -372,16 +394,22 @@ describe Users::SessionsController, type: :controller do
     context 'when the cookie is outdated' do
       before do
         emission_date = Time.zone.now - TrustedDeviceConcern::TRUSTED_DEVICE_PERIOD - 1.minute
-        controller.trust_device(emission_date)
+        controller.trust_device(emission_date, instructeur)
       end
 
       it { is_expected.to be false }
     end
 
     context 'when the cookie is ok' do
-      before { controller.trust_device(Time.zone.now) }
+      before { controller.trust_device(Time.zone.now, instructeur) }
 
       it { is_expected.to be true }
+    end
+
+    context 'when the cookie was issued for another instructeur' do
+      before { controller.trust_device(Time.zone.now, create(:instructeur)) }
+
+      it { is_expected.to be false }
     end
   end
 

--- a/spec/requests/trusted_device_spec.rb
+++ b/spec/requests/trusted_device_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+describe 'Trusted device (second factor by email link)', type: :request do
+  let(:password) { SECURE_PASSWORD }
+  let(:instructeur) { create(:instructeur, bypass_email_login_token: false, password:) }
+  let(:other_instructeur) { create(:instructeur, bypass_email_login_token: false, password:) }
+  let(:token) { instructeur.create_trusted_device_token }
+
+  def sign_in_with(user)
+    post user_session_path, params: { user: { email: user.email, password: } }
+  end
+
+  def sign_out!
+    delete destroy_user_session_path
+  end
+
+  def trusted_device_cookie
+    cookies[TrustedDeviceConcern::TRUSTED_DEVICE_COOKIE_NAME.to_s]
+  end
+
+  describe 'the cookie is bound to the instructeur it was issued for' do
+    before do
+      sign_in_with(instructeur.user)
+      get sign_in_by_link_path(instructeur.id, jeton: token)
+      sign_out!
+    end
+
+    it 'trusts the browser for the instructeur it was issued for' do
+      sign_in_with(instructeur.user)
+
+      get instructeur_procedures_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'still asks another instructeur signing in from the same browser for an email link' do
+      expect(trusted_device_cookie).to be_present
+
+      sign_in_with(other_instructeur.user)
+      get instructeur_procedures_path
+
+      expect(response).to redirect_to(%r{/lien-envoye})
+    end
+  end
+
+  describe 'following the link while signed out' do
+    before { get sign_in_by_link_path(instructeur.id, jeton: token) }
+
+    it 'does not trust the browser before anybody authenticates' do
+      expect(trusted_device_cookie).to be_blank
+    end
+
+    it 'does not trust the browser for an unrelated account signing in afterwards' do
+      sign_in_with(other_instructeur.user)
+
+      get instructeur_procedures_path
+
+      expect(response).to redirect_to(%r{/lien-envoye})
+    end
+
+    it 'trusts the browser once the matching instructeur signs in' do
+      sign_in_with(instructeur.user)
+
+      get instructeur_procedures_path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'a cookie issued before the instructeur id was stored' do
+    # Non zero microseconds on purpose: the cookie only keeps whole seconds, so this is
+    # what forces the token lookup to be a range rather than an equality.
+    let(:issued_at) { 2.days.ago.change(usec: 123456) }
+
+    # Replays the implementation of trust_device that wrote the cookies we now have to
+    # migrate: a payload carrying the timestamp and nothing else.
+    def issue_legacy_cookie_for(instructeur, token)
+      TrustedDeviceToken.find_by!(token:).update!(created_at: issued_at)
+
+      allow_any_instance_of(Users::SessionsController)
+        .to receive(:trust_device) do |controller, start_at, _instructeur, trusted_device_token|
+          controller.send(:cookies).encrypted[TrustedDeviceConcern::TRUSTED_DEVICE_COOKIE_NAME] = {
+            value: JSON.generate({ created_at: start_at }),
+            expires: start_at + TrustedDeviceConcern::TRUSTED_DEVICE_PERIOD,
+            httponly: true,
+          }
+          trusted_device_token&.update(activated_at: start_at)
+        end
+
+      sign_in_with(instructeur.user)
+      get sign_in_by_link_path(instructeur.id, jeton: token)
+      sign_out!
+    end
+
+    before { issue_legacy_cookie_for(instructeur, token) }
+
+    it 'trusts the browser again for the instructeur it was issued for' do
+      sign_in_with(instructeur.user)
+
+      get instructeur_procedures_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'rewrites the cookie so that the decision no longer depends on the token' do
+      sign_in_with(instructeur.user)
+      get instructeur_procedures_path
+
+      instructeur.trusted_device_tokens.destroy_all
+
+      get instructeur_procedures_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'still asks another instructeur signing in from the same browser for an email link' do
+      sign_in_with(other_instructeur.user)
+
+      get instructeur_procedures_path
+
+      expect(response).to redirect_to(%r{/lien-envoye})
+    end
+
+    it 'asks for an email link when no token can vouch for the cookie' do
+      instructeur.trusted_device_tokens.destroy_all
+
+      sign_in_with(instructeur.user)
+      get instructeur_procedures_path
+
+      expect(response).to redirect_to(%r{/lien-envoye})
+    end
+  end
+end


### PR DESCRIPTION
J'ai plus de token donc c'est moi qui rédige les descriptions de PR, c'est vachement moins bien.

Cette PR fait 3 choses :
- Le cookie trust device n’était pas lié à un instructeur précis : un cookie créé pour Alice pouvait donc potentiellement être réutilisé par Bob sur le même navigateur.
- Le cookie trust device est posé après qu'on se soit assuré que l'instructeur à qui il était destiné est connecté
- Les cookies déjà posés, qui ne contiennent pas d'instructeur, sont migrés silencieusement plutôt que rejetés, pour ne pas obliger tous les instructeurs à repasser par le lien e-mail au déploiement.

Sur la migration : `trust_device` écrit dans le cookie le même horodatage que celui qu'il pose dans l'`activated_at` du `TrustedDeviceToken`. On sait donc à qui appartient un ancien cookie, et on ne l'accepte que pour cet instructeur-là, avant de le réécrire au nouveau format en gardant sa date d'origine — donc sans prolonger la durée de confiance. Un autre instructeur sur le même navigateur ne trouve aucun token à son nom et reçoit son lien e-mail : la faille reste fermée pendant toute la migration.

Deux conséquences à connaître : les cookies posés par `ActivateController` (mot de passe (ré)initialisé) n'ont pas de token associé, ces instructeurs repasseront une fois par le lien e-mail ; et le code de compatibilité pourra être supprimé un mois après le déploiement, quand le dernier ancien cookie aura expiré.
