### PR TITLE
ETQ admin, révoquer un expert lui retire l'accès aux dossiers de la démarche

### DIFF
--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -267,14 +267,16 @@ module Experts
 
     def check_if_avis_revoked
       avis = Avis.find(params[:id])
-      if avis.revoked?
+      # Two independent revocations both remove access: the avis itself
+      # (instructeur) or the expert's whole link to the procedure (admin).
+      if avis.revoked? || avis.experts_procedure.revoked?
         flash.alert = "Vous n’avez plus accès à ce dossier."
         redirect_to url_for(root_path)
       end
     end
 
     def set_avis_and_dossier
-      @avis = current_expert.avis.find_by(id: params[:id])
+      @avis = current_expert.avis.not_revoked.find_by(id: params[:id])
       unless @avis
         redirect_to expert_all_avis_path, flash: { alert: "Vous n’avez pas accès à cet avis." } and return
       end

--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -45,7 +45,10 @@ class Avis < ApplicationRecord
   scope :updated_since?, -> (date) { where('avis.updated_at > ?', date) }
   scope :termine_expired_after_notice_grace, -> { unscope(:joins).where(dossier: Dossier.termine_expired_after_notice_grace) }
   scope :not_hidden_by_administration, -> { where(dossiers: { hidden_by_administration_at: nil }) }
-  scope :not_revoked, -> { where(revoked_at: nil) }
+  # Both revocations cut the expert off: the avis itself (instructeur) or the
+  # expert's whole link to the procedure (admin "révoquer l'expert"). Keep them
+  # in a single scope so no call site can filter on one dimension only.
+  scope :not_revoked, -> { joins(:experts_procedure).where(revoked_at: nil, experts_procedures: { revoked_at: nil }) }
   scope :not_termine, -> { where.not(dossiers: { state: Dossier::TERMINE }) }
 
   attr_accessor :invite_linked_dossiers

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -14,7 +14,8 @@ class Expert < ApplicationRecord
     user.email
   end
 
-  # Dossiers the expert can currently access, excluding those whose avis has been revoked.
+  # Dossiers the expert can currently access, excluding those whose avis has been
+  # revoked or whose whole ExpertsProcedure link has been revoked by an admin.
   def dossiers_from_not_revoked_avis
     Dossier.where(id: avis.not_revoked.select(:dossier_id))
   end

--- a/app/models/experts_procedure.rb
+++ b/app/models/experts_procedure.rb
@@ -5,4 +5,8 @@ class ExpertsProcedure < ApplicationRecord
   belongs_to :procedure
 
   has_many :avis, dependent: :destroy
+
+  def revoked?
+    revoked_at.present?
+  end
 end

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -42,6 +42,18 @@ describe Experts::AvisController, type: :controller do
         end
       end
 
+      context 'when the expert has been revoked from the procedure' do
+        before do
+          experts_procedure.update!(revoked_at: Time.zone.now)
+          get :index
+        end
+
+        it 'hides every avis of that procedure' do
+          expect(response).to have_http_status(:success)
+          expect(assigns(:avis_by_procedure).values.flatten).not_to include(avis_without_answer, avis_with_answer)
+        end
+      end
+
       context 'avis on termine dossier' do
         let(:another_experts_procedure) { create(:experts_procedure, expert:, procedure: another_procedure) }
         let(:dossier_termine) { create(:dossier, :accepte, procedure: another_procedure) }
@@ -173,6 +185,15 @@ describe Experts::AvisController, type: :controller do
       context 'with a revoked avis' do
         it "refuse l’accès au dossier" do
           avis_with_answer.update!(revoked_at: Time.zone.now)
+          subject
+          expect(flash.alert).to eq("Vous n’avez plus accès à ce dossier.")
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context 'when the expert has been revoked from the procedure' do
+        it "refuse l’accès au dossier même si l’avis n’est pas révoqué" do
+          experts_procedure.update!(revoked_at: Time.zone.now)
           subject
           expect(flash.alert).to eq("Vous n’avez plus accès à ce dossier.")
           expect(response).to redirect_to(root_path)

