### PR TITLE
Tech: sandbox des décodeurs (1/3) — la brique SandboxedCommand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,10 +166,15 @@ jobs:
 
       - name: Install build dependancies
         # - libvips-dev for image variant processing
+        # - libvips-tools for the vips binaries the bwrap sandbox needs
         # - fonts for watermark text rendering
         # - rust for YJIT support
         # - poppler-utils for pdf previews
-        run: sudo apt-get update && sudo apt-get install -y libvips-dev gsfonts rustc poppler-utils
+        # - bubblewrap to isolate the decoders
+        run: sudo apt-get update && sudo apt-get install -y libvips-dev libvips-tools gsfonts rustc poppler-utils bubblewrap
+
+      - name: Allow unprivileged user namespaces for the bwrap sandbox
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Run tests
         run: |

--- a/app/lib/sandboxed_command.rb
+++ b/app/lib/sandboxed_command.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "open3"
+
+# This file defines SandboxedCommand.run, which uses bwrap to ... sandbox a command.
+# The sandbox provides:
+# - isolation: no network, no environment, no privileges, no caps, no chips
+# - the input file read-only and, when asked, one writable output
+# - 60 s of CPU, 4 GB of memory, a 100 MB tmpfs and 1 GB per written file
+# - a minimal file hierarchy, with the shared libraries
+module SandboxedCommand
+  class WrapperFailed < StandardError; end
+
+  ENABLED = ENV.enabled?("BWRAP_ISOLATION")
+
+  BWRAP = "/usr/bin/bwrap"
+  PRLIMIT = "/usr/bin/prlimit"
+
+  # Address space, not resident memory: it is what the kernel refuses at allocation
+  # time. A 64 megapixel decode allocates 17 MB and reserves close to a gigabyte, so
+  # the ceiling has to sit far above what it actually uses.
+  MAX_ADDRESS_SPACE = 4.gigabytes
+  MAX_CPU_SECONDS = 60
+  MAX_FILE_SIZE = 1.gigabyte
+  MAX_TMPFS_SIZE = 100.megabytes
+
+  LIMITS = ["--as=#{MAX_ADDRESS_SPACE}", "--cpu=#{MAX_CPU_SECONDS}", "--fsize=#{MAX_FILE_SIZE}"].freeze
+
+  ISOLATION = [
+    "--unshare-all",     # no network: the loopback interface is all that remains
+    "--clearenv",        # no secrets, no credentials, no configuration
+    "--new-session",     # detach from the controlling terminal (TIOCSTI injection)
+    "--disable-userns",  # a compromised decoder cannot nest a sandbox of its own
+    "--unshare-user",    # required by --disable-userns, and fails where -try degrades
+    "--die-with-parent",
+    "--cap-drop", "ALL",
+    "--uid", "10000",
+    "--gid", "10000",
+    "--hostname", "rails_sandbox",
+    "--size", MAX_TMPFS_SIZE.to_s, # caps the --tmpfs
+    "--tmpfs", "/tmp",
+    "--chdir", "/",
+    "--setenv", "XDG_CACHE_HOME", "/tmp",
+  ].freeze
+
+  # /lib64 holds the ELF interpreter, which Debian symlinks into /lib/x86_64-linux-gnu,
+  # while a merged-usr loader searches /usr/lib alone: all three, or one host fails.
+  LIBRARIES = ["/lib", "/lib64", "/usr/lib"].freeze
+
+  class << self
+    def run(argv, readable: [], writable: [], env: {})
+      output, error, status = Open3.capture3(*wrapped_argv(argv, readable:, writable:, env:))
+      # A tool quotes back the path it failed on, and the path carries the upload's name:
+      # bytes that are not UTF-8 would make strip and match? raise, in place of the error.
+      output = output.scrub
+      error = error.scrub
+
+      raise WrapperFailed, error.strip if wrapper_failed?(error)
+
+      [output, error, status]
+    end
+
+    def wrapped_argv(argv, readable: [], writable: [], env: {})
+      prlimit(bwrap(argv, readable:, writable:, env:))
+    end
+
+    def ensure_usable!
+      raise "#{BWRAP} is missing, install the bubblewrap package" if !File.executable?(BWRAP)
+      raise "#{PRLIMIT} is missing, install the util-linux package" if !File.executable?(PRLIMIT)
+
+      _, error, status = Open3.capture3(*wrapped_argv(["/usr/bin/true"]))
+
+      raise "the sandbox will not start: #{error.strip}" if !status.success?
+    end
+
+    # Both wrappers prefix their errors
+    def wrapper_failed?(output) = output.match?(/(bwrap|prlimit): /)
+
+    # bwrap reports a child the kernel killed as an exit of 128 + the signal — the shell
+    # convention, so a status read as it is says "exit 137" and never "SIGKILL". Named
+    # here, for the message a decoder's death ends up in — the out-of-memory kill above
+    # all. A convention: a decoder choosing to exit 130 on its own would read as SIGINT.
+    def status_message(status)
+      return status.to_s if status.signaled?
+
+      signal = Signal.signame(status.exitstatus - 128) if status.exitstatus > 128
+      signal ? "exit #{status.exitstatus}, SIG#{signal}" : "exit #{status.exitstatus}"
+    end
+
+    private
+
+    # the command must be an absolute path,  it is bound read-only
+    # a bare name is left to libc's default PATH=/bin:/usr/bin, where nothing else is
+    def bwrap(argv, readable: [], writable: [], env: {})
+      # --remount-ro / comes last, no other mounting is possible after.
+      [BWRAP, *ISOLATION, *env_args(env), *readable_args([*LIBRARIES, argv.first, *readable]), *writable_args(writable), "--remount-ro", "/", "--", *argv]
+    end
+
+    def prlimit(argv) = [PRLIMIT, *LIMITS, "--", *argv]
+
+    def readable_args(paths) = paths.flat_map { ["--ro-bind", it, it] }
+
+    def writable_args(paths) = paths.flat_map { ["--bind", it, it] }
+
+    def env_args(env) = env.flat_map { |name, value| ["--setenv", name, value.to_s] }
+  end
+end

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -296,6 +296,11 @@ PROMETHEUS_EXPORTER_BIND="127.0.0.1"
 PROMETHEUS_EXPORTER_PORT="9394"
 PROMETHEUS_EXPORTER_ENABLED="disabled"
 
