### PR TITLE
Amelioration: ETQ usager, renomme le bouton « Commencer la démarche » en « Commencer un dossier »

### DIFF
--- a/app/views/commencer/show.html.erb
+++ b/app/views/commencer/show.html.erb
@@ -92,7 +92,7 @@
         <%- end -%>
       <%- end -%>
     <%- elsif @dossiers.empty? -%>
-      <%= link_to t('.start_procedure'), url_for_new_dossier(@revision), class: 'fr-btn fr-mb-2w' %>
+      <%= link_to t('.start_dossier'), url_for_new_dossier(@revision), class: 'fr-btn fr-mb-2w' %>
     <%- elsif @drafts.size == 1 && @not_drafts.empty? -%>
       <% dossier = @drafts.first %>
       <%= render Dsfr::CalloutComponent.new(title: t(".already_draft"), heading_level: 'h2') do |c| -%>

--- a/config/locales/views/users/commencer/en.yml
+++ b/config/locales/views/users/commencer/en.yml
@@ -2,6 +2,7 @@ en:
   commencer:
     show:
       start_procedure: Start the procedure
+      start_dossier: Start a file
       pro_connect_restriction_all_info_html: "This procedure requires <a href=\"%{path}\" title=\"Signin with ProConnect\">ProConnect authentication</a>. Only agents with a ProConnect account can access it."
       existing_dossiers: You already have files for this procedure
       show_dossiers: View my current files

--- a/config/locales/views/users/commencer/fr.yml
+++ b/config/locales/views/users/commencer/fr.yml
@@ -2,6 +2,7 @@ fr:
   commencer:
     show:
       start_procedure: Commencer la démarche
+      start_dossier: Commencer un dossier
       pro_connect_restriction_all_info_html: "Cette démarche nécessite une <a href=\"%{path}\" title=\"S’identifier avec ProConnect\">authentification via ProConnect</a>. Seuls les agents disposant d’un compte ProConnect peuvent y accéder."
       existing_dossiers: Vous avez déjà des dossiers pour cette démarche
       show_dossiers: Voir mes dossiers en cours

--- a/spec/system/accessibilite/wcag_usager_spec.rb
+++ b/spec/system/accessibilite/wcag_usager_spec.rb
@@ -121,13 +121,13 @@ describe 'wcag rules for usager', js: true do
     end
 
     scenario 'écran identité usager' do
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       expect(page).to be_axe_clean
     end
 
     # with no surprise, there's a lot of work on this one
     scenario "dépot d’un dossier" do
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
 
       find('label', text: "Pour vous").click
       within('.individual-infos') do
@@ -151,7 +151,7 @@ describe 'wcag rules for usager', js: true do
     end
 
     scenario "écran identification de l’entreprise" do
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       expect(page).to be_axe_clean
     end
   end

--- a/spec/system/administrateurs/api_referentiel_spec.rb
+++ b/spec/system/administrateurs/api_referentiel_spec.rb
@@ -693,7 +693,7 @@ describe 'Referentiel API:' do
   def commencer(procedure)
     # start a dossier
     visit commencer_path(procedure.path)
-    click_on("Commencer la démarche")
+    click_on("Commencer un dossier")
     find('label', text: "Pour vous").click
     expect(page).to have_content("Votre identité")
     fill_in("Prénom", with: "Jeanne")

--- a/spec/system/instructeurs/instruction_spec.rb
+++ b/spec/system/instructeurs/instruction_spec.rb
@@ -28,7 +28,7 @@ describe 'Instructing a dossier:', js: true do
       # expect(page).to have_current_path(commencer_path(path: procedure.path))
 
       visit commencer_path(path: procedure.path)
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
 
       expect(page).to have_content('Identifier votre établissement')
       expect(page).to have_current_path(siret_dossier_path(procedure.reload.dossiers.last))

--- a/spec/system/routing/rules_full_scenario_spec.rb
+++ b/spec/system/routing/rules_full_scenario_spec.rb
@@ -295,7 +295,7 @@ describe 'The routing with rules', js: true do
   def user_send_dossier(user, groupe)
     login_as user, scope: :user
     visit commencer_path(path: procedure.reload.path)
