### PR TITLE
Tech: regrouper les erreurs de connexion infra dans une seule issue Sentry par classe

### DIFF
--- a/app/lib/sentry_fingerprint.rb
+++ b/app/lib/sentry_fingerprint.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Sentry `before_send` hook grouping infrastructure outages by exception class.
+#
+# Sentry groups events by stacktrace and transaction, so a single Redis,
+# PostgreSQL or object storage outage fans out into dozens of issues (one per
+# controller action or job, times one per message variant: "Connection
+# refused", "Connection timed out", "No route to host"…). Nothing in those
+# issues is actionable in the code: they only need to be spotted, then closed
+# once the outage is over. Forcing the fingerprint to the exception class makes
+# every burst land in a single issue per class, which Sentry reopens as
+# "regressed" the next time the component goes down.
+#
+# Only connection-level errors of our own infrastructure are grouped. Errors
+# from external providers (API Entreprise, FranceConnect, mail delivery…) keep
+# the default grouping: their failures are per endpoint and per transaction.
+module SentryFingerprint
+  INFRASTRUCTURE_ERRORS = [
+    # Redis (Kredis, cache, Sidekiq)
+    Redis::BaseConnectionError,
+    RedisClient::ConnectionError,
+    # PostgreSQL
+    ActiveRecord::ConnectionNotEstablished,
+    ActiveRecord::ConnectionFailed,
+    PG::ConnectionBad,
+    PG::UnableToSend,
+    # Object storage (fog-openstack)
+    Excon::Error::Socket,
+    Excon::Error::Timeout,
+    Excon::Error::Server,
+  ].freeze
+
+  # Raised while Redis restarts and is not serving reads yet; redis-client
+  # maps READONLY and MASTERDOWN to connection errors but not LOADING.
+  REDIS_LOADING_PREFIX = "LOADING"
+
+  def self.call(event, hint)
+    fingerprint = for_exception(hint[:exception])
+    event.fingerprint = fingerprint if fingerprint
+    event
+  end
+
+  def self.for_exception(exception)
+    return if exception.nil?
+
+    infrastructure_error = Sentry::Utils::ExceptionCauseChain
+      .exception_to_array(exception)
+      .find { infrastructure_error?(it) }
+
+    [infrastructure_error.class.name] if infrastructure_error
+  end
+
+  def self.infrastructure_error?(exception)
+    case exception
+    when Redis::CommandError, RedisClient::CommandError
+      exception.message.start_with?(REDIS_LOADING_PREFIX)
+    when *INFRASTRUCTURE_ERRORS
+      true
+    else
+      false
+    end
+  end
+  private_class_method :infrastructure_error?
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -28,6 +28,9 @@ Sentry.init do |config|
 
   config.excluded_exceptions += ['APIEntreprise::Job::ProviderDownError']
 
+  # Lambda so the app constant is resolved at send time, not at boot.
+  config.before_send = -> (event, hint) { SentryFingerprint.call(event, hint) }
+
   # Note: sentry-ruby's :graphql patch is intentionally NOT enabled here.
   # It attaches GraphQL::Tracing::SentryTrace which wraps every field resolution
   # with a span + clock_gettime calls. On large API V2 responses (tens of