+# Run the image decoders — libvips, pdftoppm, ffmpeg — in a throwaway namespace
+# instead of in the worker's own process. Requires bubblewrap and libvips-tools on
+# the machine, and unprivileged user namespaces.
+BWRAP_ISOLATION="disabled"
+
 # Setup log level, info if nil
 # can be debug, info, warn, error, fatal, and unknown
 DS_LOG_LEVEL='info'

--- a/spec/lib/sandboxed_command_spec.rb
+++ b/spec/lib/sandboxed_command_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+describe SandboxedCommand, :external_deps do
+  # Asserts on what the sandbox actually denies rather than on the flags we passed:
+  # the argv is a means, the confinement is the contract. Both streams, since a denial
+  # is announced on stderr and the output it was denied would have been on stdout.
+  # The sandbox binds the command it runs and nothing else, so a spec that shells out to
+  # a second binary declares that one itself.
+  def run(argv, readable: [], writable: [], env: {})
+    output, error, _ = described_class.run(argv, readable:, writable:, env:)
+
+    output + error
+  end
+
+  # The rest of this file skips when bubblewrap is missing, which on CI would quietly
+  # retire the whole sandbox from the suite. It is also what an application asked to
+  # isolate its decoders checks at boot before refusing to start.
+  it "is usable wherever the suite provisions it" do
+    skip "bubblewrap is provisioned on CI, not necessarily on a workstation" if ENV["CI"] != "true"
+
+    expect { described_class.ensure_usable! }.not_to raise_error
+  end
+
+  context "when bwrap is usable", if: SANDBOX_USABLE do
+    # ensure_usable! runs the wrapper the way run does, prlimit included: a limit the host
+    # will not grant — a systemd hard limit below what prlimit asks for — fails the boot,
+    # not the first decode. A one-byte address space stands in for it here.
+    it "refuses to start under limits nothing can run under" do
+      stub_const("SandboxedCommand::LIMITS", ["--as=1"])
+
+      expect { described_class.ensure_usable! }.to raise_error(RuntimeError, /\Athe sandbox will not start/)
+    end
+
+    # A tool quotes back the path it failed on, and the path carries the upload's name:
+    # bytes that are not UTF-8 in it must not turn one error into another.
+    # bwrap turns a signal into an exit of 128 + its number: the name is put back for
+    # the message, since "exit 137" says nothing to whoever reads Sentry.
+    it "names the signal a killed command died of" do
+      _, _, status = described_class.run(["/bin/sh", "-c", "kill -9 $$"])
+
+      expect(described_class.status_message(status)).to eq("exit 137, SIGKILL")
+    end
+
+    it "reports a plain failure as its exit code" do
+      _, _, status = described_class.run(["/bin/sh", "-c", "exit 3"])
+
+      expect(described_class.status_message(status)).to eq("exit 3")
+    end
+
+    # 128 is signal zero, which Signal.signame calls "EXIT": not a death.
+    it "does not read 128 as a signal" do
+      _, _, status = described_class.run(["/bin/sh", "-c", "exit 128"])
+
+      expect(described_class.status_message(status)).to eq("exit 128")
+    end
+
+    it "hands back what a command printed, even where it is not UTF-8" do
+      expect(run(["/bin/cat", "/nowhere/\xFF".b])).to include("No such file or directory")
+    end
+
+    let(:input) { Tempfile.new(["input", ".txt"]).tap { it.write("readable"); it.flush } }
+
+    after { input.close! }
+
+    it "runs the command and returns its output" do
+      expect(run(["/bin/echo", "hello"])).to eq("hello\n")
+    end
+
+    # At its own path, so the command line the caller built stays valid inside.
+    it "reads what the caller declared readable" do
+      expect(run(["/bin/cat", input.path], readable: [input.path])).to eq("readable")
+    end
+
+    it "hides a file the caller did not declare, even when the argv names it" do
+      expect(run(["/bin/cat", input.path])).to include("No such file or directory")
+    end
+
+    it "passes on nothing of the environment but what it sets itself" do
+      environment = run(["/usr/bin/env"]).lines.to_h { it.chomp.split("=", 2) }
+
+      expect(environment).to eq("XDG_CACHE_HOME" => "/tmp", "PWD" => "/")
+    end
+
+    it "hands the decoder its own configuration through env:" do
+      expect(run(["/usr/bin/env"], env: { "VIPS_BLOCK_UNTRUSTED" => "1" })).to include("VIPS_BLOCK_UNTRUSTED=1")
+    end
+
+    it "hides files the argv does not name" do
+      expect(run(["/bin/sh", "-c", "/usr/bin/cat /etc/passwd"], readable: ["/usr/bin/cat"])).to include("No such file or directory")
+    end
+
+    it "hides the home directory" do
+      expect(run(["/bin/sh", "-c", "/usr/bin/ls /home"], readable: ["/usr/bin/ls"])).to include("No such file or directory")
+    end
+
+    it "refuses writes outside the output directory" do
+      expect(run(["/bin/sh", "-c", "echo produced > /usr/pwned"])).to include("Read-only file system")
+    end
+
+    # Asserted as the command sees them, since that is what stops a runaway decoder —
+    # ulimit reports the address space in kilobytes, the cpu time in seconds, a file's
+    # size in 512-byte blocks.
+    it "bounds what the command may allocate, how long it may compute and what it may write" do
+      expect(run(["/bin/sh", "-c", "ulimit -v; ulimit -t; ulimit -f"]).split).to eq(["4194304", "60", "2097152"])
+    end
+
+    it "hides the name of the host" do
+      expect(run(["/usr/bin/uname", "-n"])).to eq("rails_sandbox\n")
+    end
+
+    it "leaves no network interface but the loopback" do
+      ip = ["/usr/bin/ip", "/bin/ip", "/usr/sbin/ip", "/sbin/ip"].find { File.executable?(it) }
+
+      interfaces = run([ip, "-o", "link"]).lines.map { it.split(":")[1].strip }
+
+      expect(interfaces).to eq(["lo"])
+    end
+
+    it "writes into the output directory when one is given" do
+      Dir.mktmpdir do |output|
+        run(["/bin/sh", "-c", "echo produced > #{output}/out.txt"], writable: [output])
+
+        expect(File.read("#{output}/out.txt")).to eq("produced\n")
+      end
+    end
+
+    # Asserted on the directory rather than on what the shell says about it: a failed
+    # redirection reads "No such file or directory" under bash and "Directory
+    # nonexistent" under dash, and what matters is that nothing was written.
+    it "refuses writes to the output directory when none is given" do
+      Dir.mktmpdir do |output|
+        run(["/bin/sh", "-c", "echo produced > #{output}/out.txt"])
+
+        expect(File).not_to exist("#{output}/out.txt")
+      end
+    end
+  end
+end

