### PR TITLE
ETQ instructeur, je ne peux plus gérer un groupe instructeur que je n'ai pas rejoint

### DIFF
--- a/app/controllers/instructeurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/instructeurs/groupe_instructeurs_controller.rb
@@ -95,7 +95,11 @@ module Instructeurs
     end
 
     def groupe_instructeur
-      procedure.groupe_instructeurs.find(params[:id])
+      if current_administrateur&.owns?(procedure)
+        procedure.groupe_instructeurs.find(params[:id])
+      else
+        current_instructeur.groupe_instructeurs.where(procedure: procedure).find(params[:id])
+      end
     end
 
     def paginated_groupe_instructeurs

--- a/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
@@ -298,4 +298,52 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
       expect(gi_1_2.reload.signature).to be_attached
     end
   end
+
+  describe 'group membership scope within the same procedure' do
+    # The signed-in instructeur is a member of gi_1_2 only (top-level before),
+    # and targets gi_1_1, another group of the same procedure.
+    let(:instructeur) { create(:instructeur) }
+    let(:procedure) { create(:procedure, :published, instructeurs_self_management_enabled: true) }
+
+    describe '#show' do
+      it 'exposes the instructeurs of a group the instructeur has not joined' do
+        get :show, params: { procedure_id: procedure.id, id: gi_1_1.id }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe '#add_instructeurs' do
+      it 'lets the instructeur join a group they are not a member of' do
+        post :add_instructeurs,
+          params: { procedure_id: procedure.id, id: gi_1_1.id, emails: [instructeur.email] }
+
+        expect(gi_1_1.reload.instructeurs).to include(instructeur)
+      end
+    end
+
+    describe '#remove_instructeur' do
+      let(:victim_instructeur) { create(:instructeur) }
+
+      before { gi_1_1.instructeurs << victim_instructeur << create(:instructeur) }
+
+      it 'lets the instructeur remove a member from a group they have not joined' do
+        delete :remove_instructeur,
+          params: { procedure_id: procedure.id, id: gi_1_1.id, instructeur: { id: victim_instructeur.id } }
+
+        expect(gi_1_1.reload.instructeurs).not_to include(victim_instructeur)
+      end
+    end
+
+    describe '#add_signature' do
+      let(:signature) { fixture_file_upload('spec/fixtures/files/black.png', 'image/png') }
+
+      it 'lets the instructeur replace the signature of a group they have not joined' do
+        post :add_signature,
+          params: { procedure_id: procedure.id, id: gi_1_1.id, groupe_instructeur: { signature: signature } }
+
+        expect(gi_1_1.reload.signature).to be_attached
+      end
+    end
+  end
 end

--- a/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/instructeurs/groupe_instructeurs_controller_spec.rb
@@ -306,19 +306,21 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
     let(:procedure) { create(:procedure, :published, instructeurs_self_management_enabled: true) }
 
     describe '#show' do
