### PR TITLE
ETQ instructeur, enregistrer deux fois de suite les données d'un RIB ne provoque plus d'erreur

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
   js_tests:
     name: JavaScript tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4

--- a/app/controllers/instructeurs/champs_controller.rb
+++ b/app/controllers/instructeurs/champs_controller.rb
@@ -2,6 +2,8 @@
 
 module Instructeurs
   class ChampsController < InstructeurController
+    STREAM_UNIQUE_INDEX = 'index_champs_on_stream_and_public_id'
+
     before_action :set_dossier
     before_action :set_dossier_stream
     before_action :set_rib_champ, only: [:edit]
@@ -16,12 +18,36 @@ module Instructeurs
 
       @rib_champ_for_update.update!(value_json: { rib:, hint: 'rib' })
 
-      @dossier.merge_instructeur_buffer_stream!
+      merge_instructeur_buffer_stream
 
       redirect_to instructeur_dossier_path(@dossier.procedure, @dossier), notice: t(".success", libelle: @rib_champ_for_update.libelle)
     end
 
     private
+
+    # A merge names its history stream after the current second, so a form
+    # submitted twice inside that second trips the unique index on the second
+    # merge. The client keeps the form locked until the redirect renders; if a
+    # duplicate still gets through, the first save already holds these values
+    # and the pending copy is folded into the next checkpoint. It is still
+    # reported: it should not happen, and anything else hitting that index
+    # must keep raising.
+    def merge_instructeur_buffer_stream
+      @dossier.merge_instructeur_buffer_stream!
+    rescue ActiveRecord::RecordNotUnique => e
+      raise unless violated_constraint(e) == STREAM_UNIQUE_INDEX
+
+      Sentry.capture_exception(
+        e,
+        level: :warning,
+        fingerprint: ['rib_update_duplicate_merge'],
+        extra: { dossier: @dossier.id, public_id: params[:public_id] }
+      )
+    end
+
+    def violated_constraint(error)
+      error.cause.try(:result)&.error_field(PG::PG_DIAG_CONSTRAINT_NAME)
+    end
 
     def set_dossier
       @dossier = DossierPreloader.load_one(

--- a/app/javascript/controllers/turbo_controller.ts
+++ b/app/javascript/controllers/turbo_controller.ts
@@ -1,4 +1,8 @@
-import { session as TurboSession, type StreamElement } from '@hotwired/turbo';
+import {
+  session as TurboSession,
+  type StreamElement,
+  type TurboSubmitEndEvent
+} from '@hotwired/turbo';
 import { Actions } from 'coldwired/actions';
 import { createReactPlugin, createRoot, type Root } from 'coldwired/react';
 import { parseTurboStream } from 'coldwired/turbo-stream';
@@ -6,6 +10,7 @@ import { makeRetriable } from 'p-retry';
 import type { ComponentType } from 'react';
 import invariant from 'tiny-invariant';
 
+import { SubmitRenderGuard } from '../shared/submit-render-guard';
 import { ApplicationController } from './application_controller';
 
 type StreamRenderEvent = CustomEvent<{
@@ -22,6 +27,7 @@ export class TurboController extends ApplicationController {
   declare readonly spinnerTargets: HTMLElement[];
 
   #submitting = false;
+  #submitRenderGuard = new SubmitRenderGuard();
   #actions?: Actions;
   #root?: Root;
 
@@ -69,8 +75,18 @@ export class TurboController extends ApplicationController {
 
     // setup spinner events
     this.onGlobal('turbo:submit-start', () => this.startSpinner());
-    this.onGlobal('turbo:submit-end', () => this.stopSpinner());
-    this.onGlobal('turbo:fetch-request-error', () => this.stopSpinner());
+    this.onGlobal('turbo:submit-end', (event: TurboSubmitEndEvent) => {
+      this.stopSpinner();
+      this.#submitRenderGuard.submitEnded(event);
+    });
+    this.onGlobal('turbo:fetch-request-error', () => {
+      this.stopSpinner();
+      this.#submitRenderGuard.rendered();
+    });
+
+    // a submitted form stays locked until the page it led to is rendered
+    this.onGlobal('turbo:load', () => this.#submitRenderGuard.rendered());
+    this.onGlobal('turbo:frame-load', () => this.#submitRenderGuard.rendered());
 
     // prevent scroll on turbo form submits
     this.onGlobal('turbo:render', () => this.preventScrollIfNeeded());

--- a/app/javascript/shared/submit-render-guard.test.ts
+++ b/app/javascript/shared/submit-render-guard.test.ts
@@ -1,0 +1,94 @@
+import type { TurboSubmitEndEvent } from '@hotwired/turbo';
+import { afterEach, beforeEach, expect, suite, test } from 'vitest';
+
+import { SubmitRenderGuard } from './submit-render-guard';
+
+suite('SubmitRenderGuard', () => {
+  let form: HTMLFormElement;
+  let insideButton: HTMLButtonElement;
+  let outsideButton: HTMLButtonElement;
+  let guard: SubmitRenderGuard;
+
+  const submitEnd = (detail: Record<string, unknown>) =>
+    new CustomEvent('turbo:submit-end', {
+      detail: { formSubmission: { formElement: form }, ...detail }
+    }) as unknown as TurboSubmitEndEvent;
+
+  const redirect = { redirected: true };
+
+  // Reports whether a submit event reaches the form's own (bubbling) listener,
+  // which is where Turbo picks it up. The listener prevents the default: Firefox
+  // performs a real submission on a synthetic submit event and would navigate
+  // the test page away.
+  const submit = () => {
+    let reached = false;
+    const listener = (event: Event) => {
+      reached = true;
+      event.preventDefault();
+    };
+    form.addEventListener('submit', listener);
+    form.dispatchEvent(
+      new Event('submit', { cancelable: true, bubbles: true })
+    );
+    form.removeEventListener('submit', listener);
+    return reached;
+  };
+
+  beforeEach(() => {
+    form = document.createElement('form');
+    form.id = 'guarded-form';
+    insideButton = document.createElement('button');
+    insideButton.type = 'submit';
+    form.append(insideButton);
+    outsideButton = document.createElement('button');
+    outsideButton.type = 'submit';
+    outsideButton.setAttribute('form', form.id);
+    document.body.append(form, outsideButton);
+    guard = new SubmitRenderGuard();
+  });
+
+  afterEach(() => {
+    form.remove();
+    outsideButton.remove();
+  });
+
+  test('locks the form until the page is rendered', () => {
+    guard.submitEnded(submitEnd({ success: true, fetchResponse: redirect }));
+
+    expect(insideButton.disabled).toBe(true);
+    expect(outsideButton.disabled).toBe(true);
+    expect(submit()).toBe(false);
+
+    guard.rendered();
+
+    expect(insideButton.disabled).toBe(false);
+    expect(outsideButton.disabled).toBe(false);
+    expect(submit()).toBe(true);
+  });
+
+  test('leaves a button that was already disabled alone', () => {
+    outsideButton.disabled = true;
+
+    guard.submitEnded(submitEnd({ success: true, fetchResponse: redirect }));
+    guard.rendered();
+
+    expect(outsideButton.disabled).toBe(true);
+    expect(insideButton.disabled).toBe(false);
+  });
+
+  test('ignores failed submissions', () => {
+    guard.submitEnded(submitEnd({ success: false, fetchResponse: redirect }));
+
+    expect(insideButton.disabled).toBe(false);
+    expect(submit()).toBe(true);
+  });
+
+  test('ignores responses rendered in place, such as turbo streams', () => {
+    guard.submitEnded(
+      submitEnd({ success: true, fetchResponse: { redirected: false } })
+    );
+
+    expect(insideButton.disabled).toBe(false);
+    expect(submit()).toBe(true);
+  });
+});

--- a/app/javascript/shared/submit-render-guard.ts
+++ b/app/javascript/shared/submit-render-guard.ts
@@ -1,0 +1,67 @@
+import type { TurboSubmitEndEvent } from '@hotwired/turbo';
+
+type SubmitButton = HTMLButtonElement | HTMLInputElement;
+
+// Turbo's typings only expose `success` on the event detail; the response
+// travels with it on successful submissions.
+type SubmitEndDetail = TurboSubmitEndEvent['detail'] & {
+  fetchResponse?: { redirected: boolean };
+};
+
+// Turbo disables the submitter only while the form request is in flight. When
+// the response is a redirect, it re-enables the button before the redirected
+// page is rendered, so a second click or an Enter keypress in that window
+// submits the form again and cancels the pending visit. Keep the form locked
+// until the render settles (or the visit fails).
+//
+// Only redirects qualify: a response rendered in place (a turbo stream, a 422
+// re-render) never triggers a page load that would unlock the form again.
+export class SubmitRenderGuard {
+  #forms = new Set<HTMLFormElement>();
+  #buttons = new Set<SubmitButton>();
+
+  submitEnded(event: TurboSubmitEndEvent): void {
+    const { formSubmission, success, fetchResponse } =
+      event.detail as SubmitEndDetail;
+    if (!success || !fetchResponse?.redirected) {
+      return;
+    }
+
+    const form = formSubmission.formElement;
+    form.addEventListener('submit', preventSubmit, { capture: true });
+    this.#forms.add(form);
+
+    for (const button of submitButtons(form)) {
+      if (!button.disabled) {
+        button.disabled = true;
+        this.#buttons.add(button);
+      }
+    }
+  }
+
+  rendered(): void {
+    for (const form of this.#forms) {
+      form.removeEventListener('submit', preventSubmit, { capture: true });
+    }
+    for (const button of this.#buttons) {
+      button.disabled = false;
+    }
+    this.#forms.clear();
+    this.#buttons.clear();
+  }
+}
+
+function preventSubmit(event: Event): void {
+  event.preventDefault();
+  event.stopImmediatePropagation();
+}
+
+// `form.elements` includes the buttons associated through a `form` attribute.
+function submitButtons(form: HTMLFormElement): SubmitButton[] {
+  return Array.from(form.elements).filter(
+    (element): element is SubmitButton =>
+      (element instanceof HTMLButtonElement ||
+        element instanceof HTMLInputElement) &&
+      element.type == 'submit'
+  );
+}

--- a/spec/controllers/instructeurs/champs_controller_spec.rb
+++ b/spec/controllers/instructeurs/champs_controller_spec.rb
@@ -55,6 +55,25 @@ describe Instructeurs::ChampsController, type: :controller do
       expect(history_champ.stream).to start_with(Dossier::HISTORY_STREAM)
     end
 
+    context 'when the form is submitted twice within the same second' do
+      it 'keeps the first save, answers the duplicate with the same redirect and reports it' do
+        expect(Sentry).to receive(:capture_exception)
+          .with(an_instance_of(ActiveRecord::RecordNotUnique), hash_including(level: :warning, extra: { dossier: dossier.id, public_id: champ.public_id }))
+
+        freeze_time do
+          subject
+          put :update, params: { dossier_id: dossier.id, public_id: champ.public_id, rib: rib_params }
+        end
+
+        expect(response).to redirect_to(instructeur_dossier_path(procedure, dossier))
+        expect(flash[:notice]).to end_with("ont bien été modifiées.")
+
+        main = ChampData.find_by!(stable_id: champ.stable_id, row_id: champ.row_id, stream: Dossier::MAIN_STREAM)
+        expect(main.value_json['rib']).to eq(rib_params.stringify_keys)
+        expect(ChampData.where(stable_id: champ.stable_id, row_id: champ.row_id).count(&:history_stream?)).to eq(1)
+      end
+    end
+
     context 'when the public_id points to a public champ that is not a RIB' do
       let(:public_type_de_champs) do
         [


### PR DESCRIPTION
Ref #13816 — `RAILS-MKJ` (et `RAILS-M72` en juillet, même endpoint).

## Le problème

La fusion d'un flux tampon nomme son flux d'historique d'après la seconde courante (`history:<Time.zone.now>`) et considère comme « modifié » tout champ principal qui a un jumeau dans le tampon, sans comparer les valeurs. Deux enregistrements du même champ dans la même seconde font donc sauter l'index unique `index_champs_on_stream_and_public_id` au second, même avec des valeurs identiques. Pas besoin de concurrence : deux requêtes qui se suivent suffisent.

Côté client, Turbo ne désactive le bouton que pendant la requête : dès que la réponse (une redirection) arrive, il le réactive et lui redonne le focus alors que la page de destination n'est pas encore rendue. Un second clic ou un Entrée dans cette fenêtre renvoie le formulaire et annule la visite en cours. Le formulaire du RIB redirige vers la page du dossier, qui est lente à rendre, d'où les deux occurrences.

Le nommage à la seconde est conservé volontairement : deux fusions du même champ dans la même seconde ne sont jamais un scénario légitime, c'est un doublon qu'il faut empêcher plutôt que masquer.

## Ce que fait la PR

- **Client, pour tous les formulaires Turbo** : à `turbo:submit-end`, quand la réponse est une redirection, les boutons de soumission du formulaire restent désactivés et ses événements `submit` sont ignorés jusqu'à `turbo:load` / `turbo:frame-load`, ou jusqu'à `turbo:fetch-request-error`. Les boutons associés par l'attribut `form` (comme celui du RIB, hors du `<form>`) sont couverts via `form.elements`.
- **Serveur, sur la mise à jour du RIB uniquement** : si un doublon passe quand même, la violation d'unicité est reconnue par le nom de la contrainte que PostgreSQL renvoie (`index_champs_on_stream_and_public_id`, lu dans les champs de diagnostic de l'erreur plutôt que dans son message) et la requête répond par la même redirection avec le message de succès. Le premier enregistrement porte déjà les valeurs ; la copie en tampon est intégrée au checkpoint suivant. Le cas est remonté à Sentry en `warning`, avec une empreinte dédiée : il ne devrait pas se produire, et on veut le voir sans qu'il rouvre `RAILS-MKJ`. Toute autre violation d'unicité continue de lever.

## Tests

- `spec/controllers/instructeurs/champs_controller_spec.rb` : deux `PUT` sous `freeze_time`, le second redirige avec le message de succès, la valeur principale est celle attendue et il n'y a qu'un flux d'historique. Vérifié en échec (`ActiveRecord::RecordNotUnique`) sans le correctif.
- `app/javascript/shared/submit-render-guard.test.ts` (vitest, navigateur) : verrouillage et déverrouillage des boutons (interne et associé par `form`), `submit` neutralisé pendant la fenêtre, bouton déjà désactivé laissé tel quel, soumissions en échec et réponses rendues sur place (flux Turbo, 422) ignorées.
- Specs système `users/dossier_creation`, `instructeurs/instruction`, `users/change_email` (redirections) et `administrateurs/types_de_champ`, `administrateurs/condition`, `instructeurs/edit_dossier` (flux Turbo) passent avec la garde active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

