### PR TITLE
ETQ usager, un lien d'activation/réinitialisation expiré ne connecte plus

### DIFF
--- a/app/controllers/users/activate_controller.rb
+++ b/app/controllers/users/activate_controller.rb
@@ -26,7 +26,11 @@ class Users::ActivateController < ApplicationController
       reset_password_token: user_params[:reset_password_token],
     })
 
-    if user.valid?
+    # Gate on the errors reset_password_by_token leaves, not on User#valid?:
+    # for an expired token Devise leaves the password unchanged and only adds
+    # a :reset_password_token => :expired error, which valid? would clear before
+    # re-running (passing) model validations — signing the user in on a stale token.
+    if user.errors.empty?
       sign_in(user, scope: :user)
 
       trust_device(Time.zone.now) if user.instructeur.present?

--- a/spec/controllers/users/activate_controller_spec.rb
+++ b/spec/controllers/users/activate_controller_spec.rb
@@ -153,6 +153,34 @@ describe Users::ActivateController, type: :controller do
     end
   end
 
+  # Regression: an expired (but still digest-matching) activation / reset token
+  # must not grant a session. reset_password_by_token leaves the password
+  # unchanged and only adds a :expired error; the controller must reject on that
+  # error rather than on User#valid?, which cleared it and let the sign-in through.
+  describe '#create with an expired reset password token' do
+    let!(:user) { create(:instructeur).user }
+    let(:password) { '{another-password-ok?}' }
+    let(:token) do
+      raw = user.send(:set_reset_password_token)
+      # Push the send time past the validity window: the token still matches the
+      # stored digest but reset_password_period_valid? is now false.
+      user.update_column(:reset_password_sent_at, (Devise.reset_password_within + 1.day).ago)
+      raw
+    end
+
+    before do
+      allow(controller).to receive(:trust_device)
+      post :create, params: { user: { reset_password_token: token, password: password } }
+    end
+
+    it 'refuses to sign in, leaves the password unchanged and does not trust the device' do
+      expect(controller.current_user).to be_nil
+      expect(user.reload.valid_password?(password)).to be false
+      expect(controller).not_to have_received(:trust_device)
+      expect(response).to redirect_to(users_activate_path(token: token))
+    end
+  end
+
   describe '#create when the administrateur must use ProConnect' do
     let(:user) { administrateurs.default.user }
     let(:token) { user.send(:set_reset_password_token) }


### PR DESCRIPTION
## Problème

`Users::ActivateController#create` (activation de compte / définition du mot de passe) appelle `User.reset_password_by_token` puis teste `if user.valid?`.

Pour un jeton **expiré**, Devise ne change pas le mot de passe et ajoute seulement une erreur `reset_password_token => :expired`. Mais `user.valid?` **efface ces erreurs** et rejoue les validations du modèle, qui passent pour n'importe quel compte normal. Le `sign_in` s'exécutait donc quand même.

Conséquence : toute personne détenant le dernier lien d'activation/invitation ou de réinitialisation encore en base pouvait se connecter au compte **après** l'expiration (fenêtre de 7 jours contournée), et la session était ouverte **sans changer le mot de passe** — le propriétaire légitime n'est pas déconnecté et ne voit rien.

## Correctif

On teste `user.errors.empty?` au lieu de `user.valid?` : un jeton expiré (erreur `:expired`) ou invalide est correctement refusé, tandis qu'une réinitialisation réussie continue de connecter. Le contrôleur Devise standard vérifie déjà `resource.errors.empty?` ; seule cette action maison était concernée.

## Tests

Nouveau contexte dans `spec/controllers/users/activate_controller_spec.rb` : un jeton dont `reset_password_sent_at` est au-delà de la fenêtre de validité ne connecte pas, laisse le mot de passe inchangé et ne « trust » pas l'appareil. Vérifié en rouge sans le correctif (le compte était connecté).

🤖 Generated with [Claude Code](https://claude.com/claude-code)