### PR TITLE
ETQ instructeur, un dossier invalide en base ne bloque plus le lancement d’un traitement par lot (ni son transfert par l’usager)

### DIFF
--- a/app/models/batch_operation.rb
+++ b/app/models/batch_operation.rb
@@ -21,7 +21,11 @@ class BatchOperation < ApplicationRecord
     restaurer_repousser_expiration: 'restaurer_repousser_expiration',
   }
 
-  has_many :dossiers, dependent: :nullify
+  # autosave: attaching a dossier must not re-validate it. Without it Rails
+  # ignores a persisted dossier's own errors when validating the batch, then
+  # saves the dossier with validation on and fails the whole batch on a
+  # dossier that is invalid at rest (missing individual, blank mandataire…).
+  has_many :dossiers, dependent: :nullify, autosave: true
   has_many :dossier_operations, class_name: 'DossierBatchOperation', dependent: :destroy
   has_many :groupe_instructeurs, through: :dossier_operations
   belongs_to :instructeur

--- a/app/models/dossier_transfer.rb
+++ b/app/models/dossier_transfer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class DossierTransfer < ApplicationRecord
-  has_many :dossiers, dependent: :nullify
+  # autosave: attaching a dossier must not re-validate it (see BatchOperation).
+  has_many :dossiers, dependent: :nullify, autosave: true
 
   EXPIRATION_LIMIT = 2.weeks
 

--- a/spec/models/batch_operation_spec.rb
+++ b/spec/models/batch_operation_spec.rb
@@ -271,6 +271,17 @@ describe BatchOperation, type: :model do
         expect(subject.dossiers).not_to include(dossier)
       end
     end
+
+    context 'with a dossier that is invalid at rest' do
+      let(:dossier) { dossiers.accepte }
+
+      before { Individual.where(dossier:).delete_all }
+
+      it 'still attaches the dossier to the batch' do
+        expect(subject.dossiers).to include(dossier)
+        expect(dossier.reload.batch_operation).to eq(subject)
+      end
+    end
   end
 
   describe '#process_one' do

--- a/spec/models/dossier_transfer_spec.rb
+++ b/spec/models/dossier_transfer_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe DossierTransfer, type: :model do
       expect(dossier.transfer_logs.count).to eq(0)
     end
 
+    context 'with a dossier that is invalid at rest' do
+      # a fresh instance, so the missing individual is discovered by validation
+      let(:dossier) { Dossier.find(dossiers.brouillon.id) }
+
+      before { Individual.where(dossier:).delete_all }
+
+      it 'still attaches the dossier to the transfer' do
+        expect(subject).to be_persisted
+        expect(dossier.reload.transfer).to eq(subject)
+      end
+    end
+
     describe 'accept' do
       let(:transfer_log) { dossier.transfer_logs.first }
 


### PR DESCRIPTION
## Contexte

`RAILS-M9F` (lancement d'un lot, 34 événements, 11 instructeurs) et `RAILS-M9E` (transfert d'un dossier, 14 événements, 9 usagers) : « La validation a échoué : Le champ « Dossiers » n'est pas valide ».

Les deux passent par `has_many :dossiers`. Rails valide le parent avec indulgence : un dossier déjà en base, non modifié, mais invalide au repos (individual manquant, `for_tiers` sans nom de mandataire…) ne rend pas le parent invalide, donc `valid?` passe. L'autosave enregistre ensuite le dossier **avec** validation, qui échoue : 422 pour l'instructeur (le lot ne part pas du tout, un même instructeur a réessayé 8 fois le 6 août) et pour l'usager. Depuis la page profil, « transférer tous mes dossiers » échoue silencieusement : le transfert n'est jamais créé.

Reproduit localement à l'identique (même frame `save_collection_association`) en supprimant l'individual d'un dossier sans toucher l'objet.

## Changements

- `BatchOperation` et `DossierTransfer` : `has_many :dossiers, autosave: true`. Rattacher un dossier n'écrit que la clé étrangère, il est enregistré sans validation. Les transitions du dossier continuent de valider ce dont elles ont besoin.
- Specs de non-régression sur `safe_create!` et `initiate` avec un dossier invalide au repos.

Ref #13816

🤖 Generated with [Claude Code](https://claude.com/claude-code)