### PR TITLE
ETQ instructeur, les traitements par lot n'échouent plus sur « Timeout on validation of query »

### DIFF
--- a/app/controllers/api/public/v1/json_description_procedures_controller.rb
+++ b/app/controllers/api/public/v1/json_description_procedures_controller.rb
@@ -16,7 +16,7 @@ class API::Public::V1::JSONDescriptionProceduresController < API::Public::V1::Ba
   end
 
   def procedure_graph_ql_schema
-    API::V2::Schema.execute(API::V2::StoredQuery.get('ds-query-v2'),
+    API::V2::StoredQuery.execute('ds-query-v2',
       variables: {
         demarche: { "number": @procedure.id },
         includeRevision: true,

--- a/app/controllers/api/v2/graphql_controller.rb
+++ b/app/controllers/api/v2/graphql_controller.rb
@@ -6,7 +6,11 @@ class API::V2::GraphqlController < API::V2::BaseController
   around_action :profile_with_vernier, only: :execute, if: :vernier_profile_requested?
 
   def execute
-    result = API::V2::Schema.execute(query:, variables:, context:, operation_name:)
+    result = if params[:queryId].present?
+      API::V2::StoredQuery.execute(params[:queryId], variables:, context:, operation_name:)
+    else
+      API::V2::Schema.execute(params[:query], variables:, context:, operation_name:)
+    end
     @query_info = result.context.query_info
 
     rename_skylight_endpoint(result)
@@ -70,14 +74,6 @@ class API::V2::GraphqlController < API::V2::BaseController
     super
   rescue ActionDispatch::Http::Parameters::ParseError => exception
     render json: graphql_error(exception.cause.message, :bad_request), status: :bad_request
-  end
-
-  def query
-    if params[:queryId].present?
-      API::V2::StoredQuery.get(params[:queryId])
-    else
-      params[:query]
-    end
   end
 
   def variables

--- a/app/graphql/api/v2/stored_query.rb
+++ b/app/graphql/api/v2/stored_query.rb
@@ -1,6 +1,27 @@
 # frozen_string_literal: true
 
 class API::V2::StoredQuery
+  # Stored documents are ours and validated against the schema by the schema spec,
+  # so they are parsed once and executed without static validation or query
+  # analysis. graphql-ruby runs both under a wall-clock Timeout (validate_timeout,
+  # 3 s): re-validating the 65 operations of ds-query-v2 on every audit log entry
+  # ran past it under Sidekiq load and failed batch operations (RAILS-MJM).
+  def self.execute(query_id, variables:, context:, operation_name:)
+    API::V2::Schema.execute(document: document(query_id),
+      variables:,
+      context:,
+      operation_name:,
+      validate: false,
+      max_depth: nil,
+      max_complexity: nil)
+  end
+
+  def self.document(query_id)
+    DOCUMENTS.fetch(query_id) do
+      raise GraphQL::ExecutionError.new("No query with id \"#{query_id}\"", extensions: { code: :bad_request })
+    end
+  end
+
   def self.get(query_id)
     case query_id
     when 'ds-query-v2'
@@ -1344,4 +1365,10 @@ class API::V2::StoredQuery
     color
   }
   GRAPHQL
+
+  DOCUMENTS = {
+    'ds-query-v2' => GraphQL.parse(QUERY_V2),
+    'ds-mutation-v2' => GraphQL.parse(MUTATION_V2),
+    'introspection' => GraphQL.parse(GraphQL::Introspection::INTROSPECTION_QUERY),
+  }.freeze
 end

--- a/app/services/serializer_service.rb
+++ b/app/services/serializer_service.rb
@@ -60,7 +60,7 @@ class SerializerService
   end
 
   def self.execute_query(operation_name, variables)
-    result = API::V2::Schema.execute(API::V2::StoredQuery::QUERY_V2,
+    result = API::V2::StoredQuery.execute('ds-query-v2',
       variables: variables.stringify_keys,
       context: { internal_use: true },
       operation_name: operation_name)

--- a/app/services/serializer_service.rb
+++ b/app/services/serializer_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SerializerService
+  class Error < StandardError; end
+
   # Internal serialization (audit log, datagouv export) runs the public stored
   # queries so the recorded shape stays the one integrators see. File URLs are
   # transient signed links, so they are left out of what gets persisted.
@@ -14,12 +16,10 @@ class SerializerService
   }.freeze
 
   def self.dossier(dossier)
-    Sentry.with_scope do |scope|
-      scope.set_tags(dossier: dossier.id)
+    tag_scope(dossier: dossier.id)
 
-      data = execute_query('getDossier', DOSSIER_VARIABLES.merge(dossierNumber: dossier.id))
-      data && data['dossier']
-    end
+    data = execute_query('getDossier', DOSSIER_VARIABLES.merge(dossierNumber: dossier.id))
+    data && data['dossier']
   end
 
   def self.demarches_publiques(after: nil)
@@ -33,26 +33,22 @@ class SerializerService
   end
 
   def self.champ(champ)
-    Sentry.with_scope do |scope|
-      scope.set_tags(champ: champ.id)
+    tag_scope(dossier: champ.dossier_id, champ: champ.id)
 
-      if champ.private?
-        data = execute_records_query(number: champ.dossier_id, annotationId: champ.to_typed_id, includeAnnotations: true)
-        data && data['dossier']['annotations'].first
-      else
-        data = execute_records_query(number: champ.dossier_id, champId: champ.to_typed_id, includeChamps: true)
-        data && data['dossier']['champs'].first
-      end
+    if champ.private?
+      data = execute_records_query(number: champ.dossier_id, annotationId: champ.to_typed_id, includeAnnotations: true)
+      data && data['dossier']['annotations'].first
+    else
+      data = execute_records_query(number: champ.dossier_id, champId: champ.to_typed_id, includeChamps: true)
+      data && data['dossier']['champs'].first
     end
   end
 
   def self.message(commentaire)
-    Sentry.with_scope do |scope|
-      scope.set_tags(dossier: commentaire.dossier_id)
+    tag_scope(dossier: commentaire.dossier_id)
 
-      data = execute_records_query(number: commentaire.dossier_id, messageId: commentaire.to_typed_id, includeMessages: true)
-      data && data['dossier']["messages"].first
-    end
+    data = execute_records_query(number: commentaire.dossier_id, messageId: commentaire.to_typed_id, includeMessages: true)
+    data && data['dossier']["messages"].first
   end
 
   def self.execute_records_query(number:, **variables)
@@ -65,10 +61,16 @@ class SerializerService
       context: { internal_use: true },
       operation_name: operation_name)
     if result['errors'].present?
-      error_message = result['errors'].first['message']
-      Sentry.capture_message("SerializerService execute_query failed: " + error_message)
-      raise error_message
+      raise Error, result['errors'].first['message']
     end
     result['data']
+  end
+
+  # The tags go on the current scope, which sentry-rails and sentry-sidekiq reset
+  # per request and per job: a failure raised out of here is reported once, by the
+  # request or the job that fails on it, and still carries the record being
+  # serialized. A capture in a with_scope block would report it a second time.
+  def self.tag_scope(**tags)
+    Sentry.configure_scope { it.set_tags(**tags) }
   end
 end

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -181,6 +181,20 @@ describe API::V2::GraphqlController do
       }
     end
 