--- a/spec/support/sandbox.rb
+++ b/spec/support/sandbox.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# The sandbox specs run where the sandbox starts — CI, and the workstations that can —
+# and skip where it does not, rather than failing on a machine that never claimed to
+# isolate anything. Asked once: the check builds a sandbox, which costs a fork.
+SANDBOX_USABLE =
+  begin
+    SandboxedCommand.ensure_usable!
+    true
+  rescue RuntimeError => error
+    # Said out loud rather than raised: a workstation may carry bubblewrap (flatpak pulls
+    # it in) under a kernel that refuses it user namespaces, and that is no reason to
+    # lose the whole suite. CI, which provisions the sandbox, has a spec that fails.
+    warn "sandbox specs skipped: #{error.message}"
+    false
+  end


### PR DESCRIPTION
**1/3 d'une pile.** Base : `main`. Suite : PR2 #13854 (libvips et `BlobProcessorJob`), puis PR3 #13855 (previews et variants).

### TL;DR

```ruby
SandboxedCommand.run(
  ['/bin/ls', '/'],  # le binaire qui sera monte en executable, puis ses args
  readable: [],      # ce qui sera monté en lecture
  writable: [],      # en écriture
  env: {}            # les variables d'env
)
=> ["bin\nlib\nlib64\ntmp\nusr\n", "", #<Process::Status: pid 828969 exit 0>]
```

