### PR TITLE
Tech: retire le feature flag `usager_dossiers_alert_filters`

### DIFF
--- a/app/components/dossiers/user_filter_panel_form_component.rb
+++ b/app/components/dossiers/user_filter_panel_form_component.rb
@@ -37,10 +37,6 @@ class Dossiers::UserFilterPanelFormComponent < ApplicationComponent
     Users::DossierFilterService::ALERT_SCOPES.keys
   end
 
-  def alerts_enabled?
-    filter.alerts_enabled?
-  end
-
   def apply_disabled?
     filter.total_count.zero?
   end

--- a/app/components/dossiers/user_filter_panel_form_component/user_filter_panel_form_component.html.erb
+++ b/app/components/dossiers/user_filter_panel_form_component/user_filter_panel_form_component.html.erb
@@ -52,26 +52,24 @@
     <% end %>
   </fieldset>
 
-  <% if alerts_enabled? %>
-    <fieldset class="fr-fieldset">
-      <legend class="fr-fieldset__legend">
-        <%= t('.groups.alert') %>
-      </legend>
+  <fieldset class="fr-fieldset">
+    <legend class="fr-fieldset__legend">
+      <%= t('.groups.alert') %>
+    </legend>
 
-      <% alert_keys.each do |a| %>
-        <div class="fr-fieldset__element">
-          <div class="fr-checkbox-group">
-            <%= check_box_tag 'alert[]', a, alert_checked?(a), id: "alert_#{a}", data: { action: 'change->filter-preview#preview' } %>
+    <% alert_keys.each do |a| %>
+      <div class="fr-fieldset__element">
+        <div class="fr-checkbox-group">
+          <%= check_box_tag 'alert[]', a, alert_checked?(a), id: "alert_#{a}", data: { action: 'change->filter-preview#preview' } %>
 
-            <label class="fr-label" for="alert_<%= a %>">
-              <%= alert_label(a) %>
-              <%= labeled_count(filter.counts[:alerts][a]) %>
-            </label>
-          </div>
+          <label class="fr-label" for="alert_<%= a %>">
+            <%= alert_label(a) %>
+            <%= labeled_count(filter.counts[:alerts][a]) %>
+          </label>
         </div>
-      <% end %>
-    </fieldset>
-  <% end %>
+      </div>
+    <% end %>
+  </fieldset>
 
   <fieldset class="fr-fieldset">
     <div class="fr-fieldset__element">

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -131,8 +131,6 @@ module DossierHelper
   end
 
   def show_new_message_notification?(dossier)
-    return false unless current_user.dossiers_alerts_enabled?
-
     # Le badge « nouveau message » passe derrière « à corriger » et « en attente
     # de réponse » : on n'affiche qu'un seul badge de type messagerie à la fois.
     return false if dossier.pending_correction? || dossier.pending_response?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -243,10 +243,6 @@ class User < ApplicationRecord
     expert.present?
   end
 
-  def dossiers_alerts_enabled?
-    Flipper.enabled?(:usager_dossiers_alert_filters, self)
-  end
-
   def crisp_segments
     segments = []
     segments << 'administrateur' if administrateur?

--- a/app/services/users/dossier_filter_service.rb
+++ b/app/services/users/dossier_filter_service.rb
@@ -84,11 +84,6 @@ module Users
       @user.dossiers_invites.visible_by_user.exists?
     end
 
-    def alerts_enabled?
-      return @alerts_enabled if defined?(@alerts_enabled)
-      @alerts_enabled = @user.dossiers_alerts_enabled?
-    end
-
     def user_dossiers
       @user_dossiers ||= begin
         invited_ids = @user.dossiers_invites.visible_by_user.pluck(:id)
@@ -98,7 +93,6 @@ module Users
     end
 
     def model_alerts
-      return [] if !alerts_enabled?
       Array(@params[:alert]) & ALERT_SCOPES.keys
     end
 
@@ -160,7 +154,6 @@ module Users
     end
 
     def count_alerts
