### PR TITLE
Tech: protéger les moteurs montés sous /manager derrière l'enrôlement OTP

### DIFF
--- a/config/routes/manager.rb
+++ b/config/routes/manager.rb
@@ -103,7 +103,9 @@ namespace :manager do
   resources :safe_mailers
   resources :top_activity_procedures, only: [:index]
 
-  authenticate :super_admin do
+  # Mounted engines bypass Manager::ApplicationController, so the OTP enrollment
+  # gate (RequiresEnrolledSuperAdminOtp) has to be re-applied here.
+  authenticate :super_admin, -> (super_admin) { !SUPER_ADMIN_OTP_ENABLED || super_admin.otp_required_for_login? } do
     mount Flipper::UI.app(-> { Flipper.instance }) => "/features", as: :flipper
     mount MaintenanceTasks::Engine => "/maintenance_tasks"
     mount Sidekiq::Web => "/sidekiq"

--- a/spec/requests/manager/engines_otp_gate_spec.rb
+++ b/spec/requests/manager/engines_otp_gate_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Regression: the engines mounted under the /manager namespace (Flipper UI,
+# MaintenanceTasks, Sidekiq::Web) bypass Manager::ApplicationController, so the
+# RequiresEnrolledSuperAdminOtp gate never runs for them. A super admin who is
+# signed in but has not enrolled OTP must not be able to reach them.
+#
+# /manager/features (Flipper::UI) stands in for all three: they share the same
+# `authenticate :super_admin` route block in config/routes/manager.rb.
+describe 'Manager mounted engines require an OTP-enrolled super admin', type: :request do
+  subject { get '/manager/features' }
+
+  context 'when the super admin has enrolled OTP' do
+    let(:super_admin) { create(:super_admin, otp_required_for_login: true) }
+
+    before { login_as super_admin, scope: :super_admin }
+
+    it 'can reach the engine' do
+      subject
+      expect(response).not_to have_http_status(:not_found)
+    end
+  end
+
+  context 'when the super admin has not enrolled OTP' do
+    let(:super_admin) { create(:super_admin, otp_required_for_login: false) }
+
+    before { login_as super_admin, scope: :super_admin }
+
+    it 'cannot reach the engine' do
+      subject
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'when nobody is signed in' do
+    it 'is redirected to the super admin sign in' do
+      subject
+      expect(response).to have_http_status(:found)
+      expect(response.location).to end_with('super_admins/sign_in')
+    end
+  end
+end


### PR DESCRIPTION
## Problème

Flipper UI, MaintenanceTasks et Sidekiq::Web sont montés sous `authenticate :super_admin` dans `config/routes/manager.rb`. Cette contrainte Warden ne vérifie que la **connexion**, pas l'OTP : le garde-fou d'enrôlement (`RequiresEnrolledSuperAdminOtp`) vit dans `Manager::ApplicationController` et ne s'exécute jamais pour des moteurs montés.

Conséquence : un super admin connecté **au mot de passe seul**, sans OTP activé (compte fraîchement créé, ou après une réinitialisation OTP par un pair), pouvait atteindre `/manager/features`, `/manager/maintenance_tasks` et `/manager/sidekiq`.

## Correctif

On applique la même règle directement sur la contrainte de route : l'accès n'est autorisé que si l'OTP est désactivé au niveau de l'instance, ou si le super admin a activé l'OTP (`otp_required_for_login?`). Le `||` court-circuite quand l'OTP est désactivé, donc `otp_required_for_login?` n'est jamais appelé sur un `SuperAdmin` sans module two-factor.

Un super admin non enrôlé se voit refuser la route (404) ; il doit d'abord activer l'OTP via l'interface manager, comme pour toute autre page du manager.

## Tests

Nouveau spec de requête `spec/requests/manager/engines_otp_gate_spec.rb` : super admin enrôlé → accès ; non enrôlé → 404 ; non connecté → redirection vers la connexion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)