-    click_on 'Commencer la démarche'
+    click_on 'Commencer un dossier'
 
     find('label', text: "Pour vous").click
     fill_in('Prénom', with: 'prenom', visible: true)

--- a/spec/system/sessions/sign_in_spec.rb
+++ b/spec/system/sessions/sign_in_spec.rb
@@ -78,7 +78,7 @@ describe 'Signin in:' do
       sign_in_with user.email, password
 
       expect(page).to have_current_path(commencer_path(path: procedure.path))
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
 
       expect(page).to have_current_path identite_dossier_path(user.reload.dossiers.last)
       expect(page).to have_content(procedure.libelle)

--- a/spec/system/users/address_spec.rb
+++ b/spec/system/users/address_spec.rb
@@ -88,7 +88,7 @@ describe 'address champ', js: true do
     login_as user, scope: :user
 
     visit "/commencer/#{procedure.path}"
-    click_on 'Commencer la démarche'
+    click_on 'Commencer un dossier'
 
     find('label', text: "Pour vous").click
     expect(page).to have_content("Votre identité")

--- a/spec/system/users/date_prefill_france_connect_spec.rb
+++ b/spec/system/users/date_prefill_france_connect_spec.rb
@@ -12,7 +12,7 @@ describe 'Prefill date champ from FranceConnect:', js: true do
 
   scenario 'usager voit le champ prérempli, instructeur voit le badge, le badge disparaît si modifié' do
     visit commencer_path(path: procedure.path)
-    click_on 'Commencer la démarche'
+    click_on 'Commencer un dossier'
 
     find('label', text: "Pour vous").click
 

--- a/spec/system/users/dossier_creation_spec.rb
+++ b/spec/system/users/dossier_creation_spec.rb
@@ -17,7 +17,7 @@ describe 'Creating a new dossier:', js: true do
 
       before do
         visit commencer_path(path: procedure.path)
-        click_on 'Commencer la démarche'
+        click_on 'Commencer un dossier'
 
         expect(page).to have_current_path identite_dossier_path(user.reload.dossiers.last)
       end
@@ -223,7 +223,7 @@ describe 'Creating a new dossier:', js: true do
 
       scenario 'the user can enter the SIRET of its etablissement and create a new draft' do
         visit commencer_path(path: procedure.path)
-        click_on 'Commencer la démarche'
+        click_on 'Commencer un dossier'
 
         expect(page).to have_current_path siret_dossier_path(dossier)
         expect(page).to have_content(procedure.libelle)
@@ -240,7 +240,7 @@ describe 'Creating a new dossier:', js: true do
 
       scenario 'the user is notified when its SIRET is invalid' do
         visit commencer_path(path: procedure.path)
-        click_on 'Commencer la démarche'
+        click_on 'Commencer un dossier'
 
         expect(page).to have_current_path(siret_dossier_path(dossier))
         expect(page).to have_content(procedure.libelle)

--- a/spec/system/users/dropdown_spec.rb
+++ b/spec/system/users/dropdown_spec.rb
@@ -11,7 +11,7 @@ describe 'dropdown list with other option activated', js: true do
   before do
     login_as(user, scope: :user)
     visit "/commencer/#{procedure.path}?locale=fr"
-    click_on 'Commencer la démarche'
+    click_on 'Commencer un dossier'
   end
   context 'with radios' do
     let(:options) do
@@ -95,7 +95,7 @@ describe 'multiple dropdown tag removal', js: true do
   before do
     login_as(user, scope: :user)
     visit "/commencer/#{procedure.path}?locale=fr"
-    click_on 'Commencer la démarche'
+    click_on 'Commencer un dossier'
     find('label', text: "Pour vous").click
     within('.individual-infos') do
       fill_in('Prénom', with: 'prenom')

--- a/spec/system/users/france_connect_champ_upload_spec.rb
+++ b/spec/system/users/france_connect_champ_upload_spec.rb
@@ -10,7 +10,7 @@ describe 'Quotient familial piece justificative upload', js: true do
 
   scenario 'usager uploads a piece justificative when QF data is not fetched' do
     visit commencer_path(path: procedure.path)
-    click_on 'Commencer la démarche'
+    click_on 'Commencer un dossier'
 
     find('label', text: "Pour vous").click
     within('.individual-infos') do

