### PR TITLE
ETQ usager, être prévenu quand un titre d'identité n'a pas pu être traité

### DIFF
--- a/app/components/attachment/progress_component.rb
+++ b/app/components/attachment/progress_component.rb
@@ -15,7 +15,7 @@ class Attachment::ProgressComponent < ApplicationComponent
     case
     when !ignore_antivirus && attachment.virus_scanner.pending?
       t(".antivirus_pending")
-    when !ignore_watermark && attachment.watermark_pending?
+    when !ignore_watermark && attachment.watermark_pending? && !attachment.watermark_failed?
       t(".watermark_pending")
     end
   end

--- a/app/components/attachment/show_component.rb
+++ b/app/components/attachment/show_component.rb
@@ -19,10 +19,12 @@ class Attachment::ShowComponent < ApplicationComponent
       t(".errors.virus_infected")
     when attachment.virus_scanner.corrupt?
       t(".errors.corrupted_file")
+    when attachment.watermark_failed?
+      t(".errors.watermark_failed")
     end
   end
 
   def error?
-    attachment.virus_scanner_error?
+    attachment.virus_scanner_error? || attachment.watermark_failed?
   end
 end

--- a/app/components/attachment/show_component/show_component.en.yml
+++ b/app/components/attachment/show_component/show_component.en.yml
@@ -3,3 +3,4 @@ en:
   errors:
     virus_infected: Virus detected, download is blocked.
     corrupted_file: The file is corrupted, the download is blocked.
+    watermark_failed: "This document could not be processed (unreadable or too large). Please upload another one."

--- a/app/components/attachment/show_component/show_component.fr.yml
+++ b/app/components/attachment/show_component/show_component.fr.yml
@@ -3,3 +3,4 @@ fr:
   errors:
     virus_infected: "Virus détecté, le téléchargement est bloqué."
     corrupted_file: "Le fichier est corrompu, le téléchargement est bloqué."
+    watermark_failed: "Ce document n’a pas pu être traité (illisible ou trop volumineux). Merci d’en déposer un autre."

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -20,6 +20,8 @@ class ApplicationJob < ActiveJob::Base
       Sentry.set_tags(procedure: arg.id)
     when LLMRuleSuggestion
       Sentry.set_tags(procedure: arg.procedure_revision.procedure_id)
+    when ActiveStorage::Blob
+      Sentry.set_tags(blob: arg.id)
     end
   end
 

--- a/app/jobs/blob_processor_job.rb
+++ b/app/jobs/blob_processor_job.rb
@@ -119,7 +119,11 @@ class BlobProcessorJob < ApplicationJob
     raise if !unreadable_vips_source?(error)
 
     Rails.logger.warn("BlobProcessorJob skipped blob #{blob.id}: #{error.message}")
-    Sentry.capture_exception(error) if blob.watermark_pending?
+
+    if blob.watermark_pending?
+      blob.metadata["watermark_failed"] = true
+      Sentry.capture_exception(error)
+    end
   end
 
   def needs_mutations?

--- a/app/jobs/blob_processor_job.rb
+++ b/app/jobs/blob_processor_job.rb
@@ -29,6 +29,9 @@ class BlobProcessorJob < ApplicationJob
   retry_on "Vips::Error", attempts: 3 # not as const because vips is loaded at runtime
   retry_on WatermarkService::Error, attempts: 3
 
+  # retry if something wrong with namespace but it should not happens
+  retry_on SandboxedCommand::WrapperFailed, attempts: 3
+
   rescue_from ActiveStorage::PreviewError do |exception|
     retry_or_discard(exception)
   end
@@ -54,7 +57,7 @@ class BlobProcessorJob < ApplicationJob
         scan_virus(tempfile) if !blob.virus_scanner.done?
 
         if attachment && blob.virus_scanner.safe? && processable && needs_mutations?
-          apply_mutations(tempfile)
+          apply_mutations(tempfile.path)
         end
       end
     end
@@ -83,34 +86,40 @@ class BlobProcessorJob < ApplicationJob
   end
 
   instrument_method
-  def apply_mutations(tempfile)
-    autorotate_needed = jpeg? && autorotate_needed?(tempfile)
-    uninterlace_needed = png_embeddable_in_pdf? && interlaced?(tempfile)
+  def apply_mutations(path)
+    header = header(path) if jpeg? || png_embeddable_in_pdf?
+    autorotate_needed = jpeg? && autorotate_needed?(header)
+    uninterlace_needed = png_embeddable_in_pdf? && interlaced?(header)
+
     watermark_needed = blob.watermark_pending?
     mutations_needed = autorotate_needed || uninterlace_needed || watermark_needed
 
     return if !mutations_needed
 
-    load_opts = { access: :sequential }
-    load_opts[:autorotate] = true if autorotate_needed
-
-    image = Vips::Image.new_from_file(tempfile.to_path, **load_opts)
-    image = WatermarkService.new.apply(image, format: blob.content_type) if watermark_needed
-
     write_opts = uninterlace_needed ? { interlace: false } : {}
 
-    Tempfile.create(["processed", File.extname(tempfile.path)]) do |output|
-      image.write_to_file(output.path, **write_opts)
+    Tempfile.create(["processed", File.extname(path)]) do |output|
+      if watermark_needed
+        decode(path, autorotate: autorotate_needed) do |image|
+          WatermarkService.new.apply(image, format: blob.content_type).write_to_file(output.path, **write_opts)
+        end
+      else
+        rewrite(path, output.path, autorotate: autorotate_needed, **write_opts)
+      end
+
       blob.upload(output)
     end
 
     blob.watermarked_at = Time.current if watermark_needed
     blob.save!
   rescue Vips::Error => error
-    # Same policy as autorotate_needed?/interlaced? below: a source vips cannot decode
-    # is not a transient failure, so skip the mutations and let the rest of the job run
-    # (the blob still gets marked processed) instead of burning three retries.
+    # A source vips cannot decode is not a transient failure, so skip the mutations and
+    # let the rest of the job run (the blob still gets marked processed) instead of
+    # burning three retries.
     raise if !unreadable_vips_source?(error)
+
+    Rails.logger.warn("BlobProcessorJob skipped blob #{blob.id}: #{error.message}")
+    Sentry.capture_exception(error) if blob.watermark_pending?
   end
 
   def needs_mutations?
@@ -130,18 +139,34 @@ class BlobProcessorJob < ApplicationJob
       attachment.record_type.in?(%w[AttestationTemplate GroupeInstructeur])
   end
 
-  def autorotate_needed?(tempfile)
-    image = Vips::Image.new_from_file(tempfile.to_path)
-    image.get_fields.include?("orientation") && image.get("orientation") != 1
-  rescue Vips::Error # unreadable metadata should not abort processing: skip the mutation instead
-    false
+  def header(path)
+    return SandboxedVips.header(path) if SandboxedCommand::ENABLED
+
+    Vips::Image.new_from_file(path).then { |image| image.get_fields.index_with { image.get(it) } }
+  rescue Vips::Error
+    {}
   end
 
-  def interlaced?(tempfile)
-    image = Vips::Image.new_from_file(tempfile.to_path)
-    image.get_fields.include?("interlaced") && image.get("interlaced") != 0
-  rescue Vips::Error # unreadable metadata should not abort processing: skip the mutation instead
-    false
+  def autorotate_needed?(header) = header.include?("orientation") && header["orientation"] != 1
+
+  def interlaced?(header) = header.include?("interlaced") && header["interlaced"] != 0
+
+  def rewrite(path, target, autorotate:, **save_opts)
+    return SandboxedVips.rewrite(path, target, autorotate:, **save_opts) if SandboxedCommand::ENABLED
+
+    load_opts = { access: :sequential }
+    load_opts[:autorotate] = true if autorotate
+
+    Vips::Image.new_from_file(path, **load_opts).write_to_file(target, **save_opts)
+  end
+
+  def decode(path, autorotate:, &)
+    load_opts = { access: :sequential }
+    load_opts[:autorotate] = true if autorotate
+
+    return SandboxedVips.disarm(path, **load_opts, &) if SandboxedCommand::ENABLED
+
+    yield Vips::Image.new_from_file(path, **load_opts)
   end
 
   instrument_method

--- a/app/jobs/concerns/unreadable_vips_source_concern.rb
+++ b/app/jobs/concerns/unreadable_vips_source_concern.rb
@@ -6,12 +6,14 @@
 #   Vips::Error: VipsForeignLoad: "/tmp/ActiveStorage-123-abc.jpg" is not a known file format
 #
 # Those bytes will never become an image, so retrying cannot help and reporting it says
