### PR TITLE
ETQ admin, l'aperçu de l'objet d'un email échappe les valeurs des balises

### DIFF
--- a/app/views/administrateurs/email_templates/preview.turbo_stream.erb
+++ b/app/views/administrateurs/email_templates/preview.turbo_stream.erb
@@ -6,5 +6,8 @@
 <% end %>
 
 <% if @updated_subject %>
-  <%= turbo_stream.update "mail-subject-preview", @subject_preview %>
+  <%# The subject is plain text holding usager-typed tag values: the block escapes it, a string argument would not. %>
+  <%= turbo_stream.update "mail-subject-preview" do %>
+    <%= @subject_preview %>
+  <% end %>
 <% end %>

--- a/spec/controllers/administrateurs/email_templates_controller_spec.rb
+++ b/spec/controllers/administrateurs/email_templates_controller_spec.rb
@@ -121,5 +121,20 @@ describe Administrateurs::EmailTemplatesController, type: :controller do
       expect(response.body).to include('mail-body-preview')
       expect(response.body).to include('Salut')
     end
+
+    context 'when the sample dossier holds markup in a usager-controlled tag' do
+      let(:json_subject) { { "type" => "doc", "content" => [{ "type" => "paragraph", "content" => [{ "type" => "mention", "attrs" => { "id" => "individual_last_name", "label" => "nom" } }] }] }.to_json }
+
+      before { procedure.dossier_for_preview(admin.user).individual.update!(nom: '<img src=x onerror=alert(1)>') }
+
+      it 'escapes the subject preview' do
+        post :preview, params: {
+          procedure_id: procedure.id, id: 'passe_en_instruction',
+          emails_passe_en_instruction: { tiptap_subject: json_subject },
+        }, format: :turbo_stream
+        expect(response.body).to include('&lt;img src=x onerror=alert(1)&gt;')
+        expect(response.body).not_to include('<img src=x')
+      end
+    end
   end
 end


### PR DESCRIPTION
L'aperçu en direct de l'objet d'un modèle d'email est désormais rendu dans un bloc `turbo_stream`, comme l'aperçu du corps, pour que l'objet soit échappé.

- L'objet de l'email réellement envoyé est inchangé (texte brut).
- Test de contrôleur sur l'aperçu de l'objet avec une valeur de balise contenant du HTML.