--- a/spec/system/users/linked_dropdown_spec.rb
+++ b/spec/system/users/linked_dropdown_spec.rb
@@ -97,7 +97,7 @@ describe 'linked dropdown lists', js: true do
     sign_in_with(email, password)
 
     expect(page).to have_current_path(commencer_path(path: procedure.path))
-    click_on 'Commencer la démarche'
+    click_on 'Commencer un dossier'
 
     find('label', text: "Pour vous").click
     expect(page).to have_content("Votre identité")

--- a/spec/system/users/piece_justificative_drag_drop_spec.rb
+++ b/spec/system/users/piece_justificative_drag_drop_spec.rb
@@ -12,7 +12,7 @@ describe 'Piece justificative drag and drop', js: true do
     before do
       login_as(user, scope: :user)
       visit commencer_path(path: procedure.path)
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       fill_individual
       expect(page).to have_current_path(brouillon_dossier_path(dossier))
       visit brouillon_dossier_path(dossier)
@@ -61,7 +61,7 @@ describe 'Piece justificative drag and drop', js: true do
       procedure_pj = create(:procedure, :published, :for_individual, public_type_de_champs: [{ type: :piece_justificative, libelle: 'Document' }])
       login_as(user, scope: :user)
       visit commencer_path(path: procedure_pj.path)
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       fill_individual
 
       within find('.editable-champ', text: 'Document') do
@@ -73,7 +73,7 @@ describe 'Piece justificative drag and drop', js: true do
       procedure_ti = create(:procedure, :published, :for_individual, public_type_de_champs: [{ type: :piece_justificative, libelle: 'Pièce d\'identité', nature: 'titre_identite' }])
       login_as(user, scope: :user)
       visit commencer_path(path: procedure_ti.path)
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       fill_individual
 
       within find('.editable-champ', text: 'Pièce d\'identité') do
@@ -87,7 +87,7 @@ describe 'Piece justificative drag and drop', js: true do
       procedure_rib = create(:procedure, :published, :for_individual, public_type_de_champs: [{ type: :piece_justificative, libelle: 'RIB', nature: 'rib' }])
       login_as(user, scope: :user)
       visit commencer_path(path: procedure_rib.path)
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       fill_individual
 
       within find('.editable-champ', text: 'RIB') do
@@ -99,7 +99,7 @@ describe 'Piece justificative drag and drop', js: true do
       procedure_rib = create(:procedure, :published, :for_individual, public_type_de_champs: [{ type: :piece_justificative, libelle: 'RIB', nature: 'rib' }])
       login_as(user, scope: :user)
       visit commencer_path(path: procedure_rib.path)
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       fill_individual
 
       # Capture the persistent live region id before upload: a RIB is single-file,
@@ -130,7 +130,7 @@ describe 'Piece justificative drag and drop', js: true do
       allow_any_instance_of(EditableChamp::PieceJustificativeComponent).to receive(:max).and_return(2)
       login_as(user, scope: :user)
       visit commencer_path(path: procedure.path)
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       fill_individual
       expect(page).to have_current_path(brouillon_dossier_path(dossier))
       visit brouillon_dossier_path(dossier)
@@ -200,7 +200,7 @@ describe 'Piece justificative drag and drop', js: true do
       # Créer une procédure avec titre_identite (limite 20 Mo)
       procedure_ti = create(:procedure, :published, :for_individual, public_type_de_champs: [{ type: :piece_justificative, libelle: 'Pièce d\'identité', nature: 'titre_identite' }])
       visit commencer_path(path: procedure_ti.path)
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       fill_individual
       expect(page).to have_current_path(brouillon_dossier_path(user.dossiers.last))
 
@@ -231,7 +231,7 @@ describe 'Piece justificative drag and drop', js: true do
       # Créer une procédure avec titre_identite (accepte seulement JPEG/PNG)
       procedure_ti = create(:procedure, :published, :for_individual, public_type_de_champs: [{ type: :piece_justificative, libelle: 'Pièce d\'identité', nature: 'titre_identite' }])
       visit commencer_path(path: procedure_ti.path)
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       fill_individual
       expect(page).to have_current_path(brouillon_dossier_path(user.dossiers.last))
 