-# nothing actionable about the code. Matched narrowly on purpose: every other vips
+# nothing actionable about the code. A file whose header says decoding it would cost
+# more memory than we are willing to spend gets the same answer, for the same reason:
+# the next attempt would refuse it too. Matched narrowly on purpose: every other vips
 # failure (memory pressure, temp file trouble) is transient and keeps its retries.
 module UnreadableVipsSourceConcern
   extend ActiveSupport::Concern
 
-  UNREADABLE_SOURCE = /is not a known file format/
+  UNREADABLE_SOURCE = /is not a known file format|too large to decode/
 
   private
 

--- a/app/jobs/create_representations_job.rb
+++ b/app/jobs/create_representations_job.rb
@@ -12,6 +12,7 @@ class CreateRepresentationsJob < ApplicationJob
   discard_on ActiveRecord::InvalidForeignKey
 
   retry_on "Vips::Error", attempts: 3 # not as const because vips is loaded at runtime
+  retry_on SandboxedCommand::WrapperFailed, attempts: 3 # should be rare
 
   rescue_from ActiveStorage::PreviewError do |exception|
     if executions < 3

--- a/app/lib/sandboxed_previewer.rb
+++ b/app/lib/sandboxed_previewer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Prepended onto ActiveStorage::Previewer where the isolation is asked for, so that
+# poppler, muPDF and ffmpeg run in a sandbox. Every previewer funnels its subprocess
+# through the same private method, so one hook covers them all — including any previewer
+# Rails adds later.
+module SandboxedPreviewer
+  FONTS = [
+    "/etc/fonts",            # fontconfig configuration
+    "/usr/share/fontconfig", # where the links in /etc/fonts/conf.d point
+    "/usr/share/fonts",      # the font files
+    "/var/cache/fontconfig", # fontconfig cache, or every run rescans the fonts
+  ].freeze
+
+  private
+
+  # Every previewer downloads the blob here before running anything on it.
+  # so we override it just to store @sandboxed_input_path and make it readable
+  def download_blob_to_tempfile
+    super do |tempfile|
+      @sandboxed_input_path = tempfile.path
+
+      yield tempfile
+    end
+  end
+
+  def capture(*argv, to:)
+    # The font dirs are best guesses, and bwrap fails if a dir is missing.
+    readable = [@sandboxed_input_path, *FONTS.filter { File.exist?(it) }].compact
+
+    ActiveSupport::Notifications.instrument("decode.sandbox", decoder: File.basename(argv.first)) do
+      super(*SandboxedCommand.wrapped_argv(argv, readable:), to:)
+    end
+  rescue ActiveStorage::PreviewError => error
+    # intercept wrapper errors
+    message = error.message.scrub
+    raise SandboxedCommand::WrapperFailed, message if SandboxedCommand.wrapper_failed?(message)
+
+    raise ActiveStorage::PreviewError, message.sub(/\A\S+ failed/, "#{argv.first} failed"), error.backtrace
+  end
+end

--- a/app/lib/sandboxed_variation.rb
+++ b/app/lib/sandboxed_variation.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Prepended onto ActiveStorage::Variation where the isolation is asked for. Variants are
+# the harder half: ruby-vips is in-process, so there is no subprocess to wrap and the
+# transformer has to be replaced outright.
+module SandboxedVariation
+  private
+
+  def transformer
+    SandboxedVipsTransformer.new(transformations.except(:format))
+  end
+end

--- a/app/lib/sandboxed_vips.rb
+++ b/app/lib/sandboxed_vips.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+# libvips reached through a subprocess instead of through FFI, for the mutations
+# BlobProcessorJob applies to an upload before storing it.
+#
+# Only the decode of the user's file is dangerous; once we hold pixels, rotating or
+# compositing them is arithmetic. So the decode happens in the sandbox and lands in an
+# uncompressed PNG, and everything downstream — WatermarkService above all — keeps
+# working on a Vips::Image, in this process, unchanged.
+#
+# The allow list vips_allowed_loaders.rb installs applies to this process, not to a
+# subprocess, so the sandbox asks libvips for VIPS_BLOCK_UNTRUSTED instead.
+module SandboxedVips
+  VIPS = "/usr/bin/vips"
+  VIPSHEADER = "/usr/bin/vipsheader"
+  VIPSTHUMBNAIL = "/usr/bin/vipsthumbnail"
+  DECODERS = [VIPS, VIPSHEADER, VIPSTHUMBNAIL].freeze
+  MIN_VERSION = Gem::Version.new("8.13")
+
+  SANDBOX_ENV = { "VIPS_BLOCK_UNTRUSTED" => "1" }.freeze
+
+  # lipvips prints warning with a pid and timestamp
+  NOISE = /^\(process:\d+\): VIPS-|^(?:memory|error buffer|vips_threadset_free):/
+
+  # --vips-leak has libvips report its peak allocation : memory: high-water mark 4.42 MB
+  PEAK_MEMORY = /^memory: high-water mark ([\d.]+) (bytes|KB|MB|GB|TB)$/
+  UNITS = { "bytes" => 1, "KB" => 1.kilobyte, "MB" => 1.megabyte, "GB" => 1.gigabyte, "TB" => 1.terabyte }.freeze
+
+  # Against decompression bombs: small files but huge decoded image returned to the process
+  # an A3 scan at 600 dpi decodes to about 200 MB, a 100 megapixel photograph to 300 MB.
+  MAX_DECODED_BYTES = 512.megabytes
+  # The first line vipsheader prints, once the path it echoes is taken off:
+  #   316x352 uchar, 4 bands, srgb, pngload
+  # The four fields the ceiling is computed from are read there — before any metadata,
+  # where a value carrying a "width: 1" line of its own cannot reach.
+  SUMMARY = /\A(?<width>\d+)x(?<height>\d+) (?<format>\w+), (?<bands>\d+) bands?, /
+  FORMAT_BYTES = {
+    "uchar" => 1, "char" => 1, "ushort" => 2, "short" => 2, "uint" => 4, "int" => 4,
+    "float" => 4, "double" => 8, "complex" => 8, "dpcomplex" => 16,
+  }.freeze
+
+  class << self
+    def ensure_usable!
+      DECODERS.each { ensure_decoder_runs!(it) }
+
+      raise "libvips #{version} ignores VIPS_BLOCK_UNTRUSTED, the sandbox needs #{MIN_VERSION} or newer" if version < MIN_VERSION
+    end
+
+    # Read in the sandbox rather than on the host: it is the one that will decode.
+    def version
+      output, = run([VIPS, "--version"])
+
+      Gem::Version.new(output[/\d+\.\d+\.\d+/])
+    end
+
+    # The fields of the upload's header, by vipsheader in the sandbox — no pixel decoded —
+    # an integer typed as one, the way libvips holds it:
+    #   header(rotated_jpg)   -> { "width" => 200, "orientation" => 8, "vips-loader" => "jpegload", … }
+    def header(path)
+      output, error, status = run([VIPSHEADER, "-a", "--", path], readable: [path])
+      raise Vips::Error, "vipsheader: #{failure_message(error, status)}" if !status.success?
+
+      summary, *lines = output.delete_prefix("#{path}: ").lines
+      size = SUMMARY.match(summary)
+      raise Vips::Error, "vipsheader: #{summary.strip}" if size.nil?
+
+      # Only the lines that open a field count — and the summary, merged last, is the
+      # word on the size.
+      fields = lines.grep(/\A[\w.-]+: /).to_h { it.chomp.split(": ", 2) }.transform_values { Integer(it, exception: false) || it }
+      fields.merge("width" => size[:width].to_i, "height" => size[:height].to_i, "bands" => size[:bands].to_i, "format" => size[:format])
+    end
+
+    def refuse_if_too_large(header)
+      width, height, bands, format = header.values_at("width", "height", "bands", "format")
+      decoded = width * height * bands * FORMAT_BYTES.fetch(format, 1)
+      return if decoded <= MAX_DECODED_BYTES
+
+      raise Vips::Error, "#{width}x#{height}, #{bands} bands of #{format}: too large to decode"
+    end
+
+    # Content disarm and reconstruction: the upload is decoded in the sandbox and rebuilt
+    # as a stripped PNG, so that only pixels libvips wrote reach this process.
+    def disarm(path, autorotate: false, **load_opts)
+      refuse_if_too_large(header(path))
+
+      Tempfile.create(["disarmed", ".png"]) do |png|
+        # Rotated by the loader as it reads if needed
+        source = "#{path}[access=sequential#{',autorotate=true' if autorotate}]"
+
+        # Do not compress output to spare cpu
+        # compression=0: the PNG is read back and deleted at once, so deflating it only
+        # burns CPU — the default level spends 74 s of the 60 s budget on a large image.
+        target = "#{png.path}[compression=0,strip=true]"
+
+        ActiveSupport::Notifications.instrument("decode.sandbox", decoder: "vips") do |payload|
+          _, error, status = run([VIPS, "--vips-leak", "copy", source, target], readable: [path], writable: [png.path])
+          payload[:peak_memory] = peak_memory(error)
+
+          raise Vips::Error, "vips copy: #{failure_message(error, status)}" if !status.success?
+        end
+
+        # Yielded rather than returned: Tempfile deletes the PNG when the block ends, and
+        # read by name, sequentially, nothing of it lingers — neither in libvips' cache
+        # nor on the disk. Read through a descriptor, it would.
+        yield Vips::Image.new_from_file(png.path, **load_opts)
+      end
+    end
+
+    def error_message(stderr)
+      stderr.lines.grep_v(NOISE).join.strip
+    end
+
+    # What libvips said — or, when it died saying nothing, how.
+    def failure_message(stderr, status) = error_message(stderr).presence || SandboxedCommand.status_message(status)
+
+    def peak_memory(stderr)
+      size, unit = PEAK_MEMORY.match(stderr)&.captures
+      return if size.nil?
+
+      (size.to_f * UNITS.fetch(unit)).round
+    end
+
+    private
+
+    def ensure_decoder_runs!(decoder)
+      raise "#{decoder} is missing — on Debian and Ubuntu it ships in libvips-tools" if !File.exist?(decoder)
+
+      _, error, status = run([decoder, "--version"])
+      raise "#{decoder} will not run in the sandbox: #{failure_message(error, status)}" if !status.success?
+    end
+
+    def run(argv, readable: [], writable: [])
+      SandboxedCommand.run(argv, readable:, writable:, env: SANDBOX_ENV)
+    end
+  end
+end

