### PR TITLE
Tech : les démarches en brouillon ne sont plus lisibles anonymement via l'API GraphQL

### DIFF
--- a/app/graphql/api/v2/context.rb
+++ b/app/graphql/api/v2/context.rb
@@ -43,6 +43,14 @@ class API::V2::Context < GraphQL::Query::Context
     Administrateur.find(self[:administrateur_id])
   end
 
+  # Grants access for the rest of the query to a demarche the caller just
+  # created (e.g. the clone returned by demarcheCloner): it starts as a
+  # brouillon and is not part of the token's procedure_ids snapshot.
+  def authorize_demarche!(demarche)
+    self[:authorized] ||= {}
+    self[:authorized][demarche.id] = true
+  end
+
   def authorized_demarche?(demarche, opendata: false)
     # `Procedure` has a `default_scope -> { kept }`, so `label.procedure`,
     # `dossier.revision.procedure`, … return nil once the démarche is hidden,
@@ -54,7 +62,7 @@ class API::V2::Context < GraphQL::Query::Context
       return true
     end
 
-    if opendata && demarche.opendata?
+    if opendata && demarche.opendata? && !demarche.brouillon?
       return true
     end
 

--- a/app/graphql/mutations/demarche_cloner.rb
+++ b/app/graphql/mutations/demarche_cloner.rb
@@ -18,6 +18,7 @@ module Mutations
       if demarche.present? && (demarche.opendata? || context.authorized_demarche?(demarche))
         cloned_demarche = demarche.clone(admin: context.current_administrateur, options: { clone_service: })
         cloned_demarche.update!(libelle: title) if title.present?
+        context.authorize_demarche!(cloned_demarche)
 
         { demarche: cloned_demarche.draft_revision }
       else

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -52,9 +52,5 @@ module Types
     def groupe_instructeur(number:)
       GroupeInstructeur.for_api_v2.find(number)
     end
-
-    def self.accessible?(context)
-      context[:token] || context[:administrateur_id]
-    end
   end
 end

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -1084,6 +1084,18 @@ describe API::V2::GraphqlController do
           }
         end
 
+        context 'draft procedure, opendata left to its default' do
+          let(:draft_procedure) { create(:procedure, :with_type_de_champ, libelle: 'Secret brouillon interne') }
+          let(:variables) { { demarche: { number: draft_procedure.id } } }
+
+          it 'serves the never-published procedure to an anonymous caller' do
+            expect(draft_procedure).to be_brouillon
+            expect(draft_procedure.opendata).to be(true)
+            expect(gql_errors).to be_nil
+            expect(gql_data[:demarcheDescriptor][:id]).to eq(draft_procedure.to_typed_id)
+          end
+        end
+
         context 'not opendata' do
           let(:variables) { { demarche: { id: procedure.to_typed_id } } }
 

--- a/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_stored_queries_spec.rb
@@ -1072,6 +1072,17 @@ describe API::V2::GraphqlController do
         }
       end
 
+      context 'own draft procedure, with token' do
+        let(:draft_procedure) { create(:procedure, :with_type_de_champ, administrateurs: [admin]) }
+        let(:variables) { { demarche: { number: draft_procedure.id } } }
+
+        it 'stays readable by its administrateur' do
+          expect(draft_procedure).to be_brouillon
+          expect(gql_errors).to be_nil
+          expect(gql_data[:demarcheDescriptor][:id]).to eq(draft_procedure.to_typed_id)
+        end
+      end
+
       context 'without authorization token' do
         let(:authorization_header) { nil }
 
@@ -1088,11 +1099,21 @@ describe API::V2::GraphqlController do
           let(:draft_procedure) { create(:procedure, :with_type_de_champ, libelle: 'Secret brouillon interne') }
           let(:variables) { { demarche: { number: draft_procedure.id } } }
 
-          it 'serves the never-published procedure to an anonymous caller' do
+          it 'hides the never-published procedure from an anonymous caller' do
             expect(draft_procedure).to be_brouillon
             expect(draft_procedure.opendata).to be(true)
+            expect(gql_errors).not_to be_nil
+            expect(gql_errors.first[:message]).to eq('An object of type DemarcheDescriptor was hidden due to permissions')
+          end
+        end
+
+        context 'published then closed procedure, opendata' do
+          let(:closed_procedure) { create(:procedure, :closed) }
+          let(:variables) { { demarche: { number: closed_procedure.id } } }
+
+          it 'stays publicly readable' do
             expect(gql_errors).to be_nil
-            expect(gql_data[:demarcheDescriptor][:id]).to eq(draft_procedure.to_typed_id)
+            expect(gql_data[:demarcheDescriptor][:id]).to eq(closed_procedure.to_typed_id)
           end
         end
 


### PR DESCRIPTION
Audit détaillé : `audits/2026-09-11-graphql-demarche-descriptor-brouillon-disclosure-audit.md`
## Problème

Un appelant **anonyme** (sans token) peut lire n'importe quelle démarche **en brouillon** via
`getDemarcheDescriptor` en énumérant les ids séquentiels : structure du formulaire en cours de
conception, contact du service instructeur, URLs légales/DPO, URLs signées des pièces jointes.

Cause : le raccourci opendata de `authorized_demarche?` ne teste que `opendata?`, colonne à
`true` par défaut, sans condition d'état — alors que la liste publique voisine
(`demarche_descriptors`) exclut explicitement les brouillons via `Procedure.publiques`. Le hook
`QueryType.accessible?` qui semblait protéger est du code mort (n'existe plus dans
graphql-ruby 2.5). A01 / CWE-639, DREAD 13/15.

## Solution

- `authorized_demarche?` : le raccourci opendata exige désormais `!brouillon?`. Les démarches
  publiées/closes opendata restent publiques ; un token garde l'accès à ses propres brouillons
  (chemin `compute_demarche_authorization`) ; `demarcheCloner` autorise explicitement le clone
  qu'il renvoie (nouveau `Context#authorize_demarche!` — le clone naît brouillon, hors du
  snapshot `procedure_ids` du token).
- Suppression du hook mort `QueryType.accessible?` (commit refactor séparé).

### Preuve par les tests

- Commit 1 : spec assertant le comportement vulnérable (brouillon servi à l'anonyme) — passe sur main.
- Commit 2 : fix + assertion inversée (« hidden due to permissions ») + non-régressions
  (démarche close publique toujours lisible, brouillon lisible par son admin via token).
- Fix load-bearing vérifié : retirer la seule ligne `&& !demarche.brouillon?` fait passer la
  spec au rouge (`expected: not nil, got: nil` — le brouillon est de nouveau servi).
- `spec/controllers/api/v2/` 199/199 · Rubocop clean. (3 échecs préexistants sur
  `spec/graphql/dossier_spec.rb`, vérifiés identiques sans le fix — env local.)

### Points d'attention review

- [ ] `demarcheCloner` : le descriptor du clone reste renvoyé (spec existante verte — elle a
      justement attrapé la régression pendant le dev).
- [ ] Une intégration qui lirait un brouillon *anonymement* casserait — comportement désormais
      aligné sur la liste publique `demarche_descriptors`.

## Hors périmètre

Le durcissement du rate limiting anonyme (`config/initializers/rack_attack.rb`) est
volontairement sorti de cette PR : c'est un durcissement global indépendant, à traiter à part
si on le juge utile. Une fois la présente faille corrigée, l'énumération anonyme ne renvoie
plus rien de sensible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
