### PR TITLE
Tech: optimiser les tests de expert_spec.rb

### DIFF
--- a/spec/system/instructeurs/expert_spec.rb
+++ b/spec/system/instructeurs/expert_spec.rb
@@ -4,15 +4,15 @@ describe 'Inviting an expert:', js: true do
   include ActiveJob::TestHelper
   include ActionView::Helpers
 
-  let(:instructeur) { create(:instructeur, password: SECURE_PASSWORD) }
-  let(:expert) { create(:expert, password: expert_password) }
-  let(:expert2) { create(:expert, password: expert_password) }
-  let(:expert3) { create(:expert, password: expert_password) }
-  let(:expert4) { create(:expert, password: expert_password) }
-  let(:expert_password) { 'mot de passe d’expert' }
-  let(:procedure) { create(:procedure, :published, instructeurs: [instructeur], public_type_de_champs: [{ type: :dossier_link }]) }
-  let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
-  let(:linked_dossier) { Dossier.find_by(id: dossier.champ_data.first.value) }
+  let_it_be(:expert_password) { 'mot de passe d’expert' }
+  let_it_be(:instructeur) { create(:instructeur, password: SECURE_PASSWORD) }
+  let_it_be(:expert) { create(:expert, password: expert_password) }
+  let_it_be(:expert2) { create(:expert, password: expert_password) }
+  let_it_be(:expert3) { create(:expert, password: expert_password) }
+  let_it_be(:expert4) { create(:expert, password: expert_password) }
+  let_it_be(:procedure, reload: true) { create(:procedure, :published, instructeurs: [instructeur], public_type_de_champs: [{ type: :dossier_link }]) }
+  let_it_be(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure:) }
+  let_it_be(:linked_dossier) { Dossier.find_by(id: dossier.champ_data.first.value) }
 
   before do
     clear_emails
@@ -112,8 +112,6 @@ describe 'Inviting an expert:', js: true do
 
     context 'when experts list is restricted by admin' do
       let!(:expert_procedure) { ExpertsProcedure.create(expert: expert, procedure: procedure, allow_decision_access: true) }
-      let(:expert_email) { expert.email }
-      let(:expert2_email) { expert2.email }
 
       before do
         procedure.update!(experts_require_administrateur_invitation: true)


### PR DESCRIPTION
# Probleme

Tests systeme dans `spec/system/instructeurs/expert_spec.rb` — temps baseline : 18.59s (mediane locale, 3 runs). Le fichier utilise 12 `create(:...)` via FactoryBot et 3 `let!` dans un setup qui se repete pour chaque scenario.

# Solution

Skill [`/test-optimization`](https://github.com/mfo/night-shift/blob/main/.claude/skills/test-optimization/SKILL.md)

### Techniques appliquees

| Technique | Avant | Apres | Gain |
|-----------|-------|-------|------|
| T08 (let_it_be) | 9 let | 9 let_it_be | - (pas de gain mesurable, bruit ±34%) |
| T04 (setup inutile) | 2 let non references | supprimes | - |

### Techniques tentees sans succes

| Technique | Raison |
|-----------|--------|
| T10 (let! → let) | Les 3 let! sont necessaires : les records doivent exister en base avant le chargement de la page |
| T13 (create → seed) | Setup specifique (dossier_link, 4 experts, populated champs) non couvert par les seeds existants |

**Resultat :** pas de gain mesurable (bruit ±34% lie au navigateur Playwright). Les modifications apportees sont des ameliorations de qualite/coherence du setup.

**Modifications :**
- 9 top-level `let` convertis en `let_it_be` (setup partage entre les 3 scenarios)
- `reload: true` sur `procedure` car mute dans le context restreint
- `expert_email` et `expert2_email` supprimes (non references)

Coverage : 51.54% → 51.45% (maintenue, fluctuation dans le bruit)

Generated with [Claude Code](https://claude.com/claude-code)