### PR TITLE
ETQ admin, le détail d'une démarche de l'annuaire se limite aux démarches publiées

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -451,7 +451,7 @@ module Administrateurs
     end
 
     def detail
-      @procedure = Procedure.find(params[:id])
+      @procedure = Procedure.publiees_ou_closes.where(hidden_at_as_template: nil).find(params[:id])
       @show_detail = params[:show_detail]
       respond_to do |format|
         format.turbo_stream

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -463,6 +463,33 @@ describe Administrateurs::ProceduresController, type: :controller do
     end
   end
 
+  describe 'POST #detail' do
+    render_views
+
+    let(:procedure) { procedures.individual }
+
+    before { sign_in(administrateurs.blank.user) }
+
+    subject { post :detail, params: { id: procedure.id, show_detail: true }, format: :turbo_stream }
+
+    it 'shows the administrateurs of a procedure listed in the directory' do
+      subject
+      expect(response.body).to include(administrateurs.default.email)
+    end
+
+    context 'when the procedure is a draft' do
+      let(:procedure) { procedures.brouillon }
+
+      it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    context 'when the procedure is hidden from the templates' do
+      before { procedure.update!(hidden_at_as_template: Time.zone.now) }
+
+      it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+  end
+
   describe 'POST #search' do
     before do
       stub_const("Administrateurs::ProceduresController::SIGNIFICANT_DOSSIERS_THRESHOLD", 2)


### PR DESCRIPTION
L'action `detail` de l'annuaire applique désormais les mêmes filtres que la liste (démarches publiées, closes ou dépubliées, non masquées comme modèle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)