--- a/app/lib/sandboxed_vips.rb
+++ b/app/lib/sandboxed_vips.rb
@@ -106,6 +106,23 @@ module SandboxedVips
       end
     end
 
+    # The whole mutation in one command: rotation is a loader option, de-interlacing a
+    # saver one, so the upload is read and written without anything coming back here. No
+    # PNG in between, half the work of disarm, and the file keeps its format and its
+    # colour profile. No decode ceiling either — like the variants, nothing full size
+    # reaches this process, and what the decoder itself may spend the sandbox bounds.
+    def rewrite(path, target, autorotate: false, **save_opts)
+      source = "#{path}[access=sequential#{',autorotate=true' if autorotate}]"
+      options = save_opts.map { |name, value| "#{name}=#{value}" }.join(",")
+
+      ActiveSupport::Notifications.instrument("decode.sandbox", decoder: "vips") do |payload|
+        _, error, status = run([VIPS, "--vips-leak", "copy", source, options.empty? ? target : "#{target}[#{options}]"], readable: [path], writable: [target])
+        payload[:peak_memory] = peak_memory(error)
+
+        raise Vips::Error, "vips copy: #{failure_message(error, status)}" if !status.success?
+      end
+    end
+
     def error_message(stderr)
       stderr.lines.grep_v(NOISE).join.strip
     end

--- a/app/lib/sandboxed_vips_transformer.rb
+++ b/app/lib/sandboxed_vips_transformer.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Replaces the Vips transformer Active Storage would use. Resizing only:
+# every other transformation is a back and forth between ImageProcessing and
+# libvips over an image held in memory through FFI, which does not map onto one command
+# in one process. Anything else raises rather than coming out silently untransformed.
+#
+# vipsthumbnail does not sharpen, where ImageProcessing::Vips convolves a mask after
+# every resize: a variant made here comes out a touch softer than the in-process path
+# would make it — imperceptible on a photograph, faintly visible on the edges of text.
+# Accepted rather than matched, which would cost a second pass over every variant.
+class SandboxedVipsTransformer < ActiveStorage::Transformers::Transformer
+  class UnsupportedTransformation < StandardError; end
+
+  SIZE_ARGS = {
+    resize_to_limit: -> (width, height) { ["--size", "#{width}x#{height}>"] },
+    resize_to_fit: -> (width, height) { ["--size", "#{width}x#{height}"] },
+    resize_to_fill: -> (width, height) { ["--size", "#{width}x#{height}", "--smartcrop", "centre"] },
+  }.freeze
+
+  # vips_allowed_loaders.rb narrows this process, not a subprocess, so the loader
+  # control falls back to what libvips reads from its environment.
+  SANDBOX_ENV = { "VIPS_BLOCK_UNTRUSTED" => "1" }.freeze
+
+  private
+
+  # No refuse_if_too_large here : vipsthumbnail shrinks on load and only a small variant comes back.
+  def process(file, format:)
+    size = size_args
+
+    output = Tempfile.new(["variant", ".#{format}"], binmode: true)
+    argv = [SandboxedVips::VIPSTHUMBNAIL, "--vips-leak", *size, "-o", output.path, "--", file.path]
+
+    ActiveSupport::Notifications.instrument("decode.sandbox", decoder: "vipsthumbnail") do |payload|
+      _, error, status = SandboxedCommand.run(argv, readable: [file.path], writable: [output.path], env: SANDBOX_ENV)
+
+      # instrument emits its event even when the block raises
+      payload[:peak_memory] = SandboxedVips.peak_memory(error)
+
+      raise Vips::Error, "vipsthumbnail: #{SandboxedVips.failure_message(error, status)}" if !status.success?
+    end
+
+    output.tap(&:rewind)
+  rescue StandardError
+    output&.close!
+    raise
+  end
+
+  def size_args
+    name, (width, height) = transformations.first
+    resize = transformations.one? && SIZE_ARGS[name]
+
+    raise UnsupportedTransformation, "not supported by the sandboxed transformer: #{transformations.keys.inspect}" if !resize
+
+    resize.call(width, height)
+  end
+end

--- a/app/models/concerns/blob_processor_concern.rb
+++ b/app/models/concerns/blob_processor_concern.rb
@@ -15,6 +15,10 @@ module BlobProcessorConcern
     watermarked_at.present?
   end
 
+  def watermark_failed?
+    metadata["watermark_failed"] == true
+  end
+
   def representation_required?
     from_champ? || from_messagerie? || logo? || from_action_text? || from_avis? || from_justificatif_motivation? || from_attestation?
   end

--- a/config/initializers/bwrap_isolation.rb
+++ b/config/initializers/bwrap_isolation.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Asked for and impossible is not a state to run in: a machine told to isolate its image
+# decoders and unable to do so would decode unprotected, silently, which is the one
+# outcome the variable exists to prevent. Same parti pris as Active Storage refusing to
+# boot on a libvips too old to disable its unfuzzed loaders.
+#
+# What the isolation then changes is in config/initializers/sandboxed_decoders.rb.
+Rails.application.config.after_initialize do
+  if !SandboxedCommand::ENABLED
+    Rails.logger.info("[BWRAP_ISOLATION] off — image decoders run in this process")
+    next
+  end
+
+  SandboxedCommand.ensure_usable!
+  SandboxedVips.ensure_usable!
+
+  Rails.logger.info("[BWRAP_ISOLATION] on — image decoders run in a bubblewrap sandbox (libvips #{SandboxedVips.version})")
+end

--- a/config/initializers/sandboxed_decoders.rb
+++ b/config/initializers/sandboxed_decoders.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module SandboxedDecoders
+  # Rails names them bare but the sandbox runs an absolute path. The arguments are the
+  # ones Active Storage probes each binary with to decide whether to offer its previewer.
+  PREVIEWERS = {
+    pdftoppm: ["/usr/bin/pdftoppm", "-v"],
+    mutool: ["/usr/bin/mutool", "-v"],
+    ffmpeg: ["/usr/bin/ffmpeg", "-version"],
+  }.freeze
+
+  def self.patch_previewer!
+    PREVIEWERS.each_value { ensure_runs_in_sandbox!(it) }
+
+    ActiveStorage::Previewer.prepend(SandboxedPreviewer)
+    Rails.application.config.active_storage.paths.merge!(PREVIEWERS.transform_values(&:first))
+  end
+
+  # Active Storage asks the host whether to offer a previewer; the sandbox runs it. Absent
+  # is fine, installed and unable to start there would be offered and fail on every upload.
+  def self.ensure_runs_in_sandbox!(argv)
+    return if !File.exist?(argv.first)
+
+    _, error, status = SandboxedCommand.run(argv)
+    raise "#{argv.first} will not run in the sandbox: #{error.strip}" if !status.success?
+  end
+
+  def self.patch_variation!
+    ActiveStorage::Variation.prepend(SandboxedVariation)
+  end
+end
+
+# Previewer lives in the gem's lib/, outside Zeitwerk: required once, patched once at boot.
+Rails.application.config.after_initialize { SandboxedDecoders.patch_previewer! if SandboxedCommand::ENABLED }
+# Variation lives in the gem's app/models/, which Zeitwerk reloads: patched again each reload.
+Rails.application.reloader.to_prepare { SandboxedDecoders.patch_variation! if SandboxedCommand::ENABLED }

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -27,8 +27,37 @@ end
 Sidekiq.configure_server do |config|
   config.redis = sidekiq_redis
   if ENV['PROMETHEUS_EXPORTER_ENABLED'] == 'enabled'