+    # Stored documents are parsed once and executed without static validation, so a
+    # request does not depend on graphql-ruby's wall-clock validate_timeout.
+    context 'static validation budget' do
+      let(:variables) { { dossierNumber: dossier.id } }
+      let(:operation_name) { 'getDossier' }
+
+      before { allow(API::V2::Schema).to receive(:validate_timeout).and_return(0.001) }
+
+      it {
+        expect(gql_errors).to be_nil
+        expect(gql_data[:dossier][:id]).to eq(dossier.to_typed_id)
+      }
+    end
+
     context 'getDossier' do
       let(:variables) { { dossierNumber: dossier.id } }
       let(:operation_name) { 'getDossier' }

--- a/spec/services/serializer_service_spec.rb
+++ b/spec/services/serializer_service_spec.rb
@@ -67,4 +67,18 @@ describe SerializerService do
       expect(SerializerService.dossier(dossiers.en_construction)).to include("number" => dossiers.en_construction.id)
     end
   end
+  describe "error reporting" do
+    let(:dossier) { dossiers.en_construction }
+
+    before { allow(API::V2::StoredQuery).to receive(:execute).and_return({ "errors" => [{ "message" => "boom" }] }) }
+    after { Sentry.get_current_scope.clear }
+
+    it "raises once, tagged with the dossier, instead of capturing a message on top of the raise" do
+      expect(Sentry).not_to receive(:capture_message)
+      expect(Sentry).not_to receive(:capture_exception)
+
+      expect { SerializerService.dossier(dossier) }.to raise_error(SerializerService::Error, "boom")
+      expect(Sentry.get_current_scope.tags).to include(dossier: dossier.id)
+    end
+  end
 end