--- a/spec/lib/sentry_fingerprint_spec.rb
+++ b/spec/lib/sentry_fingerprint_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+describe SentryFingerprint do
+  def fingerprint_for(hint)
+    event = Sentry::ErrorEvent.new(configuration: Sentry.configuration)
+    described_class.call(event, hint).fingerprint
+  end
+
+  # Raises `inner`, then raises the exception built by the block from the
+  # rescue clause, so the result carries `inner` as its cause.
+  def raise_wrapped(inner)
+    begin
+      raise inner
+    rescue StandardError
+      raise yield
+    end
+  rescue StandardError => e
+    e
+  end
+
+  describe '.call' do
+    it 'is wired as the Sentry before_send hook' do
+      # No DSN in test: the client runs before_send and skips the transport.
+      event = Sentry::ErrorEvent.new(configuration: Sentry.configuration)
+      exception = Redis::CannotConnectError.new('Connection refused')
+      expect(Sentry.get_current_client.send_event(event, { exception: }).fingerprint).to eq(['Redis::CannotConnectError'])
+    end
+
+    it 'groups a Redis connection error by class, whatever the message' do
+      ['Connection refused', 'Connection timed out', 'No route to host', ''].each do |message|
+        expect(fingerprint_for(exception: Redis::CannotConnectError.new(message))).to eq(['Redis::CannotConnectError'])
+      end
+    end
+
+    it 'groups a wrapped database connection error by the infrastructure class' do
+      exception = raise_wrapped(ActiveRecord::DatabaseConnectionError.new('There is an issue connecting with your hostname')) do
+        ActiveJob::DeserializationError.new
+      end
+      expect(fingerprint_for(exception:)).to eq(['ActiveRecord::DatabaseConnectionError'])
+    end
+
+    it 'groups a PostgreSQL connection failure by the outermost infrastructure class' do
+      exception = raise_wrapped(PG::ConnectionBad.new('PQconsumeInput() server closed the connection unexpectedly')) do
+        ActiveRecord::ConnectionFailed.new('PQconsumeInput() server closed the connection unexpectedly')
+      end
+      expect(fingerprint_for(exception:)).to eq(['ActiveRecord::ConnectionFailed'])
+    end
+
+    it 'groups Sidekiq redis-client errors by class' do
+      expect(fingerprint_for(exception: RedisClient::CannotConnectError.new('timeout 1.0s'))).to eq(['RedisClient::CannotConnectError'])
+    end
+
+    it 'groups object storage socket and 5xx errors by class' do
+      expect(fingerprint_for(exception: Excon::Error::BadGateway.new('Expected(200) <=> Actual(502 Bad Gateway)'))).to eq(['Excon::Error::BadGateway'])
+      expect(fingerprint_for(exception: Excon::Error::Socket.new(Errno::ECONNREFUSED.new))).to eq(['Excon::Error::Socket'])
+    end
+
+    it 'groups Redis LOADING errors but not other command errors' do
+      loading = Redis::CommandError.new('LOADING Redis is loading the dataset in memory')
+      expect(fingerprint_for(exception: loading)).to eq(['Redis::CommandError'])
+
+      wrong_type = Redis::CommandError.new('WRONGTYPE Operation against a key holding the wrong kind of value')
+      expect(fingerprint_for(exception: wrong_type)).to be_empty
+    end
+
+    it 'leaves other errors, statement timeouts and messages to the default grouping' do
+      expect(fingerprint_for(exception: RuntimeError.new('boom'))).to be_empty
+      expect(fingerprint_for(exception: ActiveRecord::QueryCanceled.new('canceling statement'))).to be_empty
+      expect(fingerprint_for(exception: Excon::Error::Conflict.new('Expected(202) <=> Actual(409 Conflict)'))).to be_empty
+      expect(fingerprint_for(message: 'hello')).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Ref #13816 (section « Rafales d'infra »).

Sentry regroupe les événements par stacktrace et par transaction : une seule panne Redis, PostgreSQL ou stockage objet éclate donc en dizaines d'issues (une par action de contrôleur ou par job, multipliée par variante de message : « Connection refused », « Connection timed out », « No route to host »…). Le blip Redis du 3 septembre a produit à lui seul une soixantaine d'issues, toutes à résoudre à la main une fois la panne terminée.

## Changements

- Nouveau hook `before_send` (`SentryFingerprint`) qui parcourt la chaîne de causes de l'exception et, s'il rencontre une erreur de connexion de notre propre infra, force le fingerprint sur la classe de cette exception :
  - Redis : `Redis::BaseConnectionError`, `RedisClient::ConnectionError`, et les `CommandError` « LOADING » (redémarrage)
  - PostgreSQL : `ActiveRecord::ConnectionNotEstablished` (dont `DatabaseConnectionError`, pool timeout), `ActiveRecord::ConnectionFailed`, `PG::ConnectionBad`, `PG::UnableToSend`
  - Stockage objet (fog-openstack) : `Excon::Error::Socket`, `Excon::Error::Timeout`, `Excon::Error::Server` (5xx)
- Les erreurs enveloppées (`ActionView::Template::Error`, `ActiveJob::DeserializationError`) sont déballées par le parcours des causes.
- Les statement timeouts (`QueryCanceled`), les 409 du stockage et les erreurs des fournisseurs externes (API Entreprise, FranceConnect, mails…) gardent le regroupement par défaut : ce sont d'autres lignes de #13816.

Résultat attendu : une panne = une issue par classe (≈ 2 à 3 issues au lieu de 60), que Sentry rouvre en « regressed » à la panne suivante.

🤖 Generated with [Claude Code](https://claude.com/claude-code)