### PR TITLE
Tech: ne pas fabriquer d'images sur les processus qui ne font que les servir

### DIFF
--- a/app/controllers/procedures_controller.rb
+++ b/app/controllers/procedures_controller.rb
@@ -6,11 +6,7 @@ class ProceduresController < ApplicationController
   def logo
     if @procedure.logo.attached?
       logo_variant = @procedure.logo.variant(resize_to_limit: [400, 400])
-      if logo_variant.key.present?
-        redirect_to url_for(logo_variant.processed)
-      else
-        redirect_to url_for(@procedure.logo)
-      end
+      redirect_to url_for(logo_variant.image&.attached? ? logo_variant : @procedure.logo)
     else
       redirect_to ActionController::Base.helpers.image_url(PROCEDURE_DEFAULT_LOGO_SRC)
     end

--- a/app/helpers/gallery_helper.rb
+++ b/app/helpers/gallery_helper.rb
@@ -43,21 +43,24 @@ module GalleryHelper
     preview_image = attachment.blob.preview_image
     return unless preview_image.attached?
 
-    variant = preview_image.variant(resize_to_limit: [400, 400])
-    variant.key.present? ? variant.processed.url : nil
-  rescue StandardError
+    existing_variant_url(preview_image.variant(resize_to_limit: [400, 400]))
   end
 
   def image_variant_url_for(attachment)
-    variant = attachment.variant(resize_to_limit: [400, 400])
-    variant.key.present? ? variant.processed.url : nil
-  rescue StandardError
+    return if !attachment.blob.variable?
+
+    existing_variant_url(attachment.variant(resize_to_limit: [400, 400]))
   end
 
   def blob_url(attachment)
-    variant = attachment.variant(resize_to_limit: [2000, 2000])
-    attachment.blob.content_type.in?(RARE_IMAGE_TYPES) && variant.key.present? ? variant.processed.url : attachment.blob.url
-  rescue StandardError
-    attachment.blob.url
+    return attachment.blob.url if !attachment.blob.content_type.in?(RARE_IMAGE_TYPES) || !attachment.blob.variable?
+
+    existing_variant_url(attachment.variant(resize_to_limit: [2000, 2000])) || attachment.blob.url
+  end
+
+  private
+
+  def existing_variant_url(variant)
+    variant.url if variant.image&.attached?
   end
 end

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,5 +1,5 @@
 <% if blob.representable? %>
-  <% representation = blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% representation = blob.representation(resize_to_limit: [ 1024, 768 ]) %>
   <% attachment_class, to_show = (representation.image&.attached? || representation.key.present?) ? [ "attachment--preview", representation ] : [ "attachment--file", blob ] %>
   <figure class="attachment <%= attachment_class %> attachment--<%= blob.filename.extension %>">
     <%# The figcaption below already names the attachment, so the image itself is decorative %>

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -376,3 +376,7 @@ DOCUMENT_IA_KEY=""
 AMI_API_URL=""
 AMI_API_USER=""
 AMI_API_PASSWORD=""
+
+# Set on the processes that only serve images — the web servers — so they never try to
+# transform one themselves; variants and previews are made by the jobs.
+# DISABLE_IMAGE_PROCESSING="enabled"

--- a/config/initializers/image_processing.rb
+++ b/config/initializers/image_processing.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+if ENV.enabled?("DISABLE_IMAGE_PROCESSING")
+  Rails.application.config.active_storage.variable_content_types = []
+  Rails.application.config.active_storage.previewers = []
+end

--- a/spec/config/image_processing_spec.rb
+++ b/spec/config/image_processing_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe "DISABLE_IMAGE_PROCESSING" do
+  it "leaves Active Storage free to transform when unset" do
+    expect(ActiveStorage.variable_content_types).to include("image/png")
+    expect(ActiveStorage.previewers).not_to be_empty
+  end
+
+  it "empties both lists when set" do
+    config = ActiveSupport::OrderedOptions.new
+    config.variable_content_types = ["image/png"]
+    config.previewers = [ActiveStorage::Previewer::PopplerPDFPreviewer]
+    allow(Rails.application.config).to receive(:active_storage).and_return(config)
+    allow(ENV).to receive(:enabled?).and_call_original
+    allow(ENV).to receive(:enabled?).with("DISABLE_IMAGE_PROCESSING").and_return(true)
+
+    load Rails.root.join("config/initializers/image_processing.rb")
+
+    expect(config.variable_content_types).to eq([])
+    expect(config.previewers).to eq([])
+  end
+end

