### PR TITLE
Tech: purger les blobs soft-deleted par ordre de soft_deleted_at et non par curseur d'id

### DIFF
--- a/app/jobs/cron/purge_soft_deleted_blobs_job.rb
+++ b/app/jobs/cron/purge_soft_deleted_blobs_job.rb
@@ -3,14 +3,39 @@
 class Cron::PurgeSoftDeletedBlobsJob < Cron::CronJob
   self.schedule_expression = "every day at 01:00" # after PurgeUnattachedBlobsJob (00:30)
 
+  # Bounds one run: the Swift bulk delete costs about 30 s per batch, so this is
+  # roughly eight hours of work. Whatever is left waits for the next night.
+  MAX_BATCHES_PER_RUN = 1000
+
   def perform
     return if ENV['PURGE_LATER_DELAY_IN_DAY'].blank?
     return if ActiveStorage::Blob.service.name != :openstack
 
     retention = Integer(ENV['PURGE_LATER_DELAY_IN_DAY']).days
+    expired = ActiveStorage::Blob.where(service_name: :openstack, soft_deleted_at: ..retention.ago)
 
-    ActiveStorage::Blob
-      .where(service_name: :openstack, soft_deleted_at: ..retention.ago)
-      .in_batches(of: BlobService::BULK_DELETE_LIMIT) { BlobService.purge_blobs_with_variants(it.ids) }
+    # Not in_batches: its `ORDER BY id LIMIT n` cursor walks the primary key of
+    # the 170M-row blobs table and discards over a million rows before it finds
+    # the first batch (45 s in production, hence the statement timeouts).
+    # Ordering by soft_deleted_at reads the partial index in order. Every batch
+    # deletes its rows, but their index entries stay behind until vacuum, so the
+    # cursor keeps the last soft_deleted_at seen as a lower bound: without it,
+    # each batch rescans the dead entries of all the previous ones (7 s after
+    # 1000 batches on a copy of the production database).
+    cursor = nil
+    previous_ids = nil
+    MAX_BATCHES_PER_RUN.times do
+      batch = cursor ? expired.where(soft_deleted_at: cursor..) : expired
+      soft_deleted_ats, ids = batch.order(:soft_deleted_at).limit(BlobService::BULK_DELETE_LIMIT)
+        .pluck(:soft_deleted_at, :id).transpose
+
+      # ids == previous_ids: the rows survived the purge, so retrying would
+      # issue the same Swift bulk delete a thousand times.
+      break if ids.blank? || ids == previous_ids
+
+      BlobService.purge_blobs_with_variants(ids)
+      cursor = soft_deleted_ats.last
+      previous_ids = ids
+    end
   end
 end

--- a/spec/jobs/cron/purge_soft_deleted_blobs_job_spec.rb
+++ b/spec/jobs/cron/purge_soft_deleted_blobs_job_spec.rb
@@ -52,6 +52,54 @@ RSpec.describe Cron::PurgeSoftDeletedBlobsJob, type: :job do
       expect(ActiveStorage::Blob.exists?(id: blob_never_soft_deleted.id)).to be(true)
     end
 
+    context 'with more expired blobs than a batch holds' do
+      let(:blob_older) do
+        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("older"), filename: "older.txt", content_type: "text/plain").tap do |blob|
+          blob.update_columns(soft_deleted_at: 3.days.ago, service_name: 'openstack')
+        end
+      end
+
+      before do
+        blob_older
+        stub_const('BlobService::BULK_DELETE_LIMIT', 1)
+      end
+
+      it 'purges batch after batch, oldest soft-deleted first' do
+        perform
+
+        expect(client).to have_received(:delete_multiple_objects).with('bucket', [blob_older.key]).ordered
+        expect(client).to have_received(:delete_multiple_objects).with('bucket', [blob_old.key]).ordered
+        expect(ActiveStorage::Blob.exists?(id: [blob_older.id, blob_old.id])).to be(false)
+      end
+
+      it 'stops at the per-run cap and leaves the rest to the next run' do
+        stub_const('Cron::PurgeSoftDeletedBlobsJob::MAX_BATCHES_PER_RUN', 1)
+
+        perform
+
+        expect(ActiveStorage::Blob.exists?(id: blob_older.id)).to be(false)
+        expect(ActiveStorage::Blob.exists?(id: blob_old.id)).to be(true)
+      end
+
+      it 'does not skip a blob soft-deleted at the same instant as the previous batch' do
+        blob_twin = ActiveStorage::Blob
+          .create_and_upload!(io: StringIO.new("twin"), filename: "twin.txt", content_type: "text/plain")
+          .tap { it.update_columns(soft_deleted_at: blob_older.soft_deleted_at, service_name: 'openstack') }
+
+        perform
+
+        expect(ActiveStorage::Blob.exists?(id: [blob_older.id, blob_twin.id, blob_old.id])).to be(false)
+      end
+
+      it 'gives up on a batch whose rows survive the purge instead of retrying it' do
+        allow(BlobService).to receive(:purge_blobs_with_variants)
+
+        perform
+
+        expect(BlobService).to have_received(:purge_blobs_with_variants).with([blob_older.id]).once
+      end
+    end
+
     it 'keeps blobs stored on another service' do
       blob_other_service = ActiveStorage::Blob
         .create_and_upload!(io: StringIO.new("other"), filename: "other.txt", content_type: "text/plain")


### PR DESCRIPTION
`Cron::PurgeSoftDeletedBlobsJob` itérait avec `in_batches`, dont le curseur `ORDER BY id LIMIT 1000` parcourt la clé primaire de la table `active_storage_blobs` (170 M de lignes) et écarte plus d'un million de lignes avant de trouver le premier lot : 45 s en production, donc la première requête de chaque exécution nocturne tombait sur le statement timeout de 60 s (Sentry `RAILS-MEY`, 285 événements depuis le 16 août ; seules 2 nuits sur les 5 dernières ont abouti).

Le job lit désormais l'index partiel sur `soft_deleted_at` dans l'ordre (2 à 30 ms sur une copie de la base de production, quelle que soit la rétention). Chaque lot supprime ses lignes, mais leurs entrées d'index restent jusqu'au vacuum : le curseur reprend donc à partir du dernier `soft_deleted_at` vu, sinon chaque lot rebalaye les entrées mortes de tous les précédents (7 s après 1000 lots sur la copie de production). Un lot dont les lignes survivent à la purge arrête la boucle au lieu d'être relancé mille fois. Un plafond de 1000 lots par exécution borne une nuit à environ huit heures de suppressions Swift ; le reste attend la nuit suivante.

Plans `EXPLAIN ANALYZE` avant/après mesurés sur le dump de production du 7 septembre. Deuxième volet de la section « statement timeouts des jobs de purge » de #13816. Ref #13816

🤖 Generated with [Claude Code](https://claude.com/claude-code)