-      it 'exposes the instructeurs of a group the instructeur has not joined' do
-        get :show, params: { procedure_id: procedure.id, id: gi_1_1.id }
-
-        expect(response).to have_http_status(:ok)
+      it 'does not expose the instructeurs of a group the instructeur has not joined' do
+        expect {
+          get :show, params: { procedure_id: procedure.id, id: gi_1_1.id }
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     describe '#add_instructeurs' do
-      it 'lets the instructeur join a group they are not a member of' do
-        post :add_instructeurs,
-          params: { procedure_id: procedure.id, id: gi_1_1.id, emails: [instructeur.email] }
+      it 'does not let the instructeur join a group they are not a member of' do
+        expect {
+          post :add_instructeurs,
+            params: { procedure_id: procedure.id, id: gi_1_1.id, emails: [instructeur.email] }
+        }.to raise_error(ActiveRecord::RecordNotFound)
 
-        expect(gi_1_1.reload.instructeurs).to include(instructeur)
+        expect(gi_1_1.reload.instructeurs).not_to include(instructeur)
       end
     end
 
@@ -327,22 +329,46 @@ describe Instructeurs::GroupeInstructeursController, type: :controller do
 
       before { gi_1_1.instructeurs << victim_instructeur << create(:instructeur) }
 
-      it 'lets the instructeur remove a member from a group they have not joined' do
-        delete :remove_instructeur,
-          params: { procedure_id: procedure.id, id: gi_1_1.id, instructeur: { id: victim_instructeur.id } }
+      it 'does not let the instructeur remove a member from a group they have not joined' do
+        expect {
+          delete :remove_instructeur,
+            params: { procedure_id: procedure.id, id: gi_1_1.id, instructeur: { id: victim_instructeur.id } }
+        }.to raise_error(ActiveRecord::RecordNotFound)
 
-        expect(gi_1_1.reload.instructeurs).not_to include(victim_instructeur)
+        expect(gi_1_1.reload.instructeurs).to include(victim_instructeur)
       end
     end
 
     describe '#add_signature' do
       let(:signature) { fixture_file_upload('spec/fixtures/files/black.png', 'image/png') }
 
-      it 'lets the instructeur replace the signature of a group they have not joined' do
-        post :add_signature,
-          params: { procedure_id: procedure.id, id: gi_1_1.id, groupe_instructeur: { signature: signature } }
+      it 'does not let the instructeur replace the signature of a group they have not joined' do
+        expect {
+          post :add_signature,
+            params: { procedure_id: procedure.id, id: gi_1_1.id, groupe_instructeur: { signature: signature } }
+        }.to raise_error(ActiveRecord::RecordNotFound)
 
-        expect(gi_1_1.reload.signature).to be_attached
+        expect(gi_1_1.reload.signature).not_to be_attached
+      end
+    end
+
+    context 'when the instructeur owns the procedure' do
+      # Default top-level lets: instructeur is administrateur.instructeur, owner
+      # of the procedure, member of gi_1_2 only — must keep procedure-wide access.
+      let(:instructeur) { administrateur.instructeur }
+      let(:procedure) { create(:procedure, :published, administrateurs: [administrateur]) }
+
+      it 'still shows a group they have not joined' do
+        get :show, params: { procedure_id: procedure.id, id: gi_1_1.id }
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'still adds instructeurs to a group they have not joined' do
+        post :add_instructeurs,
+          params: { procedure_id: procedure.id, id: gi_1_1.id, emails: ['new_instructeur@example.com'] }
+
+        expect(gi_1_1.reload.instructeurs.map(&:email)).to include('new_instructeur@example.com')
       end
     end
   end


### PR DESCRIPTION
## Problème

Sur une démarche routée avec auto-gestion des instructeurs, tout instructeur de la démarche
peut gérer **n'importe quel groupe**, y compris ceux qu'il n'a pas rejoints : `show` (emails
des membres), `add_instructeurs` (s'auto-ajouter → accès aux dossiers du groupe),
`remove_instructeur` (éjecter un membre), `add_signature` (remplacer le tampon d'attestation).

Régression de `5aebf3fd20` : en corrigeant un IDOR inter-démarches, le commit a remplacé le
scope d'appartenance par un scope démarche. Or `current_instructeur.procedures` passe par les
groupes : il prouve l'appartenance à *au moins un* groupe de la démarche, pas *au groupe
demandé*. L'`index` (`paginated_groupe_instructeurs`) scope déjà sur « mes groupes » — l'URL
directe ne le faisait plus.

Broken Access Control (OWASP A01 / CWE-863), DREAD 14/15.

## Solution

`groupe_instructeur` reprend la logique d'`ensure_allowed!` : propriétaire de la démarche →
accès à tous les groupes ; instructeur simple → uniquement ses groupes (404 sinon, comme le
cas inter-démarches).

- Commit 1 : specs prouvant la faille (passaient sur main).
- Commit 2 : fix + assertions inversées + non-régression propriétaire.
- `groupe_instructeurs_controller_spec.rb` 24/24, specs adjacentes 116/116.

### Points d'attention review

- [ ] Le propriétaire garde l'accès procédure-large (2 specs).
- [ ] Les specs IDOR inter-démarches de `5aebf3fd20` restent inchangées.
- [ ] Pas d'impact sur les démarches non routées (groupe unique dont l'instructeur est membre).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