--- a/spec/controllers/procedures_controller_spec.rb
+++ b/spec/controllers/procedures_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+describe ProceduresController, type: :controller do
+  describe "GET #logo" do
+    subject { get :logo, params: { id: procedure.id } }
+
+    context "without a logo" do
+      let(:procedure) { create(:procedure) }
+
+      it "redirects to the default logo" do
+        expect(subject).to redirect_to(%r{/assets/.*republique-francaise-logo})
+      end
+    end
+
+    # The variant is made by BlobProcessorJob; a request that lands before it must
+    # not make one — this process may have no image library at all.
+    context "with a logo whose variant is not made yet" do
+      let(:procedure) { create(:procedure, :with_logo) }
+
+      it "redirects to the logo itself and makes no variant" do
+        expect { subject }.not_to change { ActiveStorage::VariantRecord.count }
+        expect(subject).to redirect_to(%r{/rails/active_storage/blobs/})
+      end
+    end
+
+    context "with a logo whose variant is made", :external_deps do
+      let(:procedure) { create(:procedure, :with_logo) }
+
+      before { procedure.logo.variant(resize_to_limit: [400, 400]).processed }
+
+      it "redirects to the variant" do
+        expect(subject).to redirect_to(%r{/rails/active_storage/representations/})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Les variantes et les aperçus sont fabriqués par les jobs ; les serveurs web ne font que les servir, et n'embarquent pas de bibliothèque d'images. Pourtant, trois endroits du web appellent `.processed` sur une variante — ce qui la **fabrique** si elle manque. Une requête qui arrive avant `BlobProcessorJob` (un logo tout juste téléversé) tente donc de transformer là où aucune bibliothèque n'existe : les helpers de galerie masquaient l'échec derrière un `rescue StandardError` nu, le logo de procédure répondait un 500.

Rien de tout cela n'est lié à la sandbox ; c'est un état préexistant, révélé en vérifiant où les images se calculent.

### Ce que fait la PR

- **`DISABLE_IMAGE_PROCESSING`**, un flag de processus. Posé, il vide `variable_content_types` et `previewers` : Active Storage refuse alors de transformer quoi que ce soit, avant même d'atteindre une bibliothèque, par une `InvariableError` / `UnrepresentableError` que l'app rattrape déjà en 404. Ce que les jobs ont produit reste servi — servir lit la variante stockée et ne transforme jamais. Absent par défaut : rien ne change pour une instance qui ne le pose pas.
- **Les trois `.processed` du web** (`gallery_helper`, `procedures_controller#logo`) demandent maintenant si la variante existe (`variant.image&.attached?`) et la servent, ou retombent — sur l'original, ou sur rien — sans rien fabriquer. Les `rescue` nus disparaissent : un blob non représentable est écarté par `variable?` avant qu'une variante ne soit demandée.
- `GET /procedures/:id/logo` n'avait pas de spec ; il en a un pour ses trois cas.
- **Du code mort en prime** : la taille « galerie » du partial `active_storage/blobs/_blob`, arrivée avec ActionText en 2019, n'a jamais eu d'appelant. Le partial reste (ActionText le rend pour ses pièces jointes), seule la branche `in_gallery` part.

### Pour la relecture

- Le flag est **indépendant de `BWRAP_ISOLATION`** : l'un dit « ne calcule pas ici », l'autre « isole ce que tu calcules ». Ceux qui configurent savent lesquels poser où.
- Le contrôleur de représentations de Rails n'est pas désactivé, et n'a pas à l'être : avec le flag, son `.processed` ne peut plus transformer et il ne fait que servir — c'est ce que le logo de procédure attend de lui.
- À poser (`DISABLE_IMAGE_PROCESSING=enabled`) sur les webs. Sur les jobs, ne rien poser.