--- a/spec/services/serializer_service_spec.rb
+++ b/spec/services/serializer_service_spec.rb
@@ -55,4 +55,16 @@ describe SerializerService do
       end
     end
   end
+
+  describe "execute_query" do
+    # graphql-ruby wraps static validation in a wall-clock Timeout (validate_timeout, 3 s).
+    # Re-validating the whole stored document on every audit log entry ran past that budget
+    # under Sidekiq load, and batch operations failed (RAILS-MJM). The document is our own,
+    # validated by spec/graphql/api/v2/schema_spec.rb, so it is executed without static validation.
+    it "does not depend on static validation finishing within validate_timeout" do
+      allow(API::V2::Schema).to receive(:validate_timeout).and_return(0.001)
+
+      expect(SerializerService.dossier(dossiers.en_construction)).to include("number" => dossiers.en_construction.id)
+    end
+  end
 end


### PR DESCRIPTION
Depuis le déploiement du 8 septembre, les traitements par lot échouent massivement avec « Timeout on validation of query » (RAILS-MJM/MJK, ≈ 1 200 événements et 40 instructeurs en 24 h), et l'export data.gouv rencontre la même erreur (RAILS-MK4/MK3).

## Cause

Depuis #13760, `SerializerService` exécute le document complet `ds-query-v2` (65 opérations et fragments) pour chaque entrée du journal d'opérations. graphql-ruby re-parse et re-valide tout le document à chaque exécution, et enchaîne validation et analyse de la requête sous un `Timeout` **horloge murale** de 3 s (`validate_timeout`). Sous charge Sidekiq, ce budget est dépassé et le dossier du lot échoue.

Mesuré localement à chaud : ≈ 25 ms de CPU par exécution pour parser et valider le document (≈ 500 ms à froid). Le coût est inutile : le document est une constante à nous, validée contre le schéma par `spec/graphql/api/v2/schema_spec.rb`.

## Trois commits

1. **`StoredQuery.execute`** parse les documents stockés une fois (`DOCUMENTS`) et les exécute avec `validate: false` et sans analyseurs de profondeur/complexité ; `SerializerService` passe par là. `validate: false` seul ne suffit pas : graphql-ruby fait encore tourner les analyseurs sous le reliquat du même `Timeout`, avec le même message. Le plafond d'exécution interne de 5 minutes (`API::V2::Schema::Timeout`) reste en place, et les erreurs de variables sont toujours remontées. La spec force `validate_timeout` à 1 ms et vérifie que la sérialisation aboutit ; elle échoue sans le correctif.
2. **Une seule remontée par échec.** `execute_query` capturait un message Sentry puis levait le même message, d'où les paires `MJK`/`MJM`, `MK6`/`MK7`, `MK3`/`MK4`. Le message servait à porter le tag `dossier` posé dans un `with_scope`, que le `raise` laissait derrière lui. Les tags sont désormais posés sur le scope courant, que sentry-rails et sentry-sidekiq réinitialisent par requête et par job : l'échec est remonté une fois, par la requête ou le job qui échoue dessus, avec son tag. L'erreur devient une `SerializerService::Error`.
3. **L'API publique** re-parsait et re-validait le même document à chaque requête `queryId` (≈ 25 ms par appel) : les requêtes, mutations et l'introspection stockées passent par `StoredQuery.execute`, ainsi que la description JSON des démarches. Seul changement de comportement : un `first` trop grand sur une requête stockée est borné par `default_max_page_size` (100) au lieu d'être rejeté par l'analyse de complexité, qui n'a de sens que pour un document écrit par le client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)