### PR TITLE
Tech: indexer expired_at et termine_close_to_expiration_notice_sent_at sur dossiers

### DIFF
--- a/db/migrate/20260911120000_add_dossiers_expiration_indexes.rb
+++ b/db/migrate/20260911120000_add_dossiers_expiration_indexes.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# The nightly expiration of termine dossiers (Expired::DossiersDeletionService)
+# selects on expired_at (dossiers close to expiration, never notified) and on
+# termine_close_to_expiration_notice_sent_at (notified more than two weeks ago).
+# Neither column was indexed: every one of the dozen statements of a run
+# scanned the 8M termine rows, 3 to 36 s each, and the run hit the 60 s
+# statement timeout several times a night (#13816).
+#
+# On a copy of production, the expired_at index brings the close-to-expiration
+# selection from 26 s to 2.6 s and the mail eager load from 36 s to 1 s; the
+# partial index (2 MB) brings the past-grace selection from 8 s to 0.5 s.
+class AddDossiersExpirationIndexes < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :dossiers, :expired_at,
+              algorithm: :concurrently,
+              if_not_exists: true
+
+    add_index :dossiers, :termine_close_to_expiration_notice_sent_at,
+              where: "termine_close_to_expiration_notice_sent_at IS NOT NULL",
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_07_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_11_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
   enable_extension "pg_catalog.plpgsql"
@@ -558,6 +558,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_120000) do
     t.index ["batch_operation_id"], name: "index_dossiers_on_batch_operation_id"
     t.index ["depose_at", "id"], name: "index_dossiers_on_depose_at_and_id", where: "((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL))"
     t.index ["dossier_transfer_id"], name: "index_dossiers_on_dossier_transfer_id"
+    t.index ["expired_at"], name: "index_dossiers_on_expired_at"
     t.index ["groupe_instructeur_id", "depose_at", "id"], name: "index_dossiers_on_groupe_instructeur_id_and_depose_at_and_id", where: "((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL))"
     t.index ["groupe_instructeur_id", "state", "archived"], name: "index_dossiers_on_groupe_instructeur_id_and_state_and_archived", where: "((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL))"
     t.index ["groupe_instructeur_id", "updated_at", "id"], name: "index_dossiers_on_groupe_instructeur_id_and_updated_at_and_id", where: "((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL))"
@@ -568,6 +569,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_120000) do
     t.index ["revision_id"], name: "index_dossiers_stalled_declarative", where: "(((state)::text = 'en_construction'::text) AND (declarative_triggered_at IS NULL))"
     t.index ["search_terms_tsvector"], name: "index_dossiers_on_search_terms_tsvector", using: :gin
     t.index ["state"], name: "index_dossiers_on_state"
+    t.index ["termine_close_to_expiration_notice_sent_at"], name: "index_dossiers_on_termine_close_to_expiration_notice_sent_at", where: "(termine_close_to_expiration_notice_sent_at IS NOT NULL)"
     t.index ["updated_at", "id"], name: "index_dossiers_on_updated_at_and_id", where: "((hidden_by_administration_at IS NULL) AND (hidden_by_expired_at IS NULL))"
     t.index ["user_id"], name: "index_dossiers_on_user_id"
   end


### PR DESCRIPTION
L'expiration nocturne des dossiers terminés (`Expired::DossiersDeletionService`) sélectionne sur `expired_at` (dossiers proches de l'expiration, jamais notifiés) et sur `termine_close_to_expiration_notice_sent_at` (notifiés depuis plus de deux semaines). Aucune des deux colonnes n'était indexée : chacune de la douzaine de requêtes d'une exécution balayait les 8 M de dossiers terminés, 3 à 36 s chacune, et l'exécution tombait sur le statement timeout de 60 s plusieurs fois par nuit (Sentry `RAILS-M8X`, `ME7`, `M97`, `M95`, `M98`).

Mesuré sur une copie de la base de production (dump du 7 septembre) : la sélection « proche de l'expiration » passe de 26 s à 2,6 s, le chargement pour les mails de 36 s à 1 s, la sélection « délai de grâce écoulé » de 8 s à 0,5 s. Taille des index : 202 Mo et 2 Mo. Création `concurrently`.

Les index seuls ne suffisent pas au curseur `in_batches` du service (le planificateur surestime 33 fois le nombre de lignes et garde le parcours de la clé primaire) : la PR suivante fait sélectionner les ids une fois par phase. Quatrième volet de la section « statement timeouts des jobs de purge » de #13816. Ref #13816

🤖 Generated with [Claude Code](https://claude.com/claude-code)