### PR TITLE
Tech : autoriser l’introspection GraphQL sans jeton

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -63,8 +63,33 @@ class API::V2::BaseController < ApplicationController
 
     return if query_id == 'introspection'
     return if query_id == 'ds-query-v2' && PUBLIC_OPERATIONS.include?(operation_name)
+    return if query_id.blank? && introspection_query?(params[:query])
 
     render json: graphql_error('Without a token, only the public getDemarcheDescriptor and getDemarcheDescriptors queries and introspection are allowed', :forbidden), status: :forbidden
+  end
+
+  INTROSPECTION_FIELDS = ['__schema', '__type', '__typename'].freeze
+
+  # GraphQL clients fetch the schema with their own introspection document rather
+  # than our stored `introspection` query. The schema is public, so such a document
+  # is allowed without a token as long as every root selection of every operation is
+  # an introspection field: a root fragment or a data field could reach actual data.
+  def introspection_query?(query)
+    return false if query.blank?
+
+    operations = GraphQL.parse(query).definitions.grep(GraphQL::Language::Nodes::OperationDefinition)
+
+    operations.present? && operations.all? { introspection_operation?(it) }
+  rescue GraphQL::ParseError
+    false
+  end
+
+  def introspection_operation?(operation)
+    return false unless operation.operation_type.in?([nil, 'query'])
+
+    operation.selections.all? do |selection|
+      selection.is_a?(GraphQL::Language::Nodes::Field) && INTROSPECTION_FIELDS.include?(selection.name)
+    end
   end
 
   def ensure_authorized_network

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -48,6 +48,54 @@ describe API::V2::GraphqlController do
     end
   end
 
+  describe 'anonymous introspection' do
+    let!(:authorization_header) { nil }
+    let(:forbidden_message) { 'Without a token, only the public getDemarcheDescriptor and getDemarcheDescriptors queries and introspection are allowed' }
+
+    subject { post :execute, params: { query:, operationName: operation_name }.compact, as: :json }
+
+    context 'with the standard introspection document sent by GraphQL clients' do
+      let(:query) { GraphQL::Introspection::INTROSPECTION_QUERY }
+      let(:operation_name) { 'IntrospectionQuery' }
+
+      it {
+        expect(gql_errors).to be_nil
+        expect(gql_data[:__schema][:queryType][:name]).to eq('Query')
+      }
+    end
+
+    context 'with a data query named IntrospectionQuery' do
+      let(:query) { 'query IntrospectionQuery { demarche(number: 1) { id } }' }
+      let(:operation_name) { 'IntrospectionQuery' }
+
+      it { expect(gql_errors.first[:message]).to eq(forbidden_message) }
+    end
+
+    context 'with a data field next to an introspection field' do
+      let(:query) { 'query { __schema { queryType { name } } demarche(number: 1) { id } }' }
+
+      it { expect(gql_errors.first[:message]).to eq(forbidden_message) }
+    end
+
+    context 'with a root fragment hiding a data field' do
+      let(:query) { 'query { __typename ...on Query { demarche(number: 1) { id } } }' }
+
+      it { expect(gql_errors.first[:message]).to eq(forbidden_message) }
+    end
+
+    context 'with a mutation' do
+      let(:query) { 'mutation { __typename }' }
+
+      it { expect(gql_errors.first[:message]).to eq(forbidden_message) }
+    end
+
+    context 'with an unparsable query' do
+      let(:query) { 'query {' }
+
+      it { expect(gql_errors.first[:message]).to eq(forbidden_message) }
+    end
+  end
+
   describe 'token authentication' do
     let(:query_id) { 'ds-query-v2' }
     let(:operation_name) { 'getDemarche' }


### PR DESCRIPTION
## Pourquoi

Sans jeton, l’introspection du schéma n’était possible qu’en passant par la requête stockée `queryId=introspection`. Les clients GraphQL de bureau (Altair, Bruno, Insomnia, Postman…) envoient leur propre document d’introspection : le chargement du schéma échouait donc en 403 tant que l’en-tête `Authorization` n’était pas renseigné.

Fait suite au retrait du playground (#13858) : la [nouvelle page de doc](https://doc.demarche.numerique.gouv.fr/api-graphql/premiers-pas-client-graphql) recommande ces clients, et l’avertissement « l’introspection nécessite un jeton » pourra être retiré une fois cette PR déployée.

## Quoi

- Une requête anonyme passe si son document est une introspection pure : toutes les opérations sont des `query` dont les sélections racines sont `__schema`, `__type` ou `__typename`.
- La vérification porte sur le document parsé, pas sur le nom de l’opération : un champ de données ou un fragment racine exigent toujours un jeton.
- Specs : document d’introspection standard accepté ; requête de données nommée `IntrospectionQuery`, champ de données mélangé, fragment racine, mutation et document invalide refusés.

Le schéma est déjà public (requête stockée, site du schéma), cette PR n’expose rien de nouveau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)