+    # Image decoding runs in a subprocess now, so it no longer shows in this process's
+    # RSS, and nothing in `top` outlives the decode long enough to be graphed. libvips
+    # reports its own peak (--vips-leak); SandboxedVips hands it over here, where it
+    # becomes the history needed to size the memory limit a cgroup would enforce.
+    #
+    # Declared and subscribed inside configure_server on purpose: decoding only ever
+    # happens in a job, and the web process has no business carrying Yabeda.
+    Yabeda.configure do
+      group :decoder do
+        histogram :peak_memory_bytes,
+                  comment: "Peak memory a sandboxed image decoder allocated",
+                  tags: [:decoder],
+                  buckets: [1, 8, 32, 128, 256, 512, 1024, 2048, 4096].map(&:megabytes)
+
+        histogram :duration_seconds,
+                  comment: "Wall time a sandboxed image decoder ran for",
+                  tags: [:decoder],
+                  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60]
+      end
+    end
+
     Yabeda.configure!
     Yabeda::Prometheus::Exporter.start_metrics_server!
+
+    ActiveSupport::Notifications.subscribe("decode.sandbox") do |event|
+      tags = { decoder: event.payload[:decoder] }
+      peak_memory = event.payload[:peak_memory]
+
+      Yabeda.decoder.duration_seconds.measure(tags, event.duration / 1000)
+      Yabeda.decoder.peak_memory_bytes.measure(tags, peak_memory) if peak_memory
+    end
   end
 
   if ENV['SKIP_RELIABLE_FETCH'].blank?

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -88,6 +88,34 @@ The web application and the asynchronous jobs require some binary dependencies.
     > rather than decode user-supplied files with them.
 
     > [!TIP]
