### PR TITLE
Tech : durcir l’authentification des comptes super-admin

### DIFF
--- a/app/controllers/super_admins_controller.rb
+++ b/app/controllers/super_admins_controller.rb
@@ -14,6 +14,11 @@ class SuperAdminsController < ApplicationController
       redirect_to(edit_super_admin_otp_path) and return
     end
 
+    if current_super_admin.otp_required_for_login? && !current_super_admin.validate_and_consume_otp!(params[:otp_attempt].to_s)
+      flash[:alert] = "Code OTP invalide ou manquant."
+      redirect_to(edit_super_admin_otp_path) and return
+    end
+
     current_super_admin.enable_otp!
     @qrcode = generate_qr_code
     sign_out :super_admin

--- a/app/models/super_admin.rb
+++ b/app/models/super_admin.rb
@@ -12,6 +12,7 @@ class SuperAdmin < ApplicationRecord
 
   def enable_otp!
     self.otp_secret = SuperAdmin.generate_otp_secret
+    self.consumed_timestep = nil
     self.otp_required_for_login = true
     save!
   end

--- a/app/views/super_admins/edit_otp.html.haml
+++ b/app/views/super_admins/edit_otp.html.haml
@@ -2,9 +2,19 @@
   %div
     %h2.huge-title Espace Manager
     %p Munissez-vous de votre téléphone sur lequel vous avez installé une application cliente 2FA (Google Authenticator, Authy, AndOTP, ...)
+    - if current_super_admin.otp_required_for_login?
+      %p
+        %strong Votre authentification double-facteur est déjà activée.
+        Continuer remplacera votre application actuelle par une nouvelle&nbsp;: saisissez le code qu’elle affiche pour confirmer.
     %br
     = form_with url: enable_super_admin_otp_path, method: :put, local: true do |f|
       .fr-input-group
         = f.label :current_password, "Mot de passe actuel", class: 'fr-label'
         = f.password_field :current_password, autocomplete: 'current-password', required: true, class: 'fr-input'
-      = f.submit "Activer l’authentification double-facteur", class: 'fr-btn fr-btn--lg'
+      - if current_super_admin.otp_required_for_login?
+        .fr-input-group
+          = f.label :otp_attempt, "Code de votre application d’authentification actuelle", class: 'fr-label'
+          = f.text_field :otp_attempt, inputmode: :numeric, autocomplete: 'one-time-code', required: true, class: 'fr-input'
+        = f.submit "Remplacer l’authentification double-facteur", class: 'fr-btn fr-btn--lg'
+      - else
+        = f.submit "Activer l’authentification double-facteur", class: 'fr-btn fr-btn--lg'

--- a/spec/controllers/super_admins_controller_spec.rb
+++ b/spec/controllers/super_admins_controller_spec.rb
@@ -49,29 +49,62 @@ describe SuperAdminsController, type: :controller do
     end
 
     context 'when the super admin already enrolled OTP' do
-      let(:super_admin) { create(:super_admin, otp_required_for_login: true, password:) }
+      let(:super_admin) { create(:super_admin, :with_otp, password:) }
 
-      it 'rotates the secret and signs out when the current password is provided' do
+      it 'rotates the secret and signs out with the current password and a fresh OTP code' do
         previous_secret = super_admin.otp_secret
 
-        put :enable_otp, params: { current_password: password }
+        put :enable_otp, params: { current_password: password, otp_attempt: current_otp_for(super_admin) }
 
         super_admin.reload
-        expect(super_admin.otp_secret).to be_present
         expect(super_admin.otp_secret).not_to eq(previous_secret)
         expect(super_admin.otp_required_for_login?).to be(true)
         expect(controller.super_admin_signed_in?).to be(false)
       end
 
+      it 'is rejected without an OTP code' do
+        expect { put :enable_otp, params: { current_password: password } }
+          .not_to change { super_admin.reload.otp_secret }
+
+        expect(response).to redirect_to(edit_super_admin_otp_path)
+        expect(flash[:alert]).to be_present
+      end
+
       it 'is rejected when the current password is wrong' do
         previous_secret = super_admin.otp_secret
 
-        put :enable_otp, params: { current_password: 'wrong-password' }
+        put :enable_otp, params: { current_password: 'wrong-password', otp_attempt: current_otp_for(super_admin) }
 
         super_admin.reload
         expect(super_admin.otp_secret).to eq(previous_secret)
         expect(response).to redirect_to(edit_super_admin_otp_path)
         expect(flash[:alert]).to be_present
+      end
+    end
+  end
+
+  describe 'GET #edit_otp' do
+    render_views
+
+    before { sign_in super_admin }
+
+    context 'when the super admin already enrolled OTP' do
+      let(:super_admin) { create(:super_admin, :with_otp, password:) }
+
+      it 'asks for the current OTP code' do
+        get :edit_otp
+
+        expect(response.body).to include('name="otp_attempt"')
+      end
+    end
+
+    context 'when the super admin has not enrolled OTP yet' do
+      let(:super_admin) { create(:super_admin, otp_required_for_login: false, password:) }
+
+      it 'does not ask for an OTP code' do
+        get :edit_otp
+
+        expect(response.body).not_to include('name="otp_attempt"')
       end
     end
   end

--- a/spec/models/super_admin_spec.rb
+++ b/spec/models/super_admin_spec.rb
@@ -48,6 +48,12 @@ describe SuperAdmin, type: :model do
     it 'updates otp_secret' do
       expect { subject }.to change { super_admin.otp_secret }
     end
+
+    it 'forgets the timestep consumed with the previous secret' do
+      super_admin.update!(consumed_timestep: 1)
+
+      expect { subject }.to change { super_admin.consumed_timestep }.to(nil)
+    end
   end
 
   describe 'disable_otp!' do


### PR DESCRIPTION
Durcissement sur le compte super-admin, indépendant du registre de sessions (#13817).  

**Ré-enrôlement OTP** : un super-admin déjà enrôlé doit désormais confirmer avec un code de son application actuelle pour en enregistrer une nouvelle. Le premier enrôlement (compte neuf, ou après réinitialisation par un pair depuis le Manager) reste au mot de passe seul.


