### PR TITLE
Tech: la tâche de retrait du « pour un bénéficiaire » ne dépasse plus le timeout SQL

### DIFF
--- a/app/tasks/maintenance/t20260722unset_for_tiers_on_dossiers_without_mandataire_identity_task.rb
+++ b/app/tasks/maintenance/t20260722unset_for_tiers_on_dossiers_without_mandataire_identity_task.rb
@@ -15,10 +15,16 @@ module Maintenance
     run_on_first_deploy
 
     def collection
-      Dossier
+      poisoned = Dossier
         .state_not_brouillon
         .where(for_tiers: true)
         .where("mandataire_first_name IS NULL OR mandataire_first_name = '' OR mandataire_last_name IS NULL OR mandataire_last_name = ''")
+
+      # le timeout local ne couvre pas les requêtes que la gem lance ensuite,
+      # et ce pluck doit tenir dans chaque tranche de 5 min du job, qui le rejoue
+      ids = with_statement_timeout("4min") { poisoned.pluck(:id) }
+
+      poisoned.where(id: ids)
     end
 
     def process(dossier)

--- a/spec/tasks/maintenance/t20260722unset_for_tiers_on_dossiers_without_mandataire_identity_task_spec.rb
+++ b/spec/tasks/maintenance/t20260722unset_for_tiers_on_dossiers_without_mandataire_identity_task_spec.rb
@@ -27,6 +27,13 @@ module Maintenance
         expect(collection).not_to include(valid_for_tiers)
         expect(collection).not_to include(brouillon)
       end
+
+      it "leaves out a dossier whose mandataire identity is filled once the ids are collected" do
+        relation = described_class.new.collection
+        poisoned.update_columns(mandataire_first_name: 'Jeanne', mandataire_last_name: 'Dupont')
+
+        expect(relation).not_to include(poisoned)
+      end
     end
 
     describe "#process" do


### PR DESCRIPTION
La tâche `T20260722unsetForTiersOnDossiersWithoutMandataireIdentityTask` échoue en production dès son lancement, sur le statement_timeout de 60 s. Elle collecte désormais les ids des dossiers ciblés sous un timeout local de 4 min, puis laisse maintenance_tasks itérer sur une relation restreinte à ces ids.

**Points d'attention.**
- `with_statement_timeout` n'a aucun effet autour d'une relation renvoyée par `collection` : la gem charge ses batchs plus tard, hors de la transaction qui porte le `SET LOCAL`. Il faut donc matérialiser les ids dans le bloc.
- La borne de 4 min n'est pas arbitraire. maintenance_tasks coupe le job toutes les 5 min, et le chrono démarre avant `collection` : chaque tranche refait le pluck sur son propre budget. Au-delà de 5 min, le job ne traiterait plus qu'un dossier par tranche.
- La relation renvoyée garde le filtre, pour ne pas écraser l'identité de mandataire qu'un usager aurait saisie entre la collecte et le traitement.
