### PR TITLE
Correctif: ETQ instructeur, la liste des événements d'un dossier ne tombe plus en erreur

### DIFF
--- a/app/components/instructeurs/dossier_traitements_component.rb
+++ b/app/components/instructeurs/dossier_traitements_component.rb
@@ -9,6 +9,6 @@ class Instructeurs::DossierTraitementsComponent < ApplicationComponent
 
   def traitement_props(traitement)
     processed_at = l(traitement.processed_at, format: :long_with_time)
-    { processed_at:, email: traitement.instructeur_email }.compact
+    { processed_at:, email: traitement.instructeur_email.presence || t('.instructeur_inconnu') }
   end
 end

--- a/app/components/instructeurs/dossier_traitements_component/dossier_traitements_component.en.yml
+++ b/app/components/instructeurs/dossier_traitements_component/dossier_traitements_component.en.yml
@@ -1,4 +1,5 @@
 en:
+  instructeur_inconnu: unidentified
   title: Events and decisions made
   depose: "On %{processed_at}, this file was submitted"
   depose_correction_usager: "On %{processed_at}, corrections were submitted"

--- a/app/components/instructeurs/dossier_traitements_component/dossier_traitements_component.fr.yml
+++ b/app/components/instructeurs/dossier_traitements_component/dossier_traitements_component.fr.yml
@@ -1,4 +1,5 @@
 fr:
+  instructeur_inconnu: non identifié
   title: Événements et décisions rendues
   depose: Le %{processed_at}, ce dossier a été déposé
   depose_correction_usager: Le %{processed_at}, des corrections ont été déposées

--- a/spec/components/instructeurs/dossier_traitements_component_spec.rb
+++ b/spec/components/instructeurs/dossier_traitements_component_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Instructeurs::DossierTraitementsComponent, type: :component do
+  let(:dossier) { create(:dossier, :en_construction) }
+  let(:instructeur_email) { nil }
+
+  subject { render_inline(described_class.new(traitements: dossier.traitements.reload)) }
+
+  # a dossier deposé, puis passé en instruction, puis repassé en construction
+  before do
+    dossier.traitements.destroy_all
+    dossier.traitements.create!(state: Dossier.states.fetch(:en_construction), processed_at: 3.hours.ago)
+    dossier.traitements.create!(state: Dossier.states.fetch(:en_instruction), instructeur_email:, processed_at: 2.hours.ago)
+    dossier.traitements.create!(state: Dossier.states.fetch(:en_construction), instructeur_email:, processed_at: 1.hour.ago)
+  end
+
+  context "when the traitement was made by an instructeur" do
+    let(:instructeur_email) { "instructeur@example.org" }
+
+    it "names the instructeur" do
+      expect(subject.to_html).to include("lʼinstructeur instructeur@example.org a repassé ce dossier en construction")
+    end
+  end
+
+  context "when the traitement has no instructeur email" do
+    it "renders without raising a missing interpolation error" do
+      expect { subject }.not_to raise_error
+    end
+
+    it "falls back to a neutral label" do
+      expect(subject.to_html).to include("lʼinstructeur non identifié a repassé ce dossier en construction")
+    end
+  end
+end


### PR DESCRIPTION
# Problème

`Traitement#event` renvoie `:repasse_en_construction` dès qu'un traitement `en_construction` succède à un traitement d'un autre état, sans vérifier qu'un instructeur est associé — contrairement à toutes ses autres branches. Le libellé correspondant interpole `%{email}` : quand `instructeur_email` est NULL, I18n lève `MissingInterpolationArgument` et la page « personnes impliquées » renvoie une 500.

De tels traitements existent en base : `Dossier#create_missing_traitemets` reconstitue un traitement `en_construction` daté de `en_construction_at` et sans instructeur, pour les dossiers dont les traitements manquent.

Sentry : [RAILS-MKR](https://demarches-simplifiees.sentry.io/issues/RAILS-MKR)

# Solution

Le composant retombe sur un libellé neutre quand l'email est absent, au lieu de retirer la clé d'interpolation.

`Traitement#event` garde ses autres branches inchangées : lui ajouter un événement `repasse_en_construction_automatiquement` toucherait l'enum `TraitementEvent` de l'API GraphQL publique, ce qui dépasse ce correctif.

Generated with [Claude Code](https://claude.com/claude-code)