-      return ALERT_SCOPES.keys.index_with { 0 } if !alerts_enabled?
       scope = scope_without(:alert)
       ALERT_SCOPES.keys.index_with do |alert_key|
         scope.where(id: bounded_alert_subquery(ALERT_SCOPES[alert_key])).count

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -37,7 +37,6 @@ features = [
   :ami_notifications,
   :ami_recipient_fc_hash_v2,
   :dossier_vide_weasyprint,
-  :usager_dossiers_alert_filters,
   :s3_storage,
   # Enable only once T20260728BackfillSearchTermsTsvectorTask has completed.
   :search_terms_tsvector,

--- a/spec/components/dossiers/user_filter_panel_component_spec.rb
+++ b/spec/components/dossiers/user_filter_panel_component_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Dossiers::UserFilterPanelComponent, type: :component do
     instance_double(Users::DossierFilterService,
       active?: false,
       total_count: 12,
-      alerts_enabled?: true,
       counts: {
         procedure_ids: {},
         states: { 'brouillon' => 1, 'en_construction' => 5, 'en_instruction' => 0, 'accepte' => 0, 'refuse' => 0, 'sans_suite' => 0 },

--- a/spec/components/dossiers/user_filter_panel_form_component_spec.rb
+++ b/spec/components/dossiers/user_filter_panel_form_component_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Dossiers::UserFilterPanelFormComponent, type: :component do
   let(:filter) do
     instance_double(Users::DossierFilterService,
       total_count: 12,
-      alerts_enabled?: true,
       counts: {
         procedure_ids: {},
         states: { 'brouillon' => 1, 'en_construction' => 5, 'en_instruction' => 0, 'accepte' => 0, 'refuse' => 0, 'sans_suite' => 0 },
@@ -28,24 +27,6 @@ RSpec.describe Dossiers::UserFilterPanelFormComponent, type: :component do
 
   it 'renders all 4 alert checkboxes' do
     expect(subject.css('input[name="alert[]"]').size).to eq(4)
-  end
-
-  context 'when the alert filters feature is disabled' do
-    let(:filter) do
-      instance_double(Users::DossierFilterService,
-        total_count: 12,
-        alerts_enabled?: false,
-        counts: {
-          procedure_ids: {},
-          states: { 'brouillon' => 1, 'en_construction' => 5, 'en_instruction' => 0, 'accepte' => 0, 'refuse' => 0, 'sans_suite' => 0 },
-          alerts: { 'nouveau_message' => 0, 'message_avec_attente_de_reponse' => 0, 'a_corriger' => 0, 'expire_bientot' => 0 },
-          shared_with_me: 0,
-        })
-    end
-
-    it 'does not render the alert checkboxes' do
-      expect(subject.css('input[name="alert[]"]')).to be_empty
-    end
   end
 
   it 'renders state counters inline' do
@@ -87,7 +68,6 @@ RSpec.describe Dossiers::UserFilterPanelFormComponent, type: :component do
     let(:filter) do
       instance_double(Users::DossierFilterService,
         total_count: 0,
-        alerts_enabled?: true,
         counts: {
           procedure_ids: {},
           states: { 'brouillon' => 0, 'en_construction' => 0, 'en_instruction' => 0, 'accepte' => 0, 'refuse' => 0, 'sans_suite' => 0 },

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -381,15 +381,9 @@ RSpec.describe DossierHelper, type: :helper do
   end
 
   describe "#show_new_message_notification?" do
-    let(:user) { create(:user) }
     let(:dossier) { create(:dossier, :en_construction) }
 
     subject { helper.show_new_message_notification?(dossier) }
-
-    before do
-      allow(helper).to receive(:current_user).and_return(user)
-      Flipper.enable(:usager_dossiers_alert_filters, user)
-    end
 
     context "when an instructeur sent an unread message" do
       before { create(:commentaire, dossier:, instructeur: create(:instructeur), seen_by_recipient_at: nil) }
@@ -409,15 +403,6 @@ RSpec.describe DossierHelper, type: :helper do
       before { create(:commentaire, dossier:, instructeur: create(:instructeur), seen_by_recipient_at: nil) }
 
       it { is_expected.to be_truthy }
-    end
-
-    context "when the feature flag is disabled" do
-      before do
-        Flipper.disable(:usager_dossiers_alert_filters, user)
-        create(:commentaire, dossier:, instructeur: create(:instructeur), seen_by_recipient_at: nil)
-      end
-
-      it { is_expected.to be_falsey }
     end
 
     context "when the agent message has been seen" do

--- a/spec/services/users/dossier_filter_service_spec.rb
+++ b/spec/services/users/dossier_filter_service_spec.rb
@@ -156,7 +156,6 @@ RSpec.describe Users::DossierFilterService do
     end
 
     it 'returns counts for alerts (contextualized by state filter)' do
-      Flipper.enable_actor(:usager_dossiers_alert_filters, user)
       service = described_class.new(user: user, params: ActionController::Parameters.new(state: ['en_construction']))
       expect(service.counts[:alerts]['a_corriger']).to eq(1)
     end
@@ -182,41 +181,11 @@ RSpec.describe Users::DossierFilterService do
     end
 
     it 'counts only the user own alerts, not other users matching dossiers' do
-      Flipper.enable_actor(:usager_dossiers_alert_filters, user)
       other_dossier_with_correction = create(:dossier, :en_construction)
       create(:dossier_correction, dossier: other_dossier_with_correction)
 
       service = described_class.new(user: user, params: ActionController::Parameters.new)
       expect(service.counts[:alerts]['a_corriger']).to eq(1)
-    end
-
-    context 'when the alert filters feature is disabled (default)' do
-      it 'exposes alerts_enabled? as false' do
-        expect(service.alerts_enabled?).to be(false)
-      end
-
-      it 'returns zero for every alert without running the alert subqueries' do
-        expect(service).not_to receive(:bounded_alert_subquery)
-        expect(service.counts[:alerts].values).to all(eq(0))
-      end
-
-      it 'ignores alert params forged via the URL (no alert filter tag)' do
-        service = described_class.new(user: user, params: ActionController::Parameters.new(alert: ['a_corriger']))
-        expect(service.active_filter_tags.map { it[:group] }).not_to include(:alert)
-      end
-
-      it 'does not filter dossiers by a forged alert param' do
-        service = described_class.new(user: user, params: ActionController::Parameters.new(alert: ['a_corriger']))
-        expect(service.dossiers).to include(dossier_depose_nothing)
-      end
-    end
-
-    context 'when the alert filters feature is enabled' do
-      before { Flipper.enable_actor(:usager_dossiers_alert_filters, user) }
-
-      it 'exposes alerts_enabled? as true' do
-        expect(service.alerts_enabled?).to be(true)
-      end
     end
 
     it 'runs a constant number of queries regardless of dossier volume (no N+1)' do
@@ -241,7 +210,6 @@ RSpec.describe Users::DossierFilterService do
     let!(:dossier_in_procedure) { create(:dossier, :en_construction, user: user, procedure: procedure) }
 
     it 'returns one tag per active filter value' do
-      Flipper.enable_actor(:usager_dossiers_alert_filters, user)
       service = described_class.new(user: user, params: ActionController::Parameters.new(
         procedure_id: procedure.id.to_s,
         state: ['en_construction', 'en_instruction'],
@@ -352,7 +320,6 @@ RSpec.describe Users::DossierFilterService do
     let!(:dossier_unread_message) { create(:dossier, :en_construction, user: user) }
 
     before do
-      Flipper.enable_actor(:usager_dossiers_alert_filters, user)
       # A pending correction/response always carries an unread agent message,
       # so these dossiers must NOT surface under the « nouveau_message » filter:
       # their prioritary badge is « à corriger » / « en attente de réponse ».


### PR DESCRIPTION
Retrait de `usager_dossiers_alert_filters`, activé partout en production. Les quatre filtres
par alerte de « Mes dossiers » (nouveau message, en attente de réponse, à corriger, expire
bientôt) et le badge « nouveau message » deviennent le comportement par défaut.
