### PR TITLE
ETQ instructeur, un dossier qui ne peut pas changer d’état dans un traitement par lot est signalé sans faire échouer le job

### DIFF
--- a/app/jobs/batch_operation_process_one_job.rb
+++ b/app/jobs/batch_operation_process_one_job.rb
@@ -20,7 +20,9 @@ class BatchOperationProcessOneJob < ApplicationJob
         end
         batch_operation.track_processed_dossier(false, dossier, error_message)
       end
-      raise error
+      # A failed guard (annotations privées, SIRET dégradé, correction en attente)
+      # is a per-dossier failure already reported to the instructeur, not a job failure.
+      raise error unless error.is_a?(AASM::InvalidTransition)
     ensure
       batch_operation.finalize_if_complete!
     end
@@ -48,6 +50,8 @@ class BatchOperationProcessOneJob < ApplicationJob
       I18n.t('instructeurs.dossiers.aasm_error_etablissement_as_degraded_mode', state: dossier_display_state(target_state))
     elsif exception.failures.include?(:can_terminer?) && !dossier.champs_private_valid?
       I18n.t('instructeurs.dossiers.aasm_error_annotations_no_url')
+    elsif exception.failures.include?(:can_passer_en_instruction?) && dossier.blocked_with_pending_correction?
+      I18n.t('instructeurs.dossiers.aasm_error_pending_correction')
     else
       I18n.t('instructeurs.dossiers.aasm_error_other', originating_state: dossier_display_state(exception.originating_state), target_state: dossier_display_state(target_state))
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1072,6 +1072,7 @@ en:
       aasm_error_etablissement_as_degraded_mode: "The SIRET data for this folder could not yet be verified: it is not possible to change it to %{state}."
       aasm_error_annotations_no_url: The private annotations have not been filled in correctly; they are essential to make a decision.
       aasm_error_annotations: The private annotations have not been filled in correctly; they are essential to make a decision. <a href="%{url}">Edit annotations</a>.
+      aasm_error_pending_correction: The folder is awaiting a correction from the user; it is not possible to change it to in instruction.
       aasm_error_other: "The folder is currently %{originating_state}: it is not possible to change it to %{target_state}."
       alert_error_annotations_html: 'The following private annotations <strong>were not filled out correctly</strong> and are <strong>necessary</strong> to make a decision on the file <span aria-hidden="true">:</span>'
       alert_error_annotations_link: Complete the private annotations

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1075,6 +1075,7 @@ fr:
       aasm_error_etablissement_as_degraded_mode: "Les données relatives au SIRET de ce dossier n’ont pas pu encore être vérifiées : il n’est pas possible de le passer en %{state}."
       aasm_error_annotations_no_url: Les annotations privées n’ont pas été correctement renseignées, elles sont indispensables pour rendre une décision.
       aasm_error_annotations: Les annotations privées n’ont pas été correctement renseignées, elles sont indispensables pour rendre une décision. <a href="%{url}">Modifier les annotations</a>.
+      aasm_error_pending_correction: Le dossier est en attente de correction par l’usager, il n’est pas possible de le passer en instruction.
       aasm_error_other: "Le dossier est en ce moment %{originating_state} : il n’est pas possible de le passer %{target_state}."
       alert_error_annotations_html: 'Les annotations privées suivantes <strong>n’ont pas été correctement renseignées</strong> et sont <strong>indispensables</strong> pour rendre une décision sur le dossier <span aria-hidden="true">:</span>'
       alert_error_annotations_link: Compléter les annotations privées

--- a/spec/jobs/batch_operation_process_one_job_spec.rb
+++ b/spec/jobs/batch_operation_process_one_job_spec.rb
@@ -356,9 +356,26 @@ describe BatchOperationProcessOneJob, type: :job do
         allow_any_instance_of(Dossier).to receive(:any_etablissement_as_degraded_mode?).and_return(false)
       end
 
-      it 'stores a human readable error message' do
-        expect { subject.perform_now }.to raise_error(AASM::InvalidTransition)
+      it 'stores a human readable error message without failing the job' do
+        expect { subject.perform_now }.not_to raise_error
         expect(batch_operation.dossier_operations.error.first.error_message).to include("annotations privées")
+      end
+    end
+
+    context 'when operation is "passer_en_instruction" and the dossier awaits a correction' do
+      let(:batch_operation) do
+        create(:batch_operation, :passer_en_instruction,
+               options.merge(instructeur: create(:instructeur)))
+      end
+
+      before do
+        allow_any_instance_of(Dossier).to receive(:blocked_with_pending_correction?).and_return(true)
+      end
+
+      it 'stores a human readable error message without failing the job' do
+        expect { subject.perform_now }.not_to raise_error
+        expect(batch_operation.dossier_operations.error.first.error_message).to include("attente de correction")
+        expect(dossier_job.reload).to be_en_construction
       end
     end
 
@@ -372,8 +389,8 @@ describe BatchOperationProcessOneJob, type: :job do
         allow_any_instance_of(Dossier).to receive(:any_etablissement_as_degraded_mode?).and_return(true)
       end
 
-      it 'stores a human readable error message' do
-        expect { subject.perform_now }.to raise_error(AASM::InvalidTransition)
+      it 'stores a human readable error message without failing the job' do
+        expect { subject.perform_now }.not_to raise_error
         expect(batch_operation.dossier_operations.error.first.error_message).to include("SIRET")
       end
     end


### PR DESCRIPTION
## Contexte

Quand un dossier d'un traitement par lot ne passe pas la garde de la transition (annotations privées non renseignées, SIRET en mode dégradé, correction en attente), le job enregistre déjà un message lisible sur le `DossierBatchOperation` et l'instructeur le voit dans l'alerte du lot. Mais le job relançait ensuite l'exception : un cas attendu devenait un échec Sidekiq et un événement Sentry par dossier (`RAILS-J89`/`J8G`/`J8H`/`KHR`, ≈ 600 événements depuis janvier).

## Changements

- `BatchOperationProcessOneJob` ne relance plus `AASM::InvalidTransition` une fois l'échec enregistré sur le dossier. Les autres erreurs sont toujours relancées.
- Le cas « correction en attente » a son propre message au lieu du générique « le dossier est en construction : il n'est pas possible de le passer en instruction », qui se lisait comme une contradiction.

Ref #13816

🤖 Generated with [Claude Code](https://claude.com/claude-code)