### PR TITLE
Tech: purger les blobs orphelins par tranches d'id plutôt que par balayage de created_at

### DIFF
--- a/app/jobs/cron/purge_unattached_blobs_job.rb
+++ b/app/jobs/cron/purge_unattached_blobs_job.rb
@@ -3,24 +3,36 @@
 class Cron::PurgeUnattachedBlobsJob < Cron::CronJob
   self.schedule_expression = "every day at 00:30"
 
+  # The anti-join with active_storage_attachments (130M rows) must be a nested
+  # loop probing the blob_id index, not a hash join over a full seq scan of the
+  # table (60 s, the statement timeouts). The planner keeps the nested loop as
+  # long as it expects few blobs on the outer side: it underestimates an id
+  # range 200-fold today, but a week-wide range would flip to the seq scan once
+  # estimated accurately (an index on created_at, extended statistics). 100k
+  # ids stays far below the flip point either way: 0.1 s per slice.
+  ID_SLICE = 100_000
+
   def perform
-    # .in_batches { _1.each... } is more efficient in this case that in_batches.each_record or find_each
-    # because it plucks only ids in a preliminary query, then load records with selected columns in batches by ids.
-    # This is faster than other batch strategies, which load at once selected columns with an ORDER BY in the same query, triggering timeouts.
-    #
-    # .where(created_at: 1.week.ago..1.day.ago) to limit the number of records to be joined
-    # to the attachments table because of the unattached scope. Otherwise, it is triggering timeouts.
-    #
-    # the creation of an index on created_at does not seem required yet.
-    #
-    # caveats: the job needs to be run at least once a week to avoid missing blobs
-    ActiveStorage::Blob
-      .where(created_at: 1.week.ago..1.day.ago)
-      .where(soft_deleted_at: nil)
-      .unattached
-      .select(:id, :service_name)
-      .in_batches do |relation|
-      relation.each(&:purge_later)
+    # Blobs created 1 week → 1 day ago: a day for an upload to be attached, and
+    # the job has to run at least once a week not to miss any.
+    window = 1.week.ago..1.day.ago
+
+    # Ids grow with created_at (observed lag: a minute at most), so the window
+    # is an id range whose bounds come from a backward walk of the primary key:
+    # no index on created_at needed. Never backdate a blob's created_at: a
+    # single blob with an old created_at and a recent id would push first_id
+    # past the whole window and the run would silently purge nothing.
+    first_id = ActiveStorage::Blob.where(created_at: ...window.begin).order(id: :desc).pick(:id).to_i + 1
+    last_id = ActiveStorage::Blob.where(created_at: ..window.end).order(id: :desc).pick(:id)
+    return if last_id.nil? || last_id < first_id
+
+    (first_id..last_id).step(ID_SLICE) do |from|
+      ActiveStorage::Blob
+        .where(id: from..[from + ID_SLICE - 1, last_id].min)
+        .where(created_at: window, soft_deleted_at: nil)
+        .unattached
+        .select(:id, :service_name)
+        .each(&:purge_later)
     end
   end
 end

--- a/spec/jobs/cron/purge_unattached_blobs_job_spec.rb
+++ b/spec/jobs/cron/purge_unattached_blobs_job_spec.rb
@@ -4,18 +4,21 @@ RSpec.describe Cron::PurgeUnattachedBlobsJob, type: :job do
   describe 'perform' do
     subject { described_class.perform_now }
 
-    # unattached, within the created_at window
-    let(:blob) do
-      ActiveStorage::Blob.create_and_upload!(io: StringIO.new("data"), filename: "data.txt", content_type: "text/plain").tap do |b|
-        b.update_column(:created_at, 3.days.ago)
-      end
+    def unattached_blob(name, created_at)
+      ActiveStorage::Blob
+        .create_and_upload!(io: StringIO.new(name), filename: "#{name}.txt", content_type: "text/plain")
+        .tap { it.update_column(:created_at, created_at) }
     end
 
-    before { blob }
+    # unattached, within the created_at window
+    let(:blob) { unattached_blob("data", 3.days.ago) }
+    let(:blob_too_old) { unattached_blob("old", 8.days.ago) }
 
     context 'when the blob has not been soft-deleted' do
+      before { blob }
+
       it 'enqueues a purge' do
-        expect { subject }.to have_enqueued_job(DelayedPurgeJob)
+        expect { subject }.to have_enqueued_job(DelayedPurgeJob).with(blob)
       end
     end
 
@@ -24,6 +27,43 @@ RSpec.describe Cron::PurgeUnattachedBlobsJob, type: :job do
 
       it 'does not enqueue a purge' do
         expect { subject }.not_to have_enqueued_job(DelayedPurgeJob)
+      end
+    end
+
+    context 'when the blob is outside the window' do
+      let(:blob_too_recent) { unattached_blob("recent", 1.hour.ago) }
+
+      # ids grow with created_at in production: create the blobs in that order
+      before do
+        blob_too_old
+        blob
+        blob_too_recent
+      end
+
+      # `with` filters the enqueued jobs before counting: the unfiltered count
+      # is what proves the other two blobs were left alone
+      it 'leaves it alone' do
+        expect { subject }.to have_enqueued_job(DelayedPurgeJob).once
+          .and have_enqueued_job(DelayedPurgeJob).with(blob)
+      end
+    end
+
+    context 'when the window spans several id slices' do
+      let(:other_blob) { unattached_blob("more", 2.days.ago) }
+
+      # the old blob anchors the first id right before the window, so that the
+      # one-id slices only walk the window instead of every id since the seeds
+      before do
+        blob_too_old
+        blob
+        other_blob
+        stub_const('Cron::PurgeUnattachedBlobsJob::ID_SLICE', 1)
+      end
+
+      it 'covers every slice, last id included' do
+        expect { subject }.to have_enqueued_job(DelayedPurgeJob).twice
+          .and have_enqueued_job(DelayedPurgeJob).with(blob)
+          .and have_enqueued_job(DelayedPurgeJob).with(other_blob)
       end
     end
   end


### PR DESCRIPTION
`Cron::PurgeUnattachedBlobsJob` filtrait la table `active_storage_blobs` (170 M de lignes) sur une fenêtre `created_at` sans index, puis faisait l'anti-jointure avec `active_storage_attachments` (130 M de lignes) : deux seq scans complets par lot, 60 s à froid, donc la première requête de la plupart des exécutions nocturnes tombait sur le statement timeout (Sentry `RAILS-MA4`, 72 événements depuis le 16 juillet) et une exécution réussie prenait cinq minutes.

Les ids croissent avec `created_at` : la fenêtre devient un intervalle d'ids dont les bornes viennent d'un parcours inverse de la clé primaire (2 s pour la borne « il y a une semaine », aucun index à ajouter). L'intervalle est parcouru par tranches de 100 000 ids : sur une tranche, le planificateur sonde l'index `blob_id` des attachments au lieu de balayer la table, 0,1 s par tranche sur une copie de la base de production, soit quelques secondes pour la semaine. Un index sur `created_at` seul ne suffisait pas : le planificateur gardait le seq scan des attachments (mesuré à 25 s).

Plans `EXPLAIN ANALYZE` avant/après mesurés sur le dump de production du 7 septembre. Troisième volet de la section « statement timeouts des jobs de purge » de #13816. Ref #13816

🤖 Generated with [Claude Code](https://claude.com/claude-code)