### PR TITLE
Tech: fix N+1 sur deliberation dans ChorusController

### DIFF
--- a/app/controllers/administrateurs/chorus_controller.rb
+++ b/app/controllers/administrateurs/chorus_controller.rb
@@ -11,6 +11,8 @@ module Administrateurs
       @configuration = @procedure.chorus_configuration
       @configuration.assign_attributes(configurations_params)
       if @configuration.valid?
+        # Preload deliberation to avoid N+1 in before_save callback and validations
+        @procedure.deliberation.attached?
         @procedure.update!(chorus: @configuration.attributes)
 
         if @configuration.complete?


### PR DESCRIPTION
# Probleme

N+1 detecte par [Prosopite](https://github.com/charkost/prosopite) (scan des tests) sur l'action `update` du `Administrateurs::ChorusController`.

**Triage Prosopite** : 2 patterns PROD / 0 patterns TEST ignores.

# Solution

Skill [`/n1-query-fix`](https://github.com/mfo/night-shift/blob/main/.claude/skills/n1-query-fix/SKILL.md)

### Patterns corriges

| Association | Table | Strategy | Changement |
|-------------|-------|----------|------------|
| `deliberation` | `active_storage_attachments` | preload | Ajoute `deliberation.attached?` avant `@procedure.update!` |

### Preuve Prosopite

**Avant (2 patterns PROD) :**
```
N+1 queries detected (0.4ms):
  SELECT "active_storage_attachments".* FROM "active_storage_attachments"
  WHERE "active_storage_attachments"."record_id" = $1
    AND "active_storage_attachments"."record_type" = $2
    AND "active_storage_attachments"."name" = $3 LIMIT $4
  (3 identical queries)
Call stack:
  app/controllers/administrateurs/chorus_controller.rb:14
    in 'Administrateurs::ChorusController#update'
```

**Apres (0 patterns PROD) :**
```
Aucun N+1 PROD detecte.
```

### Validation

- [x] Tests passes (rspec)
- [x] Rubocop OK
- [x] Prosopite : 0 N+1 PROD apres fix
- [x] Seuls des fichiers app/ et config/ commites

Generated with [Claude Code](https://claude.com/claude-code)