### PR TITLE
Tech : plafonner à 10 minutes les jobs CI de lint et de sauvegarde des rapports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   linters:
     name: Linters
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     services:
       postgres:
         image: postgis/postgis:17-3.5
@@ -38,6 +39,7 @@ jobs:
   js_linters:
     name: JavaScript linters
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -51,6 +53,7 @@ jobs:
   brakeman:
     name: Brakeman
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -244,6 +247,7 @@ jobs:
     name: Save test reports
     needs: [unit_tests, system_tests]
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Suite à la remarque de @LeSim sur #13876.

Les quatre jobs de tests (RSpec ×3, vitest) ont déjà un `timeout-minutes`. Les trois jobs de lint et « Save test reports » n'en avaient pas et retombaient sur les 6 heures par défaut de GitHub : un runner bloqué pouvait donc occuper un slot toute l'après-midi.

Plafond à 10 minutes pour les quatre. Sur les runs récents de `main`, le plus lent (Linters) tourne en ~3 minutes, les trois autres en moins de 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)