### PR TITLE
ETQ admin, cloner la démarche d'un autre administrateur ne reprend plus son webhook

### DIFF
--- a/app/models/concerns/procedure_clone_concern.rb
+++ b/app/models/concerns/procedure_clone_concern.rb
@@ -211,6 +211,7 @@ module ProcedureCloneConcern
     procedure.accuse_lecture = false if !options[:clone_accuse_lecture]
     procedure.experts_require_administrateur_invitation = false if !options[:clone_avis]
     procedure.api_entreprise_token = nil if !options[:clone_api_entreprise_token] || !same_admin?(admin)
+    procedure.web_hook_url = nil if !same_admin?(admin)
     procedure.sva_svr = {} if !options[:clone_sva_svr]
 
     if !options[:clone_instructeurs] || !same_admin?(admin)

--- a/spec/models/concerns/procedure_clone_concern_spec.rb
+++ b/spec/models/concerns/procedure_clone_concern_spec.rb
@@ -17,6 +17,7 @@ describe ProcedureCloneConcern, type: :model do
         public_type_de_champs:,
         private_type_de_champs:,
         api_particulier_token: '123456789012345',
+        web_hook_url: 'https://callback.exemple.fr/',
         estimated_dossiers_count: 4,
         template: true)
     end
@@ -73,6 +74,10 @@ describe ProcedureCloneConcern, type: :model do
       tag_source_pj_with_old_pj
       pj_tdc = subject.draft_revision.public_root_type_de_champs.find(&:piece_justificative?)
       expect(pj_tdc.reload.options[:old_pj]).to be_present
+    end
+
+    it 'keeps the web_hook_url when cloning for the same admin' do
+      expect(subject.web_hook_url).to eq('https://callback.exemple.fr/')
     end
 
     it 'the cloned procedure should not be a template anymore' do
@@ -282,6 +287,10 @@ describe ProcedureCloneConcern, type: :model do
 
       it "should discard the existing token" do
         expect(subject.api_particulier_token).to be_nil
+      end
+
+      it 'should discard the web_hook_url' do
+        expect(subject.web_hook_url).to be_nil
       end
 
       it 'should not route the procedure' do


### PR DESCRIPTION
Quand un administrateur clonait une démarche dont il n'est pas administrateur (bibliothèque, annuaire, mutation GraphQL `demarcheCloner`), la copie gardait le `web_hook_url` de la source.

Le `web_hook_url` est désormais vidé quand le cloneur n'administre pas la démarche source, comme on le fait déjà pour `api_entreprise_token` et `api_particulier_token`. Un admin qui clone sa propre démarche garde son webhook.

À noter : `transfer` clone vers un autre administrateur, donc la démarche transférée n'aura plus de webhook non plus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