+    > To run libvips in a throwaway namespace rather than in the worker holding the
+    > database connection and the storage credentials, install `bubblewrap` and
+    > `libvips-tools` as well, and set
+    > `BWRAP_ISOLATION=enabled`. Note that `libvips-tools` is only a *recommends* of
+    > `libvips-dev`, so `--no-install-recommends` leaves it out, and the isolated path
+    > needs its `vips`, `vipsheader` and `vipsthumbnail` binaries. `bwrap` has to be
+    > 0.8 or later: the sandbox is built with `--disable-userns`, which older releases
+    > do not have — `bwrap --version` says which one a host carries.
+    >
+    > Asked for and impossible, the application refuses to boot: it will not decode
+    > unprotected while being told to isolate. An older `bwrap` reads
+    > `the sandbox will not start: bwrap: Unknown option --disable-userns`.
+    >
+    > Set the variable on the hosts that run Sidekiq: uploads are mutated there, in a job.
+    >
+    > On Ubuntu 24.04 the package alone is not enough: AppArmor restricts the
+    > unprivileged user namespaces bubblewrap builds its sandbox out of. Grant them to
+    > `bwrap` alone, with an AppArmor profile carrying a `userns,` rule — Canonical ships
+    > those through the apparmor package. Do **not** reach for
+    > `kernel.apparmor_restrict_unprivileged_userns=0`: that restriction exists because
+    > unprivileged user namespaces were part of the exploit chain in 44% of the Linux
+    > kernel exploits submitted to Google's kCTF bug bounty ([Learnings from kCTF VRP's
+    > 42 Linux kernel CVEs](https://security.googleblog.com/2023/06/learnings-from-kctf-vrps-42-linux.html),
+    > cited by Canonical when it introduced the restriction). Turning it off machine-wide
+    > to sandbox one decoder trades a narrow protection for a broad exposure. It is fine
+    > on a CI runner that lives ten minutes, and only there.
+
+    > [!TIP]
     > At this stage you may also want to install the [compilation packages required for building Ruby and Ruby extensions](https://github.com/rbenv/ruby-build/wiki#ubuntudebianmint).
 - **Bun**. [Bun](https://bun.sh/) is the JavaScript execution environment that compiles and packages the assets. It is required to pre-build the assets before starting the application.
 	

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -88,9 +88,9 @@ The web application and the asynchronous jobs require some binary dependencies.
     > rather than decode user-supplied files with them.
 
     > [!TIP]
-    > To run libvips in a throwaway namespace rather than in the worker holding the
-    > database connection and the storage credentials, install `bubblewrap` and
-    > `libvips-tools` as well, and set
+    > To run the image decoders — libvips, pdftoppm, ffmpeg — in a throwaway namespace
+    > rather than in the worker holding the database connection and the storage
+    > credentials, install `bubblewrap` and `libvips-tools` as well, and set
     > `BWRAP_ISOLATION=enabled`. Note that `libvips-tools` is only a *recommends* of
     > `libvips-dev`, so `--no-install-recommends` leaves it out, and the isolated path
     > needs its `vips`, `vipsheader` and `vipsthumbnail` binaries. `bwrap` has to be
@@ -101,7 +101,11 @@ The web application and the asynchronous jobs require some binary dependencies.
     > unprotected while being told to isolate. An older `bwrap` reads
     > `the sandbox will not start: bwrap: Unknown option --disable-userns`.
     >
-    > Set the variable on the hosts that run Sidekiq: uploads are mutated there, in a job.
+    > Set the variable on the hosts that run Sidekiq: every upload is decoded there, in a
+    > job. The web processes decode too — a variant a page asks for before the job has
+    > produced it — and would need the same packages to boot with the variable; left
+    > without it, they decode as they always have, in-process, under the loader allow
+    > list, and a failure there is a plain error page rather than a retried job.
     >
     > On Ubuntu 24.04 the package alone is not enough: AppArmor restricts the
     > unprivileged user namespaces bubblewrap builds its sandbox out of. Grant them to

--- a/doc/MONITORING.md
+++ b/doc/MONITORING.md
@@ -24,6 +24,27 @@ Slow queues may impact:
 
 If you see too many "Waiting" jobs in some queues, you may want to restart the Sidekiq server, or drop the job(s) that are clogging the queues.
 
+## Image processing
+
+This section applies to instances running with `BWRAP_ISOLATION` enabled. Without it,
+image decoding happens in the worker's own process and shows in its memory as any other
+work does.
+
+With it, thumbnails, previews and watermarks are decoded in a subprocess, inside a
+throwaway sandbox, so libvips, `pdftoppm` and `ffmpeg` no longer show in the Sidekiq
+worker's own memory. They stay in its cgroup: `systemd-cgtop` and any per-unit metric still account
+for them, and it is the per-process view that is no longer the right one. `top` shows
+them under the name of the decoder that runs (`vips`, `vipsthumbnail`, `pdftoppm`,
+`ffmpeg`), with `bwrap` as their parent.
+
+With `PROMETHEUS_EXPORTER_ENABLED`, every decode publishes what it cost, labelled by
+decoder: `decoder_duration_seconds` and `decoder_peak_memory_bytes`. Those are what tells
+whether a memory limit on the unit would be safe, and at what value.
+
+Each decoder runs under a 4 GB address space and 60 s of CPU, and a file whose header
+announces more than 512 MB once decoded is refused before anything is allocated. A decode
+the kernel kills reports its signal in Sentry, as `exit 137, SIGKILL`.
+
 ## Postgres
 
 Use your standard system tools to monitor Postgres CPU and memory usage. You may walso want to monitor the queries response time, to know if some queries are slowing down the database, and why.

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -72,6 +72,13 @@ Rails probably thinks the connection is made over HTTP, and redirects to the HTT
 - Check the Sidekiq queues (in `Manager > Sidekiq`), some of them may be clogged.
 - Manually purge the queues, or restart the dn-sidekiq service (`systemctl restart dn-sidekiq`).
 
+### Thumbnails, previews or watermarks are not generated
+
+- On an instance running with `BWRAP_ISOLATION`, ensure the `libvips-tools` package is installed: the isolated path shells out to `vips`, `vipsheader` and `vipsthumbnail`, and it is only a *recommends* of `libvips-dev`.
+- Variants look slightly softer than before: `vipsthumbnail` does not sharpen after resizing, where the in-process path did. Only edges of text show it, and only where a variant was built under `BWRAP_ISOLATION`; it is a known trade-off, not a fault.
+- `too large to decode`: the file's header announces more than 512 MB once decoded, and it is refused on purpose — no thumbnail will ever come, and nothing is reported, since retrying could not help. One exception is reported to Sentry, without retries: a document that was to be watermarked, which stays pending — hidden from its owner — with nothing left to re-run it.
+- Look for `SandboxedCommand::WrapperFailed` in Sentry: bubblewrap failed on this particular call (a bind it could not make), where it worked at boot.
+
 ### Exports and archives are not generated
 
 - Check the failed Sidekiq job that generates archives for an error message.

--- a/spec/components/attachment/show_component_spec.rb
+++ b/spec/components/attachment/show_component_spec.rb
@@ -64,4 +64,17 @@ RSpec.describe Attachment::ShowComponent, type: :component do
       expect(subject).to have_text('corrompu')
     end
   end
+
+  context 'when a titre d’identité could not be watermarked' do
+    let(:public_type_de_champs) { [{ type: :piece_justificative, nature: 'titre_identite' }] }
+    let(:virus_scan_result) { ActiveStorage::VirusScanner::SAFE }
+
+    before { attachment.blob.update(metadata: attachment.blob.metadata.merge("watermark_failed" => true)) }
+
+    it 'shows an error instead of the file or a pending state' do
+      expect(subject).not_to have_link(filename)
+      expect(subject).to have_text('n’a pas pu être traité')
+      expect(subject).not_to have_text('en cours')
+    end
+  end
 end

--- a/spec/config/sandboxed_decoders_spec.rb
+++ b/spec/config/sandboxed_decoders_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# What the rest of the suite cannot check, since a prepend cannot be undone: what each
+# patch does to Active Storage. The prepends and the paths are intercepted rather than
+# performed. The guard is not here but on the hooks that call these — that BWRAP_ISOLATION
+# is absent under test is what the last example rests on.
+describe SandboxedDecoders do
+  describe ".patch_previewer!" do
+    it "hands the previewers over to the sandbox where the isolation is asked for" do
+      stub_const("SandboxedCommand::ENABLED", true)
+
+      allow(described_class).to receive(:ensure_runs_in_sandbox!)
+
+      expect(ActiveStorage::Previewer).to receive(:prepend).with(SandboxedPreviewer)
+      expect(Rails.application.config.active_storage.paths).to receive(:merge!)
+        .with({ pdftoppm: "/usr/bin/pdftoppm", mutool: "/usr/bin/mutool", ffmpeg: "/usr/bin/ffmpeg" })
+
+      described_class.patch_previewer!
+    end
+  end
+
+  # Active Storage asks the host whether to offer a previewer; the sandbox is where it
+  # will run. A binary that is installed and cannot start there would be offered and then
+  # fail on every upload of that type, so boot names it instead.
+  describe ".ensure_runs_in_sandbox!" do
+    it "refuses a previewer that is installed and will not run in the sandbox" do
+      allow(SandboxedCommand).to receive(:run)
+        .and_return(["", "error while loading shared libraries: libpoppler.so", instance_double(Process::Status, success?: false)])
+
+      expect { described_class.ensure_runs_in_sandbox!(["/usr/bin/pdftoppm", "-v"]) }
+        .to raise_error(RuntimeError, %r{/usr/bin/pdftoppm will not run in the sandbox})
+    end
+
+    # Absent is not a fault: Active Storage offers no previewer for that type, sandbox or
+    # not, so there is nothing to refuse a boot over.
+    it "passes over a previewer that is not installed" do
+      expect(SandboxedCommand).not_to receive(:run)
+
+      expect { described_class.ensure_runs_in_sandbox!(["/usr/bin/no-such-previewer"]) }.not_to raise_error
+    end
+  end
+
+  describe ".patch_variation!" do
+    it "hands the variants over to the sandbox where the isolation is asked for" do
+      stub_const("SandboxedCommand::ENABLED", true)
+
+      expect(ActiveStorage::Variation).to receive(:prepend).with(SandboxedVariation)
+
+      described_class.patch_variation!
+    end
+  end
+
+  # The default, and what the suite runs under: Active Storage decodes as it always has.
+  it "is not patched onto Active Storage in this process" do
+    expect(ActiveStorage::Variation.ancestors).not_to include(SandboxedVariation)
+    expect(ActiveStorage::Previewer.ancestors).not_to include(SandboxedPreviewer)
+  end
+end

--- a/spec/jobs/blob_processor_job_spec.rb
+++ b/spec/jobs/blob_processor_job_spec.rb
@@ -241,6 +241,12 @@ describe BlobProcessorJob, :external_deps, type: :job do
 
         described_class.perform_now(blob)
       end
+
+      it 'marks the blob so the usager sees an error instead of an endless pending state' do
+        described_class.perform_now(blob)
+
+        expect(blob.reload.watermark_failed?).to be true
+      end
     end
   end
 

--- a/spec/jobs/blob_processor_job_spec.rb
+++ b/spec/jobs/blob_processor_job_spec.rb
@@ -209,6 +209,30 @@ describe BlobProcessorJob, :external_deps, type: :job do
         expect(blob.watermarked_at).to be_present
       end
     end
+
+    # Refused as too large, the image is never watermarked, and the blob — processed all
+    # the same — stays pending: hidden from its owner, with nothing left to re-run it.
+    # Not a retry, which could not help, but a word to Sentry.
+    context 'when the image is too large to decode' do
+      before do
+        allow(blob).to receive(:watermark_pending?).and_return(true)
+        allow(Vips::Image).to receive(:new_from_file).and_raise(Vips::Error, "20000x20000, 3 bands of uchar: too large to decode")
+      end
+
+      it 'reports it to Sentry rather than retrying' do
+        expect(Sentry).to receive(:capture_exception).with(an_instance_of(Vips::Error))
+
+        expect { described_class.perform_now(blob) }.not_to raise_error
+        expect(blob.metadata["processed"]).to be true
+        expect(watermark_service).not_to have_received(:apply)
+      end
+
+      it 'logs the skip, so it is visible without Sentry' do
+        expect(Rails.logger).to receive(:warn).with(/too large to decode/)
+
+        described_class.perform_now(blob)
+      end
+    end
   end
 
   describe 'add ocr data' do

--- a/spec/jobs/blob_processor_job_spec.rb
+++ b/spec/jobs/blob_processor_job_spec.rb
@@ -23,6 +23,15 @@ describe BlobProcessorJob, :external_deps, type: :job do
     allow(watermark_service).to receive(:apply) { |image, **| image }
   end
 
+  # ApplicationJob tags Sentry with what it was handed — a Dossier, a Procedure, a Blob —
+  # so that every failure of one upload can be found at once.
+  it "tags Sentry with the blob" do
+    allow(ClamavService).to receive(:safe_file?).and_return(true)
+    expect(Sentry).to receive(:set_tags).with(blob: blob.id)
+
+    described_class.perform_now(blob)
+  end
+
   describe 'virus scanning' do
     context 'when virus scan passes' do
       before do

--- a/spec/lib/sandboxed_previewer_spec.rb
+++ b/spec/lib/sandboxed_previewer_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+describe SandboxedPreviewer, :external_deps, if: SANDBOX_USABLE && ActiveStorage::Previewer::PopplerPDFPreviewer.pdftoppm_exists? do
+  # The patch is the initializer's job, and it only happens where the isolation is
+  # asked for; here the module is exercised on classes that carry it themselves, so
+  # nothing is prepended onto Active Storage for the rest of the suite.
+  let(:previewer_class) { Class.new(ActiveStorage::Previewer::PopplerPDFPreviewer) { prepend SandboxedPreviewer } }
+  let(:bare_previewer_class) { Class.new(ActiveStorage::Previewer) { prepend SandboxedPreviewer } }
+
+  # What the patch hands Active Storage along with the module: its binary by its
+  # absolute path, since the sandbox has no PATH to resolve a bare name against.
+  before { allow(ActiveStorage).to receive(:paths).and_return(pdftoppm: "/usr/bin/pdftoppm") }
+
+  let(:blob) do
+    ActiveStorage::Blob.create_and_upload!(
+      io: Rails.root.join("spec/fixtures/files/file.pdf").open,
+      filename: "file.pdf",
+      content_type: "application/pdf"
+    )
+  end
+
+  it "previews a PDF through the sandbox" do
+    expect(SandboxedCommand).to receive(:wrapped_argv).once.and_call_original
+
+    preview = nil
+    previewer_class.new(blob).preview { |io:, **| preview = io.read }
+
+    expect(preview.byteslice(1, 3)).to eq("PNG")
+  end
+
+  # Prawn writes Helvetica and embeds nothing; poppler substitutes from the fonts it is
+  # given, and with none the page comes out blank, exit 0 — a preview Active Storage
+  # would keep. Asserted on the pixels, the only place it shows.
+  it "draws the text of a PDF that embeds no font" do
+    pdf = Prawn::Document.new { text "Attestation", size: 40 }.render
+    prawn_blob = ActiveStorage::Blob.create_and_upload!(io: StringIO.new(pdf), filename: "attestation.pdf", content_type: "application/pdf")
+
+    preview = nil
+    previewer_class.new(prawn_blob).preview { |io:, **| preview = io.read }
+
+    expect(Vips::Image.new_from_buffer(preview, "").avg).to be < 255
+  end
+
+  it "hands pdftoppm nothing but its own input" do
+    sandboxed = nil
+    allow(SandboxedCommand).to receive(:wrapped_argv).and_wrap_original do |original, argv, **options|
+      sandboxed = original.call(argv, **options)
+    end
+
+    previewer_class.new(blob).preview { |**| nil }
+
+    system_paths = %w[/lib /lib64 /usr/lib /usr/bin/pdftoppm /etc/fonts /usr/share/fontconfig /usr/share/fonts /var/cache/fontconfig]
+    bound = sandboxed.each_cons(3).filter { |flag, _, _| flag == "--ro-bind" }.map(&:last)
+
+    expect(bound - system_paths).to eq([sandboxed.last])
+  end
+
+  # A font dir that is not on this host must not fail the sandbox: bwrap refuses a
+  # --ro-bind on a missing source, and that would take the whole preview down.
+  it "runs even where a font directory is missing" do
+    stub_const("SandboxedPreviewer::FONTS", ["/etc/fonts", "/no/such/font/dir"])
+
+    preview = nil
+    previewer_class.new(blob).preview { |io:, **| preview = io.read }
+
+    expect(preview.byteslice(1, 3)).to eq("PNG")
+  end
+
+  it "reports what the preview cost, under the decoder that ran" do
+    events = []
+
+    ActiveSupport::Notifications.subscribed(-> (event) { events << event }, "decode.sandbox") do
+      previewer_class.new(blob).preview { |**| nil }
+    end
+
+    expect(events.sole.payload).to include(decoder: "pdftoppm")
+  end
+
+  # PreviewError opens with the command it ran, and every previewer's command is bwrap
+  # now: "bwrap failed" says nothing about which decoder gave up, and reads the same
+  # whichever one did.
+  it "names the decoder that failed rather than the sandbox" do
+    output = Tempfile.new("preview")
+
+    expect { bare_previewer_class.new(blob).send(:capture, "/usr/bin/false", to: output) }
+      .to raise_error(ActiveStorage::PreviewError, %r{\A/usr/bin/false failed})
+  ensure
+    output.close!
+  end
+
+  it "tells a sandbox that never started from a decoder that failed" do
+    output = Tempfile.new("preview")
+    allow(SandboxedCommand).to receive(:wrapped_argv)
+      .and_return([SandboxedCommand::BWRAP, "--ro-bind", "/nowhere", "/nowhere", "--", "/usr/bin/true"])
+
+    expect { bare_previewer_class.new(blob).send(:capture, "pdftoppm", to: output) }
+      .to raise_error(SandboxedCommand::WrapperFailed, /Can't find source path/)
+  ensure
+    output.close!
+  end
+end

--- a/spec/lib/sandboxed_vips_spec.rb
+++ b/spec/lib/sandboxed_vips_spec.rb
@@ -179,6 +179,51 @@ describe SandboxedVips, :external_deps, if: SANDBOX_USABLE do
     end
   end
 
+  # Rotation and de-interlacing are a loader and a saver option: no pixels have to come
+  # back for them, so the upload is read and written in one pass, and keeps its format.
+  describe ".rewrite" do
+    it "rotates and writes the file the caller asked for" do
+      Tempfile.create(["out", ".jpg"]) do |out|
+        described_class.rewrite(rotated, out.path, autorotate: true)
+        header = described_class.header(out.path)
+
+        expect(header).to include("width" => 200, "height" => 200, "vips-loader" => "jpegload", "orientation" => 1)
+      end
+    end
+
+    it "carries a saver option through" do
+      interlaced = Tempfile.new(["interlaced", ".png"])
+      Vips::Image.new_from_file(Rails.root.join("spec/fixtures/files/logo_test_procedure.png").to_s).write_to_file(interlaced.path, interlace: true)
+
+      Tempfile.create(["out", ".png"]) do |out|
+        described_class.rewrite(interlaced.path, out.path, interlace: false)
+
+        expect(described_class.header(out.path)).not_to include("interlaced")
+      end
+    ensure
+      interlaced&.close!
+    end
+
+    it "reports what the pass cost" do
+      events = []
+
+      Tempfile.create(["out", ".jpg"]) do |out|
+        ActiveSupport::Notifications.subscribed(-> (event) { events << event }, "decode.sandbox") do
+          described_class.rewrite(rotated, out.path)
+        end
+      end
+
+      expect(events.sole.payload).to include(decoder: "vips", peak_memory: be_positive)
+    end
+
+    it "raises what libvips said of a file it cannot read" do
+      Tempfile.create(["out", ".jpg"]) do |out|
+        expect { described_class.rewrite(Rails.root.join("spec/fixtures/files/not-an-image.jpg").to_s, out.path) }
+          .to raise_error(Vips::Error, /is not a known file format/)
+      end
+    end
+  end
+
   # bwrap fails before the decoder ever runs — a namespace refused, a bind it cannot
   # make — and exits 1 saying so, exactly as a decoder handed a corrupt file does. Read
   # as one, a machine that lost its sandbox reports as a run of bad uploads.

--- a/spec/lib/sandboxed_vips_spec.rb
+++ b/spec/lib/sandboxed_vips_spec.rb
@@ -1,0 +1,280 @@
+# frozen_string_literal: true
+
+describe SandboxedVips, :external_deps, if: SANDBOX_USABLE do
+  let(:rotated) { Rails.root.join("spec/fixtures/files/image-rotated.jpg").to_s }
+  let(:upright) { Rails.root.join("spec/fixtures/files/image-no-rotation.jpg").to_s }
+
+  describe ".header" do
+    it "reads the fields the file carries, an integer typed as libvips does" do
+      expect(described_class.header(rotated)).to include("width" => 200, "orientation" => 8, "vips-loader" => "jpegload")
+    end
+
+    it "carries no field the file lacks" do
+      expect(described_class.header(upright)).not_to include("interlaced")
+    end
+
+    it "reads an interlaced PNG as libvips does" do
+      png = Tempfile.new(["interlaced", ".png"])
+      Vips::Image.new_from_file(Rails.root.join("spec/fixtures/files/logo_test_procedure.png").to_s).write_to_file(png.path, interlace: true)
+
+      expect(described_class.header(png.path)).to include("interlaced" => 1)
+    ensure
+      png.close!
+    end
+
+    # vipsheader prints a text value as it is, newlines included; the line after the
+    # break has no "field: " and once broke the parse for the whole header.
+    it "survives a value that spans lines" do
+      png = Tempfile.new(["multiline", ".png"])
+      image = Vips::Image.new_from_file(Rails.root.join("spec/fixtures/files/logo_test_procedure.png").to_s).copy
+      image.set_type(GObject::GSTR_TYPE, "png-comment-0-Comment", "line 1\nline 2")
+      image.write_to_file(png.path)
+
+      expect(described_class.header(png.path)).to include("width" => 316, "png-comment-0-Comment" => "line 1")
+    ensure
+      png.close!
+    end
+
+    # A value can carry "width: 1" lines of its own: the size must not be read from it.
+    it "takes the size from the summary, whatever a value says" do
+      png = Tempfile.new(["inject", ".png"])
+      image = Vips::Image.new_from_file(Rails.root.join("spec/fixtures/files/logo_test_procedure.png").to_s).copy
+      image.set_type(GObject::GSTR_TYPE, "png-comment-0-Comment", "x\nwidth: 1\nheight: 1\nbands: 1\nformat: uchar")
+      image.write_to_file(png.path)
+
+      expect(described_class.header(png.path)).to include("width" => 316, "height" => 352, "bands" => 4, "format" => "uchar")
+    ensure
+      png.close!
+    end
+
+    # The path is taken off the summary as it was given, so a newline in the upload's
+    # extension — which the tempfile keeps — cannot split the summary either.
+    it "reads a file whose name holds a newline" do
+      png = Tempfile.new(["probe\nwidth: 1\n", ".png"], binmode: true)
+      png.write(Rails.root.join("spec/fixtures/files/logo_test_procedure.png").binread)
+      png.flush
+
+      expect(described_class.header(png.path)).to include("width" => 316, "height" => 352)
+    ensure
+      png.close!
+    end
+
+    it "raises as Vips::Image does when the file is not an image" do
+      expect { described_class.header(Rails.root.join("spec/fixtures/files/not-an-image.jpg").to_s) }.to raise_error(Vips::Error)
+    end
+  end
+
+  describe ".disarm" do
+    it "yields the decoded pixels" do
+      size = nil
+      described_class.disarm(rotated) { |image| size = [image.width, image.height] }
+
+      expect(size).to eq([200, 200])
+    end
+
+    # Metadata is stripped off the copy: no EXIF, XMP or ICC for pngload to reparse in
+    # this process, and no GPS or camera trail left on a watermarked identity document.
+    it "strips the upload's metadata off the copy" do
+      fields = nil
+      described_class.disarm(rotated, autorotate: true) { |image| fields = image.get_fields }
+
+      expect(fields.grep(/exif|icc|orientation/i)).to be_empty
+    end
+
+    # A rotation is not streamed: `vips autorot` unfolds the decoded image through a
+    # temporary file, and on the sandbox's 100 MB tmpfs that fails for any large photo
+    # held in portrait. Rotated by the loader as it reads, it stays in memory. With the
+    # metadata stripped, the pixels are the only witness that rotation did or did not run.
+    it "rotates the pixels on load when asked, and leaves them as stored otherwise" do
+      photo = Tempfile.new(["portrait", ".jpg"], binmode: true)
+      Vips::Image.black(7000, 6000, bands: 3).copy.tap { it.set_type(GObject::GINT_TYPE, "orientation", 6) }.write_to_file(photo.path)
+
+      rotated_size = upright_size = nil
+      described_class.disarm(photo.path, autorotate: true, access: :sequential) { |image| rotated_size = [image.width, image.height] }
+      described_class.disarm(photo.path, autorotate: false, access: :sequential) { |image| upright_size = [image.width, image.height] }
+
+      expect(rotated_size).to eq([6000, 7000])
+      expect(upright_size).to eq([7000, 6000])
+    ensure
+      photo&.close!
+    end
+
+    # Read by name and sequentially, the PNG is closed at the end of the read and gone
+    # with the block. Read through a descriptor, libvips' operation cache would keep it
+    # open — and its disk space allocated — long after the file was deleted.
+    it "leaves no descriptor on the copy it deleted" do
+      3.times { described_class.disarm(rotated, access: :sequential, &:avg) }
+
+      deleted = Dir.glob("/proc/self/fd/*").count { File.symlink?(it) && File.readlink(it).include?("(deleted)") }
+      expect(deleted).to eq(0)
+    end
+
+    # The header says what decoding would cost before anything is allocated, which is
+    # the only moment a decompression bomb can be refused rather than survived.
+    it "refuses a file whose header says decoding it would not be reasonable" do
+      stub_const("SandboxedVips::MAX_DECODED_BYTES", 1000)
+
+      expect { described_class.disarm(rotated) { nil } }
+        .to raise_error(Vips::Error, "200x200, 3 bands of uchar: too large to decode")
+    end
+
+    # The tempfile Active Storage downloads to carries the upload's extension, raw. A
+    # name that reads like a header line must not pass for one.
+    it "refuses on what the header says, not on what the file is named" do
+      stub_const("SandboxedVips::MAX_DECODED_BYTES", 1000)
+      bomb = Tempfile.new(["bomb.1x1 uchar, 1 band", ".jpg"], binmode: true)
+      bomb.write(File.binread(rotated))
+      bomb.flush
+
+      expect { described_class.disarm(bomb.path) { nil } }
+        .to raise_error(Vips::Error, "200x200, 3 bands of uchar: too large to decode")
+    ensure
+      bomb&.close!
+    end
+
+    # What the decoding cost is no longer visible in this process's memory, so the
+    # decoder has to say it: this is the only place that number comes from.
+    it "reports what the decoding cost" do
+      events = []
+
+      ActiveSupport::Notifications.subscribed(-> (event) { events << event }, "decode.sandbox") do
+        described_class.disarm(rotated) { nil }
+      end
+
+      expect(events.sole.payload).to include(decoder: "vips", peak_memory: be_positive)
+    end
+
+    # The out-of-memory kill is the failure worth seeing, and the only one that writes
+    # nothing at all: without the status there would be nothing to read in Sentry. Killed
+    # inside the sandbox, as it would be: bwrap reports it as an exit, not a signal.
+    it "reports the signal when the decoder is killed" do
+      allow(SandboxedCommand).to receive(:wrapped_argv).and_wrap_original { |original, *| original.call(["/bin/sh", "-c", "kill -9 $$"]) }
+
+      expect { described_class.disarm(rotated) { nil } }.to raise_error(Vips::Error, /SIGKILL/)
+    end
+
+    # SVG is on ALLOWED_VIPS_LOADERS for the overlay StaticMapService builds itself,
+    # which never comes through here. The sandbox asks for VIPS_BLOCK_UNTRUSTED, and
+    # svgload is in the family that refuses.
+    it "refuses a loader we do not trust with an upload" do
+      svg = Tempfile.new(["probe", ".svg"])
+      svg.write('<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10"/></svg>')
+      svg.flush
+
+      expect { described_class.disarm(svg.path) { nil } }.to raise_error(Vips::Error, /is not a known file format/)
+    ensure
+      svg.close!
+    end
+
+    # The watermark used to composite onto an image loaded straight from the upload;
+    # it now gets one loaded from the sandbox's PNG. Same pixels, different loader.
+    it "yields an image WatermarkService can still composite onto" do
+      size = nil
+      described_class.disarm(rotated) do |image|
+        watermarked = WatermarkService.new.apply(image, format: "image/jpeg")
+        size = [watermarked.width, watermarked.height]
+      end
+
+      expect(size).to eq([200, 200])
+    end
+  end
+
+  # bwrap fails before the decoder ever runs — a namespace refused, a bind it cannot
+  # make — and exits 1 saying so, exactly as a decoder handed a corrupt file does. Read
+  # as one, a machine that lost its sandbox reports as a run of bad uploads.
+  describe "when the sandbox will not start" do
+    before do
+      allow(SandboxedCommand).to receive(:wrapped_argv)
+        .and_return([SandboxedCommand::BWRAP, "--ro-bind", "/nowhere", "/nowhere", "--", "/usr/bin/true"])
+    end
+
+    # The dangerous one: an empty header reads as "no orientation to fix", and the
+    # mutation is skipped for every upload the machine sees, without a word.
+    it "raises rather than answering as a file with no such field" do
+      expect { described_class.header(rotated) }
+        .to raise_error(SandboxedCommand::WrapperFailed, /Can't find source path/)
+    end
+
+    it "raises rather than as a file libvips could not decode" do
+      expect { described_class.disarm(rotated) { nil } }.to raise_error(SandboxedCommand::WrapperFailed)
+    end
+  end
+end
+
+describe SandboxedVips, ".ensure_usable!", :external_deps, if: SANDBOX_USABLE do
+  # Without the tools BlobProcessorJob shells out to, boot passes and every image dies
+  # later as a bind bwrap cannot make — so the missing package is named at boot instead.
+  it "refuses without the libvips tools" do
+    stub_const("SandboxedVips::DECODERS", ["/usr/bin/no-such-vips"])
+
+    expect { described_class.ensure_usable! }.to raise_error(RuntimeError, /libvips-tools/)
+  end
+
+  # A libvips older than 8.13 ignores VIPS_BLOCK_UNTRUSTED and decodes in the subprocess
+  # what the sandbox exists to refuse — silently. Named at boot rather than trusted.
+  it "refuses a libvips too old to block untrusted loaders" do
+    allow(described_class).to receive(:version).and_return(Gem::Version.new("8.12.1"))
+
+    expect { described_class.ensure_usable! }.to raise_error(RuntimeError, /8\.12\.1 ignores VIPS_BLOCK_UNTRUSTED/)
+  end
+
+  # A decoder can be installed, executable, and still never start where it matters — a
+  # library outside LIBRARIES, an AppArmor profile naming it. Boot is where that shows.
+  it "refuses a decoder the sandbox cannot run" do
+    allow(SandboxedCommand).to receive(:run)
+      .and_return(["", "error while loading shared libraries: libvips.so.42", instance_double(Process::Status, success?: false)])
+
+    expect { described_class.ensure_usable! }.to raise_error(RuntimeError, /will not run in the sandbox: error while loading/)
+  end
+
+  it "reads the version of the libvips it would run, in the sandbox" do
+    expect(described_class.version).to be >= SandboxedVips::MIN_VERSION
+  end
+end
+
+describe SandboxedVips, ".error_message", :external_deps do
+  # A real stderr of a failed decode: the pid and the timestamp are the point — left
+  # in, two occurrences of one failure never carry the same message — and so is the
+  # "error buffer:" line, which would otherwise say everything twice.
+  it "keeps the failure and drops what libvips says around it" do
+    stderr = "\n(process:519761): VIPS-WARNING **: 08:58:15.213: unable to load \"vips-openslide.so\"\n" \
+             "VipsForeignLoad: \"probe.svg\" is not a known file format\n" \
+             "memory: high-water mark 0 bytes\n" \
+             "error buffer: VipsForeignLoad: \"probe.svg\" is not a known file format\n" \
+             "vips_threadset_free: peak of 0 threads\n"
+
+    expect(described_class.error_message(stderr)).to eq('VipsForeignLoad: "probe.svg" is not a known file format')
+  end
+end
+
+describe SandboxedVips, ".peak_memory", :external_deps do
+  it "reads what libvips reports, in bytes" do
+    expect(described_class.peak_memory("memory: high-water mark 4.42 MB\n")).to eq(4_634_706)
+  end
+
+  it "reads a decode that allocated nothing at all" do
+    expect(described_class.peak_memory("memory: high-water mark 0 bytes\n")).to eq(0)
+  end
+
+  it "is nil when the decoder never got far enough to report" do
+    expect(described_class.peak_memory("bwrap: Can't find source path /nowhere\n")).to be_nil
+  end
+end
+
+describe SandboxedVips, ".refuse_if_too_large", :external_deps do
+  it "refuses a header whose decoded size is over the ceiling" do
+    expect { described_class.refuse_if_too_large("width" => 20000, "height" => 20000, "bands" => 3, "format" => "uchar") }
+      .to raise_error(Vips::Error, "20000x20000, 3 bands of uchar: too large to decode")
+  end
+
+  # An A3 scan at 600 dpi.
+  it "lets the largest legitimate scans through" do
+    expect(described_class.refuse_if_too_large("width" => 7000, "height" => 9900, "bands" => 3, "format" => "uchar")).to be_nil
+  end
+
+  # 300 MB of pixels, 600 MB once the 16-bit format is counted.
+  it "counts the format as much as the pixels" do
+    expect { described_class.refuse_if_too_large("width" => 10000, "height" => 10000, "bands" => 3, "format" => "ushort") }
+      .to raise_error(Vips::Error, "10000x10000, 3 bands of ushort: too large to decode")
+  end
+end

--- a/spec/lib/sandboxed_vips_transformer_spec.rb
+++ b/spec/lib/sandboxed_vips_transformer_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+describe SandboxedVipsTransformer, :external_deps, if: SANDBOX_USABLE do
+  # 316x352, so a 200x200 limit shrinks it and a 400x400 limit leaves it alone.
+  let(:source) { Rails.root.join("spec/fixtures/files/logo_test_procedure.png").open }
+
+  # Straight to the transformer, the way ActiveStorage::Variation reaches it once
+  # patched: the transformations minus the format, which it is handed apart.
+  def transform(transformations, file = source)
+    described_class.new(transformations.except(:format)).transform(file, format: transformations.fetch(:format)) do |output|
+      image = Vips::Image.new_from_file(output.path)
+      [image.width, image.height]
+    end
+  end
+
+  it "fits the image inside the limit" do
+    expect(transform(resize_to_limit: [200, 200], format: :png)).to eq([180, 200])
+  end
+
+  it "never enlarges a smaller image" do
+    expect(transform(resize_to_limit: [400, 400], format: :png)).to eq([316, 352])
+  end
+
+  it "enlarges to fit the box when asked to fit rather than to limit" do
+    expect(transform(resize_to_fit: [400, 400], format: :png)).to eq([359, 400])
+  end
+
+  it "fills the box and trims what sticks out" do
+    expect(transform(resize_to_fill: [200, 200], format: :png)).to eq([200, 200])
+  end
+
+  it "refuses a resize it cannot tell apart from another" do
+    expect { transform(resize_to_limit: [200, 200], resize_to_fill: [200, 200], format: :png) }
+      .to raise_error(described_class::UnsupportedTransformation, /resize_to_fill/)
+  end
+
+  it "converts to the requested format" do
+    described_class.new(resize_to_limit: [200, 200]).transform(source, format: :jpeg) do |output|
+      expect(Vips::Image.new_from_file(output.path).get("vips-loader")).to eq("jpegload")
+    end
+  end
+
+  it "refuses a transformation it cannot reproduce" do
+    expect { transform(rotate: 90, format: :png) }
+      .to raise_error(described_class::UnsupportedTransformation, /rotate/)
+  end
+
+  it "raises the error the in-process path raised on bytes that are not an image" do
+    not_an_image = Rails.root.join("spec/fixtures/files/not-an-image.jpg").open
+
+    expect { transform({ resize_to_limit: [200, 200], format: :png }, not_an_image) }
+      .to raise_error(Vips::Error, /is not a known file format/)
+  end
+
+  # vipsthumbnail shrinks on load: a source the decode ceiling would refuse thumbnails
+  # cheaply and must not be turned away here, where nothing full-size comes back.
+  it "thumbnails a source the decode ceiling would refuse" do
+    stub_const("SandboxedVips::MAX_DECODED_BYTES", 1000)
+
+    expect(transform(resize_to_limit: [200, 200], format: :png)).to eq([180, 200])
+  end
+
+  it "reports what the variant cost" do
+    events = []
+
+    ActiveSupport::Notifications.subscribed(-> (event) { events << event }, "decode.sandbox") do
+      transform(resize_to_limit: [200, 200], format: :png)
+    end
+
+    expect(events.sole.payload).to include(decoder: "vipsthumbnail", peak_memory: be_positive)
+  end
+
+  # A killed decoder writes nothing, and that is the failure worth reading in Sentry.
+  it "reports the signal when the decoder is killed" do
+    allow(SandboxedCommand).to receive(:wrapped_argv).and_wrap_original { |original, *| original.call(["/bin/sh", "-c", "kill -9 $$"]) }
+
+    expect { transform(resize_to_limit: [200, 200], format: :png) }.to raise_error(Vips::Error, /SIGKILL/)
+  end
+end


### PR DESCRIPTION
**4/4 d'une pile.** Base : #13855 (previews et variants), au sommet de la pile d'isolation. À relire en dernier.

Suite directe de ce que le test sur staging a révélé : un **titre d'identité** qui ne peut pas être filigrané — illisible, ou trop volumineux pour être décodé (`refuse_if_too_large`) — restait **indéfiniment en « traitement en cours »**. `watermark_pending?` restait vrai, l'usager voyait un état d'attente sans fin et n'était jamais invité à en déposer un autre. La seule trace était un événement Sentry (invisible là où Sentry n'est pas branché).

### Ce que fait la PR

- `BlobProcessorJob` **marque le blob `watermark_failed`** quand il renonce au filigrane (source illisible ou trop grande).
- `watermark_pending?` est **inchangé** : le document brut n'est donc toujours jamais servi (pas de régression de confidentialité sur les titres d'identité).
- L'affichage lit ce nouvel état : le badge « en cours » laisse place à un message d'erreur invitant l'usager à redéposer un fichier. C'est un état orthogonal — `watermark_pending?` reste le gardien du lien, `watermark_failed?` bascule seulement l'affichage de « en cours » vers « erreur ».

### Pour la relecture

- Le message est volontairement sobre (« illisible ou trop volumineux ») : il n'expose pas le détail technique.
- `metadata["processed"]` reste vrai — pas de retry, comme avant.
- Le blob est partagé entre attachments ; le flag vaut pour tous, ce qui est correct puisque c'est le même fichier.
