### PR TITLE
Tech: attribue un uuid aux zones géographiques créées hors du flux principal

### DIFF
--- a/app/models/geo_area.rb
+++ b/app/models/geo_area.rb
@@ -262,8 +262,6 @@ class GeoArea < ApplicationRecord
   end
 
   def set_default_uuid
-    if champ_data.main_stream?
-      self.uuid ||= SecureRandom.uuid
-    end
+    self.uuid ||= SecureRandom.uuid
   end
 end

--- a/app/tasks/maintenance/t20260911_backfill_missing_geo_area_uuid_task.rb
+++ b/app/tasks/maintenance/t20260911_backfill_missing_geo_area_uuid_task.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class T20260911BackfillMissingGeoAreaUuidTask < MaintenanceTasks::Task
+    # Documentation: cette tâche attribue un uuid aux zones géographiques qui
+    # n'en ont pas. Jusqu'ici seules les zones créées sur le flux principal en
+    # recevaient un : une zone dessinée lors d'une correction (flux tampon)
+    # restait sans uuid après la fusion. Les copies d'une même zone dans les
+    # autres flux reçoivent le même uuid.
+
+    include RunnableOnDeployConcern
+    include StatementsHelpersConcern
+
+    run_on_first_deploy
+
+    def collection
+      GeoArea.where(uuid: nil)
+    end
+
+    def process(geo_area)
+      geo_area.reload
+      return if geo_area.uuid.present?
+
+      champ_data = geo_area.champ_data
+      siblings = GeoArea.joins(:champ_data)
+        .where(geometry: geo_area.geometry, champs: { dossier_id: champ_data.dossier_id, stable_id: champ_data.stable_id, row_id: champ_data.row_id })
+      uuid = siblings.where.not(uuid: nil).pick(:uuid) || SecureRandom.uuid
+
+      siblings.where(uuid: nil).update_all(uuid:)
+    end
+
+    def count
+      # do not count, avoid timeout
+    end
+  end
+end

--- a/spec/models/geo_area_spec.rb
+++ b/spec/models/geo_area_spec.rb
@@ -33,6 +33,34 @@ RSpec.describe GeoArea, type: :model do
     end
   end
 
+  describe 'uuid' do
+    let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :carte }]) }
+    let(:dossier) { create(:dossier, procedure:) }
+    let(:main_champ) { dossier.champ_data.first }
+    let(:buffer_champ) do
+      champ = main_champ.dup
+      champ.stream = Dossier::USER_BUFFER_STREAM
+      champ.save!(validate: false)
+      champ
+    end
+
+    it 'is assigned on the main stream' do
+      expect(create(:geo_area, :selection_utilisateur, :polygon, champ_data: main_champ).uuid).to be_present
+    end
+
+    it 'is assigned on a buffer stream too' do
+      expect(create(:geo_area, :selection_utilisateur, :polygon, champ_data: buffer_champ).uuid).to be_present
+    end
+
+    it 'survives cloning to another stream' do
+      geo_area = create(:geo_area, :selection_utilisateur, :polygon, champ_data: main_champ)
+      clone = geo_area.dup.tap { it.champ_data = buffer_champ }.tap(&:save!)
+
+      expect(clone.uuid).to eq(geo_area.uuid)
+      expect(clone.to_feature[:properties][:id]).to eq(geo_area.to_feature[:properties][:id])
+    end
+  end
+
   describe 'validations' do
     context 'geometry' do
       subject! { geo_area.validate }

--- a/spec/tasks/maintenance/t20260521_backfill_geo_area_uuid_task_spec.rb
+++ b/spec/tasks/maintenance/t20260521_backfill_geo_area_uuid_task_spec.rb
@@ -51,9 +51,12 @@ module Maintenance
           champ.save!(validate: false)
           champ
         end