@@ -272,7 +272,7 @@ describe 'Piece justificative drag and drop', js: true do
     before do
       login_as(user, scope: :user)
       visit commencer_path(path: procedure.path)
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       fill_individual
       expect(page).to have_current_path(brouillon_dossier_path(dossier))
       visit brouillon_dossier_path(dossier)
@@ -334,7 +334,7 @@ describe 'Piece justificative drag and drop', js: true do
       procedure_pjs = create(:procedure, :published, :for_individual, public_type_de_champs: [{ type: :piece_justificative, mandatory: true, libelle: 'Pièce justificative 1' }])
       login_as(user, scope: :user)
       visit commencer_path(path: procedure_pjs.path)
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       fill_individual
 
       # Make the subsequent auto-upload request fail
@@ -364,7 +364,7 @@ describe 'Piece justificative drag and drop', js: true do
       procedure_pjs = create(:procedure, :published, :for_individual, public_type_de_champs: [{ type: :piece_justificative, mandatory: true, libelle: 'Pièce justificative 1' }])
       login_as(user, scope: :user)
       visit commencer_path(path: procedure_pjs.path)
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       fill_individual
 
       attach_file('Pièce justificative 1', Rails.root.join('spec/fixtures/files/file.pdf'))
@@ -413,7 +413,7 @@ describe 'Piece justificative drag and drop', js: true do
       old_procedure_with_disabled_pj_validation = create(:procedure, :published, :for_individual, public_type_de_champs: [{ type: :piece_justificative, mandatory: true, libelle: 'Pièce justificative 1', skip_pj_validation: true }])
       login_as(user, scope: :user)
       visit commencer_path(path: old_procedure_with_disabled_pj_validation.path)
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
       fill_individual
 
       # Test invalid file type

--- a/spec/system/users/sign_up_spec.rb
+++ b/spec/system/users/sign_up_spec.rb
@@ -84,7 +84,7 @@ describe 'Signing up:', js: true do
       # (even when confirming the account in another browser).
       expect(page).to have_current_path(commencer_path(path: procedure.path))
       expect(page).to have_content I18n.t('devise.confirmations.confirmed')
-      click_on 'Commencer la démarche'
+      click_on 'Commencer un dossier'
 
       expect(page).to have_current_path identite_dossier_path(procedure.reload.dossiers.last)
       expect(page).to have_content(procedure.libelle)
@@ -116,7 +116,7 @@ describe 'Signing up:', js: true do
       # (even when confirming the account in another browser).
       expect(page).to have_current_path(commencer_path(path: procedure.path))
       expect(page).to have_content I18n.t('devise.confirmations.confirmed')
-      expect(page).to have_content 'Commencer la démarche'
+      expect(page).to have_content 'Commencer un dossier'
     end
   end
 

--- a/spec/views/commencer/show.html.haml_spec.rb
+++ b/spec/views/commencer/show.html.haml_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'commencer/show', type: :view do
     end
 
     context 'and they don’t have any dossier on this procedure' do
-      it_behaves_like 'it renders a link to create a new dossier', 'Commencer la démarche'
+      it_behaves_like 'it renders a link to create a new dossier', 'Commencer un dossier'
     end
 
     context 'and they have a pending draft' do


### PR DESCRIPTION
mentionné en point ux

# Problème

Sur la page `/commencer`, le bouton qui crée le dossier s’intitule « Commencer la démarche ».
L’usager ne commence pas une démarche : il ouvre un dossier sur une démarche déjà publiée.
Le libellé ne correspond donc ni à l’action réalisée, ni au reste de la page, qui parle déjà de
dossier (« Commencer un nouveau dossier », « Continuer à remplir mon dossier »).

# Solution

Le bouton passe à « Commencer un dossier », via une nouvelle clé i18n `start_dossier` (fr + en).
Le titre du bloc de connexion, affiché au visiteur non authentifié, garde « Commencer la démarche » :
il annonce l’entrée dans la démarche, pas la création du dossier.

## Avant / Après

| Avant | Après |
|---|---|
| ![before.png](https://gist.githubusercontent.com/mfo/ba5f85685afae8887d04949599603e2e/raw/before.png) | ![after.png](https://gist.githubusercontent.com/mfo/ba5f85685afae8887d04949599603e2e/raw/after.png) |

Generated with [Claude Code](https://claude.com/claude-code)