En très gros : ça lance un binaire dans un bac à sable dont on espère qu'il est en acier trempé.

### En plus long

Les décodeurs auxquels on confie des octets envoyés par les usagers — `pdftoppm`, `ffmpeg`, libvips — tournent aujourd'hui dans le processus du worker, celui qui détient la connexion à la base, les identifiants du stockage objet et l'environnement.

Cette PR pose la brique qui permettra de les faire tourner ailleurs : `SandboxedCommand` réécrit un argv pour l'exécuter dans un namespace jetable (bubblewrap), sans réseau, sans environnement, sans capacités, et sans rien du système de fichiers hormis le binaire lancé, le fichier d'entrée et, si besoin, un fichier de sortie. Le tout sous un plafond de mémoire et de temps CPU (`prlimit`), pour qu'un décodeur qui s'emballe s'arrête lui-même plutôt que la machine.

**Rien ne l'appelle encore.** `BWRAP_ISOLATION` est la variable qui le demandera, machine par machine ; elle est lue ici pour que les briques suivantes sachent de quel côté elles décodent. Cette PR seule ne change donc aucun comportement.

### Pour la relecture

- Les specs assertent ce que la sandbox **refuse** plutôt que les options passées : l'argv est un moyen, le confinement est le contrat.
- Elles ne tournent que là où bubblewrap est provisionné, et se skippent ailleurs avec un message. Un exemple échoue sur la CI si la sandbox n'y démarre pas, pour qu'une régression ne se traduise pas par une suite verte et vide.
- La CI installe `bubblewrap` et lève `apparmor_restrict_unprivileged_userns` — acceptable sur un runner qui vit dix minutes, et seulement là ; `DEPLOYMENT` (PR suivante) dit pourquoi il ne faut pas le faire ailleurs.