-        let!(:buffer_geo_area) { create(:geo_area, :selection_utilisateur, :point, champ_data: buffer_champ) }
+        let!(:buffer_geo_area) do
+          create(:geo_area, :selection_utilisateur, :point, champ_data: buffer_champ).tap { it.update_column(:uuid, nil) }
+        end
 
         it 'does not update its uuid' do
+          process
           expect(buffer_geo_area.reload.uuid).to be_nil
         end
       end

--- a/spec/tasks/maintenance/t20260911_backfill_missing_geo_area_uuid_task_spec.rb
+++ b/spec/tasks/maintenance/t20260911_backfill_missing_geo_area_uuid_task_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe T20260911BackfillMissingGeoAreaUuidTask do
+    describe "#process" do
+      let(:procedure) { create(:procedure, public_type_de_champs: [{ type: :carte }]) }
+      let(:dossier) { create(:dossier, procedure:) }
+      let(:main_champ) { dossier.champ_data.first }
+      let(:buffer_champ) do
+        champ = main_champ.dup
+        champ.stream = Dossier::USER_BUFFER_STREAM
+        champ.save!(validate: false)
+        champ
+      end
+
+      def create_geo_area_without_uuid(champ_data, *traits)
+        create(:geo_area, :selection_utilisateur, *traits, champ_data:).tap do |geo_area|
+          geo_area.update_column(:uuid, nil)
+        end
+      end
+
+      let(:geo_area) { create_geo_area_without_uuid(main_champ, :polygon) }
+
+      subject(:process) { described_class.new.process(geo_area) }
+
+      it 'assigns a uuid to a geo_area that has none' do
+        expect { process }.to change { geo_area.reload.uuid }.from(nil).to(a_kind_of(String))
+      end
+
+      it 'is idempotent' do
+        process
+        expect { described_class.new.process(geo_area) }.not_to change { geo_area.reload.uuid }
+      end
+
+      it 'is not restricted to the main stream' do
+        buffer_geo_area = create_geo_area_without_uuid(buffer_champ, :polygon)
+
+        expect { described_class.new.process(buffer_geo_area) }.to change { buffer_geo_area.reload.uuid }.from(nil).to(a_kind_of(String))
+      end
+
+      context 'when the same area exists in another stream' do
+        let!(:buffer_geo_area) { create_geo_area_without_uuid(buffer_champ, :polygon) }
+
+        it 'gives both copies the same uuid' do
+          process
+          expect(buffer_geo_area.reload.uuid).to eq(geo_area.reload.uuid)
+        end
+
+        it 'reuses the uuid a copy already carries' do
+          buffer_geo_area.update_column(:uuid, 'already-there')
+          process
+          expect(geo_area.reload.uuid).to eq('already-there')
+        end
+      end
+
+      context 'when another stream holds a different area' do
+        let!(:buffer_geo_area) { create_geo_area_without_uuid(buffer_champ, :point) }
+
+        it 'leaves it alone' do
+          process
+          expect(buffer_geo_area.reload.uuid).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Le `uuid` d'une `GeoArea` sert à retrouver la même zone d'un flux à l'autre (il est conservé par le `dup` lors du clonage d'un champ vers un flux tampon). Il n'était attribué que sur le flux principal : une zone dessinée lors d'une correction restait sans uuid après la fusion, et chaque clonage ultérieur la désignait par un nouvel id en base (`to_feature`, lookup du `CarteController`).

## Correction

- Le uuid est attribué à la création quel que soit le flux.
- Tâche de maintenance `T20260911BackfillMissingGeoAreaUuid` (exécutée au déploiement) pour les zones existantes sans uuid : les copies d'une même zone dans les autres flux reçoivent le même uuid, en réutilisant celui qu'une copie porte déjà.

## Tests

Spec modèle sur l'attribution (flux principal, flux tampon, clonage), spec de la tâche. Le spec de l'ancienne tâche de backfill supposait qu'une zone en flux tampon n'avait pas de uuid : il la vide désormais explicitement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)