--- a/spec/controllers/instructeurs/commentaires_controller_spec.rb
+++ b/spec/controllers/instructeurs/commentaires_controller_spec.rb
@@ -172,6 +172,17 @@ describe Instructeurs::CommentairesController, type: :controller do
           expect(commentaire.reload).not_to be_discarded
         end
       end
+
+      context 'when the expert has been revoked from the procedure' do
+        let!(:experts_procedure) { create(:experts_procedure, expert:, procedure:, revoked_at: 1.day.ago) }
+        let!(:commentaire) { create(:commentaire, expert: expert, dossier: dossier) }
+        subject { delete :destroy, params: { dossier_id: dossier.id, procedure_id: procedure.id, id: commentaire.id, statut: 'a-suivre' }, format: :turbo_stream }
+
+        it 'returns 404 and does not delete the commentaire' do
+          expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+          expect(commentaire.reload).not_to be_discarded
+        end
+      end
     end
   end
 end

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -163,4 +163,30 @@ RSpec.describe Expert, type: :model do
       end
     end
   end
+
+  describe '#dossiers_from_not_revoked_avis' do
+    let(:expert) { create(:expert) }
+    let(:claimant) { create(:expert) }
+    let(:procedure) { create(:procedure, :published) }
+    let(:experts_procedure) { create(:experts_procedure, expert:, procedure:) }
+    let(:dossier) { create(:dossier, :en_construction, procedure:) }
+    let!(:avis) { create(:avis, dossier:, claimant:, experts_procedure:) }
+
+    subject { expert.dossiers_from_not_revoked_avis }
+
+    it { is_expected.to contain_exactly(dossier) }
+
+    context 'when the avis itself is revoked' do
+      # update_column: revoking bypasses the on: :update answer-presence validation
+      before { avis.update_column(:revoked_at, Time.zone.now) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the expert is revoked from the procedure' do
+      before { experts_procedure.update!(revoked_at: Time.zone.now) }
+
+      it { is_expected.to be_empty }
+    end
+  end
 end


### PR DESCRIPTION
## Problème

Révoquer un expert d'une démarche (bouton « révoquer ») ne fait que positionner `experts_procedures.revoked_at`. Or le côté expert lit ses avis via `current_expert.avis` (association `through: :experts_procedures`) **sans filtrer ce `revoked_at`**, et `check_if_avis_revoked` ne regardait que la révocation d'un avis isolé (`avis.revoked_at`, une autre dimension).

Conséquence : un expert révoqué conservait l'accès complet aux dossiers déjà partagés — consultation, téléchargement des pièces, messagerie, dépôt de réponse, et invitation d'autres experts.

## Correctif

- Le scope `Avis.not_revoked` couvre désormais **les deux** révocations (avis isolé et `ExpertsProcedure`), en un seul scope pour qu'aucun appelant ne puisse filtrer sur une seule dimension.
- Il est déjà utilisé partout côté expert : listes (`index`, `procedure`), finder d'accès (`set_avis_and_dossier`), recherche (`Expert#dossiers_from_not_revoked_avis`) et messagerie (`Instructeurs::CommentairesController#dossier`).
- `check_if_avis_revoked` refuse l'accès aussi bien quand l'avis est révoqué que quand l'`ExpertsProcedure` l'est (`ExpertsProcedure#revoked?`).

Les deux dimensions de révocation (avis isolé vs lien expert⇄démarche) coupent maintenant l'accès.

## Tests

- Spec contrôleur `Experts::AvisController` : un expert révoqué de la démarche ne voit plus les avis dans `#index` et se voit refuser `#show`. Vérifié en rouge sans le correctif.
- Spec modèle `Expert#dossiers_from_not_revoked_avis` : exclut les dossiers d'un avis révoqué **et** d'un `ExpertsProcedure` révoqué.
- Spec contrôleur `Instructeurs::CommentairesController` : un expert révoqué de la démarche ne peut plus agir sur la messagerie du dossier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
